### PR TITLE
Avoid using downcast<>() in ElementData::attributesIterator()

### DIFF
--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -264,11 +264,11 @@ inline const ImmutableStyleProperties* ElementData::presentationalHintStyle() co
 
 inline AttributeIteratorAccessor ElementData::attributesIterator() const
 {
-    if (auto* uniqueData = dynamicDowncast<UniqueElementData>(*this)) {
-        auto& attributeVector = uniqueData->m_attributeVector;
+    if (isUnique()) {
+        auto& attributeVector = uncheckedDowncast<UniqueElementData>(*this).m_attributeVector;
         return AttributeIteratorAccessor(attributeVector.data(), attributeVector.size());
     }
-    return AttributeIteratorAccessor(downcast<ShareableElementData>(*this).m_attributeArray, arraySize());
+    return AttributeIteratorAccessor(uncheckedDowncast<ShareableElementData>(*this).m_attributeArray, arraySize());
 }
 
 ALWAYS_INLINE const Attribute* ElementData::findAttributeByName(const AtomString& name, bool shouldIgnoreAttributeCase) const


### PR DESCRIPTION
#### d7f01add50ebcfedd921f6f4d0ee721839f2dec0
<pre>
Avoid using downcast&lt;&gt;() in ElementData::attributesIterator()
<a href="https://bugs.webkit.org/show_bug.cgi?id=270834">https://bugs.webkit.org/show_bug.cgi?id=270834</a>

Reviewed by Ryosuke Niwa.

Avoid using downcast&lt;&gt;() in ElementData::attributesIterator(), for
performance reasons.

* Source/WebCore/dom/ElementData.h:
(WebCore::ElementData::attributesIterator const):

Canonical link: <a href="https://commits.webkit.org/275978@main">https://commits.webkit.org/275978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be055870d26f63b49a21fdedff60eebfe1773fa0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46032 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39523 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45701 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19845 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35874 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16850 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17031 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38446 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1453 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39591 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47576 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42657 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19848 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41319 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20027 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5905 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19479 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->