### PR TITLE
Should crash when deserializing JSArray object containing named property length

### DIFF
--- a/JSTests/stress/regress-120777816.js
+++ b/JSTests/stress/regress-120777816.js
@@ -1,0 +1,96 @@
+function assert(x) {
+    if (!x)
+        throw new Error("Bad assertion!");
+}
+
+(function() {
+    function tryToLeakThisViaGetById() {
+        class Leaker {
+            leak() {
+                return super.foo;
+            }
+        }
+
+        Leaker.prototype.__proto__ = new Proxy({}, {
+            get(target, propertyName, receiver) {
+                return receiver;
+            }
+        });
+
+        const foo = 42;
+        const {leak} = Leaker.prototype;
+
+        return (() => leak())();
+    }
+
+    function tryToLeakThisViaGetByVal() {
+        class Leaker {
+            leak() {
+                return super[Math.random() < 0.5 ? "foo" : "bar"];
+            }
+        }
+
+        Leaker.prototype.__proto__ = new Proxy({}, {
+            get(target, propertyName, receiver) {
+                return receiver;
+            }
+        });
+
+        const foo = 42;
+        const bar = 84;
+        const {leak} = Leaker.prototype;
+
+        return (() => leak())();
+    }
+
+    function tryToLeakThisViaSetById() {
+        let receiver;
+        class Leaker {
+            leak() {
+                super.foo = {};
+                return receiver;
+            }
+        }
+        Leaker.prototype.__proto__ = new Proxy({}, {
+            set(target, propertyName, value, __receiver) {
+                receiver = __receiver;
+                return true;
+            }
+        });
+
+        const foo = 42;
+        const {leak} = Leaker.prototype;
+
+        return (() => leak())();
+    }
+
+    function tryToLeakThisViaSetByVal() {
+        let receiver;
+        class Leaker {
+            leak() {
+                super[Math.random() < 0.5 ? "foo" : "bar"] = {};
+                return receiver;
+            }
+        }
+
+        Leaker.prototype.__proto__ = new Proxy({}, {
+            set(target, propertyName, value, __receiver) {
+                receiver = __receiver;
+                return true;
+            }
+        });
+
+        const foo = 42;
+        const bar = 84;
+        const {leak} = Leaker.prototype;
+
+        return (() => leak())();
+    }
+
+    for (var i = 0; i < 1e5; i++) {
+        assert(tryToLeakThisViaGetById() === undefined);
+        assert(tryToLeakThisViaGetByVal() === undefined);
+        assert(tryToLeakThisViaSetById() === undefined);
+        assert(tryToLeakThisViaSetByVal() === undefined);
+    }
+})();

--- a/LayoutTests/fast/inline/dynamic-inline-content-with-out-of-flow-child-expected.txt
+++ b/LayoutTests/fast/inline/dynamic-inline-content-with-out-of-flow-child-expected.txt
@@ -1,0 +1,2 @@
+
+PASS if no crash or assert

--- a/LayoutTests/fast/inline/dynamic-inline-content-with-out-of-flow-child.html
+++ b/LayoutTests/fast/inline/dynamic-inline-content-with-out-of-flow-child.html
@@ -1,0 +1,19 @@
+<style>
+img {
+  position: absolute;
+}
+</style>
+<div><img id=img></div>
+<div id=move_here>remove</div>
+<div id=result></div>
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+document.execCommand("selectAll", false);
+let selection = document.getSelection();
+move_here.appendChild(img);
+document.body.offsetHeight;
+selection.deleteFromDocument();
+document.body.offsetHeight;
+result.innerText = "PASS if no crash or assert";
+</script>

--- a/LayoutTests/fast/multicol/pagination/pagination-diry-sections-crash-expected.txt
+++ b/LayoutTests/fast/multicol/pagination/pagination-diry-sections-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no assert in Debug.

--- a/LayoutTests/fast/multicol/pagination/pagination-diry-sections-crash.html
+++ b/LayoutTests/fast/multicol/pagination/pagination-diry-sections-crash.html
@@ -1,0 +1,54 @@
+<head style="display:none">
+    <style>
+        i,
+        :invalid {
+            position: absolute;
+        }
+    
+        *:empty {
+            -webkit-column-rule-width: medium;
+        }
+    
+        *:scope,
+        ruby {
+            overflow-y: -webkit-paged-y;
+            column-rule-width: 81em;
+            position: static;
+        }
+    
+        :read-only {
+            display: table-row-group;
+            perspective: 0px;
+        }
+    </style>
+</head>
+
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+        
+    function main() {
+        try { 
+            var attrs = document.getElementsByTagName("select"); 
+            var v118 = attrs.item(42 % attrs.length); 
+            x2.after(v118); 
+        } catch { }
+    }
+</script>
+
+<body onload="main()">
+    PASS if no assert in Debug.
+    <ol>
+    </ol>
+    <menu>
+        <menu>
+        </menu>
+        <object>
+        </object>
+    </menu>
+    <cite id="x2">
+        <i lang="jw">
+            <select></select>
+        </i>
+    </cite>
+</body>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/multipart-three-part-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/multipart-three-part-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: Blocked script execution in 'http://127.0.0.1:8000/security/contentSecurityPolicy/multipart-three-part.py' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/multipart-three-part.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/multipart-three-part.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    'Content-Type: multipart/x-mixed-replace; boundary=TEST\r\n'
+    'Content-Security-Policy: sandbox\r\n\r\n'
+    '--TEST\r\n'
+    'Content-Type: text/html\r\n\r\n'
+    '--TEST\r\n'
+    'Content-Type: text/html\r\n'
+    'Content-Security-Policy:\r\n\r\n'
+    '<script>alert("FAIL")</script>\r\n'
+    '--TEST--'
+)

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/multipart-two-part-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/multipart-two-part-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: Blocked script execution in 'http://127.0.0.1:8000/security/contentSecurityPolicy/multipart-two-part.py' because the document's frame is sandboxed and the 'allow-scripts' permission is not set.
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/multipart-two-part.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/multipart-two-part.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    'Content-Type: multipart/x-mixed-replace; boundary=TEST\r\n'
+    'Content-Security-Policy: sandbox\r\n\r\n'
+    '--TEST\r\n'
+    'Content-Type: text/html\r\n'
+    'Content-Security-Policy:\r\n\r\n'
+    '<script>alert("FAIL")</script>\r\n'
+    '--TEST--'
+)

