### PR TITLE
Make WebAuthn interface easier to call from Swift

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.mm
@@ -37,9 +37,9 @@
     if (!(self = [super initWithClientDataJSON:clientDataJSON rawId:rawId extensions:WTFMove(extensions) attachment:attachment]))
         return nil;
 
-    _authenticatorData = authenticatorData;
-    _signature = signature;
-    _userHandle = userHandle;
+    _authenticatorData = [authenticatorData retain];
+    _signature = [signature retain];
+    _userHandle = [userHandle retain];
     return self;
 }
 
@@ -48,10 +48,18 @@
     if (!(self = [super initWithClientDataJSON:clientDataJSON rawId:rawId extensionOutputsCBOR:extensionOutputsCBOR attachment:attachment]))
         return nil;
 
-    _authenticatorData = authenticatorData;
-    _signature = signature;
-    _userHandle = userHandle;
+    _authenticatorData = [authenticatorData retain];
+    _signature = [signature retain];
+    _userHandle = [userHandle retain];
     return self;
+}
+
+- (void)dealloc
+{
+    [_authenticatorData release];
+    [_signature release];
+    [_userHandle release];
+    [super dealloc];
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h
@@ -160,12 +160,12 @@ WK_CLASS_AVAILABLE(macos(10.15.4), ios(13.4))
 - (instancetype)init;
 
 // FIXME: <rdar://problem/71509485> Adds detailed NSError.
-- (void)makeCredentialWithChallenge:(NSData *)challenge origin:(NSString *)origin options:(_WKPublicKeyCredentialCreationOptions *)options completionHandler:(void (^)(_WKAuthenticatorAttestationResponse *, NSError *))handler WK_API_AVAILABLE(macos(12.0), ios(15.0));
-- (void)makeCredentialWithClientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialCreationOptions *)options completionHandler:(void (^)(_WKAuthenticatorAttestationResponse *, NSError *))handler WK_API_AVAILABLE(macos(13.0), ios(16.0));
-- (void)makeCredentialWithMediationRequirement:(_WKWebAuthenticationMediationRequirement)mediation clientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialCreationOptions *)options completionHandler:(void (^)(_WKAuthenticatorAttestationResponse *, NSError *))handler WK_API_AVAILABLE(macos(13.0), ios(16.0));
-- (void)getAssertionWithChallenge:(NSData *)challenge origin:(NSString *)origin options:(_WKPublicKeyCredentialRequestOptions *)options completionHandler:(void (^)(_WKAuthenticatorAssertionResponse *, NSError *))handler WK_API_AVAILABLE(macos(12.0), ios(15.0));
-- (void)getAssertionWithClientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialRequestOptions *)options completionHandler:(void (^)(_WKAuthenticatorAssertionResponse *, NSError *))handler WK_API_AVAILABLE(macos(13.0), ios(16.0));
-- (void)getAssertionWithMediationRequirement:(_WKWebAuthenticationMediationRequirement)mediation clientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialRequestOptions *)options completionHandler:(void (^)(_WKAuthenticatorAssertionResponse *, NSError *))handler WK_API_AVAILABLE(macos(13.0), ios(16.0));
+- (void)makeCredentialWithChallenge:(NSData *)challenge origin:(NSString *)origin options:(_WKPublicKeyCredentialCreationOptions *)options completionHandler:(void (^)(_WKAuthenticatorAttestationResponse * _Nullable, NSError * _Nullable))handler WK_API_AVAILABLE(macos(12.0), ios(15.0));
+- (void)makeCredentialWithClientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialCreationOptions *)options completionHandler:(void (^)(_WKAuthenticatorAttestationResponse * _Nullable, NSError * _Nullable))handler WK_API_AVAILABLE(macos(13.0), ios(16.0));
+- (void)makeCredentialWithMediationRequirement:(_WKWebAuthenticationMediationRequirement)mediation clientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialCreationOptions *)options completionHandler:(void (^)(_WKAuthenticatorAttestationResponse *  _Nullable, NSError *  _Nullable))handler WK_API_AVAILABLE(macos(13.0), ios(16.0));
+- (void)getAssertionWithChallenge:(NSData *)challenge origin:(NSString *)origin options:(_WKPublicKeyCredentialRequestOptions *)options completionHandler:(void (^)(_WKAuthenticatorAssertionResponse * _Nullable, NSError * _Nullable))handler WK_API_AVAILABLE(macos(12.0), ios(15.0));
+- (void)getAssertionWithClientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialRequestOptions *)options completionHandler:(void (^)(_WKAuthenticatorAssertionResponse * _Nullable, NSError * _Nullable))handler WK_API_AVAILABLE(macos(13.0), ios(16.0));
+- (void)getAssertionWithMediationRequirement:(_WKWebAuthenticationMediationRequirement)mediation clientDataHash:(NSData *)clientDataHash options:(_WKPublicKeyCredentialRequestOptions *)options completionHandler:(void (^)(_WKAuthenticatorAssertionResponse * _Nullable, NSError * _Nullable))handler WK_API_AVAILABLE(macos(13.0), ios(16.0));
 - (void)cancel;
 
 // FIXME: <rdar://problem/71509848> Deprecate the following properties.


### PR DESCRIPTION
#### 6f20a053abaf3366ff82a0fff43fb4d61e24cc46
<pre>
Make WebAuthn interface easier to call from Swift
<a href="https://rdar.apple.com/124490616">rdar://124490616</a>

Reviewed by Brent Fulgham.

This patch updates a few bits from the WebAuthn interface to make them easier to call from
Swift.

* Source/WebKit/UIProcess/API/Cocoa/_WKAuthenticatorAssertionResponse.mm:
(-[_WKAuthenticatorAssertionResponse initWithClientDataJSON:rawId:extensions:authenticatorData:signature:userHandle:attachment:]):
(-[_WKAuthenticatorAssertionResponse initWithClientDataJSON:rawId:extensionOutputsCBOR:authenticatorData:signature:userHandle:attachment:]):
(-[_WKAuthenticatorAssertionResponse dealloc]):
None of the ivars in this class were being retained/released. This hasn&apos;t been an issue
for ObjC because they&apos;re all retained by the callsite, but it matters for Swift due to the
bridging between Data and NSData. The superclass already retains/releases its ivars
correctly.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.h:
All of the results in these completion handlers are nullable (e.g. we never expect to
return an assertion _and_ an error). ObjC doesn&apos;t care if they&apos;re annotated incorrectly,
but Swift does.

Canonical link: <a href="https://commits.webkit.org/276180@main">https://commits.webkit.org/276180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c7c9187f7ca36ab2870f77ffb3c01060a7450fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46254 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39741 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36041 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17011 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17227 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1669 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39773 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47802 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18652 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15253 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42831 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; Exiting early after 500 failures. 39391 tests run. 500 failures; Uploaded test results; 87 flakes 368 failures; Running compile-webkit-without-change") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20070 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41502 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9781 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20250 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->