### PR TITLE
[css-nesting] Remove feature flag

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1183,20 +1183,6 @@ CSSMotionPathEnabled:
     WebCore:
       default: true
 
-CSSNestingEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "CSS Nesting"
-  humanReadableDescription: "Enable support for CSS nesting https://www.w3.org/TR/css-nesting-1/"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 CSSOMViewScrollingAPIEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/css/CSSStyleRule.idl
+++ b/Source/WebCore/css/CSSStyleRule.idl
@@ -31,7 +31,7 @@ typedef USVString CSSOMString;
     // https://drafts.css-houdini.org/css-typed-om/#declared-stylepropertymap-objects
     [SameObject, EnabledBySetting=CSSTypedOMEnabled] readonly attribute StylePropertyMap styleMap;
 
-    [EnabledBySetting=CSSNestingEnabled, SameObject] readonly attribute CSSRuleList cssRules;
-    [EnabledBySetting=CSSNestingEnabled] unsigned long insertRule(CSSOMString rule, optional unsigned long index = 0);
-    [EnabledBySetting=CSSNestingEnabled] undefined deleteRule(unsigned long index);
+    [SameObject] readonly attribute CSSRuleList cssRules;
+    unsigned long insertRule(CSSOMString rule, optional unsigned long index = 0);
+    undefined deleteRule(unsigned long index);
 };

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -101,7 +101,6 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , gradientInterpolationColorSpacesEnabled { document.settings().cssGradientInterpolationColorSpacesEnabled() }
     , subgridEnabled { document.settings().subgridEnabled() }
     , masonryEnabled { document.settings().masonryEnabled() }
-    , cssNestingEnabled { document.settings().cssNestingEnabled() }
 #if ENABLE(CSS_PAINTING_API)
     , cssPaintingAPIEnabled { document.settings().cssPaintingAPIEnabled() }
 #endif
@@ -147,23 +146,22 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.gradientInterpolationColorSpacesEnabled   << 15
         | context.subgridEnabled                            << 16
         | context.masonryEnabled                            << 17
-        | context.cssNestingEnabled                         << 18
-        | context.cssPaintingAPIEnabled                     << 19
-        | context.cssScopeAtRuleEnabled                     << 20
-        | context.cssTextUnderlinePositionLeftRightEnabled  << 21
-        | context.cssWordBreakAutoPhraseEnabled             << 22
-        | context.popoverAttributeEnabled                   << 23
-        | context.sidewaysWritingModesEnabled               << 24
-        | context.cssTextWrapPrettyEnabled                  << 25
-        | context.highlightAPIEnabled                       << 26
-        | context.grammarAndSpellingPseudoElementsEnabled   << 27
-        | context.customStateSetEnabled                     << 28
-        | context.thumbAndTrackPseudoElementsEnabled        << 29
+        | context.cssPaintingAPIEnabled                     << 18
+        | context.cssScopeAtRuleEnabled                     << 19
+        | context.cssTextUnderlinePositionLeftRightEnabled  << 20
+        | context.cssWordBreakAutoPhraseEnabled             << 21
+        | context.popoverAttributeEnabled                   << 22
+        | context.sidewaysWritingModesEnabled               << 23
+        | context.cssTextWrapPrettyEnabled                  << 24
+        | context.highlightAPIEnabled                       << 25
+        | context.grammarAndSpellingPseudoElementsEnabled   << 26
+        | context.customStateSetEnabled                     << 27
+        | context.thumbAndTrackPseudoElementsEnabled        << 28
 #if ENABLE(SERVICE_CONTROLS)
-        | context.imageControlsEnabled                      << 30
+        | context.imageControlsEnabled                      << 29
 #endif
