### PR TITLE
Conditionally exclude crossorigin attribute when saving web page resources

### DIFF
--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -96,7 +96,7 @@ protected:
     void appendNonElementNode(StringBuilder&, const Node&, Namespaces*);
 
     static void appendAttributeValue(StringBuilder&, const String&, bool isSerializingHTML);
-    void appendAttribute(StringBuilder&, const Element&, const Attribute&, Namespaces*);
+    bool appendAttribute(StringBuilder&, const Element&, const Attribute&, Namespaces*);
 
     OptionSet<EntityMask> entityMaskForText(const Text&) const;
 
@@ -104,14 +104,15 @@ protected:
 
 private:
     void appendNamespace(StringBuilder&, const AtomString& prefix, const AtomString& namespaceURI, Namespaces&, bool allowEmptyDefaultNS = false);
-    String resolveURLIfNeeded(const Element&, const String&) const;
+    enum class IsCreatedByURLReplacement : bool { No, Yes };
+    std::pair<String, IsCreatedByURLReplacement> resolveURLIfNeeded(const Element&, const String&) const;
     void serializeNodesWithNamespaces(Node& targetNode, SerializedNodes, const Namespaces*);
     bool inXMLFragmentSerialization() const { return m_serializationSyntax == SerializationSyntax::XML; }
     void generateUniquePrefix(QualifiedName&, const Namespaces&);
     QualifiedName xmlAttributeSerialization(const Attribute&, Namespaces*);
     LocalFrame* frameForAttributeReplacement(const Element&) const;
     Attribute replaceAttributeIfNecessary(const Element&, const Attribute&);
-    void appendURLAttributeIfNecessary(StringBuilder&, const Element&, Namespaces*);
+    bool appendURLAttributeForReplacementIfNecessary(StringBuilder&, const Element&, Namespaces*);
     RefPtr<Element> replacementElement(const Node&);
     bool shouldExcludeElement(const Element&);
 


### PR DESCRIPTION
#### 5b67039b6533405bf352d6071aff8fbb8aca5519
<pre>
Conditionally exclude crossorigin attribute when saving web page resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=270874">https://bugs.webkit.org/show_bug.cgi?id=270874</a>
<a href="https://rdar.apple.com/124074708">rdar://124074708</a>

Reviewed by Ryosuke Niwa.

When saving complete web page, we may replace URLs of elements with relative paths that point to saved subresource
files. In this case, we should drop crossorigin attribute on these elements, otherwise the saved page may not have
subresources loaded correctly as browsers can perform CORS checks on the element (e.g. requiring response to contain
Access-Control-Allow-Origin header).

Test: WebArchive.SaveResourcesExcludeCrossOriginAttribute

* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::resolveURLIfNeeded const):
(WebCore::isURLAttributeForElement):
(WebCore::MarkupAccumulator::appendStartTag):
(WebCore::MarkupAccumulator::appendURLAttributeForReplacementIfNecessary):
(WebCore::MarkupAccumulator::appendAttribute):
(WebCore::MarkupAccumulator::appendURLAttributeIfNecessary): Deleted.
* Source/WebCore/editing/MarkupAccumulator.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:

Canonical link: <a href="https://commits.webkit.org/276043@main">https://commits.webkit.org/276043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20964cd2185dbd2d9cf94d98c6f18af942d39265

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43609 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46251 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39738 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45913 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20065 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17010 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38615 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1666 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47799 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18648 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42828 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9707 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20247 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->