### PR TITLE
Cannot manage extension storage with WebKit extensions in Safari

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
@@ -213,8 +213,10 @@ using namespace WebKit;
         return @"Failed to delete extension storage database file.";
     }
 
-    if (!reopenDatabase)
+    if (!reopenDatabase) {
+        _database = nil;
         return errorMessage;
+    }
 
     // Only try to recover from errors opening the database by deleting the file once.
     return [self _openDatabase:databaseURL deleteDatabaseFileOnError:NO];

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm
@@ -201,6 +201,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionControllerConfiguration, We
     return nil;
 }
 
+- (void)_setStorageDirectoryPath:(NSString *)path
+{
+    _webExtensionControllerConfiguration->setStorageDirectory(path);
+}
+
 #pragma mark WKObject protocol implementation
 
 - (API::Object&)_apiObject
@@ -285,6 +290,10 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionControllerConfiguration, We
 - (NSString *)_storageDirectoryPath
 {
     return nil;
+}
+
+- (void)_setStorageDirectoryPath:(NSString *)path
+{
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion This property contains the file path to the storage directory used by the configuration. It is `nil` for non-persistent
  configurations. For persistent configurations, it provides the path where data is stored, which may be a temporary directory.
 */
-@property (nonatomic, readonly, copy, nullable) NSString *_storageDirectoryPath;
+@property (nonatomic, nullable, copy, setter=_setStorageDirectoryPath:) NSString *_storageDirectoryPath;
 
 @end
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -389,14 +389,14 @@ bool WebExtensionContext::readLastBaseURLFromState(const String& filePath, URL& 
     return outLastBaseURL.isValid();
 }
 
-bool WebExtensionContext::readDisplayNameAndLastBaseURLFromState(const String& filePath, String& outDisplayName, URL& outLastBaseURL)
+bool WebExtensionContext::readDisplayNameFromState(const String& filePath, String& outDisplayName)
 {
     auto *state = readStateFromPath(filePath);
 
     if (auto *displayName = objectForKey<NSString>(state, lastSeenDisplayNameStateKey))
         outDisplayName = displayName;
 
-    return !outDisplayName.isEmpty() && readLastBaseURLFromState(filePath, outLastBaseURL);
+    return !outDisplayName.isEmpty();
 }
 
 NSDictionary *WebExtensionContext::readStateFromStorage()
@@ -445,7 +445,6 @@ void WebExtensionContext::moveLocalStorageIfNeeded(const URL& previousBaseURL, C
 
 void WebExtensionContext::invalidateStorage()
 {
-    m_storageDirectory = nullString();
     m_registeredContentScriptsStorage = nullptr;
     m_localStorageStore = nullptr;
     m_sessionStorageStore = nullptr;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm
@@ -43,7 +43,7 @@ String WebExtensionControllerConfiguration::createStorageDirectoryPath(std::opti
     String libraryPath = [NSFileManager.defaultManager URLForDirectory:NSLibraryDirectory inDomain:NSUserDomainMask appropriateForURL:nil create:NO error:nullptr].path;
     RELEASE_ASSERT(!libraryPath.isEmpty());
 
-    String identifierPath = identifier ? identifier->toString() : "Default"_s;
+    String identifierPath = identifier ? identifier->toString().convertToASCIIUppercase() : "Default"_s;
 
     if (processHasContainer())
         return FileSystem::pathByAppendingComponents(libraryPath, { "WebKit"_s, "WebExtensions"_s, identifierPath });

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -141,7 +141,7 @@ public:
     static String plistFileName() { return "State.plist"_s; };
     static NSMutableDictionary *readStateFromPath(const String&);
     static bool readLastBaseURLFromState(const String& filePath, URL& outLastBaseURL);
-    static bool readDisplayNameAndLastBaseURLFromState(const String& filePath, String& outDisplayName, URL& outLastBaseURL);
+    static bool readDisplayNameFromState(const String& filePath, String& outDisplayName);
 
     static WebExtensionContext* get(WebExtensionContextIdentifier);
 
@@ -261,6 +261,8 @@ public:
 
     bool storageIsPersistent() const { return !m_storageDirectory.isEmpty(); }
     const String& storageDirectory() const { return m_storageDirectory; }
+
+    void invalidateStorage();
 
     _WKWebExtensionStorageSQLiteStore *storageForType(WebExtensionDataType);
 
@@ -537,8 +539,6 @@ private:
     void writeStateToStorage() const;
 
     void moveLocalStorageIfNeeded(const URL& previousBaseURL, CompletionHandler<void()>&&);
-
-    void invalidateStorage();
 
     void permissionsDidChange(const PermissionsSet&);
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -187,7 +187,7 @@ private:
     String storageDirectory(WebExtensionContext&) const;
 
     String stateFilePath(const String& uniqueIdentifier) const;
-    _WKWebExtensionStorageSQLiteStore* sqliteStore(const String& storageDirectory, WebExtensionDataType, std::optional<RefPtr<WebExtensionContext>>);
+    _WKWebExtensionStorageSQLiteStore* sqliteStore(const String& storageDirectory, WebExtensionDataType, RefPtr<WebExtensionContext>);
 
     void didStartProvisionalLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);
     void didCommitLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);


### PR DESCRIPTION
#### 51b371557ac72cf9ffaf6db5b1f90b90c2472704
<pre>
Cannot manage extension storage with WebKit extensions in Safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=270869">https://bugs.webkit.org/show_bug.cgi?id=270869</a>
<a href="https://rdar.apple.com/124037961">rdar://124037961</a>

Reviewed by Timothy Hatcher.

Update methods for fetching and removing data records. Since it&apos;s not guarenteed the context
will be loaded, don&apos;t refer to the controller&apos;s map of extension context. Instead, do a direct
comparision with the uniqueIdentifier from the context passed to determine if a match is found.

Also, update _storageDirectoryPath so that a custom storage path can be set.

* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
(-[_WKWebExtensionSQLiteStore _deleteDatabaseFileAtURL:reopenDatabase:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfiguration.mm:
(-[_WKWebExtensionControllerConfiguration _setStorageDirectoryPath:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::readDisplayNameFromState):
(WebKit::WebExtensionContext::invalidateStorage):
Make this public so it can be used after sql dbs are closed when data records are removed.
(WebKit::WebExtensionContext::readDisplayNameAndLastBaseURLFromState): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::getDataRecords):
(WebKit::WebExtensionController::getDataRecord):
(WebKit::WebExtensionController::sqliteStore):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerConfigurationCocoa.mm:
(WebKit::WebExtensionControllerConfiguration::createStorageDirectoryPath):
Convert identifier back to uppercase after toString(). This was causing a bug where
a new (lowercased) directory would be used for extension storage.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:

Canonical link: <a href="https://commits.webkit.org/275999@main">https://commits.webkit.org/275999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea10953c9e96329f74be4c5e2c7d4b8b51b0228d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46128 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39620 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35958 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19572 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16933 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1549 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47672 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19946 "Built successfully") | | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5917 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19576 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->