### PR TITLE
[JSC] RegExp /u flag doesn't respect atomicity of surrogate pairs

### DIFF
--- a/JSTests/stress/regexp-unicode-dangling-surrogates.js
+++ b/JSTests/stress/regexp-unicode-dangling-surrogates.js
@@ -1,0 +1,190 @@
+// With verbose set to false, this test is successful if there is no output.  Set verbose to true to see expected matches.
+let verbose = false;
+
+function arrayToString(arr)
+{
+    let str = '';
+    arr.forEach(function(v, index) {
+        if (typeof v == "string")
+            str += "\"" + v + "\"";
+        else
+            str += v;
+
+        if (index != (arr.length - 1))
+            str += ',';
+      });
+  return str;
+}
+
+function objectToString(obj)
+{
+    let str = "";
+
+    firstEntry = true;
+
+    for (const [key, value] of Object.entries(obj)) {
+        if (!firstEntry)
+            str += ", ";
+
+        str += key + ": " + dumpValue(value);
+
+        firstEntry = false;
+    }
+
+    return "{ " + str + " }";
+}
+
+function dumpValue(v)
+{
+    if (v === null)
+        return "<null>";
+
+    if (v === undefined)
+        return "<undefined>";
+
+    if (typeof v == "string")
+        return "\"" + v + "\"";
+
+    let str = "";
+
+    if (v.length)
+        str += arrayToString(v);
+
+    if (v.groups) {
+        groupStr = objectToString(v.groups);
+
+        if (str.length) {
+            if ( groupStr.length)
+                str += ", " + groupStr;
+        } else
+            str = groupStr;
+    }
+
+    return "[ " + str + " ]";
+}
+
+function compareArray(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected is null, actual is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected is not null, actual is null");
+        return false;
+    }
+
+    if (expected.length !== actual.length) {
+        print("### expected.length: " + expected.length + ", actual.length: " + actual.length);
+        return false;
+    }
+
+    for (var i = 0; i < expected.length; i++) {
+        if (expected[i] !== actual[i]) {
+            print("### expected[" + i + "]: \"" + expected[i] + "\" !== actual[" + i + "]: \"" + actual[i] + "\"");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function compareGroups(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected group is null, actual group is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected group is not null, actual group is null");
+        return false;
+    }
+
+    for (const key in expected) {
+        if (expected[key] !== actual[key]) {
+            print("### expected." + key + ": " + dumpValue(expected[key]) + " !== actual." + key + ": " + dumpValue(actual[key]));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+let testNumber = 0;
+
+function testRegExp(re, str, exp, groups)
+{
+    testNumber++;
+
+    if (groups)
+        exp.groups = groups;
+
+    let actual = re.exec(str);
+
+    let result = compareArray(exp, actual);;
+
+    if (exp && exp.groups) {
+        if (!compareGroups(exp.groups, actual.groups))
+            result = false;
+    }
+
+    if (result) {
+        if (verbose)
+            print(re.toString() + ".exec(" + dumpValue(str) + "), passed ", dumpValue(exp));
+    } else
+        print(re.toString() + ".exec(" + dumpValue(str) + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
+}
+
+function testRegExpSyntaxError(reString, flags, expError)
+{
+    testNumber++;
+
+    try {
+        let re = new RegExp(reString, flags);
+        print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError);
+    } catch (e) {
+        if (e != expError)
+            print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
+        else if (verbose)
+            print("/" + reString + "/" + flags + " passed, it threw \"" + expError + "\" as expected");
+    }
+}
+
+// Test 1
+testRegExp(/\uDC9A$/u, "a\u{1F49A}", null);
+testRegExp(/[\uDC9A|\uD83D]$/u, "a\u{1F49A}", null);
+testRegExp(/[\uDC9A|\uD83D]+$/u, "a\u{1F49A}", null);
+testRegExp(/[\uDC9A|\uD83D]+?$/u, "a\u{1F49A}", null);
+testRegExp(/\uDC9A$/u, "a\uDC9A", ["\uDC9A"]);
+
+// Test 6
+testRegExp(/[\uDC9A|\uD83D]$/u, "a\uD83D", ["\uD83D"]);
+testRegExp(/[\uDC9A|\uD83D]$/u, "a\uDC9A", ["\uDC9A"]);
+testRegExp(/[\uDC9A|\uD83D]$/u, "a\uDC9A\uD83D", ["\uD83D"]);
+testRegExp(/[\uDC9A|\uD83D]+$/u, "a\uD83D", ["\uD83D"]);
+testRegExp(/[\uDC9A|\uD83D]+$/u, "a\uDC9A", ["\uDC9A"]);
+
+// Test 11
+testRegExp(/[\uDC9A|\uD83D]+$/u, "a\uDC9A\uD83D", ["\uDC9A\uD83D"]);
+testRegExp(/[\uDC9A|\uD83D]+?$/u, "a\uD83D", ["\uD83D"]);
+testRegExp(/[\uDC9A|\uD83D]+?$/u, "a\uDC9A", ["\uDC9A"]);
+testRegExp(/[\uDC9A|\uD83D]+?$/u, "a\uDC9A\uD83D", ["\uDC9A\uD83D"]);
+testRegExp(/[^\u{1F49A}]/u, "a\u{1F49A}", ["a"]);
+
+// Test 16
+testRegExp(/[^\u{1F49A}]/u, "\u{1F49A}a", ["a"]);
+testRegExp(/(?<=(\u{1F49A}))a/u, "\u{1F49A}a", ["a", "\u{1F49A}"]);
+testRegExp(/(?<=(\u{1F49A}))./u, "\u{1F49A}a", ["a", "\u{1F49A}"]);
+testRegExp(/(?<=(\uDC9A))a/u, "\u{1F49A}a", null);
+testRegExp(/(?<=(\uD83D))./u, "\u{1F49A}a", null);
+
+// Test 21
+testRegExp(/(?<=(\uDC9A))./u, "\u{1F49A}a", null);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -58,9 +58,6 @@ test/built-ins/Proxy/construct/return-not-object-throws-undefined-realm.js:
 test/built-ins/Proxy/construct/trap-is-not-callable-realm.js:
   default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
   strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/RegExp/prototype/Symbol.match/builtin-infer-unicode.js:
-  default: 'Test262Error: Expected SameValue(«�», «null») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«�», «null») to be true'
 test/built-ins/RegExp/prototype/Symbol.match/flags-tostring-error.js:
   default: 'Test262Error: Expected a CustomError but got a Test262Error'
   strict mode: 'Test262Error: Expected a CustomError but got a Test262Error'
@@ -79,15 +76,6 @@ test/built-ins/RegExp/prototype/Symbol.replace/get-flags-err.js:
 test/built-ins/RegExp/prototype/Symbol.replace/get-unicode-error.js:
   default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
   strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
-test/built-ins/RegExp/prototype/Symbol.search/u-lastindex-advance.js:
-  default: 'Test262Error: Expected SameValue(«1», «-1») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«1», «-1») to be true'
-test/built-ins/RegExp/prototype/Symbol.split/u-lastindex-adv-thru-failure.js:
-  default: 'Test262Error: Expected SameValue(«2», «1») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«2», «1») to be true'
-test/built-ins/RegExp/prototype/exec/u-lastindex-adv.js:
-  default: 'Test262Error: Expected SameValue(«�», «null») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«�», «null») to be true'
 test/built-ins/RegExp/quantifier-integer-limit.js:
   default: 'SyntaxError: Invalid regular expression: number too large in {} quantifier'
   strict mode: 'SyntaxError: Invalid regular expression: number too large in {} quantifier'
@@ -1023,9 +1011,6 @@ test/language/import/import-assertions/json-value-string.js:
   module: "SyntaxError: Unexpected identifier 'assert'. Expected a ';' following a targeted import declaration."
 test/language/import/import-assertions/json-via-namespace.js:
   module: "SyntaxError: Unexpected identifier 'assert'. Expected a ';' following a targeted import declaration."
-test/language/literals/regexp/u-astral-char-class-invert.js:
-  default: 'Test262Error: Expected SameValue(«�», «null») to be true'
-  strict mode: 'Test262Error: Expected SameValue(«�», «null») to be true'
 test/language/module-code/import-assertions/eval-gtbndng-indirect-faux-assertion.js:
   raw: "SyntaxError: Unexpected token '*'. import call expects one or two arguments."
 test/language/module-code/import-assertions/import-assertion-empty.js:

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -3568,6 +3568,12 @@ public:
         m_assembler.csel<64>(dest, src, dest, ARM64Condition(cond));
     }
 
+    void moveConditionallyTest32(ResultCondition cond, RegisterID testReg, TrustedImm32 mask, RegisterID src, RegisterID dest)
+    {
+        test32(testReg, mask);
+        m_assembler.csel<64>(dest, src, dest, ARM64Condition(cond));
+    }
+
     void moveConditionallyTest32(ResultCondition cond, RegisterID left, RegisterID right, RegisterID thenCase, RegisterID elseCase, RegisterID dest)
     {
         m_assembler.tst<32>(left, right);
@@ -4610,6 +4616,11 @@ public:
     {
         test32(src, mask);
         m_assembler.cset<32>(dest, ARM64Condition(cond));
+    }
+
+    void addOneConditionally32(ResultCondition cond, RegisterID src, RegisterID dest)
+    {
+        m_assembler.cinc<32>(dest, src, ARM64Condition(cond));
     }
 
     void test32(ResultCondition cond, Address address, TrustedImm32 mask, RegisterID dest)

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -285,7 +285,8 @@ public:
                     return errorCodePoint;
                 next();
                 return U16_GET_SUPPLEMENTARY(result, input[p + 1]);
-            }
+            } else if (decodeSurrogatePairs && p > 0 && U16_IS_TRAIL(result) && U16_IS_LEAD(input[p - 1]))
+                return errorCodePoint;
             return result;
         }
 

--- a/Source/JavaScriptCore/yarr/YarrJITRegisters.h
+++ b/Source/JavaScriptCore/yarr/YarrJITRegisters.h
@@ -70,7 +70,10 @@ public:
     static constexpr GPRReg regUnicodeInputAndTrail = ARM64Registers::x10;
     static constexpr GPRReg unicodeAndSubpatternIdTemp = ARM64Registers::x5;
     static constexpr GPRReg initialStart = ARM64Registers::x11;
-    static constexpr GPRReg supplementaryPlanesBase = ARM64Registers::x12;
+
+#define UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP 1
+    static constexpr GPRReg firstCharacterAdditionalReadSize = ARM64Registers::x12;
+
     static constexpr GPRReg leadingSurrogateTag = ARM64Registers::x13;
     static constexpr GPRReg trailingSurrogateTag = ARM64Registers::x14;
     static constexpr GPRReg endOfStringAddress = ARM64Registers::x15;
@@ -78,6 +81,7 @@ public:
     static constexpr GPRReg returnRegister = ARM64Registers::x0;
     static constexpr GPRReg returnRegister2 = ARM64Registers::x1;
 
+    static constexpr MacroAssembler::TrustedImm32 supplementaryPlanesBase = MacroAssembler::TrustedImm32(0x10000);
     static constexpr MacroAssembler::TrustedImm32 surrogateTagMask = MacroAssembler::TrustedImm32(0xfffffc00);
 #elif CPU(X86_64)
 #if !OS(WINDOWS)
@@ -211,6 +215,7 @@ public:
     GPRReg regUnicodeInputAndTrail { InvalidGPRReg };
     GPRReg unicodeAndSubpatternIdTemp { InvalidGPRReg };
     GPRReg endOfStringAddress { InvalidGPRReg };
+    GPRReg firstCharacterAdditionalReadSize { InvalidGPRReg };
 
     const MacroAssembler::TrustedImm32 supplementaryPlanesBase = MacroAssembler::TrustedImm32(0x10000);
     const MacroAssembler::TrustedImm32 leadingSurrogateTag = MacroAssembler::TrustedImm32(0xd800);


### PR DESCRIPTION
#### 67969c218ddf357855d3c26ca4769b194fb1f4db
<pre>
[JSC] RegExp /u flag doesn&apos;t respect atomicity of surrogate pairs
<a href="https://bugs.webkit.org/show_bug.cgi?id=267011">https://bugs.webkit.org/show_bug.cgi?id=267011</a>
<a href="https://rdar.apple.com/124217243">rdar://124217243</a>

Reviewed by Yusuke Suzuki.

Fixed bug where a dangling surrogate in a pattern matches half a valid surrogate pair in a subject string.
Updated the reading of surrogates that when we read starting in the middle of a valid surrogate pair, we return an error
code point which we never match.  Updated backtracking for non-greedy character class matching to use the start index
as the appropriate index to reset when we fail to match, instead of doing math with the current match count.

The fix above originally landed Jan 13, but it  regressed some Unicode performance tests and was subsequently rolled out.

This change builds on the prior fix by adding three optimizations to mitigate the performance loss in the earlier fix..
 1. We don&apos;t need to check for the errorCodePoint (-1) if we read a dangling surrogate when we are matching a normal,
    non-inverted atoms.  The errorCodePoint won&apos;t match in that case.  For inverted atoms, we still need to check for the
    errorCodePoint and fail matching that atom.

 2. Changed the code emitted for a character class that has only one range.  Before this change, we&apos;d emit all range
    checks with each range check&apos;s failure target address the instruction right after the two conditional branches.
    This works fine if there is another range check.  When all range checks have been performed, we add a branch to the
    failure (backtracking) code.

    If the character class has only one range and doesn&apos;t have any list of single characters, we can eliminate the branch
    to failure code by changing the two conditional branches that make up a range check go directly to the failure code.

    This change appears to help JetStream2/babylon-wtp by at least 1.5+%.

 3. (ARM64 only) When we read a non-BMB code point, consisting of two surrogate code units, and we fail to match any atom
    in the body of a RegExp, we were incrementing the subject string index by 1 and going back to the top of the loop to
    start matching the pattern again.  Now we dedicate a register to hold either 0 or 1 depending on the width of the first
    character read for that loop iteration.  When advancing the index for the next iteration, we add the value of that register
    to the updated index.  This eliminates one iteration through the matching loop for each non-BMP code point that doesn&apos;t
    match.

    This change appears to help JetStream2/UniPoker by 3+%.

Added a new test and updated the Test262 exceptions file.

* JSTests/stress/regexp-unicode-dangling-surrogates.js: Added.
(arrayToString):
(objectToString):
(dumpValue):
(compareArray):
(compareGroups):
(testRegExp):
(testRegExpSyntaxError):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::moveConditionallyTest32): Added to conditionally zero a register.
(JSC::MacroAssemblerARM64::addOneConditionally32): Added to conditionally increment a register.
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::InputStream::readChecked):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrJITRegisters.h:

Canonical link: <a href="https://commits.webkit.org/276031@main">https://commits.webkit.org/276031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f22795bfee30736e304bdec9e283294c8ea079be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46136 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39631 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35967 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16942 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38546 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1557 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/36961 "Built successfully and passed tests") | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39676 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; 58 api tests failed or timed out; 54 api tests failed or timed out; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47680 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43126 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15163 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42752 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19954 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41422 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20133 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50135 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5936 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19584 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10109 "Passed tests") | 
<!--EWS-Status-Bubble-End-->