### PR TITLE
[JSC] Validate that HasStaticPropertyTable is present only if there is a static property table

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayIteratorPrototype.h
+++ b/Source/JavaScriptCore/runtime/ArrayIteratorPrototype.h
@@ -32,7 +32,7 @@ namespace JSC {
 class ArrayIteratorPrototype final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/runtime/AsyncGeneratorFunctionPrototype.h
+++ b/Source/JavaScriptCore/runtime/AsyncGeneratorFunctionPrototype.h
@@ -32,7 +32,7 @@ namespace JSC {
 class AsyncGeneratorFunctionPrototype final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/runtime/IntlLocaleConstructor.h
+++ b/Source/JavaScriptCore/runtime/IntlLocaleConstructor.h
@@ -35,7 +35,7 @@ class IntlLocalePrototype;
 class IntlLocaleConstructor final : public InternalFunction {
 public:
     using Base = InternalFunction;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static IntlLocaleConstructor* create(VM&, Structure*, IntlLocalePrototype*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.h
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.h
@@ -38,7 +38,7 @@ class SourceCode;
 class JSModuleLoader final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/runtime/MapConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/MapConstructor.cpp
@@ -34,16 +34,9 @@
 #include "MapPrototype.h"
 #include "VMInlines.h"
 
-#include "MapConstructor.lut.h"
-
 namespace JSC {
 
-const ClassInfo MapConstructor::s_info = { "Function"_s, &Base::s_info, &mapConstructorTable, nullptr, CREATE_METHOD_TABLE(MapConstructor) };
-
-/* Source for MapConstructor.lut.h
-@begin mapConstructorTable
-@end
-*/
+const ClassInfo MapConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(MapConstructor) };
 
 void MapConstructor::finishCreation(VM& vm, MapPrototype* mapPrototype)
 {

--- a/Source/JavaScriptCore/runtime/MapPrototype.h
+++ b/Source/JavaScriptCore/runtime/MapPrototype.h
@@ -40,7 +40,7 @@ public:
         return &vm.plainObjectSpace();
     }
 
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static MapPrototype* create(VM& vm, JSGlobalObject* globalObject, Structure* structure)
     {

--- a/Source/JavaScriptCore/runtime/RegExpStringIteratorPrototype.h
+++ b/Source/JavaScriptCore/runtime/RegExpStringIteratorPrototype.h
@@ -33,7 +33,7 @@ namespace JSC {
 class RegExpStringIteratorPrototype final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/runtime/SetPrototype.h
+++ b/Source/JavaScriptCore/runtime/SetPrototype.h
@@ -40,7 +40,7 @@ public:
         return &vm.plainObjectSpace();
     }
 
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static SetPrototype* create(VM& vm, JSGlobalObject* globalObject, Structure* structure)
     {

--- a/Source/JavaScriptCore/runtime/StringIteratorPrototype.h
+++ b/Source/JavaScriptCore/runtime/StringIteratorPrototype.h
@@ -33,7 +33,7 @@ namespace JSC {
 class StringIteratorPrototype final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -130,6 +130,13 @@ void Structure::dumpStatistics()
 #if ASSERT_ENABLED
 void Structure::validateFlags()
 {
+    bool hasStaticPropertyTable = false;
+    for (const ClassInfo* ci = classInfoForCells(); ci; ci = ci->parentClass) {
+        if (ci->staticPropHashTable)
+            hasStaticPropertyTable = true;
+    }
+    RELEASE_ASSERT(hasStaticPropertyTable == typeInfo().hasStaticPropertyTable());
+
     const MethodTable& methodTable = m_classInfo->methodTable;
 
     bool overridesGetCallData = methodTable.getCallData != JSCell::getCallData;

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -987,7 +987,7 @@ static const struct JSC::HashTable staticDontDeleteDontEnumTable =
 
 class ObjectDoingSideEffectPutWithoutCorrectSlotStatus : public JSNonFinalObject {
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesPut;
+    static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesPut | HasStaticPropertyTable;
 public:
     template<typename CellType, SubspaceAccess>
     static CompleteSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyArrayConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyArrayConstructor.cpp
@@ -32,19 +32,12 @@
 #include "JSWebAssemblyArray.h"
 #include "WebAssemblyArrayPrototype.h"
 
-#include "WebAssemblyArrayConstructor.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyArrayConstructor::s_info = { "Function"_s, &Base::s_info, &constructorTableWebAssemblyArray, nullptr, CREATE_METHOD_TABLE(WebAssemblyArrayConstructor) };
+const ClassInfo WebAssemblyArrayConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyArrayConstructor) };
 
 static JSC_DECLARE_HOST_FUNCTION(constructJSWebAssemblyArray);
 static JSC_DECLARE_HOST_FUNCTION(callJSWebAssemblyArray);
-
-/* Source for WebAssemblyArrayConstructor.lut.h
- @begin constructorTableWebAssemblyArray
- @end
- */
 
 JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyArray, (JSGlobalObject* globalObject, CallFrame*))
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyArrayConstructor.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyArrayConstructor.h
@@ -37,7 +37,7 @@ class WebAssemblyArrayPrototype;
 class WebAssemblyArrayConstructor final : public InternalFunction {
 public:
     using Base = InternalFunction;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static WebAssemblyArrayConstructor* create(VM&, Structure*, WebAssemblyArrayPrototype*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyArrayPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyArrayPrototype.cpp
@@ -33,16 +33,10 @@
 #include "JSObjectInlines.h"
 #include "JSWebAssemblyArray.h"
 #include "StructureInlines.h"
-#include "WebAssemblyArrayPrototype.lut.h"
 
 namespace JSC {
 
-const ClassInfo WebAssemblyArrayPrototype::s_info = { "WebAssembly.Array"_s, &Base::s_info, &prototypeTableWebAssemblyArray, nullptr, CREATE_METHOD_TABLE(WebAssemblyArrayPrototype) };
-
-/* Source for WebAssemblyArrayPrototype.lut.h
- @begin prototypeTableWebAssemblyArray
- @end
- */
+const ClassInfo WebAssemblyArrayPrototype::s_info = { "WebAssembly.Array"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyArrayPrototype) };
 
 WebAssemblyArrayPrototype* WebAssemblyArrayPrototype::create(VM& vm, JSGlobalObject*, Structure* structure)
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyArrayPrototype.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyArrayPrototype.h
@@ -34,7 +34,7 @@ namespace JSC {
 class WebAssemblyArrayPrototype final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyCompileErrorConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyCompileErrorConstructor.cpp
@@ -32,19 +32,12 @@
 #include "JSWebAssemblyCompileError.h"
 #include "WebAssemblyCompileErrorPrototype.h"
 
-#include "WebAssemblyCompileErrorConstructor.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyCompileErrorConstructor::s_info = { "Function"_s, &Base::s_info, &constructorTableWebAssemblyCompileError, nullptr, CREATE_METHOD_TABLE(WebAssemblyCompileErrorConstructor) };
+const ClassInfo WebAssemblyCompileErrorConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyCompileErrorConstructor) };
 
 static JSC_DECLARE_HOST_FUNCTION(constructJSWebAssemblyCompileError);
 static JSC_DECLARE_HOST_FUNCTION(callJSWebAssemblyCompileError);
-
-/* Source for WebAssemblyCompileErrorConstructor.lut.h
- @begin constructorTableWebAssemblyCompileError
- @end
- */
 
 JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyCompileError, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyCompileErrorConstructor.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyCompileErrorConstructor.h
@@ -37,7 +37,7 @@ class WebAssemblyCompileErrorPrototype;
 class WebAssemblyCompileErrorConstructor final : public InternalFunction {
 public:
     typedef InternalFunction Base;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static WebAssemblyCompileErrorConstructor* create(VM&, Structure*, WebAssemblyCompileErrorPrototype*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyCompileErrorPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyCompileErrorPrototype.cpp
@@ -31,16 +31,9 @@
 #include "AuxiliaryBarrierInlines.h"
 #include "JSCInlines.h"
 
-#include "WebAssemblyCompileErrorPrototype.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyCompileErrorPrototype::s_info = { "WebAssembly.CompileError"_s, &Base::s_info, &prototypeTableWebAssemblyCompileError, nullptr, CREATE_METHOD_TABLE(WebAssemblyCompileErrorPrototype) };
-
-/* Source for WebAssemblyCompileErrorPrototype.lut.h
- @begin prototypeTableWebAssemblyCompileError
- @end
- */
+const ClassInfo WebAssemblyCompileErrorPrototype::s_info = { "WebAssembly.CompileError"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyCompileErrorPrototype) };
 
 WebAssemblyCompileErrorPrototype* WebAssemblyCompileErrorPrototype::create(VM& vm, JSGlobalObject*, Structure* structure)
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyCompileErrorPrototype.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyCompileErrorPrototype.h
@@ -35,7 +35,7 @@ namespace JSC {
 class WebAssemblyCompileErrorPrototype final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp
@@ -36,19 +36,12 @@
 #include "JSWebAssemblyTag.h"
 #include "WebAssemblyExceptionPrototype.h"
 
-#include "WebAssemblyExceptionConstructor.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyExceptionConstructor::s_info = { "Function"_s, &Base::s_info, &constructorTableWebAssemblyException, nullptr, CREATE_METHOD_TABLE(WebAssemblyExceptionConstructor) };
+const ClassInfo WebAssemblyExceptionConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyExceptionConstructor) };
 
 static JSC_DECLARE_HOST_FUNCTION(constructJSWebAssemblyException);
 static JSC_DECLARE_HOST_FUNCTION(callJSWebAssemblyException);
-
-/* Source for WebAssemblyExceptionConstructor.lut.h
- @begin constructorTableWebAssemblyException
- @end
- */
 
 JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyException, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.h
@@ -37,7 +37,7 @@ class WebAssemblyExceptionPrototype;
 class WebAssemblyExceptionConstructor final : public InternalFunction {
 public:
     using Base = InternalFunction;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static WebAssemblyExceptionConstructor* create(VM&, Structure*, WebAssemblyExceptionPrototype*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp
@@ -35,19 +35,12 @@
 #include "WasmFormat.h"
 #include "WebAssemblyGlobalPrototype.h"
 
-#include "WebAssemblyGlobalConstructor.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyGlobalConstructor::s_info = { "Function"_s, &Base::s_info, &constructorGlobalWebAssemblyGlobal, nullptr, CREATE_METHOD_TABLE(WebAssemblyGlobalConstructor) };
+const ClassInfo WebAssemblyGlobalConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyGlobalConstructor) };
 
 static JSC_DECLARE_HOST_FUNCTION(constructJSWebAssemblyGlobal);
 static JSC_DECLARE_HOST_FUNCTION(callJSWebAssemblyGlobal);
-
-/* Source for WebAssemblyGlobalConstructor.lut.h
- @begin constructorGlobalWebAssemblyGlobal
- @end
- */
 
 JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyGlobal, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.h
@@ -37,7 +37,7 @@ class WebAssemblyGlobalPrototype;
 class WebAssemblyGlobalConstructor final : public InternalFunction {
 public:
     using Base = InternalFunction;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static WebAssemblyGlobalConstructor* create(VM&, Structure*, WebAssemblyGlobalPrototype*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyInstanceConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyInstanceConstructor.cpp
@@ -33,19 +33,12 @@
 #include "JSWebAssemblyModule.h"
 #include "WebAssemblyInstancePrototype.h"
 
-#include "WebAssemblyInstanceConstructor.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyInstanceConstructor::s_info = { "Function"_s, &Base::s_info, &constructorTableWebAssemblyInstance, nullptr, CREATE_METHOD_TABLE(WebAssemblyInstanceConstructor) };
+const ClassInfo WebAssemblyInstanceConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyInstanceConstructor) };
 
 static JSC_DECLARE_HOST_FUNCTION(constructJSWebAssemblyInstance);
 static JSC_DECLARE_HOST_FUNCTION(callJSWebAssemblyInstance);
-
-/* Source for WebAssemblyInstanceConstructor.lut.h
- @begin constructorTableWebAssemblyInstance
- @end
- */
 
 using Wasm::Plan;
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyInstanceConstructor.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyInstanceConstructor.h
@@ -39,7 +39,7 @@ class WebAssemblyInstancePrototype;
 class WebAssemblyInstanceConstructor final : public InternalFunction {
 public:
     typedef InternalFunction Base;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static WebAssemblyInstanceConstructor* create(VM&, Structure*, WebAssemblyInstancePrototype*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyInstancePrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyInstancePrototype.cpp
@@ -36,18 +36,8 @@
 
 namespace JSC {
 static JSC_DECLARE_HOST_FUNCTION(webAssemblyInstanceProtoGetterExports);
-}
 
-#include "WebAssemblyInstancePrototype.lut.h"
-
-namespace JSC {
-
-const ClassInfo WebAssemblyInstancePrototype::s_info = { "WebAssembly.Instance"_s, &Base::s_info, &prototypeTableWebAssemblyInstance, nullptr, CREATE_METHOD_TABLE(WebAssemblyInstancePrototype) };
-
-/* Source for WebAssemblyInstancePrototype.lut.h
- @begin prototypeTableWebAssemblyInstance
- @end
- */
+const ClassInfo WebAssemblyInstancePrototype::s_info = { "WebAssembly.Instance"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyInstancePrototype) };
 
 static ALWAYS_INLINE JSWebAssemblyInstance* getInstance(JSGlobalObject* globalObject, VM& vm, JSValue v)
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyInstancePrototype.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyInstancePrototype.h
@@ -35,7 +35,7 @@ namespace JSC {
 class WebAssemblyInstancePrototype final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyLinkErrorConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyLinkErrorConstructor.cpp
@@ -32,19 +32,12 @@
 #include "JSWebAssemblyLinkError.h"
 #include "WebAssemblyLinkErrorPrototype.h"
 
-#include "WebAssemblyLinkErrorConstructor.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyLinkErrorConstructor::s_info = { "Function"_s, &Base::s_info, &constructorTableWebAssemblyLinkError, nullptr, CREATE_METHOD_TABLE(WebAssemblyLinkErrorConstructor) };
+const ClassInfo WebAssemblyLinkErrorConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyLinkErrorConstructor) };
 
 static JSC_DECLARE_HOST_FUNCTION(constructJSWebAssemblyLinkError);
 static JSC_DECLARE_HOST_FUNCTION(callJSWebAssemblyLinkError);
-
-/* Source for WebAssemblyLinkErrorConstructor.lut.h
- @begin constructorTableWebAssemblyLinkError
- @end
- */
 
 JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyLinkError, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyLinkErrorConstructor.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyLinkErrorConstructor.h
@@ -37,7 +37,7 @@ class WebAssemblyLinkErrorPrototype;
 class WebAssemblyLinkErrorConstructor final : public InternalFunction {
 public:
     typedef InternalFunction Base;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static WebAssemblyLinkErrorConstructor* create(VM&, Structure*, WebAssemblyLinkErrorPrototype*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyLinkErrorPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyLinkErrorPrototype.cpp
@@ -31,16 +31,9 @@
 #include "AuxiliaryBarrierInlines.h"
 #include "JSCInlines.h"
 
-#include "WebAssemblyLinkErrorPrototype.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyLinkErrorPrototype::s_info = { "WebAssembly.LinkError"_s, &Base::s_info, &prototypeTableWebAssemblyLinkError, nullptr, CREATE_METHOD_TABLE(WebAssemblyLinkErrorPrototype) };
-
-/* Source for WebAssemblyLinkErrorPrototype.lut.h
- @begin prototypeTableWebAssemblyLinkError
- @end
- */
+const ClassInfo WebAssemblyLinkErrorPrototype::s_info = { "WebAssembly.LinkError"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyLinkErrorPrototype) };
 
 WebAssemblyLinkErrorPrototype* WebAssemblyLinkErrorPrototype::create(VM& vm, JSGlobalObject*, Structure* structure)
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyLinkErrorPrototype.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyLinkErrorPrototype.h
@@ -35,7 +35,7 @@ namespace JSC {
 class WebAssemblyLinkErrorPrototype final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
@@ -38,19 +38,12 @@
 #include "WasmMemory.h"
 #include "WebAssemblyMemoryPrototype.h"
 
-#include "WebAssemblyMemoryConstructor.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyMemoryConstructor::s_info = { "Function"_s, &Base::s_info, &constructorTableWebAssemblyMemory, nullptr, CREATE_METHOD_TABLE(WebAssemblyMemoryConstructor) };
+const ClassInfo WebAssemblyMemoryConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyMemoryConstructor) };
 
 static JSC_DECLARE_HOST_FUNCTION(constructJSWebAssemblyMemory);
 static JSC_DECLARE_HOST_FUNCTION(callJSWebAssemblyMemory);
-
-/* Source for WebAssemblyMemoryConstructor.lut.h
- @begin constructorTableWebAssemblyMemory
- @end
- */
 
 JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyMemory, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.h
@@ -37,7 +37,7 @@ class WebAssemblyMemoryPrototype;
 class WebAssemblyMemoryConstructor final : public InternalFunction {
 public:
     typedef InternalFunction Base;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static WebAssemblyMemoryConstructor* create(VM&, Structure*, WebAssemblyMemoryPrototype*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModulePrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModulePrototype.cpp
@@ -31,16 +31,9 @@
 #include "AuxiliaryBarrierInlines.h"
 #include "JSCInlines.h"
 
-#include "WebAssemblyModulePrototype.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyModulePrototype::s_info = { "WebAssembly.Module"_s, &Base::s_info, &prototypeTableWebAssemblyModule, nullptr, CREATE_METHOD_TABLE(WebAssemblyModulePrototype) };
-
-/* Source for WebAssemblyModulePrototype.lut.h
- @begin prototypeTableWebAssemblyModule
- @end
- */
+const ClassInfo WebAssemblyModulePrototype::s_info = { "WebAssembly.Module"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyModulePrototype) };
 
 WebAssemblyModulePrototype* WebAssemblyModulePrototype::create(VM& vm, JSGlobalObject*, Structure* structure)
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModulePrototype.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModulePrototype.h
@@ -35,7 +35,7 @@ namespace JSC {
 class WebAssemblyModulePrototype final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyRuntimeErrorConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyRuntimeErrorConstructor.cpp
@@ -32,19 +32,12 @@
 #include "JSWebAssemblyRuntimeError.h"
 #include "WebAssemblyRuntimeErrorPrototype.h"
 
-#include "WebAssemblyRuntimeErrorConstructor.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyRuntimeErrorConstructor::s_info = { "Function"_s, &Base::s_info, &constructorTableWebAssemblyRuntimeError, nullptr, CREATE_METHOD_TABLE(WebAssemblyRuntimeErrorConstructor) };
+const ClassInfo WebAssemblyRuntimeErrorConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyRuntimeErrorConstructor) };
 
 static JSC_DECLARE_HOST_FUNCTION(constructJSWebAssemblyRuntimeError);
 static JSC_DECLARE_HOST_FUNCTION(callJSWebAssemblyRuntimeError);
-
-/* Source for WebAssemblyRuntimeErrorConstructor.lut.h
- @begin constructorTableWebAssemblyRuntimeError
- @end
- */
 
 JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyRuntimeError, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyRuntimeErrorConstructor.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyRuntimeErrorConstructor.h
@@ -37,7 +37,7 @@ class WebAssemblyRuntimeErrorPrototype;
 class WebAssemblyRuntimeErrorConstructor final : public InternalFunction {
 public:
     typedef InternalFunction Base;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static WebAssemblyRuntimeErrorConstructor* create(VM&, Structure*, WebAssemblyRuntimeErrorPrototype*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyRuntimeErrorPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyRuntimeErrorPrototype.cpp
@@ -30,16 +30,10 @@
 
 #include "AuxiliaryBarrierInlines.h"
 #include "JSCInlines.h"
-#include "WebAssemblyRuntimeErrorPrototype.lut.h"
 
 namespace JSC {
 
-const ClassInfo WebAssemblyRuntimeErrorPrototype::s_info = { "WebAssembly.RuntimeError"_s, &Base::s_info, &prototypeTableWebAssemblyRuntimeError, nullptr, CREATE_METHOD_TABLE(WebAssemblyRuntimeErrorPrototype) };
-
-/* Source for WebAssemblyRuntimeErrorPrototype.lut.h
- @begin prototypeTableWebAssemblyRuntimeError
- @end
- */
+const ClassInfo WebAssemblyRuntimeErrorPrototype::s_info = { "WebAssembly.RuntimeError"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyRuntimeErrorPrototype) };
 
 WebAssemblyRuntimeErrorPrototype* WebAssemblyRuntimeErrorPrototype::create(VM& vm, JSGlobalObject*, Structure* structure)
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyRuntimeErrorPrototype.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyRuntimeErrorPrototype.h
@@ -35,7 +35,7 @@ namespace JSC {
 class WebAssemblyRuntimeErrorPrototype final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyStructConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyStructConstructor.cpp
@@ -34,19 +34,12 @@
 #include "JSWebAssemblyStruct.h"
 #include "WebAssemblyStructPrototype.h"
 
-#include "WebAssemblyStructConstructor.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyStructConstructor::s_info = { "Function"_s, &Base::s_info, &constructorTableWebAssemblyStruct, nullptr, CREATE_METHOD_TABLE(WebAssemblyStructConstructor) };
+const ClassInfo WebAssemblyStructConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyStructConstructor) };
 
 static JSC_DECLARE_HOST_FUNCTION(constructJSWebAssemblyStruct);
 static JSC_DECLARE_HOST_FUNCTION(callJSWebAssemblyStruct);
-
-/* Source for WebAssemblyStructConstructor.lut.h
- @begin constructorTableWebAssemblyStruct
- @end
- */
 
 JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyStruct, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyStructConstructor.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyStructConstructor.h
@@ -37,7 +37,7 @@ class WebAssemblyStructPrototype;
 class WebAssemblyStructConstructor final : public InternalFunction {
 public:
     using Base = InternalFunction;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static WebAssemblyStructConstructor* create(VM&, Structure*, WebAssemblyStructPrototype*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyStructPrototype.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyStructPrototype.cpp
@@ -32,16 +32,9 @@
 #include "JSCInlines.h"
 #include "JSWebAssemblyStruct.h"
 
-#include "WebAssemblyStructPrototype.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyStructPrototype::s_info = { "WebAssembly.Struct"_s, &Base::s_info, &prototypeTableWebAssemblyStruct, nullptr, CREATE_METHOD_TABLE(WebAssemblyStructPrototype) };
-
-/* Source for WebAssemblyStructPrototype.lut.h
- @begin prototypeTableWebAssemblyStruct
- @end
- */
+const ClassInfo WebAssemblyStructPrototype::s_info = { "WebAssembly.Struct"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyStructPrototype) };
 
 WebAssemblyStructPrototype* WebAssemblyStructPrototype::create(VM& vm, JSGlobalObject*, Structure* structure)
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyStructPrototype.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyStructPrototype.h
@@ -34,7 +34,7 @@ namespace JSC {
 class WebAssemblyStructPrototype final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp
@@ -36,19 +36,12 @@
 #include "StructureInlines.h"
 #include "WebAssemblyTablePrototype.h"
 
-#include "WebAssemblyTableConstructor.lut.h"
-
 namespace JSC {
 
-const ClassInfo WebAssemblyTableConstructor::s_info = { "Function"_s, &Base::s_info, &constructorTableWebAssemblyTable, nullptr, CREATE_METHOD_TABLE(WebAssemblyTableConstructor) };
+const ClassInfo WebAssemblyTableConstructor::s_info = { "Function"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(WebAssemblyTableConstructor) };
 
 static JSC_DECLARE_HOST_FUNCTION(callJSWebAssemblyTable);
 static JSC_DECLARE_HOST_FUNCTION(constructJSWebAssemblyTable);
-
-/* Source for WebAssemblyTableConstructor.lut.h
- @begin constructorTableWebAssemblyTable
- @end
- */
 
 JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyTable, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.h
@@ -37,7 +37,7 @@ class WebAssemblyTablePrototype;
 class WebAssemblyTableConstructor final : public InternalFunction {
 public:
     typedef InternalFunction Base;
-    static constexpr unsigned StructureFlags = Base::StructureFlags | HasStaticPropertyTable;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     static WebAssemblyTableConstructor* create(VM&, Structure*, WebAssemblyTablePrototype*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -7978,7 +7978,7 @@ sub GeneratePrototypeDeclaration
     push(@$outputArray, "\n");
     push(@$outputArray, "    void finishCreation(JSC::VM&);\n");
 
-    $structureFlags{"JSC::HasStaticPropertyTable"} = 1 if PrototypeHasStaticPropertyTable($interface) && IsGlobalInterface($interface);
+    $structureFlags{"JSC::HasStaticPropertyTable"} = 1 if !ShouldUseOrdinaryObjectPrototype($interface) && IsDOMGlobalObject($interface);
     $structureFlags{"JSC::IsImmutablePrototypeExoticObject"} = 1 if $interface->extendedAttributes->{IsImmutablePrototypeExoticObjectOnPrototype};
 
     # structure flags

--- a/Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.h
@@ -101,6 +101,8 @@ private:
     }
 
     void finishCreation(JSC::VM&);
+public:
+    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::HasStaticPropertyTable;
 };
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSDedicatedWorkerGlobalScopePrototype, JSDedicatedWorkerGlobalScopePrototype::Base);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSLocalDOMWindow.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSLocalDOMWindow.h
@@ -101,6 +101,8 @@ private:
     }
 
     void finishCreation(JSC::VM&);
+public:
+    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::HasStaticPropertyTable;
 };
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSLocalDOMWindowPrototype, JSLocalDOMWindowPrototype::Base);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.h
@@ -101,6 +101,8 @@ private:
     }
 
     void finishCreation(JSC::VM&);
+public:
+    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::HasStaticPropertyTable;
 };
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSPaintWorkletGlobalScopePrototype, JSPaintWorkletGlobalScopePrototype::Base);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.h
@@ -101,6 +101,8 @@ private:
     }
 
     void finishCreation(JSC::VM&);
+public:
+    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::HasStaticPropertyTable;
 };
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSServiceWorkerGlobalScopePrototype, JSServiceWorkerGlobalScopePrototype::Base);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.h
@@ -101,6 +101,8 @@ private:
     }
 
     void finishCreation(JSC::VM&);
+public:
+    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::HasStaticPropertyTable;
 };
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSSharedWorkerGlobalScopePrototype, JSSharedWorkerGlobalScopePrototype::Base);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.h
@@ -104,6 +104,8 @@ private:
     }
 
     void finishCreation(JSC::VM&);
