### PR TITLE
[UnifiedPDF] WebCore::DataDetectorHighlight should be decoupled from the page

### DIFF
--- a/Source/WebCore/page/ImageOverlayController.h
+++ b/Source/WebCore/page/ImageOverlayController.h
@@ -28,6 +28,7 @@
 #include "Color.h"
 #include "LayoutRect.h"
 #include "PageOverlay.h"
+#include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
 
@@ -40,6 +41,8 @@ namespace WebCore {
 class Document;
 class Element;
 class GraphicsContext;
+class GraphicsLayer;
+class GraphicsLayerClient;
 class HTMLElement;
 class IntRect;
 class FloatQuad;
@@ -47,6 +50,7 @@ class LocalFrame;
 class Page;
 class RenderElement;
 class WeakPtrImplWithEventTargetData;
+enum class RenderingUpdateStep : uint32_t;
 struct GapRects;
 
 class ImageOverlayController final : private PageOverlay::Client
@@ -85,7 +89,13 @@ private:
     void clearDataDetectorHighlights();
     bool handleDataDetectorAction(const HTMLElement&, const IntPoint&);
 
+    // DataDetectorHighlightClient
+#if ENABLE(DATA_DETECTION)
     DataDetectorHighlight* activeHighlight() const final { return m_activeDataDetectorHighlight.get(); }
+    void scheduleRenderingUpdate(OptionSet<RenderingUpdateStep>) final;
+    float deviceScaleFactor() const final;
+    RefPtr<GraphicsLayer> createGraphicsLayer(GraphicsLayerClient&) final;
+#endif
 #endif
 
     void platformUpdateElementUnderMouse(LocalFrame&, Element* elementUnderMouse);

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -63,7 +63,7 @@ public:
         virtual Vector<String> copyAccessibilityAttributeNames(PageOverlay&, bool /* parameterizedNames */)  { return { }; }
     };
 
-    enum class OverlayType {
+    enum class OverlayType : bool {
         View, // Fixed to the view size; does not scale or scroll with the document, repaints on scroll.
         Document, // Scales and scrolls with the document.
     };
@@ -102,7 +102,7 @@ public:
 
     Client& client() const { return m_client; }
 
-    enum class FadeMode { DoNotFade, Fade };
+    enum class FadeMode : bool { DoNotFade, Fade };
 
     OverlayType overlayType() { return m_overlayType; }
     AlwaysTileOverlayLayer alwaysTileOverlayLayer() { return m_alwaysTileOverlayLayer; }

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -28,6 +28,7 @@
 #if (ENABLE(SERVICE_CONTROLS) || ENABLE(TELEPHONE_NUMBER_DETECTION)) && PLATFORM(MAC)
 
 #include "DataDetectorHighlight.h"
+#include "GraphicsLayer.h"
 #include "GraphicsLayerClient.h"
 #include "PageOverlay.h"
 #include "Timer.h"
@@ -39,6 +40,8 @@ namespace WebCore {
     
 class LayoutRect;
 class Page;
+
+enum class RenderingUpdateStep : uint32_t;
 
 struct GapRects;
 
@@ -74,7 +77,14 @@ private:
 
     void determineActiveHighlight(bool& mouseIsOverButton);
     void clearActiveHighlight();
+
+#if ENABLE(DATA_DETECTION)
+    // DataDetectorHighlightClient
     DataDetectorHighlight* activeHighlight() const final { return m_activeHighlight.get(); }
+    void scheduleRenderingUpdate(OptionSet<RenderingUpdateStep>) final;
+    float deviceScaleFactor() const final;
+    RefPtr<GraphicsLayer> createGraphicsLayer(GraphicsLayerClient&) final;
+#endif
 
     DataDetectorHighlight* findTelephoneNumberHighlightContainingSelectionHighlight(DataDetectorHighlight&);
 
@@ -87,6 +97,7 @@ private:
     Vector<SimpleRange> telephoneNumberRangesForFocusedFrame();
 
     Page& page() const { return m_page; }
+    Ref<Page> protectedPage() const { return m_page.get(); }
 
     SingleThreadWeakRef<Page> m_page;
     WeakPtr<PageOverlay> m_servicesOverlay;

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -379,7 +379,7 @@ void ServicesOverlayController::buildPhoneNumberHighlights()
 
         CGRect cgRect = rect;
         auto ddHighlight = adoptCF(PAL::softLink_DataDetectors_DDHighlightCreateWithRectsInVisibleRectWithStyleScaleAndDirection(nullptr, &cgRect, 1, mainFrameView.visibleContentRect(), static_cast<DDHighlightStyle>(DDHighlightStyleBubbleStandard) | static_cast<DDHighlightStyle>(DDHighlightStyleStandardIconArrow), YES, NSWritingDirectionNatural, NO, YES, 0));
-        auto highlight = DataDetectorHighlight::createForTelephoneNumber(page, *this, WTFMove(ddHighlight), WTFMove(range));
+        auto highlight = DataDetectorHighlight::createForTelephoneNumber(*this, WTFMove(ddHighlight), WTFMove(range));
         m_highlights.add(highlight.get());
         newPotentialHighlights.add(WTFMove(highlight));
     }
@@ -418,7 +418,7 @@ void ServicesOverlayController::buildSelectionHighlight()
         if (!cgRects.isEmpty()) {
             CGRect visibleRect = mainFrameView->visibleContentRect();
             auto ddHighlight = adoptCF(PAL::softLink_DataDetectors_DDHighlightCreateWithRectsInVisibleRectWithStyleScaleAndDirection(nullptr, cgRects.begin(), cgRects.size(), visibleRect, static_cast<DDHighlightStyle>(DDHighlightStyleBubbleNone) | static_cast<DDHighlightStyle>(DDHighlightStyleStandardIconArrow) | static_cast<DDHighlightStyle>(DDHighlightStyleButtonShowAlways), YES, NSWritingDirectionNatural, NO, YES, 0));
-            auto highlight = DataDetectorHighlight::createForSelection(page, *this, WTFMove(ddHighlight), WTFMove(*selectionRange));
+            auto highlight = DataDetectorHighlight::createForSelection(*this, WTFMove(ddHighlight), WTFMove(*selectionRange));
             m_highlights.add(highlight.get());
             newPotentialHighlights.add(WTFMove(highlight));
         }
@@ -657,6 +657,27 @@ void ServicesOverlayController::handleClick(const IntPoint& clickPoint, DataDete
     } else if (highlight.type() == DataDetectorHighlight::Type::TelephoneNumber)
         page->chrome().client().handleTelephoneNumberClick(plainText(highlight.range()), windowPoint, frameView->contentsToWindow(focusedOrMainFrame->editor().firstRectForRange(highlight.range())));
 }
