### PR TITLE
[iOS 17.4] 21+ layout tests assert under WebPage::requestDocumentEditingContext

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4900,10 +4900,8 @@ static VisiblePosition moveByGranularityRespectingWordBoundary(const VisiblePosi
         if (atBoundaryOfGranularity(currentPosition, granularity, direction))
             --granularityCount;
     } while (granularityCount);
-    if (granularity == TextGranularity::SentenceGranularity) {
-        ASSERT(atBoundaryOfGranularity(currentPosition, TextGranularity::SentenceGranularity, direction));
+    if (granularity == TextGranularity::SentenceGranularity)
         return currentPosition;
-    }
     // Note that this rounds to the nearest word, which may cross a line boundary when using line granularity.
     // For example, suppose the text is laid out as follows and the insertion point is at |:
     //     |This is the first sen

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -63,11 +63,6 @@
 #import <UIKit/UIWindow_Private.h>
 #import <UIKit/_UINavigationInteractiveTransition.h>
 
-#if !__has_include(<UIKit/UIAsyncTextInput_ForWebKitOnly.h>)
-#define UITextDocumentContext UIWKDocumentContext
-#define UITextDocumentRequest UIWKDocumentRequest
-#endif
-
 IGNORE_WARNINGS_BEGIN("deprecated-implementations")
 #import <UIKit/UIWebBrowserView.h>
 #import <UIKit/UIWebScrollView.h>
@@ -83,9 +78,6 @@ IGNORE_WARNINGS_END
 #endif // PLATFORM(IOS) || PLATFORM(VISION)
 
 #else // USE(APPLE_INTERNAL_SDK)
-
-#define UITextDocumentContext UIWKDocumentContext
-#define UITextDocumentRequest UIWKDocumentRequest
 
 @interface NSTextAlternatives : NSObject
 - (id)initWithPrimaryString:(NSString *)primaryString alternativeStrings:(NSArray<NSString *> *)alternativeStrings;
@@ -255,9 +247,9 @@ typedef NS_ENUM(NSInteger, UIWKGestureType) {
 - (void)applyAutocorrection:(NSString *)correction toString:(NSString *)input shouldUnderline:(BOOL)shouldUnderline withCompletionHandler:(void (^)(UIWKAutocorrectionRects *rectsForCorrection))completionHandler;
 
 #if HAVE(UI_WK_DOCUMENT_CONTEXT)
-- (void)requestDocumentContext:(UITextDocumentRequest *)request completionHandler:(void (^)(UITextDocumentContext *))completionHandler;
+- (void)requestDocumentContext:(UIWKDocumentRequest *)request completionHandler:(void (^)(UIWKDocumentContext *))completionHandler;
 - (void)adjustSelectionWithDelta:(NSRange)deltaRange completionHandler:(void (^)(void))completionHandler;
-- (void)selectPositionAtPoint:(CGPoint)point withContextRequest:(UITextDocumentRequest *)request completionHandler:(void (^)(UITextDocumentContext *))completionHandler;
+- (void)selectPositionAtPoint:(CGPoint)point withContextRequest:(UIWKDocumentRequest *)request completionHandler:(void (^)(UIWKDocumentContext *))completionHandler;
 #endif
 
 @property (nonatomic, readonly) NSString *selectedText;


### PR DESCRIPTION
#### b8cacf190ad60d1d602a3b40509bb52d9ec4b5fb
<pre>
[iOS 17.4] 21+ layout tests assert under WebPage::requestDocumentEditingContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=270899">https://bugs.webkit.org/show_bug.cgi?id=270899</a>
<a href="https://rdar.apple.com/123028247">rdar://123028247</a>

Reviewed by Abrar Rahman Protyasha.

As a part of BrowserEngineKit adoption in iOS 17.4, UIKit began issuing document editing context
requests to grab 2 sentences worth of context before and after the selection while the keyboard is
shown. This triggers a frequent debug assertion when running tests on iOS 17.4, due to the fact that
the current implementation of `nextSentenceBoundaryInDirection` frequently returns a position that
ends up being upstream of the initial `vp` when the `direction` is downstream, or downstream of the
`vp` when the given `direction` is upstream. For instance, this can happen when we&apos;re trying to find
the next downstream sentence boundary when the `vp` is anchored to a cell in a table; we end up
first moving to the end of the table with `nextSentencePosition`, but then `startOfSentence` takes
us back up to before the table, leaving us at a position before the initial `vp` (despite the fact
that we wanted to go downstream). To fix this, we make `nextSentenceBoundaryInDirection` more
robust with some minor adjustments:

1.  When moving downstream, if the start of the next sentence is before `vp`, then move to the end
    of the next sentence instead (and vice versa when moving upstream).

2.  Repeat the process of moving to the next `startOfSentence` or `endOfSentence` until the `result`
    is in the requested `direction` relative to the initial `vp`.

This ensures that we&apos;ll find the closest visible position that satisfies the following constraints:

1.  It is the result of either `startOfSentence` or `endOfSentence`.
2.  It is downstream of the initial `vp` when the `direction` is downstream, and vice versa when the
    `direction` is upstream.

* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::nextSentenceBoundaryInDirection):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::moveByGranularityRespectingWordBoundary):

Also, remove an unnecessary assertion here. This assertion can fire in the case where the given
`position` already denotes the end of the last (if moving downstream) or the start of the first (if
moving upstream) sentence in the document or editable root, in which case
`positionOfNextBoundaryOfGranularity` will just return the null position. This scenario is already
handled gracefully.

* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:
(makeRequest):

Remove staging for `UITextDocumentRequest` / `UITextDocumentContext`, since the rename from
`UIWKDocument*` to `UITextDocument*` never ended up happening (and we alternatively went with
introducing these objects in BrowserEngineKit, as `BETextDocument*`).

(-[TestWKWebView synchronouslyRequestDocumentContext:]):
(TEST):
(-[UITextDocumentContext markedTextRects]): Deleted.
(-[UITextDocumentContext contextBeforeLength]): Deleted.
(-[UITextDocumentContext markedTextLength]): Deleted.
(-[UITextDocumentContext markedTextRange]): Deleted.
(-[UITextDocumentContext textRects]): Deleted.
(-[UITextDocumentContext boundingRectForCharacterRange:]): Deleted.

Also fix these failing API tests on iOS 17.4 (which currently expect `UIWKDocumentContext` instead
of a `BETextDocumentContext`, and therefore throw ObjC exceptions at runtime when attempting to
access `contextBefore` and other methods).

Canonical link: <a href="https://commits.webkit.org/276067@main">https://commits.webkit.org/276067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/286b80b95cb5548ac55ad4c07f357ff2d7f4f418

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46270 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39757 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20084 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36047 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17019 "Passed tests") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17240 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (failure); Uploaded test results; Running re-run-layout-tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38632 "Found 1 new test failure: imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1685 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39785 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38944 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47839 "Build is in progress. Recent messages:Printed configuration") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15268 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42853 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20086 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41525 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9713 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20266 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19717 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Running checkout-pull-request; Running compile-webkit") | | | 
<!--EWS-Status-Bubble-End-->