### PR TITLE
Clean up serialized type info for IPC test API

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
@@ -53,7 +53,7 @@ messages -> RemoteSourceBufferProxy NotRefCounted {
     SetMaximumBufferSize(size_t size) -> ()
     ComputeSeekTime(struct WebCore::SeekTarget target) -> (WebCore::SourceBufferPrivate::ComputeSeekPromise::Result seekedTime)
     SeekToTime(MediaTime time)
-    UpdateTrackIds(Vector<std::pair<WebCore::TrackID , WebCore::TrackID >> identifierPairs)
+    UpdateTrackIds(Vector<std::pair<WebCore::TrackID, WebCore::TrackID >> identifierPairs)
     BufferedSamplesForTrackId(WebCore::TrackID trackID) -> (WebCore::SourceBufferPrivate::SamplesPromise::Result samples)
     EnqueuedSamplesForTrackID(WebCore::TrackID trackID) -> (WebCore::SourceBufferPrivate::SamplesPromise::Result samples)
     MemoryPressure(MediaTime currentTime)

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -1238,8 +1238,8 @@ def generate_optional_tuple_type_info(type):
 
 def generate_one_serialized_type_info(type):
     result = []
-    if type.cf_type is not None:
-        return result
+    if type.condition is not None:
+        result.append('#if ' + type.condition)
     result.append('        { "' + type.name_declaration_for_serialized_type_info() + '"_s, {')
     if type.members_are_subclasses:
         result.append('            { "std::variant<"')
@@ -1252,12 +1252,30 @@ def generate_one_serialized_type_info(type):
                 result.append('#endif')
         result.append('            ">"_s, "subclasses"_s }')
         result.append('        } },')
+        if type.condition is not None:
+            result.append('#endif // ' + type.condition)
+        return result
+
+    if type.cf_type is not None:
+        result.append('            { "WebKit::' + type.cpp_struct_or_class_name() + '"_s, "wrapper"_s }')
+        result.append('        } },')
+        if type.condition is not None:
+            result.append('#endif // ' + type.condition)
         return result
 
     if type.is_webkit_secure_coding_type():
         for member in type.dictionary_members:
+            if member.condition is not None:
+                result.append('#if ' + member.condition)
             result.append('            { "' + member.dictionary_type() + '"_s , "' + member.type + '"_s },')
+            if member.condition is not None:
+                result.append('#endif // ' + member.condition)
         result.append('        } },')
+        result.append('        { "' + type.name + '"_s, {')
+        result.append('            { "WebKit::' + type.cpp_struct_or_class_name() + '"_s, "wrapper"_s }')
+        result.append('        } },')
+        if type.condition is not None:
+            result.append('#endif // ' + type.condition)
         return result
 
     serialized_members = type.members_for_serialized_type_info()
@@ -1295,6 +1313,8 @@ def generate_one_serialized_type_info(type):
         result.append('                "optionalTuple"_s')
         result.append('            },')
     result.append('        } },')
+    if type.condition is not None:
+        result.append('#endif // ' + type.condition)
     return result
 
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -105,9 +105,7 @@ template<> struct VirtualTableAndRefCountOverhead<true, false> {
 };
 template<> struct VirtualTableAndRefCountOverhead<false, false> { };
 
-#if COMPILER(GCC)
 IGNORE_WARNINGS_BEGIN("invalid-offsetof")
-#endif
 
 namespace IPC {
 
@@ -1585,6 +1583,4 @@ template<> bool isValidEnum<EnumNamespace::InnerEnumType, void>(uint8_t value)
 
 } // namespace WTF
 
-#if COMPILER(GCC)
 IGNORE_WARNINGS_END
-#endif

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -96,6 +96,7 @@ namespace WebKit {
 Vector<SerializedTypeInfo> allSerializedTypes()
 {
     return {
+#if ENABLE(TEST_FEATURE)
         { "Namespace::Subnamespace::StructName"_s, {
             {
                 "FirstMemberType"_s,
@@ -112,6 +113,7 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "nullableTestMember"_s
             },
         } },
+#endif // ENABLE(TEST_FEATURE)
         { "Namespace::OtherClass"_s, {
             {
                 "int"_s,
@@ -256,12 +258,14 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 ", WebCore::SpringTimingFunction"
             ">"_s, "subclasses"_s }
         } },
+#if ENABLE(TEST_FEATURE)
         { "Namespace::ConditionalCommonClass"_s, {
             {
                 "int"_s,
                 "value"_s
             },
         } },
+#endif // ENABLE(TEST_FEATURE)
         { "Namespace::CommonClass"_s, {
             {
                 "int"_s,
@@ -368,10 +372,15 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "request"_s
             },
         } },
+#if USE(AVFOUNDATION)
         { "WebKit::CoreIPCAVOutputContext"_s, {
             { "RetainPtr<NSString>"_s , "AVOutputContextSerializationKeyContextID"_s },
             { "RetainPtr<NSString>"_s , "AVOutputContextSerializationKeyContextType"_s },
         } },
+        { "AVOutputContext"_s, {
+            { "WebKit::CoreIPCAVOutputContext"_s, "wrapper"_s }
+        } },
+#endif // USE(AVFOUNDATION)
         { "WebKit::CoreIPCNSSomeFoundationType"_s, {
             { "RetainPtr<NSString>"_s , "StringKey"_s },
             { "RetainPtr<NSNumber>"_s , "NumberKey"_s },
@@ -381,6 +390,10 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             { "RetainPtr<NSDictionary>"_s , "DictionaryKey"_s },
             { "RetainPtr<NSDictionary>"_s , "OptionalDictionaryKey"_s },
         } },
+        { "NSSomeFoundationType"_s, {
+            { "WebKit::CoreIPCNSSomeFoundationType"_s, "wrapper"_s }
+        } },
+#if ENABLE(DATA_DETECTION)
         { "WebKit::CoreIPCDDScannerResult"_s, {
             { "RetainPtr<NSString>"_s , "StringKey"_s },
             { "RetainPtr<NSNumber>"_s , "NumberKey"_s },
@@ -392,6 +405,18 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             { "Vector<RetainPtr<NSData>>"_s , "DataArrayKey"_s },
             { "Vector<RetainPtr<SecTrustRef>>"_s , "SecTrustArrayKey"_s },
         } },
+        { "DDScannerResult"_s, {
+            { "WebKit::CoreIPCDDScannerResult"_s, "wrapper"_s }
+        } },
+#endif // ENABLE(DATA_DETECTION)
+        { "CFFooRef"_s, {
+            { "WebKit::FooWrapper"_s, "wrapper"_s }
+        } },
+#if USE(CFBAR)
+        { "CFBarRef"_s, {
+            { "WebKit::BarWrapper"_s, "wrapper"_s }
+        } },
+#endif // USE(CFBAR)
         { "WebKit::RValueWithFunctionCalls"_s, {
             {
                 "SandboxExtensionHandle"_s,
@@ -418,18 +443,23 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "pendingReads()"_s
             },
         } },
+#if ENABLE(OUTER_CONDITION)
         { "Namespace::OuterClass"_s, {
             {
                 "int"_s,
                 "outerValue"_s
             },
         } },
+#endif // ENABLE(OUTER_CONDITION)
+#if !(ENABLE(OUTER_CONDITION))
         { "Namespace::OtherOuterClass"_s, {
             {
                 "int"_s,
                 "outerValue"_s
             },
         } },
+#endif // !(ENABLE(OUTER_CONDITION))
+#if USE(APPKIT)
         { "WebCore::AppKitControlSystemImage"_s, {
             {
                 "WebCore::Color"_s,
@@ -440,6 +470,7 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "m_useDarkAppearance"_s
             },
         } },
+#endif // USE(APPKIT)
         { "WebCore::SharedStringHash"_s, {
             { "uint32_t"_s, "alias"_s }
         } },

--- a/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp
@@ -54,9 +54,7 @@ template<> struct VirtualTableAndRefCountOverhead<true, false> {
 };
 template<> struct VirtualTableAndRefCountOverhead<false, false> { };
 
-#if COMPILER(GCC)
 IGNORE_WARNINGS_BEGIN("invalid-offsetof")
-#endif
 
 namespace IPC {
 
@@ -320,6 +318,4 @@ namespace WTF {
 
 } // namespace WTF
 
-#if COMPILER(GCC)
 IGNORE_WARNINGS_END
-#endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6059,11 +6059,11 @@ struct WebCore::AnimationEffectTiming {
     WebCore::PlaybackDirection direction;
     double iterationStart;
     double iterations;
-    WTF::Seconds delay;
-    WTF::Seconds endDelay;
-    WTF::Seconds iterationDuration;
-    WTF::Seconds activeDuration;
-    WTF::Seconds endTime;
+    Seconds delay;
+    Seconds endDelay;
+    Seconds iterationDuration;
+    Seconds activeDuration;
+    Seconds endTime;
 };
 
 header: <WebCore/AcceleratedEffect.h>
@@ -6084,8 +6084,8 @@ header: <WebCore/AcceleratedEffect.h>
     OptionSet<WebCore::AcceleratedEffectProperty> animatedProperties();
     bool paused();
     double playbackRate();
-    std::optional<WTF::Seconds> startTime();
-    std::optional<WTF::Seconds> holdTime();
+    std::optional<Seconds> startTime();
+    std::optional<Seconds> holdTime();
 };
 #endif // ENABLE(THREADED_ANIMATION_RESOLUTION)
 
@@ -7113,7 +7113,7 @@ enum class WebCore::RepaintRectCalculation : bool;
 };
 
 [RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ByteArrayPixelBuffer {
-    WebCore:: PixelBufferFormat format();
+    WebCore::PixelBufferFormat format();
     WebCore::IntSize size();
     std::span<const uint8_t> dataSpan();
 }

--- a/Source/WebKit/Shared/WebGPU/WebGPUColor.serialization.in
+++ b/Source/WebKit/Shared/WebGPU/WebGPUColor.serialization.in
@@ -29,3 +29,5 @@ header: "WebGPUColor.h"
     double b
     double a
 }
+
+using WebKit::WebGPU::Color = std::variant<Vector<double>, WebKit::WebGPU::ColorDict>


### PR DESCRIPTION
#### 85ca8bbdbc74fb2a06470bfc623af965a5db6ee1
<pre>
Clean up serialized type info for IPC test API
<a href="https://bugs.webkit.org/show_bug.cgi?id=270884">https://bugs.webkit.org/show_bug.cgi?id=270884</a>
<a href="https://rdar.apple.com/124491555">rdar://124491555</a>

Reviewed by Mike Wyrzykowski.

This fixes a number of issues:
  Incorrect spaces in serialization.in files
  Missing C preprocessor guards around type info for types with conditions
  Missing wrapper information for webkit_secure_coding_types and cf_types

I also improved the test to know about more container types and fundamental types.

* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in:
* Source/WebKit/Scripts/generate-serializers.py:
(generate_one_serialized_type_info):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebGPU/WebGPUColor.serialization.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:

Canonical link: <a href="https://commits.webkit.org/276023@main">https://commits.webkit.org/276023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/572b1abb1c6ae9a0bf7ae688cf0d22aee90787f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46154 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39648 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35983 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44093 "Passed tests") | [💥 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19631 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 4 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16957 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/43390 "Passed tests") | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17174 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 5 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38559 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1575 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47700 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42770 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19972 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41444 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20151 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5932 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->