### PR TITLE
REGRESSION (275981@main): [ macOS ] 7 tests in TestWebKitAPI.WKWebExtensionAPIPermissions are a constant failure/timeout.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm
@@ -123,14 +123,14 @@ void WebExtensionContext::permissionsRequest(HashSet<String> permissions, HashSe
         resultHolder->matchPatternsAreGranted = neededMatchPatterns.size() == allowedMatchPatterns.size();
         resultHolder->neededMatchPatterns = WTFMove(neededMatchPatterns);
         resultHolder->permissionExpirationDate = expirationDate;
-    }, GrantOnCompletion::No);
+    }, GrantOnCompletion::No, PermissionStateOptions::IncludeOptionalPermissions);
 
     requestPermissions(permissions, nullptr, [callbackAggregator, resultHolder](PermissionsSet&& neededPermissions, PermissionsSet&& allowedPermissions, WallTime expirationDate) {
         // The permissions.request() API only allows granting all or none.
         resultHolder->permissionsAreGranted = neededPermissions.size() == allowedPermissions.size();
         resultHolder->neededPermissions = WTFMove(neededPermissions);
         resultHolder->matchPatternExpirationDate = expirationDate;
-    }, GrantOnCompletion::No);
+    }, GrantOnCompletion::No, PermissionStateOptions::IncludeOptionalPermissions);
 }
 
 void WebExtensionContext::permissionsRemove(HashSet<String> permissions, HashSet<String> origins, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm
@@ -68,10 +68,20 @@ WebExtensionMatchPattern::URLSchemeSet& WebExtensionMatchPattern::supportedSchem
     return schemes;
 }
 