-        | context.lightDarkEnabled                          << 31
-        | (uint64_t)context.mode                            << 32; // This is multiple bits, so keep it last.
+        | context.lightDarkEnabled                          << 30
+        | (uint64_t)context.mode                            << 31; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -91,7 +91,6 @@ struct CSSParserContext {
     bool gradientInterpolationColorSpacesEnabled : 1 { false };
     bool subgridEnabled : 1 { false };
     bool masonryEnabled : 1 { false };
-    bool cssNestingEnabled : 1 { false };
     bool cssPaintingAPIEnabled : 1 { false };
     bool cssScopeAtRuleEnabled : 1 { false };
     bool cssStartingStyleAtRuleEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -190,7 +190,7 @@ private:
 
     bool isStyleNestedContext()
     {
-        return (m_isAlwaysNestedContext == CSSParserEnum::IsNestedContext::Yes || m_styleRuleNestingLevel) && context().cssNestingEnabled;
+        return m_isAlwaysNestedContext == CSSParserEnum::IsNestedContext::Yes || m_styleRuleNestingLevel;
     }
 
     bool isNestedContext()

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -564,7 +564,7 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumeSimpleSelector(CSS
         selector = consumeId(range);
     else if (token.type() == DelimiterToken && token.delimiter() == '.')
         selector = consumeClass(range);
-    else if (token.type() == DelimiterToken && token.delimiter() == '&' && m_context.cssNestingEnabled)
+    else if (token.type() == DelimiterToken && token.delimiter() == '&')
         selector = consumeNesting(range);
     else if (token.type() == LeftBracketToken)
         selector = consumeAttribute(range);

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -34,7 +34,6 @@ namespace WebCore {
 
 CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& context)
     : mode(context.mode)
-    , cssNestingEnabled(context.cssNestingEnabled)
     , customStateSetEnabled(context.customStateSetEnabled)
     , focusVisibleEnabled(context.focusVisibleEnabled)
     , grammarAndSpellingPseudoElementsEnabled(context.grammarAndSpellingPseudoElementsEnabled)
@@ -51,7 +50,6 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
 
 CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     : mode(document.inQuirksMode() ? HTMLQuirksMode : HTMLStandardMode)
-    , cssNestingEnabled(document.settings().cssNestingEnabled())
     , customStateSetEnabled(document.settings().customStateSetEnabled())
     , focusVisibleEnabled(document.settings().focusVisibleEnabled())
     , grammarAndSpellingPseudoElementsEnabled(document.settings().grammarAndSpellingPseudoElementsEnabled())
@@ -70,7 +68,6 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
 {
     add(hasher,
         context.mode,
-        context.cssNestingEnabled,
         context.customStateSetEnabled,
         context.focusVisibleEnabled,
         context.grammarAndSpellingPseudoElementsEnabled,

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -36,7 +36,6 @@ class Document;
 
 struct CSSSelectorParserContext {
     CSSParserMode mode { CSSParserMode::HTMLStandardMode };
-    bool cssNestingEnabled { false };
     bool customStateSetEnabled { false };
     bool focusVisibleEnabled { false };
     bool grammarAndSpellingPseudoElementsEnabled { false };


### PR DESCRIPTION
#### e7871abaf4a9965474bf64a776163402e0ef5b84
<pre>
[css-nesting] Remove feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=270793">https://bugs.webkit.org/show_bug.cgi?id=270793</a>
<a href="https://rdar.apple.com/124389194">rdar://124389194</a>

Reviewed by Matthieu Dubet and Anne van Kesteren.

Some WebVTT user agent CSS and WebInspector CSS are starting to rely on nesting, turning it off will break core functionality.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSStyleRule.idl:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSParserImpl.h:
(WebCore::CSSParserImpl::isStyleNestedContext):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeSimpleSelector):
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:

Canonical link: <a href="https://commits.webkit.org/275922@main">https://commits.webkit.org/275922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9413a3cb6ee390bf9405762e4952926c8b32a779

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45903 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/39395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19717 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43840 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1325 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/36726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47448 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42900 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19720 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/9624 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49902 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5881 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19351 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10074 "Passed tests") | 
<!--EWS-Status-Bubble-End-->