### PR TITLE
[watchOS] Text input list view controller is not legible when presented over a transparent background

### DIFF
--- a/Source/WebKit/Platform/spi/watchos/PepperUICoreSPI.h
+++ b/Source/WebKit/Platform/spi/watchos/PepperUICoreSPI.h
@@ -254,7 +254,6 @@ extern UIButtonType const PUICButtonTypePill;
 #endif
 
 @interface PUICQuickboardListViewController : PUICQuickboardViewController
-@property (nonatomic, readonly) PUICTableView *listView;
 @property (strong, nonatomic, readonly) PUICQuickboardListViewSpecs *specs;
 @property (nonatomic, copy) UITextContentType textContentType;
 @property (nonatomic, strong) PUICTextInputContext *textInputContext;

--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerViewController.mm
@@ -231,6 +231,8 @@ struct EraAndYear {
 {
     [super viewDidLoad];
 
+    self.view.backgroundColor = UIColor.systemBackgroundColor;
+
     self.headerView.hidden = YES;
 
     NSString *localeIdentifier = [NSLocale currentLocale].localeIdentifier;

--- a/Source/WebKit/UIProcess/ios/forms/WKNumberPadViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKNumberPadViewController.mm
@@ -79,6 +79,8 @@ static CGFloat inputLabelFontSize()
 {
     [super viewDidLoad];
 
+    self.view.backgroundColor = UIColor.systemBackgroundColor;
+
     _numberPadView = adoptNS([[WKNumberPadView alloc] initWithFrame:UIRectInset(self.contentView.bounds, numberPadViewTopMargin, 0, 0, 0) controller:self]);
     [self.contentView addSubview:_numberPadView.get()];
 

--- a/Source/WebKit/UIProcess/ios/forms/WKSelectMenuListViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKSelectMenuListViewController.mm
@@ -146,6 +146,8 @@ static constexpr CGFloat itemCellBaselineToBottom = 8;
 {
     [super viewDidLoad];
 
+    self.view.backgroundColor = UIColor.systemBackgroundColor;
+
     self.cancelButton.hidden = YES;
     self.showsAcceptButton = YES;
 
@@ -202,11 +204,6 @@ static constexpr CGFloat itemCellBaselineToBottom = 8;
     if (!indexPathsToReload.count)
         return;
 
-    if (self.listView) {
-        [self.listView reloadRowsAtIndexPaths:indexPathsToReload withRowAnimation:UITableViewRowAnimationNone];
-        return;
-    }
-
 #if HAVE(QUICKBOARD_COLLECTION_VIEWS)
     [self.collectionView reloadItemsAtIndexPaths:indexPathsToReload];
 #endif
@@ -220,33 +217,6 @@ static constexpr CGFloat itemCellBaselineToBottom = 8;
 - (CGFloat)heightForListItem:(NSInteger)itemNumber width:(CGFloat)width
 {
     return selectMenuItemCellHeight;
-}
-
-// FIXME: This method can be removed when <rdar://problem/57807445> lands in a build.
-- (PUICQuickboardListItemCell *)cellForListItem:(NSInteger)itemNumber
-{
-    auto reusableCell = retainPtr([self.listView dequeueReusableCellWithIdentifier:selectMenuCellReuseIdentifier]);
-    if (!reusableCell) {
-        reusableCell = adoptNS([[WKSelectMenuItemCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:selectMenuCellReuseIdentifier]);
-        [reusableCell itemLabel].numberOfLines = 1;
-        [reusableCell itemLabel].lineBreakMode = NSLineBreakByTruncatingTail;
-        [reusableCell itemLabel].allowsDefaultTighteningForTruncation = YES;
-        [reusableCell imageView].frame = UIRectInset([reusableCell contentView].bounds, 0, 0, 0, CGRectGetWidth([reusableCell contentView].bounds) - checkmarkImageViewWidth);
-    }
-
-    NSString *optionText = [self.delegate selectMenu:self displayTextForItemAtIndex:itemNumber];
-    [reusableCell configureForText:optionText width:CGRectGetWidth(self.listView.bounds)];
-    [reusableCell setRadioSectionCell:!_isMultipleSelect];
-
-    if ([_indicesOfCheckedOptions containsIndex:itemNumber]) {
-        [reusableCell itemLabel].frame = UIRectInset([reusableCell contentView].bounds, 0, selectMenuItemHorizontalMargin + checkmarkImageViewWidth, 0, selectMenuItemHorizontalMargin);
-        [reusableCell imageView].hidden = NO;
-    } else {
-        [reusableCell itemLabel].frame = UIRectInset([reusableCell contentView].bounds, 0, selectMenuItemHorizontalMargin, 0, selectMenuItemHorizontalMargin);
-        [reusableCell imageView].hidden = YES;
-    }
-
-    return reusableCell.autorelease();
 }
 
 - (NSString *)listItemCellReuseIdentifier

--- a/Source/WebKit/UIProcess/ios/forms/WKTextInputListViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKTextInputListViewController.mm
@@ -49,6 +49,13 @@
     return self;
 }
 
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+
+    self.view.backgroundColor = UIColor.systemBackgroundColor;
+}
+
 - (void)reloadContextView
 {
     _contextViewNeedsUpdate = YES;

--- a/Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm
@@ -107,6 +107,8 @@ static NSString *timePickerDateFormat = @"HH:mm";
 {
     [super viewDidLoad];
 
+    self.view.backgroundColor = UIColor.systemBackgroundColor;
+
     self.headerView.hidden = YES;
 
     _timePicker = adoptNS([allocCLKUIWheelsOfTimeViewInstance() initWithFrame:self.view.bounds style:CLKUIWheelsOfTimeStyleAlarm12]);


### PR DESCRIPTION
#### 3218bc287cc3297da11f4d198fe6fe561f439d1e
<pre>
[watchOS] Text input list view controller is not legible when presented over a transparent background
<a href="https://bugs.webkit.org/show_bug.cgi?id=270821">https://bugs.webkit.org/show_bug.cgi?id=270821</a>
<a href="https://rdar.apple.com/118537615">rdar://118537615</a>

Reviewed by Abrar Rahman Protyasha and Tim Horton.

Explicitly set the input view controllers&apos; views&apos; background colors to be `+systemBackgroundColor`.
Currently, these views are transparent, which works well in practice (since they present over a
black background anyways), but for certain clients that use a transparent background, this can cause
system UI to show up from behind the input view controllers.

* Source/WebKit/Platform/spi/watchos/PepperUICoreSPI.h:

Drive-by fix: remove some dead code, now that `-listView` is no longer implemented by the base
class when presenting a single or multi-select menu. Instead, reloading the `-collectionView` is
sufficient.

* Source/WebKit/UIProcess/ios/forms/WKDatePickerViewController.mm:
(-[WKDatePickerViewController viewDidLoad]):
* Source/WebKit/UIProcess/ios/forms/WKNumberPadViewController.mm:
(-[WKNumberPadViewController viewDidLoad]):
* Source/WebKit/UIProcess/ios/forms/WKSelectMenuListViewController.mm:
(-[WKSelectMenuListViewController viewDidLoad]):
(-[WKSelectMenuListViewController didSelectListItemAtIndexPath:]):
(-[WKSelectMenuListViewController cellForListItem:]): Deleted.
* Source/WebKit/UIProcess/ios/forms/WKTextInputListViewController.mm:
(-[WKTextInputListViewController viewDidLoad]):
* Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm:
(-[WKTimePickerViewController viewDidLoad]):

Canonical link: <a href="https://commits.webkit.org/275947@main">https://commits.webkit.org/275947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32c390be56eef55191dd0ddcfd3c67205737deff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/45993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39484 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35837 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19405 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16815 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/16981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1414 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39538 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47537 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42622 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19809 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41282 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9644 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/19988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->