### PR TITLE
PresentationContextIOSurface::getCurrentTexture should return an invalid texture instead of null

### DIFF
--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -62,6 +62,7 @@ private:
     };
     Vector<RenderBuffer> m_renderBuffers;
     RefPtr<Device> m_device;
+    RefPtr<Texture> m_invalidTexture;
     size_t m_currentIndex { 0 };
     id<MTLFunction> m_luminanceClampFunction;
     id<MTLComputePipelineState> m_computePipelineState;

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -74,6 +74,7 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
 {
     m_renderBuffers.clear();
     m_currentIndex = 0;
+    m_invalidTexture = Texture::createInvalid(device);
 
     if (descriptor.nextInChain)
         return;
@@ -235,7 +236,7 @@ void PresentationContextIOSurface::present()
 Texture* PresentationContextIOSurface::getCurrentTexture()
 {
     if (m_ioSurfaces.count != m_renderBuffers.size() || m_renderBuffers.size() <= m_currentIndex)
-        return nullptr;
+        return m_invalidTexture.get();
 
     auto& texturePtr = m_renderBuffers[m_currentIndex].luminanceClampTexture;
     if (texturePtr.get()) {

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
@@ -72,6 +72,7 @@ void RemotePresentationContext::unconfigure()
 void RemotePresentationContext::getCurrentTexture(WebGPUIdentifier identifier)
 {
     auto texture = m_backing->getCurrentTexture();
+    ASSERT(texture);
     if (!texture)
         return;
 


### PR DESCRIPTION
#### b5d883c007df4a82390ff0f9e00028dee0044d28
<pre>
PresentationContextIOSurface::getCurrentTexture should return an invalid texture instead of null
<a href="https://bugs.webkit.org/show_bug.cgi?id=270800">https://bugs.webkit.org/show_bug.cgi?id=270800</a>
<a href="https://rdar.apple.com/124392010">rdar://124392010</a>

Reviewed by Mike Wyrzykowski.

This, along with <a href="https://github.com/WebKit/WebKit/pull/25636">https://github.com/WebKit/WebKit/pull/25636</a> is necessary to fix <a href="https://rdar.apple.com/124213314">rdar://124213314</a>

* Source/WebGPU/WebGPU/PresentationContextIOSurface.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
(WebGPU::PresentationContextIOSurface::configure):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp:
(WebKit::RemotePresentationContext::getCurrentTexture):

Canonical link: <a href="https://commits.webkit.org/275912@main">https://commits.webkit.org/275912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3e257b7d3d6c5b29dd858f1b84fc612f141556b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22315 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/45695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/39411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19733 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/45919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43856 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/45695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/45919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/45695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/1341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/45695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/47464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/14988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/47464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/19736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/45695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/47464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5875 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->