--- a/Source/JavaScriptCore/builtins/ProxyHelpers.js
+++ b/Source/JavaScriptCore/builtins/ProxyHelpers.js
@@ -68,7 +68,7 @@ function performProxyObjectGet(propertyName, receiver)
     if (!@isCallable(trap))
         @throwTypeError("'get' property of a Proxy's handler should be callable");
 
-    var trapResult = trap.@call(handler, target, propertyName, receiver);
+    var trapResult = trap.@call(handler, target, propertyName, @toThis(receiver));
 
     if (@mustValidateResultOfProxyGetAndSetTraps(target))
         @handleProxyGetTrapResult(trapResult, target, propertyName);
@@ -95,7 +95,7 @@ function performProxyObjectGetByVal(propertyName, receiver)
     if (!@isCallable(trap))
         @throwTypeError("'get' property of a Proxy's handler should be callable");
 
-    var trapResult = trap.@call(handler, target, propertyName, receiver);
+    var trapResult = trap.@call(handler, target, propertyName, @toThis(receiver));
 
     if (@mustValidateResultOfProxyGetAndSetTraps(target))
         @handleProxyGetTrapResult(trapResult, target, propertyName);
@@ -123,7 +123,7 @@ function performProxyObjectSetSloppy(propertyName, receiver, value)
     if (!@isCallable(trap))
         @throwTypeError("'set' property of a Proxy's handler should be callable");
 
-    if (!trap.@call(handler, target, propertyName, value, receiver))
+    if (!trap.@call(handler, target, propertyName, value, @toThis(receiver)))
         return;
 
     if (@mustValidateResultOfProxyGetAndSetTraps(target))
@@ -150,7 +150,7 @@ function performProxyObjectSetStrict(propertyName, receiver, value)
     if (!@isCallable(trap))
         @throwTypeError("'set' property of a Proxy's handler should be callable");
 
-    if (!trap.@call(handler, target, propertyName, value, receiver))
+    if (!trap.@call(handler, target, propertyName, value, @toThis(receiver)))
         @throwTypeError("Proxy object's 'set' trap returned falsy value for property '" + @String(propertyName) + "'");
 
     if (@mustValidateResultOfProxyGetAndSetTraps(target))

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -99,6 +99,7 @@ enum class LinkTimeConstant : int32_t;
     macro(toString) \
     macro(toPropertyKey) \
     macro(toObject) \
+    macro(toThis) \
     macro(mustValidateResultOfProxyGetAndSetTraps) \
     macro(mustValidateResultOfProxyTrapsExceptGetAndSet) \
     macro(newArrayWithSize) \

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -5632,9 +5632,10 @@ void StaticPropertyAnalysis::record()
     }
 }
 
