### PR TITLE
Remove WebVTTRubyElement and WebVTTRubyTextElement

### DIFF
--- a/LayoutTests/media/track/webvtt-ruby-expected.txt
+++ b/LayoutTests/media/track/webvtt-ruby-expected.txt
@@ -6,7 +6,7 @@ RUN(video.textTracks[0].mode = 'showing')
 RUN(video.currentTime = 1)
 EVENT(seeked)
 EXPECTED (window.internals.shadowRoot(video).querySelector('rt') != 'null') OK
-EXPECTED (rubyText.offsetTop < rubyBase.offsetTop == 'true') OK
-EXPECTED (rubyBase.offsetTop == (rubyText.offsetTop + rubyText.offsetHeight) == 'true') OK
+EXPECTED (rubyText.getBoundingClientRect().top < rubyBase.getBoundingClientRect().top == 'true') OK
+EXPECTED (rubyBase.getBoundingClientRect().top == rubyText.getBoundingClientRect().bottom == 'true') OK
 END OF TEST
 

--- a/LayoutTests/media/track/webvtt-ruby.html
+++ b/LayoutTests/media/track/webvtt-ruby.html
@@ -26,8 +26,8 @@
                 await testExpectedEventually("window.internals.shadowRoot(video).querySelector('rt')", null, "!=", 1000);
                 rubyBase = window.internals.shadowRoot(video).querySelector('ruby');
                 rubyText = window.internals.shadowRoot(video).querySelector('rt');
-                await testExpected("rubyText.offsetTop < rubyBase.offsetTop", true);
-                await testExpected("rubyBase.offsetTop == (rubyText.offsetTop + rubyText.offsetHeight)", true);
+                testExpected("rubyText.getBoundingClientRect().top < rubyBase.getBoundingClientRect().top", true);
+                testExpected("rubyBase.getBoundingClientRect().top == rubyText.getBoundingClientRect().bottom", true);
                 endTest();
             }
         </script>

