### PR TITLE
[WPE] WPE Platform: make width, height, scale and state read only properties of WPEView

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -52,6 +52,9 @@ struct _WPEViewClass
                                                    WPEBuffer    *buffer,
                                                    GError      **error);
     WPEMonitor *(* get_monitor)                   (WPEView      *view);
+    gboolean    (* resize)                        (WPEView      *view,
+                                                   int           width,
+                                                   int           height);
     gboolean    (* set_fullscreen)                (WPEView      *view,
                                                    gboolean      fullscreen);
     gboolean    (* set_maximized)                 (WPEView      *view,
@@ -105,15 +108,14 @@ WPE_API WPEView     *wpe_view_new                           (WPEDisplay   *displ
 WPE_API WPEDisplay  *wpe_view_get_display                   (WPEView      *view);
 WPE_API int          wpe_view_get_width                     (WPEView      *view);
 WPE_API int          wpe_view_get_height                    (WPEView      *view);
-WPE_API void         wpe_view_set_width                     (WPEView      *view,
-                                                             int           width);
-WPE_API void         wpe_view_set_height                    (WPEView      *view,
+WPE_API gboolean     wpe_view_resize                        (WPEView      *view,
+                                                             int           width,
                                                              int           height);
-WPE_API void         wpe_view_resize                        (WPEView      *view,
+WPE_API void         wpe_view_resized                       (WPEView      *view,
                                                              int           width,
                                                              int           height);
 WPE_API gdouble      wpe_view_get_scale                     (WPEView      *view);
-WPE_API void         wpe_view_set_scale                     (WPEView      *view,
+WPE_API void         wpe_view_scale_changed                 (WPEView      *view,
                                                              gdouble       scale);
 WPE_API void         wpe_view_set_cursor_from_name          (WPEView      *view,
                                                              const char   *name);
@@ -125,7 +127,7 @@ WPE_API void         wpe_view_set_cursor_from_bytes         (WPEView      *view,
                                                              guint         hotspot_x,
                                                              guint         hotspot_y);
 WPE_API WPEViewState wpe_view_get_state                     (WPEView      *view);
-WPE_API void         wpe_view_set_state                     (WPEView      *view,
+WPE_API void         wpe_view_state_changed                 (WPEView      *view,
                                                              WPEViewState  state);
 WPE_API WPEMonitor  *wpe_view_get_monitor                   (WPEView      *view);
 WPE_API gboolean     wpe_view_fullscreen                    (WPEView      *view);

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
@@ -78,9 +78,9 @@ static void wpeViewDRMConstructed(GObject* object)
     auto* mode = wpeMonitorDRMGetMode(WPE_MONITOR_DRM(monitor));
     double scale = wpe_monitor_get_scale(monitor);
     auto* wpeView = WPE_VIEW(view);
-    wpe_view_resize(wpeView, mode->hdisplay / scale, mode->vdisplay / scale);
-    wpe_view_set_scale(wpeView, scale);
-    wpe_view_set_state(wpeView, WPE_VIEW_STATE_FULLSCREEN);
+    wpe_view_resized(wpeView, mode->hdisplay / scale, mode->vdisplay / scale);
+    wpe_view_scale_changed(wpeView, scale);
+    wpe_view_state_changed(wpeView, WPE_VIEW_STATE_FULLSCREEN);
 
     priv->refreshDuration = Seconds(1 / (wpe_monitor_get_refresh_rate(monitor) / 1000.));
 

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
@@ -111,6 +111,12 @@ static gboolean wpeViewHeadlessRenderBuffer(WPEView* view, WPEBuffer* buffer, GE
     return TRUE;
 }
 
+static gboolean wpeViewHeadlessResize(WPEView* view, int width, int height)
+{
+    wpe_view_resized(view, width, height);
+    return TRUE;
+}
+
 static gboolean wpeViewHeadlessSetFullscreen(WPEView* view, gboolean fullscreen)
 {
     auto state = wpe_view_get_state(view);
@@ -118,11 +124,10 @@ static gboolean wpeViewHeadlessSetFullscreen(WPEView* view, gboolean fullscreen)
         state = static_cast<WPEViewState>(state | WPE_VIEW_STATE_FULLSCREEN);
     else
         state = static_cast<WPEViewState>(state & ~WPE_VIEW_STATE_FULLSCREEN);
-    wpe_view_set_state(view, state);
+    wpe_view_state_changed(view, state);
 
     return TRUE;
 }
-
 
 static void wpe_view_headless_class_init(WPEViewHeadlessClass* viewHeadlessClass)
 {
@@ -132,6 +137,7 @@ static void wpe_view_headless_class_init(WPEViewHeadlessClass* viewHeadlessClass
 
     WPEViewClass* viewClass = WPE_VIEW_CLASS(viewHeadlessClass);
     viewClass->render_buffer = wpeViewHeadlessRenderBuffer;
+    viewClass->resize = wpeViewHeadlessResize;
     viewClass->set_fullscreen = wpeViewHeadlessSetFullscreen;
 }
 


### PR DESCRIPTION
#### 2f03251130ef53d46a41acffbebd1cb1a5f50f1f
<pre>
[WPE] WPE Platform: make width, height, scale and state read only properties of WPEView
<a href="https://bugs.webkit.org/show_bug.cgi?id=270906">https://bugs.webkit.org/show_bug.cgi?id=270906</a>

Reviewed by Alejandro G. Castro.

The API to get and set those properties is a bit confusing and users are
confused thinking they can call wpe_view_resize() from the app to resize
the view, for example. Those properties should only be changed by WPEView
derived classes in platform implementations.

This patch makes the properties read only and the setters are renamed as
notification functions and documented as only expected to be called by
derived classes. wpe_view_resize() now requests a resize and a virtual
method has been added for platforms to implement it only if they support
resizing (DRM doesn&apos;t, for example).

* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpeViewGetProperty):
(wpe_view_class_init):
(wpe_view_get_width):
(wpe_view_get_height):
(wpe_view_resize):
(wpe_view_resized):
(wpe_view_scale_changed):
(wpe_view_state_changed):
(wpe_view_set_width): Deleted.
(wpe_view_set_height): Deleted.
(wpe_view_set_scale): Deleted.
(wpe_view_set_state): Deleted.
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp:
(wpeViewDRMConstructed):
* Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp:
(wpeViewHeadlessResize):
(wpeViewHeadlessSetFullscreen):
(wpe_view_headless_class_init):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(wpeViewWaylandConstructed):
(wpeViewWaylandResize):
(wpe_view_wayland_class_init):

Canonical link: <a href="https://commits.webkit.org/276070@main">https://commits.webkit.org/276070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42b743cf654cf2bf70f1ba6c44988e5d69f9ee03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43565 "Passed style check") | [💥 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22603 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/45982 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46204 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39694 "Built successfully") 
| | [💥 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26418 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20017 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/46204 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44139 "Passed tests") | [💥 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/26418 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/45982 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/46204 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/26418 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/45982 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1621 "Built successfully") | 
| | [💥 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/26418 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/45982 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47750 "An unexpected error occured. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18598 "Built successfully") | [💥 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/20017 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/47750 "An unexpected error occured. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20021 "Built successfully") | [💥 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/45982 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [💥 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/47750 "An unexpected error occured. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20199 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5961 "Built successfully and passed tests") | [💥 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19649 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->