### PR TITLE
IdentityCredentialsContainer should not be forwarding options

### DIFF
--- a/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
+++ b/Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp
@@ -45,7 +45,7 @@ IdentityCredentialsContainer::IdentityCredentialsContainer(WeakPtr<Document, Wea
 
 void IdentityCredentialsContainer::get(CredentialRequestOptions&& options, CredentialPromise&& promise)
 {
-    if (!performCommonChecks(std::forward<CredentialRequestOptions>(options), promise))
+    if (!performCommonChecks(options, promise))
         return;
 
     if (!options.digital) {
@@ -67,7 +67,7 @@ void IdentityCredentialsContainer::get(CredentialRequestOptions&& options, Crede
 
 void IdentityCredentialsContainer::isCreate(CredentialCreationOptions&& options, CredentialPromise&& promise)
 {
-    if (!performCommonChecks(std::forward<CredentialCreationOptions>(options), promise))
+    if (!performCommonChecks(options, promise))
         return;
 
     // Default as per Cred Man spec is to resolve with null.


### PR DESCRIPTION
#### 3190d0ab267d38d66be1cf4ef023e8e1f637c6cb
<pre>
IdentityCredentialsContainer should not be forwarding options
<a href="https://bugs.webkit.org/show_bug.cgi?id=270829">https://bugs.webkit.org/show_bug.cgi?id=270829</a>
<a href="https://rdar.apple.com/124419446">rdar://124419446</a>

Reviewed by Abrar Rahman Protyasha.

Removed unnecessary forwarding of options to the underlying CredentialManager.

* Source/WebCore/Modules/identity/IdentityCredentialsContainer.cpp:
(WebCore::IdentityCredentialsContainer::get):
(WebCore::IdentityCredentialsContainer::isCreate):

Canonical link: <a href="https://commits.webkit.org/276342@main">https://commits.webkit.org/276342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6820775c594d5c74d815472b50f6538f820fc2bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47020 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40396 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36515 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17556 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17967 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39325 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2419 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40577 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48631 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43416 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20707 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42145 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9871 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21035 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->