### PR TITLE
Mark request as same-site when we have a matching CORS-disabling pattern

### DIFF
--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -78,6 +78,7 @@ class LocalFrameLoaderClient;
 class NavigationAction;
 class NetworkingContext;
 class Node;
+class Page;
 class ResourceError;
 class ResourceRequest;
 class ResourceResponse;
@@ -228,7 +229,7 @@ public:
     void detachViewsAndDocumentLoader();
 
     static void addHTTPOriginIfNeeded(ResourceRequest&, const String& origin);
-    static void addSameSiteInfoToRequestIfNeeded(ResourceRequest&, const Document* initiator = nullptr);
+    static void addSameSiteInfoToRequestIfNeeded(ResourceRequest&, const Document* initiator = nullptr, const Page* = nullptr);
 
     const LocalFrameLoaderClient& client() const { return m_client.get(); }
     LocalFrameLoaderClient& client() { return m_client.get(); }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1011,6 +1011,7 @@ public:
     void forEachWindowEventLoop(const Function<void(WindowEventLoop&)>&);
 
     bool shouldDisableCorsForRequestTo(const URL&) const;
+    bool shouldAssumeSameSiteForRequestTo(const URL& url) const { return shouldDisableCorsForRequestTo(url); }
     const HashSet<String>& maskedURLSchemes() const { return m_maskedURLSchemes; }
 
     WEBCORE_EXPORT void injectUserStyleSheet(UserStyleSheet&);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
@@ -1046,3 +1046,65 @@ TEST(WKHTTPCookieStore, WebSocketSetCookiesThroughRedirectToThirdParty)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/ninja", serverPort]]]];
     Util::run(&receivedWebSocket);
 }
+
+TEST(WKHTTPCookieStore, SameSiteWithPatternMatch)
+{
+    using namespace TestWebKitAPI;
+    HTTPServer httpServer { HTTPServer::UseCoroutines::Yes, [&] (Connection connection) -> Task {
+        while (true) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = HTTPServer::parsePath(request);
+            request.append(0);
+            if (path == "http://site1.example/set-cookie"_s || path == "http://site2.example/set-cookie"_s) {
+                co_await connection.awaitableSend(HTTPResponse({ { { "Set-Cookie"_s, "exists=1;samesite=strict"_s } }, "<body></body>"_s }).serialize());
+                continue;
+            }
+            StringView requestView(request.data(), request.size());
+            if (path == "http://site1.example/get-cookie"_s)
+                EXPECT_EQ(requestView.find("Cookie: exists=1"_s), notFound);
+            else if (path == "http://site2.example/get-cookie"_s)
+                EXPECT_NE(requestView.find("Cookie: exists=1"_s), notFound);
+            else
+                EXPECT_WK_STREQ(@"SHOULD NOT BE REACH", path);
+            co_await connection.awaitableSend(HTTPResponse("<body></body>"_s).serialize());
+        }
+    }, HTTPServer::Protocol::Http };
+
+    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    [storeConfiguration setProxyConfiguration:@{
+        (NSString *)kCFStreamPropertyHTTPProxyHost: @"127.0.0.1",
+        (NSString *)kCFStreamPropertyHTTPProxyPort: @(httpServer.port()),
+    }];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    [configuration.get() setWebsiteDataStore:dataStore.get()];
+    [configuration.get() _setCORSDisablingPatterns:@[@"http://site1.example/*"]];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site1.example/set-cookie"]]];
+    [webView _test_waitForDidFinishNavigation];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site2.example/set-cookie"]]];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView loadHTMLString:@"<body>body</body>" baseURL:[NSURL URLWithString:@"http://site3.example"]];
+
+    __block bool doneEvaluatingJavaScript { false };
+    [webView evaluateJavaScript:@"fetch(\"http://site1.example/get-cookie\").then(() => alert(\"Fetched\")).catch(() => alert(\"Failed\")); true" completionHandler:^(id value, NSError *error) {
+        EXPECT_NULL(error);
+        EXPECT_WK_STREQ(error.description, @"");
+        doneEvaluatingJavaScript = true;
+    }];
+    Util::run(&doneEvaluatingJavaScript);
+    EXPECT_WK_STREQ([webView _test_waitForAlert], @"Failed");
+    doneEvaluatingJavaScript = false;
+
+    [webView evaluateJavaScript:@"fetch(\"http://site2.example/get-cookie\").then(() => alert(\"Fetched\")).catch(() => alert(\"Failed\")); true" completionHandler:^(id value, NSError *error) {
+        EXPECT_NULL(error);
+        EXPECT_WK_STREQ(error.description, @"");
+        doneEvaluatingJavaScript = true;
+    }];
+    Util::run(&doneEvaluatingJavaScript);
+    EXPECT_WK_STREQ([webView _test_waitForAlert], @"Fetched");
+    doneEvaluatingJavaScript = false;
+}


### PR DESCRIPTION
#### 930a87998c722414706d546c1f9dfc123fc62daa
<pre>
Mark request as same-site when we have a matching CORS-disabling pattern
<a href="https://bugs.webkit.org/show_bug.cgi?id=270830">https://bugs.webkit.org/show_bug.cgi?id=270830</a>
<a href="https://rdar.apple.com/123848604">rdar://123848604</a>

Reviewed by Alex Christensen.

Some requests can be considered as same-site, even if they aren&apos;t according to
the spec, just like we disble CORS for some requests that are cross-origin. We
can leverage the existing CORS-Disabling patterns to decide when a request
should be considered same-site.

Covered by a new API test.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::setOriginalURLForDownloadRequest):
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
(WebCore::FrameLoader::addSameSiteInfoToRequestIfNeeded):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/Page.h:
(WebCore::Page::shouldAssumeSameSiteForRequestTo const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/276015@main">https://commits.webkit.org/276015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9afcdb80106fcecd26667364f96aa7d367e8ea4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46122 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19936 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35969 "Failure limit exceed. At least found 1 new test failure: http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37466 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16932 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38527 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1543 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47666 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42739 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19940 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41421 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9683 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->