### PR TITLE
Regression: Pages that update their title now get suspended when backgrounded

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -123,7 +123,6 @@ ProcessThrottler::ProcessThrottler(AuxiliaryProcessProxy& process, bool shouldTa
     , m_prepareToSuspendTimeoutTimer(RunLoop::main(), this, &ProcessThrottler::prepareToSuspendTimeoutTimerFired)
     , m_dropNearSuspendedAssertionTimer(RunLoop::main(), this, &ProcessThrottler::dropNearSuspendedAssertionTimerFired)
     , m_prepareToDropLastAssertionTimeoutTimer(RunLoop::main(), this, &ProcessThrottler::prepareToDropLastAssertionTimeoutTimerFired)
-    , m_pageAllowedToRunInTheBackgroundCounter([this](RefCounterEvent) { numberOfPagesAllowedToRunInTheBackgroundChanged(); })
     , m_shouldTakeUIBackgroundAssertion(shouldTakeUIBackgroundAssertion)
 {
 }
@@ -362,10 +361,7 @@ void ProcessThrottler::dropNearSuspendedAssertionTimerFired()
     PROCESSTHROTTLER_RELEASE_LOG("dropNearSuspendedAssertionTimerFired: Removing near-suspended process assertion");
     RELEASE_ASSERT(isHoldingNearSuspendedAssertion());
     ASSERT(m_shouldDropNearSuspendedAssertionAfterDelay);
-    if (m_pageAllowedToRunInTheBackgroundCounter.value())
-        PROCESSTHROTTLER_RELEASE_LOG("dropNearSuspendedAssertionTimerFired: Not releasing near-suspended assertion because a page is allowed to run in the background");
-    else
-        clearAssertion();
+    clearAssertion();
 }
 
 void ProcessThrottler::processReadyToSuspend()
@@ -520,25 +516,6 @@ void ProcessThrottler::clearAssertion()
 Ref<AuxiliaryProcessProxy> ProcessThrottler::protectedProcess() const
 {
     return m_process.get();
-}
-
-PageAllowedToRunInTheBackgroundCounter::Token ProcessThrottler::pageAllowedToRunInTheBackgroundToken()
-{
-    return m_pageAllowedToRunInTheBackgroundCounter.count();
-}
-
-void ProcessThrottler::numberOfPagesAllowedToRunInTheBackgroundChanged()
-{
-    if (m_pageAllowedToRunInTheBackgroundCounter.value())
-        return;
-
-    if (m_dropNearSuspendedAssertionTimer.isActive())
-        return;
-
-    if (isHoldingNearSuspendedAssertion()) {
-        PROCESSTHROTTLER_RELEASE_LOG("numberOfPagesAllowedToRunInTheBackgroundChanged: Releasing near-suspended assertion");
-        clearAssertion();
-    }
 }
 
 bool ProcessThrottler::isSuspended() const

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -50,9 +50,6 @@ enum ProcessSuppressionDisabledCounterType { };
 using ProcessSuppressionDisabledCounter = RefCounter<ProcessSuppressionDisabledCounterType>;
 using ProcessSuppressionDisabledToken = ProcessSuppressionDisabledCounter::Token;
 
-enum PageAllowedToRunInTheBackgroundCounterType { };
-using PageAllowedToRunInTheBackgroundCounter = RefCounter<PageAllowedToRunInTheBackgroundCounterType>;
-
 enum class IsSuspensionImminent : bool { No, Yes };
 enum class ProcessThrottleState : uint8_t { Suspended, Background, Foreground };
 enum class ProcessThrottlerActivityType : bool { Background, Foreground };
@@ -124,11 +121,6 @@ public:
     static bool isValidBackgroundActivity(const ActivityVariant&);
     static bool isValidForegroundActivity(const ActivityVariant&);
 
-    // If any page holds one of these tokens, we will never release the "suspended" assertion which
-    // means that the page will not be suspended when in the background, except if the application
-    // also gets backgrounded.
-    PageAllowedToRunInTheBackgroundCounter::Token pageAllowedToRunInTheBackgroundToken();
-
     using TimedActivity = ProcessThrottlerTimedActivity;
 
     void didConnectToProcess(AuxiliaryProcessProxy&);
@@ -168,7 +160,6 @@ private:
     void assertionWasInvalidated();
 
     void clearPendingRequestToSuspend();
-    void numberOfPagesAllowedToRunInTheBackgroundChanged();
     void clearAssertion();
 
     class ProcessAssertionCache;
@@ -186,7 +177,6 @@ private:
     WeakHashSet<Activity> m_backgroundActivities;
     std::optional<uint64_t> m_pendingRequestToSuspendID;
     ProcessThrottleState m_state { ProcessThrottleState::Suspended };
-    PageAllowedToRunInTheBackgroundCounter m_pageAllowedToRunInTheBackgroundCounter;
     bool m_shouldDropNearSuspendedAssertionAfterDelay { false };
     const bool m_shouldTakeUIBackgroundAssertion { false };
     bool m_shouldTakeNearSuspendedAssertion { true };

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -216,7 +216,7 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     WebCore::IntRect visibleScrollerThumbRect;
     WebCore::PageIdentifier webPageID;
     WindowKind windowKind { WindowKind::Unparented };
-    PageAllowedToRunInTheBackgroundCounter::Token pageAllowedToRunInTheBackgroundToken;
+    std::unique_ptr<ProcessThrottlerActivity> pageAllowedToRunInTheBackgroundActivityDueToTitleChanges;
     std::unique_ptr<ProcessThrottlerActivity> pageAllowedToRunInTheBackgroundActivityDueToNotifications;
 
     WebPageProxyMessageReceiverRegistration messageReceiverRegistration;


### PR DESCRIPTION
#### 3130b409ab451147e7df0c39c8a431e50547e7dd
<pre>
Regression: Pages that update their title now get suspended when backgrounded
<a href="https://bugs.webkit.org/show_bug.cgi?id=270813">https://bugs.webkit.org/show_bug.cgi?id=270813</a>
<a href="https://rdar.apple.com/124222280">rdar://124222280</a>

Reviewed by Ben Nham.

Pages that update their title now get suspended when backgrounded since we&apos;ve
stopped taking near-suspended assertions on both iOS and macOS. We used to
monitor pages in the background for 8 minutes to see if they update their title
while in the background, if they did, we would let them keep running in the
background.

Since we no longer take near-suspended assertions, we can no longer observe
pages in the background (since they&apos;d get suspended as soon as backgrounded).
To address the issue, we now monitor title changes while in the foreground. If
the page updates its title, we now take a background assertion to let it keep
running after backgrounding.

This is not perfect but this addresses the regression for now. We should
revisit though because this is too permissive. Maybe we only want to consider
title changes without recent user interaction for e.g.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::ProcessThrottler):
(WebKit::ProcessThrottler::dropNearSuspendedAssertionTimerFired):
(WebKit::m_shouldTakeUIBackgroundAssertion): Deleted.
(WebKit::ProcessThrottler::pageAllowedToRunInTheBackgroundToken): Deleted.
(WebKit::ProcessThrottler::numberOfPagesAllowedToRunInTheBackgroundChanged): Deleted.
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didFailLoadForFrame):
(WebKit::WebPageProxy::didReceiveTitleForFrame):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

Canonical link: <a href="https://commits.webkit.org/275960@main">https://commits.webkit.org/275960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72e0109a909e2a242a85ba48c7e40d6704a23cb0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39495 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35846 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37347 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16825 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/16989 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1425 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47548 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15037 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42631 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19820 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41291 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9654 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/19999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->