-void BytecodeGenerator::emitToThis()
+RegisterID* BytecodeGenerator::emitToThis(RegisterID* srcDst)
 {
-    OpToThis::emit(this, kill(&m_thisRegister), ecmaMode(), nextValueProfileIndex());
+    OpToThis::emit(this, kill(srcDst), ecmaMode(), nextValueProfileIndex());
+    return srcDst;
 }
 
 ForInContext* BytecodeGenerator::findForInContext(RegisterID* property)

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -752,6 +752,7 @@ namespace JSC {
         RegisterID* emitToNumeric(RegisterID* dst, RegisterID* src);
         RegisterID* emitToString(RegisterID* dst, RegisterID* src);
         RegisterID* emitToObject(RegisterID* dst, RegisterID* src, const Identifier& message);
+        RegisterID* emitToThis(RegisterID* srcDst);
         RegisterID* emitInc(RegisterID* srcDst);
         RegisterID* emitDec(RegisterID* srcDst);
 
@@ -1080,7 +1081,7 @@ namespace JSC {
         bool isNewTargetUsedInInnerArrowFunction();
         bool isArgumentsUsedInInnerArrowFunction();
 
-        void emitToThis();
+        void emitToThis() { emitToThis(&m_thisRegister); }
 
         RegisterID* emitMove(RegisterID* dst, RegisterID* src);
 

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -2023,6 +2023,15 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_toObject(BytecodeGenerator& ge
     return generator.move(dst, generator.emitToObject(temp.get(), src.get(), generator.vm().propertyNames->emptyIdentifier));
 }
 
+RegisterID* BytecodeIntrinsicNode::emit_intrinsic_toThis(BytecodeGenerator& generator, RegisterID* dst)
+{
+    ArgumentListNode* node = m_args->m_listNode;
+    RefPtr<RegisterID> src = generator.emitNode(node);
+    ASSERT(!node->m_next);
+
+    return generator.move(dst, generator.emitToThis(src.get()));
+}
+
 RegisterID* BytecodeIntrinsicNode::emit_intrinsic_idWithProfile(BytecodeGenerator& generator, RegisterID* dst)
 {
     ArgumentListNode* node = m_args->m_listNode;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -769,17 +769,6 @@ private:
         return jsConstant(m_graph.freeze(constantValue));
     }
 
-    // Helper functions to get/set the this value.
-    Node* getThis()
-    {
-        return get(m_inlineStackTop->m_codeBlock->thisRegister());
-    }
-
-    void setThis(Node* value)
-    {
-        set(m_inlineStackTop->m_codeBlock->thisRegister(), value);
-    }
-
     InlineCallFrame* inlineCallFrame()
     {
         return m_inlineStackTop->m_inlineCallFrame;
@@ -6232,8 +6221,8 @@ void ByteCodeParser::parseBlock(unsigned limit)
         }
             
         case op_to_this: {
-            Node* op1 = getThis();
             auto bytecode = currentInstruction->as<OpToThis>();
+            Node* op1 = get(VirtualRegister(bytecode.m_srcDst));
             auto& metadata = bytecode.metadata(codeBlock);
             StructureID cachedStructureID = metadata.m_cachedStructureID;
             Structure* cachedStructure = nullptr;
@@ -6245,7 +6234,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
                 || cachedStructure->classInfoForCells()->isSubClassOf(JSScope::info())
                 || m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadCache)
                 || (op1->op() == GetLocal && op1->variableAccessData()->structureCheckHoistingFailed())) {
-                setThis(addToGraph(ToThis, OpInfo(bytecode.m_ecmaMode), OpInfo(getPrediction()), op1));
+                set(bytecode.m_srcDst, addToGraph(ToThis, OpInfo(bytecode.m_ecmaMode), OpInfo(getPrediction()), op1));
             } else {
                 addToGraph(
                     CheckStructure,

--- a/Source/JavaScriptCore/runtime/CommonSlowPaths.h
+++ b/Source/JavaScriptCore/runtime/CommonSlowPaths.h
@@ -180,7 +180,7 @@ static ALWAYS_INLINE void putDirectWithReify(VM& vm, JSGlobalObject* globalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     bool isJSFunction = baseObject->inherits<JSFunction>();
     if (isJSFunction) {
-        jsCast<JSFunction*>(baseObject)->reifyLazyPropertyIfNeeded(vm, globalObject, propertyName);
+        jsCast<JSFunction*>(baseObject)->reifyLazyPropertyIfNeeded<>(vm, globalObject, propertyName);
         RETURN_IF_EXCEPTION(scope, void());
     }
 
@@ -204,7 +204,7 @@ static ALWAYS_INLINE void putDirectAccessorWithReify(VM& vm, JSGlobalObject* glo
     auto scope = DECLARE_THROW_SCOPE(vm);
     bool isJSFunction = baseObject->inherits<JSFunction>();
     if (isJSFunction) {
-        jsCast<JSFunction*>(baseObject)->reifyLazyPropertyIfNeeded(vm, globalObject, propertyName);
+        jsCast<JSFunction*>(baseObject)->reifyLazyPropertyIfNeeded<>(vm, globalObject, propertyName);
         RETURN_IF_EXCEPTION(scope, void());
     }
 

--- a/Source/JavaScriptCore/runtime/IntlCollatorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollatorPrototype.cpp
@@ -127,7 +127,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlCollatorPrototypeGetterCompare, (JSGlobalObject* gl
         // c. Let bc be BoundFunctionCreate(F, «this value»).
         boundCompare = JSBoundFunction::create(vm, globalObject, targetObject, collator, { }, 2, jsEmptyString(vm));
         RETURN_IF_EXCEPTION(scope, { });
-        boundCompare->reifyLazyPropertyIfNeeded(vm, globalObject, vm.propertyNames->name);
+        boundCompare->reifyLazyPropertyIfNeeded<>(vm, globalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(scope, { });
         boundCompare->putDirect(vm, vm.propertyNames->name, jsEmptyString(vm), PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
         // d. Set collator.[[boundCompare]] to bc.

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormatPrototype.cpp
@@ -151,7 +151,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlDateTimeFormatPrototypeGetterFormat, (JSGlobalObjec
         // c. Let bf be BoundFunctionCreate(F, «this value»).
         boundFormat = JSBoundFunction::create(vm, globalObject, targetObject, dtf, { }, 1, jsEmptyString(vm));
         RETURN_IF_EXCEPTION(scope, { });
-        boundFormat->reifyLazyPropertyIfNeeded(vm, globalObject, vm.propertyNames->name);
+        boundFormat->reifyLazyPropertyIfNeeded<>(vm, globalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(scope, { });
         boundFormat->putDirect(vm, vm.propertyNames->name, jsEmptyString(vm), PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
         // d. Set dtf.[[boundFormat]] to bf.

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatPrototype.cpp
@@ -132,7 +132,7 @@ JSC_DEFINE_CUSTOM_GETTER(intlNumberFormatPrototypeGetterFormat, (JSGlobalObject*
         // c. Let bf be BoundFunctionCreate(F, «this value»).
         boundFormat = JSBoundFunction::create(vm, globalObject, targetObject, nf, { }, 1, jsEmptyString(vm));
         RETURN_IF_EXCEPTION(scope, { });
-        boundFormat->reifyLazyPropertyIfNeeded(vm, globalObject, vm.propertyNames->name);
+        boundFormat->reifyLazyPropertyIfNeeded<>(vm, globalObject, vm.propertyNames->name);
         RETURN_IF_EXCEPTION(scope, { });
         boundFormat->putDirect(vm, vm.propertyNames->name, jsEmptyString(vm), PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
         // d. Set nf.[[boundFormat]] to bf.

--- a/Source/JavaScriptCore/runtime/JSFunction.h
+++ b/Source/JavaScriptCore/runtime/JSFunction.h
@@ -106,6 +106,7 @@ public:
 
     // To call any of these methods include JSFunctionInlines.h
     bool isHostFunction() const;
+    bool isNonBoundHostFunction() const;
     FunctionExecutable* jsExecutable() const;
     Intrinsic intrinsic() const;
 
@@ -163,6 +164,8 @@ public:
         Lazy,
         Reified,
     };
+    enum class SetHasModifiedLengthOrName : uint8_t { Yes, No };
+    template <SetHasModifiedLengthOrName set = SetHasModifiedLengthOrName::Yes>
     PropertyStatus reifyLazyPropertyIfNeeded(VM&, JSGlobalObject*, PropertyName);
 
     bool canAssumeNameAndLengthAreOriginal(VM&);

--- a/Source/JavaScriptCore/runtime/JSFunctionInlines.h
+++ b/Source/JavaScriptCore/runtime/JSFunctionInlines.h
@@ -84,6 +84,11 @@ inline bool JSFunction::isHostFunction() const
     return executable()->isHostFunction();
 }
 
+inline bool JSFunction::isNonBoundHostFunction() const
+{
+    return isHostFunction() && !inherits<JSBoundFunction>();
+}
+
 inline Intrinsic JSFunction::intrinsic() const
 {
     return executable()->intrinsic();
@@ -203,12 +208,10 @@ inline JSString* JSFunction::originalName(JSGlobalObject* globalObject)
 
 inline bool JSFunction::canAssumeNameAndLengthAreOriginal(VM&)
 {
-    if (isHostFunction()) {
-        // Bound functions are not eagerly generating name and length.
-        // Thus, we can use FunctionRareData's tracking. This is useful to optimize func.bind().bind() case.
-        if (!inherits<JSBoundFunction>())
-            return false;
-    }
+    // Bound functions are not eagerly generating name and length.
+    // Thus, we can use FunctionRareData's tracking. This is useful to optimize func.bind().bind() case.
+    if (isNonBoundHostFunction())
+        return false;
     FunctionRareData* rareData = this->rareData();
     if (!rareData)
         return true;

--- a/Source/JavaScriptCore/runtime/ProxyObject.cpp
+++ b/Source/JavaScriptCore/runtime/ProxyObject.cpp
@@ -187,7 +187,7 @@ static JSValue performProxyGet(JSGlobalObject* globalObject, ProxyObject* proxyO
     MarkedArgumentBuffer arguments;
     arguments.append(target);
     arguments.append(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid())));
-    arguments.append(receiver);
+    arguments.append(receiver.toThis(globalObject, ECMAMode::strict()));
     ASSERT(!arguments.hasOverflowed());
     JSValue trapResult = call(globalObject, getHandler, callData, handler, arguments);
     RETURN_IF_EXCEPTION(scope, { });
@@ -517,7 +517,7 @@ bool ProxyObject::performPut(JSGlobalObject* globalObject, JSValue putValue, JSV
     arguments.append(target);
     arguments.append(identifierToSafePublicJSValue(vm, Identifier::fromUid(vm, propertyName.uid())));
     arguments.append(putValue);
-    arguments.append(thisValue);
+    arguments.append(thisValue.toThis(globalObject, ECMAMode::strict()));
     ASSERT(!arguments.hasOverflowed());
     JSValue trapResult = call(globalObject, setMethod, callData, handler, arguments);
     RETURN_IF_EXCEPTION(scope, false);

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -156,8 +156,9 @@ enum class SerializationReturnCode {
     UnspecifiedError
 };
 
-enum WalkerState { StateUnknown, ArrayStartState, ArrayStartVisitMember, ArrayEndVisitMember,
-    ObjectStartState, ObjectStartVisitMember, ObjectEndVisitMember,
+enum WalkerState { StateUnknown, ArrayStartState, ArrayStartVisitIndexedMember, ArrayEndVisitIndexedMember,
+    ArrayStartVisitNamedMember, ArrayEndVisitNamedMember,
+    ObjectStartState, ObjectStartVisitNamedMember, ObjectEndVisitNamedMember,
     MapDataStartVisitEntry, MapDataEndVisitKey, MapDataEndVisitValue,
     SetDataStartVisitEntry, SetDataEndVisitKey };
 
@@ -2721,9 +2722,9 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                 indexStack.append(0);
                 lengthStack.append(length);
             }
-            arrayStartVisitMember:
+            arrayStartVisitIndexedMember:
             FALLTHROUGH;
-            case ArrayStartVisitMember: {
+            case ArrayStartVisitIndexedMember: {
                 JSObject* array = inputObjectStack.last();
                 uint32_t index = indexStack.last();
                 if (index == lengthStack.last()) {
@@ -2738,7 +2739,7 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                     if (propertyStack.last().size()) {
                         write(NonIndexPropertiesTag);
                         indexStack.append(0);
-                        goto objectStartVisitMember;
+                        goto startVisitNamedMember;
                     }
                     propertyStack.removeLast();
 
@@ -2751,7 +2752,7 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                     return SerializationReturnCode::ExistingExceptionError;
                 if (!inValue) {
                     indexStack.last()++;
-                    goto arrayStartVisitMember;
+                    goto arrayStartVisitIndexedMember;
                 }
 
                 write(index);
@@ -2760,15 +2761,18 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                     if (terminalCode != SerializationReturnCode::SuccessfullyCompleted)
                         return terminalCode;
                     indexStack.last()++;
-                    goto arrayStartVisitMember;
+                    goto arrayStartVisitIndexedMember;
                 }
-                stateStack.append(ArrayEndVisitMember);
+                stateStack.append(ArrayEndVisitIndexedMember);
                 goto stateUnknown;
             }
-            case ArrayEndVisitMember: {
+            case ArrayEndVisitIndexedMember: {
                 indexStack.last()++;
-                goto arrayStartVisitMember;
+                goto arrayStartVisitIndexedMember;
             }
+            case ArrayStartVisitNamedMember:
+            case ArrayEndVisitNamedMember:
+                RELEASE_ASSERT_NOT_REACHED();
             objectStartState:
             case ObjectStartState: {
                 ASSERT(inValue.isObject());
@@ -2791,9 +2795,9 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                 if (UNLIKELY(scope.exception()))
                     return SerializationReturnCode::ExistingExceptionError;
             }
-            objectStartVisitMember:
+            startVisitNamedMember:
             FALLTHROUGH;
-            case ObjectStartVisitMember: {
+            case ObjectStartVisitNamedMember: {
                 JSObject* object = inputObjectStack.last();
                 uint32_t index = indexStack.last();
                 PropertyNameArray& properties = propertyStack.last();
@@ -2811,7 +2815,7 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                 if (!inValue) {
                     // Property was removed during serialisation
                     indexStack.last()++;
-                    goto objectStartVisitMember;
+                    goto startVisitNamedMember;
                 }
                 write(properties[index]);
 
@@ -2820,19 +2824,19 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
 
                 auto terminalCode = SerializationReturnCode::SuccessfullyCompleted;
                 if (!dumpIfTerminal(inValue, terminalCode)) {
-                    stateStack.append(ObjectEndVisitMember);
+                    stateStack.append(ObjectEndVisitNamedMember);
                     goto stateUnknown;
                 }
                 if (terminalCode != SerializationReturnCode::SuccessfullyCompleted)
                     return terminalCode;
                 FALLTHROUGH;
             }
-            case ObjectEndVisitMember: {
+            case ObjectEndVisitNamedMember: {
                 if (UNLIKELY(scope.exception()))
                     return SerializationReturnCode::ExistingExceptionError;
 
                 indexStack.last()++;
-                goto objectStartVisitMember;
+                goto startVisitNamedMember;
             }
             mapStartState: {
                 ASSERT(inValue.isObject());
@@ -2862,7 +2866,7 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                         return SerializationReturnCode::ExistingExceptionError;
                     write(NonMapPropertiesTag);
                     indexStack.append(0);
-                    goto objectStartVisitMember;
+                    goto startVisitNamedMember;
                 }
                 inValue = key;
                 m_keepAliveBuffer.appendWithCrashOnOverflow(value);
@@ -2908,7 +2912,7 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
                         return SerializationReturnCode::ExistingExceptionError;
                     write(NonSetPropertiesTag);
                     indexStack.append(0);
-                    goto objectStartVisitMember;
+                    goto startVisitNamedMember;
                 }
                 inValue = key;
                 stateStack.append(SetDataEndVisitKey);
@@ -3257,6 +3261,47 @@ private:
     {
         if (!read(m_version))
             m_version = 0xFFFFFFFF;
+    }
+
+    enum class VisitNamedMemberResult : uint8_t { Error, Break, Start, Unknown };
+
+    template<WalkerState endState>
+    ALWAYS_INLINE VisitNamedMemberResult startVisitNamedMember(MarkedVector<JSObject*, 32>& outputObjectStack, Vector<Identifier, 16>& propertyNameStack, Vector<WalkerState, 16>& stateStack, JSValue& outValue)
+    {
+        static_assert(endState == ArrayEndVisitNamedMember || endState == ObjectEndVisitNamedMember);
+        VM& vm = m_lexicalGlobalObject->vm();
+        CachedStringRef cachedString;
+        bool wasTerminator = false;
+        if (!readStringData(cachedString, wasTerminator, ShouldAtomize::Yes)) {
+            if (!wasTerminator) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                return VisitNamedMemberResult::Error;
+            }
+
+            JSObject* outObject = outputObjectStack.last();
+            outValue = outObject;
+            outputObjectStack.removeLast();
+            return VisitNamedMemberResult::Break;
+        }
+
+        Identifier identifier = Identifier::fromString(vm, cachedString->string());
+        if constexpr (endState == ArrayEndVisitNamedMember)
+            RELEASE_ASSERT(identifier != vm.propertyNames->length);
+
+        if (JSValue terminal = readTerminal()) {
+            putProperty(outputObjectStack.last(), identifier, terminal);
+            return VisitNamedMemberResult::Start;
+        }
+
+        stateStack.append(endState);
+        propertyNameStack.append(identifier);
+        return VisitNamedMemberResult::Unknown;
+    }
+
+    ALWAYS_INLINE void objectEndVisitNamedMember(MarkedVector<JSObject*, 32>& outputObjectStack, Vector<Identifier, 16>& propertyNameStack, JSValue& outValue)
+    {
+        putProperty(outputObjectStack.last(), propertyNameStack.last(), outValue);
+        propertyNameStack.removeLast();
     }
 
     DeserializationResult deserialize();
@@ -5346,9 +5391,9 @@ DeserializationResult CloneDeserializer::deserialize()
             addToObjectPool<ArrayTag>(outArray);
             outputObjectStack.append(outArray);
         }
-        arrayStartVisitMember:
+        arrayStartVisitIndexedMember:
         FALLTHROUGH;
-        case ArrayStartVisitMember: {
+        case ArrayStartVisitIndexedMember: {
             uint32_t index;
             if (!read(index)) {
                 SERIALIZE_TRACE("FAIL deserialize");
@@ -5373,7 +5418,7 @@ DeserializationResult CloneDeserializer::deserialize()
                         break;
                     }
                     if (index == NonIndexPropertiesTag)
-                        goto objectStartVisitMember;
+                        goto arrayStartVisitNamedMember;
                 }
             } else {
                 if (index == TerminatorTag) {
@@ -5382,24 +5427,42 @@ DeserializationResult CloneDeserializer::deserialize()
                     outputObjectStack.removeLast();
                     break;
                 } else if (index == NonIndexPropertiesTag)
-                    goto objectStartVisitMember;
+                    goto arrayStartVisitNamedMember;
             }
 
             if (JSValue terminal = readTerminal()) {
                 putProperty(outputObjectStack.last(), index, terminal);
-                goto arrayStartVisitMember;
+                goto arrayStartVisitIndexedMember;
             }
             if (m_failed)
                 goto error;
             indexStack.append(index);
-            stateStack.append(ArrayEndVisitMember);
+            stateStack.append(ArrayEndVisitIndexedMember);
             goto stateUnknown;
         }
-        case ArrayEndVisitMember: {
+        case ArrayEndVisitIndexedMember: {
             JSObject* outArray = outputObjectStack.last();
             putProperty(outArray, indexStack.last(), outValue);
             indexStack.removeLast();
-            goto arrayStartVisitMember;
+            goto arrayStartVisitIndexedMember;
+        }
+        arrayStartVisitNamedMember:
+        case ArrayStartVisitNamedMember: {
+            switch (startVisitNamedMember<ArrayEndVisitNamedMember>(outputObjectStack, propertyNameStack, stateStack, outValue)) {
+            case VisitNamedMemberResult::Error:
+                goto error;
+            case VisitNamedMemberResult::Break:
+                break;
+            case VisitNamedMemberResult::Start:
+                goto arrayStartVisitNamedMember;
+            case VisitNamedMemberResult::Unknown:
+                goto stateUnknown;
+            }
+            break;
+        }
+        case ArrayEndVisitNamedMember: {
+            objectEndVisitNamedMember(outputObjectStack, propertyNameStack, outValue);
+            goto arrayStartVisitNamedMember;
         }
         objectStartState:
         case ObjectStartState: {
@@ -5409,35 +5472,24 @@ DeserializationResult CloneDeserializer::deserialize()
             addToObjectPool<ObjectTag>(outObject);
             outputObjectStack.append(outObject);
         }
-        objectStartVisitMember:
+        startVisitNamedMember:
         FALLTHROUGH;
-        case ObjectStartVisitMember: {
-            CachedStringRef cachedString;
-            bool wasTerminator = false;
-            if (!readStringData(cachedString, wasTerminator, ShouldAtomize::Yes)) {
-                if (!wasTerminator) {
-                    SERIALIZE_TRACE("FAIL deserialize");
-                    goto error;
-                }
-
-                JSObject* outObject = outputObjectStack.last();
-                outValue = outObject;
-                outputObjectStack.removeLast();
+        case ObjectStartVisitNamedMember: {
+            switch (startVisitNamedMember<ObjectEndVisitNamedMember>(outputObjectStack, propertyNameStack, stateStack, outValue)) {
+            case VisitNamedMemberResult::Error:
+                goto error;
+            case VisitNamedMemberResult::Break:
                 break;
+            case VisitNamedMemberResult::Start:
+                goto startVisitNamedMember;
+            case VisitNamedMemberResult::Unknown:
+                goto stateUnknown;
             }
-
-            if (JSValue terminal = readTerminal()) {
-                putProperty(outputObjectStack.last(), Identifier::fromString(vm, cachedString->string()), terminal);
-                goto objectStartVisitMember;
-            }
-            stateStack.append(ObjectEndVisitMember);
-            propertyNameStack.append(Identifier::fromString(vm, cachedString->string()));
-            goto stateUnknown;
+            break;
         }
-        case ObjectEndVisitMember: {
-            putProperty(outputObjectStack.last(), propertyNameStack.last(), outValue);
-            propertyNameStack.removeLast();
-            goto objectStartVisitMember;
+        case ObjectEndVisitNamedMember: {
+            objectEndVisitNamedMember(outputObjectStack, propertyNameStack, outValue);
+            goto startVisitNamedMember;
         }
         mapStartState: {
             if (outputObjectStack.size() > maximumFilterRecursion) {
@@ -5454,7 +5506,7 @@ DeserializationResult CloneDeserializer::deserialize()
         case MapDataStartVisitEntry: {
             if (consumeCollectionDataTerminationIfPossible<NonMapPropertiesTag>()) {
                 mapStack.removeLast();
-                goto objectStartVisitMember;
+                goto startVisitNamedMember;
             }
             stateStack.append(MapDataEndVisitKey);
             goto stateUnknown;
@@ -5485,7 +5537,7 @@ DeserializationResult CloneDeserializer::deserialize()
         case SetDataStartVisitEntry: {
             if (consumeCollectionDataTerminationIfPossible<NonSetPropertiesTag>()) {
                 setStack.removeLast();
-                goto objectStartVisitMember;
+                goto startVisitNamedMember;
             }
             stateStack.append(SetDataEndVisitKey);
             goto stateUnknown;

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -554,6 +554,8 @@ private:
     bool maybeLoadEmpty();
     void loadErrorDocument();
 
+    bool shouldClearContentSecurityPolicyForResponse(const ResourceResponse&) const;
+
     bool isMultipartReplacingLoad() const;
     bool isPostOrRedirectAfterPost(const ResourceRequest&, const ResourceResponse&);
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4042,6 +4042,8 @@ void RenderBlockFlow::layoutModernLines(bool relayoutChildren, LayoutUnit& repai
 
     if (hasSimpleOutOfFlowContentOnly) {
         // Shortcut the layout.
+        m_lineLayout = std::monostate();
+
         setStaticPositionsForSimpleOutOfFlowContent();
         setLogicalHeight(borderAndPaddingBefore() + borderAndPaddingAfter() + scrollbarLogicalHeight());
         return;

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -1679,8 +1679,7 @@ void RenderTable::markForPaginationRelayoutIfNeeded()
         return;
     
     // When a table moves, we have to dirty all of the sections too.
-    if (!needsLayout())
-        setChildNeedsLayout(MarkOnlyThis);
+    setChildNeedsLayout(MarkOnlyThis);
     for (auto& child : childrenOfType<RenderTableSection>(*this)) {
         if (!child.needsLayout())
             child.setChildNeedsLayout(MarkOnlyThis);


### PR DESCRIPTION
#### 18b2179221761d08ccea246b4f4f36ec24e9cc5e
<pre>
Should crash when deserializing JSArray object containing named property length
<a href="https://bugs.webkit.org/show_bug.cgi?id=267036">https://bugs.webkit.org/show_bug.cgi?id=267036</a>
<a href="https://rdar.apple.com/120410983">rdar://120410983</a>

Reviewed by Sihui Liu and Mark Lam.

`length` is treated as a special property in JSArray. There shouldn&apos;t
be any named property `length` in JSArray. So, should crash when
deserializing JSArray object containing named property `length`.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::serialize):
(WebCore::CloneDeserializer::objectStartVisitMember):
(WebCore::CloneDeserializer::objectEndVisitMember):
(WebCore::CloneDeserializer::deserialize):

Originally-landed-as: 272448.74@safari-7618-branch (7bd07231e704). <a href="https://rdar.apple.com/124556898">rdar://124556898</a>
Canonical link: <a href="https://commits.webkit.org/276108@main">https://commits.webkit.org/276108@main</a>
</pre>
----------------------------------------------------------------------
#### 93603245b1ebc4cd2c451af93d98c86533c0d6fe
<pre>
Content-Type x-mixed-replace can be abused to bypass CSP
<a href="https://bugs.webkit.org/show_bug.cgi?id=264811">https://bugs.webkit.org/show_bug.cgi?id=264811</a>
<a href="https://rdar.apple.com/118394343">rdar://118394343</a>

Reviewed by John Wilander and Brent Fulgham.

When replacing the document in a multipart/x-mixed-replace response, the
DocumentLoader would reset its CSP every time a new response was received.
This change makes the CSP persistent across document replacements when
loading multipart content. Now the CSP can only become more restrictive
as new parts are received.

* LayoutTests/http/tests/security/contentSecurityPolicy/multipart-three-part-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/multipart-three-part.py: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/multipart-two-part-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/multipart-two-part.py: Added.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::shouldClearContentSecurityPolicyForResponse const):
(WebCore::DocumentLoader::responseReceived):
* Source/WebCore/loader/DocumentLoader.h:

Originally-landed-as: 272448.100@safari-7618-branch (7f3ac60a98fc). <a href="https://rdar.apple.com/124556491">rdar://124556491</a>
Canonical link: <a href="https://commits.webkit.org/276107@main">https://commits.webkit.org/276107@main</a>
</pre>
----------------------------------------------------------------------
#### 4e7c454bf50238f063d9614230027e7d1c1f5cd7
<pre>
[JSC] setHasModifiedLengthForBoundOrNonHostFunction and setHasModifiedNameForBoundOrNonHostFunction shouldn&apos;t be called if it fails to reify the property
<a href="https://bugs.webkit.org/show_bug.cgi?id=267380">https://bugs.webkit.org/show_bug.cgi?id=267380</a>
<a href="https://rdar.apple.com/118761737">rdar://118761737</a>

Reviewed by Yusuke Suzuki.

setHasModifiedLengthForBoundOrNonHostFunction and setHasModifiedNameForBoundOrNonHostFunction
can be called if JSFunction::put() fails to reify the property. This case may
cause inconsistency between the AI and the runtime environment.

* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::put):

Originally-landed-as: 272448.101@safari-7618-branch (70ca9c1f54a0). <a href="https://rdar.apple.com/124556382">rdar://124556382</a>
Canonical link: <a href="https://commits.webkit.org/276106@main">https://commits.webkit.org/276106@main</a>
</pre>
----------------------------------------------------------------------
#### ffe58e2be703e4f6b69eb8c315b1c186676bb4b5
<pre>
Invalidate existing inline layout content when simplified out-of-flow is sufficient
<a href="https://bugs.webkit.org/show_bug.cgi?id=267487">https://bugs.webkit.org/show_bug.cgi?id=267487</a>
<a href="https://rdar.apple.com/120496542">rdar://120496542</a>

Reviewed by Antti Koivisto.

Do not leave stale inline content around.

* LayoutTests/fast/inline/dynamic-inline-content-with-out-of-flow-child-expected.txt: Added.
* LayoutTests/fast/inline/dynamic-inline-content-with-out-of-flow-child.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutModernLines):

Originally-landed-as: 272448.102@safari-7618-branch (6d2f579ca0ad). <a href="https://rdar.apple.com/124556312">rdar://124556312</a>
Canonical link: <a href="https://commits.webkit.org/276105@main">https://commits.webkit.org/276105@main</a>
</pre>
----------------------------------------------------------------------
#### ceb7e89febcd92b46d65396ce68e0d58ae6bcd6e
<pre>
[JSC] get_by_id_with_this + ProxyObject can leak JSScope objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=267425">https://bugs.webkit.org/show_bug.cgi?id=267425</a>
&lt;<a href="https://rdar.apple.com/120777816">rdar://120777816</a>&gt;

Reviewed by Yusuke Suzuki and Justin Michaud.

According to the spec [1], `var base = { foo }; with (base) foo();` should be called with `this`
value of `base`, which is why FunctionCallResolveNode moves resolved scope to thisRegister().
That is arguably a bad design, and there is an effort [2] to abolish using JSScope as `this` value.

When `this` value is accessed by JS code, it&apos;s being sanitized via ToThis (JSScope replaced with
`undefined`), yet not in case of `super.property` access calling into ProxyObject `get` trap,
which passes raw `this` value as receiver parameter, leaking JSScope to be exploited.

For performance reasons, we can&apos;t call toThis() whenever `get_by_id_with_this` is used, so this
change introduces @toThis() intrinsic specifically for ProxyObject IC helpers, tweaks DFG to respect
`m_srcDst`, and also fixes baseline code.

Inlineability of ProxyObject IC helpers was verified to remain unaffected (`performProxyObjectGet`
is smaller then 120 while other helpers were already exceeding inline size limit).

[1]: <a href="https://tc39.es/ecma262/#sec-evaluatecall">https://tc39.es/ecma262/#sec-evaluatecall</a> (step 1.b.iii)
[2]: <a href="https://bugs.webkit.org/show_bug.cgi?id=225397">https://bugs.webkit.org/show_bug.cgi?id=225397</a>

* JSTests/stress/regress-120777816.js: Added.
* Source/JavaScriptCore/builtins/ProxyHelpers.js:
(linkTimeConstant.performProxyObjectGet):
(linkTimeConstant.performProxyObjectGetByVal):
(linkTimeConstant.performProxyObjectSetSloppy):
(linkTimeConstant.performProxyObjectSetStrict):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitToThis):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
(JSC::BytecodeGenerator::emitToThis):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::BytecodeIntrinsicNode::emit_intrinsic_toThis):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
(JSC::DFG::ByteCodeParser::getThis): Deleted.
(JSC::DFG::ByteCodeParser::setThis): Deleted.
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::performProxyGet):
(JSC::ProxyObject::performPut):

Originally-landed-as: 272448.103@safari-7618-branch (e3a75800fe85). <a href="https://rdar.apple.com/124556295">rdar://124556295</a>
Canonical link: <a href="https://commits.webkit.org/276104@main">https://commits.webkit.org/276104@main</a>
</pre>
----------------------------------------------------------------------
#### 8b2e50918a1c6a0c064267a241b81c5b6f01115e
<pre>
ASAN_ILL | WebCore::RenderTableSection::layoutRows; WebCore::RenderTable::simplifiedNormalFlowLayout; WebCore::RenderBlock::simplifiedLayout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267198">https://bugs.webkit.org/show_bug.cgi?id=267198</a>
<a href="https://rdar.apple.com/113940614">rdar://113940614</a>

Reviewed by Alan Baradlay.

Always setChildNeedsLayout for sections to make sure normalChildNeedsLayout is flagged,
as for pagination we need to run a full layout on child table sections even when the initial change,
otherwise requires simplified layout only.

* LayoutTests/fast/multicol/pagination/pagination-diry-sections-crash-expected.txt: Added.
* LayoutTests/fast/multicol/pagination/pagination-diry-sections-crash.html: Added.
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt: re-baseline again, adding end of line back.
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::markForPaginationRelayoutIfNeeded):

Originally-landed-as: 272448.104@safari-7618-branch (8737c0374652). <a href="https://rdar.apple.com/124556239">rdar://124556239</a>
Canonical link: <a href="https://commits.webkit.org/276103@main">https://commits.webkit.org/276103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb89ddcfb5437d5a3176353910b46759d269013f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46319 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39796 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/45980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36084 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17063 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17332 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38679 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1733 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37131 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39887 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47871 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43308 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42879 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37885 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41557 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9734 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20313 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50309 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19756 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10139 "Passed tests") | 
<!--EWS-Status-Bubble-End-->