### PR TITLE
Fix rendering of ruby block with continuation children

### DIFF
--- a/LayoutTests/fast/ruby/ruby-block-with-continuation-children.html
+++ b/LayoutTests/fast/ruby/ruby-block-with-continuation-children.html
@@ -1,0 +1,10 @@
+<body>
+    <ruby id="ruby" style="position: absolute">
+        Before the b.
+        <b>Inside the b, before the div.
+            <div>Inside the div</div>
+            Iside the b, after the div.
+        </b>
+        After the b.
+    </ruby>
+</body>

--- a/LayoutTests/platform/glib/fast/ruby/ruby-block-with-continuation-children-expected.txt
+++ b/LayoutTests/platform/glib/fast/ruby/ruby-block-with-continuation-children-expected.txt
@@ -1,0 +1,25 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+layer at (8,8) size 269x54
+  RenderBlock (positioned) {RUBY} at (8,8) size 269x54
+    RenderBlock (anonymous) at (0,0) size 269x18
+      RenderInline (generated) at (0,0) size 269x17
+        RenderInline (generated) at (0,0) size 269x17
+          RenderText {#text} at (0,0) size 86x17
+            text run at (0,0) width 86: "Before the b. "
+          RenderInline {B} at (86,0) size 183x17
+            RenderText {#text} at (86,0) size 183x17
+              text run at (86,0) width 183: "Inside the b, before the div."
+    RenderBlock (anonymous) at (0,18) size 269x18
+      RenderBlock {DIV} at (0,0) size 269x18
+        RenderText {#text} at (0,0) size 91x17
+          text run at (0,0) width 91: "Inside the div"
+    RenderBlock (anonymous) at (0,36) size 269x18
+      RenderInline {B} at (0,0) size 167x17
+        RenderText {#text} at (0,0) size 167x17
+          text run at (0,0) width 167: "Iside the b, after the div. "
+      RenderText {#text} at (166,0) size 73x17
+        text run at (166,0) width 73: "After the b."

--- a/LayoutTests/platform/ios/fast/ruby/ruby-block-with-continuation-children-expected.txt
+++ b/LayoutTests/platform/ios/fast/ruby/ruby-block-with-continuation-children-expected.txt
@@ -1,0 +1,25 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+layer at (8,8) size 272x60
+  RenderBlock (positioned) {RUBY} at (8,8) size 273x60
+    RenderBlock (anonymous) at (0,0) size 273x20
+      RenderInline (generated) at (0,0) size 273x19
+        RenderInline (generated) at (0,0) size 273x19
+          RenderText {#text} at (0,0) size 88x19
+            text run at (0,0) width 88: "Before the b. "
+          RenderInline {B} at (87,0) size 186x19
+            RenderText {#text} at (87,0) size 186x19
+              text run at (87,0) width 186: "Inside the b, before the div."
+    RenderBlock (anonymous) at (0,20) size 273x20
+      RenderBlock {DIV} at (0,0) size 273x20
+        RenderText {#text} at (0,0) size 93x19
+          text run at (0,0) width 93: "Inside the div"
+    RenderBlock (anonymous) at (0,40) size 273x20
+      RenderInline {B} at (0,0) size 170x19
+        RenderText {#text} at (0,0) size 170x19
+          text run at (0,0) width 170: "Iside the b, after the div. "
+      RenderText {#text} at (169,0) size 74x19
+        text run at (169,0) width 74: "After the b."

--- a/LayoutTests/platform/mac/fast/ruby/ruby-block-with-continuation-children-expected.txt
+++ b/LayoutTests/platform/mac/fast/ruby/ruby-block-with-continuation-children-expected.txt
@@ -1,0 +1,25 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+layer at (8,8) size 272x54
+  RenderBlock (positioned) {RUBY} at (8,8) size 273x54
+    RenderBlock (anonymous) at (0,0) size 273x18
+      RenderInline (generated) at (0,0) size 273x18
+        RenderInline (generated) at (0,0) size 273x18
+          RenderText {#text} at (0,0) size 88x18
+            text run at (0,0) width 88: "Before the b. "
+          RenderInline {B} at (87,0) size 186x18
+            RenderText {#text} at (87,0) size 186x18
+              text run at (87,0) width 186: "Inside the b, before the div."
+    RenderBlock (anonymous) at (0,18) size 273x18
+      RenderBlock {DIV} at (0,0) size 273x18
+        RenderText {#text} at (0,0) size 93x18
+          text run at (0,0) width 93: "Inside the div"
+    RenderBlock (anonymous) at (0,36) size 273x18
+      RenderInline {B} at (0,0) size 170x18
+        RenderText {#text} at (0,0) size 170x18
+          text run at (0,0) width 170: "Iside the b, after the div. "
+      RenderText {#text} at (169,0) size 74x18
+        text run at (169,0) width 74: "After the b."

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
@@ -67,8 +67,14 @@ RenderElement& RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild
 
     if (parent.style().display() == DisplayType::RubyBlock && parent.firstChild()) {
         // See if we have an anonymous ruby box already.
-        ASSERT(parent.firstChild()->style().display() == DisplayType::Ruby);
-        return downcast<RenderElement>(*parent.firstChild());
+        if (parent.firstChild()->style().display() == DisplayType::Ruby)
+            return downcast<RenderElement>(*parent.firstChild());
+
+        // If the child is not a ruby box, then we might have continuations.
+        ASSERT(parent.firstChild()->isAnonymousBlock());
+        auto* previous = beforeChild ? beforeChild->previousSibling() : parent.lastChild();
+        beforeChild = nullptr;
+        return downcast<RenderElement>(*previous);
     }
 
     if (parent.style().display() != DisplayType::Ruby) {


### PR DESCRIPTION
#### 1fc0dc06c964e58a8903d4600fc1f29b36208722
<pre>
Fix rendering of ruby block with continuation children
<a href="https://bugs.webkit.org/show_bug.cgi?id=270792">https://bugs.webkit.org/show_bug.cgi?id=270792</a>

Reviewed by NOBODY (OOPS!).

RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild() assumes that
if a Ruby block has an anonymous child, it must be a Ruby box. This assumption
is not correct, as when there is mixed block and inline children, there might
be anonymous blocks created for using with continuations.

This assumption is strictly enforced in Debug builds with an ASSERT, but
in Release builds it results in the wrong anonymous block being returned as
the candidate parent for the child to be inserted, which can cause
elements to be rendered in the wrong place.

* LayoutTests/fast/ruby/ruby-block-with-continuation-children.html: Added.
* LayoutTests/platform/glib/fast/ruby/ruby-block-with-continuation-children-expected.txt: Added.
* LayoutTests/platform/ios/fast/ruby/ruby-block-with-continuation-children-expected.txt: Added.
* LayoutTests/platform/mac/fast/ruby/ruby-block-with-continuation-children-expected.txt: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp:
(WebCore::RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fc0dc06c964e58a8903d4600fc1f29b36208722

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46057 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39548 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35897 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16874 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38464 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1478 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47601 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18408 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15087 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42681 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41345 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->