### PR TITLE
CommandEncoder::clearTexture should only allocate once to make temporaryBuffer

### DIFF
--- a/LayoutTests/fast/webgpu/copy-texture-more-than-4gb-expected.txt
+++ b/LayoutTests/fast/webgpu/copy-texture-more-than-4gb-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/copy-texture-more-than-4gb.html
+++ b/LayoutTests/fast/webgpu/copy-texture-more-than-4gb.html
@@ -1,0 +1,69 @@
+<script>
+if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+onload = async () => {
+    try {
+        let adapter0 = await navigator.gpu.requestAdapter();
+        let device0 = await adapter0.requestDevice(
+        {
+        label: '\u0a1d',
+        requiredFeatures: [
+        'depth-clip-control',
+        'depth32float-stencil8',
+        'texture-compression-etc2',
+        'texture-compression-astc',
+        'indirect-first-instance',
+        'shader-f16',
+        'rg11b10ufloat-renderable',
+        'bgra8unorm-storage'
+        ],
+        }
+        );
+
+        let imageData1 = new ImageData(104, 188);
+        let texture17 = device0.createTexture(
+        {
+        label: '\u2801',
+        size: {
+        width: 1177,
+        height: 963,
+        depthOrArrayLayers: 319,
+        },
+        mipLevelCount: 1,
+        sampleCount: 1,
+        dimension: '3d',
+        format: 'bgra8unorm-srgb',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+        viewFormats: [
+        'bgra8unorm',
+        'bgra8unorm-srgb',
+        'bgra8unorm-srgb',
+        'bgra8unorm-srgb',
+        'bgra8unorm',
+        'bgra8unorm-srgb',
+        'bgra8unorm',
+        'bgra8unorm',
+        'bgra8unorm-srgb'
+        ],
+        }
+        );
+        device0.queue.copyExternalImageToTexture(
+        {
+          source: imageData1,
+          origin: { x: 45, y: 127 },
+          flipY: true,
+        },
+        {
+          texture: texture17,
+          mipLevel: 0,
+          origin: { x: 261, y: 0, z: 114 },
+          aspect: 'all',
+          colorSpace: 'srgb',
+          premultipliedAlpha: true,
+        },
+        {width: 56, height: 1, depthOrArrayLayers: 0}
+        );
+    } catch {}
+    if (window.testRunner) { testRunner.notifyDone() }
+};
+</script>
+This test passes if it does not crash.

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -1120,8 +1120,11 @@ void CommandEncoder::clearTexture(const WGPUImageCopyTexture& destination, NSUIn
     auto depth = texture.dimension() == WGPUTextureDimension_3D ? logicalSize.depthOrArrayLayers : 1;
     NSUInteger sourceBytesPerRow = 16 * logicalSize.width;
     NSUInteger sourceBytesPerImage = sourceBytesPerRow * logicalSize.height;
-    Vector<uint8_t> zeroData(sourceBytesPerImage * depth, 0);
-    id<MTLBuffer> temporaryBuffer = [device newBufferWithBytes:zeroData.data() length:zeroData.size() options:MTLResourceStorageModeShared];
+    NSUInteger bufferLength = sourceBytesPerImage * depth;
+    id<MTLBuffer> temporaryBuffer = [device newBufferWithLength:bufferLength options:MTLResourceStorageModeShared];
+    if (!temporaryBuffer)
+        return;
+
     MTLSize sourceSize;
     switch (texture.dimension()) {
     case WGPUTextureDimension_1D:


### PR DESCRIPTION
#### 8e39803a4c17f35737254dbc26993ab097ef187f
<pre>
CommandEncoder::clearTexture should only allocate once to make temporaryBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=270938">https://bugs.webkit.org/show_bug.cgi?id=270938</a>
<a href="https://rdar.apple.com/124475200">rdar://124475200</a>

Reviewed by Mike Wyrzykowski.

Instead of allocating a Vector then allocating a buffer from it with newBufferWithBytes,
just use newBufferWithLength.  This also fixes crashes
where the buffer length is more than 4GB, which Vector can&apos;t allocate.

* LayoutTests/fast/webgpu/copy-texture-more-than-4gb-expected.txt: Added.
* LayoutTests/fast/webgpu/copy-texture-more-than-4gb.html: Added.
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::clearTexture):

Canonical link: <a href="https://commits.webkit.org/276058@main">https://commits.webkit.org/276058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c53ad672a05f7e8d3d00df7a45ba763f94df4684

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46300 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39783 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20113 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44231 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19725 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17046 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17273 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1714 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39819 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47850 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18696 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42859 "Passed tests") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41538 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20295 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5957 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->