### PR TITLE
[JSC] JSCell::toX should use jsDynamicCast/jsSecureCast

### DIFF
--- a/Source/JavaScriptCore/runtime/JSCell.cpp
+++ b/Source/JavaScriptCore/runtime/JSCell.cpp
@@ -147,36 +147,35 @@ bool JSCell::deletePropertyByIndex(JSCell* cell, JSGlobalObject* globalObject, u
 
 JSValue JSCell::toPrimitive(JSGlobalObject* globalObject, PreferredPrimitiveType preferredType) const
 {
-    if (isString())
-        return static_cast<const JSString*>(this)->toPrimitive(globalObject, preferredType);
-    if (isSymbol())
-        return static_cast<const Symbol*>(this)->toPrimitive(globalObject, preferredType);
-    if (isHeapBigInt())
-        return static_cast<const JSBigInt*>(this)->toPrimitive(globalObject, preferredType);
-    return static_cast<const JSObject*>(this)->toPrimitive(globalObject, preferredType);
+    if (const auto* string = jsDynamicCast<const JSString*>(this))
+        return string->toPrimitive(globalObject, preferredType);
+    if (const auto* symbol = jsDynamicCast<const Symbol*>(this))
+        return symbol->toPrimitive(globalObject, preferredType);
+    if (const auto* bigInt = jsDynamicCast<const JSBigInt*>(this))
+        return bigInt->toPrimitive(globalObject, preferredType);
+    return jsSecureCast<const JSObject*>(this)->toPrimitive(globalObject, preferredType);
 }
 
 double JSCell::toNumber(JSGlobalObject* globalObject) const
 {
-    if (isString())
-        return static_cast<const JSString*>(this)->toNumber(globalObject);
-    if (isSymbol())
-        return static_cast<const Symbol*>(this)->toNumber(globalObject);
-    if (isHeapBigInt())
-        return static_cast<const JSBigInt*>(this)->toNumber(globalObject);
-    return static_cast<const JSObject*>(this)->toNumber(globalObject);
+    if (const auto* string = jsDynamicCast<const JSString*>(this))
+        return string->toNumber(globalObject);
+    if (const auto* symbol = jsDynamicCast<const Symbol*>(this))
+        return symbol->toNumber(globalObject);
+    if (const auto* bigInt = jsDynamicCast<const JSBigInt*>(this))
+        return bigInt->toNumber(globalObject);
+    return jsSecureCast<const JSObject*>(this)->toNumber(globalObject);
 }
 
 JSObject* JSCell::toObjectSlow(JSGlobalObject* globalObject) const
 {
     Integrity::auditStructureID(structureID());
     ASSERT(!isObject());
-    if (isString())
-        return static_cast<const JSString*>(this)->toObject(globalObject);
-    if (isHeapBigInt())
-        return static_cast<const JSBigInt*>(this)->toObject(globalObject);
-    ASSERT(isSymbol());
-    return static_cast<const Symbol*>(this)->toObject(globalObject);
+    if (const auto* string = jsDynamicCast<const JSString*>(this))
+        return string->toObject(globalObject);
+    if (const auto* bigInt = jsDynamicCast<const JSBigInt*>(this))
+        return bigInt->toObject(globalObject);
+    return jsSecureCast<const Symbol*>(this)->toObject(globalObject);
 }
 
 void slowValidateCell(JSCell* cell)


### PR DESCRIPTION
#### 2a042fede0e705bae4b8ce039b18442696ebb5ce
<pre>
[JSC] JSCell::toX should use jsDynamicCast/jsSecureCast
<a href="https://bugs.webkit.org/show_bug.cgi?id=270797">https://bugs.webkit.org/show_bug.cgi?id=270797</a>
<a href="https://rdar.apple.com/124119022">rdar://124119022</a>

Reviewed by Mark Lam.

General code quality improvement. We also might as well add a release assert
that the final case is correct as it doesn&apos;t seem to be a perf regression.

* Source/JavaScriptCore/runtime/JSCell.cpp:
(JSC::JSCell::toPrimitive const):
(JSC::JSCell::toNumber const):
(JSC::JSCell::toObjectSlow const):

Canonical link: <a href="https://commits.webkit.org/275948@main">https://commits.webkit.org/275948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4769b81aa4d96eb2b79be02c25b4766f13ae9271

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45910 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39402 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19724 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35787 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16775 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38347 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1332 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/36733 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/simple-inline-stacktrace-with-catch.js.wasm-agressive-inline (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39467 "re-run-api-tests (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47455 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/42901 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14981 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42576 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19727 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41231 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9647 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19906 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/49909 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19358 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10075 "Passed tests") | 
<!--EWS-Status-Bubble-End-->