-bool WebExtensionMatchPattern::patternsMatchURL(const MatchPatternSet& matchPatterns, URL& url)
+bool WebExtensionMatchPattern::patternsMatchURL(const MatchPatternSet& matchPatterns, const URL& url)
 {
     for (auto& matchPattern : matchPatterns) {
         if (matchPattern->matchesURL(url))
+            return true;
+    }
+
+    return false;
+}
+
+bool WebExtensionMatchPattern::patternsMatchPattern(const MatchPatternSet& matchPatterns, const WebExtensionMatchPattern& otherPattern)
+{
+    for (auto& matchPattern : matchPatterns) {
+        if (matchPattern->matchesPattern(otherPattern))
             return true;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -241,6 +241,7 @@ public:
     enum class PermissionStateOptions : uint8_t {
         RequestedWithTabsPermission = 1 << 0, // Request access to a URL if the extension also has the "tabs" permission.
         SkipRequestedPermissions    = 1 << 1, // Don't check requested permissions.
+        IncludeOptionalPermissions  = 1 << 2, // Check the optional permissions, and count them as RequestedImplicitly.
     };
 
     using InstallReason = WebExtensionContextInstallReason;
@@ -328,9 +329,9 @@ public:
     bool removeDeniedPermissions(PermissionsSet&);
     bool removeDeniedPermissionMatchPatterns(MatchPatternSet&, EqualityOnly = EqualityOnly::Yes);
 
-    void requestPermissionMatchPatterns(const MatchPatternSet&, RefPtr<WebExtensionTab> = nullptr, CompletionHandler<void(MatchPatternSet&& neededMatchPatterns, MatchPatternSet&& allowedMatchPatterns, WallTime expirationDate)>&& = nullptr, GrantOnCompletion = GrantOnCompletion::Yes);
-    void requestPermissionToAccessURLs(const URLVector&, RefPtr<WebExtensionTab> = nullptr, CompletionHandler<void(URLSet&& neededURLs, URLSet&& allowedURLs, WallTime expirationDate)>&& = nullptr, GrantOnCompletion = GrantOnCompletion::Yes);
-    void requestPermissions(const PermissionsSet&, RefPtr<WebExtensionTab> = nullptr, CompletionHandler<void(PermissionsSet&& neededPermissions, PermissionsSet&& allowedPermissions, WallTime expirationDate)>&& = nullptr, GrantOnCompletion = GrantOnCompletion::Yes);
+    void requestPermissionMatchPatterns(const MatchPatternSet&, RefPtr<WebExtensionTab> = nullptr, CompletionHandler<void(MatchPatternSet&& neededMatchPatterns, MatchPatternSet&& allowedMatchPatterns, WallTime expirationDate)>&& = nullptr, GrantOnCompletion = GrantOnCompletion::Yes, OptionSet<PermissionStateOptions> = { });
+    void requestPermissionToAccessURLs(const URLVector&, RefPtr<WebExtensionTab> = nullptr, CompletionHandler<void(URLSet&& neededURLs, URLSet&& allowedURLs, WallTime expirationDate)>&& = nullptr, GrantOnCompletion = GrantOnCompletion::Yes, OptionSet<PermissionStateOptions> = { PermissionStateOptions::RequestedWithTabsPermission });
+    void requestPermissions(const PermissionsSet&, RefPtr<WebExtensionTab> = nullptr, CompletionHandler<void(PermissionsSet&& neededPermissions, PermissionsSet&& allowedPermissions, WallTime expirationDate)>&& = nullptr, GrantOnCompletion = GrantOnCompletion::Yes, OptionSet<PermissionStateOptions> = { PermissionStateOptions::RequestedWithTabsPermission });
 
     PermissionsMap::KeysConstIteratorRange currentPermissions() { return grantedPermissions().keys(); }
     PermissionMatchPatternsMap::KeysConstIteratorRange currentPermissionMatchPatterns() { return grantedPermissionMatchPatterns().keys(); }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -75,7 +75,8 @@ public:
     static Ref<WebExtensionMatchPattern> allHostsAndSchemesMatchPattern();
 
     static bool patternsMatchAllHosts(const MatchPatternSet&);
-    static bool patternsMatchURL(const MatchPatternSet&, URL&);
+    static bool patternsMatchURL(const MatchPatternSet&, const URL&);
+    static bool patternsMatchPattern(const MatchPatternSet&, const WebExtensionMatchPattern&);
 
     explicit WebExtensionMatchPattern() { }
     explicit WebExtensionMatchPattern(const String& pattern, NSError **outError = nullptr);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -46,6 +46,8 @@ static auto *tabsManifest = @{
         @"type": @"module",
         @"persistent": @NO,
     },
+
+    @"permissions": @[ @"tabs" ],
 };
 
 static auto *tabsManifestV2 = @{
@@ -740,6 +742,8 @@ TEST(WKWebExtensionAPITabs, QueryWithAccessPrompt)
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:tabsManifest resources:@{ @"background.js": backgroundScript }]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    [manager.get().context setPermissionStatus:_WKWebExtensionContextPermissionStatusGrantedExplicitly forPermission:_WKWebExtensionPermissionTabs];
 
     __block bool firstPermissionRequest = true;
     auto *localhostURL = server.requestWithLocalhost().URL;


### PR DESCRIPTION
#### b74a5a42516e4102fd5b9b594e566099bf782ad2
<pre>
REGRESSION (275981@main): [ macOS ] 7 tests in TestWebKitAPI.WKWebExtensionAPIPermissions are a constant failure/timeout.
<a href="https://webkit.org/b/270872">https://webkit.org/b/270872</a>
<a href="https://rdar.apple.com/problem/124475393">rdar://problem/124475393</a>

Reviewed by Jeff Miller.

When requesting permissions via permissions.request(), we need to include optional permissions
in the check. That was actually happening by accident before, since !hasPermission() was returning
true for any unknown permission. With the change to needsPermission(), only RequestedExplicitly
or RequestedImplicitly results were counted. To fix this, a new option was added for use by
the permissions API to include optional permissions in the RequestedImplicitly category.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIPermissionsCocoa.mm:
(WebKit::WebExtensionContext::permissionsRequest): Pass the IncludeOptionalPermissions option.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::requestPermissionMatchPatterns): Pass through options to needsPermission().
(WebKit::WebExtensionContext::requestPermissionToAccessURLs): Ditto.
(WebKit::WebExtensionContext::requestPermissions): Ditto.
(WebKit::WebExtensionContext::permissionState): Added support for IncludeOptionalPermissions to check
the optional permissions from the extension&apos;s manifest.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMatchPatternCocoa.mm:
(WebKit::WebExtensionMatchPattern::patternsMatchURL): Added const to URL to fix build issue.
(WebKit::WebExtensionMatchPattern::patternsMatchPattern): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::requestPermissionMatchPatterns): Added options parameter.
(WebKit::WebExtensionContext::requestPermissionToAccessURLs): Ditto.
(WebKit::WebExtensionContext::requestPermissions): Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TEST(WKWebExtensionAPITabs, QueryWithAccessPrompt)): Grant tabs permission so the tab URL counts as a
requested URL and the prompt delegate will be called.

Canonical link: <a href="https://commits.webkit.org/276003@main">https://commits.webkit.org/276003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1348f23c52a79df0b0bd48ea689ba8c7e6011fca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22541 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46144 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/39638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45813 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19958 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/35978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19592 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/16952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38548 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1565 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47688 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15170 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42759 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19962 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41430 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5918 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->