### PR TITLE
Use smart pointers to store references to ObjectHeap

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.cpp
@@ -84,10 +84,10 @@ Vector<MachSendRight> CompositorIntegrationImpl::recreateRenderBuffers(int width
 }
 #endif
 
-void CompositorIntegrationImpl::withDisplayBufferAsNativeImage(uint32_t bufferIndex, Function<void(WebCore::NativeImage&)> completion)
+void CompositorIntegrationImpl::withDisplayBufferAsNativeImage(uint32_t bufferIndex, Function<void(WebCore::NativeImage*)> completion)
 {
     if (!m_renderBuffers.size() || bufferIndex >= m_renderBuffers.size())
-        return;
+        return completion(nullptr);
 
     RefPtr<NativeImage> displayImage;
 
@@ -98,10 +98,10 @@ void CompositorIntegrationImpl::withDisplayBufferAsNativeImage(uint32_t bufferIn
         displayImage = NativeImage::create(renderBuffer->createImage(cgContext.get()));
 
     if (!displayImage)
-        return;
+        return completion(nullptr);
 
     CGImageSetCachingFlags(displayImage->platformImage().get(), kCGImageCachingTransient);
-    completion(*displayImage);
+    completion(displayImage.get());
 }
 
 void CompositorIntegrationImpl::paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t)

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCompositorIntegrationImpl.h
@@ -74,7 +74,7 @@ public:
         m_onSubmittedWorkScheduledCallback = WTFMove(onSubmittedWorkScheduledCallback);
     }
 
-    void withDisplayBufferAsNativeImage(uint32_t bufferIndex, Function<void(WebCore::NativeImage&)>) final;
+    void withDisplayBufferAsNativeImage(uint32_t bufferIndex, Function<void(WebCore::NativeImage*)>) final;
     void paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t) final;
 
 private:

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUCompositorIntegration.h
@@ -53,7 +53,7 @@ public:
 #endif
 
     virtual void prepareForDisplay(CompletionHandler<void()>&&) = 0;
-    virtual void withDisplayBufferAsNativeImage(uint32_t bufferIndex, Function<void(WebCore::NativeImage&)>) = 0;
+    virtual void withDisplayBufferAsNativeImage(uint32_t bufferIndex, Function<void(WebCore::NativeImage*)>) = 0;
     virtual void paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t bufferIndex) = 0;
 
 protected:

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -183,10 +183,10 @@ public:
     }
 
 private:
-    Logger& logger() final { return m_process.logger(); }
+    Logger& logger() final { return m_process->logger(); }
     void addMessageReceiver(IPC::ReceiverName, IPC::MessageReceiver&) final { }
     void removeMessageReceiver(IPC::ReceiverName messageReceiverName) final { }
