### PR TITLE
REGRESSION(275801@main): Fix issues with InteractionRegion generation

### DIFF
--- a/LayoutTests/interaction-region/content-hint-expected.txt
+++ b/LayoutTests/interaction-region/content-hint-expected.txt
@@ -14,29 +14,30 @@
         (interaction (0,41) width=522.50 height=318)
         (cornerRadius 8.00),
         (interaction (52.50,41) width=418 height=313.50)
-        (content hint photo)
-        (cornerRadius 8.00),
+        (content hint photo),
         (interaction (538.50,0) width=523 height=400)
         (content hint photo),
         (interaction (1077.50,0) width=522.50 height=400),
-        (interaction (40,416) width=442.50 height=400)
+        (interaction (0,416) width=522.50 height=400),
+        (interaction (578.50,416) width=443 height=400)
         (cornerRadius 8.00),
-        (interaction (84.50,416) width=354 height=265.50)
+        (interaction (623,416) width=354 height=265.50)
+        (content hint photo),
+        (interaction (1113.50,471) width=450.50 height=294)
         (content hint photo)
+        (clipPath move to (48,0), add line to (48,0), add line to (402,0), add line to (402,0), add line to (402,265.50), add line to (402,265.50), add line to (48,265.50), add line to (48,265.50), close subpath),
+        (interaction (1113.50,737) width=450.50 height=28)
         (cornerRadius 8.00),
-        (interaction (574.50,471) width=451 height=294)
-        (content hint photo)
-        (clipPath move to (48.50,0), add line to (48.50,0), add line to (402.50,0), add line to (402.50,0), add line to (402.50,265.50), add line to (402.50,265.50), add line to (48.50,265.50), add line to (48.50,265.50), close subpath, move to (0,266), add line to (0,266), add line to (451,266), add line to (451,266), add line to (451,294), add line to (451,294), add line to (0,294), add line to (0,294), close subpath),
-        (interaction (574.50,737) width=451 height=28),
-        (interaction (758.18,737) width=83.63 height=28),
-        (interaction (1077.50,416) width=522.50 height=400)
+        (interaction (1296.84,737) width=83.63 height=28)
         (cornerRadius 8.00),
-        (interaction (750,992.50) width=100 height=79)
+        (interaction (0,832) width=522.50 height=400)
+        (cornerRadius 8.00),
+        (interaction (1288.50,992.50) width=100 height=79)
         (cornerRadius 8.00)])
       )
       (children 1
         (GraphicsLayer
-          (position 85.00 888.00)
+          (position 623.50 888.00)
           (bounds 352.50 288.00)
           (event region
             (rect (0,0) width=353 height=288)

--- a/LayoutTests/interaction-region/content-hint.html
+++ b/LayoutTests/interaction-region/content-hint.html
@@ -32,6 +32,10 @@
             background-size: cover;
             background-position: center;
         }
+        .background-gradient {
+            cursor: pointer;
+            background: linear-gradient(blue, pink);
+        }
         .svg a, .svg img {
             display: block;
             width: 100%;
@@ -53,6 +57,8 @@
         </a>
     </section>
     <section class="background-image">
+    </section>
+    <section class="background-gradient">
     </section>
     <section class="svg background-image">
         <a href="#">

--- a/LayoutTests/interaction-region/overlap-same-group-expected.txt
+++ b/LayoutTests/interaction-region/overlap-same-group-expected.txt
@@ -12,7 +12,7 @@
 
       (interaction regions [
         (interaction (50,0) width=200 height=125)
-        (cornerRadius 12.00)])
+        (clipPath move to (0,12), add line to (0,12), add curve to (0,5.37) (5.37,0) (12,0), add line to (138,0), add line to (138,0), add curve to (144.63,0) (150,5.37) (150,12), add line to (150,13), add line to (150,13), add curve to (150,19.63) (155.37,25) (162,25), add line to (188,25), add line to (188,25), add curve to (194.63,25) (200,30.37) (200,37), add line to (200,113), add line to (200,113), add curve to (200,119.63) (194.63,125) (188,125), add line to (62,125), add line to (62,125), add curve to (55.37,125) (50,119.63) (50,113), add line to (50,112), add line to (50,112), add curve to (50,105.37) (44.63,100) (38,100), add line to (12,100), add line to (12,100), add curve to (5.37,100) (0,94.63) (0,88), close subpath)])
       )
     )
   )

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -60,7 +60,7 @@ public:
     void uniteInteractionRegions(RenderObject&, const FloatRect&);
     bool shouldConsolidateInteractionRegion(RenderObject&, const IntRect&);
     void removeSuperfluousInteractionRegions();
