### PR TITLE
Update http/wpt/webrtc/video-script-transform.html, http/wpt/webrtc/video-script-transform-simulcast.html and imported/w3c/web-platform-tests/webrtc/simulcast/basic.https.html test expectations

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1876,9 +1876,6 @@ webkit.org/b/263049 [ Sonoma+ ] fast/forms/scroll-into-view-and-show-validation-
 
 webkit.org/b/263136 [ Sonoma+ ] imported/w3c/web-platform-tests/css/css-text/line-break/line-break-anywhere-overrides-uax-behavior-011.html [ ImageOnlyFailure ]
 
-webkit.org/b/263227 imported/w3c/web-platform-tests/webrtc/simulcast/basic.https.html [ Pass Failure ]
-webkit.org/b/263227 imported/w3c/web-platform-tests/webrtc/protocol/handover-datachannel.html [ Pass Failure ]
-
 webkit.org/b/261356 [ Debug ] fast/mediastream/device-change-event-2.html [ Pass Timeout ] # CHANGE TO [ Pass Timeout ] WITHOUT DEBUG AFTER FIX ACCORDING TO webkit.org/b/188924
 
 webkit.org/b/263396 css3/color/text.html [ Skip ]
@@ -1959,11 +1956,11 @@ webkit.org/b/267891 [ Sonoma+ Release ] fast/css/nested-table-with-collapsed-bor
 
 webkit.org/b/267796 [ Monterey+ Release ] imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic.html [ Pass Failure ]
 
-webkit.org/b/267953 [ Monterey+ ] http/wpt/webrtc/video-script-transform.html [ Pass Failure ]
-
 webkit.org/b/268018 [ Sonoma+ Release ] fast/images/text-recognition/mac/select-word-in-transparent-image-overlay.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/268047 [ Monterey+ ] http/wpt/webrtc/video-script-transform-simulcast.html [ Pass Failure ]
+webkit.org/b/270790 [ Monterey+ x86_64 ] http/wpt/webrtc/video-script-transform.html [ Pass Failure ]
+webkit.org/b/270790 [ Monterey+ x86_64 ] http/wpt/webrtc/video-script-transform-simulcast.html [ Pass Failure ]
+webkit.org/b/270790 [ Monterey+ x86_64 ] imported/w3c/web-platform-tests/webrtc/simulcast/basic.https.html [ Pass Failure ]
 
 webkit.org/b/268200 [ Sonoma+ Release ] inspector/console/console-screenshot.html [ Pass Failure ]
 


### PR DESCRIPTION
#### aee4e88c815c823b7d149668b0ebbf2a0542fae2
<pre>
Update http/wpt/webrtc/video-script-transform.html, http/wpt/webrtc/video-script-transform-simulcast.html and imported/w3c/web-platform-tests/webrtc/simulcast/basic.https.html test expectations
<a href="https://rdar.apple.com/124384964">rdar://124384964</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=270791">https://bugs.webkit.org/show_bug.cgi?id=270791</a>

Unreviewed.

http/wpt/webrtc/video-script-transform.html, http/wpt/webrtc/video-script-transform-simulcast.html and imported/w3c/web-platform-tests/webrtc/simulcast/basic.https.html
are only failing on Monterey x86_64, updating test expectations accordingly.
imported/w3c/web-platform-tests/webrtc/protocol/handover-datachannel.html is no longer flaky, removing test expectation.

* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/275964@main">https://commits.webkit.org/275964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e61a6a3e95e0cf5dc827ba7df3a88c6c30da75b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45898 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39390 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35781 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16769 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38337 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1320 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47443 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14971 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42565 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19715 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41220 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9660 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->