### PR TITLE
Unreviewed, correct fast/forms/switch/no-pixels-outside-the-box fuzziness for Intel

### DIFF
--- a/LayoutTests/fast/forms/switch/no-pixels-outside-the-box-vertical-lr-rtl.html
+++ b/LayoutTests/fast/forms/switch/no-pixels-outside-the-box-vertical-lr-rtl.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html class="reftest-wait" dir=rtl>
-<meta name="fuzzy" content="maxDifference=0-33; totalPixels=0-626">
+<meta name="fuzzy" content="maxDifference=0-33; totalPixels=0-628">
 <style>
 body { zoom: 5; display: grid; writing-mode:vertical-lr }
 span { display: inline-block; background: white }

--- a/LayoutTests/fast/forms/switch/no-pixels-outside-the-box.html
+++ b/LayoutTests/fast/forms/switch/no-pixels-outside-the-box.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html class="reftest-wait">
-<meta name="fuzzy" content="maxDifference=0-33; totalPixels=0-626">
+<meta name="fuzzy" content="maxDifference=0-33; totalPixels=0-628">
 <style>
 body { zoom: 5; display: grid }
 span { display: inline-block; background: white }

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2008,7 +2008,3 @@ webkit.org/b/270235 [ Ventura+ Debug x86_64 ] webgl/pending/conformance/glsl/mis
 # webkit.org/b/266168 Two wheel/mousewheel passive event listeners WPT test pass on macOS Sonoma and up
 [ Sonoma+ ] imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-mousewheel-event-listener-on-div.html [ Pass ]
 [ Sonoma+ ] imported/w3c/web-platform-tests/dom/events/non-cancelable-when-passive/passive-wheel-event-listener-on-div.html [ Pass ]
-
-# webkit.org/b/270823 REGRESSION (275808@main): [ MacOS ] 2x fast/forms/switch/no-pixels-outside-the-box tests are constant failures 
-[ Sonoma+ x86_64 ] fast/forms/switch/no-pixels-outside-the-box-vertical-lr-rtl.html [ ImageOnlyFailure ]
-[ Sonoma+ x86_64 ] fast/forms/switch/no-pixels-outside-the-box.html [ ImageOnlyFailure ]


### PR DESCRIPTION
#### e0f90e9713f350d396dc0e5113af7dc71f81ca63
<pre>
Unreviewed, correct fast/forms/switch/no-pixels-outside-the-box fuzziness for Intel
<a href="https://bugs.webkit.org/show_bug.cgi?id=270823">https://bugs.webkit.org/show_bug.cgi?id=270823</a>
<a href="https://rdar.apple.com/124413482">rdar://124413482</a>

Unfortunately I did not learn last time around that on Intel there&apos;s
two additional pixels that differ.

* LayoutTests/fast/forms/switch/no-pixels-outside-the-box-vertical-lr-rtl.html:
* LayoutTests/fast/forms/switch/no-pixels-outside-the-box.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/275984@main">https://commits.webkit.org/275984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14101566b0ad9284229898f75c73afcfcf11066f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46055 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39546 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35893 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/43994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16870 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38461 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1476 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47599 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42677 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19872 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37690 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41341 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20052 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5909 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->