### PR TITLE
[content-visibility] ASSERTION FAILED: !renderer.needsLayout() causing imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html to constantly crash

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2327,7 +2327,6 @@ webkit.org/b/203676 svg/custom/pointer-events-text.svg [ Failure ]
 webkit.org/b/245324 http/tests/notifications/notification.html  [ Crash Pass ]
 
 webgl/1.0.x/conformance/textures/misc/texture-corner-case-videos.html [ Timeout ]
-imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html [ Timeout ]
 
 fast/mediastream/mediastreamtrack-video-frameRate-clone-decreasing.html [ Crash Pass ]
 

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -875,7 +875,7 @@ webkit.org/b/260926 imported/w3c/web-platform-tests/html/browsers/browsing-the-w
 
 webkit.org/b/262088 [ Debug ] imported/w3c/web-platform-tests/fetch/private-network-access/iframe.tentative.https.window.html [ Pass Failure ]
 
-webkit.org/b/262157 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html [ Pass ImageOnlyFailure Crash ]
+imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/261314 [ Debug ] fast/mediastream/captureStream/canvas3d.html [ Pass Failure ]
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2473,7 +2473,7 @@ bool RenderElement::hasEligibleContainmentForSizeQuery() const
 
 void RenderElement::clearNeedsLayoutForSkippedContent()
 {
-    for (CheckedRef descendant : descendantsOfType<RenderObject>(*this))
+    for (CheckedRef descendant : descendantsOfTypePostOrder<RenderObject>(*this))
         descendant->clearNeedsLayout(EverHadSkippedContentLayout::No);
     clearNeedsLayout(EverHadSkippedContentLayout::No);
 }

--- a/Source/WebCore/rendering/RenderIterator.h
+++ b/Source/WebCore/rendering/RenderIterator.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -79,6 +80,46 @@ private:
     const T* m_current;
 };
 
+template <typename T>
+class RenderPostOrderIterator {
+public:
+    RenderPostOrderIterator(const RenderElement* root);
+    RenderPostOrderIterator(const RenderElement* root, T* current);
+
+    T& operator*();
+    T* operator->();
+
+    operator bool() const { return m_current; }
+
+    bool operator==(const RenderPostOrderIterator&) const;
+
+    RenderPostOrderIterator& traverseNext();
+
+private:
+    const RenderElement* m_root;
+    T* m_current;
+};
+
+template <typename T>
+class RenderPostOrderConstIterator {
+public:
+    RenderPostOrderConstIterator(const RenderElement* root);
+    RenderPostOrderConstIterator(const RenderElement* root, const T* current);
+
+    const T& operator*() const;
+    const T* operator->() const;
+
+    operator bool() const { return m_current; }
+
+    bool operator==(const RenderPostOrderConstIterator& other) const;
+
+    RenderPostOrderConstIterator& traverseNext();
+
+private:
+    const RenderElement* m_root;
+    const T* m_current;
+};
+
 // Similar to is<>() but without the static_assert() making sure the check is necessary.
 template <typename T, typename U>
 inline bool isRendererOfType(const U& renderer) { return TypeCastTraits<const T, const U>::isOfType(renderer); }
@@ -140,7 +181,25 @@ inline RenderObject* nextSkippingChildren(RenderObject& current, const RenderObj
     return nextAncestorSibling(current, stayWithin);
 }
 
+} // namespace WebCore::RenderObjectTraversal
+
+namespace RenderObjectPostOrderTraversal {
+
+inline RenderObject* next(RenderObject& current, const RenderObject* stayWithin)
+{
+    if (auto* sibling = current.nextSibling()) {
+        if (auto* firstLeafChild = sibling->firstLeafChild())
+            return firstLeafChild;
+        return sibling;
+    }
+
+    auto* parent = current.parent();
+    if (parent == stayWithin)
+        return nullptr;
+    return parent;
 }
+
+} // namespace WebCore::RenderObjectPostOrderTraversal
 
 namespace RenderTraversal {
 
@@ -209,6 +268,28 @@ inline T* next(U& current, const RenderObject* stayWithin)
 }
 
 } // namespace WebCore::RenderTraversal