+
+#pragma mark - DataDetectorHighlightClient
+
+#if ENABLE(DATA_DETECTION)
+
+void ServicesOverlayController::scheduleRenderingUpdate(OptionSet<RenderingUpdateStep> requestedSteps)
+{
+    protectedPage()->scheduleRenderingUpdate(requestedSteps);
+}
+
+float ServicesOverlayController::deviceScaleFactor() const
+{
+    return protectedPage()->deviceScaleFactor();
+}
+
+RefPtr<GraphicsLayer> ServicesOverlayController::createGraphicsLayer(GraphicsLayerClient& client)
+{
+    return GraphicsLayer::create(protectedPage()->chrome().client().graphicsLayerFactory(), client);
+}
+
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebCore/platform/mac/DataDetectorHighlight.mm
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.mm
@@ -35,7 +35,6 @@
 #import "GraphicsLayer.h"
 #import "GraphicsLayerFactory.h"
 #import "ImageBuffer.h"
-#import "Page.h"
 #import <wtf/Seconds.h>
 #import <pal/mac/DataDetectorsSoftLink.h>
 
@@ -44,30 +43,30 @@ namespace WebCore {
 constexpr Seconds highlightFadeAnimationDuration = 300_ms;
 constexpr double highlightFadeAnimationFrameRate = 30;
 
-Ref<DataDetectorHighlight> DataDetectorHighlight::createForSelection(Page& page, DataDetectorHighlightClient& client, RetainPtr<DDHighlightRef>&& ddHighlight, SimpleRange&& range)
+Ref<DataDetectorHighlight> DataDetectorHighlight::createForSelection(DataDetectorHighlightClient& client, RetainPtr<DDHighlightRef>&& ddHighlight, SimpleRange&& range)
 {
-    return adoptRef(*new DataDetectorHighlight(page, client, DataDetectorHighlight::Type::Selection, WTFMove(ddHighlight), WTFMove(range)));
+    return adoptRef(*new DataDetectorHighlight(client, DataDetectorHighlight::Type::Selection, WTFMove(ddHighlight), { WTFMove(range) }));
 }
 
-Ref<DataDetectorHighlight> DataDetectorHighlight::createForTelephoneNumber(Page& page, DataDetectorHighlightClient& client, RetainPtr<DDHighlightRef>&& ddHighlight, SimpleRange&& range)
+Ref<DataDetectorHighlight> DataDetectorHighlight::createForTelephoneNumber(DataDetectorHighlightClient& client, RetainPtr<DDHighlightRef>&& ddHighlight, SimpleRange&& range)
 {
-    return adoptRef(*new DataDetectorHighlight(page, client, DataDetectorHighlight::Type::TelephoneNumber, WTFMove(ddHighlight), WTFMove(range)));
+    return adoptRef(*new DataDetectorHighlight(client, DataDetectorHighlight::Type::TelephoneNumber, WTFMove(ddHighlight), { WTFMove(range) }));
 }
 
-Ref<DataDetectorHighlight> DataDetectorHighlight::createForImageOverlay(Page& page, DataDetectorHighlightClient& client, RetainPtr<DDHighlightRef>&& ddHighlight, SimpleRange&& range)
+Ref<DataDetectorHighlight> DataDetectorHighlight::createForImageOverlay(DataDetectorHighlightClient& client, RetainPtr<DDHighlightRef>&& ddHighlight, SimpleRange&& range)
 {
-    return adoptRef(*new DataDetectorHighlight(page, client, DataDetectorHighlight::Type::ImageOverlay, WTFMove(ddHighlight), WTFMove(range)));
+    return adoptRef(*new DataDetectorHighlight(client, DataDetectorHighlight::Type::ImageOverlay, WTFMove(ddHighlight), { WTFMove(range) }));
 }
 
-DataDetectorHighlight::DataDetectorHighlight(Page& page, DataDetectorHighlightClient& client, Type type, RetainPtr<DDHighlightRef>&& ddHighlight, SimpleRange&& range)
+DataDetectorHighlight::DataDetectorHighlight(DataDetectorHighlightClient& client, Type type, RetainPtr<DDHighlightRef>&& ddHighlight, std::optional<SimpleRange>&& range)
     : m_client(client)
-    , m_page(page)
     , m_range(WTFMove(range))
-    , m_graphicsLayer(GraphicsLayer::create(page.chrome().client().graphicsLayerFactory(), *this))
+    , m_graphicsLayer(client.createGraphicsLayer(*this).releaseNonNull())
     , m_type(type)
     , m_fadeAnimationTimer(*this, &DataDetectorHighlight::fadeAnimationTimerFired)
 {
     ASSERT(ddHighlight);
+    ASSERT(isRangeSupportingType() == m_range.has_value());
 
     m_graphicsLayer->setDrawsContent(true);
 
@@ -106,15 +105,14 @@ void DataDetectorHighlight::invalidate()
     m_fadeAnimationTimer.stop();
     layer().removeFromParent();
     m_client = nullptr;
-    m_page = nullptr;
 }
 
 void DataDetectorHighlight::notifyFlushRequired(const GraphicsLayer*)
 {
-    if (!m_page)
+    if (!m_client)
         return;
 
-    m_page->scheduleRenderingUpdate(RenderingUpdateStep::LayerFlush);
+    m_client->scheduleRenderingUpdate(RenderingUpdateStep::LayerFlush);
 }
 
 void DataDetectorHighlight::paintContents(const GraphicsLayer*, GraphicsContext& graphicsContext, const FloatRect&, OptionSet<GraphicsLayerPaintBehavior>)
@@ -145,10 +143,28 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 float DataDetectorHighlight::deviceScaleFactor() const
 {
-    if (!m_page)
+    if (!m_client)
         return 1;
 
-    return m_page->deviceScaleFactor();
+    return m_client->deviceScaleFactor();
+}
+
+bool DataDetectorHighlight::isRangeSupportingType() const
+{
+    static constexpr OptionSet rangeSupportingHighlightTypes {
+        DataDetectorHighlight::Type::TelephoneNumber,
+        DataDetectorHighlight::Type::Selection,
+        DataDetectorHighlight::Type::ImageOverlay,
+    };
+
+    return rangeSupportingHighlightTypes.contains(m_type);
+}
+
+const SimpleRange& DataDetectorHighlight::range() const
+{
+    ASSERT(isRangeSupportingType());
+
+    return *m_range;
 }
 
 void DataDetectorHighlight::fadeAnimationTimerFired()
@@ -213,7 +229,10 @@ bool areEquivalent(const DataDetectorHighlight* a, const DataDetectorHighlight* 
     if (!a || !b)
         return false;
 
-    return a->type() == b->type() && a->range() == b->range();
+    if (a->type() != b->type())
+        return false;
+
+    return !a->isRangeSupportingType() || a->range() == b->range();
 }
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -31,6 +31,7 @@
 #include "PDFPluginBase.h"
 #include <WebCore/ElementIdentifier.h>
 #include <WebCore/GraphicsLayer.h>
+#include <WebCore/Page.h>
 #include <wtf/OptionSet.h>
 
 OBJC_CLASS PDFAction;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
@@ -386,7 +386,7 @@ void UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithR
         return;
     }
 
