### PR TITLE
[Skia] Improve the way we decide when to use CPU or GPU

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -307,14 +307,15 @@ bool CanvasBase::shouldAccelerate(const IntSize& size) const
 
 bool CanvasBase::shouldAccelerate(uint64_t area) const
 {
-#if USE(IOSURFACE_CANVAS_BACKING_STORE)
+#if USE(IOSURFACE_CANVAS_BACKING_STORE) || USE(SKIA)
     if (!scriptExecutionContext()->settingsValues().canvasUsesAcceleratedDrawing)
         return false;
     if (area < scriptExecutionContext()->settingsValues().minimumAccelerated2DContextArea)
         return false;
-    return true;
-#elif USE(SKIA)
-    UNUSED_PARAM(area);
+#if PLATFORM(GTK)
+    if (!scriptExecutionContext()->settingsValues().acceleratedCompositingEnabled)
+        return false;
+#endif
     return true;
 #else
     UNUSED_PARAM(area);

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -349,7 +349,7 @@ CanvasRenderingContext2D* HTMLCanvasElement::createContext2d(const String& type,
 
     m_context = CanvasRenderingContext2D::create(*this, WTFMove(settings), document().inQuirksMode());
 
-#if USE(IOSURFACE_CANVAS_BACKING_STORE)
+#if USE(IOSURFACE_CANVAS_BACKING_STORE) || USE(SKIA)
     // Need to make sure a RenderLayer and compositing layer get created for the Canvas.
     invalidateStyleAndLayerComposition();
 #endif
@@ -485,7 +485,7 @@ ImageBitmapRenderingContext* HTMLCanvasElement::createContextBitmapRenderer(cons
     m_context = WTFMove(context);
     weakContext->transferFromImageBitmap(nullptr);
 
-#if USE(IOSURFACE_CANVAS_BACKING_STORE)
+#if USE(IOSURFACE_CANVAS_BACKING_STORE) || USE(SKIA)
     // Need to make sure a RenderLayer and compositing layer get created for the Canvas.
     invalidateStyleAndLayerComposition();
 #endif
@@ -616,7 +616,7 @@ void HTMLCanvasElement::reset()
 bool HTMLCanvasElement::paintsIntoCanvasBuffer() const
 {
     ASSERT(m_context);
-#if USE(IOSURFACE_CANVAS_BACKING_STORE)
+#if USE(IOSURFACE_CANVAS_BACKING_STORE) || USE(SKIA)
     if (m_context->is2d() || m_context->isBitmapRenderer())
         return true;
 #endif
@@ -875,7 +875,7 @@ void HTMLCanvasElement::createImageBuffer() const
     m_didClearImageBuffer = true;
     setImageBuffer(allocateImageBuffer());
 
-#if USE(IOSURFACE_CANVAS_BACKING_STORE)
+#if USE(IOSURFACE_CANVAS_BACKING_STORE) || USE(SKIA)
     if (m_context && m_context->is2d()) {
         // Recalculate compositing requirements if acceleration state changed.
         const_cast<HTMLCanvasElement*>(this)->invalidateStyleAndLayerComposition();

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -252,7 +252,7 @@ CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase()
 
 bool CanvasRenderingContext2DBase::isAccelerated() const
 {
-#if USE(IOSURFACE_CANVAS_BACKING_STORE)
+#if USE(IOSURFACE_CANVAS_BACKING_STORE) || USE(SKIA)
     auto* context = canvasBase().existingDrawingContext();
     return context && context->renderingMode() == RenderingMode::Accelerated;
 #else

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -305,6 +305,7 @@ MinimumAccelerated2DContextArea:
   type: uint64_t
   defaultValue:
     WebCore:
+      USE(SKIA): 128 * 129
       default: 0
 
 NeedsDeferKeyDownAndKeyPressTimersUntilNextEditingCommandQuirk:

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -85,14 +85,9 @@ RefPtr<ImageBuffer> ImageBuffer::create(const FloatSize& size, RenderingPurpose 
 #endif
 
 #if USE(SKIA)
-    static const char* enableCPURendering = getenv("WEBKIT_SKIA_ENABLE_CPU_RENDERING");
-    if (!enableCPURendering || !strcmp(enableCPURendering, "0")) {
-        static const char* disableAccelerated2DCanvas = getenv("WEBKIT_DISABLE_ACCELERATED_2D_CANVAS");
-        if (!disableAccelerated2DCanvas || !strcmp(disableAccelerated2DCanvas, "0")) {
-            // FIXME: check options.contains(ImageBufferOptions::Accelerated) too.
-            if (auto imageBuffer = ImageBuffer::create<ImageBufferSkiaAcceleratedBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, { }))
-                return imageBuffer;
-        }
+    if (options.contains(ImageBufferOptions::Accelerated)) {
+        if (auto imageBuffer = ImageBuffer::create<ImageBufferSkiaAcceleratedBackend>(size, resolutionScale, colorSpace, pixelFormat, purpose, { }))
+            return imageBuffer;
     }
 #endif
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -56,6 +56,9 @@ std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBac
     RELEASE_ASSERT(grContext);
     auto imageInfo = SkImageInfo::MakeN32Premul(backendSize.width(), backendSize.height());
     auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, nullptr);
+    if (!surface)
+        return nullptr;
+
     return std::unique_ptr<ImageBufferSkiaAcceleratedBackend>(new ImageBufferSkiaAcceleratedBackend(parameters, WTFMove(surface)));
 }
 

--- a/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.h
@@ -41,7 +41,7 @@ public:
     SkiaAcceleratedBufferPool();
     ~SkiaAcceleratedBufferPool();
 
-    Ref<Nicosia::Buffer> acquireBuffer(const IntSize&, bool supportsAlpha);
+    RefPtr<Nicosia::Buffer> acquireBuffer(const IntSize&, bool supportsAlpha);
 
 private:
     struct Entry {
@@ -57,7 +57,7 @@ private:
         MonotonicTime m_lastUsedTime;
     };
 
-    Ref<Nicosia::Buffer> createAcceleratedBuffer(const IntSize&, bool supportsAlpha);
+    RefPtr<Nicosia::Buffer> createAcceleratedBuffer(const IntSize&, bool supportsAlpha);
     void scheduleReleaseUnusedBuffers();
 
     void releaseUnusedBuffersTimerFired();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp
@@ -77,9 +77,10 @@ Ref<Nicosia::Buffer> CoordinatedGraphicsLayer::paintTile(const IntRect& tileRect
     // Skia/GPU - accelerated rendering.
     if (auto* acceleratedBufferPool = m_coordinator->skiaAcceleratedBufferPool()) {
         PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent();
-        auto buffer = acceleratedBufferPool->acquireBuffer(tileRect.size(), !contentsOpaque());
-        paintBuffer(buffer.get());
-        return buffer;
+        if (auto buffer = acceleratedBufferPool->acquireBuffer(tileRect.size(), !contentsOpaque())) {
+            paintBuffer(*buffer);
+            return Ref { *buffer };
+        }
     }
 
     // Skia/CPU - unaccelerated rendering.

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -258,6 +258,7 @@ UIProcess/soup/WebProcessPoolSoup.cpp
 UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
 UIProcess/wpe/ScreenManagerWPE.cpp
 UIProcess/wpe/WebPageProxyWPE.cpp
+UIProcess/wpe/WebPreferencesWPE.cpp
 
 WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
 

--- a/Source/WebKit/UIProcess/WebPreferences.cpp
+++ b/Source/WebKit/UIProcess/WebPreferences.cpp
@@ -239,7 +239,7 @@ void WebPreferences::registerDefaultUInt32ValueForKey(const String& key, uint32_
         m_store.setUInt32ValueForKey(key, userValue);
 }
 
-#if !PLATFORM(COCOA) && !PLATFORM(GTK)
+#if !PLATFORM(COCOA) && !PLATFORM(GTK) && !PLATFORM(WPE)
 void WebPreferences::platformInitializeStore()
 {
     notImplemented();

--- a/Source/WebKit/UIProcess/wpe/WebPreferencesWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPreferencesWPE.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
- * Portions Copyright (c) 2010 Motorola Mobility, Inc.  All rights reserved.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,26 +26,10 @@
 #include "config.h"
 #include "WebPreferences.h"
 
-#include "HardwareAccelerationManager.h"
-#include <WebCore/NotImplemented.h>
-
 namespace WebKit {
 
 void WebPreferences::platformInitializeStore()
 {
-    struct {
-        bool acceleratedCompositingEnabled { true };
-        bool forceCompositingMode { false };
-    } compositingState;
-
-    if (!HardwareAccelerationManager::singleton().canUseHardwareAcceleration())
-        compositingState = { false, false };
-    else if (HardwareAccelerationManager::singleton().forceHardwareAcceleration())
-        compositingState = { true, true };
-
-    setAcceleratedCompositingEnabled(compositingState.acceleratedCompositingEnabled);
-    setForceCompositingMode(compositingState.forceCompositingMode);
-    setThreadedScrollingEnabled(compositingState.forceCompositingMode);
 #if USE(SKIA)
     // FIXME: Expose this as a setting when we switch to Skia.
     static const char* disableAccelerated2DCanvas = getenv("WEBKIT_DISABLE_ACCELERATED_2D_CANVAS");


### PR DESCRIPTION
#### 071a8e4ca7a56a134f7c3573e76e00b392515861
<pre>
[Skia] Improve the way we decide when to use CPU or GPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=270083">https://bugs.webkit.org/show_bug.cgi?id=270083</a>

Reviewed by Adrian Perez de Castro.

We normally assume we always want hardware acceleration for rendering
with Skia, but there are several situations in which we need to use the
CPU:

 - If we fail to create the GL context.
 - If we fail to create the SkSurface (for example because the size
   is bigger than the maximum render target size allowed).
 - When accelerated compositing is disabled.
 - When accelerated 2D canvas is disabled.
 - When CPU rendering is disabled.
 - When the canvas is too small (we use 128 * 129 to match chromium).

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::shouldAccelerate const):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createContext2d):
(WebCore::HTMLCanvasElement::createContextBitmapRenderer):
(WebCore::HTMLCanvasElement::paintsIntoCanvasBuffer const):
(WebCore::HTMLCanvasElement::createImageBuffer const):
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::bufferRenderingMode):
(WebCore::ImageBitmap::create):
(WebCore::ImageBitmap::createImageBuffer):
(WebCore::ImageBitmap::createBlankImageBuffer):
(WebCore::ImageBitmap::createCompletionHandler):
(WebCore::ImageBitmap::createFromBuffer):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::isAccelerated const):
* Source/WebCore/page/Settings.yaml:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::create):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::create):
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
(WebCore::PlatformDisplay::skiaGLContext):
* Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp:
(WebCore::SkiaAcceleratedBufferPool::acquireBuffer):
(WebCore::SkiaAcceleratedBufferPool::createAcceleratedBuffer):
* Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp:
(WebCore::CoordinatedGraphicsLayer::paintTile):
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/UIProcess/WebPreferences.cpp:
* Source/WebKit/UIProcess/gtk/WebPreferencesGtk.cpp:
(WebKit::WebPreferences::platformInitializeStore):
* Source/WebKit/UIProcess/wpe/WebPreferencesWPE.cpp: Copied from Source/WebKit/UIProcess/gtk/WebPreferencesGtk.cpp.
(WebKit::WebPreferences::platformInitializeStore):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::CompositingCoordinator):
(WebKit::skiaForceUseCpuRendering): Deleted.

Canonical link: <a href="https://commits.webkit.org/276016@main">https://commits.webkit.org/276016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1b53dc9ca784904c0790124b22d01fb6cbb5b93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46064 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45733 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35901 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37411 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16878 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38474 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1485 "Built successfully") | 
| | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39670 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 51 api tests failed or timed out; 59 api tests failed or timed out; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47608 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42692 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19881 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41357 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20061 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5925 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19512 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->