-    IPC::Connection& connection() final { return m_process.connection(); }
+    IPC::Connection& connection() final { return m_process->connection(); }
     bool willStartCapture(CaptureDevice::DeviceType type) const final
     {
         switch (type) {
@@ -195,9 +195,9 @@ private:
         case CaptureDevice::DeviceType::Speaker:
             return false;
         case CaptureDevice::DeviceType::Microphone:
-            return m_process.allowsAudioCapture();
+            return m_process->allowsAudioCapture();
         case CaptureDevice::DeviceType::Camera:
-            if (!m_process.allowsVideoCapture())
+            if (!m_process->allowsVideoCapture())
                 return false;
 #if PLATFORM(IOS) || PLATFORM(VISION)
             MediaSessionManageriOS::providePresentingApplicationPID();
@@ -205,28 +205,28 @@ private:
             return true;
             break;
         case CaptureDevice::DeviceType::Screen:
-            return m_process.allowsDisplayCapture();
+            return m_process->allowsDisplayCapture();
         case CaptureDevice::DeviceType::Window:
-            return m_process.allowsDisplayCapture();
+            return m_process->allowsDisplayCapture();
         }
     }
     
     bool setCaptureAttributionString() final
     {
-        return m_process.setCaptureAttributionString();
+        return m_process->setCaptureAttributionString();
     }
 
 #if ENABLE(APP_PRIVACY_REPORT)
     void setTCCIdentity() final
     {
-        m_process.setTCCIdentity();
+        m_process->setTCCIdentity();
     }
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
     bool setCurrentMediaEnvironment(WebCore::PageIdentifier pageIdentifier) final
     {
-        auto mediaEnvironment = m_process.mediaEnvironment(pageIdentifier);
+        auto mediaEnvironment = m_process->mediaEnvironment(pageIdentifier);
         bool result = !mediaEnvironment.isEmpty();
         WebCore::RealtimeMediaSourceCenter::singleton().setCurrentMediaEnvironment(WTFMove(mediaEnvironment));
         return result;
@@ -236,21 +236,21 @@ private:
     void startProducingData(CaptureDevice::DeviceType type) final
     {
         if (type == CaptureDevice::DeviceType::Microphone)
-            m_process.startCapturingAudio();
+            m_process->startCapturingAudio();
 #if PLATFORM(IOS)
         else if (type == CaptureDevice::DeviceType::Camera)
-            m_process.overridePresentingApplicationPIDIfNeeded();
+            m_process->overridePresentingApplicationPIDIfNeeded();
 #endif
     }
 
     const ProcessIdentity& resourceOwner() const final
     {
-        return m_process.webProcessIdentity();
+        return m_process->webProcessIdentity();
     }
 
-    RemoteVideoFrameObjectHeap* remoteVideoFrameObjectHeap() final { return &m_process.videoFrameObjectHeap(); }
+    RemoteVideoFrameObjectHeap* remoteVideoFrameObjectHeap() final { return &m_process->videoFrameObjectHeap(); }
 
-    GPUConnectionToWebProcess& m_process;
+    WeakRef<GPUConnectionToWebProcess> m_process;
 };
 
 #endif

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp
@@ -50,7 +50,7 @@ RemoteBarcodeDetector::~RemoteBarcodeDetector() = default;
 
 void RemoteBarcodeDetector::detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedBarcode>&&)>&& completionHandler)
 {
-    auto sourceImage = m_backend.imageBuffer(renderingResourceIdentifier);
+    auto sourceImage = m_backend->imageBuffer(renderingResourceIdentifier);
     if (!sourceImage) {
         completionHandler({ });
         return;

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h
@@ -35,6 +35,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore::ShapeDetection {
 class BarcodeDetector;
@@ -75,8 +76,8 @@ private:
     void detect(WebCore::RenderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedBarcode>&&)>&&);
 
     Ref<WebCore::ShapeDetection::BarcodeDetector> m_backing;
-    ShapeDetection::ObjectHeap& m_objectHeap;
-    RemoteRenderingBackend& m_backend;
+    WeakRef<ShapeDetection::ObjectHeap> m_objectHeap;
+    WeakRef<RemoteRenderingBackend> m_backend;
     const ShapeDetectionIdentifier m_identifier;
     const WebCore::ProcessIdentifier m_webProcessIdentifier;
 };

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp
@@ -49,7 +49,7 @@ RemoteFaceDetector::~RemoteFaceDetector() = default;
 
 void RemoteFaceDetector::detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&& completionHandler)
 {
-    auto sourceImage = m_backend.imageBuffer(renderingResourceIdentifier);
+    auto sourceImage = m_backend->imageBuffer(renderingResourceIdentifier);
     if (!sourceImage) {
         completionHandler({ });
         return;

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
@@ -35,6 +35,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore::ShapeDetection {
 struct DetectedFace;
@@ -74,8 +75,8 @@ private:
     void detect(WebCore::RenderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&&);
 
     Ref<WebCore::ShapeDetection::FaceDetector> m_backing;
-    ShapeDetection::ObjectHeap& m_objectHeap;
-    RemoteRenderingBackend& m_backend;
+    WeakRef<ShapeDetection::ObjectHeap> m_objectHeap;
+    WeakRef<RemoteRenderingBackend> m_backend;
     const ShapeDetectionIdentifier m_identifier;
     const WebCore::ProcessIdentifier m_webProcessIdentifier;
 };

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.cpp
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.cpp
@@ -49,7 +49,7 @@ RemoteTextDetector::~RemoteTextDetector() = default;
 
 void RemoteTextDetector::detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedText>&&)>&& completionHandler)
 {
-    auto imageBuffer = m_backend.imageBuffer(renderingResourceIdentifier);
+    auto imageBuffer = m_backend->imageBuffer(renderingResourceIdentifier);
     if (!imageBuffer) {
         completionHandler({ });
         return;

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
@@ -35,6 +35,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore::ShapeDetection {
 struct DetectedText;
@@ -74,8 +75,8 @@ private:
     void detect(WebCore::RenderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedText>&&)>&&);
 
     Ref<WebCore::ShapeDetection::TextDetector> m_backing;
-    ShapeDetection::ObjectHeap& m_objectHeap;
-    RemoteRenderingBackend& m_backend;
+    WeakRef<ShapeDetection::ObjectHeap> m_objectHeap;
+    WeakRef<RemoteRenderingBackend> m_backend;
     const ShapeDetectionIdentifier m_identifier;
     const WebCore::ProcessIdentifier m_webProcessIdentifier;
 };

--- a/Source/WebKit/GPUProcess/ShapeDetection/ShapeDetectionObjectHeap.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/ShapeDetectionObjectHeap.h
@@ -33,6 +33,7 @@
 #include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore::ShapeDetection {
 class BarcodeDetector;
@@ -48,7 +49,7 @@ class RemoteTextDetector;
 
 namespace WebKit::ShapeDetection {
 
-class ObjectHeap final : public RefCounted<ObjectHeap> {
+class ObjectHeap final : public RefCounted<ObjectHeap>, public CanMakeWeakPtr<ObjectHeap> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<ObjectHeap> create()

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -50,6 +50,7 @@
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <wtf/HashMap.h>
+#include <wtf/WeakPtr.h>
 
 namespace WTF {
 enum class Critical : bool;
@@ -88,7 +89,7 @@ namespace ShapeDetection {
 class ObjectHeap;
 }
 
-class RemoteRenderingBackend : private IPC::MessageSender, public IPC::StreamMessageReceiver {
+class RemoteRenderingBackend : private IPC::MessageSender, public IPC::StreamMessageReceiver, public CanMakeWeakPtr<RemoteRenderingBackend> {
 public:
     static Ref<RemoteRenderingBackend> create(GPUConnectionToWebProcess&, RemoteRenderingBackendCreationParameters&&, Ref<IPC::StreamServerConnection>&&);
     virtual ~RemoteRenderingBackend();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
@@ -55,7 +55,7 @@ RemoteAdapter::~RemoteAdapter() = default;
 
 void RemoteAdapter::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteAdapter::stopListeningForIPC()
@@ -65,14 +65,14 @@ void RemoteAdapter::stopListeningForIPC()
 
 void RemoteAdapter::requestDevice(const WebGPU::DeviceDescriptor& descriptor, WebGPUIdentifier identifier, WebGPUIdentifier queueIdentifier, CompletionHandler<void(WebGPU::SupportedFeatures&&, WebGPU::SupportedLimits&&)>&& callback)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     ASSERT(convertedDescriptor);
     if (!convertedDescriptor) {
         callback({ { } }, { });
         return;
     }
 
-    m_backing->requestDevice(*convertedDescriptor, [callback = WTFMove(callback), objectHeap = Ref { m_objectHeap }, streamConnection = m_streamConnection.copyRef(), identifier, queueIdentifier, &gpuConnectionToWebProcess = m_gpuConnectionToWebProcess] (RefPtr<WebCore::WebGPU::Device>&& devicePtr) mutable {
+    m_backing->requestDevice(*convertedDescriptor, [callback = WTFMove(callback), objectHeap = Ref { m_objectHeap.get() }, streamConnection = m_streamConnection.copyRef(), identifier, queueIdentifier, &gpuConnectionToWebProcess = m_gpuConnectionToWebProcess] (RefPtr<WebCore::WebGPU::Device>&& devicePtr) mutable {
         if (!devicePtr.get()) {
             callback({ }, { });
             return;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
@@ -32,6 +32,7 @@
 #include "WebGPUIdentifier.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore::WebGPU {
 class Adapter;
@@ -80,9 +81,9 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::Adapter> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
-    GPUConnectionToWebProcess& m_gpuConnectionToWebProcess;
+    WeakRef<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     WebGPUIdentifier m_identifier;
 };
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
@@ -48,7 +48,7 @@ RemoteBindGroup::~RemoteBindGroup() = default;
 
 void RemoteBindGroup::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteBindGroup::stopListeningForIPC()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
@@ -30,6 +30,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -76,7 +77,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::BindGroup> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
@@ -48,7 +48,7 @@ RemoteBindGroupLayout::~RemoteBindGroupLayout() = default;
 
 void RemoteBindGroupLayout::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteBindGroupLayout::stopListeningForIPC()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
@@ -30,6 +30,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -76,7 +77,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::BindGroupLayout> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
@@ -98,7 +98,7 @@ void RemoteBuffer::destroy()
 
 void RemoteBuffer::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteBuffer::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
@@ -35,6 +35,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -87,7 +88,7 @@ private:
     void setLabel(String&&);
 
     Ref<WebCore::WebGPU::Buffer> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
     bool m_isMapped { false };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
@@ -48,7 +48,7 @@ RemoteCommandBuffer::~RemoteCommandBuffer() = default;
 
 void RemoteCommandBuffer::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteCommandBuffer::stopListeningForIPC()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
@@ -30,6 +30,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -76,7 +77,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::CommandBuffer> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp
@@ -52,7 +52,7 @@ RemoteCommandEncoder::~RemoteCommandEncoder() = default;
 
 void RemoteCommandEncoder::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteCommandEncoder::stopListeningForIPC()
@@ -62,20 +62,20 @@ void RemoteCommandEncoder::stopListeningForIPC()
 
 void RemoteCommandEncoder::beginRenderPass(const WebGPU::RenderPassDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto renderPassEncoder = m_backing->beginRenderPass(*convertedDescriptor);
     RELEASE_ASSERT(renderPassEncoder);
     auto remoteRenderPassEncoder = RemoteRenderPassEncoder::create(*renderPassEncoder, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteRenderPassEncoder);
+    m_objectHeap->addObject(identifier, remoteRenderPassEncoder);
 }
 
 void RemoteCommandEncoder::beginComputePass(const std::optional<WebGPU::ComputePassDescriptor>& descriptor, WebGPUIdentifier identifier)
 {
     std::optional<WebCore::WebGPU::ComputePassDescriptor> convertedDescriptor;
     if (descriptor) {
-        auto resultDescriptor = m_objectHeap.convertFromBacking(*descriptor);
+        auto resultDescriptor = m_objectHeap->convertFromBacking(*descriptor);
         RELEASE_ASSERT(resultDescriptor);
         convertedDescriptor = WTFMove(resultDescriptor);
     }
@@ -83,7 +83,7 @@ void RemoteCommandEncoder::beginComputePass(const std::optional<WebGPU::ComputeP
     auto computePassEncoder = m_backing->beginComputePass(convertedDescriptor);
     RELEASE_ASSERT(computePassEncoder);
     auto computeRenderPassEncoder = RemoteComputePassEncoder::create(*computePassEncoder, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, computeRenderPassEncoder);
+    m_objectHeap->addObject(identifier, computeRenderPassEncoder);
 }
 
 void RemoteCommandEncoder::copyBufferToBuffer(
@@ -93,9 +93,9 @@ void RemoteCommandEncoder::copyBufferToBuffer(
     WebCore::WebGPU::Size64 destinationOffset,
     WebCore::WebGPU::Size64 size)
 {
-    auto convertedSource = m_objectHeap.convertBufferFromBacking(source);
+    auto convertedSource = m_objectHeap->convertBufferFromBacking(source);
     ASSERT(convertedSource);
-    auto convertedDestination = m_objectHeap.convertBufferFromBacking(destination);
+    auto convertedDestination = m_objectHeap->convertBufferFromBacking(destination);
     ASSERT(convertedDestination);
     if (!convertedSource || !convertedDestination)
         return;
@@ -108,11 +108,11 @@ void RemoteCommandEncoder::copyBufferToTexture(
     const WebGPU::ImageCopyTexture& destination,
     const WebGPU::Extent3D& copySize)
 {
-    auto convertedSource = m_objectHeap.convertFromBacking(source);
+    auto convertedSource = m_objectHeap->convertFromBacking(source);
     ASSERT(convertedSource);
-    auto convertedDestination = m_objectHeap.convertFromBacking(destination);
+    auto convertedDestination = m_objectHeap->convertFromBacking(destination);
     ASSERT(convertedDestination);
-    auto convertedCopySize = m_objectHeap.convertFromBacking(copySize);
+    auto convertedCopySize = m_objectHeap->convertFromBacking(copySize);
     ASSERT(convertedCopySize);
     if (!convertedSource || !convertedDestination || !convertedCopySize)
         return;
@@ -125,11 +125,11 @@ void RemoteCommandEncoder::copyTextureToBuffer(
     const WebGPU::ImageCopyBuffer& destination,
     const WebGPU::Extent3D& copySize)
 {
-    auto convertedSource = m_objectHeap.convertFromBacking(source);
+    auto convertedSource = m_objectHeap->convertFromBacking(source);
     ASSERT(convertedSource);
-    auto convertedDestination = m_objectHeap.convertFromBacking(destination);
+    auto convertedDestination = m_objectHeap->convertFromBacking(destination);
     ASSERT(convertedDestination);
-    auto convertedCopySize = m_objectHeap.convertFromBacking(copySize);
+    auto convertedCopySize = m_objectHeap->convertFromBacking(copySize);
     ASSERT(convertedCopySize);
     if (!convertedSource || !convertedDestination || !convertedCopySize)
         return;
@@ -142,11 +142,11 @@ void RemoteCommandEncoder::copyTextureToTexture(
     const WebGPU::ImageCopyTexture& destination,
     const WebGPU::Extent3D& copySize)
 {
-    auto convertedSource = m_objectHeap.convertFromBacking(source);
+    auto convertedSource = m_objectHeap->convertFromBacking(source);
     ASSERT(convertedSource);
-    auto convertedDestination = m_objectHeap.convertFromBacking(destination);
+    auto convertedDestination = m_objectHeap->convertFromBacking(destination);
     ASSERT(convertedDestination);
-    auto convertedCopySize = m_objectHeap.convertFromBacking(copySize);
+    auto convertedCopySize = m_objectHeap->convertFromBacking(copySize);
     ASSERT(convertedCopySize);
     if (!convertedSource || !convertedDestination || !convertedCopySize)
         return;
@@ -159,7 +159,7 @@ void RemoteCommandEncoder::clearBuffer(
     WebCore::WebGPU::Size64 offset,
     std::optional<WebCore::WebGPU::Size64> size)
 {
-    auto convertedBuffer = m_objectHeap.convertBufferFromBacking(buffer);
+    auto convertedBuffer = m_objectHeap->convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
     if (!convertedBuffer)
         return;
@@ -184,7 +184,7 @@ void RemoteCommandEncoder::insertDebugMarker(String&& markerLabel)
 
 void RemoteCommandEncoder::writeTimestamp(WebGPUIdentifier querySet, WebCore::WebGPU::Size32 queryIndex)
 {
-    auto convertedQuerySet = m_objectHeap.convertQuerySetFromBacking(querySet);
+    auto convertedQuerySet = m_objectHeap->convertQuerySetFromBacking(querySet);
     ASSERT(convertedQuerySet);
     if (!convertedQuerySet)
         return;
@@ -199,9 +199,9 @@ void RemoteCommandEncoder::resolveQuerySet(
     WebGPUIdentifier destination,
     WebCore::WebGPU::Size64 destinationOffset)
 {
-    auto convertedQuerySet = m_objectHeap.convertQuerySetFromBacking(querySet);
+    auto convertedQuerySet = m_objectHeap->convertQuerySetFromBacking(querySet);
     ASSERT(convertedQuerySet);
-    auto convertedDestination = m_objectHeap.convertBufferFromBacking(destination);
+    auto convertedDestination = m_objectHeap->convertBufferFromBacking(destination);
     ASSERT(convertedDestination);
     if (!convertedQuerySet || !convertedDestination)
         return;
@@ -211,13 +211,13 @@ void RemoteCommandEncoder::resolveQuerySet(
 
 void RemoteCommandEncoder::finish(const WebGPU::CommandBufferDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto commandBuffer = m_backing->finish(*convertedDescriptor);
     RELEASE_ASSERT(commandBuffer);
     auto remoteCommandBuffer = RemoteCommandBuffer::create(*commandBuffer, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteCommandBuffer);
+    m_objectHeap->addObject(identifier, remoteCommandBuffer);
 }
 
 void RemoteCommandEncoder::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
@@ -32,6 +32,7 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUIntegralTypes.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -128,7 +129,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::CommandEncoder> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
@@ -50,14 +50,15 @@ RemoteCompositorIntegration::~RemoteCompositorIntegration() = default;
 
 void RemoteCompositorIntegration::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteCompositorIntegration::paintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBufferIdentifier, uint32_t bufferIndex, CompletionHandler<void()>&& completionHandler)
 {
     UNUSED_PARAM(imageBufferIdentifier);
-    m_backing->withDisplayBufferAsNativeImage(bufferIndex, [&](WebCore::NativeImage& image) {
-        m_gpu.paintNativeImageToImageBuffer(image, imageBufferIdentifier);
+    m_backing->withDisplayBufferAsNativeImage(bufferIndex, [gpu = m_gpu, imageBufferIdentifier, completionHandler = WTFMove(completionHandler)] (WebCore::NativeImage* image) mutable {
+        if (image)
+            gpu->paintNativeImageToImageBuffer(*image, imageBufferIdentifier);
         completionHandler();
     });
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
@@ -32,6 +32,7 @@
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <WebCore/WebGPUIntegralTypes.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 #if PLATFORM(COCOA)
@@ -94,10 +95,10 @@ private:
     void prepareForDisplay(CompletionHandler<void(bool)>&&);
 
     Ref<WebCore::WebGPU::CompositorIntegration> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
-    RemoteGPU& m_gpu;
+    WeakRef<RemoteGPU> m_gpu;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
@@ -48,7 +48,7 @@ RemoteComputePassEncoder::~RemoteComputePassEncoder() = default;
 
 void RemoteComputePassEncoder::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteComputePassEncoder::stopListeningForIPC()
@@ -58,7 +58,7 @@ void RemoteComputePassEncoder::stopListeningForIPC()
 
 void RemoteComputePassEncoder::setPipeline(WebGPUIdentifier computePipeline)
 {
-    auto convertedComputePipeline = m_objectHeap.convertComputePipelineFromBacking(computePipeline);
+    auto convertedComputePipeline = m_objectHeap->convertComputePipelineFromBacking(computePipeline);
     ASSERT(convertedComputePipeline);
     if (!convertedComputePipeline)
         return;
@@ -73,7 +73,7 @@ void RemoteComputePassEncoder::dispatch(WebCore::WebGPU::Size32 workgroupCountX,
 
 void RemoteComputePassEncoder::dispatchIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    auto convertedIndirectBuffer = m_objectHeap.convertBufferFromBacking(indirectBuffer);
+    auto convertedIndirectBuffer = m_objectHeap->convertBufferFromBacking(indirectBuffer);
     ASSERT(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
@@ -89,7 +89,7 @@ void RemoteComputePassEncoder::end()
 void RemoteComputePassEncoder::setBindGroup(WebCore::WebGPU::Index32 index, WebGPUIdentifier bindGroup,
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& offsets)
 {
-    auto convertedBindGroup = m_objectHeap.convertBindGroupFromBacking(bindGroup);
+    auto convertedBindGroup = m_objectHeap->convertBindGroupFromBacking(bindGroup);
     ASSERT(convertedBindGroup);
     if (!convertedBindGroup)
         return;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
@@ -31,6 +31,7 @@
 #include "WebGPUIdentifier.h"
 #include <WebCore/WebGPUIntegralTypes.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -90,7 +91,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::ComputePassEncoder> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
@@ -50,7 +50,7 @@ RemoteComputePipeline::~RemoteComputePipeline() = default;
 
 void RemoteComputePipeline::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteComputePipeline::stopListeningForIPC()
@@ -63,7 +63,7 @@ void RemoteComputePipeline::getBindGroupLayout(uint32_t index, WebGPUIdentifier 
     // "A new GPUBindGroupLayout wrapper is returned each time"
     auto bindGroupLayout = m_backing->getBindGroupLayout(index);
     auto remoteBindGroupLayout = RemoteBindGroupLayout::create(bindGroupLayout, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteBindGroupLayout);
+    m_objectHeap->addObject(identifier, remoteBindGroupLayout);
 }
 
 void RemoteComputePipeline::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
@@ -30,6 +30,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -78,7 +79,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::ComputePipeline> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -120,40 +120,40 @@ void RemoteDevice::destroy()
 
 void RemoteDevice::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteDevice::createBuffer(const WebGPU::BufferDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto buffer = m_backing->createBuffer(*convertedDescriptor);
     RELEASE_ASSERT(buffer);
     auto remoteBuffer = RemoteBuffer::create(*buffer, m_objectHeap, m_streamConnection.copyRef(), descriptor.mappedAtCreation, identifier);
-    m_objectHeap.addObject(identifier, remoteBuffer);
+    m_objectHeap->addObject(identifier, remoteBuffer);
 }
 
 void RemoteDevice::createTexture(const WebGPU::TextureDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto texture = m_backing->createTexture(*convertedDescriptor);
     RELEASE_ASSERT(texture);
     auto remoteTexture = RemoteTexture::create(texture.releaseNonNull(), m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteTexture);
+    m_objectHeap->addObject(identifier, remoteTexture);
 }
 
 void RemoteDevice::createSampler(const WebGPU::SamplerDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto sampler = m_backing->createSampler(*convertedDescriptor);
     RELEASE_ASSERT(sampler);
     auto remoteSampler = RemoteSampler::create(*sampler, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteSampler);
+    m_objectHeap->addObject(identifier, remoteSampler);
 }
 
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
@@ -178,19 +178,19 @@ void RemoteDevice::importExternalTextureFromVideoFrame(const WebGPU::ExternalTex
         if (auto videoFrame = m_sharedVideoFrameReader.read(WTFMove(*sharedVideoFrame)))
             pixelBuffer = videoFrame->pixelBuffer();
     } else if (descriptor.mediaIdentifier) {
-        m_gpuConnectionToWebProcess.performWithMediaPlayerOnMainThread(*descriptor.mediaIdentifier, [&] (auto& player) mutable {
+        m_gpuConnectionToWebProcess->performWithMediaPlayerOnMainThread(*descriptor.mediaIdentifier, [&] (auto& player) mutable {
             auto videoFrame = player.videoFrameForCurrentTime();
             pixelBuffer = videoFrame ? videoFrame->pixelBuffer() : nullptr;
         });
     }
 
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor, pixelBuffer);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor, pixelBuffer);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto externalTexture = m_backing->importExternalTexture(*convertedDescriptor);
     RELEASE_ASSERT(externalTexture);
     auto remoteExternalTexture = RemoteExternalTexture::create(*externalTexture, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteExternalTexture);
+    m_objectHeap->addObject(identifier, remoteExternalTexture);
 #else
     UNUSED_PARAM(identifier);
 #endif
@@ -199,80 +199,81 @@ void RemoteDevice::importExternalTextureFromVideoFrame(const WebGPU::ExternalTex
 
 void RemoteDevice::createBindGroupLayout(const WebGPU::BindGroupLayoutDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto bindGroupLayout = m_backing->createBindGroupLayout(*convertedDescriptor);
     RELEASE_ASSERT(bindGroupLayout);
     auto remoteBindGroupLayout = RemoteBindGroupLayout::create(*bindGroupLayout, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteBindGroupLayout);
+    m_objectHeap->addObject(identifier, remoteBindGroupLayout);
 }
 
 void RemoteDevice::createPipelineLayout(const WebGPU::PipelineLayoutDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto pipelineLayout = m_backing->createPipelineLayout(*convertedDescriptor);
     RELEASE_ASSERT(pipelineLayout);
     auto remotePipelineLayout = RemotePipelineLayout::create(*pipelineLayout, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remotePipelineLayout);
+    m_objectHeap->addObject(identifier, remotePipelineLayout);
 }
 
 void RemoteDevice::createBindGroup(const WebGPU::BindGroupDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto bindGroup = m_backing->createBindGroup(*convertedDescriptor);
     RELEASE_ASSERT(bindGroup);
     auto remoteBindGroup = RemoteBindGroup::create(*bindGroup, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteBindGroup);
+    m_objectHeap->addObject(identifier, remoteBindGroup);
 }
 
 void RemoteDevice::createShaderModule(const WebGPU::ShaderModuleDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto shaderModule = m_backing->createShaderModule(*convertedDescriptor);
     RELEASE_ASSERT(shaderModule);
     auto remoteShaderModule = RemoteShaderModule::create(*shaderModule, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteShaderModule);
+    m_objectHeap->addObject(identifier, remoteShaderModule);
+
 }
 
 void RemoteDevice::createComputePipeline(const WebGPU::ComputePipelineDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto computePipeline = m_backing->createComputePipeline(*convertedDescriptor);
     RELEASE_ASSERT(computePipeline);
     auto remoteComputePipeline = RemoteComputePipeline::create(*computePipeline, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteComputePipeline);
+    m_objectHeap->addObject(identifier, remoteComputePipeline);
 }
 
 void RemoteDevice::createRenderPipeline(const WebGPU::RenderPipelineDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto renderPipeline = m_backing->createRenderPipeline(*convertedDescriptor);
     RELEASE_ASSERT(renderPipeline);
     auto remoteRenderPipeline = RemoteRenderPipeline::create(*renderPipeline, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteRenderPipeline);
+    m_objectHeap->addObject(identifier, remoteRenderPipeline);
 }
 
 void RemoteDevice::createComputePipelineAsync(const WebGPU::ComputePipelineDescriptor& descriptor, WebGPUIdentifier identifier, CompletionHandler<void(bool)>&& callback)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     ASSERT(convertedDescriptor);
     if (!convertedDescriptor) {
         callback(false);
         return;
     }
 
-    m_backing->createComputePipelineAsync(*convertedDescriptor, [callback = WTFMove(callback), objectHeap = Ref { m_objectHeap }, streamConnection = m_streamConnection.copyRef(), identifier] (RefPtr<WebCore::WebGPU::ComputePipeline>&& computePipeline) mutable {
+    m_backing->createComputePipelineAsync(*convertedDescriptor, [callback = WTFMove(callback), objectHeap = Ref { m_objectHeap.get() }, streamConnection = m_streamConnection.copyRef(), identifier] (RefPtr<WebCore::WebGPU::ComputePipeline>&& computePipeline) mutable {
         bool result = computePipeline.get();
         if (result) {
             auto remoteComputePipeline = RemoteComputePipeline::create(computePipeline.releaseNonNull(), objectHeap, WTFMove(streamConnection), identifier);
@@ -284,14 +285,14 @@ void RemoteDevice::createComputePipelineAsync(const WebGPU::ComputePipelineDescr
 
 void RemoteDevice::createRenderPipelineAsync(const WebGPU::RenderPipelineDescriptor& descriptor, WebGPUIdentifier identifier, CompletionHandler<void(bool)>&& callback)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     ASSERT(convertedDescriptor);
     if (!convertedDescriptor) {
         callback(false);
         return;
     }
 
-    m_backing->createRenderPipelineAsync(*convertedDescriptor, [callback = WTFMove(callback), objectHeap = Ref { m_objectHeap }, streamConnection = m_streamConnection.copyRef(), identifier] (RefPtr<WebCore::WebGPU::RenderPipeline>&& renderPipeline) mutable {
+    m_backing->createRenderPipelineAsync(*convertedDescriptor, [callback = WTFMove(callback), objectHeap = Ref { m_objectHeap.get() }, streamConnection = m_streamConnection.copyRef(), identifier] (RefPtr<WebCore::WebGPU::RenderPipeline>&& renderPipeline) mutable {
         bool result = renderPipeline.get();
         if (result) {
             auto remoteRenderPipeline = RemoteRenderPipeline::create(renderPipeline.releaseNonNull(), objectHeap, WTFMove(streamConnection), identifier);
@@ -305,36 +306,36 @@ void RemoteDevice::createCommandEncoder(const std::optional<WebGPU::CommandEncod
 {
     std::optional<WebCore::WebGPU::CommandEncoderDescriptor> convertedDescriptor;
     if (descriptor) {
-        auto resultDescriptor = m_objectHeap.convertFromBacking(*descriptor);
+        auto resultDescriptor = m_objectHeap->convertFromBacking(*descriptor);
         RELEASE_ASSERT(resultDescriptor);
         convertedDescriptor = WTFMove(resultDescriptor);
     }
     auto commandEncoder = m_backing->createCommandEncoder(convertedDescriptor);
     RELEASE_ASSERT(commandEncoder);
     auto remoteCommandEncoder = RemoteCommandEncoder::create(*commandEncoder, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteCommandEncoder);
+    m_objectHeap->addObject(identifier, remoteCommandEncoder);
 }
 
 void RemoteDevice::createRenderBundleEncoder(const WebGPU::RenderBundleEncoderDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto renderBundleEncoder = m_backing->createRenderBundleEncoder(*convertedDescriptor);
     RELEASE_ASSERT(renderBundleEncoder);
     auto remoteRenderBundleEncoder = RemoteRenderBundleEncoder::create(*renderBundleEncoder, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteRenderBundleEncoder);
+    m_objectHeap->addObject(identifier, remoteRenderBundleEncoder);
 }
 
 void RemoteDevice::createQuerySet(const WebGPU::QuerySetDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto querySet = m_backing->createQuerySet(*convertedDescriptor);
     RELEASE_ASSERT(querySet);
     auto remoteQuerySet = RemoteQuerySet::create(*querySet, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteQuerySet);
+    m_objectHeap->addObject(identifier, remoteQuerySet);
 }
 
 void RemoteDevice::pushErrorScope(WebCore::WebGPU::ErrorFilter errorFilter)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -38,6 +38,7 @@
 #include <WebCore/WebGPUErrorFilter.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 #if ENABLE(VIDEO)
@@ -147,7 +148,7 @@ private:
     void setSharedVideoFrameMemory(WebCore::SharedMemoryHandle&&);
 
     Ref<WebCore::WebGPU::Device> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
     Ref<RemoteQueue> m_queue;
@@ -157,7 +158,7 @@ private:
     SharedVideoFrameReader m_sharedVideoFrameReader;
 #endif
 #endif
-    GPUConnectionToWebProcess& m_gpuConnectionToWebProcess;
+    WeakRef<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp
@@ -58,7 +58,7 @@ void RemoteExternalTexture::undestroy()
 
 void RemoteExternalTexture::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteExternalTexture::stopListeningForIPC()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
@@ -30,6 +30,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -78,7 +79,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::ExternalTexture> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -42,6 +42,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/ThreadAssertions.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore::WebGPU {
 class GPU;
@@ -68,7 +69,7 @@ class ObjectHeap;
 struct RequestAdapterOptions;
 }
 
-class RemoteGPU final : public IPC::StreamMessageReceiver {
+class RemoteGPU final : public IPC::StreamMessageReceiver, public CanMakeWeakPtr<RemoteGPU> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<RemoteGPU> create(WebGPUIdentifier identifier, GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteRenderingBackend& renderingBackend, Ref<IPC::StreamServerConnection>&& serverConnection)
@@ -113,7 +114,7 @@ private:
 
     void createCompositorIntegration(WebGPUIdentifier);
 
-    GPUConnectionToWebProcess& m_gpuConnectionToWebProcess;
+    WeakRef<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     RefPtr<IPC::StreamServerConnection> m_streamConnection;
     RefPtr<WebCore::WebGPU::GPU> m_backing WTF_GUARDED_BY_CAPABILITY(workQueue());

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp
@@ -48,7 +48,7 @@ RemotePipelineLayout::~RemotePipelineLayout() = default;
 
 void RemotePipelineLayout::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemotePipelineLayout::stopListeningForIPC()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
@@ -30,6 +30,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -76,7 +77,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::PipelineLayout> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp
@@ -56,7 +56,7 @@ void RemotePresentationContext::stopListeningForIPC()
 
 void RemotePresentationContext::configure(const WebGPU::CanvasConfiguration& canvasConfiguration)
 {
-    auto convertedConfiguration = m_objectHeap.convertFromBacking(canvasConfiguration);
+    auto convertedConfiguration = m_objectHeap->convertFromBacking(canvasConfiguration);
     ASSERT(convertedConfiguration);
     if (!convertedConfiguration)
         return;
@@ -86,7 +86,7 @@ void RemotePresentationContext::getCurrentTexture(WebGPUIdentifier identifier)
     // The Web Process should already be caching these current textures internally, so it's unlikely that we'll
     // actually run into a problem here.
     auto remoteTexture = RemoteTexture::create(*texture, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteTexture);
+    m_objectHeap->addObject(identifier, remoteTexture);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
@@ -30,6 +30,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -79,7 +80,7 @@ private:
     void getCurrentTexture(WebGPUIdentifier);
 
     Ref<WebCore::WebGPU::PresentationContext> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp
@@ -58,7 +58,7 @@ void RemoteQuerySet::destroy()
 
 void RemoteQuerySet::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteQuerySet::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
@@ -30,6 +30,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -78,7 +79,7 @@ private:
     void setLabel(String&&);
 
     Ref<WebCore::WebGPU::QuerySet> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
@@ -48,7 +48,7 @@ RemoteQueue::~RemoteQueue() = default;
 
 void RemoteQueue::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteQueue::stopListeningForIPC()
@@ -61,7 +61,7 @@ void RemoteQueue::submit(Vector<WebGPUIdentifier>&& commandBuffers)
     Vector<std::reference_wrapper<WebCore::WebGPU::CommandBuffer>> convertedCommandBuffers;
     convertedCommandBuffers.reserveInitialCapacity(commandBuffers.size());
     for (WebGPUIdentifier identifier : commandBuffers) {
-        auto convertedCommandBuffer = m_objectHeap.convertCommandBufferFromBacking(identifier);
+        auto convertedCommandBuffer = m_objectHeap->convertCommandBufferFromBacking(identifier);
         ASSERT(convertedCommandBuffer);
         if (!convertedCommandBuffer)
             return;
@@ -82,7 +82,7 @@ void RemoteQueue::writeBuffer(
     WebCore::WebGPU::Size64 bufferOffset,
     Vector<uint8_t>&& data)
 {
-    auto convertedBuffer = m_objectHeap.convertBufferFromBacking(buffer);
+    auto convertedBuffer = m_objectHeap->convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
     if (!convertedBuffer)
         return;
@@ -96,11 +96,11 @@ void RemoteQueue::writeTexture(
     const WebGPU::ImageDataLayout& dataLayout,
     const WebGPU::Extent3D& size)
 {
-    auto convertedDestination = m_objectHeap.convertFromBacking(destination);
+    auto convertedDestination = m_objectHeap->convertFromBacking(destination);
     ASSERT(convertedDestination);
-    auto convertedDataLayout = m_objectHeap.convertFromBacking(dataLayout);
+    auto convertedDataLayout = m_objectHeap->convertFromBacking(dataLayout);
     ASSERT(convertedDestination);
-    auto convertedSize = m_objectHeap.convertFromBacking(size);
+    auto convertedSize = m_objectHeap->convertFromBacking(size);
     ASSERT(convertedSize);
     if (!convertedDestination || !convertedDestination || !convertedSize)
         return;
@@ -113,11 +113,11 @@ void RemoteQueue::copyExternalImageToTexture(
     const WebGPU::ImageCopyTextureTagged& destination,
     const WebGPU::Extent3D& copySize)
 {
-    auto convertedSource = m_objectHeap.convertFromBacking(source);
+    auto convertedSource = m_objectHeap->convertFromBacking(source);
     ASSERT(convertedSource);
-    auto convertedDestination = m_objectHeap.convertFromBacking(destination);
+    auto convertedDestination = m_objectHeap->convertFromBacking(destination);
     ASSERT(convertedDestination);
-    auto convertedCopySize = m_objectHeap.convertFromBacking(copySize);
+    auto convertedCopySize = m_objectHeap->convertFromBacking(copySize);
     ASSERT(convertedCopySize);
     if (!convertedDestination || !convertedDestination || !convertedCopySize)
         return;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
@@ -35,6 +35,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -105,7 +106,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::Queue> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
@@ -48,7 +48,7 @@ RemoteRenderBundle::~RemoteRenderBundle() = default;
 
 void RemoteRenderBundle::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteRenderBundle::stopListeningForIPC()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
@@ -30,6 +30,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -76,7 +77,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::RenderBundle> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
@@ -50,7 +50,7 @@ RemoteRenderBundleEncoder::~RemoteRenderBundleEncoder() = default;
 
 void RemoteRenderBundleEncoder::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteRenderBundleEncoder::stopListeningForIPC()
@@ -60,7 +60,7 @@ void RemoteRenderBundleEncoder::stopListeningForIPC()
 
 void RemoteRenderBundleEncoder::setPipeline(WebGPUIdentifier renderPipeline)
 {
-    auto convertedRenderPipeline = m_objectHeap.convertRenderPipelineFromBacking(renderPipeline);
+    auto convertedRenderPipeline = m_objectHeap->convertRenderPipelineFromBacking(renderPipeline);
     ASSERT(convertedRenderPipeline);
     if (!convertedRenderPipeline)
         return;
@@ -70,7 +70,7 @@ void RemoteRenderBundleEncoder::setPipeline(WebGPUIdentifier renderPipeline)
 
 void RemoteRenderBundleEncoder::setIndexBuffer(WebGPUIdentifier buffer, WebCore::WebGPU::IndexFormat indexFormat, std::optional<WebCore::WebGPU::Size64> offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    auto convertedBuffer = m_objectHeap.convertBufferFromBacking(buffer);
+    auto convertedBuffer = m_objectHeap->convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
     if (!convertedBuffer)
         return;
@@ -80,7 +80,7 @@ void RemoteRenderBundleEncoder::setIndexBuffer(WebGPUIdentifier buffer, WebCore:
 
 void RemoteRenderBundleEncoder::setVertexBuffer(WebCore::WebGPU::Index32 slot, WebGPUIdentifier buffer, std::optional<WebCore::WebGPU::Size64> offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    auto convertedBuffer = m_objectHeap.convertBufferFromBacking(buffer);
+    auto convertedBuffer = m_objectHeap->convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
     if (!convertedBuffer)
         return;
@@ -109,7 +109,7 @@ void RemoteRenderBundleEncoder::drawIndexed(WebCore::WebGPU::Size32 indexCount, 
 
 void RemoteRenderBundleEncoder::drawIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    auto convertedIndirectBuffer = m_objectHeap.convertBufferFromBacking(indirectBuffer);
+    auto convertedIndirectBuffer = m_objectHeap->convertBufferFromBacking(indirectBuffer);
     ASSERT(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
@@ -119,7 +119,7 @@ void RemoteRenderBundleEncoder::drawIndirect(WebGPUIdentifier indirectBuffer, We
 
 void RemoteRenderBundleEncoder::drawIndexedIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    auto convertedIndirectBuffer = m_objectHeap.convertBufferFromBacking(indirectBuffer);
+    auto convertedIndirectBuffer = m_objectHeap->convertBufferFromBacking(indirectBuffer);
     ASSERT(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
@@ -130,7 +130,7 @@ void RemoteRenderBundleEncoder::drawIndexedIndirect(WebGPUIdentifier indirectBuf
 void RemoteRenderBundleEncoder::setBindGroup(WebCore::WebGPU::Index32 index, WebGPUIdentifier bindGroup,
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& dynamicOffsets)
 {
-    auto convertedBindGroup = m_objectHeap.convertBindGroupFromBacking(bindGroup);
+    auto convertedBindGroup = m_objectHeap->convertBindGroupFromBacking(bindGroup);
     ASSERT(convertedBindGroup);
     if (!convertedBindGroup)
         return;
@@ -155,13 +155,13 @@ void RemoteRenderBundleEncoder::insertDebugMarker(String&& markerLabel)
 
 void RemoteRenderBundleEncoder::finish(const WebGPU::RenderBundleDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-    auto convertedDescriptor = m_objectHeap.convertFromBacking(descriptor);
+    auto convertedDescriptor = m_objectHeap->convertFromBacking(descriptor);
     RELEASE_ASSERT(convertedDescriptor);
 
     auto renderBundle = m_backing->finish(*convertedDescriptor);
     RELEASE_ASSERT(renderBundle);
     auto remoteRenderBundle = RemoteRenderBundle::create(*renderBundle, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteRenderBundle);
+    m_objectHeap->addObject(identifier, remoteRenderBundle);
 }
 
 void RemoteRenderBundleEncoder::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
@@ -32,6 +32,7 @@
 #include <WebCore/WebGPUIndexFormat.h>
 #include <WebCore/WebGPUIntegralTypes.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -104,7 +105,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::RenderBundleEncoder> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
@@ -48,7 +48,7 @@ RemoteRenderPassEncoder::~RemoteRenderPassEncoder() = default;
 
 void RemoteRenderPassEncoder::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteRenderPassEncoder::stopListeningForIPC()
@@ -58,7 +58,7 @@ void RemoteRenderPassEncoder::stopListeningForIPC()
 
 void RemoteRenderPassEncoder::setPipeline(WebGPUIdentifier renderPipeline)
 {
-    auto convertedRenderPipeline = m_objectHeap.convertRenderPipelineFromBacking(renderPipeline);
+    auto convertedRenderPipeline = m_objectHeap->convertRenderPipelineFromBacking(renderPipeline);
     ASSERT(convertedRenderPipeline);
     if (!convertedRenderPipeline)
         return;
@@ -68,7 +68,7 @@ void RemoteRenderPassEncoder::setPipeline(WebGPUIdentifier renderPipeline)
 
 void RemoteRenderPassEncoder::setIndexBuffer(WebGPUIdentifier buffer, WebCore::WebGPU::IndexFormat indexFormat, std::optional<WebCore::WebGPU::Size64> offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    auto convertedBuffer = m_objectHeap.convertBufferFromBacking(buffer);
+    auto convertedBuffer = m_objectHeap->convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
     if (!convertedBuffer)
         return;
@@ -78,7 +78,7 @@ void RemoteRenderPassEncoder::setIndexBuffer(WebGPUIdentifier buffer, WebCore::W
 
 void RemoteRenderPassEncoder::setVertexBuffer(WebCore::WebGPU::Index32 slot, WebGPUIdentifier buffer, std::optional<WebCore::WebGPU::Size64> offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    auto convertedBuffer = m_objectHeap.convertBufferFromBacking(buffer);
+    auto convertedBuffer = m_objectHeap->convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
     if (!convertedBuffer)
         return;
@@ -108,7 +108,7 @@ void RemoteRenderPassEncoder::drawIndexed(WebCore::WebGPU::Size32 indexCount,
 
 void RemoteRenderPassEncoder::drawIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    auto convertedIndirectBuffer = m_objectHeap.convertBufferFromBacking(indirectBuffer);
+    auto convertedIndirectBuffer = m_objectHeap->convertBufferFromBacking(indirectBuffer);
     ASSERT(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
@@ -118,7 +118,7 @@ void RemoteRenderPassEncoder::drawIndirect(WebGPUIdentifier indirectBuffer, WebC
 
 void RemoteRenderPassEncoder::drawIndexedIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    auto convertedIndirectBuffer = m_objectHeap.convertBufferFromBacking(indirectBuffer);
+    auto convertedIndirectBuffer = m_objectHeap->convertBufferFromBacking(indirectBuffer);
     ASSERT(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
@@ -129,7 +129,7 @@ void RemoteRenderPassEncoder::drawIndexedIndirect(WebGPUIdentifier indirectBuffe
 void RemoteRenderPassEncoder::setBindGroup(WebCore::WebGPU::Index32 index, WebGPUIdentifier bindGroup,
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& dynamicOffsets)
 {
-    auto convertedBindGroup = m_objectHeap.convertBindGroupFromBacking(bindGroup);
+    auto convertedBindGroup = m_objectHeap->convertBindGroupFromBacking(bindGroup);
     if (!convertedBindGroup)
         return;
 
@@ -166,7 +166,7 @@ void RemoteRenderPassEncoder::setScissorRect(WebCore::WebGPU::IntegerCoordinate 
 
 void RemoteRenderPassEncoder::setBlendConstant(WebGPU::Color color)
 {
-    auto convertedColor = m_objectHeap.convertFromBacking(color);
+    auto convertedColor = m_objectHeap->convertFromBacking(color);
     ASSERT(convertedColor);
     if (!convertedColor)
         return;
@@ -194,7 +194,7 @@ void RemoteRenderPassEncoder::executeBundles(Vector<WebGPUIdentifier>&& renderBu
     Vector<std::reference_wrapper<WebCore::WebGPU::RenderBundle>> convertedBundles;
     convertedBundles.reserveInitialCapacity(renderBundles.size());
     for (WebGPUIdentifier identifier : renderBundles) {
-        auto convertedBundle = m_objectHeap.convertRenderBundleFromBacking(identifier);
+        auto convertedBundle = m_objectHeap->convertRenderBundleFromBacking(identifier);
         ASSERT(convertedBundle);
         if (!convertedBundle)
             return;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
@@ -33,6 +33,7 @@
 #include <WebCore/WebGPUIndexFormat.h>
 #include <WebCore/WebGPUIntegralTypes.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -118,7 +119,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::RenderPassEncoder> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
@@ -50,7 +50,7 @@ RemoteRenderPipeline::~RemoteRenderPipeline() = default;
 
 void RemoteRenderPipeline::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteRenderPipeline::stopListeningForIPC()
@@ -63,7 +63,7 @@ void RemoteRenderPipeline::getBindGroupLayout(uint32_t index, WebGPUIdentifier i
     // "A new GPUBindGroupLayout wrapper is returned each time"
     auto bindGroupLayout = m_backing->getBindGroupLayout(index);
     auto remoteBindGroupLayout = RemoteBindGroupLayout::create(bindGroupLayout, m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteBindGroupLayout);
+    m_objectHeap->addObject(identifier, remoteBindGroupLayout);
 }
 
 void RemoteRenderPipeline::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
@@ -30,6 +30,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -78,7 +79,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::RenderPipeline> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp
@@ -48,7 +48,7 @@ RemoteSampler::~RemoteSampler() = default;
 
 void RemoteSampler::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteSampler::stopListeningForIPC()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
@@ -30,6 +30,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -76,7 +77,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::Sampler> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
@@ -50,7 +50,7 @@ RemoteShaderModule::~RemoteShaderModule() = default;
 
 void RemoteShaderModule::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteShaderModule::stopListeningForIPC()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
@@ -33,6 +33,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -81,7 +82,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::ShaderModule> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
@@ -59,14 +59,14 @@ void RemoteTexture::createView(const std::optional<WebGPU::TextureViewDescriptor
 {
     std::optional<WebCore::WebGPU::TextureViewDescriptor> convertedDescriptor;
     if (descriptor) {
-        auto resultDescriptor = m_objectHeap.convertFromBacking(*descriptor);
+        auto resultDescriptor = m_objectHeap->convertFromBacking(*descriptor);
         RELEASE_ASSERT(resultDescriptor);
         convertedDescriptor = WTFMove(resultDescriptor);
     }
     auto textureView = m_backing->createView(convertedDescriptor);
     RELEASE_ASSERT(textureView);
     auto remoteTextureView = RemoteTextureView::create(textureView.releaseNonNull(), m_objectHeap, m_streamConnection.copyRef(), identifier);
-    m_objectHeap.addObject(identifier, remoteTextureView);
+    m_objectHeap->addObject(identifier, remoteTextureView);
 }
 
 void RemoteTexture::destroy()
@@ -76,7 +76,7 @@ void RemoteTexture::destroy()
 
 void RemoteTexture::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteTexture::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
@@ -30,6 +30,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -81,7 +82,7 @@ private:
     void setLabel(String&&);
 
     Ref<WebCore::WebGPU::Texture> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp
@@ -48,7 +48,7 @@ RemoteTextureView::~RemoteTextureView() = default;
 
 void RemoteTextureView::destruct()
 {
-    m_objectHeap.removeObject(m_identifier);
+    m_objectHeap->removeObject(m_identifier);
 }
 
 void RemoteTextureView::stopListeningForIPC()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
@@ -30,6 +30,7 @@
 #include "StreamMessageReceiver.h"
 #include "WebGPUIdentifier.h"
 #include <wtf/Ref.h>
+#include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore::WebGPU {
@@ -76,7 +77,7 @@ private:
     void destruct();
 
     Ref<WebCore::WebGPU::TextureView> m_backing;
-    WebGPU::ObjectHeap& m_objectHeap;
+    WeakRef<WebGPU::ObjectHeap> m_objectHeap;
     Ref<IPC::StreamServerConnection> m_streamConnection;
     WebGPUIdentifier m_identifier;
 };

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h
@@ -34,6 +34,7 @@
 #include <variant>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore::WebGPU {
 class Adapter;
@@ -90,7 +91,7 @@ class RemoteTextureView;
 
 namespace WebKit::WebGPU {
 
-class ObjectHeap final : public RefCounted<ObjectHeap>, public WebGPU::ConvertFromBackingContext {
+class ObjectHeap final : public RefCounted<ObjectHeap>, public WebGPU::ConvertFromBackingContext, public CanMakeWeakPtr<ObjectHeap> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<ObjectHeap> create()

--- a/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp
+++ b/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp
@@ -59,17 +59,17 @@ void LocalAudioSessionRoutingArbitrator::processDidTerminate()
 void LocalAudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory(AudioSession::CategoryType category, CompletionHandler<void(RoutingArbitrationError, DefaultRouteChanged)>&& callback)
 {
     ALWAYS_LOG(LOGIDENTIFIER, category);
-    m_connectionToWebProcess.connection().sendWithAsyncReply(Messages::GPUProcessConnection::BeginRoutingArbitrationWithCategory(category), WTFMove(callback), 0);
+    m_connectionToWebProcess->connection().sendWithAsyncReply(Messages::GPUProcessConnection::BeginRoutingArbitrationWithCategory(category), WTFMove(callback), 0);
 }
 
 void LocalAudioSessionRoutingArbitrator::leaveRoutingAbritration()
 {
-    m_connectionToWebProcess.connection().send(Messages::GPUProcessConnection::EndRoutingArbitration(), 0);
+    m_connectionToWebProcess->connection().send(Messages::GPUProcessConnection::EndRoutingArbitration(), 0);
 }
 
 Logger& LocalAudioSessionRoutingArbitrator::logger()
 {
-    return m_connectionToWebProcess.logger();
+    return m_connectionToWebProcess->logger();
 };
 
 WTFLogChannel& LocalAudioSessionRoutingArbitrator::logChannel() const
@@ -79,7 +79,7 @@ WTFLogChannel& LocalAudioSessionRoutingArbitrator::logChannel() const
 
 bool LocalAudioSessionRoutingArbitrator::canLog() const
 {
-    return m_connectionToWebProcess.sessionID().isAlwaysOnLoggingAllowed();
+    return m_connectionToWebProcess->sessionID().isAlwaysOnLoggingAllowed();
 }
 
 }

--- a/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
@@ -28,6 +28,7 @@
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
 
 #include "AudioSessionRoutingArbitratorProxy.h"
+#include <wtf/WeakRef.h>
 
 namespace WTF {
 class Logger;
@@ -63,7 +64,7 @@ private:
     const void* logIdentifier() const final { return m_logIdentifier; }
     bool canLog() const final;
 
-    GPUConnectionToWebProcess& m_connectionToWebProcess;
+    WeakRef<GPUConnectionToWebProcess> m_connectionToWebProcess;
     const void* m_logIdentifier;
 };
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -43,15 +43,15 @@
 #endif
 
 #if ENABLE(IPC_TESTING_API)
-#define WEB_PROCESS_TERMINATE_CONDITION !m_gpuConnectionToWebProcess.connection().ignoreInvalidMessageForTesting()
+#define WEB_PROCESS_TERMINATE_CONDITION !m_gpuConnectionToWebProcess->connection().ignoreInvalidMessageForTesting()
 #else
 #define WEB_PROCESS_TERMINATE_CONDITION true
 #endif
 
 #define TERMINATE_WEB_PROCESS_WITH_MESSAGE(message) \
     if (WEB_PROCESS_TERMINATE_CONDITION) { \
-        RELEASE_LOG_FAULT(IPC, "Requesting termination of web process %" PRIu64 " for reason: %" PUBLIC_LOG_STRING, m_gpuConnectionToWebProcess.webProcessIdentifier().toUInt64(), #message); \
-        m_gpuConnectionToWebProcess.terminateWebProcess(); \
+        RELEASE_LOG_FAULT(IPC, "Requesting termination of web process %" PRIu64 " for reason: %" PUBLIC_LOG_STRING, m_gpuConnectionToWebProcess->webProcessIdentifier().toUInt64(), #message); \
+        m_gpuConnectionToWebProcess->terminateWebProcess(); \
     }
 
 #define MESSAGE_CHECK(assertion, message) do { \
@@ -183,7 +183,7 @@ RemoteAudioDestinationManager::~RemoteAudioDestinationManager() = default;
 
 void RemoteAudioDestinationManager::createAudioDestination(RemoteAudioDestinationIdentifier identifier, const String& inputDeviceId, uint32_t numberOfInputChannels, uint32_t numberOfOutputChannels, float sampleRate, float hardwareSampleRate, IPC::Semaphore&& renderSemaphore, WebCore::SharedMemory::Handle&& handle)
 {
-    MESSAGE_CHECK(!m_gpuConnectionToWebProcess.isLockdownModeEnabled(), "Received a createAudioDestination() message from a webpage in Lockdown mode.");
+    MESSAGE_CHECK(!m_gpuConnectionToWebProcess->isLockdownModeEnabled(), "Received a createAudioDestination() message from a webpage in Lockdown mode.");
 
     auto destination = makeUniqueRef<RemoteAudioDestination>(m_gpuConnectionToWebProcess, inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate, hardwareSampleRate, WTFMove(renderSemaphore));
 #if PLATFORM(COCOA)
@@ -196,17 +196,17 @@ void RemoteAudioDestinationManager::createAudioDestination(RemoteAudioDestinatio
 
 void RemoteAudioDestinationManager::deleteAudioDestination(RemoteAudioDestinationIdentifier identifier)
 {
-    MESSAGE_CHECK(!m_gpuConnectionToWebProcess.isLockdownModeEnabled(), "Received a deleteAudioDestination() message from a webpage in Lockdown mode.");
+    MESSAGE_CHECK(!m_gpuConnectionToWebProcess->isLockdownModeEnabled(), "Received a deleteAudioDestination() message from a webpage in Lockdown mode.");
 
     m_audioDestinations.remove(identifier);
 
     if (allowsExitUnderMemoryPressure())
-        m_gpuConnectionToWebProcess.gpuProcess().tryExitIfUnusedAndUnderMemoryPressure();
+        m_gpuConnectionToWebProcess->gpuProcess().tryExitIfUnusedAndUnderMemoryPressure();
 }
 
 void RemoteAudioDestinationManager::startAudioDestination(RemoteAudioDestinationIdentifier identifier, CompletionHandler<void(bool)>&& completionHandler)
 {
-    MESSAGE_CHECK(!m_gpuConnectionToWebProcess.isLockdownModeEnabled(), "Received a startAudioDestination() message from a webpage in Lockdown mode.");
+    MESSAGE_CHECK(!m_gpuConnectionToWebProcess->isLockdownModeEnabled(), "Received a startAudioDestination() message from a webpage in Lockdown mode.");
 
     bool isPlaying = false;
     if (auto* item = m_audioDestinations.get(identifier)) {
@@ -218,7 +218,7 @@ void RemoteAudioDestinationManager::startAudioDestination(RemoteAudioDestination
 
 void RemoteAudioDestinationManager::stopAudioDestination(RemoteAudioDestinationIdentifier identifier, CompletionHandler<void(bool)>&& completionHandler)
 {
-    MESSAGE_CHECK(!m_gpuConnectionToWebProcess.isLockdownModeEnabled(), "Received a stopAudioDestination() message from a webpage in Lockdown mode.");
+    MESSAGE_CHECK(!m_gpuConnectionToWebProcess->isLockdownModeEnabled(), "Received a stopAudioDestination() message from a webpage in Lockdown mode.");
 
     bool isPlaying = false;
     if (auto* item = m_audioDestinations.get(identifier)) {

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
@@ -34,6 +34,7 @@
 #include <memory>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
+#include <wtf/WeakRef.h>
 
 #if PLATFORM(COCOA)
 #include "SharedCARingBuffer.h"
@@ -76,7 +77,7 @@ private:
 #endif
 
     HashMap<RemoteAudioDestinationIdentifier, UniqueRef<RemoteAudioDestination>> m_audioDestinations;
-    GPUConnectionToWebProcess& m_gpuConnectionToWebProcess;
+    WeakRef<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
 };
 
 } // namespace WebKit;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -54,9 +54,14 @@ RemoteAudioSessionProxy::RemoteAudioSessionProxy(GPUConnectionToWebProcess& gpuC
 
 RemoteAudioSessionProxy::~RemoteAudioSessionProxy() = default;
 
+GPUConnectionToWebProcess& RemoteAudioSessionProxy::gpuConnectionToWebProcess() const
+{
+    return m_gpuConnection.get();
+}
+
 WebCore::ProcessIdentifier RemoteAudioSessionProxy::processIdentifier()
 {
-    return m_gpuConnection.webProcessIdentifier();
+    return m_gpuConnection->webProcessIdentifier();
 }
 
 RemoteAudioSessionConfiguration RemoteAudioSessionProxy::configuration()
@@ -145,28 +150,28 @@ void RemoteAudioSessionProxy::endInterruptionRemote(AudioSession::MayResume mayR
 
 RemoteAudioSessionProxyManager& RemoteAudioSessionProxy::audioSessionManager()
 {
-    return m_gpuConnection.gpuProcess().audioSessionManager();
+    return m_gpuConnection->gpuProcess().audioSessionManager();
 }
 
 bool RemoteAudioSessionProxy::allowTestOnlyIPC()
 {
-    return m_gpuConnection.allowTestOnlyIPC();
+    return m_gpuConnection->allowTestOnlyIPC();
 }
 
 IPC::Connection& RemoteAudioSessionProxy::connection()
 {
-    return m_gpuConnection.connection();
+    return m_gpuConnection->connection();
 }
 
 void RemoteAudioSessionProxy::triggerBeginInterruptionForTesting()
 {
-    MESSAGE_CHECK(m_gpuConnection.allowTestOnlyIPC());
+    MESSAGE_CHECK(m_gpuConnection->allowTestOnlyIPC());
     AudioSession::sharedSession().beginInterruptionForTesting();
 }
 
 void RemoteAudioSessionProxy::triggerEndInterruptionForTesting()
 {
-    MESSAGE_CHECK(m_gpuConnection.allowTestOnlyIPC());
+    MESSAGE_CHECK(m_gpuConnection->allowTestOnlyIPC());
     AudioSession::sharedSession().endInterruptionForTesting();
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -32,6 +32,7 @@
 #include <WebCore/AudioSession.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/WeakRef.h>
 
 namespace IPC {
 class Connection;
@@ -67,7 +68,7 @@ public:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
 
-    GPUConnectionToWebProcess& gpuConnectionToWebProcess() const { return m_gpuConnection; }
+    GPUConnectionToWebProcess& gpuConnectionToWebProcess() const;
 
 private:
     friend UniqueRef<RemoteAudioSessionProxy> WTF::makeUniqueRefWithoutFastMallocCheck<RemoteAudioSessionProxy>(GPUConnectionToWebProcess&);
@@ -90,7 +91,7 @@ private:
     RemoteAudioSessionProxyManager& audioSessionManager();
     IPC::Connection& connection();
 
-    GPUConnectionToWebProcess& m_gpuConnection;
+    WeakRef<GPUConnectionToWebProcess> m_gpuConnection;
     WebCore::AudioSession::CategoryType m_category { WebCore::AudioSession::CategoryType::None };
     WebCore::AudioSession::Mode m_mode { WebCore::AudioSession::Mode::Default };
     WebCore::RouteSharingPolicy m_routeSharingPolicy { WebCore::RouteSharingPolicy::Default };

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -214,7 +214,7 @@ void RemoteAudioSessionProxyManager::updatePresentingProcesses()
 
     Vector<audit_token_t> presentingProcesses;
 
-    if (auto token = m_gpuProcess.parentProcessConnection()->getAuditToken())
+    if (auto token = m_gpuProcess->parentProcessConnection()->getAuditToken())
         presentingProcesses.append(*token);
 
     // AVAudioSession will take out an assertion on all the "presenting applications"

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
@@ -30,6 +30,7 @@
 #include <WebCore/AudioSession.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <wtf/WeakHashSet.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -76,7 +77,7 @@ private:
     bool hasOtherActiveProxyThan(RemoteAudioSessionProxy& proxyToExclude);
     bool hasActiveNotInterruptedProxy();
 
-    GPUProcess& m_gpuProcess;
+    WeakRef<GPUProcess> m_gpuProcess;
     WeakHashSet<RemoteAudioSessionProxy> m_proxies;
 };
 

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
@@ -81,47 +81,47 @@ void RemoteMediaSessionHelperProxy::overridePresentingApplicationPIDIfNeeded()
 
 void RemoteMediaSessionHelperProxy::applicationWillEnterForeground(SuspendedUnderLock suspendedUnderLock)
 {
-    m_gpuConnection.connection().send(Messages::RemoteMediaSessionHelper::ApplicationWillEnterForeground(suspendedUnderLock), { });
+    m_gpuConnection->connection().send(Messages::RemoteMediaSessionHelper::ApplicationWillEnterForeground(suspendedUnderLock), { });
 }
 
 void RemoteMediaSessionHelperProxy::applicationDidEnterBackground(SuspendedUnderLock suspendedUnderLock)
 {
-    m_gpuConnection.connection().send(Messages::RemoteMediaSessionHelper::ApplicationDidEnterBackground(suspendedUnderLock), { });
+    m_gpuConnection->connection().send(Messages::RemoteMediaSessionHelper::ApplicationDidEnterBackground(suspendedUnderLock), { });
 }
 
 void RemoteMediaSessionHelperProxy::applicationWillBecomeInactive()
 {
-    m_gpuConnection.connection().send(Messages::RemoteMediaSessionHelper::ApplicationWillBecomeInactive(), { });
+    m_gpuConnection->connection().send(Messages::RemoteMediaSessionHelper::ApplicationWillBecomeInactive(), { });
 }
 
 void RemoteMediaSessionHelperProxy::applicationDidBecomeActive()
 {
-    m_gpuConnection.connection().send(Messages::RemoteMediaSessionHelper::ApplicationDidBecomeActive(), { });
+    m_gpuConnection->connection().send(Messages::RemoteMediaSessionHelper::ApplicationDidBecomeActive(), { });
 }
 
 void RemoteMediaSessionHelperProxy::externalOutputDeviceAvailableDidChange(HasAvailableTargets hasAvailableTargets)
 {
-    m_gpuConnection.connection().send(Messages::RemoteMediaSessionHelper::ExternalOutputDeviceAvailableDidChange(hasAvailableTargets), { });
+    m_gpuConnection->connection().send(Messages::RemoteMediaSessionHelper::ExternalOutputDeviceAvailableDidChange(hasAvailableTargets), { });
 }
 
 void RemoteMediaSessionHelperProxy::isPlayingToAutomotiveHeadUnitDidChange(PlayingToAutomotiveHeadUnit playing)
 {
-    m_gpuConnection.connection().send(Messages::RemoteMediaSessionHelper::IsPlayingToAutomotiveHeadUnitDidChange(playing), { });
+    m_gpuConnection->connection().send(Messages::RemoteMediaSessionHelper::IsPlayingToAutomotiveHeadUnitDidChange(playing), { });
 }
 
 void RemoteMediaSessionHelperProxy::activeAudioRouteDidChange(ShouldPause shouldPause)
 {
-    m_gpuConnection.connection().send(Messages::RemoteMediaSessionHelper::ActiveAudioRouteDidChange(shouldPause), { });
+    m_gpuConnection->connection().send(Messages::RemoteMediaSessionHelper::ActiveAudioRouteDidChange(shouldPause), { });
 }
 
 void RemoteMediaSessionHelperProxy::activeVideoRouteDidChange(SupportsAirPlayVideo supportsAirPlayVideo, Ref<WebCore::MediaPlaybackTarget>&& target)
 {
-    m_gpuConnection.connection().send(Messages::RemoteMediaSessionHelper::ActiveVideoRouteDidChange(supportsAirPlayVideo, MediaPlaybackTargetContextSerialized { target->targetContext() }), { });
+    m_gpuConnection->connection().send(Messages::RemoteMediaSessionHelper::ActiveVideoRouteDidChange(supportsAirPlayVideo, MediaPlaybackTargetContextSerialized { target->targetContext() }), { });
 }
 
 void RemoteMediaSessionHelperProxy::activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback supportsSpatialPlayback)
 {
-    m_gpuConnection.connection().send(Messages::RemoteMediaSessionHelper::ActiveAudioRouteSupportsSpatialPlaybackDidChange(supportsSpatialPlayback), { });
+    m_gpuConnection->connection().send(Messages::RemoteMediaSessionHelper::ActiveAudioRouteSupportsSpatialPlaybackDidChange(supportsSpatialPlayback), { });
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
@@ -29,6 +29,7 @@
 
 #include "MessageReceiver.h"
 #include <WebCore/MediaSessionHelperIOS.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -67,7 +68,7 @@ private:
     void activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback) final;
 
     bool m_isMonitoringWirelessRoutes { false };
-    GPUConnectionToWebProcess& m_gpuConnection;
+    WeakRef<GPUConnectionToWebProcess> m_gpuConnection;
     std::optional<int> m_presentingApplicationPID;
 };
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp
@@ -110,7 +110,7 @@ RemoteAudioMediaStreamTrackRendererInternalUnitManager::~RemoteAudioMediaStreamT
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::createUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>, size_t)>&& callback)
 {
     ASSERT(!m_units.contains(identifier));
-    m_units.add(identifier, makeUniqueRef<RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit>(identifier, m_gpuConnectionToWebProcess.connection(), m_gpuConnectionToWebProcess.isLastToCaptureAudio(), WTFMove(callback)));
+    m_units.add(identifier, makeUniqueRef<RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit>(identifier, m_gpuConnectionToWebProcess->connection(), m_gpuConnectionToWebProcess->isLastToCaptureAudio(), WTFMove(callback)));
 }
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::deleteUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier)
@@ -119,7 +119,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::deleteUnit(AudioMed
         return;
 
     if (m_units.isEmpty())
-        m_gpuConnectionToWebProcess.gpuProcess().tryExitIfUnusedAndUnderMemoryPressure();
+        m_gpuConnectionToWebProcess->gpuProcess().tryExitIfUnusedAndUnderMemoryPressure();
 }
 
 void RemoteAudioMediaStreamTrackRendererInternalUnitManager::startUnit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, ConsumerSharedCARingBuffer::Handle&& handle, IPC::Semaphore&& semaphore)
@@ -144,7 +144,7 @@ void RemoteAudioMediaStreamTrackRendererInternalUnitManager::notifyLastToCapture
 {
     // FIXME: When supporting multiple units to different speakers, we should only select the unit matching the VPIO output device.
     for (auto& unit : m_units.values())
-        unit->setShouldRegisterAsSpeakerSamplesProducer(m_gpuConnectionToWebProcess.isLastToCaptureAudio());
+        unit->setShouldRegisterAsSpeakerSamplesProducer(m_gpuConnectionToWebProcess->isLastToCaptureAudio());
 }
 
 RemoteAudioMediaStreamTrackRendererInternalUnitManager::Unit::Unit(AudioMediaStreamTrackRendererInternalUnitIdentifier identifier, Ref<IPC::Connection>&& connection, bool shouldRegisterAsSpeakerSamplesProducer, CompletionHandler<void(std::optional<WebCore::CAAudioStreamDescription>, size_t)>&& callback)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h
@@ -69,7 +69,7 @@ private:
     void setAudioOutputDevice(AudioMediaStreamTrackRendererInternalUnitIdentifier, const String&);
 
     HashMap<AudioMediaStreamTrackRendererInternalUnitIdentifier, UniqueRef<Unit>> m_units;
-    GPUConnectionToWebProcess& m_gpuConnectionToWebProcess;
+    WeakRef<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
 };
 
 } // namespace WebKit;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.cpp
@@ -37,7 +37,7 @@
 #include <WebCore/WebAudioBufferList.h>
 #include <wtf/CompletionHandler.h>
 
-#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, (&m_gpuConnectionToWebProcess.connection()))
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, (&m_gpuConnectionToWebProcess->connection()))
 
 namespace WebKit {
 using namespace WebCore;

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorder.h
@@ -35,6 +35,7 @@
 #include <WebCore/CAAudioStreamDescription.h>
 #include <WebCore/MediaRecorderPrivateWriterCocoa.h>
 #include <wtf/MediaTime.h>
+#include <wtf/WeakRef.h>
 
 namespace IPC {
 class Connection;
@@ -76,7 +77,7 @@ private:
     void setSharedVideoFrameSemaphore(IPC::Semaphore&&);
     void setSharedVideoFrameMemory(WebCore::SharedMemory::Handle&&);
 
-    GPUConnectionToWebProcess& m_gpuConnectionToWebProcess;
+    WeakRef<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     MediaRecorderIdentifier m_identifier;
     Ref<WebCore::MediaRecorderPrivateWriter> m_writer;
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorderManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorderManager.cpp
@@ -67,7 +67,7 @@ void RemoteMediaRecorderManager::releaseRecorder(MediaRecorderIdentifier identif
 {
     m_recorders.remove(identifier);
     if (allowsExitUnderMemoryPressure())
-        m_gpuConnectionToWebProcess.gpuProcess().tryExitIfUnusedAndUnderMemoryPressure();
+        m_gpuConnectionToWebProcess->gpuProcess().tryExitIfUnusedAndUnderMemoryPressure();
 }
 
 bool RemoteMediaRecorderManager::allowsExitUnderMemoryPressure() const

--- a/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorderManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteMediaRecorderManager.h
@@ -31,6 +31,7 @@
 #include "MessageReceiver.h"
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/WeakRef.h>
 
 namespace IPC {
 class Connection;
@@ -64,7 +65,7 @@ private:
     void createRecorder(MediaRecorderIdentifier, bool recordAudio, bool recordVideo, const WebCore::MediaRecorderPrivateOptions&, CompletionHandler<void(std::optional<WebCore::ExceptionData>&&, String&&, unsigned, unsigned)>&&);
     void releaseRecorder(MediaRecorderIdentifier);
 
-    GPUConnectionToWebProcess& m_gpuConnectionToWebProcess;
+    WeakRef<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     HashMap<MediaRecorderIdentifier, std::unique_ptr<RemoteMediaRecorder>> m_recorders;
 };
 

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.cpp
@@ -51,7 +51,7 @@ RemoteSampleBufferDisplayLayer::RemoteSampleBufferDisplayLayer(GPUConnectionToWe
     , m_identifier(identifier)
     , m_connection(WTFMove(connection))
     , m_sampleBufferDisplayLayer(LocalSampleBufferDisplayLayer::create(*this))
-    , m_sharedVideoFrameReader(Ref { m_gpuConnection.videoFrameObjectHeap() }, m_gpuConnection.webProcessIdentity())
+    , m_sharedVideoFrameReader(Ref { m_gpuConnection->videoFrameObjectHeap() }, m_gpuConnection->webProcessIdentity())
 {
     ASSERT(m_sampleBufferDisplayLayer);
 }

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -36,6 +36,7 @@
 #include <WebCore/SampleBufferDisplayLayer.h>
 #include <wtf/MediaTime.h>
 #include <wtf/ThreadAssertions.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 class ImageTransferSessionVT;
@@ -89,14 +90,13 @@ private:
     // WebCore::SampleBufferDisplayLayer::Client
     void sampleBufferDisplayLayerStatusDidFail() final;
 
-    GPUConnectionToWebProcess& m_gpuConnection WTF_GUARDED_BY_CAPABILITY(m_consumeThread);
+    WeakRef<GPUConnectionToWebProcess> m_gpuConnection WTF_GUARDED_BY_CAPABILITY(m_consumeThread);
     SampleBufferDisplayLayerIdentifier m_identifier;
     Ref<IPC::Connection> m_connection;
     RefPtr<WebCore::LocalSampleBufferDisplayLayer> m_sampleBufferDisplayLayer;
     std::unique_ptr<LayerHostingContext> m_layerHostingContext;
     SharedVideoFrameReader m_sharedVideoFrameReader;
     ThreadLikeAssertion m_consumeThread NO_UNIQUE_ADDRESS;
-
 };
 
 }

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.cpp
@@ -47,16 +47,16 @@ RemoteSampleBufferDisplayLayerManager::RemoteSampleBufferDisplayLayerManager(GPU
 
 void RemoteSampleBufferDisplayLayerManager::startListeningForIPC()
 {
-    m_connectionToWebProcess.connection().addWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayer::messageReceiverName(), m_queue, *this);
-    m_connectionToWebProcess.connection().addWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayerManager::messageReceiverName(), m_queue, *this);
+    m_connectionToWebProcess->connection().addWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayer::messageReceiverName(), m_queue, *this);
+    m_connectionToWebProcess->connection().addWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayerManager::messageReceiverName(), m_queue, *this);
 }
 
 RemoteSampleBufferDisplayLayerManager::~RemoteSampleBufferDisplayLayerManager() = default;
 
 void RemoteSampleBufferDisplayLayerManager::close()
 {
-    m_connectionToWebProcess.connection().removeWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayer::messageReceiverName());
-    m_connectionToWebProcess.connection().removeWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayerManager::messageReceiverName());
+    m_connectionToWebProcess->connection().removeWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayer::messageReceiverName());
+    m_connectionToWebProcess->connection().removeWorkQueueMessageReceiver(Messages::RemoteSampleBufferDisplayLayerManager::messageReceiverName());
     m_queue->dispatch([this, protectedThis = Ref { *this }] {
         Locker lock(m_layersLock);
         callOnMainRunLoop([layers = WTFMove(m_layers)] { });

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayerManager.h
@@ -34,6 +34,7 @@
 #include <WebCore/FloatRect.h>
 #include <WebCore/IntSize.h>
 #include <wtf/HashMap.h>
+#include <wtf/WeakRef.h>
 
 namespace IPC {
 class Decoder;
@@ -77,7 +78,7 @@ private:
     void createLayer(SampleBufferDisplayLayerIdentifier, bool hideRootLayer, WebCore::IntSize, bool shouldMaintainAspectRatio, LayerCreationCallback);
     void releaseLayer(SampleBufferDisplayLayerIdentifier);
 
-    GPUConnectionToWebProcess& m_connectionToWebProcess;
+    WeakRef<GPUConnectionToWebProcess> m_connectionToWebProcess;
     Ref<IPC::Connection> m_connection;
     Ref<WorkQueue> m_queue;
     mutable Lock m_layersLock;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.cpp
@@ -77,7 +77,7 @@ void RemoteCompositorIntegrationProxy::paintCompositedResultsToCanvas(WebCore::I
     UNUSED_VARIABLE(sendResult);
 }
 
-void RemoteCompositorIntegrationProxy::withDisplayBufferAsNativeImage(uint32_t, Function<void(WebCore::NativeImage&)>)
+void RemoteCompositorIntegrationProxy::withDisplayBufferAsNativeImage(uint32_t, Function<void(WebCore::NativeImage*)>)
 {
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -61,7 +61,7 @@ public:
     }
 
     void paintCompositedResultsToCanvas(WebCore::ImageBuffer&, uint32_t) final;
-    void withDisplayBufferAsNativeImage(uint32_t, Function<void(WebCore::NativeImage&)>) final;
+    void withDisplayBufferAsNativeImage(uint32_t, Function<void(WebCore::NativeImage*)>) final;
 
 private:
     friend class DowncastConvertToBackingContext;


### PR DESCRIPTION
#### 60aeffa2f9b8aaa7da3ae2fe2815090ca79f2e9d
<pre>
Use smart pointers to store references to ObjectHeap
<a href="https://bugs.webkit.org/show_bug.cgi?id=270892">https://bugs.webkit.org/show_bug.cgi?id=270892</a>
<a href="https://rdar.apple.com/124497369">rdar://124497369</a>

Reviewed by Mike Wyrzykowski.

We expect the objects to never outlive the ObjectHeap, so use WeakRef
instead of WeakPtr.  However, the objects are ThreadSafeRefCounted,
so if something does happen and something keeps a strong reference to
the objects to keep them alive beyond the lifetime of the ObjectHeap,
we want to dereference null and crash safely instead of using a C++
reference to a freed object.

While I was at it, I did the same with all stored C++ references in
Source/WebKit/GPUProcess, and made withDisplayBufferAsNativeImage
always call its completion handler.

* Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h:
* Source/WebKit/GPUProcess/ShapeDetection/ShapeDetectionObjectHeap.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp:
(WebKit::RemoteAdapter::destruct):
(WebKit::RemoteAdapter::requestDevice):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp:
(WebKit::RemoteBindGroup::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp:
(WebKit::RemoteBindGroupLayout::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp:
(WebKit::RemoteCommandBuffer::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp:
(WebKit::RemoteCommandEncoder::destruct):
(WebKit::RemoteCommandEncoder::beginRenderPass):
(WebKit::RemoteCommandEncoder::beginComputePass):
(WebKit::RemoteCommandEncoder::copyBufferToBuffer):
(WebKit::RemoteCommandEncoder::copyBufferToTexture):
(WebKit::RemoteCommandEncoder::copyTextureToBuffer):
(WebKit::RemoteCommandEncoder::copyTextureToTexture):
(WebKit::RemoteCommandEncoder::clearBuffer):
(WebKit::RemoteCommandEncoder::writeTimestamp):
(WebKit::RemoteCommandEncoder::resolveQuerySet):
(WebKit::RemoteCommandEncoder::finish):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp:
(WebKit::RemoteCompositorIntegration::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp:
(WebKit::RemoteComputePassEncoder::destruct):
(WebKit::RemoteComputePassEncoder::setPipeline):
(WebKit::RemoteComputePassEncoder::dispatchIndirect):
(WebKit::RemoteComputePassEncoder::setBindGroup):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp:
(WebKit::RemoteComputePipeline::destruct):
(WebKit::RemoteComputePipeline::getBindGroupLayout):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp:
(WebKit::RemoteDevice::destruct):
(WebKit::RemoteDevice::createBuffer):
(WebKit::RemoteDevice::createTexture):
(WebKit::RemoteDevice::createSampler):
(WebKit::RemoteDevice::importExternalTextureFromVideoFrame):
(WebKit::RemoteDevice::createBindGroupLayout):
(WebKit::RemoteDevice::createPipelineLayout):
(WebKit::RemoteDevice::createBindGroup):
(WebKit::RemoteDevice::createShaderModule):
(WebKit::RemoteDevice::createComputePipeline):
(WebKit::RemoteDevice::createRenderPipeline):
(WebKit::RemoteDevice::createComputePipelineAsync):
(WebKit::RemoteDevice::createRenderPipelineAsync):
(WebKit::RemoteDevice::createCommandEncoder):
(WebKit::RemoteDevice::createRenderBundleEncoder):
(WebKit::RemoteDevice::createQuerySet):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp:
(WebKit::RemoteExternalTexture::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp:
(WebKit::RemotePipelineLayout::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp:
(WebKit::RemotePresentationContext::configure):
(WebKit::RemotePresentationContext::getCurrentTexture):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp:
(WebKit::RemoteQuerySet::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp:
(WebKit::RemoteQueue::destruct):
(WebKit::RemoteQueue::submit):
(WebKit::RemoteQueue::writeBuffer):
(WebKit::RemoteQueue::writeTexture):
(WebKit::RemoteQueue::copyExternalImageToTexture):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp:
(WebKit::RemoteRenderBundle::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp:
(WebKit::RemoteRenderBundleEncoder::destruct):
(WebKit::RemoteRenderBundleEncoder::setPipeline):
(WebKit::RemoteRenderBundleEncoder::setIndexBuffer):
(WebKit::RemoteRenderBundleEncoder::setVertexBuffer):
(WebKit::RemoteRenderBundleEncoder::drawIndirect):
(WebKit::RemoteRenderBundleEncoder::drawIndexedIndirect):
(WebKit::RemoteRenderBundleEncoder::setBindGroup):
(WebKit::RemoteRenderBundleEncoder::finish):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp:
(WebKit::RemoteRenderPassEncoder::destruct):
(WebKit::RemoteRenderPassEncoder::setPipeline):
(WebKit::RemoteRenderPassEncoder::setIndexBuffer):
(WebKit::RemoteRenderPassEncoder::setVertexBuffer):
(WebKit::RemoteRenderPassEncoder::drawIndirect):
(WebKit::RemoteRenderPassEncoder::drawIndexedIndirect):
(WebKit::RemoteRenderPassEncoder::setBindGroup):
(WebKit::RemoteRenderPassEncoder::setBlendConstant):
(WebKit::RemoteRenderPassEncoder::executeBundles):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp:
(WebKit::RemoteRenderPipeline::destruct):
(WebKit::RemoteRenderPipeline::getBindGroupLayout):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp:
(WebKit::RemoteSampler::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp:
(WebKit::RemoteShaderModule::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp:
(WebKit::RemoteTexture::createView):
(WebKit::RemoteTexture::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp:
(WebKit::RemoteTextureView::destruct):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/WebGPUObjectHeap.h:

Canonical link: <a href="https://commits.webkit.org/276036@main">https://commits.webkit.org/276036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf783607edad400d4b5c03481e3b48582a08df1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46171 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39665 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19985 "Built successfully") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36001 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 35 flakes 215 failures 1 missing results; Uploaded test results; 25 flakes 186 failures 1 missing results; Compiled WebKit (warnings); 12 flakes 174 failures 1 missing results") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16975 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17170 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 5 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38577 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1592 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39712 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47717 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18566 "Built successfully") | [💥 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15196 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 8 flakes 17 failures; Uploaded test results; 4 flakes 16 failures") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42784 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Exiting early after 500 failures. 47869 tests run. 499 failures 1 missing results; Uploaded test results; 70 flakes 372 failures 1 missing results; Compiled WebKit; 2 flakes 370 failures 1 missing results") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/19989 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41458 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20169 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5939 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19619 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->