### PR TITLE
[iOS] Top safe area is too large after rotating fullscreen to landscape mode

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -404,6 +404,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #endif // PLATFORM(VISION)
 
++ (NSSet<NSString *> *)keyPathsForValuesAffectingAdditionalSafeAreaInsets
+{
+    return [NSSet setWithObjects:@"prefersStatusBarHidden", @"view.window.windowScene.statusBarManager.statusBarHidden", @"view.window.safeAreaInsets", nil];
+}
+
 - (UIEdgeInsets)additionalSafeAreaInsets
 {
     // When the status bar hides, the resulting changes to safeAreaInsets cause
@@ -411,6 +416,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     // Do not add additional insets if the status bar is not hidden.
     if (!self.view.window.windowScene.statusBarManager.statusBarHidden)
+        return UIEdgeInsetsZero;
+
+    // If the status bar is hidden while would would prefer it not be,
+    // we should not reserve space as it likely won't re-appear.
+    if (!self.prefersStatusBarHidden)
         return UIEdgeInsetsZero;
 
     // Additionally, hiding the status bar does not reduce safeAreaInsets when


### PR DESCRIPTION
#### 5b49cc72181585bf45892391d2d33fd9cf65d4bf
<pre>
[iOS] Top safe area is too large after rotating fullscreen to landscape mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=270923">https://bugs.webkit.org/show_bug.cgi?id=270923</a>
<a href="https://rdar.apple.com/124288251">rdar://124288251</a>

Reviewed by Aditya Keerthi.

On iPhone, the status bar is hidden in a fullscreen presentation when the device orientation is
landscape. This causes us to skip updating the `_nonZeroStatusBarHeight` in
WKFullScreenViewController, and reserve the space previously held by the status bar and possibly
the camera notch safe area.

When in fullscreen, if the status bar is hidden and we didn&apos;t specifically ask it to hide,
don&apos;t try to reserve space for it, as it likely won&apos;t re-appear.

In order to ensure that the calculated property `-additionalSafeAreaInsets` is re-queried correctly,
mark it as depending on `-prefersStatusBarHidden`, the window&apos;s `-safeAreaInsets`, and on the
status bar manager&apos;s `-statusBarHidden` property.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(+[WKFullScreenViewController keyPathsForValuesAffectingAdditionalSafeAreaInsets]):
(-[WKFullScreenViewController additionalSafeAreaInsets]):

Canonical link: <a href="https://commits.webkit.org/276116@main">https://commits.webkit.org/276116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/910c743f5457bd6002681d03834378cc1109f330

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43625 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46267 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39754 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running compile-webkit") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26490 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36046 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19709 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17018 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17258 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1682 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39803 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47815 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18665 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15266 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42836 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Exiting early after 500 failures. 59281 tests run. 1 flakes 499 failures 1 missing results; Uploaded test results; 65 flakes 376 failures 1 missing results; Compiled WebKit; 376 failures 1 missing results") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20083 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41507 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9739 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20263 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19714 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Running compile-webkit") | | | 
<!--EWS-Status-Bubble-End-->