### PR TITLE
[GTK][Skia] Add support for shared memory buffer in accelerated compositing mode

### DIFF
--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -116,7 +116,7 @@ private:
         virtual cairo_surface_t* surface() const { return nullptr; }
 
         uint64_t id() const { return m_id; }
-        const WebCore::IntSize size() const { return m_size; }
+        const WebCore::IntSize& size() const { return m_size; }
         float deviceScaleFactor() const { return m_deviceScaleFactor; }
         float unscaledWidth() const { return static_cast<float>(m_size.width() / m_deviceScaleFactor); }
         float unscaledHeight() const { return static_cast<float>(m_size.height() / m_deviceScaleFactor); }


### PR DESCRIPTION
#### 8efe423f38b6d002cf19bbb2a0548ebe1a62f568
<pre>
[GTK][Skia] Add support for shared memory buffer in accelerated compositing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=270789">https://bugs.webkit.org/show_bug.cgi?id=270789</a>

Reviewed by Adrian Perez de Castro.

Create a cairo surface for the ShareableBitmap data.

* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::BufferSHM::didUpdateContents):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/276017@main">https://commits.webkit.org/276017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/869c0d81f40b66ca6abaf46d348e0b3e71a53540

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45888 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39380 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35772 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16759 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16909 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1310 "Built successfully") | 
| | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39450 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47433 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42559 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19705 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41213 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19884 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5927 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->