+
+namespace RenderPostOrderTraversal {
+
+template <typename T>
+inline T* firstWithin(RenderObject& current)
+{
+    auto* descendant = current.firstLeafChild();
+    while (descendant && !isRendererOfType<T>(*descendant))
+        descendant = RenderObjectPostOrderTraversal::next(*descendant, &current);
+    return static_cast<T*>(descendant);
+}
+
+template <typename T>
+inline T* next(RenderObject& current, const RenderObject* stayWithin)
+{
+    auto* descendant = RenderObjectPostOrderTraversal::next(current, stayWithin);
+    while (descendant && !isRendererOfType<T>(*descendant))
+        descendant = RenderObjectPostOrderTraversal::next(*descendant, stayWithin);
+    return static_cast<T*>(descendant);
+}
+
+} // namespace WebCore::RenderPostOrderTraversal
 
 // RenderIterator
 
@@ -362,6 +443,96 @@ inline const T* RenderConstIterator<T>::operator->() const
 
 template <typename T>
 inline bool RenderConstIterator<T>::operator==(const RenderConstIterator& other) const
+{
+    ASSERT(m_root == other.m_root);
+    return m_current == other.m_current;
+}
+
+// RenderPostOrderIterator
+
+template <typename T>
+inline RenderPostOrderIterator<T>::RenderPostOrderIterator(const RenderElement* root)
+    : m_root(root)
+    , m_current(nullptr)
+{
+}
+
+template <typename T>
+inline RenderPostOrderIterator<T>::RenderPostOrderIterator(const RenderElement* root, T* current)
+    : m_root(root)
+    , m_current(current)
+{
+}
+
+template <typename T>
+inline RenderPostOrderIterator<T>& RenderPostOrderIterator<T>::traverseNext()
+{
+    ASSERT(m_current);
+    m_current = RenderPostOrderTraversal::next<T>(*m_current, m_root);
+    return *this;
+}
+
+template <typename T>
+inline T& RenderPostOrderIterator<T>::operator*()
+{
+    ASSERT(m_current);
+    return *m_current;
+}
+
+template <typename T>
+inline T* RenderPostOrderIterator<T>::operator->()
+{
+    ASSERT(m_current);
+    return m_current;
+}
+
+template <typename T>
+inline bool RenderPostOrderIterator<T>::operator==(const RenderPostOrderIterator& other) const
+{
+    ASSERT(m_root == other.m_root);
+    return m_current == other.m_current;
+}
+
+// RenderConstIterator
+
+template <typename T>
+inline RenderPostOrderConstIterator<T>::RenderPostOrderConstIterator(const RenderElement* root)
+    : m_root(root)
+    , m_current(nullptr)
+{
+}
+
+template <typename T>
+inline RenderPostOrderConstIterator<T>::RenderPostOrderConstIterator(const RenderElement* root, const T* current)
+    : m_root(root)
+    , m_current(current)
+{
+}
+
+template <typename T>
+inline RenderPostOrderConstIterator<T>& RenderPostOrderConstIterator<T>::traverseNext()
+{
+    ASSERT(m_current);
+    m_current = RenderPostOrderTraversal::next<T>(*m_current, m_root);
+    return *this;
+}
+
+template <typename T>
+inline const T& RenderPostOrderConstIterator<T>::operator*() const
+{
+    ASSERT(m_current);
+    return *m_current;
+}
+
+template <typename T>
+inline const T* RenderPostOrderConstIterator<T>::operator->() const
+{
+    ASSERT(m_current);
+    return m_current;
+}
+
+template <typename T>
+inline bool RenderPostOrderConstIterator<T>::operator==(const RenderPostOrderConstIterator& other) const
 {
     ASSERT(m_root == other.m_root);
     return m_current == other.m_current;


### PR DESCRIPTION
#### 836cb999ce8c37075ae7c05ef485328a4b96e73c
<pre>
[content-visibility] ASSERTION FAILED: !renderer.needsLayout() causing imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-video.html to constantly crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=262157">https://bugs.webkit.org/show_bug.cgi?id=262157</a>

Reviewed by Darin Adler.

Normally, when we do `RenderElement::layout()`, we first lay out its
children and then clear the `needsLayout` flag. When assertions are
enabled, in `RenderObject::clearNeedsLayout()` we check that
block-positioned children don&apos;t need layout.

But if the element is skipped for layout, we call
`RenderElement::clearNeedsLayoutForSkippedContent()` instead.

As the first step, this method calls `RenderObject::clearNeedsLayout()`
on every descendent. Note that it won&apos;t lay out the descendant&apos;s
children but will still check that the block-positioned children of the
descendent don&apos;t need layout, which might be false and cause the
assertion to fail.

This patch implements `descendantsOfTypePostOrder&lt;T&gt;()` function which
is then used to guarantee that `RenderElement`&apos;s needs-layout flag is
always cleared after its children.

* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wk2/TestExpectations:
* Source/WebCore/rendering/RenderDescendantIterator.h:
(WebCore::RenderDescendantPostOrderIterator&lt;T&gt;::RenderDescendantPostOrderIterator):
(WebCore::RenderDescendantPostOrderIterator&lt;T&gt;::operator):
(WebCore::RenderDescendantPostOrderConstIterator&lt;T&gt;::RenderDescendantPostOrderConstIterator):
(WebCore::RenderDescendantPostOrderConstIterator&lt;T&gt;::operator):
(WebCore::RenderDescendantPostOrderIteratorAdapter&lt;T&gt;::RenderDescendantPostOrderIteratorAdapter):
(WebCore::RenderDescendantPostOrderIteratorAdapter&lt;T&gt;::begin):
(WebCore::RenderDescendantPostOrderIteratorAdapter&lt;T&gt;::end):
(WebCore::RenderDescendantPostOrderIteratorAdapter&lt;T&gt;::at):
(WebCore::RenderDescendantPostOrderConstIteratorAdapter&lt;T&gt;::RenderDescendantPostOrderConstIteratorAdapter):
(WebCore::RenderDescendantPostOrderConstIteratorAdapter&lt;T&gt;::begin const):
(WebCore::RenderDescendantPostOrderConstIteratorAdapter&lt;T&gt;::end const):
(WebCore::RenderDescendantPostOrderConstIteratorAdapter&lt;T&gt;::at const):
(WebCore::descendantsOfTypePostOrder):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::clearNeedsLayoutForSkippedContent):
* Source/WebCore/rendering/RenderIterator.h:
(WebCore::RenderPostOrderIterator::operator bool const):
(WebCore::RenderPostOrderConstIterator::operator bool const):
(WebCore::RenderObjectPostOrderTraversal::next):
(WebCore::RenderPostOrderTraversal::firstWithin):
(WebCore::RenderPostOrderTraversal::next):
(WebCore::RenderPostOrderIterator&lt;T&gt;::RenderPostOrderIterator):
(WebCore::RenderPostOrderIterator&lt;T&gt;::traverseNext):
(WebCore::RenderPostOrderIterator&lt;T&gt;::operator):
(WebCore::= const):
(WebCore::RenderPostOrderConstIterator&lt;T&gt;::RenderPostOrderConstIterator):
(WebCore::RenderPostOrderConstIterator&lt;T&gt;::traverseNext):
(WebCore::RenderPostOrderConstIterator&lt;T&gt;::operator const):
(WebCore:: const):

Canonical link: <a href="https://commits.webkit.org/277019@main">https://commits.webkit.org/277019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3918e6f1d1d60c5991ea9aee705e35f333991a39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49099 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42465 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23023 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40029 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19128 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41134 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4469 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41503 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50952 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17870 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10274 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22419 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->