### PR TITLE
[git-webkit revert] Temporarily disable reopening radars automatically

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py
@@ -236,12 +236,14 @@ class Revert(Command):
         for r_link in CommitProgram.bug_urls(issue):
             r_issue = Tracker.from_string(r_link)
             for c_issue in commit_issues.get(r_issue.tracker.NAME, []):
-                try:
-                    c_issue.open(why="Reopened {}.\n{}, tracking revert in {}.".format(r_issue.tracker.NAME, revert_reason, r_issue.link))
-                except radar.Tracker.radarclient().exceptions.UnsuccessfulResponseException as e:
-                    sys.stderr.write('Failed to re-open {}\n'.format(c_issue.link))
-                    sys.stderr.write('{}\n'.format(str(e)))
-                    c_issue.add_comment('{}, tracking revert in {}.'.format(revert_reason, r_issue.link))
+                # FIXME: Reopen radars after rdar://124165667
+                if not isinstance(c_issue.tracker, radar.Tracker):
+                    try:
+                        c_issue.open(why="Reopened {}.\n{}, tracking revert in {}.".format(r_issue.tracker.NAME, revert_reason, r_issue.link))
+                    except radar.Tracker.radarclient().exceptions.UnsuccessfulResponseException as e:
+                        sys.stderr.write('Failed to re-open {}\n'.format(c_issue.link))
+                        sys.stderr.write('{}\n'.format(str(e)))
+                        c_issue.add_comment('{}, tracking revert in {}.'.format(revert_reason, r_issue.link))
 
                 # Revert tracking bug blocks commit bugs, revert tracking radar caused by commit radars
                 if isinstance(c_issue.tracker, bugzilla.Tracker):


### PR DESCRIPTION
#### 6588b141aa98b0b22a5d9e83e1010015e0ecd648
<pre>
[git-webkit revert] Temporarily disable reopening radars automatically
<a href="https://bugs.webkit.org/show_bug.cgi?id=270803">https://bugs.webkit.org/show_bug.cgi?id=270803</a>
<a href="https://rdar.apple.com/124393291">rdar://124393291</a>

Reviewed by Ryan Haddad.

Disable reopening radars until work in webkitbugspy is done.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/revert.py:
(Revert.relate_issues):

Canonical link: <a href="https://commits.webkit.org/275957@main">https://commits.webkit.org/275957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/895fc5adb081c57df90aca1f5378b65dfc7b4dc0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45948 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35805 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37316 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16791 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/43184 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16950 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38372 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1369 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39495 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47492 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42602 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/43357 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19764 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41317 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9651 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19943 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->