### PR TITLE
Assertion in TIntermUnary::replaceChildNode

### DIFF
--- a/Source/ThirdParty/ANGLE/src/compiler/translator/msl/RewritePipelines.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/msl/RewritePipelines.cpp
@@ -457,8 +457,15 @@ class PipelineFunctionEnv
                     mPipelineMainLocalVar.externalExtra = lastFragmentOut;
                 }
             }
-            else if (isMain && (mPipeline.type == Pipeline::Type::InvocationVertexGlobals ||
-                                mPipeline.type == Pipeline::Type::InvocationFragmentGlobals))
+            else if (isMain && (mPipeline.type == Pipeline::Type::InvocationVertexGlobals))
+            {
+                auto *vertexIDMetalVar =
+                    new TVariable(&mSymbolTable, ImmutableString("vertexIDMetal"),
+                                  new TType(TBasicType::EbtUInt), SymbolType::AngleInternal);
+                newFunc = &func;
+                mPipelineMainLocalVar.external = vertexIDMetalVar;
+            }
+            else if (isMain && (mPipeline.type == Pipeline::Type::InvocationFragmentGlobals))
             {
                 std::vector<const TVariable *> variables;
                 for (const TField *field : mPipelineStruct.external->fields())
@@ -805,8 +812,23 @@ class UpdatePipelineFunctions : private TIntermRebuild
             auto *newBody = new TIntermBlock();
             newBody->appendStatement(new TIntermDeclaration{mPipelineMainLocalVar.internal});
 
-            if (mPipeline.type == Pipeline::Type::InvocationVertexGlobals ||
-                mPipeline.type == Pipeline::Type::InvocationFragmentGlobals)
+            if (mPipeline.type == Pipeline::Type::InvocationVertexGlobals)
+            {
+                // Populate struct instance with references to main pipeline variables.
+                for (const TField *field : mPipelineStruct.external->fields())
+                {
+                    auto *var          = new TVariable(&mSymbolTable, field->name(), field->type(),
+                                                       field->symbolType());
+                    auto &accessNode   = AccessField(*mPipelineMainLocalVar.internal, Name(*var));
+                    auto vertexIDMetal = new TIntermSymbol(&getExternalPipelineVariable(func));
+                    auto *assignNode   = new TIntermBinary(TOperator::EOpAssign, &accessNode,
+                                                           &AsType(mSymbolEnv, *new TType(TBasicType::EbtInt),
+                                                                   *vertexIDMetal));
+                    newBody->appendStatement(assignNode);
+                }
+                
+            }
+            else if (mPipeline.type == Pipeline::Type::InvocationFragmentGlobals)
             {
                 // Populate struct instance with references to global pipeline variables.
                 for (const TField *field : mPipelineStruct.external->fields())

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/IntroduceVertexIndexID.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/IntroduceVertexIndexID.cpp
@@ -17,8 +17,8 @@ namespace
 {
 
 constexpr const TVariable kgl_VertexIDMetal(BuiltInId::gl_VertexID,
-                                            ImmutableString("gl_VertexID"),
-                                            SymbolType::BuiltIn,
+                                            ImmutableString("vertexIDMetal"),
+                                            SymbolType::AngleInternal,
                                             TExtension::UNDEFINED,
                                             StaticType::Get<EbtUInt, EbpHigh, EvqVertexID, 1, 1>());
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_msl_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_msl_utils.mm
@@ -506,7 +506,7 @@ std::string GenerateTransformFeedbackVaryingOutput(const gl::TransformFeedbackVa
                 result << "        ";
                 result << "ANGLE_" << "xfbBuffer" << bufferIndex << "[" << "ANGLE_"
                        << std::string(sh::kUniformsVar) << ".ANGLE_xfbBufferOffsets[" << bufferIndex
-                       << "] + (gl_VertexID + (ANGLE_instanceIdMod - ANGLE_baseInstance) * "
+                       << "] + (ANGLE_vertexIDMetal + (ANGLE_instanceIdMod - ANGLE_baseInstance) * "
                        << "ANGLE_" << std::string(sh::kUniformsVar)
                        << ".ANGLE_xfbVerticesPerInstance) * " << stride << " + " << offset
                        << "] = " << "as_type<float>" << "(" << "ANGLE_vertexOut.";

--- a/Source/ThirdParty/ANGLE/src/tests/compiler_tests/MSLOutput_test.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/compiler_tests/MSLOutput_test.cpp
@@ -904,3 +904,10 @@ void main(){
 })";
     compile(kShader);
 }
+
+TEST_F(MSLVertexOutputTest, VertexIDIvecNoCrash)
+{
+    const char kShader[] = R"(#version 300 es
+void main(){ivec2 xy=ivec2((+gl_VertexID));gl_Position=vec4((xy), 0,1);})";
+    compile(kShader);
+}


### PR DESCRIPTION
#### a74f751c6ec4f129acae8bcfec3a2ecb1c9bccd4
<pre>
Assertion in TIntermUnary::replaceChildNode
<a href="https://rdar.apple.com/123840822">rdar://123840822</a>

Reviewed by NOBODY (OOPS!).

Basic type between kgl_VertexID, kgl_VertexIndex and kgl_VertexIDMetal are different naturally,
Casting kgl_VertexIDMetal(Uint) to kgl_VertexID/kgl_VertexIndex(Int) instead of replace veriable during complie.

* Source/ThirdParty/ANGLE/src/compiler/translator/msl/RewritePipelines.cpp:
(sh::PipelineFunctionEnv::getUpdatedFunction):
(sh::UpdatePipelineFunctions::visitMain):
* Source/ThirdParty/ANGLE/src/compiler/translator/msl/TranslatorMSL.cpp:
(sh::TranslatorMSL::translateImpl):
* Source/ThirdParty/ANGLE/src/compiler/translator/tree_ops/msl/IntroduceVertexIndexID.cpp:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_msl_utils.mm:
(rx::mtl::GenerateTransformFeedbackVaryingOutput):
* Source/ThirdParty/ANGLE/src/tests/compiler_tests/MSLOutput_test.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a74f751c6ec4f129acae8bcfec3a2ecb1c9bccd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40228 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36417 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20337 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38079 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17451 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39184 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2251 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40412 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48447 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43294 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20542 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42019 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20766 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->