### PR TITLE
"NULL Object : Crash under WebCore::RenderObject::~RenderObject; WebCore::RenderText::~RenderText; WebCore::RenderTreeBuilder::destroy"

### DIFF
--- a/LayoutTests/dom/html/document-renderobject-null-crash-expected.txt
+++ b/LayoutTests/dom/html/document-renderobject-null-crash-expected.txt
@@ -1,0 +1,2 @@
+style,#x4 { } code:last-child,style { no-repeat;quotes: 'a' 'd';-webkit-box-shadow: } *:dir(ltr) { 100%;display: contents;order: } function gc() { { } } function main() { try { v20 } catch { } try { x35.rel = "stylesheet"; } catch { } try { } catch { } try { document.dir = "auto"; } catch { } try { v14 = document.caretRangeFromPoint(15,9); } catch { } } if (window.testRunner) { testRunner.dumpAsText(); } This test passes if it doesn't crash.
+

--- a/LayoutTests/dom/html/document-renderobject-null-crash.html
+++ b/LayoutTests/dom/html/document-renderobject-null-crash.html
@@ -1,0 +1,34 @@
+<style>
+style,#x4 { }
+code:last-child,style { no-repeat;quotes: 'a' 'd';-webkit-box-shadow: }
+*:dir(ltr) { 100%;display: contents;order: }
+</style>
+<script>
+function gc() {
+ {
+ }
+}
+function main() {
+try { v20 } catch { }
+try { x35.rel = "stylesheet"; } catch { }
+try { } catch { }
+try { document.dir = "auto"; } catch { }
+try { v14 = document.caretRangeFromPoint(15,9); } catch { }
+}
+</script>
+<head>
+<div onload="main()">
+<link id="x35" href="x" importance="high">
+</table>
+</dialog>
+<input disabled="">
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+}
+</script>
+</head>
+<body>
+<div></div>
+<p>This test passes if it doesn't crash.</p>
+</body>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2068,6 +2068,8 @@ std::optional<BoundaryPoint> Document::caretPositionFromPoint(const LayoutPoint&
     if (!node)
         return std::nullopt;
 
+    updateLayoutIgnorePendingStylesheets();
+
     CheckedPtr renderer = node->renderer();
     if (!renderer)
         return std::nullopt;


### PR DESCRIPTION
#### 0be766940c18b3f779d8cac89d2e9696720e1b91
<pre>
&quot;NULL Object : Crash under WebCore::RenderObject::~RenderObject; WebCore::RenderText::~RenderText; WebCore::RenderTreeBuilder::destroy&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=267297">https://bugs.webkit.org/show_bug.cgi?id=267297</a>
<a href="https://rdar.apple.com/119186861">rdar://119186861</a>.

Reviewed by Alan Baradlay.

Document::caretPositionFromPoint API is using CheckPtr to get RenderObject
even though the Object is already destroyed. In order to make sure CheckedPtr
is valid the render needs to be destroyed earlier not after. Using updateLayoutIgnorePendingStylesheets API for uptodate renderer tree.

* LayoutTests/dom/html/document-renderobject-null-crash-expected.txt: Added test expected file.
* LayoutTests/dom/html/document-renderobject-null-crash.html: Added test case.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::caretPositionFromPoint): Added updateLayoutIgnorePendingStylesheets to get updated renderer tree before using CheckedPtr.

Originally-landed-as: 272448.251@safari-7618-branch (9baf7178103b). <a href="https://rdar.apple.com/124556134">rdar://124556134</a>
Canonical link: <a href="https://commits.webkit.org/276275@main">https://commits.webkit.org/276275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/701cf5873819a3c071d5474882e6328bbee8e9f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46864 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40073 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20475 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36437 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38092 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17472 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39199 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2070 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48241 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43149 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41872 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9829 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->