### PR TITLE
[GTK][Skia] Add support for non-accelerated rendering

### DIFF
--- a/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
@@ -62,9 +62,14 @@ void ShareableBitmap::paint(GraphicsContext& context, const IntPoint& dstPoint, 
     paint(context, 1, dstPoint, srcRect);
 }
 
-void ShareableBitmap::paint(GraphicsContext&, float /*scaleFactor*/, const IntPoint&, const IntRect&)
+void ShareableBitmap::paint(GraphicsContext& context, float scaleFactor, const IntPoint& dstPoint, const IntRect& srcRect)
 {
-    notImplemented();
+    FloatRect scaledSrcRect(srcRect);
+    scaledSrcRect.scale(scaleFactor);
+    FloatRect scaledDestRect(dstPoint, srcRect.size());
+    scaledDestRect.scale(scaleFactor);
+    auto image = createPlatformImage(BackingStoreCopy::DontCopyBackingStore);
+    context.platformContext()->drawImageRect(image.get(), scaledSrcRect, scaledDestRect, { }, nullptr, { });
 }
 
 RefPtr<Image> ShareableBitmap::createImage()


### PR DESCRIPTION
#### 015bce0872dcce7de3173685094b0a73dbfb93b6
<pre>
[GTK][Skia] Add support for non-accelerated rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=270788">https://bugs.webkit.org/show_bug.cgi?id=270788</a>

Reviewed by Adrian Perez de Castro.

GTK uses cairo for non-accelerated rendering, so we need to render the
ShareableBitmap with skia, but into a cairo surface.

* Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp:
(WebCore::ShareableBitmap::paint):
* Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp:
(WebKit::BackingStore::incorporateUpdate):
(WebKit::BackingStore::scroll):

Canonical link: <a href="https://commits.webkit.org/276018@main">https://commits.webkit.org/276018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1dddc06fa5a39efb9310aaee24c7da6c916306b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43563 "Passed style check") | [💥 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22601 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45978 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46202 "An unexpected error occured. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/39692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45867 "Passed tests") | [💥 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26415 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/20015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/46202 "An unexpected error occured. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44137 "Passed tests") | [💥 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/26415 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/45978 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/46202 "An unexpected error occured. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/26415 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/45978 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1619 "Built successfully") | 
| | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/26415 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/45978 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47748 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/20015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/47748 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/45978 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/47748 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5929 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->