+public:
+    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::HasStaticPropertyTable;
 };
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSWorkerGlobalScopePrototype, JSWorkerGlobalScopePrototype::Base);
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.h
@@ -104,6 +104,8 @@ private:
     }
 
     void finishCreation(JSC::VM&);
+public:
+    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::HasStaticPropertyTable;
 };
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSWorkletGlobalScopePrototype, JSWorkletGlobalScopePrototype::Base);
 


### PR DESCRIPTION
#### ed9f215ec22744e680c5a1f6f382f2b7afca56ad
<pre>
[JSC] Validate that HasStaticPropertyTable is present only if there is a static property table
<a href="https://bugs.webkit.org/show_bug.cgi?id=270889">https://bugs.webkit.org/show_bug.cgi?id=270889</a>
&lt;<a href="https://rdar.apple.com/problem/124493762">rdar://problem/124493762</a>&gt;

Reviewed by Yusuke Suzuki.

This change:

  1) Removes empty static property tables.
  2) Removes HasStaticPropertyTable structure flag from classes without static property tables.
  3) Fixes bindings generator condition for setting HasStaticPropertyTable to match the condition for
     setting `staticPropHashTable`, which isn&apos;t observable because we eagerly reify all static properties.
  4) Adds an assertion to validate that HasStaticPropertyTable is present only if there is an own or
     inherited static property table.

