### PR TITLE
RegisteredContentScripts.db should only be created if needed.

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm
@@ -107,7 +107,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray *keys)
             return;
 
         NSString *errorMessage;
-        if (![strongSelf _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
+        if (![strongSelf _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage createIfNecessary:NO]) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 completionHandler(errorMessage);
             });
@@ -191,7 +191,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray *keys)
 {
     dispatch_assert_queue(_databaseQueue);
 
-    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage])
+    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage createIfNecessary:NO])
         return @[ ];
 
     ASSERT(!(*outErrorMessage).length);

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatabase.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatabase.mm
@@ -211,6 +211,9 @@ using namespace WebKit;
     sqlite3_close_v2(_handle);
     _handle = nullptr;
 
+    if (result == SQLITE_CANTOPEN && !(flags & SQLITE_OPEN_CREATE))
+        return NO;
+
     if (error)
         *error = [[self class] _errorWith_WKSQLiteErrorCode:result userInfo:nil];
 

--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.h
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.h
@@ -50,6 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)deleteDatabaseWithCompletionHandler:(void (^)(NSString * _Nullable errorMessage))completionHandler;
 
 - (BOOL)_openDatabaseIfNecessaryReturningErrorMessage:(NSString * _Nullable * _Nonnull)outErrorMessage;
+- (BOOL)_openDatabaseIfNecessaryReturningErrorMessage:(NSString * _Nullable * _Nonnull)outErrorMessage createIfNecessary:(BOOL)createIfNecessary;
+
 - (nullable NSString *)_deleteDatabaseIfEmpty;
 
 - (void)createSavepointWithCompletionHandler:(void (^)(NSUUID * _Nullable savepointIdentifer, NSString * _Nullable errorMessage))completionHandler;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm
@@ -156,7 +156,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
             return;
 
         NSString *errorMessage;
-        if (![strongSelf _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
+        if (![strongSelf _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage createIfNecessary:NO]) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 completionHandler(errorMessage);
             });
@@ -203,7 +203,7 @@ static const SchemaVersion currentDatabaseSchemaVersion = 1;
 {
     dispatch_assert_queue(_databaseQueue);
 
-    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage])
+    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage createIfNecessary:NO])
         return @[ ];
 
     ASSERT(!(*outErrorMessage).length);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm
@@ -112,7 +112,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
         }
 
         // Return storage size for all keys if no keys are specified.
-        if (![self _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
+        if (![self _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage createIfNecessary:NO]) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 completionHandler(0, errorMessage);
             });
@@ -211,7 +211,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
         }
 
         NSString *errorMessage;
-        if (![self _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage]) {
+        if (![self _openDatabaseIfNecessaryReturningErrorMessage:&errorMessage createIfNecessary:NO]) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 completionHandler(errorMessage);
             });
@@ -274,7 +274,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
 {
     dispatch_assert_queue(_databaseQueue);
 
-    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage])
+    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage createIfNecessary:NO])
         return @{ };
 
     ASSERT(!(*outErrorMessage).length);
@@ -301,7 +301,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
 {
     dispatch_assert_queue(_databaseQueue);
 
-    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage])
+    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage createIfNecessary:NO])
         return [NSSet set];
 
     ASSERT(!(*outErrorMessage).length);
@@ -317,7 +317,8 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
 - (NSDictionary<NSString *, NSString *> *)_getValuesForKeys:(NSArray<NSString *> *)keys outErrorMessage:(NSString **)outErrorMessage
 {
     dispatch_assert_queue(_databaseQueue);
-    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage])
+
+    if (![self _openDatabaseIfNecessaryReturningErrorMessage:outErrorMessage createIfNecessary:NO])
         return @{ };
 
     ASSERT(!(*outErrorMessage).length);


### PR DESCRIPTION
#### 5745aee1167a4b0f77891efe606302d5160fdbde
<pre>
RegisteredContentScripts.db should only be created if needed.
<a href="https://webkit.org/b/270931">https://webkit.org/b/270931</a>
<a href="https://rdar.apple.com/problem/124554561">rdar://problem/124554561</a>

Reviewed by Sihui Liu and Jeff Miller.

Change the APIs that use SQL store to use the new _openDatabaseIfNecessaryReturningErrorMessage:createIfNecessary:
method and pass NO when the access is deleting or getting data. This makes sure we don&apos;t create an empty database
just to read or delete no data.

* Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm:
(-[_WKWebExtensionRegisteredScriptsSQLiteStore deleteScriptsWithIDs:completionHandler:]): Pass createIfNecessary:NO.
(-[_WKWebExtensionRegisteredScriptsSQLiteStore _getScriptsWithOutErrorMessage:]): Ditto.
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteDatabase.mm:
(-[_WKWebExtensionSQLiteDatabase _openWithFlags:vfs:error:]): Return no error if thsi is a can&apos;t open error and
we were not asekd to create the file.
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.h:
* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
(-[_WKWebExtensionSQLiteStore _openDatabaseIfNecessaryReturningErrorMessage:]): Call the new method with YES.
(-[_WKWebExtensionSQLiteStore _openDatabaseIfNecessaryReturningErrorMessage:createIfNecessary:]): Added.
(-[_WKWebExtensionSQLiteStore _openDatabase:withAccessType:deleteDatabaseFileOnError:]): Added accessType param.
(-[_WKWebExtensionSQLiteStore _deleteDatabaseFileAtURL:reopenDatabase:]): Pass SQLiteDatabaseAccessTypeReadWriteCreate.
(-[_WKWebExtensionSQLiteStore _openDatabase:deleteDatabaseFileOnError:]): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionDeclarativeNetRequestSQLiteStore.mm:
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore deleteRules:completionHandler:]): Pass createIfNecessary:NO.
(-[_WKWebExtensionDeclarativeNetRequestSQLiteStore _getRulesWithOutErrorMessage:]): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm:
(-[_WKWebExtensionStorageSQLiteStore getStorageSizeForKeys:completionHandler:]):
(-[_WKWebExtensionStorageSQLiteStore deleteValuesForKeys:completionHandler:]):
(-[_WKWebExtensionStorageSQLiteStore _getValuesForAllKeysReturningErrorMessage:]):
(-[_WKWebExtensionStorageSQLiteStore _getAllKeysReturningErrorMessage:]):
(-[_WKWebExtensionStorageSQLiteStore _getValuesForKeys:outErrorMessage:]):

Canonical link: <a href="https://commits.webkit.org/276063@main">https://commits.webkit.org/276063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/defbaf7e48be7fa08c1878f561fd182f1812dad9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22711 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46306 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39787 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20119 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44237 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19724 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17049 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17272 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1720 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/38970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47857 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18702 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Running compile-webkit") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15293 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42866 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20120 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41542 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20301 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5958 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19747 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->