### PR TITLE
[MSE] ManagedMediaSource isn't usable in a DedicatedWorker

### DIFF
--- a/LayoutTests/media/media-source/worker/media-managedmse-worker-expected.txt
+++ b/LayoutTests/media/media-source/worker/media-managedmse-worker-expected.txt
@@ -1,0 +1,6 @@
+
+RUN(video.disableRemotePlayback = true)
+received handle message: [object MediaSourceHandle] OK
+info message from worker: sourceopen event received OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/worker/media-managedmse-worker.html
+++ b/LayoutTests/media/media-source/worker/media-managedmse-worker.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>managedmediasource in worker</title>
+    <script src="../../../media/video-test.js"></script>
+    <script>
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        const worker = new Worker('worker.js');
+        worker.onmessage = msg => {
+            switch (msg.data.topic) {
+                case 'handle':
+                logResult(true, 'received handle message: ' + msg.data.arg);
+                video.srcObject = msg.data.arg;
+                break;
+                case 'info':
+                logResult(true, 'info message from worker: ' + msg.data.arg);
+                endTest();
+                break;
+                default:
+                logResult(false, 'error: Unrecognized topic in message from worker');
+                break;
+            }
+        };
+        run('video.disableRemotePlayback = true');
+        worker.postMessage({ });
+    });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/worker/worker.js
+++ b/LayoutTests/media/media-source/worker/worker.js
@@ -1,0 +1,16 @@
+function logToMain(msg) {
+    postMessage({topic: 'info', arg: msg});
+}
+
+onmessage = (e) => {
+    const ms = new ManagedMediaSource();
+    const handle = ms.handle;
+
+    ms.onsourceopen = () => {
+        logToMain("sourceopen event received");
+    };
+    // Transfer the MediaSourceHandle to the main thread for use in attaching to
+    // the main thread media element that will play the content being buffered
+    // here in the worker.
+    postMessage({topic: 'handle', arg: handle}, [handle]);
+};

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1084,6 +1084,9 @@ media/media-source/media-managedmse-memorypressure.html [ Timeout ]
 media/media-source/media-managedmse-memorypressure-inactive.html [ Timeout ]
 media/media-source/media-managedmse-eviction.html [ Timeout ]
 
+# No MSE in a worker on glib platforms for now (requires GPU process).
+media/media-source/worker/media-managedmse-worker.html [ Timeout ]
+
 webkit.org/b/211995 fast/images/animated-image-mp4.html [ Failure Timeout ]
 
 webkit.org/b/214038 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-cuechange.html [ Missing Failure ]

--- a/Source/WebCore/Modules/mediasource/MediaSourceHandle.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceHandle.cpp
@@ -120,9 +120,9 @@ bool MediaSourceHandle::isManaged() const
     return m_private->m_isManaged;
 }
 
-void MediaSourceHandle::ensureOnDispatcher(MediaSourceHandle::TaskType&& task) const
+void MediaSourceHandle::ensureOnDispatcher(MediaSourceHandle::TaskType&& task, bool forceRun) const
 {
-    m_private->dispatch(WTFMove(task));
+    m_private->dispatch(WTFMove(task), forceRun);
 }
 
 Ref<DetachedMediaSourceHandle> MediaSourceHandle::detach()

--- a/Source/WebCore/Modules/mediasource/MediaSourceHandle.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceHandle.h
@@ -55,7 +55,7 @@ public:
     bool isManaged() const;
 
     using TaskType = Function<void(MediaSource&)>;
-    void ensureOnDispatcher(TaskType&&) const;
+    void ensureOnDispatcher(TaskType&&, bool forceRun = false) const;
 
     RefPtr<MediaSourcePrivateClient> mediaSourcePrivateClient() const;
     RefPtr<MediaSourcePrivate> mediaSourcePrivate() const;

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
@@ -96,9 +96,10 @@ bool MediaSourceInterfaceWorker::attachToElement(WeakPtr<HTMLMediaElement>&& ele
     if (m_handle->hasEverBeenAssignedAsSrcObject())
         return false;
     m_handle->setHasEverBeenAssignedAsSrcObject();
+    bool forceRun = true;
     m_handle->ensureOnDispatcher([element = WTFMove(element)](MediaSource& mediaSource) mutable {
         mediaSource.attachToElement(WTFMove(element));
-    });
+    }, forceRun);
     return true;
 }
 


### PR DESCRIPTION
#### 321003e22c50fc0c6997243a1a81cca118d16645
<pre>
[MSE] ManagedMediaSource isn&apos;t usable in a DedicatedWorker
<a href="https://bugs.webkit.org/show_bug.cgi?id=270891">https://bugs.webkit.org/show_bug.cgi?id=270891</a>
<a href="https://rdar.apple.com/124499286">rdar://124499286</a>

Reviewed by Youenn Fablet.

The HTMLMediaElement was never attached to the MediaSource (or ManagedMediaSource) running
in the dedicated worker.
While this didn&apos;t prevent MediaSource to work, it would have caused the ManagedMediaSource
to never move to the `Open` readyState as the MMS need to check the HTMLMediaElement if
an AirPlay alternative is present.
The MediaSourceHandle uses the ensureOnDispatcher utility to dispatch to the MediaSource
dispatcher, which will not run the function should MediaSource::isClosed() return true.
We need to force the function to run when we attach the HTMLMediaElement which in turn
will move the readyState to `open`.

Added test.

* LayoutTests/media/media-source/worker/media-managedmse-worker-expected.txt: Added.
* LayoutTests/media/media-source/worker/media-managedmse-worker.html: Added.
* LayoutTests/media/media-source/worker/worker.js: Added.
(logToMain):
(onmessage):
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediasource/MediaSourceHandle.cpp:
(WebCore::MediaSourceHandle::ensureOnDispatcher const):
* Source/WebCore/Modules/mediasource/MediaSourceHandle.h:
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp:
(WebCore::MediaSourceInterfaceWorker::attachToElement):

Canonical link: <a href="https://commits.webkit.org/276140@main">https://commits.webkit.org/276140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39ce5b39e84837cbd36722aff95da4c88a5a03d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46505 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39947 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36193 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19942 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37782 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17194 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38864 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1917 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48096 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18874 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15452 "Found 1 new test failure: http/tests/navigation/parsed-iframe-dynamic-form-back-entry.html (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43027 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41731 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9759 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20471 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->