### PR TITLE
REGRESSION (iOS 17.4, macOS 14.4, 270890@main): Animating element with display: none still remain visible

### DIFF
--- a/LayoutTests/fast/animation/animation-with-DOM-mutation-and-display-none-expected.html
+++ b/LayoutTests/fast/animation/animation-with-DOM-mutation-and-display-none-expected.html
@@ -1,0 +1,1 @@
+This document should show nothing except this text.

--- a/LayoutTests/fast/animation/animation-with-DOM-mutation-and-display-none.html
+++ b/LayoutTests/fast/animation/animation-with-DOM-mutation-and-display-none.html
@@ -1,0 +1,17 @@
+<style>
+#target {
+    background-color: green;
+}
+</style>
+<div id=container></div>
+<div id=target>target</div>
+This document should show nothing except this text.
+<body onload="test()">
+<script>
+target.animate([{ color: "red" }, { color: "green" }], { duration: 1000, iterations: Infinity });
+
+function test() {
+    target.style.display = "none";
+    container.appendChild(target);
+}
+</script>

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -261,8 +261,10 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
     Styleable styleable { element, { } };
     auto resolvedStyle = styleForStyleable(styleable, resolutionType, resolutionContext);
 
-    if (!affectsRenderedSubtree(element, *resolvedStyle.style))
+    if (!affectsRenderedSubtree(element, *resolvedStyle.style)) {
+        styleable.setLastStyleChangeEventStyle(nullptr);
         return { };
+    }
 
     auto update = createAnimatedElementUpdate(WTFMove(resolvedStyle), styleable, parent().change, resolutionContext);
     auto descendantsToResolve = computeDescendantsToResolve(update, existingStyle, element.styleValidity());


### PR DESCRIPTION
#### d83537abc7e7901653c42553b3f7d71505f5dbc8
<pre>
REGRESSION (iOS 17.4, macOS 14.4, 270890@main): Animating element with display: none still remain visible
<a href="https://bugs.webkit.org/show_bug.cgi?id=270697">https://bugs.webkit.org/show_bug.cgi?id=270697</a>
<a href="https://rdar.apple.com/124289418">rdar://124289418</a>

Reviewed by Antoine Quint and Darin Adler.

The page sets the root of the overlay containing tree to display:none and immediately (before style recall) reinserts
it into another position in the document, causing render tree teardown. When we recompute the style (applying display:none)
we don&apos;t consider it a style change since there was no existing style due to the earlier teardown.
In this case we fail to clear lastStyleChangeEventStyle which has been set by an animation on the element.

Another animation triggered style recalc comes along, takes the optimized AnimationOnly code path and picks up
the lastStyleChangeEventStyle (which doesn&apos;t have display:none) bringing the element back alive.

* LayoutTests/fast/animation/animation-with-DOM-mutation-and-display-none-expected.html: Added.
* LayoutTests/fast/animation/animation-with-DOM-mutation-and-display-none.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):

Fix by clearing lastStyleChangeEventStyle also when we have a style change to display:none without existing renderer.

Canonical link: <a href="https://commits.webkit.org/276035@main">https://commits.webkit.org/276035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5914ae1fee3302c42d6154bdf837599f687dacde

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46216 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39704 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20031 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37522 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/16982 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17198 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38584 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1631 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47779 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15221 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42815 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41484 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9702 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20212 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->