### PR TITLE
[Skia] Implement PathSkia::applySegments()

### DIFF
--- a/Source/WebCore/platform/graphics/PathImpl.cpp
+++ b/Source/WebCore/platform/graphics/PathImpl.cpp
@@ -80,6 +80,33 @@ void PathImpl::addBeziersForRoundedRect(const FloatRoundedRect& roundedRect)
     add(PathCloseSubpath { });
 }
 
+void PathImpl::applySegments(const PathSegmentApplier& applier) const
+{
+    applyElements([&](const PathElement& pathElement) {
+        switch (pathElement.type) {
+        case PathElement::Type::MoveToPoint:
+            applier({ PathMoveTo { pathElement.points[0] } });
+            break;
+
+        case PathElement::Type::AddLineToPoint:
+            applier({ PathLineTo { pathElement.points[0] } });
+            break;
+
+        case PathElement::Type::AddQuadCurveToPoint:
+            applier({ PathQuadCurveTo { pathElement.points[0], pathElement.points[1] } });
+            break;
+
+        case PathElement::Type::AddCurveToPoint:
+            applier({ PathBezierCurveTo { pathElement.points[0], pathElement.points[1], pathElement.points[2] } });
+            break;
+
+        case PathElement::Type::CloseSubpath:
+            applier({ PathCloseSubpath { } });
+            break;
+        }
+    });
+}
+
 bool PathImpl::isClosed() const
 {
     bool lastElementIsClosed = false;

--- a/Source/WebCore/platform/graphics/PathImpl.h
+++ b/Source/WebCore/platform/graphics/PathImpl.h
@@ -67,7 +67,7 @@ public:
     void addLinesForRect(const FloatRect&);
     void addBeziersForRoundedRect(const FloatRoundedRect&);
 
-    virtual void applySegments(const PathSegmentApplier&) const = 0;
+    virtual void applySegments(const PathSegmentApplier&) const;
     virtual bool applyElements(const PathElementApplier&) const = 0;
 
     virtual bool transform(const AffineTransform&) = 0;

--- a/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.cpp
@@ -331,33 +331,6 @@ void PathCairo::addPath(const PathCairo& path, const AffineTransform& transform)
     m_elementsStream = nullptr;
 }
 
-void PathCairo::applySegments(const PathSegmentApplier& applier) const
-{
-    applyElements([&](const PathElement& pathElement) {
-        switch (pathElement.type) {
-        case PathElement::Type::MoveToPoint:
-            applier({ PathMoveTo { pathElement.points[0] } });
-            break;
-
-        case PathElement::Type::AddLineToPoint:
-            applier({ PathLineTo { pathElement.points[0] } });
-            break;
-
-        case PathElement::Type::AddQuadCurveToPoint:
-            applier({ PathQuadCurveTo { pathElement.points[0], pathElement.points[1] } });
-            break;
-
-        case PathElement::Type::AddCurveToPoint:
-            applier({ PathBezierCurveTo { pathElement.points[0], pathElement.points[1], pathElement.points[2] } });
-            break;
-
-        case PathElement::Type::CloseSubpath:
-            applier({ PathCloseSubpath { } });
-            break;
-        }
-    });
-}
-
 bool PathCairo::applyElements(const PathElementApplier& applier) const
 {
     if (m_elementsStream && m_elementsStream->applyElements(applier))

--- a/Source/WebCore/platform/graphics/cairo/PathCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/PathCairo.h
@@ -75,8 +75,6 @@ public:
     FloatRect strokeBoundingRect(const Function<void(GraphicsContext&)>& strokeStyleApplier) const;
 
 private:
-    void applySegments(const PathSegmentApplier&) const final;
-
     bool isEmpty() const final;
 
     FloatPoint currentPoint() const final;

--- a/Source/WebCore/platform/graphics/cg/PathCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/PathCG.cpp
@@ -314,39 +314,6 @@ void PathCG::addPath(const PathCG& path, const AffineTransform& transform)
     CGPathAddPath(ensureMutablePlatformPath(), &transformCG, pathCopy.get());
 }
 
