### PR TITLE
REGRESSION (274816@main): [visionOS] Fullscreen window size does not always match the video's aspect ratio

### DIFF
--- a/Source/WebKit/Shared/FullScreenMediaDetails.h
+++ b/Source/WebKit/Shared/FullScreenMediaDetails.h
@@ -31,7 +31,7 @@
 namespace WebKit {
 
 struct FullScreenMediaDetails {
-    enum class Type : uint8_t { None, Video, Image };
+    enum class Type : uint8_t { None, Video, ElementWithVideo, Image };
 
     Type type { Type::None };
     WebCore::FloatSize videoDimensions { };

--- a/Source/WebKit/Shared/FullScreenMediaDetails.serialization.in
+++ b/Source/WebKit/Shared/FullScreenMediaDetails.serialization.in
@@ -24,6 +24,7 @@
 [Nested] enum class WebKit::FullScreenMediaDetails::Type : uint8_t {
     None,
     Video,
+    ElementWithVideo,
     Image
 };
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -266,9 +266,9 @@ void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element, 
     updateMainVideoElement();
 
 #if PLATFORM(VISION)
-    if (m_mainVideoElement && is<HTMLVideoElement>(element)) {
+    if (m_mainVideoElement) {
         mediaDetails = {
-            FullScreenMediaDetails::Type::Video,
+            is<HTMLVideoElement>(element) ? FullScreenMediaDetails::Type::Video : FullScreenMediaDetails::Type::ElementWithVideo,
             FloatSize(m_mainVideoElement->videoWidth(), m_mainVideoElement->videoHeight())
         };
     }


### PR DESCRIPTION
#### 7f87b7bf71aefae08144aa6948d677afe9a366cd
<pre>
REGRESSION (274816@main): [visionOS] Fullscreen window size does not always match the video&apos;s aspect ratio
<a href="https://bugs.webkit.org/show_bug.cgi?id=270897">https://bugs.webkit.org/show_bug.cgi?id=270897</a>
<a href="https://rdar.apple.com/124506779">rdar://124506779</a>

Reviewed by Abrar Rahman Protyasha.

Fullscreen video on visionOS is intended to be presented at the aspect ratio of
the video element. In cases where the video element is not actually the fullscreen
element, the &quot;main&quot; video element is used, as determined by the heuristic in
`WebFullScreenManager::updateMainVideoElement`. If a &quot;main&quot; video element exists,
it&apos;s size is sent to the UI process for appropriate window sizing.

To add a distinct path for image fullscreen on visionOS, 274816@main refactored
fullscreen presentation logic to specify media type (image/video) and video size
in a single struct. However, in this refactoring, the logic for size determination
was additionally gated on whether or not the fullscreen element was a video element,
and not simply the existence of a &quot;main&quot; video element.

Fix by splitting up the &quot;video element is fullscreen&quot; and &quot;the fullscreen element
contains a prominent video&quot; cases by introducing a new `FullScreenMediaDetails::Type`,
ensuring the size is sent over in both cases. The distinction between the two
cases is necessary, as `FullScreenMediaDetails::Type::Video` is used further down
the line, to determine whether native, UI-process side controls should be shown.

* Source/WebKit/Shared/FullScreenMediaDetails.h:
* Source/WebKit/Shared/FullScreenMediaDetails.serialization.in:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):

Do not check `is&lt;HTMLVideoElement&gt;(element)` prior to populating the details,
as the size should always be specified if there is a &quot;main&quot; video element.

Canonical link: <a href="https://commits.webkit.org/276059@main">https://commits.webkit.org/276059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a72ad9be667fec081a54e58d51c85747c5fe607

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43547 "Passed style check") | [💥 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22581 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45959 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46185 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39676 "Built successfully") 
| | [💥 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26398 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/19997 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/46185 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44121 "Passed tests") | [💥 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/26398 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/45959 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/46185 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/26398 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/45959 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1603 "Built successfully") | 
| | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/26398 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/45959 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47731 "An unexpected error occured. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| | [💥 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18578 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/19997 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/47731 "An unexpected error occured. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| | [💥 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20002 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/45959 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/47731 "An unexpected error occured. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9710 "Built successfully and passed tests") | [💥 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20181 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
| | [💥 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19631 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->