### PR TITLE
StreamServerConnection::dispatchStreamMessages should report invalid message if it has no receiver

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -173,13 +173,7 @@ StreamServerConnection::DispatchResult StreamServerConnection::dispatchStreamMes
             currentReceiver = m_receivers.get(key);
         }
         if (!currentReceiver) {
-            // Valid scenario is when receiver has been removed, but there are messages for it in the buffer.
-            // FIXME: Since we do not have a receiver, we don't know how to decode the message.
-            // This means we must timeout every receiver in the stream connection.
-            // Currently we assert that the receivers are empty, as we only have up to one receiver in
-            // a stream connection until possibility of skipping is implemented properly.
-            Locker locker { m_receiversLock };
-            ASSERT(m_receivers.isEmpty());
+            protectedConnection()->dispatchDidReceiveInvalidMessage(decoder.messageName());
             return DispatchResult::HasNoMessages;
         }
         if (!dispatchStreamMessage(WTFMove(decoder), *currentReceiver))


### PR DESCRIPTION
#### 55aabe4eca1fcb3ca7e3b3b8bfa2a67fe7c121b6
<pre>
StreamServerConnection::dispatchStreamMessages should report invalid message if it has no receiver
<a href="https://bugs.webkit.org/show_bug.cgi?id=270802">https://bugs.webkit.org/show_bug.cgi?id=270802</a>
<a href="https://rdar.apple.com/124392155">rdar://124392155</a>

Reviewed by NOBODY (OOPS!).

I implemented message skipping in an earlier version of <a href="https://github.com/WebKit/WebKit/pull/25636">https://github.com/WebKit/WebKit/pull/25636</a>
but was advised that we instead consider that an invalid state for a web process to be in.

* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::dispatchStreamMessages):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55aabe4eca1fcb3ca7e3b3b8bfa2a67fe7c121b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45921 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39413 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35793 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16781 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17145 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1343 "Built successfully") | 
| | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39687 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; 50 api tests failed or timed out; 52 api tests failed or timed out; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47466 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18201 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14990 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42584 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19738 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41240 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19369 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->