-    Vector<InteractionRegion> shrinkWrappedInteractionRegions();
+    void shrinkWrapInteractionRegions();
     void copyInteractionRegionsToEventRegion();
 #endif
 
@@ -73,7 +73,7 @@ private:
     HashSet<IntRect> m_occlusionRects;
     HashSet<ElementIdentifier> m_containerRemovalCandidates;
     HashSet<ElementIdentifier> m_containersToRemove;
-    HashMap<ElementIdentifier, Vector<FloatRect>> m_discoveredRectsByElement;
+    HashMap<ElementIdentifier, Vector<InteractionRegion>> m_discoveredRegionsByElement;
 #endif
 };
 
@@ -133,7 +133,7 @@ public:
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     const Vector<InteractionRegion>& interactionRegions() const { return m_interactionRegions; }
-    void appendInteractionRegions(Vector<InteractionRegion>&&);
+    void appendInteractionRegions(const Vector<InteractionRegion>&);
     void clearInteractionRegions();
 #endif
 


### PR DESCRIPTION
#### 9aea4732b3b78dc83e2a101a6df2dd80aed79c05
<pre>
REGRESSION(275801@main): Fix issues with InteractionRegion generation
<a href="https://bugs.webkit.org/show_bug.cgi?id=270799">https://bugs.webkit.org/show_bug.cgi?id=270799</a>
&lt;<a href="https://rdar.apple.com/124340905">rdar://124340905</a>&gt;

Reviewed by Mike Wyrzykowski.

Add the missing nullptr check when looking for photo background images,
fix a logic issue when deciding if we need to generate a shrink wrapped
Path, and go back to modifying the `m_interactionRegions` Vector
directly.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::cachedImageIsPhoto):
(WebCore::interactionRegionForRenderedRegion):
Fix a potential crash when generating InteractionRegions for elements
with background images.

* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::shouldConsolidateInteractionRegion):
(WebCore::EventRegionContext::uniteInteractionRegions):
Keep track of complete InteractionRegion structs instead of just rects
when aggregating by element.
(WebCore::EventRegionContext::copyInteractionRegionsToEventRegion):
(WebCore::EventRegion::appendInteractionRegions):
(WebCore::EventRegionContext::shrinkWrappedInteractionRegions): Deleted.
(WebCore::EventRegionContext::shrinkWrapInteractionRegions):
Switch back to modifying the `m_interactionRegions` Vector directly
during the shrink wrap phase (before copy-ing to the EventRegion).
Fix a logic bug with `canUseSingleRect`.

* LayoutTests/interaction-region/content-hint.html:
* LayoutTests/interaction-region/content-hint-expected.txt:
Add a test case for the crash.
Expectation update without lost InteractionRegion parameters.
* LayoutTests/interaction-region/overlap-same-group-expected.txt:
Re-baseline with the overlap shape regression fixed.

Canonical link: <a href="https://commits.webkit.org/275936@main">https://commits.webkit.org/275936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8a7115d9b841319650f809feeb84632daa363b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45591 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19736 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35796 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16784 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38377 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1344 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39481 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47467 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18202 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/14991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42585 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37593 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41241 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9639 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->