### PR TITLE
Add bounds check when writing multidimensional texture

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2073,6 +2073,7 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 
 [ Debug ] fast/workers/worker-cloneport.html [ Slow ]
 [ Debug ] fast/webgpu/present-without-compute-pipeline.html [ Slow ]
+[ Debug ] fast/webgpu/multidimensional-texture-bounds.html [ Slow ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/multidimensional-texture-bounds-expected.txt
+++ b/LayoutTests/fast/webgpu/multidimensional-texture-bounds-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/multidimensional-texture-bounds.html
+++ b/LayoutTests/fast/webgpu/multidimensional-texture-bounds.html
@@ -1,0 +1,75 @@
+<script>
+if (window.testRunner) { testRunner.dumpAsText(); testRunner.waitUntilDone() }
+onload = async () => {
+    try {
+        let adapter1 = await navigator.gpu.requestAdapter({ });
+        let device3 = await adapter1.requestDevice(
+        {
+        label: '\u0f95',
+        requiredFeatures: [
+        'depth-clip-control',
+        'texture-compression-etc2',
+        'indirect-first-instance',
+        'shader-f16',
+        'rg11b10ufloat-renderable',
+        'bgra8unorm-storage'
+        ],
+        requiredLimits: {
+        maxColorAttachmentBytesPerSample: 49,
+        maxVertexAttributes: 22,
+        maxVertexBufferArrayStride: 22731,
+        maxStorageTexturesPerShaderStage: 13,
+        maxBindingsPerBindGroup: 2463,
+        maxTextureArrayLayers: 717,
+        maxTextureDimension1D: 9624,
+        maxTextureDimension2D: 12505,
+        maxVertexBuffers: 12,
+        minUniformBufferOffsetAlignment: 32,
+        },
+        }
+        );
+        
+        let texture10 = device3.createTexture(
+        {
+        label: '\udec9',
+        size: {width: 1521, height: 1, depthOrArrayLayers: 1613},
+        mipLevelCount: 3,
+        dimension: '3d',
+        format: 'rg32uint',
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+        viewFormats: [
+        'rg32uint',
+        'rg32uint',
+        'rg32uint',
+        'rg32uint',
+        'rg32uint',
+        'rg32uint',
+        'rg32uint',
+        'rg32uint',
+        'rg32uint'
+        ],
+        }
+        );
+        
+        device3.queue.writeTexture(
+        {
+          texture: texture10,
+          mipLevel: 0,
+          origin: { x: 218, y: 0, z: 616 },
+          aspect: 'all',
+        },
+        new ArrayBuffer(4250119698), {
+        offset: 70,
+        bytesPerRow: 10739,
+        rowsPerImage: 652,
+        },
+        {width: 1254, height: 1, depthOrArrayLayers: 608}
+        );
+    } catch {}
+    
+    setTimeout(()=>{
+        if (window.testRunner) { testRunner.notifyDone() }
+    }, 1000)
+};
+</script>
+This test passes if it does not crash.

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -558,7 +558,11 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
 
                     for (uint32_t x = 0; x < widthForMetal; x += maxRowBytes) {
                         newDestination.origin.x = destination.origin.x + x;
-                        writeTexture(newDestination, static_cast<uint8_t*>(data) + x + y * bytesPerRow + z * bytesPerImage, bytesPerRow * newSize.height, newDataLayout, newSize);
+                        auto offset = x + y * bytesPerRow + z * bytesPerImage;
+                        auto size = bytesPerRow * newSize.height;
+                        if (offset + size > dataSize)
+                            return;
+                        writeTexture(newDestination, static_cast<uint8_t*>(data) + offset, size, newDataLayout, newSize);
                     }
                 }
             }


### PR DESCRIPTION
#### e87abc019b58b6bec3af3db905ff83ba39a9302e
<pre>
Add bounds check when writing multidimensional texture
<a href="https://bugs.webkit.org/show_bug.cgi?id=270896">https://bugs.webkit.org/show_bug.cgi?id=270896</a>
<a href="https://rdar.apple.com/124475299">rdar://124475299</a>

Reviewed by Mike Wyrzykowski.

* LayoutTests/TestExpectations:
* LayoutTests/fast/webgpu/multidimensional-texture-bounds-expected.txt: Added.
* LayoutTests/fast/webgpu/multidimensional-texture-bounds.html: Added.
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeTexture):

Canonical link: <a href="https://commits.webkit.org/276024@main">https://commits.webkit.org/276024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74793a9165e122c912657eb807435be52f495c50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43545 "Passed style check") | [💥 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22579 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45957 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46183 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39674 "Built successfully") 
| | [💥 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26396 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19995 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/46183 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44119 "Passed tests") | [💥 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/26396 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/45957 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/46183 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/26396 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/45957 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1601 "Built successfully") | 
| | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/26396 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/45957 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47729 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [💥 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18576 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/19995 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/47729 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [💥 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20000 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/45957 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/47729 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| | [💥 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20179 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5933 "Built successfully and passed tests") | [💥 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19629 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->