### PR TITLE
Web Inspector: Color Improved Contrast in prefers-contrast: more

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.css
@@ -188,4 +188,10 @@
     .content-view.audit-test > header table.controls > tr > th {
         color: var(--text-color-secondary);
     }
+
+    @media (prefers-contrast: more) {
+        .content-view.audit-test {
+            --audit-test-header-background-color: hsl(0, 0%, 10%);
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/AuditTestGroupContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditTestGroupContentView.css
@@ -168,4 +168,13 @@
         /* FIXME: Use CSS4 color blend functions once they're available. */
         color: hsla(0, 0%, 88%, 0.65);
     }
+    @media (prefers-contrast: more) {
+        .content-view.audit-test-group > header > .percentage-pass {
+            color: hsla(0, 0%, 100%);
+        }
+
+        .content-view.audit-test-group > header > .percentage-pass > span {
+            color: hsla(0, 0%, 100%);
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/BoxModelDetailsSectionRow.css
+++ b/Source/WebInspectorUI/UserInterface/Views/BoxModelDetailsSectionRow.css
@@ -188,5 +188,48 @@
     .details-section .row.box-model .box.border {
         border-color: var(--text-color-quaternary);
     }
-}
 
+    @media (prefers-contrast: more) {
+        .details-section .row.box-model .box.margin {
+            border-color: black;
+        }
+
+        .details-section .row.box-model .box.border {
+            border-color: black;
+        }
+
+        .details-section .row.box-model .box {
+            border-color: black;
+        }
+
+        .details-section .row.box-model:not(.hovered) .box.margin,
+        .details-section .row.box-model .box.margin.active {
+            background-color: hsla(30, 100%, 90%);
+        }
+
+        .details-section .row.box-model:not(.hovered) .box.padding,
+        .details-section .row.box-model .box.padding.active {
+            background-color: hsla(100, 100%, 90%);
+        }
+
+        .details-section .row.box-model:not(.hovered) .box.border,
+        .details-section .row.box-model .box.border.active {
+            background-color: hsla(70, 100%, 90%);
+        }
+
+        .details-section .row.box-model:is(.hovered) .box.margin,
+        .details-section .row.box-model .box.margin.active {
+            border-color: white;
+        }
+
+        .details-section .row.box-model:is(.hovered) .box.padding,
+        .details-section .row.box-model .box.padding.active {
+            border-color: white;
+        }
+
+        .details-section .row.box-model:is(.hovered) .box.border,
+        .details-section .row.box-model .box.border.active {
+            border-color: white;
+        }
+    }
+}

--- a/Source/WebInspectorUI/UserInterface/Views/ChangesDetailsSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ChangesDetailsSidebarPanel.css
@@ -106,3 +106,9 @@
     left: var(--css-declaration-horizontal-padding);
     pointer-events: none;
 }
+
+@media (prefers-contrast: more) and @media (prefers-color-scheme: dark) {
+    .changes-panel .css-property-line.added {
+    color: hsl(90, 61%, 10%);
+    }
+}

--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
@@ -352,4 +352,9 @@
     .console-message .go-to-link:focus {
         color: var(--selected-secondary-text-color-active);
     }
