### PR TITLE
Navigator.mediaDevices.getSupportedConstraints mistakenly reports torch as false.

### DIFF
--- a/LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints-expected.txt
@@ -13,14 +13,29 @@ PASS supportedConstraints.deviceId is true
 PASS supportedConstraints.echoCancellation is true
 PASS supportedConstraints.facingMode is true
 PASS supportedConstraints.frameRate is true
-PASS supportedConstraints.groupId is false
+PASS supportedConstraints.groupId is true
 PASS supportedConstraints.height is true
-PASS supportedConstraints.sampleRate is false
-PASS supportedConstraints.sampleSize is false
+PASS supportedConstraints.sampleRate is true
+PASS supportedConstraints.sampleSize is true
 PASS supportedConstraints.volume is true
 PASS supportedConstraints.width is true
 PASS supportedConstraints.zoom is true
 
+PASS supportedConstraints["aspectRatio"] is true
+PASS supportedConstraints["deviceId"] is true
+PASS supportedConstraints["displaySurface"] is true
+PASS supportedConstraints["echoCancellation"] is true
+PASS supportedConstraints["facingMode"] is true
+PASS supportedConstraints["frameRate"] is true
+PASS supportedConstraints["groupId"] is true
+PASS supportedConstraints["height"] is true
+PASS supportedConstraints["sampleRate"] is true
+PASS supportedConstraints["sampleSize"] is true
+PASS supportedConstraints["torch"] is true
+PASS supportedConstraints["volume"] is true
+PASS supportedConstraints["whiteBalanceMode"] is true
+PASS supportedConstraints["width"] is true
+PASS supportedConstraints["zoom"] is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints.html
+++ b/LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints.html
@@ -23,15 +23,17 @@
             shouldBeTrue("supportedConstraints.echoCancellation");
             shouldBeTrue("supportedConstraints.facingMode");
             shouldBeTrue("supportedConstraints.frameRate");
-            shouldBeFalse("supportedConstraints.groupId");
+            shouldBeTrue("supportedConstraints.groupId");
             shouldBeTrue("supportedConstraints.height");
-            shouldBeFalse("supportedConstraints.sampleRate");
-            shouldBeFalse("supportedConstraints.sampleSize");
+            shouldBeTrue("supportedConstraints.sampleRate");
+            shouldBeTrue("supportedConstraints.sampleSize");
             shouldBeTrue("supportedConstraints.volume");
             shouldBeTrue("supportedConstraints.width");
             shouldBeTrue("supportedConstraints.zoom");
             debug("");
 
+            for (const key of Object.keys(supportedConstraints))
+                shouldBeTrue(`supportedConstraints["${key}"]`);
 
             finishJSTest();
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getSupportedConstraints.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getSupportedConstraints.https-expected.txt
@@ -10,13 +10,13 @@ PASS aspectRatio is supported
 PASS frameRate is supported
 PASS facingMode is supported
 FAIL resizeMode is supported assert_true: expected true got undefined
-FAIL sampleRate is supported assert_true: expected true got false
-FAIL sampleSize is supported assert_true: expected true got false
+PASS sampleRate is supported
+PASS sampleSize is supported
 PASS echoCancellation is supported
 FAIL autoGainControl is supported assert_true: expected true got undefined
 FAIL noiseSuppression is supported assert_true: expected true got undefined
 FAIL latency is supported assert_true: expected true got undefined
 FAIL channelCount is supported assert_true: expected true got undefined
 PASS deviceId is supported
-FAIL groupId is supported assert_true: expected true got false
+PASS groupId is supported
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https-expected.txt
@@ -4,8 +4,8 @@ This test checks for the presence of the navigator.mediaDevices.getUserMedia met
 
 
 PASS mediaDevices.getUserMedia() is present on navigator
-FAIL groupId is correctly supported by getUserMedia() for video devices assert_true: groupId should be supported expected true got false
-FAIL groupId is correctly supported by getUserMedia() for audio devices assert_true: groupId should be supported expected true got false
+FAIL groupId is correctly supported by getUserMedia() for video devices assert_equals: expected "groupId" but got ""
+FAIL groupId is correctly supported by getUserMedia() for audio devices assert_equals: expected "groupId" but got ""
 FAIL getUserMedia() supports setting none as resizeMode. assert_true: resizeMode should be supported expected true got undefined
 FAIL getUserMedia() supports setting crop-and-scale as resizeMode. assert_true: resizeMode should be supported expected true got undefined
 FAIL getUserMedia() fails with exact invalid resizeMode. assert_true: resizeMode should be supported expected true got undefined

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -362,24 +362,7 @@ void MediaDevices::enumerateDevices(EnumerateDevicesPromise&& promise)
 
 MediaTrackSupportedConstraints MediaDevices::getSupportedConstraints()
 {
-    auto& supported = RealtimeMediaSourceCenter::singleton().supportedConstraints();
-    MediaTrackSupportedConstraints result;
-    result.width = supported.supportsWidth();
-    result.height = supported.supportsHeight();
-    result.aspectRatio = supported.supportsAspectRatio();
-    result.frameRate = supported.supportsFrameRate();
-    result.facingMode = supported.supportsFacingMode();
-    result.whiteBalanceMode = supported.supportsWhiteBalanceMode();
-    result.volume = supported.supportsVolume();
-    result.sampleRate = supported.supportsSampleRate();
-    result.sampleSize = supported.supportsSampleSize();
-    result.echoCancellation = supported.supportsEchoCancellation();
-    result.deviceId = supported.supportsDeviceId();
-    result.groupId = supported.supportsGroupId();
-    result.displaySurface = supported.supportsDisplaySurface();
-    result.zoom = supported.supportsZoom();
-
-    return result;
+    return { };
 }
 
 void MediaDevices::scheduledEventTimerFired()

