### PR TITLE
Null check video element in imageBytesForSource

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2074,6 +2074,7 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Debug ] fast/workers/worker-cloneport.html [ Slow ]
 [ Debug ] fast/webgpu/present-without-compute-pipeline.html [ Slow ]
 [ Debug ] fast/webgpu/multidimensional-texture-bounds.html [ Slow ]
+[ Debug ] fast/webgpu/null-video-texture.html [ Skip ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/null-video-texture-expected.txt
+++ b/LayoutTests/fast/webgpu/null-video-texture-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/null-video-texture.html
+++ b/LayoutTests/fast/webgpu/null-video-texture.html
@@ -1,0 +1,75 @@
+<script>
+if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+onload = async () => {
+  try {
+    let adapter1 = await navigator.gpu.requestAdapter(
+    {
+    }
+    );
+
+    let device1 = await adapter1.requestDevice(
+    {
+    label: '\u026b',
+    requiredLimits: {
+    maxColorAttachmentBytesPerSample: 39,
+    maxVertexAttributes: 30,
+    maxVertexBufferArrayStride: 52234,
+    maxStorageTexturesPerShaderStage: 5,
+    maxBindingsPerBindGroup: 2969,
+    maxTextureArrayLayers: 896,
+    maxTextureDimension1D: 12165,
+    maxTextureDimension2D: 10419,
+    maxVertexBuffers: 12,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 64,
+    },
+    }
+    );
+
+    let texture9 = device1.createTexture(
+    {
+    label: '\u8d2c',
+    size: {width: 3482, height: 1, depthOrArrayLayers: 165},
+    mipLevelCount: 10,
+    dimension: '2d',
+    format: 'bgra8unorm',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_DST,
+    viewFormats: [
+    'bgra8unorm',
+    'bgra8unorm',
+    'bgra8unorm',
+    'bgra8unorm',
+    'bgra8unorm',
+    'bgra8unorm',
+    'bgra8unorm',
+    'bgra8unorm-srgb',
+    'bgra8unorm-srgb',
+    'bgra8unorm'
+    ],
+    }
+    );
+    
+    let video0 = document.createElement('video');
+    video0.height = 278;
+
+    device1.queue.copyExternalImageToTexture(
+    {
+      source: video0,
+      origin: { x: 3, y: 6 },
+      flipY: true,
+    },
+    {
+      texture: texture9,
+      mipLevel: 3,
+      origin: { x: 404, y: 0, z: 6 },
+      aspect: 'all',
+      colorSpace: 'srgb',
+      premultipliedAlpha: false,
+    },
+    {width: 10, height: 0, depthOrArrayLayers: 1}
+    );
+  } catch { }
+  if (window.testRunner) { testRunner.notifyDone() }
+};
+</script>
+This test passes if it does not crash.


### PR DESCRIPTION
#### 7debec9d62d0792976658aede004da32cefc88b0
<pre>
Null check video element in imageBytesForSource
<a href="https://bugs.webkit.org/show_bug.cgi?id=270922">https://bugs.webkit.org/show_bug.cgi?id=270922</a>
<a href="https://rdar.apple.com/124475221">rdar://124475221</a>

Reviewed by Mike Wyrzykowski.

Also add a release assertion to verify that the callback is called synchronously
so that the captured references are still in scope.

* LayoutTests/fast/webgpu/null-video-texture-expected.txt: Added.
* LayoutTests/fast/webgpu/null-video-texture.html: Added.
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::imageBytesForSource):
(WebCore::GPUQueue::copyExternalImageToTexture):

Canonical link: <a href="https://commits.webkit.org/276047@main">https://commits.webkit.org/276047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/142a272e599aa77e9b921ca15f24f270b74e68ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22692 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46082 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46286 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/39773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20100 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19705 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1701 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/38958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47836 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18684 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/46082 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5946 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->