+    @media (prefers-contrast: more) {
+        .console-error-level .console-message-body {
+            color: hsl(10, 100%, 90%);
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
@@ -299,4 +299,34 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-with
     .tree-outline.dom .html-pseudo-element {
         color: hsl(0, 80%, 65%);
     }
+
+    @media (prefers-contrast: more) {
+        .tree-outline.dom {
+            --shadow-subtree-background-color: hsl(0, 0%, 95%);
+        }
+
+        .tree-outline.dom li.inspected-node > span::after {
+            color: hsl(0, 0%, 95%);
+        }
+
+        body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-within li.inspected-node.selected > span::after {
+            color: hsl(0, 0%, 95%);
+        }
+
+        .tree-outline.dom .shadow {
+            color: hsl(0, 0%, 10%);
+        }
+
+        .tree-outline.dom .html-pseudo-element {
+            color: hsl(0, 0%, 15%);
+        }
+
+        .showing-find-banner .tree-outline.dom .search-highlight {
+            background-color: hsla(53, 0%, 53%);
+        }
+
+        .tree-outline.dom .html-pseudo-element {
+            color: hsl(0, 0%, 65%);
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
@@ -313,4 +313,16 @@ body[dir=rtl] .details-section > .header::before {
     .details-section > .content > .group > .row.simple > .label {
         color: var(--text-color-secondary);
     }
+    @media (prefers-contrast: more) {
+        .details-section > .header {
+            color: white;
+        }
+        .details-section > .content > .group > .row:is(.empty, .text) {
+            color: white;
+        }
+        .details-section > .header > label,
+        .details-section > .content > .group > .row.simple > .label {
+            color: white;
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/FilterBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FilterBar.css
@@ -116,3 +116,9 @@
 :is(.filter-bar, .search-bar).invalid > input[type="search"] {
     border-color: var(--error-text-color);
 }
+
+@media (prefers-color-scheme: dark) and (prefers-contrast: more) {
+    :is(.filter-bar, .search-bar) > input[type="search"] {
+        color: white;
+    }
+}

--- a/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.css
@@ -140,3 +140,8 @@
     background-size: var(--warning-icon-size) var(--warning-icon-size);
     background-position: center;
 }
+
+@media (prefers-contrast: more) and @media (prefers-color-scheme: dark) {}
+.details-section > .content > .group > .row.font-variation > .variation-range > input[type="range"] {
+
+}

--- a/Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.css
@@ -195,6 +195,12 @@
     .sidebar > .panel.details.css-style > .content ~ .options-container > .new-rule {
         filter: var(--filter-invert);
     }
+
+    @media (prefers-contrast: more) {
+        .sidebar > .panel.details.css-style > .content ~ .options-container > .toggle {
+            border: white 1px solid;
+        }
+    }
 }
 
 .multi-sidebar.showing-multiple > .sidebar > .panel.details:not(.style-rules) > .options-container > .toggle,

--- a/Source/WebInspectorUI/UserInterface/Views/LogContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/LogContentView.css
@@ -427,4 +427,14 @@ body[dir=rtl] .console-group-title::before {
         color: var(--search-highlight-text-color-active);
         background-color: var(--search-highlight-background-color-active);
     }
+
+    @media (prefers-contrast: more) {
+        .console-messages a {
+            color: white;
+        }
+
+        .console-other-filters-button.active > .glyph {
+            color: hsl(212, 100%, 70%);
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/Main.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Main.css
@@ -504,7 +504,7 @@ body[dir=rtl] [dir=ltr] .go-to-arrow {
     height: var(--reference-page-link-size);
     font-size: 14px;
     line-height: 18px;
-    color: var(--text-color);
+    color: var(--question-mark-color);
     text-decoration: none;
     background-color: var(--button-background-color);
     border: var(--stroke-width) solid var(--border-color);
@@ -527,17 +527,6 @@ body[dir=rtl] [dir=ltr] .go-to-arrow {
     }
 }
 
-@media (prefers-color-scheme: dark) {
-    .reference-page-link {
-        border: var(--stroke-width) solid hsl(0, 0%, 20%);
-        box-shadow: 0 var(--stroke-width) 1px hsl(0, 0%, 20%);
-    }
-
-    .reference-page-link:active {
-        background-color: hsl(0, 0%, 50%);
-    }
-}
-
 @keyframes tab-bar-console-item-pulse {
     50% { opacity: 0.6; }
 }
@@ -548,6 +537,15 @@ body[dir=rtl] [dir=ltr] .go-to-arrow {
 }
 
 @media (prefers-color-scheme: dark) {
+    .reference-page-link {
+        border: var(--stroke-width) solid hsl(0, 0%, 20%);
+        box-shadow: 0 var(--stroke-width) 1px hsl(0, 0%, 20%);
+    }
+
+    .reference-page-link:active {
+        background-color: hsl(0, 0%, 50%);
+    }
+
     #undocked-title-area {
         box-shadow: none;
     }
@@ -587,5 +585,29 @@ body[dir=rtl] [dir=ltr] .go-to-arrow {
 
     :is(img, canvas).show-grid {
         --checkerboard-dark-square: hsl(0, 0%, 5%);
+    }
+
+    @media (prefers-contrast: more) {
+        .search-settings > .glyph {
+            color: white;
+        }
+
+        .search-settings:active > .glyph {
+            color: white;
+        }
+
+        .search-settings.active > .glyph {
+            color: white;
+        }
+
+        .search-settings:active.active > .glyph {
+            color: white;
+        }
+
+        body {
+            color: white;
+            --text-color: white;
+            background-size: contain;
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
@@ -442,4 +442,18 @@ body[dir=rtl] .waterfall.network .block {
     .network-table > .table .cell.dom-node.name .icon {
         content: url(../Images/TypeIcons.svg#DOMElement-dark);
     }
+
+    @media (prefers-contrast: more) {
+        .network-table > .table .data-container .cell.name .range {
+            color: white;
+        }
+
+        .network-table > .table :not(.header) .cell.waterfall .waterfall-container > .area.dom-fullscreen {
+            background-color: hsl(0, 0%, 90%);
+        }
+
+        .network-table > .table .header .cell.waterfall:is(.sort-ascending, .sort-descending) {
+            background-color: black;
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/RadioButtonNavigationItem.css
+++ b/Source/WebInspectorUI/UserInterface/Views/RadioButtonNavigationItem.css
@@ -61,3 +61,33 @@
 .navigation-bar .item.radio.button.text-only.selected:active::before {
     filter: brightness(0.8);
 }
+
+@media (prefers-color-scheme: dark) and (prefers-contrast: more) {
+    .navigation-bar .item.radio.button.text-only:is(.selected, :hover)::before {
+        --scope-bar-background-color-default: hsl(212, 0%, 20%);
+        --scope-bar-background-color: var(--scope-bar-background-color-override, var(--scope-bar-background-color-default));
+        --scope-bar-background-opacity: var(--scope-bar-background-opacity-override, var(--scope-bar-background-opacity-default));
+    }
+
+    .navigation-bar .item.radio.button.text-only::before {
+        --scope-bar-background-color: var(--scope-bar-background-color-override, var(--scope-bar-background-color-default));
+        --scope-bar-background-opacity: var(--scope-bar-background-opacity-override, var(--scope-bar-background-opacity-default));
+    }
+
+    .navigation-bar .item.radio.button.text-only:is(.selected, :hover)::before {
+        --scope-bar-background-color: var(--scope-bar-background-color-override, var(--scope-bar-background-color-default));
+        --scope-bar-background-opacity: var(--scope-bar-background-opacity-override, var(--scope-bar-background-opacity-default));
+    }
+
+    .navigation-bar .item.radio.button.text-only {
+        border: white 1px solid;
+    }
+
+    .navigation-bar .item.button:not(.disabled):is(.activate.activated, .radio.selected) > .glyph {
+        color: hsl(212, 100%, 70%);
+    }
+
+    .navigation-bar .item.radio.button.text-only:is(.selected, :hover)::before {
+        background-color: hsl(212, 100%, 70%);
+    }
+}

--- a/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
@@ -119,3 +119,20 @@
     margin-bottom: -1px;
     margin-inline: 6px 2px;
 }
+
+@media (prefers-color-scheme: dark) and (prefers-contrast: more) {
+    .scope-bar {
+        --scope-bar-text-color-default: hsl(288, 0%, 90%);
+        --scope-bar-border-color-default: white;
+    }
+
+    .scope-bar > li {
+        color: hsl(0, 0%, 90%);
+    }
+
+    .scope-bar > li:is(.selected, :hover) {
+        --scope-bar-text-color-default: black;
+        --scope-bar-background-color-default: var(--selected-background-color);
+        --scope-bar-border-color-default: white;
+    }
+}

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.css
@@ -169,5 +169,10 @@
     .spreadsheet-css-declaration .origin .go-to-link:hover {
         color: var(--text-color-secondary);
     }
-}
 
+    @media (prefers-contrast: more) {
+        .spreadsheet-css-declaration .origin {
+            color: white;
+        }
+    }
+}

--- a/Source/WebInspectorUI/UserInterface/Views/SyntaxHighlightingDefaultTheme.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SyntaxHighlightingDefaultTheme.css
@@ -162,4 +162,8 @@
     .cm-s-default .cm-builtin {
         color: hsl(218, 64%, 76%);
     }
+
+    .syntax-highlighted :is(.html-doctype, .html-processing-instruction) {
+        color: hsl(0, 0%, 90%);
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TabBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TabBar.css
@@ -416,4 +416,40 @@ body.window-inactive .tab-bar > .tabs.animating.closing-tab > .item:not(.disable
     body:not(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar > .tabs > .item:not(.disabled).selected {
         --tab-item-background: hsl(0, 0%, 19%);
     }
+
+    @media (prefers-contrast: more) {
+        .tab-bar > .tabs > .item > .icon {
+            .tab-bar > .tabs > .item > .name {
+                color: hsl(0, 0%, var(--foreground-lightness));
+                filter: none;
+            }
+
+            body.window-inactive .tab-bar > .tabs > .item > .name {
+                color: hsl(0, 100%, var(--foreground-lightness));
+            }
+
+            .tab-bar > .tabs > .item:not(.selected):hover > .name {
+                color: hsl(0, 100%, var(--foreground-lightness));
+            }
+
+            .tab-bar > .tabs > .item:not(.disabled).selected > .name {
+                color: hsl(0, 100%, var(--foreground-lightness));
+            }
+
+            .tab-bar > .tabs > .item:not(.disabled).selected > .name {
+                color: hsl(0, 100%, var(--foreground-lightness));
+            }
+
+            body.window-inactive .tab-bar > .tabs > .item:not(.disabled).selected > .name {
+                color: hsl(0, 100%, var(--foreground-lightness));
+            }
+
+            body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar, body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar {
+                --tab-item-dark-border-color: hsl(0, 100%, 90%);
+                --tab-item-medium-border-color: hsl(0, 100%, 95%);
+                --tab-item-light-border-color: hsl(0, 100%, 100%);
+                --tab-item-border-color: hsl(0, 100%, 95%);
+            }
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
@@ -227,4 +227,26 @@ body.mac-platform.legacy .timeline-overview > .graphs-container {
     .timeline-overview:not(.frames) > .graphs-container > .timeline-overview-graph:nth-child(even) {
         background: var(--background-color-alternate);
     }
+
+    @media (prefers-contrast: more) {
+        .navigation-bar.timelines .item.text.enabled-timelines {
+            color: hsl(0, 0%, 90%);
+        }
+
+        .navigation-bar.timelines .item.button.toggle-edit-instruments:not(.disabled):is(:focus, .activate.activated, .radio.selected) {
+            color: hsl(0, 0%, 95%);
+        }
+
+        .navigation-bar.timelines .item.button.toggle-edit-instruments:not(.disabled):active:is(:focus, .activate.activated, .radio.selected) {
+            color: hsl(0, 0%, 95%);
+        }
+
+        .navigation-bar.timelines .item.button.toggle-edit-instruments.disabled {
+            color: var(--glyph-color-disabled);
+        }
+
+        .navigation-bar.timelines .toggle-edit-instruments:not(.disabled):active {
+            color: hsl(0, 0%, 95%);
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css
@@ -262,4 +262,22 @@ body[dir=rtl] .timeline-ruler > .selection-handle.left {
     .timeline-ruler > .markers > .marker.dom-content-event {
         color: hsl(240, 100%, 70%);
     }
+
+    @media (prefers-contrast: more) {
+        .timeline-ruler > .markers > .marker.load-event {
+            color: hsl(0, 100%, 100%);
+        }
+
+        .timeline-ruler > .markers > .marker.dom-content-event {
+            color: hsl(240, 100%, 100%);
+        }
+
+        .timeline-ruler > .markers > .marker.timestamp {
+            color: hsl(119, 100%, 100%);
+        }
+
+        .timeline-ruler > .header > .divider > .label {
+            color: hsl(0, 0%, 100%);
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -32,7 +32,10 @@
     --z-index-glass-pane-for-drag: 2048;
     --z-index-uncaught-exception-sheet: 4096;
 
+    --question-mark-color: black;
+
     --foreground-lightness: 0%;
+    --text-color-light: 0%;
 
     --text-color: black;
     --text-color-transparent: hsla(0, 0%, 0%, 0.4);
@@ -47,7 +50,7 @@
     /* Dividers, separators, background fills */
     --text-color-quaternary: hsl(0, 0%, 85%);
 
-    --separator-color: hsla(0, 0%, var(--foreground-lightness), 0.15);
+    --separator-color: hsla(0, 0%, var(--text-color-light), 0.15);
 
     --background-color: white;
 
@@ -236,6 +239,7 @@
         color: var(--text-color);
 
         --foreground-lightness: 100%;
+        --text-color-lightness: 100%;
 
         --text-color: hsl(0, 0%, 88%);
         --text-color-transparent: hsla(0, 0%, 88%, 0.4);
@@ -253,6 +257,8 @@
         --text-color-gray-dark: hsl(0, 0%, 75%);
         --text-color-gray-medium: var(--text-color-secondary);
 
+        --question-mark-color: hsl(0, 0%, 88%);
+
         --background-color: hsl(0, 0%, 24%);
         --background-color-secondary: hsl(0, 0%, 27%);
         --background-color-tertiary: hsl(0, 0%, 31%);
@@ -268,8 +274,8 @@
         --color-button-active: var(--text-color-active);
 
         --selected-foreground-color: var(--text-color-active);
-        --selected-secondary-text-color: hsla(0, 0%, var(--foreground-lightness), 0.7);
-        --selected-secondary-text-color-active: hsla(0, 0%, var(--foreground-lightness), 0.85);
+        --selected-secondary-text-color: hsla(0, 0%, var(--text-color-light), 0.7);
+        --selected-secondary-text-color-active: hsla(0, 0%, var(--text-color-light), 0.85);
         --selected-background-color: hsl(219, 80%, 43%);
         --selected-background-color-unfocused: hsla(0, 0%, var(--foreground-lightness), 0.15);
         --selected-background-color-active: hsl(218, 85%, 62%);
@@ -280,7 +286,7 @@
         --glyph-color: hsl(0, 0%, 80%);
         --glyph-color-pressed: hsl(0, 0%, 100%);
         --glyph-color-disabled: hsla(0, 0%, 80%, 0.4);
-        --glyph-color-active: hsl(212, 100%, 71%);
+        --glyph-color-active: hsl(212, 100%, 50%);
         --glyph-color-active-pressed: hsl(212, 92%, 74%);
         --glyph-color-inactive: hsl(0, 0%, 36%);
 
@@ -365,8 +371,76 @@
         --slider-track-background: hsl(0, 0%, 35%);
         --slider-track-box-shadow: inset 0 0 3px hsl(0, 0%, 20%);
         --slider-track-tick-background: hsl(0, 0%, 55%);
+
+        @media (prefers-contrast: more) {
+            color: white;
+
+            --background-color: hsl(0, 0%, 10%);
+            --background-color-content: hsl(0, 0%, 10%);
+            --background-color-intermediate: hsl(0, 0%, 10%);
+            --background-color-secondary: hsl(0, 0%, 10%);
+            --background-color-tertiary: hsl(0, 0%, 10%);
+
+            --button-background-color: hsl(0, 0%, 90%);
+            --button-background-color-hover: hsl(0, 0%, 95%);
+            --button-background-color-pressed: hsl(0, 0%, 10%);
+            --button-background-color-inactive: hsl(0, 0%, 90%);
+            --button-color: hsl(200, 90%, 10%);
+
+            --border-color: hsl(0, 0%, 90%);
+            --border-color-secondary: hsl(0, 0%, 96%);
+            --border-color-tertiary: hsl(0, 0%, 93%);
+            
+            --console-secondary-text-color: hsl(0, 0%, 90%);
+
+            --panel-background-color: hsl(0, 0%, 10%);
+            --panel-background-color-light: hsl(0, 0%, 13%);
+
+            --question-mark-color: black;
+
+            --graph-line-color: hsla(0, 0%, var(--foreground-lightness));
+
+            --glyph-color: hsl(0, 0%, 95%);
+            --glyph-color-pressed: hsl(0, 0%, 100%);
+            --glyph-color-disabled: hsla(0, 0%, 20%);
+            --glyph-color-active: hsl(212, 100%, 95%);
+            --glyph-color-active-pressed: hsl(212, 92%, 80%);
+            --glyph-color-inactive: hsl(0, 0%, 10%);
+
+            --scope-bar-text-color: hsl(0, 0%, 95%);
+            --scope-bar-background-color: hsl(0, 0%, 10%);
+            --scope-bar-background-opacity: hsl(0, 0%, 15%);
+            --scope-bar-border-color: hsl(0, 0%, 90%);
+            --scope-bar-text-color-default: hsl(0, 0%, 95%);
+            --scope-bar-background-color-default: hsl(0, 0%, 15%);
+            --scope-bar-background-opacity-default: hsl(0, 0%, 15%);
+            --scope-bar-border-color-default: hsl(0, 0%, 90%);
+
+            --syntax-highlight-boolean-color: hsl(299, 71%, 90%);
+            --syntax-highlight-number-color: hsl(276, 100%, 90%);
+            --syntax-highlight-link-color: hsl(223, 100%, 90%);
+            --syntax-highlight-regexp-color: hsl(20, 100%, 90%);
+            --syntax-highlight-string-color: hsl(28, 84%, 90%);
+            --syntax-highlight-symbol-color: hsl(20, 100%, 90%);
+            --syntax-highlight-comment-color: hsl(119, 40%, 90%);
+            --syntax-highlight-bigint-color: hsl(195, 100%, 90%);
+
+            --error-text-color: hsl(0, 86%, 90%);
+            --text-color: hsl(0, 0%, 90%);
+            --text-color-transparent: hsla(0, 0%, 90%);
+            --text-color-secondary: hsl(0, 0%, 92%);
+            --text-color-tertiary: hsl(0, 0%, 94%);
+            --text-color-quaternary: hsl(0, 0%, 96%);
+
+            --yellow-highlight-background-color: hsl(13, 20%, 10%);
+            --green-highlight-background-color: hsl(120, 15%, 10%);
+
+            --green-highlight-text-color: hsl(80, 75%, 90%);
+            --yellow-highlight-text-color: hsl(50, 96%, 90%);
+
+            --warning-background-color: hsl(43, 100%, 10%);
+        }
     }
-}
 
 body {
     &.window-inactive {
@@ -383,12 +457,19 @@ body {
 
             --glyph-color: hsl(0, 0%, 52%);
             --glyph-color-disabled: hsla(0, 0%, 52%, 0.4);
+
+            @media (prefers-contrast: more) {
+            --selected-background-color-active: hsl(218, 85%, 62%);
+            }
         }
     }
+}
 
     &:is(.mac-platform.monterey, .mac-platform.big-sur) {
         --text-color: hsl(0, 0%, 15%);
         --text-color-transparent: hsla(0, 0%, 15%, 0.4);
+
+        --question-mark-color: hsl(0, 0%, 15%);
 
         --background-color-intermediate: hsl(0, 0%, 98.5%);
 
@@ -405,6 +486,7 @@ body {
         @media (prefers-color-scheme: dark) {
             --text-color: hsl(0, 0%, 85%);
             --text-color-transparent: hsla(0, 0%, 85%, 0.4);
+            --text-color-light: 85%;
 
             --background-color: hsl(0, 0%, 20%);
             --background-color-secondary: hsl(0, 0%, 23%);
@@ -412,6 +494,8 @@ body {
 
             --background-color-content: hsl(0, 0%, 17%);
             --background-color-intermediate: hsl(0, 0%, 19%);
+
+            --question-mark-color: hsl(0, 0%, 15%);
 
             --glyph-color: hsl(0, 0%, 69%);
             --glyph-color-pressed: hsl(0, 0%, 100%);
@@ -421,6 +505,28 @@ body {
 
             --border-color: hsl(0, 0%, 30%);
             --border-color-secondary: hsl(0, 0%, 24%);
+
+            @media (prefers-contrast: more) {
+                --text-color: hsl(0, 0%, 95%);
+                --text-color-light: 100%;
+
+                --text-color-transparent: hsla(0, 0%, 90%);
+
+                --background-color: hsl(0, 0%, 15%);
+                --background-color-content: hsl(0, 0%, 15%);
+                --background-color-intermediate: hsl(0, 0%, 15%);
+                --background-color-secondary: hsl(0, 0%, 15%);
+                --background-color-tertiary: hsl(0, 0%, 15%);
+
+                --panel-background-color: hsl(0, 0%, 15%);
+                --panel-background-color-light: hsl(0, 0%, 15%);
+
+                --glyph-color: hsl(0, 0%, 90%);
+                --glyph-color-active: hsl(212, 100%, 10%);
+
+                --border-color: hsl(0, 0%, 90%);
+                --border-color-secondary: hsl(0, 0%, 85%);
+            }
         }
     }
     


### PR DESCRIPTION
#### 785e2bbba30201c42c7d62ea92b9b01c81a30077
<pre>
Web Inspector: Color Improved Contrast in prefers-contrast: more
<a href="https://bugs.webkit.org/show_bug.cgi?id=267604">https://bugs.webkit.org/show_bug.cgi?id=267604</a>

Reviewed by NOBODY (OOPS!).

Add @media (prefers-contrast: more) nested in @media (prefers-color-scheme: dark) to:
DetailsSection.css, NetworkTableContentView.css, TabBar.css, BoxModelDetailsSectionRow.css,
Variables.css, Main.css, SpreadsheetCSSStyleDeclarationSection.css, NetworkTableContentView.css,
TimelineOverview.css, FilterBar.css, AuditTestContentView.css, SyntaxHighlightingDefaultTheme.css,
DOMTreeOutline.css, RadiobuttonNavigationItem.css, TimelineRuler.css, GeneralStyleDetailsSidebarPanel.css,
ChangesDetailsSidebarPanel.css, and ScopeBar.css.
Darken the colors of backgrounds and panels.
Delete the fourth alpha-content variable for transparent text (hsla to hsl).
Add a white border around scope bars.
Lighten the colors of text, console, selected, syntax, borders, glyphs, and errors.
Create --question-mark-color for .reference-page-link.
Create --text-color-light for light colored text.

* Source/WebInspectorUI/UserInterface/Views/AuditTestContentView.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view.audit-test):
* Source/WebInspectorUI/UserInterface/Views/AuditTestGroupContentView.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view.audit-test-group &gt; header &gt; .percentage-pass):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view.audit-test-group &gt; header &gt; .percentage-pass &gt; span):
* Source/WebInspectorUI/UserInterface/Views/BoxModelDetailsSectionRow.css:
(@media (prefers-color-scheme: dark) .details-section .row.box-model .box.border):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section .row.box-model .box.margin):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section .row.box-model .box.border):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section .row.box-model .box):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section .row.box-model:not(.hovered) .box.margin,):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section .row.box-model:not(.hovered) .box.padding,):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section .row.box-model:not(.hovered) .box.border,):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section .row.box-model:is(.hovered) .box.margin,):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section .row.box-model:is(.hovered) .box.padding,):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section .row.box-model:is(.hovered) .box.border,):
(@media (prefers-contrast: more) and @media (prefers-color-scheme: dark) .changes-panel .css-property-line.added):
* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-error-level .console-message-body):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .tree-outline.dom):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .tree-outline.dom li.inspected-node &gt; span::after):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-within li.inspected-node.selected &gt; span::after):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .tree-outline.dom .shadow):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .tree-outline.dom .html-pseudo-element):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .showing-find-banner .tree-outline.dom .search-highlight):
* Source/WebInspectorUI/UserInterface/Views/DetailsSection.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section &gt; .header):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section &gt; .content &gt; .group &gt; .row:is(.empty, .text)):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section &gt; .header &gt; label,):
* Source/WebInspectorUI/UserInterface/Views/FilterBar.css:
(@media (prefers-color-scheme: dark) and (prefers-contrast: more) :is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]):
* Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.css:
(.details-section &gt; .content &gt; .group &gt; .row.font-variation &gt; .variation-range &gt; input[type=&quot;range&quot;]):
* Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .sidebar &gt; .panel.details.css-style &gt; .content ~ .options-container &gt; .toggle):
* Source/WebInspectorUI/UserInterface/Views/LogContentView.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-messages a):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-other-filters-button.active &gt; .glyph):
* Source/WebInspectorUI/UserInterface/Views/Main.css:
(@media (prefers-color-scheme: dark) .reference-page-link):
(@media (prefers-color-scheme: dark) .reference-page-link:active):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .search-settings &gt; .glyph):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .search-settings:active &gt; .glyph):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .search-settings.active &gt; .glyph):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .search-settings:active.active &gt; .glyph):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) body):
* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .network-table &gt; .table .data-container .cell.name .range):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .network-table &gt; .table :not(.header) .cell.waterfall .waterfall-container &gt; .area.dom-fullscreen):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .network-table &gt; .table .header .cell.waterfall:is(.sort-ascending, .sort-descending)):
* Source/WebInspectorUI/UserInterface/Views/RadioButtonNavigationItem.css:
(.reference-page-link):
(@media (prefers-color-scheme: dark) and (prefers-contrast: more) .navigation-bar .item.radio.button.text-only:is(.selected, :hover)::before):
(@media (prefers-color-scheme: dark) and (prefers-contrast: more) .navigation-bar .item.radio.button.text-only::before):
(@media (prefers-color-scheme: dark) and (prefers-contrast: more) .navigation-bar .item.radio.button.text-only):
(@media (prefers-color-scheme: dark) and (prefers-contrast: more) .navigation-bar .item.button:not(.disabled):is(.activate.activated, .radio.selected) &gt; .glyph):
* Source/WebInspectorUI/UserInterface/Views/ScopeBar.css:
(@media (prefers-color-scheme: dark) and (prefers-contrast: more) .scope-bar):
(@media (prefers-color-scheme: dark) and (prefers-contrast: more) .scope-bar &gt; li):
(@media (prefers-color-scheme: dark) and (prefers-contrast: more) .scope-bar &gt; li:is(.selected, :hover)):
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.css:
(@media (prefers-color-scheme: dark) .spreadsheet-css-declaration .origin .go-to-link,):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .spreadsheet-css-declaration .origin):
* Source/WebInspectorUI/UserInterface/Views/SyntaxHighlightingDefaultTheme.css:
(@media (prefers-color-scheme: dark) .syntax-highlighted :is(.html-doctype, .html-processing-instruction)):
* Source/WebInspectorUI/UserInterface/Views/TabBar.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .tab-bar &gt; .tabs &gt; .item &gt; .icon):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) body.window-inactive .tab-bar &gt; .tabs &gt; .item &gt; .name):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .tab-bar &gt; .tabs &gt; .item:not(.selected):hover &gt; .name):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected &gt; .name):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) body.window-inactive .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected &gt; .name):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) body:is(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar, body:not(.mac-platform.monterey, .mac-platform.big-sur) .tab-bar):
* Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .navigation-bar.timelines .item.text.enabled-timelines):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .navigation-bar.timelines .item.button.toggle-edit-instruments:not(.disabled):is(:focus, .activate.activated, .radio.selected)):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .navigation-bar.timelines .item.button.toggle-edit-instruments:not(.disabled):active:is(:focus, .activate.activated, .radio.selected)):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .navigation-bar.timelines .item.button.toggle-edit-instruments.disabled):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .navigation-bar.timelines .toggle-edit-instruments:not(.disabled):active):
* Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .timeline-ruler &gt; .markers &gt; .marker.load-event):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .timeline-ruler &gt; .markers &gt; .marker.dom-content-event):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .timeline-ruler &gt; .markers &gt; .marker.timestamp):
* Source/WebInspectorUI/UserInterface/Views/Variables.css:
(:root):
(body):
(&amp;:is(.mac-platform.monterey, .mac-platform.big-sur)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/785e2bbba30201c42c7d62ea92b9b01c81a30077

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47657 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41006 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36930 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18019 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18582 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39874 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3047 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49360 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43956 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21287 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42730 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21633 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->