### PR TITLE
Some APIs like tabs.query need to prompt for permission before returning.

### DIFF
--- a/Source/WebCore/page/UserContentURLPattern.cpp
+++ b/Source/WebCore/page/UserContentURLPattern.cpp
@@ -40,8 +40,10 @@ UserContentURLPattern::UserContentURLPattern(StringView scheme, StringView host,
         return;
     }
 
+    bool isFileScheme = equalLettersIgnoringASCIICase(m_scheme, "file"_s);
+
     m_host = host.toString();
-    if (m_host.isEmpty()) {
+    if (!isFileScheme && m_host.isEmpty()) {
         m_error = Error::MissingHost;
         return;
     }

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.h
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.h
@@ -26,6 +26,7 @@
 #import <wtf/HashSet.h>
 #import <wtf/OptionSet.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/URLHash.h>
 #import <wtf/UUID.h>
 #import <wtf/WallTime.h>
 #import <wtf/text/StringHash.h>
@@ -123,9 +124,10 @@ void callAfterRandomDelay(Function<void()>&&);
 NSDate *toAPI(const WallTime&);
 WallTime toImpl(NSDate *);
 
-NSSet *toAPI(HashSet<String>&);
-NSArray *toAPIArray(HashSet<String>&);
-Vector<String> toImpl(NSArray *);
-HashSet<String> toImplSet(NSArray *);
+NSSet *toAPI(const HashSet<URL>&);
+
+NSSet *toAPI(const HashSet<String>&);
+NSArray *toAPIArray(const HashSet<String>&);
+HashSet<String> toImpl(NSSet *);
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/CocoaHelpers.mm
@@ -462,38 +462,39 @@ WallTime toImpl(NSDate *date)
     return WallTime::fromRawSeconds(date.timeIntervalSince1970);
 }
 
-NSSet *toAPI(HashSet<String>& set)
+NSSet *toAPI(const HashSet<URL>& set)
+{
+    NSMutableSet *result = [[NSMutableSet alloc] initWithCapacity:set.size()];
+    for (auto& element : set)
+        [result addObject:static_cast<NSURL *>(element)];
+    return [result copy];
+}
+
+NSSet *toAPI(const HashSet<String>& set)
 {
     NSMutableSet *result = [[NSMutableSet alloc] initWithCapacity:set.size()];
     for (auto& element : set)
         [result addObject:static_cast<NSString *>(element)];
-
     return [result copy];
 }
 
-NSArray *toAPIArray(HashSet<String>& set)
+NSArray *toAPIArray(const HashSet<String>& set)
 {
     NSMutableArray *result = [[NSMutableArray alloc] initWithCapacity:set.size()];
     for (auto& element : set)
         [result addObject:static_cast<NSString *>(element)];
-
     return [result copy];
 }
 
