### PR TITLE
[WPE] Fix text highlight on HTTP RWI running on Chromium

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
@@ -274,7 +274,7 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-with
 }
 
 .highlight .selection-area {
-    animation: "dom-tree-outline-highlight-fadeout" 2s;
+    animation: dom-tree-outline-highlight-fadeout 2s;
 }
 
 .tree-outline.dom li .highlight {

--- a/Source/WebInspectorUI/UserInterface/Views/TextEditor.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TextEditor.css
@@ -124,7 +124,7 @@
 }
 
 .text-editor > .CodeMirror .highlighted {
-    animation: "text-editor-highlight-fadeout" 2s;
+    animation: text-editor-highlight-fadeout 2s;
 }
 
 @keyframes text-editor-highlight-fadeout {
@@ -132,7 +132,7 @@
 }
 
 .text-editor > .CodeMirror .hovered-expression-highlight {
-    animation: "text-editor-hovered-expression-highlight-fadeout" 2s;
+    animation: text-editor-hovered-expression-highlight-fadeout 2s;
     background-color: hsla(0, 0%, 0%, 0.1);
 }
 


### PR DESCRIPTION
#### d1ce25eca8a320cae095a34eb9c64050f4a45e2a
<pre>
[WPE] Fix text highlight on HTTP RWI running on Chromium
<a href="https://bugs.webkit.org/show_bug.cgi?id=270849">https://bugs.webkit.org/show_bug.cgi?id=270849</a>

Reviewed by Tim Nguyen.

Remove the quotes around the CSS animation name in the relevant definitions,
as they should not be there.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css:
(.highlight .selection-area):
* Source/WebInspectorUI/UserInterface/Views/TextEditor.css:
(.text-editor &gt; .CodeMirror .highlighted):
(.text-editor &gt; .CodeMirror .hovered-expression-highlight):

Canonical link: <a href="https://commits.webkit.org/276081@main">https://commits.webkit.org/276081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b8afa747d4b598af678e03b08b257d574a86bcb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46074 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39565 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35912 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37418 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16888 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17070 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38481 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1495 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39625 "Found 3 new API test failures: TestWebKitAPI.WebAuthenticationPanel.NoPanelHidSuccess, TestWebKitAPI.WebAuthenticationPanel.PanelHidSuccess2, TestWebKitAPI.WebAuthenticationPanel.NullPanelHidSuccess (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47618 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42697 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19891 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41362 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9720 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->