### PR TITLE
http/wpt/webrtc/video-script-transform.html, http/wpt/webrtc/video-script-transform-simulcast.html and imported/w3c/web-platform-tests/webrtc/simulcast/basic.https.html are failing on x86_64 bots

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
+++ b/Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm
@@ -100,7 +100,7 @@ void MockRealtimeVideoSourceMac::updateSampleBuffer()
     auto presentationTime = MediaTime::createWithDouble((elapsedTime() + 100_ms).seconds());
     auto videoFrame = m_imageTransferSession->createVideoFrame(platformImage.get(), presentationTime, size(), videoFrameRotation());
     if (!videoFrame) {
-        static const size_t MaxPixelGenerationFailureCount = 30;
+        static const size_t MaxPixelGenerationFailureCount = 150;
         if (++m_pixelGenerationFailureCount > MaxPixelGenerationFailureCount)
             captureFailed();
         return;


### PR DESCRIPTION
#### 87648049b5dd892907ba27366340fce58cc06f4d
<pre>
http/wpt/webrtc/video-script-transform.html, http/wpt/webrtc/video-script-transform-simulcast.html and imported/w3c/web-platform-tests/webrtc/simulcast/basic.https.html are failing on x86_64 bots
<a href="https://rdar.apple.com/124384840">rdar://124384840</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=270790">https://bugs.webkit.org/show_bug.cgi?id=270790</a>

Reviewed by Eric Carlson.

I can reproduce locally on my x86 device by running one of these tests in parallel.
The mock camera is failing capture if no frame is generated during 1 second.
This happens since we are using a max buffer pool of 10 pixel buffers and it can take some time to free the pixel buffers.
When increasing the limit to 5 seconds (aka 150 at 30fps), I am no longer able to reproduce.

* Source/WebCore/platform/mediastream/mac/MockRealtimeVideoSourceMac.mm:
(WebCore::MockRealtimeVideoSourceMac::updateSampleBuffer):

Canonical link: <a href="https://commits.webkit.org/275975@main">https://commits.webkit.org/275975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc5ae1435d3143805738c84d01a2738b0c409796

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46056 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35895 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16872 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38462 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1477 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47600 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42679 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19873 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41343 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9665 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->