--- a/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
@@ -98,3 +98,11 @@ video[controls]::-webkit-media-text-track-container.visible-controls-bar {
 [useragentpart="-webkit-media-text-track-display"] u { text-decoration: underline; }
 [useragentpart="-webkit-media-text-track-display"] i { font-style: italic; }
 [useragentpart="-webkit-media-text-track-display"] .hidden { display: none; }
+[useragentpart="-webkit-media-text-track-display"] ruby { display: ruby; }
+[useragentpart="-webkit-media-text-track-display"] ruby > rt {
+    display: ruby-text;
+    font-size: -webkit-ruby-text;
+    text-align: start;
+    line-height: normal;
+}
+[useragentpart="-webkit-media-text-track-display"] ruby > :not(ruby) { white-space: nowrap; }

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -207,10 +207,6 @@ ALWAYS_INLINE bool matchesLangPseudoClass(const Element& element, const FixedVec
 #if ENABLE(VIDEO)
     if (auto* vttElement = dynamicDowncast<WebVTTElement>(element))
         language = vttElement->language();
-    else if (auto* ruby = dynamicDowncast<WebVTTRubyElement>(element))
-        language = ruby->language();
-    else if (auto* rubyText = dynamicDowncast<WebVTTRubyTextElement>(element))
-        language = rubyText->language();
     else
 #endif
         language = element.effectiveLang();
@@ -458,10 +454,6 @@ ALWAYS_INLINE bool matchesFutureCuePseudoClass(const Element& element)
 {
     if (auto* webVTTElement = dynamicDowncast<WebVTTElement>(element))
         return !webVTTElement->isPastNode();
-    if (auto* webVTTRubyElement = dynamicDowncast<WebVTTRubyElement>(element))
-        return !webVTTRubyElement->isPastNode();
-    if (auto* webVTTRubyTextElement = dynamicDowncast<WebVTTRubyTextElement>(element))
-        return !webVTTRubyTextElement->isPastNode();
     return false;
 }
 
@@ -469,10 +461,6 @@ ALWAYS_INLINE bool matchesPastCuePseudoClass(const Element& element)
 {
     if (auto* vttElement = dynamicDowncast<WebVTTElement>(element))
         return vttElement->isPastNode();
-    if (auto* ruby = dynamicDowncast<WebVTTRubyElement>(element))
-        return ruby->isPastNode();
-    if (auto* rubyText = dynamicDowncast<WebVTTRubyTextElement>(element))
-        return rubyText->isPastNode();
     return false;
 }
 

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1362,7 +1362,7 @@ area:any-link {
 }
 
 /* HTML5 ruby elements */
-
+/* Note that text-tracks.css contains a subset of this ruby styling for WebVTT elements. It should be kept in sync. */
 ruby {
     display: ruby;
 }

--- a/Source/WebCore/css/mediaControls.css
+++ b/Source/WebCore/css/mediaControls.css
@@ -277,5 +277,13 @@ video::cue(:future) {
 [useragentpart="-webkit-media-text-track-display"] u { text-decoration: underline; }
 [useragentpart="-webkit-media-text-track-display"] i { font-style: italic; }
 [useragentpart="-webkit-media-text-track-display"] .hidden { display: none; }
+[useragentpart="-webkit-media-text-track-display"] ruby { display: ruby; }
+[useragentpart="-webkit-media-text-track-display"] ruby > rt {
+    display: ruby-text;
+    font-size: -webkit-ruby-text;
+    text-align: start;
+    line-height: normal;
+}
+[useragentpart="-webkit-media-text-track-display"] ruby > :not(ruby) { white-space: nowrap; }
 
 #endif

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -238,8 +238,6 @@ public:
 
 #if ENABLE(VIDEO)
     virtual bool isWebVTTElement() const { return false; }
-    virtual bool isWebVTTRubyElement() const { return false; }
-    virtual bool isWebVTTRubyTextElement() const { return false; }
 #endif
     bool isStyledElement() const { return hasTypeFlag(TypeFlag::IsHTMLElement) || hasTypeFlag(TypeFlag::IsSVGElement) || hasTypeFlag(TypeFlag::IsMathMLElement); }
     virtual bool isAttributeNode() const { return false; }

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -1008,10 +1008,6 @@ void VTTCue::markFutureAndPastNodes(ContainerNode* root, const MediaTime& previo
         
         if (auto* childElement = dynamicDowncast<WebVTTElement>(*child))
             childElement->setIsPastNode(isPastNode);
-        else if (auto* childElement = dynamicDowncast<WebVTTRubyElement>(*child))
-            childElement->setIsPastNode(isPastNode);
-        else if (auto* childElement = dynamicDowncast<WebVTTRubyTextElement>(*child))
-            childElement->setIsPastNode(isPastNode);
 
         // Make an element id match a cue id for style matching purposes.
         if (auto* childElement = dynamicDowncast<Element>(*child); !id().isEmpty() && childElement)

--- a/Source/WebCore/html/track/WebVTTElement.cpp
+++ b/Source/WebCore/html/track/WebVTTElement.cpp
@@ -39,8 +39,6 @@
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(WebVTTElement);
-WTF_MAKE_ISO_ALLOCATED_IMPL(WebVTTRubyElement);
-WTF_MAKE_ISO_ALLOCATED_IMPL(WebVTTRubyTextElement);
 
 static const QualifiedName& nodeTypeToTagName(WebVTTNodeType nodeType)
 {
@@ -77,36 +75,23 @@ static const QualifiedName& nodeTypeToTagName(WebVTTNodeType nodeType)
 }
 
 WebVTTElement::WebVTTElement(WebVTTNodeType nodeType, AtomString language, Document& document)
-    : WebVTTElementImpl(nodeType, language)
-    , Element(nodeTypeToTagName(nodeType), document, { })
+    : Element(nodeTypeToTagName(nodeType), document, { })
+    , m_webVTTNodeType(nodeType)
+    , m_language(language)
 {
 }
 
-Ref<Element> WebVTTElementImpl::create(WebVTTNodeType nodeType, AtomString language, Document& document)
+Ref<Element> WebVTTElement::create(WebVTTNodeType nodeType, AtomString language, Document& document)
 {
-    switch (nodeType) {
-    default:
-    case WebVTTNodeTypeNone:
-    case WebVTTNodeTypeClass:
-    case WebVTTNodeTypeItalic:
-    case WebVTTNodeTypeLanguage:
-    case WebVTTNodeTypeBold:
-    case WebVTTNodeTypeUnderline:
-    case WebVTTNodeTypeVoice:
-        return adoptRef(*new WebVTTElement(nodeType, language, document));
-    case WebVTTNodeTypeRuby:
-        return adoptRef(*new WebVTTRubyElement(language, document));
-    case WebVTTNodeTypeRubyText:
-        return adoptRef(*new WebVTTRubyTextElement(language, document));
-    }
+    return adoptRef(*new WebVTTElement(nodeType, language, document));
 }
 
-Ref<Element> WebVTTElementImpl::cloneElementWithoutAttributesAndChildren(Document& targetDocument)
+Ref<Element> WebVTTElement::cloneElementWithoutAttributesAndChildren(Document& targetDocument)
 {
-    return create(static_cast<WebVTTNodeType>(m_webVTTNodeType), m_language, targetDocument);
+    return create(m_webVTTNodeType, m_language, targetDocument);
 }
 
-Ref<HTMLElement> WebVTTElementImpl::createEquivalentHTMLElement(Document& document)
+Ref<HTMLElement> WebVTTElement::createEquivalentHTMLElement(Document& document)
 {
     RefPtr<HTMLElement> htmlElement;
 
@@ -115,8 +100,8 @@ Ref<HTMLElement> WebVTTElementImpl::createEquivalentHTMLElement(Document& docume
     case WebVTTNodeTypeLanguage:
     case WebVTTNodeTypeVoice:
         htmlElement = HTMLSpanElement::create(document);
-        htmlElement->setAttributeWithoutSynchronization(HTMLNames::titleAttr, toElement().attributeWithoutSynchronization(voiceAttributeName()));
-        htmlElement->setAttributeWithoutSynchronization(HTMLNames::langAttr, toElement().attributeWithoutSynchronization(langAttributeName()));
+        htmlElement->setAttributeWithoutSynchronization(HTMLNames::titleAttr, attributeWithoutSynchronization(voiceAttributeName()));
+        htmlElement->setAttributeWithoutSynchronization(HTMLNames::langAttr, attributeWithoutSynchronization(langAttributeName()));
         break;
     case WebVTTNodeTypeItalic:
         htmlElement = HTMLElement::create(HTMLNames::iTag, document);
@@ -133,11 +118,14 @@ Ref<HTMLElement> WebVTTElementImpl::createEquivalentHTMLElement(Document& docume
     case WebVTTNodeTypeRubyText:
         htmlElement = RubyTextElement::create(document);
         break;
+    case WebVTTNodeTypeNone:
+        ASSERT_NOT_REACHED();
+        break;
     }
 
     ASSERT(htmlElement);
     if (htmlElement)
-        htmlElement->setAttributeWithoutSynchronization(HTMLNames::classAttr, toElement().attributeWithoutSynchronization(HTMLNames::classAttr));
+        htmlElement->setAttributeWithoutSynchronization(HTMLNames::classAttr, attributeWithoutSynchronization(HTMLNames::classAttr));
     return htmlElement.releaseNonNull();
 }
 

--- a/Source/WebCore/html/track/WebVTTElement.h
+++ b/Source/WebCore/html/track/WebVTTElement.h
@@ -46,17 +46,16 @@ enum WebVTTNodeType {
     WebVTTNodeTypeVoice
 };
 
-class WebVTTElement;
-
-class WebVTTElementImpl {
+class WebVTTElement final : public Element {
+    WTF_MAKE_ISO_ALLOCATED(WebVTTElement);
 public:
     static Ref<Element> create(const WebVTTNodeType, AtomString language, Document&);
     Ref<HTMLElement> createEquivalentHTMLElement(Document&);
 
     Ref<Element> cloneElementWithoutAttributesAndChildren(Document&);
 
-    void setWebVTTNodeType(WebVTTNodeType type) { m_webVTTNodeType = static_cast<unsigned>(type); }
-    WebVTTNodeType webVTTNodeType() const { return static_cast<WebVTTNodeType>(m_webVTTNodeType); }
+    void setWebVTTNodeType(WebVTTNodeType type) { m_webVTTNodeType = type; }
+    WebVTTNodeType webVTTNodeType() const { return m_webVTTNodeType; }
 
     bool isPastNode() const { return m_isPastNode; }
     void setIsPastNode(bool value) { m_isPastNode = value; }
@@ -77,81 +76,19 @@ public:
     }
 
 protected:
-    WebVTTElementImpl(WebVTTNodeType nodeType, AtomString language)
-        : m_isPastNode { false }
-        , m_webVTTNodeType { static_cast<unsigned>(nodeType) }
-        , m_language { language }
-    {
-    }
-    virtual ~WebVTTElementImpl() = default;
-    virtual Element& toElement() = 0;
-
-    unsigned m_isPastNode : 1;
-    unsigned m_webVTTNodeType : 4;
-
-    AtomString m_language;
-};
-
-class WebVTTElement final : public WebVTTElementImpl, public Element {
-    WTF_MAKE_ISO_ALLOCATED(WebVTTElement);
-public:
-    Ref<Element> cloneElementWithoutAttributesAndChildren(Document& document) final { return WebVTTElementImpl::cloneElementWithoutAttributesAndChildren(document); }
-
-private:
-    friend class WebVTTElementImpl;
     WebVTTElement(WebVTTNodeType, AtomString language, Document&);
 
     bool isWebVTTElement() const final { return true; }
-    Element& toElement() final { return *this; }
+
+    bool m_isPastNode { false };
+    WebVTTNodeType m_webVTTNodeType;
+    AtomString m_language;
 };
-
-class WebVTTRubyElement final : public WebVTTElementImpl, public RubyElement {
-    WTF_MAKE_ISO_ALLOCATED(WebVTTRubyElement);
-public:
-    Ref<Element> cloneElementWithoutAttributesAndChildren(Document& document) final { return WebVTTElementImpl::cloneElementWithoutAttributesAndChildren(document); }
-
-private:
-    friend class WebVTTElementImpl;
-    WebVTTRubyElement(AtomString language, Document& document)
-        : WebVTTElementImpl(WebVTTNodeTypeRuby, language)
-        , RubyElement(HTMLNames::rubyTag, document)
-    {
-    }
-
-    bool isWebVTTRubyElement() const final { return true; }
-    Element& toElement() final { return *this; }
-};
-
-class WebVTTRubyTextElement final : public WebVTTElementImpl, public RubyTextElement {
-    WTF_MAKE_ISO_ALLOCATED(WebVTTRubyTextElement);
-public:
-    Ref<Element> cloneElementWithoutAttributesAndChildren(Document& document) final { return WebVTTElementImpl::cloneElementWithoutAttributesAndChildren(document); }
-
-private:
-    friend class WebVTTElementImpl;
-    WebVTTRubyTextElement(AtomString language, Document& document)
-        : WebVTTElementImpl(WebVTTNodeTypeRubyText, language)
-        , RubyTextElement(HTMLNames::rtTag, document)
-    {
-    }
-
-    bool isWebVTTRubyTextElement() const final { return true; }
-    Element& toElement() final { return *this; }
-};
-
 
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebVTTElement)
     static bool isType(const WebCore::Node& node) { return node.isWebVTTElement(); }
-SPECIALIZE_TYPE_TRAITS_END()
-
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebVTTRubyElement)
-    static bool isType(const WebCore::Node& node) { return node.isWebVTTRubyElement(); }
-SPECIALIZE_TYPE_TRAITS_END()
-
-SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebVTTRubyTextElement)
-    static bool isType(const WebCore::Node& node) { return node.isWebVTTRubyTextElement(); }
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -703,7 +703,7 @@ void WebVTTTreeBuilder::constructTreeFromToken(Document& document)
             break;
 
         auto language = !m_languageStack.isEmpty() ? m_languageStack.last() : emptyAtom();
-        auto child = WebVTTElementImpl::create(nodeType, language, document);
+        auto child = WebVTTElement::create(nodeType, language, document);
         if (!m_token.classes().isEmpty())
             child->setAttributeWithoutSynchronization(classAttr, m_token.classes());
 

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -400,8 +400,7 @@ void ElementRuleCollector::collectMatchingUserAgentPartRules(const MatchRequest&
 
     auto& rules = matchRequest.ruleSet;
 #if ENABLE(VIDEO)
-    // FXIME: WebVTT should not be done by styling UA shadow trees like this.
-    if (element().isWebVTTElement() || element().isWebVTTRubyElement() || element().isWebVTTRubyTextElement())
+    if (element().isWebVTTElement())
         collectMatchingRulesForList(&rules.cuePseudoRules(), matchRequest);
 #endif
     if (auto& part = element().userAgentPart(); !part.isEmpty())

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -387,9 +387,10 @@ static bool hasUnsupportedRubyDisplay(DisplayType display, const Element* elemen
     switch (display) {
     case DisplayType::Ruby:
     case DisplayType::RubyBlock:
-        return !element || !element->hasTagName(rubyTag);
+        // Test for localName so this also allows WebVTT ruby elements.
+        return !element || !element->hasLocalName(rubyTag->localName());
     case DisplayType::RubyAnnotation:
-        return !element || !element->hasTagName(rtTag);
+        return !element || !element->hasLocalName(rtTag->localName());
     case DisplayType::RubyBase:
         ASSERT_NOT_REACHED();
         return false;


### PR DESCRIPTION
#### 99e7a283e2ed8bda5d0455d2cabb581ee66cf3d9
<pre>
Remove WebVTTRubyElement and WebVTTRubyTextElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=270852">https://bugs.webkit.org/show_bug.cgi?id=270852</a>
<a href="https://rdar.apple.com/problem/124449628">rdar://problem/124449628</a>

Reviewed by Alan Baradlay.

WebVTT tree is implemented using an Element subclass, except for ruby elements. For those there
were special subclasses inheriting from RubyElement and RubyTextElement. These are no longer needed
since ruby is now CSS based. We can style WebVTT ruby elements similarly to other WebVTT elements.

* LayoutTests/media/track/webvtt-ruby-expected.txt:
* LayoutTests/media/track/webvtt-ruby.html:

Turns our offsetFoo functions are only available on HTMLElement. Since all WebVTT elements now inherit from plain Element
we can no longer use it to inspect the internal state. Use more universal getBoundingClientRect() instead.

* Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css:
([useragentpart=&quot;-webkit-media-text-track-display&quot;] ruby):
([useragentpart=&quot;-webkit-media-text-track-display&quot;] ruby &gt; rt):
([useragentpart=&quot;-webkit-media-text-track-display&quot;] ruby &gt; :not(ruby)):

Add a relevant subset of ruby rules to the text-track stylesheet, similar to other WebVTT elements.
The rules on html.css don&apos;t match since these elements are not in HTML namespace.

* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesLangPseudoClass):
(WebCore::matchesFutureCuePseudoClass):
(WebCore::matchesPastCuePseudoClass):
* Source/WebCore/css/mediaControls.css:
([useragentpart=&quot;-webkit-media-text-track-display&quot;] ruby):
([useragentpart=&quot;-webkit-media-text-track-display&quot;] ruby &gt; rt):
([useragentpart=&quot;-webkit-media-text-track-display&quot;] ruby &gt; :not(ruby)):
* Source/WebCore/dom/Node.h:
(WebCore::Node::isWebVTTElement const):
(WebCore::Node::isWebVTTRubyElement const): Deleted.
(WebCore::Node::isWebVTTRubyTextElement const): Deleted.
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::markFutureAndPastNodes):
* Source/WebCore/html/track/WebVTTElement.cpp:
(WebCore::WebVTTElement::WebVTTElement):
(WebCore::m_language):
(WebCore::WebVTTElement::create):
(WebCore::WebVTTElement::cloneElementWithoutAttributesAndChildren):
(WebCore::WebVTTElement::createEquivalentHTMLElement):
(WebCore::WebVTTElementImpl::create): Deleted.

Remove the now-unnedeed WebVTTElement/WebVTTElementImpl split.

(WebCore::WebVTTElementImpl::cloneElementWithoutAttributesAndChildren): Deleted.
(WebCore::WebVTTElementImpl::createEquivalentHTMLElement): Deleted.
* Source/WebCore/html/track/WebVTTElement.h:
(WebCore::WebVTTElementImpl::setWebVTTNodeType): Deleted.
(WebCore::WebVTTElementImpl::webVTTNodeType const): Deleted.
(WebCore::WebVTTElementImpl::isPastNode const): Deleted.
(WebCore::WebVTTElementImpl::setIsPastNode): Deleted.
(WebCore::WebVTTElementImpl::language const): Deleted.
(WebCore::WebVTTElementImpl::setLanguage): Deleted.
(WebCore::WebVTTElementImpl::voiceAttributeName): Deleted.
(WebCore::WebVTTElementImpl::langAttributeName): Deleted.
(WebCore::WebVTTElementImpl::WebVTTElementImpl): Deleted.
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTTreeBuilder::constructTreeFromToken):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::collectMatchingUserAgentPartRules):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::hasUnsupportedRubyDisplay):

Relax the check to allow any elements called &quot;ruby&quot; or &quot;rt&quot; to have ruby display type, not just the HTML ones

Canonical link: <a href="https://commits.webkit.org/276025@main">https://commits.webkit.org/276025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71833124083927ded7e6d445527b3e74c98b1939

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43551 "Passed style check") | [💥 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22586 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45965 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46189 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39680 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45855 "Passed tests") | [💥 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26402 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20001 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/46189 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44125 "Passed tests") | [💥 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/26402 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/45965 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/46189 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/26402 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/45965 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1607 "Built successfully") | 
| | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/26402 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/45965 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47735 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [💥 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18583 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/20001 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/47735 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [💥 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20007 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/45965 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/47735 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9692 "Built successfully and passed tests") | [💥 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20185 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [💥 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19635 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->