### PR TITLE
Remove Quirk when booking.com sends simple JPEG instead of JPEG2000 to WebKit on iOS

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3241,7 +3241,7 @@ void FrameLoader::updateRequestAndAddExtraFields(ResourceRequest& request, IsMai
     applyUserAgentIfNeeded(request);
 
     if (isMainResource)
-        request.setHTTPHeaderField(HTTPHeaderName::Accept, CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type::MainResource, request, protectedFrame().ptr()));
+        request.setHTTPHeaderField(HTTPHeaderName::Accept, CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type::MainResource));
 
     if (RefPtr document = m_frame->document(); document && frame().settings().privateTokenUsageByThirdPartyEnabled() && !frame().loader().client().isRemoteWorkerFrameLoaderClient())
         request.setIsPrivateTokenUsageByThirdPartyAllowed(isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::PrivateToken, *document, LogFeaturePolicyFailure::No));

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -910,7 +910,7 @@ void CachedResourceLoader::prepareFetch(CachedResource::Type type, CachedResourc
             request.setSelectedServiceWorkerRegistrationIdentifierIfNeeded(activeServiceWorker->registrationIdentifier());
     }
 
-    request.setAcceptHeaderIfNone(type, protectedFrame().get());
+    request.setAcceptHeaderIfNone(type);
 
     // Accept-Language value is handled in underlying port-specific code.
     // FIXME: Decide whether to support client hints

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -167,14 +167,10 @@ static String acceptHeaderValueForImageResource()
     return builder.toString();
 }
 
-String CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type type, ResourceRequest& request, LocalFrame* frame)
+String CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type type)
 {
-    auto url = request.url();
-
     switch (type) {
     case CachedResource::Type::MainResource:
-        if (Quirks::shouldSendLongerAcceptHeaderQuirk(url, frame))
-            return "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"_s;
         return "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"_s;
     case CachedResource::Type::ImageResource:
         return acceptHeaderValueForImageResource();
@@ -192,10 +188,10 @@ String CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type typ
     }
 }
 
-void CachedResourceRequest::setAcceptHeaderIfNone(CachedResource::Type type, LocalFrame* frame)
+void CachedResourceRequest::setAcceptHeaderIfNone(CachedResource::Type type)
 {
     if (!m_resourceRequest.hasHTTPHeader(HTTPHeaderName::Accept))
-        m_resourceRequest.setHTTPHeaderField(HTTPHeaderName::Accept, acceptHeaderValueFromType(type, m_resourceRequest, frame));
+        m_resourceRequest.setHTTPHeaderField(HTTPHeaderName::Accept, acceptHeaderValueFromType(type));
 }
 
 void CachedResourceRequest::disableCachingIfNeeded()

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -86,7 +86,7 @@ public:
     void updateReferrerAndOriginHeaders(FrameLoader&);
     void updateUserAgentHeader(FrameLoader&);
     void upgradeInsecureRequestIfNeeded(Document&, ContentSecurityPolicy::AlwaysUpgradeRequest = ContentSecurityPolicy::AlwaysUpgradeRequest::No);
-    void setAcceptHeaderIfNone(CachedResource::Type, LocalFrame*);
+    void setAcceptHeaderIfNone(CachedResource::Type);
     void updateAccordingCacheMode();
     void updateAcceptEncodingHeader();
     void updateCacheModeIfNeeded(CachePolicy);
@@ -113,7 +113,7 @@ public:
     void clearFragmentIdentifier() { m_fragmentIdentifier = { }; }
 
     static String splitFragmentIdentifierFromRequestURL(ResourceRequest&);
-    static String acceptHeaderValueFromType(CachedResource::Type, ResourceRequest&, LocalFrame*);
+    static String acceptHeaderValueFromType(CachedResource::Type);
 
     void setClientIdentifierIfNeeded(ScriptExecutionContextIdentifier);
     void setSelectedServiceWorkerRegistrationIdentifierIfNeeded(ServiceWorkerRegistrationIdentifier);

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1722,20 +1722,6 @@ bool Quirks::shouldDisableNavigatorStandaloneQuirk() const
     return false;
 }
 
-// booking.com https://webkit.org/b/269875
-// FIXME: booking.com https://webkit.org/b/269876 when outreach has been successful.
-bool Quirks::shouldSendLongerAcceptHeaderQuirk(const URL& url, LocalFrame* frame)
-{
-    if (frame && !frame->settings().needsSiteSpecificQuirks())
-        return false;
-
-    auto host = url.host();
-    if (host == "booking.com"_s || host.endsWith(".booking.com"_s))
-        return true;
-
-    return false;
-}
-
 // This section is dedicated to UA override for iPad. iPads (but iPad Mini) are sending a desktop user agent
 // to websites. In some cases, the website breaks in some ways, not expecting a touch interface for the website.
 // Controls not active or too small, form factor, etc. In this case it is better to send the iPad Mini UA.

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -84,7 +84,6 @@ public:
     bool shouldExposeShowModalDialog() const;
     bool shouldNavigatorPluginsBeEmpty() const;
     bool shouldDisableNavigatorStandaloneQuirk() const;
-    static bool shouldSendLongerAcceptHeaderQuirk(const URL&, LocalFrame*);
 
     WEBCORE_EXPORT bool shouldDispatchSyntheticMouseEventsWhenModifyingSelection() const;
     WEBCORE_EXPORT bool shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas() const;


### PR DESCRIPTION
#### 9374282dca203b624bed17ffc1fd178216c19e0a
<pre>
Remove Quirk when booking.com sends simple JPEG instead of JPEG2000 to WebKit on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=269876">https://bugs.webkit.org/show_bug.cgi?id=269876</a>
<a href="https://rdar.apple.com/123409087">rdar://123409087</a>

Reviewed by Chris Dumez.

Booking.com doesn&apos;t JPEG2 anymore to Safari since March 8, 2024.
The Quirk can be removed.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::prepareFetch):
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::CachedResourceRequest::acceptHeaderValueFromType):
(WebCore::CachedResourceRequest::setAcceptHeaderIfNone):
* Source/WebCore/loader/cache/CachedResourceRequest.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldSendLongerAcceptHeaderQuirk): Deleted.
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/276027@main">https://commits.webkit.org/276027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/542641c05ab41539feebe4afc8b6e295f0ee6cc9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22435 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46040 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39531 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35880 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16856 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38444 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1461 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39648 "Found 4 new API test failures: TestWebKitAPI.WebAuthenticationPanel.GetAssertionPinInvalidErrorAndRetry, TestWebKitAPI.WebAuthenticationPanel.GetAssertionPinAuthBlockedError, TestWebKitAPI.WebAuthenticationPanel.PanelTwice, TestWebKitAPI.WebAuthenticationPanel.GetAssertionInternalUV (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47584 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42667 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19856 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41331 "Passed tests") | 
| [💥 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9689 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Checked out pull request; Reviewed by Chris Dumez; Compiled WebKit (warnings)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20035 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5934 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->