### PR TITLE
Block notification service in sandbox

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -445,8 +445,7 @@
        (iokit-property "IORegistryEntryPropertyKeys"))
 
 (deny mach-lookup (with no-report)
-    (global-name "com.apple.runningboard")
-)
+    (global-name "com.apple.runningboard"))
 
 (allow system-sched
        (require-entitlement "com.apple.private.kernel.override-cpumon"))
@@ -467,35 +466,31 @@
         (literal "/private/var/run/syslog")))
 
 (define (notifyd-message-numbers) (message-number 1002 1011 1012 1016 1017 1018 1021 1025 1026 1028 1029 1030 1031 1032))
-
-(allow mach-lookup (global-name "com.apple.system.notification_center")
-    (apply-message-filter
-        (deny mach-message-send)
-        (deny mach-message-send (with no-report) (message-number 1023))
-        (allow mach-message-send (notifyd-message-numbers))))
-
-(allow ipc-posix-shm-read*
-    (ipc-posix-name "apple.shm.notification_center"))
-
-#if ENABLE(NOTIFY_BLOCKING)
-(with-filter (state-flag "EnableExperimentalSandbox")
+(define (allow-notifyd)
+    (allow ipc-posix-shm-read* (ipc-posix-name "apple.shm.notification_center"))
     (allow mach-lookup (global-name "com.apple.system.notification_center")
         (apply-message-filter
             (deny mach-message-send)
             (deny mach-message-send (with no-report) (message-number 1023))
-            (deny mach-message-send (with telemetry-backtrace) (notifyd-message-numbers)))))
+            (allow mach-message-send (notifyd-message-numbers)))))
+
+#if ENABLE(NOTIFY_BLOCKING)
+(with-filter (require-not (notify-blocking))
+    (allow-notifyd))
+#else
+(allow-notifyd)
 #endif
 
 (managed-configuration-read-public)
 
 (deny system-info (with no-report)
-      (info-type "net.link.addr"))
+    (info-type "net.link.addr"))
 
 (allow file-read*
-       (subpath "/private/var/db/datadetectors/sys"))
+    (subpath "/private/var/db/datadetectors/sys"))
 
 (allow-well-known-system-group-container-subpath-read
-       "/systemgroup.com.apple.icloud.findmydevice.managed/Library")
+    "/systemgroup.com.apple.icloud.findmydevice.managed/Library")
 
 (allow mach-task-name (target self))
 

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -193,6 +193,19 @@ function webcontent_sandbox_entitlements()
     plistbuddy Add :com.apple.private.security.enable-state-flags:2 string local:WebContentProcessLaunched
 }
 