-Vector<String> toImpl(NSArray *array)
-{
-    return Vector<String>(array.count, [array](size_t i) {
-        return (NSString *)array[i];
-    });
-}
-
-HashSet<String> toImplSet(NSArray *array)
+HashSet<String> toImpl(NSSet *set)
 {
     HashSet<String> result;
-    result.reserveInitialCapacity(array.count);
+    result.reserveInitialCapacity(set.count);
 
-    for (NSString *element in array)
-        result.addVoid(element);
+    for (id element in set) {
+        if (auto *string = dynamic_objc_cast<NSString>(element))
+            result.addVoid(string);
+    }
 
     return result;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm
@@ -30,6 +30,7 @@
 #import "config.h"
 #import "_WKWebExtensionInternal.h"
 
+#import "CocoaHelpers.h"
 #import "CocoaImage.h"
 #import "WebExtension.h"
 #import "_WKWebExtensionMatchPatternInternal.h"

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h
@@ -113,14 +113,15 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @abstract Called when an extension context requests permissions.
  @param controller The web extension controller that is managing the extension.
  @param permissions The set of permissions being requested by the extension.
- @param tab The tab in which the extension is running, or \c nil if the request are not specific to a tab.
+ @param tab The tab in which the extension is running, or \c nil if the request is not specific to a tab.
  @param extensionContext The context in which the web extension is running.
- @param completionHandler A block to be called with the set of allowed permissions.
+ @param completionHandler A block to be called with the set of allowed permissions and an optional expiration date.
  @discussion This method should be implemented by the app to prompt the user for permission and call the completion handler with the
- set of permissions that were granted. If not implemented or the completion handler is not called within a reasonable amount of time, the
- request is assumed to have been denied.
+ set of permissions that were granted and an optional expiration date. If not implemented or the completion handler is not called within a reasonable
+ amount of time, the request is assumed to have been denied. The expiration date can be used to specify when the permissions expire. If `nil`,
+ permissions are assumed to not expire.
  */
-- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissions:(NSSet<_WKWebExtensionPermission> *)permissions inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionPermission> *allowedPermissions))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissions:in:for:completionHandler:));
+- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissions:(NSSet<_WKWebExtensionPermission> *)permissions inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionPermission> *allowedPermissions, NSDate * _Nullable expirationDate))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissions:in:for:completionHandler:));
 
 /*!
  @abstract Called when an extension context requests access to a set of URLs.
@@ -128,12 +129,13 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param urls The set of URLs that the extension is requesting access to.
  @param tab The tab in which the extension is running, or \c nil if the request is not specific to a tab.
  @param extensionContext The context in which the web extension is running.
- @param completionHandler A block to be called with the set of allowed URLs.
+ @param completionHandler A block to be called with the set of allowed URLs and an optional expiration date.
  @discussion This method should be implemented by the app to prompt the user for permission and call the completion handler with the
- set of URLs that were granted access to. If not implemented or the completion handler is not called within a reasonable amount of time, the
- request is assumed to have been denied.
+ set of URLs that were granted access to and an optional expiration date. If not implemented or the completion handler is not called within a
+ reasonable amount of time, the request is assumed to have been denied. The expiration date can be used to specify when the URLs expire.
+ If `nil`, URLs are assumed to not expire.
  */
-- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionToAccessURLs:(NSSet<NSURL *> *)urls inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<NSURL *> *allowedURLs))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissionToAccess:in:for:completionHandler:));
+- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionToAccessURLs:(NSSet<NSURL *> *)urls inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<NSURL *> *allowedURLs, NSDate * _Nullable expirationDate))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissionToAccess:in:for:completionHandler:));
 
 /*!
  @abstract Called when an extension context requests access to a set of match patterns.
@@ -141,12 +143,13 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
  @param matchPatterns The set of match patterns that the extension is requesting access to.
  @param tab The tab in which the extension is running, or \c nil if the request is not specific to a tab.
  @param extensionContext The context in which the web extension is running.
- @param completionHandler A block to be called with the set of allowed match patterns.
+ @param completionHandler A block to be called with the set of allowed match patterns and an optional expiration date.
  @discussion This method should be implemented by the app to prompt the user for permission and call the completion handler with the
- set of match patterns that were granted access to. If not implemented or the completion handler is not called within a reasonable amount of time,
- the request is assumed to have been denied.
+ set of match patterns that were granted access to and an optional expiration date. If not implemented or the completion handler is not called
+ within a reasonable amount of time, the request is assumed to have been denied. The expiration date can be used to specify when the match
+ patterns expire. If `nil`, match patterns are assumed to not expire.
  */
-- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionMatchPatterns:(NSSet<_WKWebExtensionMatchPattern *> *)matchPatterns inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionMatchPattern *> *allowedMatchPatterns))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissionMatchPatterns:in:for:completionHandler:));
+- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionMatchPatterns:(NSSet<_WKWebExtensionMatchPattern *> *)matchPatterns inTab:(nullable id <_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionMatchPattern *> *allowedMatchPatterns, NSDate * _Nullable expirationDate))completionHandler NS_SWIFT_NAME(webExtensionController(_:promptForPermissionMatchPatterns:in:for:completionHandler:));
 
 /*!
  @abstract Called when a popup is requested to be displayed for a specific action.

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -2113,26 +2113,6 @@ void WebExtension::populatePermissionsPropertiesIfNeeded()
     }
 }
 
-NSSet<_WKWebExtensionPermission> *toAPI(const WebExtension::PermissionsSet& permissions)
-{
-    NSMutableSet<_WKWebExtensionPermission> *result = [NSMutableSet setWithCapacity:permissions.size()];
-
-    for (auto& permission : permissions)
-        [result addObject:(NSString *)permission];
-
-    return [result copy];
-}
-
-NSSet<_WKWebExtensionMatchPattern *> *toAPI(const WebExtension::MatchPatternSet& patterns)
-{
-    NSMutableSet<_WKWebExtensionMatchPattern *> *result = [NSMutableSet setWithCapacity:patterns.size()];
-
-    for (auto& matchPattern : patterns)
-        [result addObject:matchPattern->wrapper()];
-
-    return [result copy];
-}
-
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -384,13 +384,6 @@ private:
     bool m_parsedExternallyConnectable : 1 { false };
 };
 
-#ifdef __OBJC__
-
-NSSet<_WKWebExtensionPermission> *toAPI(const WebExtension::PermissionsSet&);
-NSSet<_WKWebExtensionMatchPattern *> *toAPI(const WebExtension::MatchPatternSet&);
-
-#endif
-
 } // namespace WebKit
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -159,6 +159,8 @@ public:
     using MatchPatternSet = WebExtension::MatchPatternSet;
     using InjectedContentData = WebExtension::InjectedContentData;
     using InjectedContentVector = WebExtension::InjectedContentVector;
+    using URLSet = HashSet<URL>;
+    using URLVector = Vector<URL>;
 
     using WeakPageCountedSet = WeakHashCountedSet<WebPageProxy>;
     using EventListenerTypeCountedSet = HashCountedSet<WebExtensionEventListenerType>;
@@ -217,6 +219,7 @@ public:
     enum class UpdateWindowOrder : bool { No, Yes };
     enum class IgnoreExtensionAccess : bool { No, Yes };
     enum class IncludeExtensionViews : bool { No, Yes };
+    enum class GrantOnCompletion : bool { No, Yes };
 
     enum class Error : uint8_t {
         Unknown = 1,
@@ -323,6 +326,10 @@ public:
     bool removeDeniedPermissions(PermissionsSet&);
     bool removeDeniedPermissionMatchPatterns(MatchPatternSet&, EqualityOnly = EqualityOnly::Yes);
 
+    void requestPermissionMatchPatterns(const MatchPatternSet&, RefPtr<WebExtensionTab> = nullptr, CompletionHandler<void(MatchPatternSet&& neededMatchPatterns, MatchPatternSet&& allowedMatchPatterns, WallTime expirationDate)>&& = nullptr, GrantOnCompletion = GrantOnCompletion::Yes);
+    void requestPermissionToAccessURLs(const URLVector&, RefPtr<WebExtensionTab> = nullptr, CompletionHandler<void(URLSet&& neededURLs, URLSet&& allowedURLs, WallTime expirationDate)>&& = nullptr, GrantOnCompletion = GrantOnCompletion::Yes);
+    void requestPermissions(const PermissionsSet&, RefPtr<WebExtensionTab> = nullptr, CompletionHandler<void(PermissionsSet&& neededPermissions, PermissionsSet&& allowedPermissions, WallTime expirationDate)>&& = nullptr, GrantOnCompletion = GrantOnCompletion::Yes);
+
     PermissionsMap::KeysConstIteratorRange currentPermissions() { return grantedPermissions().keys(); }
     PermissionMatchPatternsMap::KeysConstIteratorRange currentPermissionMatchPatterns() { return grantedPermissionMatchPatterns().keys(); }
 
@@ -331,6 +338,8 @@ public:
 
     bool hasPermission(const String& permission, WebExtensionTab* = nullptr, OptionSet<PermissionStateOptions> = { });
     bool hasPermission(const URL&, WebExtensionTab* = nullptr, OptionSet<PermissionStateOptions> = { PermissionStateOptions::RequestedWithTabsPermission });
+    bool hasPermission(const WebExtensionMatchPattern&, WebExtensionTab* = nullptr, OptionSet<PermissionStateOptions> = { PermissionStateOptions::RequestedWithTabsPermission });
+
     bool hasPermissions(PermissionsSet, MatchPatternSet);
 
     PermissionState permissionState(const String& permission, WebExtensionTab* = nullptr, OptionSet<PermissionStateOptions> = { });
@@ -339,8 +348,8 @@ public:
     PermissionState permissionState(const URL&, WebExtensionTab* = nullptr, OptionSet<PermissionStateOptions> = { PermissionStateOptions::RequestedWithTabsPermission });
     void setPermissionState(PermissionState, const URL&, WallTime expirationDate = WallTime::infinity());
 
-    PermissionState permissionState(WebExtensionMatchPattern&, WebExtensionTab* = nullptr, OptionSet<PermissionStateOptions> = { PermissionStateOptions::RequestedWithTabsPermission });
-    void setPermissionState(PermissionState, WebExtensionMatchPattern&, WallTime expirationDate = WallTime::infinity());
+    PermissionState permissionState(const WebExtensionMatchPattern&, WebExtensionTab* = nullptr, OptionSet<PermissionStateOptions> = { PermissionStateOptions::RequestedWithTabsPermission });
+    void setPermissionState(PermissionState, const WebExtensionMatchPattern&, WallTime expirationDate = WallTime::infinity());
 
     void clearCachedPermissionStates();
 
@@ -849,6 +858,8 @@ private:
 
     ListHashSet<URL> m_cachedPermissionURLs;
     HashMap<URL, PermissionState> m_cachedPermissionStates;
+
+    size_t m_pendingPermissionRequests { 0 };
 
     bool m_requestedOptionalAccessToAllHosts { false };
     bool m_hasAccessInPrivateBrowsing { false };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -55,8 +55,21 @@ public:
     using URLSchemeSet = HashSet<String>;
     using MatchPatternSet = HashSet<Ref<WebExtensionMatchPattern>>;
 
+    enum class Options : uint8_t {
+        IgnoreSchemes        = 1 << 0, // Ignore the scheme component when matching.
+        IgnorePaths          = 1 << 1, // Ignore the path component when matching.
+        MatchBidirectionally = 1 << 2, // Match two patterns in either direction (A matches B, or B matches A). Invalid for matching URLs.
+    };
+
+    enum class CreateOptions : uint8_t {
+        MatchExactScheme = 1 << 0, // Create a pattern that matches only the exact scheme, otherwise HTTP family URLs will be `*`.
+        MatchSubdomains  = 1 << 1, // Create a pattern that matches subdomains of the supplied host.
+        MatchAllPaths    = 1 << 2, // Create a pattern that matches all paths, ignoring the supplied path.
+    };
+
     static RefPtr<WebExtensionMatchPattern> getOrCreate(const String& pattern);
     static RefPtr<WebExtensionMatchPattern> getOrCreate(const String& scheme, const String& host, const String& path);
+    static RefPtr<WebExtensionMatchPattern> getOrCreate(const URL&, OptionSet<CreateOptions> = { CreateOptions::MatchSubdomains, CreateOptions::MatchAllPaths });
 
     static Ref<WebExtensionMatchPattern> allURLsMatchPattern();
     static Ref<WebExtensionMatchPattern> allHostsAndSchemesMatchPattern();
@@ -69,12 +82,6 @@ public:
     explicit WebExtensionMatchPattern(const String& scheme, const String& host, const String& path, NSError **outError = nullptr);
 
     ~WebExtensionMatchPattern() { }
-
-    enum class Options : uint8_t {
-        IgnoreSchemes        = 1 << 0, // Ignore the scheme component when matching.
-        IgnorePaths          = 1 << 1, // Ignore the path component when matching.
-        MatchBidirectionally = 1 << 2, // Match two patterns in either direction (A matches B, or B matches A). Invalid for matching URLs.
-    };
 
     static URLSchemeSet& extensionSchemes();
     static URLSchemeSet& validSchemes();
@@ -127,9 +134,10 @@ private:
 
 using MatchPatternSet = HashSet<Ref<WebExtensionMatchPattern>>;
 
-NSSet *toAPI(MatchPatternSet&);
+NSSet *toAPI(const MatchPatternSet&);
+MatchPatternSet toPatterns(const HashSet<String>&);
+MatchPatternSet toPatterns(NSSet *);
 HashSet<String> toStrings(const MatchPatternSet&);
-MatchPatternSet toPatterns(HashSet<String>&);
 
 } // namespace WebKit
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm
@@ -204,6 +204,8 @@ TEST(WKWebExtensionAPIDevTools, InspectedWindowEval)
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:devToolsManifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:server.requestWithLocalhost().URL];
+
     [manager.get().defaultTab.mainWebView loadRequest:server.requestWithLocalhost()];
     [manager.get().defaultTab.mainWebView._inspector show];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
@@ -180,18 +180,18 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsRequest)
     __block bool requestComplete = false;
 
     // Implement the delegate methods that're called when a call to permissions.request() is made.
-    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
         EXPECT_EQ(requestedPermissions.count, permissions.count);
         EXPECT_TRUE([requestedPermissions isEqualToSet:permissions]);
-        callback(requestedPermissions);
+        callback(requestedPermissions, nil);
     };
 
-    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *, NSDate *)) {
         EXPECT_EQ(requestedMatchPatterns.count, matchPatterns.count);
         EXPECT_TRUE([requestedMatchPatterns isEqualToSet:matchPatterns]);
 
         dispatch_async(dispatch_get_main_queue(), ^{
-            callback(requestedMatchPatterns);
+            callback(requestedMatchPatterns, nil);
             requestComplete = true;
         });
     };
@@ -234,13 +234,13 @@ TEST(WKWebExtensionAPIPermissions, DenyPermissionsRequest)
     __block bool requestComplete = false;
 
     // Implement the delegate methods, but don't grant the permissions.
-    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
-        callback(NSSet.set);
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
+        callback(NSSet.set, NSDate.distantPast);
     };
 
-    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *, NSDate *)) {
         requestComplete = true;
-        callback(NSSet.set);
+        callback(NSSet.set, NSDate.distantFuture);
     };
 
     manager.get().controllerDelegate = requestDelegate.get();
@@ -281,14 +281,14 @@ TEST(WKWebExtensionAPIPermissions, AcceptPermissionsDenyMatchPatternsRequest)
     __block bool requestComplete = false;
 
     // Grant the requested permissions.
-    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
-        callback(requestedPermissions);
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
+        callback(requestedPermissions, nil);
     };
 
     // Deny the requested match patterns.
-    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *, NSDate *)) {
         requestComplete = true;
-        callback(NSSet.set);
+        callback(NSSet.set, nil);
     };
 
     manager.get().controllerDelegate = requestDelegate.get();
@@ -329,15 +329,15 @@ TEST(WKWebExtensionAPIPermissions, RequestPermissionsOnly)
     __block bool requestComplete = false;
 
     // Grant the requested permissions.
-    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
         dispatch_async(dispatch_get_main_queue(), ^{
             requestComplete = true;
-            callback(requestedPermissions);
+            callback(requestedPermissions, nil);
         });
     };
 
     // Match patterns method should not be called.
-    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *, NSDate *)) {
         ASSERT_NOT_REACHED();
     };
 
@@ -379,15 +379,15 @@ TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)
     __block bool requestComplete = false;
 
     // Permissions method should not be called.
-    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
         ASSERT_NOT_REACHED();
     };
 
     // Grant the requested match patterns.
-    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *, NSDate *)) {
         dispatch_async(dispatch_get_main_queue(), ^{
             requestComplete = true;
-            callback(requestedMatchPatterns);
+            callback(requestedMatchPatterns, [NSDate dateWithTimeIntervalSinceNow:10]);
         });
     };
 
@@ -429,15 +429,15 @@ TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)
     __block bool requestComplete = false;
 
     // Grant the requested permissions.
-    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
         dispatch_async(dispatch_get_main_queue(), ^{
             requestComplete = true;
-            callback(requestedPermissions);
+            callback(requestedPermissions, nil);
         });
     };
 
     // Match patterns method should not be called.
-    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *, NSDate *)) {
         ASSERT_NOT_REACHED();
     };
 
@@ -479,14 +479,14 @@ TEST(WKWebExtensionAPIPermissions, GrantOnlySomeMatchPatterns)
     __block bool requestComplete = false;
 
     // Permissions method should not be called.
-    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *)) {
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
         ASSERT_NOT_REACHED();
     };
 
     // Grant only one of the requested match patterns.
-    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *)) {
+    requestDelegate.get().promptForPermissionMatchPatterns = ^(id<_WKWebExtensionTab> tab, NSSet<_WKWebExtensionMatchPattern *> *requestedMatchPatterns, void (^callback)(NSSet<_WKWebExtensionMatchPattern *> *, NSDate *)) {
         requestComplete = true;
-        callback([NSSet setWithObject:requestedMatchPatterns.anyObject]);
+        callback([NSSet setWithObject:requestedMatchPatterns.anyObject], NSDate.distantFuture);
     };
 
     manager.get().controllerDelegate = requestDelegate.get();
@@ -678,11 +678,11 @@ TEST(WKWebExtensionAPIPermissions, ClipboardWriteWithRequest)
 
     auto requestDelegate = adoptNS([[TestWebExtensionsDelegate alloc] init]);
 
-    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *grantedPermissions)) {
+    requestDelegate.get().promptForPermissions = ^(id<_WKWebExtensionTab> tab, NSSet<NSString *> *requestedPermissions, void (^callback)(NSSet<NSString *> *, NSDate *)) {
         EXPECT_EQ(requestedPermissions.count, 1ul);
         EXPECT_TRUE([requestedPermissions containsObject:_WKWebExtensionPermissionClipboardWrite]);
 
-        callback(requestedPermissions);
+        callback(requestedPermissions, nil);
     };
 
     manager.get().controllerDelegate = requestDelegate.get();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm
@@ -413,6 +413,8 @@ TEST(WKWebExtensionMatchPattern, PatternDescriptions)
     EXPECT_NS_EQUAL(toPattern(@"http://*.example.com/*").description, @"http://*.example.com/*");
     EXPECT_NS_EQUAL(toPattern(@"file:///*").description, @"file:///*");
     EXPECT_NS_EQUAL(toPattern(@"file://localhost/*").description, @"file:///*");
+    EXPECT_NS_EQUAL(toPattern(@"file", @"", @"/*").description, @"file:///*");
+    EXPECT_NS_EQUAL(toPattern(@"file", @"localhost", @"/*").description, @"file:///*");
 }
 
 TEST(WKWebExtensionMatchPattern, MatchesAllHosts)

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h
@@ -50,8 +50,9 @@
 @property (nonatomic, copy) void (^openNewTab)(_WKWebExtensionTabCreationOptions *, _WKWebExtensionContext *, void (^)(id<_WKWebExtensionTab>, NSError *));
 @property (nonatomic, copy) void (^openOptionsPage)(_WKWebExtensionContext *, void (^)(NSError *));
 
-@property (nonatomic, copy) void (^promptForPermissions)(id <_WKWebExtensionTab>, NSSet<NSString *> *, void (^)(NSSet<_WKWebExtensionPermission> *));
-@property (nonatomic, copy) void (^promptForPermissionMatchPatterns)(id <_WKWebExtensionTab>, NSSet<_WKWebExtensionMatchPattern *> *, void (^)(NSSet<_WKWebExtensionMatchPattern *> *));
+@property (nonatomic, copy) void (^promptForPermissions)(id <_WKWebExtensionTab>, NSSet<NSString *> *, void (^)(NSSet<_WKWebExtensionPermission> *, NSDate *));
+@property (nonatomic, copy) void (^promptForPermissionMatchPatterns)(id <_WKWebExtensionTab>, NSSet<_WKWebExtensionMatchPattern *> *, void (^)(NSSet<_WKWebExtensionMatchPattern *> *, NSDate *));
+@property (nonatomic, copy) void (^promptForPermissionToAccessURLs)(id <_WKWebExtensionTab>, NSSet<NSURL *> *, void (^)(NSSet<NSURL *> *, NSDate *));
 
 @property (nonatomic, copy) void (^sendMessage)(id message, NSString *applicationIdentifier, void (^)(id replyMessage, NSError *));
 @property (nonatomic, copy) void (^connectUsingMessagePort)(_WKWebExtensionMessagePort *);

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -88,20 +88,28 @@
         completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"runtime.openOptionsPage() not implemneted" }]);
 }
 
-- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissions:(NSSet<_WKWebExtensionPermission> *)permissions inTab:(id<_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionPermission> *allowedPermissions))completionHandler
+- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissions:(NSSet<_WKWebExtensionPermission> *)permissions inTab:(id<_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionPermission> *allowedPermissions, NSDate *expirationDate))completionHandler
 {
     if (_promptForPermissions)
         _promptForPermissions(tab, permissions, completionHandler);
     else
-        completionHandler(permissions);
+        completionHandler(permissions, nil);
 }
 
-- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionMatchPatterns:(NSSet<_WKWebExtensionMatchPattern *> *)matchPatterns inTab:(id<_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionMatchPattern *> *allowedMatchPatterns))completionHandler
+- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionMatchPatterns:(NSSet<_WKWebExtensionMatchPattern *> *)matchPatterns inTab:(id<_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionMatchPattern *> *allowedMatchPatterns, NSDate *expirationDate))completionHandler
 {
     if (_promptForPermissionMatchPatterns)
         _promptForPermissionMatchPatterns(tab, matchPatterns, completionHandler);
     else
-        completionHandler(matchPatterns);
+        completionHandler(matchPatterns, nil);
+}
+
+- (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissionToAccessURLs:(NSSet<NSURL *> *)urls inTab:(id<_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<NSURL *> *allowedURLs, NSDate *expirationDate))completionHandler
+{
+    if (_promptForPermissionToAccessURLs)
+        _promptForPermissionToAccessURLs(tab, urls, completionHandler);
+    else
+        completionHandler(urls, nil);
 }
 
 - (void)webExtensionController:(_WKWebExtensionController *)controller sendMessage:(id)message toApplicationIdentifier:(NSString *)applicationIdentifier forExtensionContext:(_WKWebExtensionContext *)extensionContext replyHandler:(void (^)(id, NSError *))replyHandler


### PR DESCRIPTION
#### 33e22ac2d07d9761d8b07b0e73df2d6ade6f84b1
<pre>
Some APIs like tabs.query need to prompt for permission before returning.
<a href="https://webkit.org/b/262714">https://webkit.org/b/262714</a>
<a href="https://rdar.apple.com/problem/116535817">rdar://problem/116535817</a>

Reviewed by Jeff Miller.

Change the existing permission delegate calls from being just used for permissions.request()
and into helper methods on WebExtensionContext. Now filter out already granted permissions,
and only send the delegate messages if some of them are still required.

Also add the timeout for these requests, so they auto expire in 2 minutes, preventing the
extensions scripts from waiting for a response for too long.

Also add expirationDate parameter to the completionHandler, so the app can grant for a limited
amount of time, or pass nil to grant indefinitely.

Finally, wrap many extension APIs with the new requestPermissionToAccessURLs() and request the
URLs for the tabs and cookies needed by those APIs. This includes some like scripting, which
were never wrapped like this in Safari&apos;s implementation.

Deleted some redundant toImpl / toAPI helpers that we already had elsewhere.

* Source/WebCore/page/UserContentURLPattern.cpp:
(WebCore::UserContentURLPattern::UserContentURLPattern):
* Source/WebKit/Platform/cocoa/CocoaHelpers.h:
* Source/WebKit/Platform/cocoa/CocoaHelpers.mm:
(WebKit::toAPI):
(WebKit::toAPIArray):
(WebKit::toImpl):
(WebKit::toImplSet): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtension.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerDelegate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm:
(WebKit::WebExtensionContext::cookiesGet):
(WebKit::WebExtensionContext::cookiesGetAll):
(WebKit::WebExtensionContext::cookiesSet):
(WebKit::WebExtensionContext::cookiesRemove):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::declarativeNetRequestGetMatchedRules):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsInspectedWindow.mm:
(WebKit::WebExtensionContext::devToolsInspectedWindowEval):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm:
(WebKit::WebExtensionContext::permissionsRequest):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingExecuteScript):
(WebKit::WebExtensionContext::scriptingInsertCSS):
(WebKit::WebExtensionContext::scriptingRemoveCSS):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsGet):
(WebKit::WebExtensionContext::tabsGetCurrent):
(WebKit::WebExtensionContext::tabsQuery):
(WebKit::WebExtensionContext::tabsDetectLanguage):
(WebKit::WebExtensionContext::tabsCaptureVisibleTab):
(WebKit::WebExtensionContext::tabsRemove):
(WebKit::WebExtensionContext::tabsExecuteScript):
(WebKit::WebExtensionContext::tabsInsertCSS):
(WebKit::WebExtensionContext::tabsRemoveCSS):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsGet):
(WebKit::WebExtensionContext::windowsGetLastFocused):
(WebKit::WebExtensionContext::windowsGetAll):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::grantPermissions):
(WebKit::WebExtensionContext::denyPermissions):
(WebKit::WebExtensionContext::grantPermissionMatchPatterns):
(WebKit::WebExtensionContext::denyPermissionMatchPatterns):
(WebKit::WebExtensionContext::requestPermissionMatchPatterns):
(WebKit::WebExtensionContext::requestPermissionToAccessURLs):
(WebKit::WebExtensionContext::requestPermissions):
(WebKit::WebExtensionContext::hasPermission):
(WebKit::WebExtensionContext::permissionState):
(WebKit::WebExtensionContext::setPermissionState):
(WebKit::WebExtensionContext::getCurrentTab const):
(WebKit::WebExtensionContext::unloadBackgroundContentIfPossible):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm:
(WebKit::WebExtensionMatchPattern::getOrCreate):
(WebKit::toPatterns):
(WebKit::toAPI):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::hasPermission):
(WebKit::WebExtensionContext::permissionState):
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
(WebKit::WebExtensionMatchPattern::getOrCreate):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionMatchPattern.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate webExtensionController:promptForPermissions:inTab:forExtensionContext:completionHandler:]):
(-[TestWebExtensionsDelegate webExtensionController:promptForPermissionMatchPatterns:inTab:forExtensionContext:completionHandler:]):
(-[TestWebExtensionsDelegate webExtensionController:promptForPermissionToAccessURLs:inTab:forExtensionContext:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/275950@main">https://commits.webkit.org/275950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26c1f7a7e956f2b45398636874b12c7a8775e9cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45803 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46028 "Failed to checkout and rebase branch from PR 25738") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39519 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45697 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19841 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/46028 "Failed to checkout and rebase branch from PR 25738") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43967 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/46028 "Failed to checkout and rebase branch from PR 25738") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1449 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47572 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19844 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5893 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19475 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->