-static void pathSegmentApplierCallback(void* info, const CGPathElement* element)
-{
-    const auto& applier = *(PathSegmentApplier*)info;
-    auto* cgPoints = element->points;
-
-    switch (element->type) {
-    case kCGPathElementMoveToPoint:
-        applier({ PathMoveTo { cgPoints[0] } });
-        break;
-
-    case kCGPathElementAddLineToPoint:
-        applier({ PathLineTo { cgPoints[0] } });
-        break;
-
-    case kCGPathElementAddQuadCurveToPoint:
-        applier({ PathQuadCurveTo { cgPoints[0], cgPoints[1] } });
-        break;
-
-    case kCGPathElementAddCurveToPoint:
-        applier({ PathBezierCurveTo { cgPoints[0], cgPoints[1], cgPoints[2] } });
-        break;
-
-    case kCGPathElementCloseSubpath:
-        applier({ PathCloseSubpath { } });
-        break;
-    }
-}
-
-void PathCG::applySegments(const PathSegmentApplier& applier) const
-{
-    CGPathApply(platformPath(), (void*)&applier, pathSegmentApplierCallback);
-}
-
 static void pathElementApplierCallback(void* info, const CGPathElement* element)
 {
     const auto& applier = *(PathElementApplier*)info;

--- a/Source/WebCore/platform/graphics/cg/PathCG.h
+++ b/Source/WebCore/platform/graphics/cg/PathCG.h
@@ -80,8 +80,6 @@ private:
 
     PlatformPathPtr ensureMutablePlatformPath();
 
-    void applySegments(const PathSegmentApplier&) const final;
-
     bool isEmpty() const final;
 
     FloatPoint currentPoint() const final;

--- a/Source/WebCore/platform/graphics/skia/PathSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PathSkia.cpp
@@ -185,11 +185,6 @@ void PathSkia::addPath(const PathSkia& path, const AffineTransform& transform)
     m_platformPath.addPath(*path.platformPath(), transform);
 }
 
-void PathSkia::applySegments(const PathSegmentApplier&) const
-{
-    notImplemented();
-}
-
 bool PathSkia::applyElements(const PathElementApplier& applier) const
 {
     auto convertPoints = [](FloatPoint dst[], const SkPoint src[], int count) {

--- a/Source/WebCore/platform/graphics/skia/PathSkia.h
+++ b/Source/WebCore/platform/graphics/skia/PathSkia.h
@@ -76,8 +76,6 @@ private:
     PathSkia() = default;
     explicit PathSkia(const SkPath&);
 
-    void applySegments(const PathSegmentApplier&) const final;
-
     bool isEmpty() const final;
 
     FloatPoint currentPoint() const final;


### PR DESCRIPTION
#### 27beb283af66084a09a6991dfefdc796dfad17da
<pre>
[Skia] Implement PathSkia::applySegments()
<a href="https://bugs.webkit.org/show_bug.cgi?id=270841">https://bugs.webkit.org/show_bug.cgi?id=270841</a>

Reviewed by Carlos Garcia Campos.

* Source/WebCore/platform/graphics/PathImpl.cpp:
(WebCore::PathImpl::applySegments const):
* Source/WebCore/platform/graphics/PathImpl.h:
* Source/WebCore/platform/graphics/cairo/PathCairo.cpp:
(WebCore::PathCairo::applySegments const): Deleted.
* Source/WebCore/platform/graphics/cairo/PathCairo.h:
* Source/WebCore/platform/graphics/cg/PathCG.cpp:
(WebCore::pathSegmentApplierCallback): Deleted.
(WebCore::PathCG::applySegments const): Deleted.
* Source/WebCore/platform/graphics/cg/PathCG.h:
* Source/WebCore/platform/graphics/skia/PathSkia.cpp:
(WebCore::PathSkia::applySegments const): Deleted.
* Source/WebCore/platform/graphics/skia/PathSkia.h:

Canonical link: <a href="https://commits.webkit.org/276394@main">https://commits.webkit.org/276394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/feaf397291c99da0af7d4215887b575c42050b83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40498 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36596 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38292 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17655 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39430 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2538 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40725 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48760 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43512 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20801 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42250 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9909 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21129 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20448 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->