### PR TITLE
[iOS 17.4] ~11 layout tests debug assert in `-handleKeyEntry:withCompletionHandler:`

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -276,6 +276,11 @@ struct WKAutoCorrectionData {
     CGRect textLastRect;
 };
 
+struct KeyEventAndCompletionBlock {
+    RetainPtr<::WebEvent> event;
+    BlockPtr<void(::WebEvent *, BOOL)> completionBlock;
+};
+
 enum class RequestAutocorrectionContextResult : bool { Empty, LastContext };
 
 struct RemoveBackgroundData {
@@ -448,7 +453,8 @@ struct ImageAnalysisContextMenuActionData {
     std::optional<WebCore::TextIndicatorData> _positionInformationLinkIndicator;
     WebKit::FocusedElementInformation _focusedElementInformation;
     RetainPtr<NSObject<WKFormPeripheral>> _inputPeripheral;
-    BlockPtr<void(::WebEvent *, BOOL)> _keyWebEventHandler;
+
+    Vector<WebKit::KeyEventAndCompletionBlock, 1> _keyWebEventHandlers;
 
     CGPoint _lastInteractionLocation;
     WebKit::TransactionID _layerTreeTransactionIdAtLastInteractionStart;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1597,7 +1597,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     [self _resetPanningPreventionFlags];
     [self _handleDOMPasteRequestWithResult:WebCore::DOMPasteAccessResponse::DeniedForGesture];
-    [self _cancelPendingKeyEventHandler];
+    [self _cancelPendingKeyEventHandlers:NO];
 
 #if HAVE(UI_PASTE_CONFIGURATION)
     self.pasteConfiguration = nil;
@@ -1612,17 +1612,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _removeContainerForContextMenuHintPreviews];
 }
 
-- (void)_cancelPendingKeyEventHandler
+- (void)_cancelPendingKeyEventHandlers:(BOOL)handled
 {
-    if (!_page)
-        return;
-
-    ASSERT_IMPLIES(_keyWebEventHandler, _page->hasQueuedKeyEvent());
-    if (!_page->hasQueuedKeyEvent())
-        return;
-
-    if (auto keyEventHandler = std::exchange(_keyWebEventHandler, nil))
-        keyEventHandler(_page->firstQueuedKeyEvent().nativeEvent(), NO);
+    for (auto [event, keyEventHandler] : std::exchange(_keyWebEventHandlers, { }))
+        keyEventHandler(event.get(), handled);
 }
 
 - (void)_removeDefaultGestureRecognizers
@@ -2004,23 +1997,12 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
         _isHandlingActiveKeyEvent = NO;
         _isHandlingActivePressesEvent = NO;
 
-        if (_keyWebEventHandler) {
-            RunLoop::main().dispatch([weakHandler = WeakObjCPtr<id>(_keyWebEventHandler.get()), weakSelf = WeakObjCPtr<WKContentView>(self)] {
-                auto strongSelf = weakSelf.get();
+        if (!_keyWebEventHandlers.isEmpty()) {
+            RunLoop::main().dispatch([weakSelf = WeakObjCPtr<WKContentView>(self)] {
+                RetainPtr strongSelf = weakSelf.get();
                 if (!strongSelf || [strongSelf isFirstResponder])
                     return;
-                auto strongHandler = weakHandler.get();
-                if (!strongHandler)
-                    return;
-                if (strongSelf->_keyWebEventHandler.get() != strongHandler.get())
-                    return;
-                auto keyEventHandler = std::exchange(strongSelf->_keyWebEventHandler, nil);
-                auto page = strongSelf->_page;
-                if (!page)
-                    return;
-                if (!page->hasQueuedKeyEvent())
-                    return;
-                keyEventHandler(page->firstQueuedKeyEvent().nativeEvent(), YES);
+                [strongSelf _cancelPendingKeyEventHandlers:YES];
             });
         }
     }
@@ -7231,7 +7213,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
     }
 
     if (_page->handleKeyboardEvent(WebKit::NativeWebKeyboardEvent(event, HandledByInputMethod::No)))
-        _keyWebEventHandler = makeBlockPtr(completionHandler);
+        _keyWebEventHandlers.append({ event, makeBlockPtr(completionHandler) });
     else
         completionHandler(event, NO);
 }
@@ -7247,10 +7229,12 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
     if (event.type == WebEventKeyUp)
         _isHandlingActiveKeyEvent = NO;
 
-    if (auto handler = WTFMove(_keyWebEventHandler)) {
-        handler(event, eventWasHandled);
-        return;
-    }
+    _keyWebEventHandlers.removeFirstMatching([&](auto& entry) {
+        if (entry.event != event)
+            return false;
+        entry.completionBlock(event, eventWasHandled);
+        return true;
+    });
 }
 
 - (BOOL)_interpretKeyEvent:(::WebEvent *)event isCharEvent:(BOOL)isCharEvent


### PR DESCRIPTION
#### a477452eb93ff56f535304cccb7b0acb9cad0698
<pre>
[iOS 17.4] ~11 layout tests debug assert in `-handleKeyEntry:withCompletionHandler:`
<a href="https://bugs.webkit.org/show_bug.cgi?id=270928">https://bugs.webkit.org/show_bug.cgi?id=270928</a>
<a href="https://rdar.apple.com/123028621">rdar://123028621</a>

Reviewed by Abrar Rahman Protyasha.

The new debug assertion in `-handleKeyEntry:withCompletionHandler:` (which sanity checks that the
key event completion handler for an incoming event `e` is invoked with `e`) is sometimes hit when
running layout tests that send synthetic key events. This reveals an existing bug, wherein
`WKContentView`&apos;s `_keyWebEventHandler` is replaced with another incoming ObjC block in the case
when async key events are invoked back-to-back, before the preceding key event&apos;s completion handler
has been called. This causes the latter key event handler to be called with the previous key event,
and also means that the previous key event handler won&apos;t ever be called.

In practice, this is not an issue because UIKit&apos;s `UIKeyboardTaskQueue` doesn&apos;t attempt to send the
next key event until the previous one has finished processing (i.e., WebKit has called the
completion block associated with the event); this is likely an artifact of how HID key events are
synthesized and dispatched in WebKitTestRunner.

However, the `BETextInput` protocol doesn&apos;t inherently require or enforce this invariant, so it
probably makes more sense for `WKContentView` to be robust for this scenario and call all incoming
key event handler completion blocks with their corresponding appropriate events. To ensure this, we
replace the current `_keyWebEventHandler` instance variable with a vector of events and completion
blocks. This allows us to store multiple completion blocks if needed (for each key event that&apos;s
currently in-flight), and invoke the correct event handler in response.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:

Replace `_keyWebEventHandler` with `_keyWebEventHandlers`, a `Vector` of `WebEvent`s and completion
handler blocks. See above for more details.

(-[WKContentView cleanUpInteraction]):
(-[WKContentView _cancelPendingKeyEventHandlers:]):
(-[WKContentView resignFirstResponderForWebView]):
(-[WKContentView _internalHandleKeyWebEvent:withCompletionHandler:]):
(-[WKContentView _didHandleKeyEvent:eventWasHandled:]):
(-[WKContentView _cancelPendingKeyEventHandler]): Deleted.

Canonical link: <a href="https://commits.webkit.org/276062@main">https://commits.webkit.org/276062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7abc1001944c0cab8b0c08798f4195e276af56cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46299 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39782 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/26568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20112 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44230 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17044 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17264 "layout-tests (failure)") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1713 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39810 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47849 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18695 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15289 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42860 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20113 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41535 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9714 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->