### PR TITLE
Remove FIXME about `resetClip` in CanvasDrawPath.idl

### DIFF
--- a/Source/WebCore/html/canvas/CanvasDrawPath.idl
+++ b/Source/WebCore/html/canvas/CanvasDrawPath.idl
@@ -33,8 +33,6 @@ interface mixin CanvasDrawPath {
     undefined stroke(Path2D path);
     undefined clip(optional CanvasFillRule fillRule = "nonzero");
     undefined clip(Path2D path, optional CanvasFillRule fillRule = "nonzero");
-    // FIXME: Implement resetClip.
-    // undefined resetClip();
 
     boolean isPointInPath(unrestricted double x, unrestricted double y, optional CanvasFillRule fillRule = "nonzero");
     boolean isPointInPath(Path2D path, unrestricted double x, unrestricted double y, optional CanvasFillRule fillRule = "nonzero");


### PR DESCRIPTION
#### 333abc3ffa529b870b611f130f3745834f3821eb
<pre>
Remove FIXME about `resetClip` in CanvasDrawPath.idl

<a href="https://bugs.webkit.org/show_bug.cgi?id=270890">https://bugs.webkit.org/show_bug.cgi?id=270890</a>

Reviewed by Simon Fraser.

There is no web specification about `resetClip`, so no reason to
keep this FIXME.

&gt; <a href="https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawpath">https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawpath</a>

It was trialed in past for implementation in bug 82801, which was
concluded with similar conclusion as below W3C thread:

&gt; <a href="https://lists.w3.org/Archives/Public/public-whatwg-archive/2013Oct/0057.html">https://lists.w3.org/Archives/Public/public-whatwg-archive/2013Oct/0057.html</a>

&quot;The reason resetClip() is a bad API is that it breaks the ability...&quot;

* Source/WebCore/html/canvas/CanvasDrawPath.idl:

Canonical link: <a href="https://commits.webkit.org/276022@main">https://commits.webkit.org/276022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f70d9d89a18d786f051841438ad80830323656cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46168 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39662 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19982 "Built successfully") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36005 "An unexpected error occured. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; Exiting early after 500 failures. 17632 tests run. 1 flakes 500 failures; Uploaded test results") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37508 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16972 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17167 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (failure); Uploaded test results; layout-tests (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38573 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1589 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38879 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47714 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15194 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42782 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19986 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41456 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9694 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20166 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->