+function notify_entitlements()
+{
+    plistbuddy Add :com.apple.developer.web-browser-engine.restrict.notifyd bool YES
+    plistbuddy Add :com.apple.private.darwin-notification.introspect array
+    plistbuddy Add :com.apple.private.darwin-notification.introspect:0 string com.apple.language.changed
+    plistbuddy Add :com.apple.private.darwin-notification.introspect:1 string com.apple.mediaaccessibility.captionAppearanceSettingsChanged
+    plistbuddy Add :com.apple.private.darwin-notification.introspect:2 string com.apple.powerlog.state_changed
+    plistbuddy Add :com.apple.private.darwin-notification.introspect:3 string com.apple.system.logging.prefschanged
+    plistbuddy Add :com.apple.private.darwin-notification.introspect:4 string com.apple.system.lowpowermode
+    plistbuddy Add :com.apple.private.darwin-notification.introspect:5 string com.apple.system.timezone
+    plistbuddy Add :com.apple.private.darwin-notification.introspect:6 string com.apple.zoomwindow
+}
+
 function mac_process_webcontent_shared_entitlements()
 {
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
@@ -217,7 +230,7 @@ function mac_process_webcontent_shared_entitlements()
 
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" > 140000 ))
         then
-            plistbuddy Add :com.apple.developer.web-browser-engine.restrict.notifyd bool YES
+            notify_entitlements
         fi
 
         if [[ "${WK_WEBCONTENT_SERVICE_NEEDS_XPC_DOMAIN_EXTENSION_ENTITLEMENT}" == YES ]]
@@ -371,7 +384,6 @@ function ios_family_process_webcontent_shared_entitlements()
     plistbuddy Add :com.apple.QuartzCore.webkit-end-points bool YES
     plistbuddy add :com.apple.QuartzCore.webkit-limited-types bool YES
     plistbuddy Add :com.apple.developer.coremedia.allow-alternate-video-decoder-selection bool YES
-    plistbuddy Add :com.apple.developer.web-browser-engine.restrict.notifyd bool YES
     plistbuddy Add :com.apple.mediaremote.set-playback-state bool YES
     plistbuddy Add :com.apple.pac.shared_region_id string WebContent
     plistbuddy Add :com.apple.private.allow-explicit-graphics-priority bool YES
@@ -394,6 +406,8 @@ if [[ "${PRODUCT_NAME}" != WebContentExtension && "${PRODUCT_NAME}" != WebConten
 fi
     plistbuddy add :com.apple.coreaudio.LoadDecodersInProcess bool YES
     plistbuddy add :com.apple.coreaudio.allow-vorbis-decode bool YES
+
+    notify_entitlements
     webcontent_sandbox_entitlements
 }
 

--- a/Source/WebKit/Shared/Sandbox/common.sb
+++ b/Source/WebKit/Shared/Sandbox/common.sb
@@ -72,3 +72,4 @@
 (define (webcontent-process-launched)
     (state-flag "local:WebContentProcessLaunched"))
 
+(define (notify-blocking) (require-entitlement "com.apple.developer.web-browser-engine.restrict.notifyd"))

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -714,6 +714,7 @@ void WebProcessPool::registerNotificationObservers()
         "com.apple.language.changed"_s,
         "com.apple.mediaaccessibility.captionAppearanceSettingsChanged"_s,
         "com.apple.powerlog.state_changed"_s,
+        "com.apple.system.logging.prefschanged"_s,
         "com.apple.system.lowpowermode"_s,
         "com.apple.system.timezone"_s,
         "com.apple.zoomwindow"_s,

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -157,13 +157,10 @@
     (require-all (prefix "/cores/")
         (vnode-type REGULAR-FILE)))
 
-;;; Allow IPC to standard system agents.
-(allow ipc-posix-shm-read*
-    (ipc-posix-name "apple.shm.notification_center")
 #if !ENABLE(CFPREFS_DIRECT_MODE)
-    (ipc-posix-name-prefix "apple.cfprefs.")
+(allow ipc-posix-shm-read*
+    (ipc-posix-name-prefix "apple.cfprefs."))
 #endif
-)
 
 (define (IOAcceleratorMessageFilter)
     (apply-message-filter
@@ -1211,33 +1208,23 @@
 
 #if PLATFORM(MAC)
 (define (notifyd-message-numbers) (message-number 1002 1010 1011 1012 1016 1017 1018 1021 1022 1025 1026 1028 1029 1030 1031 1032))
+(define (allow-notifyd)
+    (allow ipc-posix-shm-read* (ipc-posix-name "apple.shm.notification_center"))
+    (when (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "NO")
+        (allow mach-lookup (global-name "com.apple.system.notification_center")))
+    (when (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow mach-lookup (global-name "com.apple.system.notification_center")
+            (apply-message-filter
+                (deny mach-message-send)
+                (deny mach-message-send (with no-report) (message-number 1023))
+                (allow mach-message-send (notifyd-message-numbers))))))
 
-;; FIXME should be removed when <rdar://problem/9347205> + related radar in Safari is fixed
-(if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "NO")
-    (allow mach-lookup (global-name "com.apple.system.notification_center"))
-;; else
-    (allow mach-lookup (global-name "com.apple.system.notification_center")
-        (apply-message-filter
-            (deny mach-message-send)
-            (deny mach-message-send (with no-report) (message-number 1023))
-            (allow mach-message-send (notifyd-message-numbers)))))
 
 #if ENABLE(NOTIFY_BLOCKING)
-(if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-    (with-filter (state-flag "EnableExperimentalSandbox")
-        (allow mach-lookup (global-name "com.apple.system.notification_center")
-            (apply-message-filter
-                (deny mach-message-send)
-                (deny mach-message-send (with no-report) (message-number 1023))
-                (deny mach-message-send (with telemetry-backtrace) (notifyd-message-numbers))))))
-
-(if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-    (with-filter (require-not (state-flag "EnableExperimentalSandbox"))
-        (allow mach-lookup (global-name "com.apple.system.notification_center")
-            (apply-message-filter
-                (deny mach-message-send)
-                (deny mach-message-send (with no-report) (message-number 1023))
-                (allow mach-message-send (with report) (with telemetry-backtrace) (notifyd-message-numbers))))))
+(with-filter (require-not (notify-blocking))
+    (allow-notifyd))
+#else
+(allow-notifyd)
 #endif // ENABLE(NOTIFY_BLOCKING)
 #endif // PLATFORM(MAC)
 


### PR DESCRIPTION
#### 01a6cf5f9913b9794742ea236abf2c4369a6d794
<pre>
Block notification service in sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=270805">https://bugs.webkit.org/show_bug.cgi?id=270805</a>
<a href="https://rdar.apple.com/124395477">rdar://124395477</a>

Reviewed by Sihui Liu and Chris Dumez.

Block notification service in the WebContent process sandbox.

* Source/WTF/wtf/PlatformEnableCocoa.h:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/Shared/Sandbox/common.sb:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/277077@main">https://commits.webkit.org/277077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2914df430caee0a1cdaeb45fc7fc5e5a8795032a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46121 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48792 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42161 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37706 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39783 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18901 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/45986 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19737 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4165 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42437 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50586 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17631 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44874 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22417 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43776 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22776 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6516 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22111 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->