### PR TITLE
REGRESSION (274873@main): Audio is not anchored to WKWebView's spatial location

### DIFF
--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -341,6 +341,9 @@ inline void swap(String& a, String& b) { a.swap(b); }
 // Used in a small number of places where the long standing behavior has been "nil if empty".
 NSString * nsStringNilIfEmpty(const String&);
 
+// Used in a small number of places where null strings should be converted to nil but empty strings should be maintained.
+NSString * nsStringNilIfNull(const String&);
+
 #endif
 
 WTF_EXPORT_PRIVATE int codePointCompare(const String&, const String&);
@@ -513,6 +516,13 @@ inline String::operator NSString *() const
 inline NSString * nsStringNilIfEmpty(const String& string)
 {
     if (string.isEmpty())
+        return nil;
+    return *string.impl();
+}
+
+inline NSString * nsStringNilIfNull(const String& string)
+{
+    if (string.isNull())
         return nil;
     return *string.impl();
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1154,7 +1154,7 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayer()
     }
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
-    [m_avPlayer _setSTSLabel:m_spatialTrackingLabel];
+    [m_avPlayer _setSTSLabel:nsStringNilIfNull(m_spatialTrackingLabel)];
 #endif
 
     if (m_avPlayerItem)
@@ -4011,9 +4011,9 @@ void MediaPlayerPrivateAVFoundationObjC::setSpatialTrackingLabel(String&& spatia
 {
     if (m_spatialTrackingLabel == spatialTrackingLabel)
         return;
-    m_spatialTrackingLabel = spatialTrackingLabel;
+    m_spatialTrackingLabel = WTFMove(spatialTrackingLabel);
     if (m_avPlayer)
-        [m_avPlayer _setSTSLabel:spatialTrackingLabel];
+        [m_avPlayer _setSTSLabel:nsStringNilIfNull(m_spatialTrackingLabel)];
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1677,7 +1677,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel()
     if (!m_visible)
         [m_sampleBufferDisplayLayer sampleBufferRenderer].STSLabel = session.spatialTrackingLabel;
     else
-        [m_sampleBufferDisplayLayer sampleBufferRenderer].STSLabel = m_spatialTrackingLabel;
+        [m_sampleBufferDisplayLayer sampleBufferRenderer].STSLabel = nsStringNilIfNull(m_spatialTrackingLabel);
 }
 #endif
 


### PR DESCRIPTION
#### 81afed49cdfeb190a1004c3665002e81d129b6da
<pre>
REGRESSION (274873@main): Audio is not anchored to WKWebView&apos;s spatial location
<a href="https://bugs.webkit.org/show_bug.cgi?id=270919">https://bugs.webkit.org/show_bug.cgi?id=270919</a>
<a href="https://rdar.apple.com/123800596">rdar://123800596</a>

Reviewed by Jer Noble.

In 274873@main we added the infrastructure for passing a spatial tracking label from the UI process
to the GPU process. Because a null WTF::String is implicitly converted to @&quot;&quot;, this change had the
unintended side effect of setting AVSampleBufferVidoRenderer and AVPlayer&apos;s spatial tracking label
to the empty string rather than the default value of nil, breaking spatial tracking for the audio
emitted from WKWebView.

Resolved this by introducing nsStringNilIfNull -- returning nil if the WTF::String is null otherwise
converting it as-is to NSString -- and using it to set spatial tracking labels in MediaPlayerPrivate.

* Source/WTF/wtf/text/WTFString.h:
(WTF::nsStringNilIfNull):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setSpatialTrackingLabel):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel):

Canonical link: <a href="https://commits.webkit.org/276074@main">https://commits.webkit.org/276074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a48106cda6fe76cab428713d7c0fa77fa2bd5410

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46260 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36049 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17021 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17284 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38628 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1675 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37082 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39831 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47808 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43252 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15262 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42834 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Exiting early after 500 failures. 63689 tests run. 499 failures 1 missing results; Uploaded test results; 56 flakes 400 failures 1 missing results; Running compile-webkit-without-change") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20076 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41505 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9716 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20256 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50251 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19707 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10127 "Passed tests") | 
<!--EWS-Status-Bubble-End-->