1) and 2) are performance micro-optimizations that avoid calling into getOwnStaticPropertySlot()
for property lookup if there is no static property table, own nor inherited, while 4) ensures
consistency across the JSC codebase.

* Source/JavaScriptCore/runtime/ArrayIteratorPrototype.h:
* Source/JavaScriptCore/runtime/AsyncGeneratorFunctionPrototype.h:
* Source/JavaScriptCore/runtime/IntlLocaleConstructor.h:
* Source/JavaScriptCore/runtime/JSModuleLoader.h:
* Source/JavaScriptCore/runtime/MapConstructor.cpp:
* Source/JavaScriptCore/runtime/MapPrototype.h:
* Source/JavaScriptCore/runtime/RegExpStringIteratorPrototype.h:
* Source/JavaScriptCore/runtime/SetPrototype.h:
* Source/JavaScriptCore/runtime/StringIteratorPrototype.h:
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::validateFlags):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyArrayConstructor.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyArrayConstructor.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyArrayPrototype.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyArrayPrototype.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyCompileErrorConstructor.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyCompileErrorConstructor.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyCompileErrorPrototype.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyCompileErrorPrototype.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyExceptionConstructor.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyGlobalConstructor.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyInstanceConstructor.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyInstanceConstructor.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyInstancePrototype.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyInstancePrototype.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyLinkErrorConstructor.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyLinkErrorConstructor.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyLinkErrorPrototype.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyLinkErrorPrototype.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModulePrototype.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyModulePrototype.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyRuntimeErrorConstructor.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyRuntimeErrorConstructor.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyRuntimeErrorPrototype.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyRuntimeErrorPrototype.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyStructConstructor.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyStructConstructor.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyStructPrototype.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyStructPrototype.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.cpp:
* Source/JavaScriptCore/wasm/js/WebAssemblyTableConstructor.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GeneratePrototypeDeclaration):
* Source/WebCore/bindings/scripts/test/JS/*: Updated.

Canonical link: <a href="https://commits.webkit.org/276069@main">https://commits.webkit.org/276069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/101e0016d93ca10f373e29d5dfeebd0d6086ee8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46312 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39791 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20125 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37605 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17052 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; 1 api test failed or timed out; Running re-run-api-tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38667 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1726 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37126 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47864 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43302 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42872 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20125 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41550 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20306 "Built successfully") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5960 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19751 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10136 "Passed tests") | 
<!--EWS-Status-Bubble-End-->