### PR TITLE
REGRESSION(275922@main) fast/css/cssom-mutation-stylerule.html is a constant crash

### DIFF
--- a/Source/WebCore/css/parser/CSSParserImpl.h
+++ b/Source/WebCore/css/parser/CSSParserImpl.h
@@ -178,7 +178,10 @@ private:
 
     static Vector<double> consumeKeyframeKeyList(CSSParserTokenRange);
 
-    RefPtr<StyleSheetContents> protectedStyleSheet() const;
+    RefPtr<StyleSheetContents> protectedStyleSheet() const
+    {
+        return m_styleSheet;
+    }
 
     Ref<StyleRuleBase> createNestingParentRule();
     void runInNewNestingContext(auto&& run);


### PR DESCRIPTION
#### adcdfbcd7aafd263053e181a5d18a4242181c551
<pre>
REGRESSION(275922@main) fast/css/cssom-mutation-stylerule.html is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=270851">https://bugs.webkit.org/show_bug.cgi?id=270851</a>

Reviewed by NOBODY (OOPS!).

`CSSParserImpl::m_styleSheet` is nullable. We must always check that
it&apos;s not null before dereferencing it.

* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeNestedGroupRules):
(WebCore::CSSParserImpl::consumeScopeRule):
(WebCore::CSSParserImpl::consumeStyleRule):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adcdfbcd7aafd263053e181a5d18a4242181c551

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46089 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39580 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35925 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16901 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17090 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38496 "Found 1 new test failure: imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1510 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47633 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18483 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42709 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19906 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41375 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->