### PR TITLE
[iOS] Entering fullscreen from iframe without explicit viewport results in badly cropped video

### DIFF
--- a/LayoutTests/fast/viewport/ios/full-screen-safe-area-insets-expected.txt
+++ b/LayoutTests/fast/viewport/ios/full-screen-safe-area-insets-expected.txt
@@ -40,6 +40,13 @@ EVENT(load)
 RUN(enterFullscreen())
 EXPECTED (visibleRect.left == '-100') OK
 EXPECTED (visibleRect.top == '-50') OK
+Test that fullscreen within an iframe without an explicit viewport setting has native viewport behavior:
+RUN(frame.src = "resources/no-viewport.html")
+EVENT(load)
+RUN(enterFullscreen())
+EXPECTED (visibleRect.left == '-100') OK
+EXPECTED (visibleRect.top == '-50') OK
+EXPECTED (visibleRect.width < '980') OK
 RUN(exitFullscreen())
 
 RUN(setSafeAreaInsets(0, 0))

--- a/LayoutTests/fast/viewport/ios/full-screen-safe-area-insets.html
+++ b/LayoutTests/fast/viewport/ios/full-screen-safe-area-insets.html
@@ -105,6 +105,13 @@
         await waitFor(frame, 'load');
         await run('enterFullscreen()');
         await testExpectedVisibleRect(-100, -50);
+
+        consoleWrite('Test that fullscreen within an iframe without an explicit viewport setting has native viewport behavior:')
+        run('frame.src = "resources/no-viewport.html"');
+        await waitFor(frame, 'load');
+        await run('enterFullscreen()');
+        await testExpectedVisibleRect(-100, -50);
+        testExpected('visibleRect.width', 980, '<');
         await run('exitFullscreen()');
         consoleWrite('')
 

--- a/LayoutTests/fast/viewport/ios/resources/no-viewport.html
+++ b/LayoutTests/fast/viewport/ios/resources/no-viewport.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<script>
+window.addEventListener('load', event => {
+    document.body.onclick = function() {
+        document.body.webkitRequestFullScreen();
+    };
+});
+</script>
+<body>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -329,6 +329,8 @@ void WebFullScreenManager::willEnterFullScreen(WebCore::HTMLMediaElementEnums::V
         return;
     }
 
+    m_page->isInFullscreenChanged(WebPage::IsInFullscreenMode::Yes);
+
 #if !PLATFORM(IOS_FAMILY)
     m_page->hidePageBanners();
 #endif
