### PR TITLE
[Skia] Handle image interpolation quality when filling with an image pattern

### DIFF
--- a/Source/WebCore/platform/graphics/Pattern.h
+++ b/Source/WebCore/platform/graphics/Pattern.h
@@ -72,7 +72,11 @@ public:
     const Parameters& parameters() const { return m_parameters; }
 
     // Pattern space is an abstract space that maps to the default user space by the transformation 'userSpaceTransform'
+#if USE(SKIA)
+    PlatformPatternPtr createPlatformPattern(const AffineTransform& userSpaceTransform, const SkSamplingOptions&) const;
+#else
     PlatformPatternPtr createPlatformPattern(const AffineTransform& userSpaceTransform) const;
+#endif
 
     void setTileImage(SourceImage&& tileImage) { m_tileImage = WTFMove(tileImage); }
     void setPatternSpaceTransform(const AffineTransform&);

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -411,7 +411,7 @@ SkPaint GraphicsContextSkia::createFillPaint(std::optional<Color> fillColor) con
     paint.setBlendMode(toSkiaBlendMode(state.compositeMode().operation, state.compositeMode().blendMode));
 
     if (auto fillPattern = state.fillBrush().pattern())
-        paint.setShader(fillPattern->createPlatformPattern({ }));
+        paint.setShader(fillPattern->createPlatformPattern({ }, toSkSamplingOptions(m_state.imageInterpolationQuality())));
     else if (auto fillGradient = state.fillBrush().gradient())
         paint.setShader(fillGradient->shader(state.alpha(), state.fillBrush().gradientSpaceTransform()));
     else
@@ -440,7 +440,7 @@ SkPaint GraphicsContextSkia::createStrokePaint(std::optional<Color> strokeColor)
     paint.setAntiAlias(true);
 
     if (auto strokePattern = state.strokeBrush().pattern())
-        paint.setShader(strokePattern->createPlatformPattern({ }));
+        paint.setShader(strokePattern->createPlatformPattern({ }, toSkSamplingOptions(m_state.imageInterpolationQuality())));
     else if (auto strokeGradient = state.strokeBrush().gradient())
         paint.setShader(strokeGradient->shader(state.alpha(), state.strokeBrush().gradientSpaceTransform()));
     else

--- a/Source/WebCore/platform/graphics/skia/PatternSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PatternSkia.cpp
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-sk_sp<SkShader> Pattern::createPlatformPattern(const AffineTransform&) const
+sk_sp<SkShader> Pattern::createPlatformPattern(const AffineTransform&, const SkSamplingOptions& samplingOptions) const
 {
     auto nativeImage = tileNativeImage();
     if (!nativeImage)
@@ -45,8 +45,7 @@ sk_sp<SkShader> Pattern::createPlatformPattern(const AffineTransform&) const
     if (!platformImage)
         return nullptr;
 
-    // FIXME: image interpolation quality.
-    return platformImage->makeShader(repeatX() ? SkTileMode::kRepeat : SkTileMode::kDecal, repeatY() ? SkTileMode::kRepeat : SkTileMode::kDecal, { }, patternSpaceTransform());
+    return platformImage->makeShader(repeatX() ? SkTileMode::kRepeat : SkTileMode::kDecal, repeatY() ? SkTileMode::kRepeat : SkTileMode::kDecal, samplingOptions, patternSpaceTransform());
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### fd23a60530416cf834c6d5695914eca7839c9ac1
<pre>
[Skia] Handle image interpolation quality when filling with an image pattern
<a href="https://bugs.webkit.org/show_bug.cgi?id=270685">https://bugs.webkit.org/show_bug.cgi?id=270685</a>

Reviewed by Carlos Garcia Campos.

This change takes image interpolation quality into account when using image pattern
as CanvasRenderingContext2D.fillStyle or CanvasRenderingContext2D.strokeStyle.

* Source/WebCore/platform/graphics/Pattern.h:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::createFillPaint const):
(WebCore::GraphicsContextSkia::createStrokePaint const):
* Source/WebCore/platform/graphics/skia/PatternSkia.cpp:
(WebCore::Pattern::createPlatformPattern const):

Canonical link: <a href="https://commits.webkit.org/275966@main">https://commits.webkit.org/275966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a0e29e2661bd9cf73aa35d45b1bbbfa8033e2a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45887 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35770 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16915 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38362 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1309 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47432 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42560 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19704 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41234 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19883 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5899 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->