-    auto updatedLiveRange = createLiveRange({ *extendedSelectedTextRangeStartPoint, *extendedSelectionTextRangeEndPoint });
+    auto updatedLiveRange = WebCore::createLiveRange({ *extendedSelectedTextRangeStartPoint, *extendedSelectionTextRangeEndPoint });
 
     m_contextRanges.set(uuid, updatedLiveRange);
 }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h
@@ -27,6 +27,10 @@
 
 #include "PlatformCALayerRemote.h"
 
+namespace WebCore {
+class PlatformCALayerClient;
+}
+
 namespace WebKit {
 
 class LayerHostingContext;
@@ -36,7 +40,7 @@ class PlatformCALayerRemoteCustom final : public PlatformCALayerRemote {
     friend class PlatformCALayerRemote;
 public:
     static Ref<PlatformCALayerRemote> create(PlatformLayer *, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
-    static Ref<PlatformCALayerRemote> create(LayerHostingContextID, PlatformCALayerClient*, RemoteLayerTreeContext&);
+    static Ref<PlatformCALayerRemote> create(LayerHostingContextID, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
 #if HAVE(AVKIT)
     static Ref<PlatformCALayerRemote> create(WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
 #endif
@@ -54,7 +58,7 @@ public:
 
 private:
     PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType, PlatformLayer *, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
-    PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType, LayerHostingContextID, PlatformCALayerClient* owner, RemoteLayerTreeContext&);
+    PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType, LayerHostingContextID, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
     PlatformCALayerRemoteCustom(WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
 
     Ref<WebCore::PlatformCALayer> clone(WebCore::PlatformCALayerClient* owner) const override;


### PR DESCRIPTION
#### c4304291691ca9767872d81459d4a6553fb45869
<pre>
[UnifiedPDF] WebCore::DataDetectorHighlight should be decoupled from the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=270883">https://bugs.webkit.org/show_bug.cgi?id=270883</a>
<a href="https://rdar.apple.com/124490748">rdar://124490748</a>

Reviewed by Aditya Keerthi.

Currently, DataDetectorHighlight instances require a WebCore::Page
object at construction time. This object is used for some IPC needs
such as for scheduling rendering updates and for creating graphics layers,
among other things. While having a Page object around is convenient, it
does not fit well when trying to integrate the DataDetectorHighlight
data type in the UnifiedPDF Data Detection code path.

This patch rips out the dependency of DataDetectorHighlight on
the page object, instead delegating its duties to the abstract interface
DataDetectorHighlightClient, which can be satisifed by downstream
overlay controllers, or even PDF plugins. We make this change in
anticipation of a forthcoming patch where we construct and display
DataDetectorHighlight instances in a UnifiedPDFPlugin-specific document
overlay controller. Furthermore, we also adopt the changes made to the
DataDetectorHighlightClient interface in two notable overlay controllers
- ImageOverlayController and ServicesOverlayController.

Furthermore, we make a few miscellaneous unified sources build fixes and
annotate a couple of `enum class` declarations with the tightest
possible data type representation.

* Source/WebCore/page/ImageOverlayController.h:
* Source/WebCore/page/PageOverlay.h:
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::updateDataDetectorHighlights):
(WebCore::ImageOverlayController::scheduleRenderingUpdate):
(WebCore::ImageOverlayController::deviceScaleFactor const):
(WebCore::ImageOverlayController::createGraphicsLayer):
* Source/WebCore/page/mac/ServicesOverlayController.h:
(WebCore::ServicesOverlayController::protectedPage const):
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::buildPhoneNumberHighlights):
(WebCore::ServicesOverlayController::buildSelectionHighlight):
(WebCore::ServicesOverlayController::scheduleRenderingUpdate):
(WebCore::ServicesOverlayController::deviceScaleFactor const):
(WebCore::ServicesOverlayController::createGraphicsLayer):
* Source/WebCore/platform/mac/DataDetectorHighlight.h:
(WebCore::DataDetectorHighlight::range const): Deleted.
* Source/WebCore/platform/mac/DataDetectorHighlight.mm:
(WebCore::DataDetectorHighlight::createForSelection):
(WebCore::DataDetectorHighlight::createForTelephoneNumber):
(WebCore::DataDetectorHighlight::createForImageOverlay):
(WebCore::DataDetectorHighlight::DataDetectorHighlight):
(WebCore::DataDetectorHighlight::invalidate):
(WebCore::DataDetectorHighlight::notifyFlushRequired):
(WebCore::DataDetectorHighlight::deviceScaleFactor const):
(WebCore::DataDetectorHighlight::isRangeSupportingType const):
(WebCore::DataDetectorHighlight::range const):
(WebCore::areEquivalent):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm:
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithReplacementRange):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h:

Canonical link: <a href="https://commits.webkit.org/276060@main">https://commits.webkit.org/276060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92facdace047aa7b66d56a1edc1234709ed992bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46157 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39651 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45826 "Passed tests") | [💥 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26391 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/35986 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16959 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17156 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38562 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1578 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47703 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42772 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19975 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41445 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9711 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->