@@ -430,6 +432,8 @@ static Vector<Ref<Element>> collectFullscreenElementsFromElement(Element* elemen
 
 void WebFullScreenManager::didExitFullScreen()
 {
+    m_page->isInFullscreenChanged(WebPage::IsInFullscreenMode::No);
+
     if (!m_element)
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5143,6 +5143,18 @@ WebFullScreenManager* WebPage::fullScreenManager()
         m_fullScreenManager = WebFullScreenManager::create(*this);
     return m_fullScreenManager.get();
 }
+
+void WebPage::isInFullscreenChanged(IsInFullscreenMode isInFullscreenMode)
+{
+    if (m_isInFullscreenMode == isInFullscreenMode)
+        return;
+    m_isInFullscreenMode = isInFullscreenMode;
+
+#if ENABLE(META_VIEWPORT)
+    resetViewportDefaultConfiguration(m_mainFrame.ptr(), m_isMobileDoctype);
+#endif
+}
+
 #endif
 
 void WebPage::addConsoleMessage(FrameIdentifier frameID, MessageSource messageSource, MessageLevel messageLevel, const String& message, std::optional<WebCore::ResourceLoaderIdentifier> requestID)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -522,6 +522,9 @@ public:
 
 #if ENABLE(FULLSCREEN_API)
     WebFullScreenManager* fullScreenManager();
+
+    enum class IsInFullscreenMode : bool { No, Yes };
+    void isInFullscreenChanged(IsInFullscreenMode);
 #endif
 
     void addConsoleMessage(WebCore::FrameIdentifier, MessageSource, MessageLevel, const String&, std::optional<WebCore::ResourceLoaderIdentifier> = std::nullopt);
@@ -2371,6 +2374,7 @@ private:
 
 #if ENABLE(FULLSCREEN_API)
     RefPtr<WebFullScreenManager> m_fullScreenManager;
+    IsInFullscreenMode m_isInFullscreenMode { IsInFullscreenMode::No };
 #endif
 
     RefPtr<WebPopupMenu> m_activePopupMenu;
@@ -2573,6 +2577,8 @@ private:
     std::optional<std::pair<TransactionID, double>> m_lastLayerTreeTransactionIdAndPageScaleBeforeScalingPage;
     bool m_sendAutocorrectionContextAfterFocusingElement { false };
     std::unique_ptr<WebCore::IgnoreSelectionChangeForScope> m_ignoreSelectionChangeScopeForDictation;
+
+    bool m_isMobileDoctype { false };
 #endif // PLATFORM(IOS_FAMILY)
 
     WebCore::Timer m_layerVolatilityTimer;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -454,6 +454,7 @@ FloatSize WebPage::overrideScreenSize() const
 
 void WebPage::didReceiveMobileDocType(bool isMobileDoctype)
 {
+    m_isMobileDoctype = isMobileDoctype;
     resetViewportDefaultConfiguration(m_mainFrame.ptr(), isMobileDoctype);
 }
 
@@ -4101,6 +4102,10 @@ void WebPage::resetViewportDefaultConfiguration(WebFrame* frame, bool hasMobileD
     }
 
     auto parametersForStandardFrame = [&] {
+#if ENABLE(FULLSCREEN_API)
+        if (m_isInFullscreenMode == IsInFullscreenMode::Yes)
+            return m_viewportConfiguration.nativeWebpageParameters();
+#endif
         if (shouldIgnoreMetaViewport())
             return m_viewportConfiguration.nativeWebpageParameters();
         return ViewportConfiguration::webpageParameters();


### PR DESCRIPTION
#### 66ba699e69102c7efbd92303666a45a23ab74bb2
<pre>
[iOS] Entering fullscreen from iframe without explicit viewport results in badly cropped video
<a href="https://bugs.webkit.org/show_bug.cgi?id=270909">https://bugs.webkit.org/show_bug.cgi?id=270909</a>
<a href="https://rdar.apple.com/123725878">rdar://123725878</a>

Reviewed by Abrar Rahman Protyasha.

In 270199@main, support was added for using the viewport settings from the outermost fullscreen
document, rather than the top document. This allowed an &lt;iframe&gt; whose contents specified a
viewport-fit=cover behavior to work within a hosting document without that viewport setting.
However, for an &lt;iframe&gt; whose contents did not specify a viewport at all, it would receive
the default desktop viewport, which is 980px wide. This, combined with the iOS fullscreen
behavior of blocking zoom, meant that the fullscreen viewport would be much, much larger than
the physical viewport.

When entering or exiting fullscreen mode, notify the WebPage, and reset the default viewport
such that in fullscreen the web page will receive the &quot;native&quot; viewport rather than the &quot;desktop&quot;
one by default. This requires storing the results of didReceiveMobileDocType(), so that it
can be re-used after page load.

* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::willEnterFullScreen):
(WebKit::WebFullScreenManager::didExitFullScreen):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::isInFullscreenChanged):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::didReceiveMobileDocType):
(WebKit::WebPage::resetViewportDefaultConfiguration):

Canonical link: <a href="https://commits.webkit.org/276138@main">https://commits.webkit.org/276138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f7a0c50e654017b1ba5a4f203c490b931ab5caa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46457 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39908 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20268 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36168 "8 flakes 18 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37736 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17162 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38813 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1867 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39990 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48015 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18837 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42976 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20233 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41679 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9754 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20433 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19857 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->