--- a/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h
@@ -35,21 +35,21 @@
 namespace WebCore {
 
 struct MediaTrackSupportedConstraints {
-    bool width;
-    bool height;
-    bool aspectRatio;
-    bool frameRate;
-    bool facingMode;
-    bool volume;
-    bool sampleRate;
-    bool sampleSize;
-    bool echoCancellation;
-    bool deviceId;
-    bool groupId;
-    bool displaySurface;
-    bool whiteBalanceMode;
-    bool zoom;
-    bool torch;
+    bool width { true };
+    bool height { true };
+    bool aspectRatio { true };
+    bool frameRate { true };
+    bool facingMode { true };
+    bool volume { true };
+    bool sampleRate { true };
+    bool sampleSize { true };
+    bool echoCancellation { true };
+    bool deviceId { true };
+    bool groupId { true };
+    bool displaySurface { true };
+    bool whiteBalanceMode { true };
+    bool zoom { true };
+    bool torch { true };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -59,19 +59,6 @@ RealtimeMediaSourceCenter& RealtimeMediaSourceCenter::singleton()
 RealtimeMediaSourceCenter::RealtimeMediaSourceCenter()
     : m_debounceTimer(RunLoop::main(), this, &RealtimeMediaSourceCenter::triggerDevicesChangedObservers)
 {
-    m_supportedConstraints.setSupportsEchoCancellation(true);
-    m_supportedConstraints.setSupportsWidth(true);
-    m_supportedConstraints.setSupportsHeight(true);
-    m_supportedConstraints.setSupportsAspectRatio(true);
-    m_supportedConstraints.setSupportsFrameRate(true);
-    m_supportedConstraints.setSupportsFacingMode(true);
-    m_supportedConstraints.setSupportsVolume(true);
-    m_supportedConstraints.setSupportsDeviceId(true);
-    m_supportedConstraints.setSupportsDisplaySurface(true);
-
-    m_supportedConstraints.setSupportsWhiteBalanceMode(true);
-    m_supportedConstraints.setSupportsZoom(true);
-    m_supportedConstraints.setSupportsTorch(true);
 }
 
 RealtimeMediaSourceCenter::~RealtimeMediaSourceCenter() = default;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h
@@ -37,7 +37,6 @@
 #include "ExceptionOr.h"
 #include "MediaStreamRequest.h"
 #include "RealtimeMediaSource.h"
-#include "RealtimeMediaSourceSupportedConstraints.h"
 #include <wtf/Function.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RunLoop.h>
@@ -53,7 +52,6 @@ namespace WebCore {
 class CaptureDevice;
 class CaptureDeviceManager;
 class RealtimeMediaSourceSettings;
-class RealtimeMediaSourceSupportedConstraints;
 class TrackSourceInfo;
 
 struct MediaConstraints;
@@ -81,8 +79,6 @@ public:
 
     WEBCORE_EXPORT void getMediaStreamDevices(CompletionHandler<void(Vector<CaptureDevice>&&)>&&);
     WEBCORE_EXPORT std::optional<RealtimeMediaSourceCapabilities> getCapabilities(const CaptureDevice&);
-
-    const RealtimeMediaSourceSupportedConstraints& supportedConstraints() { return m_supportedConstraints; }
 
     WEBCORE_EXPORT AudioCaptureFactory& audioCaptureFactory();
     WEBCORE_EXPORT void setAudioCaptureFactory(AudioCaptureFactory&);
@@ -133,8 +129,6 @@ private:
     void getUserMediaDevices(const MediaStreamRequest&, MediaDeviceHashSalts&&, Vector<DeviceInfo>& audioDevices, Vector<DeviceInfo>& videoDevices, MediaConstraintType&);
     void validateRequestConstraintsAfterEnumeration(ValidConstraintsHandler&&, InvalidConstraintsHandler&&, const MediaStreamRequest&, MediaDeviceHashSalts&&);
     void enumerateDevices(bool shouldEnumerateCamera, bool shouldEnumerateDisplay, bool shouldEnumerateMicrophone, bool shouldEnumerateSpeakers, CompletionHandler<void()>&&);
-
-    RealtimeMediaSourceSupportedConstraints m_supportedConstraints;
 
     RunLoop::Timer m_debounceTimer;
     void triggerDevicesChangedObservers();


### PR DESCRIPTION
#### 8153861f277e5f0d37a63bf3070945661a11a7e6
<pre>
Navigator.mediaDevices.getSupportedConstraints mistakenly reports torch as false.
<a href="https://rdar.apple.com/124372654">rdar://124372654</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=270779">https://bugs.webkit.org/show_bug.cgi?id=270779</a>

Reviewed by Eric Carlson.

As per spec, MediaTrackConstraints member must be true if present.
Each individual source may still or may not support a particular constraint.
We remove RealtimeMediaSourceCenter::m_supportedConstraints and instead make all MediaTrackSupportedConstraints members true by default.
Covered by updated tests.

* LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints-expected.txt:
* LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints.html:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getSupportedConstraints.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaDevices-getUserMedia.https-expected.txt:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::getSupportedConstraints):
* Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::RealtimeMediaSourceCenter::RealtimeMediaSourceCenter):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.h:

Canonical link: <a href="https://commits.webkit.org/275945@main">https://commits.webkit.org/275945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6941eea2f92cce386b2c1f6cbb65b149ed64983

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39383 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35774 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16762 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38338 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1313 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39453 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47436 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42564 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19708 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41219 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9646 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19887 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->