### PR TITLE
Drop Vector constructor taking a raw pointer and a size

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -276,7 +276,7 @@ RefPtr<ArrayBuffer> ArrayBuffer::tryCreate(const void* source, size_t byteLength
     return createInternal(WTFMove(contents), source, byteLength);
 }
 
-RefPtr<ArrayBuffer> ArrayBuffer::tryCreate(std::span<uint8_t> span)
+RefPtr<ArrayBuffer> ArrayBuffer::tryCreate(std::span<const uint8_t> span)
 {
     return tryCreate(span.data(), span.size_bytes());
 }

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -275,7 +275,7 @@ public:
     JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(size_t numElements, unsigned elementByteSize, std::optional<size_t> maxByteLength = std::nullopt);
     JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(ArrayBuffer&);
     JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(const void* source, size_t byteLength);
-    JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(std::span<uint8_t>);
+    JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreate(std::span<const uint8_t>);
     JS_EXPORT_PRIVATE static RefPtr<ArrayBuffer> tryCreateShared(VM&, size_t numElements, unsigned elementByteSize, size_t maxByteLength);
 
     // Only for use by Uint8ClampedArray::tryCreateUninitialized and FragmentedSharedBuffer::tryCreateArrayBuffer.
@@ -331,7 +331,8 @@ public:
     Expected<int64_t, GrowFailReason> grow(VM&, size_t newByteLength);
     Expected<int64_t, GrowFailReason> resize(VM&, size_t newByteLength);
 
-    Vector<uint8_t> toVector() const { return { static_cast<const uint8_t*>(data()), byteLength() }; };
+    std::span<const uint8_t> bytes() const { return std::span { static_cast<const uint8_t*>(data()), byteLength() }; }
+    Vector<uint8_t> toVector() const { return { bytes() }; }
 
 private:
     static Ref<ArrayBuffer> create(size_t numElements, unsigned elementByteSize, ArrayBufferContents::InitializationPolicy);

--- a/Source/JavaScriptCore/runtime/ArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/ArrayBufferView.h
@@ -77,6 +77,7 @@ public:
     }
 
     void* data() const { return baseAddress(); }
+    std::span<const uint8_t> bytes() const { return { static_cast<const uint8_t*>(data()), byteLength() }; }
 
     size_t byteOffsetRaw() const { return m_byteOffset; }
 

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -696,8 +696,7 @@ static std::optional<std::variant<Vector<LChar>, int64_t>> parseTimeZoneBrackete
         if (!isValidComponent(currentNameComponentStartIndex, nameLength))
             return std::nullopt;
 
-        Vector<LChar> result(buffer.position(), nameLength);
-        buffer.advanceBy(nameLength);
+        Vector<LChar> result(buffer.consume(nameLength));
 
         if (buffer.atEnd())
             return std::nullopt;
@@ -834,8 +833,7 @@ static std::optional<CalendarRecord> parseCalendar(StringParsingBuffer<Character
     if (!isValidComponent(currentNameComponentStartIndex, nameLength))
         return std::nullopt;
 
-    Vector<LChar, maxCalendarLength> result(buffer.position(), nameLength);
-    buffer.advanceBy(nameLength);
+    Vector<LChar, maxCalendarLength> result(buffer.consume(nameLength));
 
     if (buffer.atEnd())
         return std::nullopt;

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -1578,7 +1578,7 @@ JSValue IntlDateTimeFormat::formatRange(JSGlobalObject* globalObject, double sta
         throwTypeError(globalObject, scope, "Failed to format date interval"_s);
         return { };
     }
-    Vector<UChar, 32> buffer(formattedStringPointer, formattedStringLength);
+    Vector<UChar, 32> buffer(std::span<const UChar> { formattedStringPointer, static_cast<size_t>(formattedStringLength) });
     replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(buffer);
 
     return jsString(vm, String(WTFMove(buffer)));
@@ -1694,7 +1694,7 @@ JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, dou
         throwTypeError(globalObject, scope, "Failed to format date interval"_s);
         return { };
     }
-    Vector<UChar, 32> buffer(formattedStringPointer, formattedStringLength);
+    Vector<UChar, 32> buffer(std::span<const UChar> { formattedStringPointer, static_cast<size_t>(formattedStringLength) });
     replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(buffer);
 
     StringView resultStringView(buffer.data(), buffer.size());

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -63,6 +63,7 @@ public:
 
     const uint8_t* source() const { return m_source; }
     size_t length() const { return m_sourceLength; }
+    std::span<const uint8_t> sourceSpan() const { return { m_source, m_sourceLength }; }
     size_t offset() const { return m_offset; }
 
 protected:

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -822,7 +822,7 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
     size_t initExprOffset;
     WASM_FAIL_IF_HELPER_FAILS(parseExtendedConstExpr(source() + initialOffset, length() - initialOffset, initialOffset + m_offsetInSource, initExprOffset, m_info, expectedType));
     m_offset += (initExprOffset - (m_offset - initialOffset));
-    WASM_PARSER_FAIL_IF(!m_info->constantExpressions.tryConstructAndAppend(source() + initialOffset, initExprOffset), "could not allocate memory for init expr");
+    WASM_PARSER_FAIL_IF(!m_info->constantExpressions.tryConstructAndAppend(sourceSpan().subspan(initialOffset, initExprOffset)), "could not allocate memory for init expr");
     bitsOrImportNumber = m_info->constantExpressions.size() - 1;
     isExtendedConstantExpression = true;
     resultType = expectedType;

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -224,7 +224,7 @@ auto StreamingParser::consume(const uint8_t* bytes, size_t bytesSize, size_t& of
     }
 
     if (m_remaining.size() > requiredSize) {
-        Vector<uint8_t> result { m_remaining.data(), requiredSize };
+        auto result = m_remaining.subvector(0, requiredSize);
         m_remaining.remove(0, requiredSize);
         m_nextOffset += requiredSize;
         return result;

--- a/Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py
+++ b/Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py
@@ -569,7 +569,7 @@ class PropertyData:
                 output += codePoint
             else:
                 output += "\\x{:x}".format(ord(codePoint))
-        file.write("{{ const_cast<char32_t*>(U\"{}\"), {}}}".format(output, len(utf32String)))
+        file.write("{{ std::span {{ const_cast<char32_t*>(U\"{}\"), {} }}}}".format(output, len(utf32String)))
 
     def dump(self, file, commaAfter):
         file.write("static std::unique_ptr<CharacterClass> {}()\n{{\n".format(self.getCreateFuncName()))

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		463CCFBC2B251D77009AB04E /* SingleThreadIntegralWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46449E8B2822E5680005A8BC /* WeakHashCountedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4655743627F5FC4A002D5522 /* ASCIILiteralCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */; };
+		466D69112BA4E433005D43F4 /* SpanCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 466D69102BA4E433005D43F4 /* SpanCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46BEB6EB22FFE24900269867 /* RefCounted.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269867 /* RefCounted.cpp */; };
 		46E93049271F1205005BA6E5 /* SafeStrerror.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46E43647271F10AA00C88C90 /* SafeStrerror.cpp */; };
 		50DE35F5215BB01500B979C7 /* ExternalStringImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 50DE35F3215BB01500B979C7 /* ExternalStringImpl.cpp */; };
@@ -1162,6 +1163,7 @@
 		463CCFBB2B251D77009AB04E /* SingleThreadIntegralWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SingleThreadIntegralWrapper.h; sourceTree = "<group>"; };
 		46449E8A2822E5670005A8BC /* WeakHashCountedSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakHashCountedSet.h; sourceTree = "<group>"; };
 		4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCIILiteralCocoa.mm; sourceTree = "<group>"; };
+		466D69102BA4E433005D43F4 /* SpanCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpanCocoa.h; sourceTree = "<group>"; };
 		46BA9EAB1F4CD61E009A2BBC /* CompletionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompletionHandler.h; sourceTree = "<group>"; };
 		46BEB6E922FFDDD500269867 /* RefCounted.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RefCounted.cpp; sourceTree = "<group>"; };
 		46E43646271F10AA00C88C90 /* SafeStrerror.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SafeStrerror.h; sourceTree = "<group>"; };
@@ -2976,6 +2978,7 @@
 				1CA85CA8241B0B260071C2F5 /* RuntimeApplicationChecksCocoa.cpp */,
 				1CA85CA7241B0B110071C2F5 /* RuntimeApplicationChecksCocoa.h */,
 				A30D412C1F0DE0BA00B71954 /* SoftLinking.h */,
+				466D69102BA4E433005D43F4 /* SpanCocoa.h */,
 				EB61EDC62409CCC0001EFE36 /* SystemTracingCocoa.cpp */,
 				4434F91B27948A65007E3E8A /* TollFreeBridging.h */,
 				44CDE4D226EE6CDA009F6ACB /* TypeCastsCocoa.h */,
@@ -3383,6 +3386,7 @@
 				DDF3076727C086CD006A526F /* SoftLinking.h in Headers */,
 				DD3DC8D727A4BF8E007E5B61 /* SoftLinking.h in Headers */,
 				DD3DC91F27A4BF8E007E5B61 /* SortedArrayMap.h in Headers */,
+				466D69112BA4E433005D43F4 /* SpanCocoa.h in Headers */,
 				DD3DC8CD27A4BF8E007E5B61 /* SpanningTree.h in Headers */,
 				DD3DC87727A4BF8E007E5B61 /* Spectrum.h in Headers */,
 				DD3DC97F27A4BF8E007E5B61 /* StackBounds.h in Headers */,

--- a/Source/WTF/wtf/Algorithms.h
+++ b/Source/WTF/wtf/Algorithms.h
@@ -67,6 +67,14 @@ std::span<T> spanReinterpretCast(std::span<U> span)
     return std::span<T> { reinterpret_cast<T*>(const_cast<std::remove_const_t<U>*>(span.data())), span.size_bytes() / sizeof(T) };
 }
 
+template<typename T>
+bool equalSpans(std::span<T> a, std::span<T> b)
+{
+    if (a.size() != b.size())
+        return false;
+    return !memcmp(a.data(), b.data(), a.size() * sizeof(T));
+}
+
 template<typename T, typename U>
 void memcpySpan(std::span<T> destination, std::span<U> source)
 {
@@ -87,5 +95,6 @@ void memsetSpan(std::span<T> destination, uint8_t byte)
 } // namespace WTF
 
 using WTF::spanReinterpretCast;
+using WTF::equalSpans;
 using WTF::memcpySpan;
 using WTF::memsetSpan;

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -31,6 +31,7 @@
 #include <wtf/HexNumber.h>
 #include <wtf/Logging.h>
 #include <wtf/Scope.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -562,7 +563,7 @@ std::optional<Vector<uint8_t>> readEntireFile(const String& path)
     return contents;
 }
 
-int overwriteEntireFile(const String& path, std::span<uint8_t> span)
+int overwriteEntireFile(const String& path, std::span<const uint8_t> span)
 {
     auto fileHandle = FileSystem::openFile(path, FileSystem::FileOpenMode::Truncate);
     auto closeFile = makeScopeExit([&] {
@@ -909,7 +910,7 @@ String createTemporaryDirectory()
 
     std::string newTempDirTemplate = tempDir + "XXXXXXXX";
 
-    Vector<char> newTempDir(newTempDirTemplate.c_str(), newTempDirTemplate.size());
+    Vector<char> newTempDir(std::span<const char> { newTempDirTemplate });
     if (!mkdtemp(newTempDir.data()))
         return String();
 

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -156,7 +156,7 @@ using Salt = std::array<uint8_t, 8>;
 WTF_EXPORT_PRIVATE std::optional<Salt> readOrMakeSalt(const String& path);
 WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> readEntireFile(PlatformFileHandle);
 WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> readEntireFile(const String& path);
-WTF_EXPORT_PRIVATE int overwriteEntireFile(const String& path, std::span<uint8_t>);
+WTF_EXPORT_PRIVATE int overwriteEntireFile(const String& path, std::span<const uint8_t>);
 
 // Prefix is what the filename should be prefixed with, not the full path.
 WTF_EXPORT_PRIVATE std::pair<String, PlatformFileHandle> openTemporaryFile(StringView prefix, StringView suffix = { });

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -28,6 +28,7 @@
 
 #include <cstring>
 #include <memory>
+#include <span>
 #include <type_traits>
 #include <utility>
 #include <variant>

--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -160,9 +160,14 @@ template<typename MapLambdaType> Vector<typename LambdaTypeTraits<MapLambdaType>
     return vector;
 }
 
-inline Vector<uint8_t> vectorFromCFData(CFDataRef data)
+inline std::span<const uint8_t> toSpan(CFDataRef data)
 {
     return { reinterpret_cast<const uint8_t*>(CFDataGetBytePtr(data)), Checked<size_t>(CFDataGetLength(data)) };
+}
+
+inline Vector<uint8_t> toVector(CFDataRef data)
+{
+    return toSpan(data);
 }
 
 // Conversion function implementations. See also StringCF.cpp.
@@ -183,6 +188,6 @@ inline std::optional<float> makeVectorElement(const float*, CFNumberRef cfNumber
 
 using WTF::createCFArray;
 using WTF::makeVector;
-using WTF::vectorFromCFData;
+using WTF::toVector;
 
 #endif // USE(CF)

--- a/Source/WTF/wtf/cocoa/SpanCocoa.h
+++ b/Source/WTF/wtf/cocoa/SpanCocoa.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,33 +23,19 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "ContentExtensionStringSerialization.h"
+#pragma once
 
-#if ENABLE(CONTENT_EXTENSIONS)
+#include <span>
 
-namespace WebCore::ContentExtensions {
+namespace WTF {
 
-String deserializeString(std::span<const uint8_t> span)
+inline std::span<const uint8_t> toSpan(NSData *data)
 {
-    auto serializedLength = *reinterpret_cast<const uint32_t*>(span.data());
-    return String::fromUTF8(span.data() + sizeof(uint32_t), serializedLength - sizeof(uint32_t));
+    if (!data)
+        return { };
+    return { static_cast<const uint8_t*>(data.bytes), data.length };
 }
 
-void serializeString(Vector<uint8_t>& actions, const String& string)
-{
-    auto utf8 = string.utf8();
-    uint32_t serializedLength = sizeof(uint32_t) + utf8.length();
-    actions.reserveCapacity(actions.size() + serializedLength);
-    actions.append(std::span { reinterpret_cast<const uint8_t*>(&serializedLength), sizeof(serializedLength) });
-    actions.append(utf8.bytes());
-}
+} // namespace WTF
 
-size_t stringSerializedLength(std::span<const uint8_t> span)
-{
-    return *reinterpret_cast<const uint32_t*>(span.data());
-}
-
-} // namespace WebCore::ContentExtensions
-
-#endif // ENABLE(CONTENT_EXTENSIONS)
+using WTF::toSpan;

--- a/Source/WTF/wtf/cocoa/VectorCocoa.h
+++ b/Source/WTF/wtf/cocoa/VectorCocoa.h
@@ -30,6 +30,7 @@
 
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
+#include <wtf/cocoa/SpanCocoa.h>
 
 namespace WTF {
 
@@ -112,13 +113,13 @@ template<typename MapFunctionType> Vector<typename std::invoke_result_t<MapFunct
     return vector;
 }
 
-inline Vector<uint8_t> vectorFromNSData(NSData* data)
+inline Vector<uint8_t> toVector(NSData *data)
 {
-    return { reinterpret_cast<const uint8_t*>(data.bytes), data.length };
+    return toSpan(data);
 }
 
 } // namespace WTF
 
 using WTF::createNSArray;
 using WTF::makeVector;
-using WTF::vectorFromNSData;
+using WTF::toVector;

--- a/Source/WTF/wtf/persistence/PersistentEncoder.h
+++ b/Source/WTF/wtf/persistence/PersistentEncoder.h
@@ -71,6 +71,7 @@ public:
 
     const uint8_t* buffer() const { return m_buffer.data(); }
     size_t bufferSize() const { return m_buffer.size(); }
+    std::span<const uint8_t> bytes() const { return m_buffer.span(); }
 
     WTF_EXPORT_PRIVATE static void updateChecksumForData(SHA1&, std::span<const uint8_t>);
     template <typename Type> static void updateChecksumForNumber(SHA1&, Type);

--- a/Source/WTF/wtf/text/IntegerToStringConversion.h
+++ b/Source/WTF/wtf/text/IntegerToStringConversion.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 #include <string>
 #include <wtf/Forward.h>
 #include <wtf/text/LChar.h>
@@ -134,7 +135,8 @@ template<size_t N>
 struct IntegerToStringConversionTrait<Vector<LChar, N>> {
     using ReturnType = Vector<LChar, N>;
     using AdditionalArgumentType = void;
-    static ReturnType flush(LChar* characters, unsigned length, void*) { return { characters, length }; }
+    // FIXME: Should take in a std::span.
+    static ReturnType flush(LChar* characters, unsigned length, void*) { return { std::span { characters, length } }; }
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringParsingBuffer.h
+++ b/Source/WTF/wtf/text/StringParsingBuffer.h
@@ -77,6 +77,14 @@ public:
         return character;
     }
 
+    std::span<const CharacterType> consume(size_t count)
+    {
+        ASSERT(count <= lengthRemaining());
+        std::span result { m_position, count };
+        m_position += count;
+        return result;
+    }
+
     CharacterType operator[](unsigned i) const
     {
         ASSERT(i < lengthRemaining());

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -651,7 +651,7 @@ Vector<char> asciiDebug(StringImpl* impl)
         }
     }
     CString narrowString = buffer.toString().ascii();
-    return { reinterpret_cast<const char*>(narrowString.data()), narrowString.length() + 1 };
+    return { narrowString.bytesInludingNullTerminator() };
 }
 
 Vector<char> asciiDebug(String& string)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -271,7 +271,8 @@ public:
     static String fromUTF8(const char* characters, size_t length) { return fromUTF8(reinterpret_cast<const LChar*>(characters), length); }
     static String fromUTF8(const char* string) { return fromUTF8(reinterpret_cast<const LChar*>(string)); }
     WTF_EXPORT_PRIVATE static String fromUTF8(const CString&);
-    static String fromUTF8(const Vector<LChar>& characters);
+    static String fromUTF8(const std::span<const LChar>& characters);
+    static String fromUTF8(const Vector<LChar>& characters) { return fromUTF8(characters.span()); }
     static String fromUTF8ReplacingInvalidSequences(const LChar*, size_t);
 
     // Tries to convert the passed in string to UTF-8, but will fall back to Latin-1 if the string is not valid UTF-8.
@@ -534,9 +535,9 @@ inline bool codePointCompareLessThan(const String& a, const String& b)
     return codePointCompare(a.impl(), b.impl()) < 0;
 }
 
-inline String String::fromUTF8(const Vector<LChar>& characters)
+inline String String::fromUTF8(const std::span<const LChar>& characters)
 {
-    if (characters.isEmpty())
+    if (characters.empty())
         return emptyString();
     return fromUTF8(characters.data(), characters.size());
 }

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
@@ -47,7 +47,7 @@ FaceDetectorImpl::~FaceDetectorImpl() = default;
 
 static Vector<FloatPoint> convertLandmark(VNFaceLandmarkRegion2D *landmark, const FloatSize& imageSize)
 {
-    return Vector { [landmark pointsInImageOfSize:imageSize], landmark.pointCount }.map([&imageSize](const CGPoint& point) {
+    return Vector(std::span { [landmark pointsInImageOfSize:imageSize], landmark.pointCount }).map([&imageSize](const CGPoint& point) {
         return convertPointFromUnnormalizedVisionToWeb(imageSize, point);
     });
 }

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
@@ -41,8 +41,7 @@ ClipboardItem::~ClipboardItem() = default;
 
 Ref<Blob> ClipboardItem::blobFromString(ScriptExecutionContext* context, const String& stringData, const String& type)
 {
-    auto utf8 = stringData.utf8();
-    return Blob::create(context, Vector { utf8.dataAsUInt8Ptr(), utf8.length() }, Blob::normalizedContentType(type));
+    return Blob::create(context, Vector(stringData.utf8().bytes()), Blob::normalizedContentType(type));
 }
 
 static ClipboardItem::PresentationStyle clipboardItemPresentationStyle(const PasteboardItemInfo& info)

--- a/Source/WebCore/Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
+++ b/Source/WebCore/Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
@@ -30,6 +30,8 @@
 
 #import "Document.h"
 #import "SharedBuffer.h"
+#import <wtf/cocoa/VectorCocoa.h>
+
 #import <pal/ios/UIKitSoftLink.h>
 
 namespace WebCore {
@@ -39,7 +41,7 @@ void ClipboardImageReader::readBuffer(const String&, const String&, Ref<SharedBu
     if (m_mimeType == "image/png"_s) {
         auto image = adoptNS([PAL::allocUIImageInstance() initWithData:buffer->createNSData().get()]);
         if (auto nsData = UIImagePNGRepresentation(image.get()))
-            m_result = Blob::create(m_document.get(), Vector { static_cast<const uint8_t*>(nsData.bytes), nsData.length }, m_mimeType);
+            m_result = Blob::create(m_document.get(), toVector(nsData), m_mimeType);
     }
 }
 

--- a/Source/WebCore/Modules/async-clipboard/mac/ClipboardImageReaderMac.mm
+++ b/Source/WebCore/Modules/async-clipboard/mac/ClipboardImageReaderMac.mm
@@ -30,6 +30,7 @@
 
 #import "Document.h"
 #import "SharedBuffer.h"
+#import <wtf/cocoa/VectorCocoa.h>
 
 namespace WebCore {
 
@@ -40,7 +41,7 @@ void ClipboardImageReader::readBuffer(const String&, const String&, Ref<SharedBu
         if (auto cgImage = [image CGImageForProposedRect:nil context:nil hints:nil]) {
             auto representation = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:cgImage]);
             NSData* nsData = [representation representationUsingType:NSBitmapImageFileTypePNG properties:@{ }];
-            m_result = Blob::create(m_document.get(), Vector { static_cast<const uint8_t*>(nsData.bytes), nsData.length }, m_mimeType);
+            m_result = Blob::create(m_document.get(), toVector(nsData), m_mimeType);
         }
     }
 }

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -138,19 +138,18 @@ FetchBodyConsumer::~FetchBodyConsumer() = default;
 FetchBodyConsumer& FetchBodyConsumer::operator=(FetchBodyConsumer&&) = default;
 
 // https://fetch.spec.whatwg.org/#concept-body-package-data
-RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* context, const String& contentType, const uint8_t* data, size_t length)
+RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* context, const String& contentType, std::span<const uint8_t> data)
 {
     auto parseMultipartPart = [context] (const uint8_t* part, size_t partLength, DOMFormData& form) -> bool {
         const uint8_t* headerEnd = static_cast<const uint8_t*>(memmem(part, partLength, "\r\n\r\n", 4));
         if (!headerEnd)
             return false;
-        const uint8_t* headerBegin = part;
-        size_t headerLength = headerEnd - headerBegin;
+        std::span headerBytes { part, static_cast<size_t>(headerEnd - part) };
 
-        const uint8_t* bodyBegin = headerEnd + strlen("\r\n\r\n");
-        size_t bodyLength = partLength - (bodyBegin - headerBegin);
+        auto* bodyBegin = headerEnd + strlen("\r\n\r\n");
+        std::span body { bodyBegin, partLength - (bodyBegin - headerBytes.data()) };
 
-        String header = String::fromUTF8(headerBegin, headerLength);
+        String header = String::fromUTF8(headerBytes);
 
         constexpr auto contentDispositionCharacters = "content-disposition:"_s;
         size_t contentDispositionBegin = header.findIgnoringASCIICase(contentDispositionCharacters);
@@ -167,7 +166,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
             return false;
         String filename = parameters.get<HashTranslatorASCIILiteral>("filename"_s);
         if (!filename)
-            form.append(name, String::fromUTF8(bodyBegin, bodyLength));
+            form.append(name, String::fromUTF8(body));
         else {
             String contentType = "text/plain"_s;
 
@@ -179,7 +178,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
                 contentType = StringView(header).substring(contentTypeBegin + contentTypePrefixLength, contentTypeEnd - contentTypeBegin - contentTypePrefixLength).trim(isASCIIWhitespaceWithoutFF<UChar>).toString();
             }
 
-            form.append(name, File::create(context, Blob::create(context, Vector { bodyBegin, bodyLength }, Blob::normalizedContentType(contentType)).get(), filename).get(), filename);
+            form.append(name, File::create(context, Blob::create(context, Vector(body), Blob::normalizedContentType(contentType)).get(), filename).get(), filename);
         }
         return true;
     };
@@ -202,17 +201,17 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
         CString boundary = boundaryWithDashes.utf8();
         size_t boundaryLength = boundary.length();
 
-        const uint8_t* currentBoundary = static_cast<const uint8_t*>(memmem(data, length, boundary.data(), boundaryLength));
+        const uint8_t* currentBoundary = static_cast<const uint8_t*>(memmem(data.data(), data.size(), boundary.data(), boundaryLength));
         if (!currentBoundary)
             return nullptr;
-        const uint8_t* nextBoundary = static_cast<const uint8_t*>(memmem(currentBoundary + boundaryLength, length - (currentBoundary + boundaryLength - data), boundary.data(), boundaryLength));
+        const uint8_t* nextBoundary = static_cast<const uint8_t*>(memmem(currentBoundary + boundaryLength, data.size() - (currentBoundary + boundaryLength - data.data()), boundary.data(), boundaryLength));
         while (nextBoundary) {
             parseMultipartPart(currentBoundary + boundaryLength, nextBoundary - currentBoundary - boundaryLength - strlen("\r\n"), form.get());
             currentBoundary = nextBoundary;
-            nextBoundary = static_cast<const uint8_t*>(memmem(nextBoundary + boundaryLength, length - (nextBoundary + boundaryLength - data), boundary.data(), boundaryLength));
+            nextBoundary = static_cast<const uint8_t*>(memmem(nextBoundary + boundaryLength, data.size() - (nextBoundary + boundaryLength - data.data()), boundary.data(), boundaryLength));
         }
     } else if (mimeType && equalLettersIgnoringASCIICase(mimeType->type, "application"_s) && equalLettersIgnoringASCIICase(mimeType->subtype, "x-www-form-urlencoded"_s)) {
-        auto dataString = String::fromUTF8(data, length);
+        auto dataString = String::fromUTF8(data);
         for (auto& pair : WTF::URLParser::parseURLEncodedForm(dataString))
             form->append(pair.key, pair.value);
     } else
@@ -221,27 +220,27 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
     return form;
 }
 
-static void resolveWithTypeAndData(Ref<DeferredPromise>&& promise, FetchBodyConsumer::Type type, const String& contentType, const unsigned char* data, unsigned length)
+static void resolveWithTypeAndData(Ref<DeferredPromise>&& promise, FetchBodyConsumer::Type type, const String& contentType, std::span<const uint8_t> data)
 {
     RefPtr context = promise->scriptExecutionContext();
 
     switch (type) {
     case FetchBodyConsumer::Type::ArrayBuffer:
-        fulfillPromiseWithArrayBuffer(WTFMove(promise), data, length);
+        fulfillPromiseWithArrayBufferFromSpan(WTFMove(promise), data);
         return;
     case FetchBodyConsumer::Type::Blob:
-        promise->resolveCallbackValueWithNewlyCreated<IDLInterface<Blob>>([&data, &length, &contentType](auto& context) {
-            return blobFromData(&context, { data, length }, contentType);
+        promise->resolveCallbackValueWithNewlyCreated<IDLInterface<Blob>>([data, &contentType](auto& context) {
+            return blobFromData(&context, { data }, contentType);
         });
         return;
     case FetchBodyConsumer::Type::JSON:
-        fulfillPromiseWithJSON(WTFMove(promise), TextResourceDecoder::textFromUTF8(data, length));
+        fulfillPromiseWithJSON(WTFMove(promise), TextResourceDecoder::textFromUTF8(data));
         return;
     case FetchBodyConsumer::Type::Text:
-        promise->resolve<IDLDOMString>(TextResourceDecoder::textFromUTF8(data, length));
+        promise->resolve<IDLDOMString>(TextResourceDecoder::textFromUTF8(data));
         return;
     case FetchBodyConsumer::Type::FormData:
-        if (auto formData = FetchBodyConsumer::packageFormData(context.get(), contentType, data, length))
+        if (auto formData = FetchBodyConsumer::packageFormData(context.get(), contentType, data))
             promise->resolve<IDLInterface<DOMFormData>>(*formData);
         else
             promise->reject(ExceptionCode::TypeError);
@@ -264,15 +263,15 @@ void FetchBodyConsumer::clean()
     }
 }
 
-void FetchBodyConsumer::resolveWithData(Ref<DeferredPromise>&& promise, const String& contentType, const unsigned char* data, unsigned length)
+void FetchBodyConsumer::resolveWithData(Ref<DeferredPromise>&& promise, const String& contentType, std::span<const uint8_t> data)
 {
-    resolveWithTypeAndData(WTFMove(promise), m_type, contentType, data, length);
+    resolveWithTypeAndData(WTFMove(promise), m_type, contentType, data);
 }
 
 void FetchBodyConsumer::resolveWithFormData(Ref<DeferredPromise>&& promise, const String& contentType, const FormData& formData, ScriptExecutionContext* context)
 {
     if (auto sharedBuffer = formData.asSharedBuffer()) {
-        resolveWithData(WTFMove(promise), contentType, sharedBuffer->makeContiguous()->data(), sharedBuffer->size());
+        resolveWithData(WTFMove(promise), contentType, sharedBuffer->makeContiguous()->dataAsSpanForContiguousData());
         return;
     }
 
@@ -290,7 +289,7 @@ void FetchBodyConsumer::resolveWithFormData(Ref<DeferredPromise>&& promise, cons
         if (value.empty()) {
             auto protectedPromise = WTFMove(promise);
             auto buffer = builder.takeAsContiguous();
-            resolveWithData(WTFMove(protectedPromise), contentType, buffer->data(), buffer->size());
+            resolveWithData(WTFMove(protectedPromise), contentType, buffer->dataAsSpanForContiguousData());
             return;
         }
 
@@ -349,7 +348,7 @@ void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& co
             if (!chunk) {
                 auto protectedPromise = WTFMove(promise);
                 auto buffer = data.takeAsContiguous();
-                resolveWithTypeAndData(WTFMove(protectedPromise), type, contentType, buffer->data(), buffer->size());
+                resolveWithTypeAndData(WTFMove(protectedPromise), type, contentType, buffer->dataAsSpanForContiguousData());
                 return;
             }
 
@@ -384,7 +383,7 @@ void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& co
         return;
     case FetchBodyConsumer::Type::FormData: {
         auto buffer = takeData();
-        if (auto formData = packageFormData(promise->scriptExecutionContext(), contentType, buffer ? buffer->makeContiguous()->data() : nullptr, buffer ? buffer->size() : 0))
+        if (auto formData = packageFormData(promise->scriptExecutionContext(), contentType, buffer ? buffer->makeContiguous()->dataAsSpanForContiguousData() : std::span<const uint8_t> { }))
             promise->resolve<IDLInterface<DOMFormData>>(*formData);
         else
             promise->reject(ExceptionCode::TypeError);
@@ -439,7 +438,7 @@ String FetchBodyConsumer::takeAsText()
         return String();
 
     auto buffer = m_buffer.takeAsContiguous();
-    auto text = TextResourceDecoder::textFromUTF8(buffer->data(), buffer->size());
+    auto text = TextResourceDecoder::textFromUTF8(buffer->dataAsSpanForContiguousData());
     return text;
 }
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.h
@@ -72,7 +72,7 @@ public:
 
     void extract(ReadableStream&, ReadableStreamToSharedBufferSink::Callback&&);
     void resolve(Ref<DeferredPromise>&&, const String& contentType, FetchBodyOwner*, ReadableStream*);
-    void resolveWithData(Ref<DeferredPromise>&&, const String& contentType, const unsigned char*, unsigned);
+    void resolveWithData(Ref<DeferredPromise>&&, const String& contentType, std::span<const uint8_t>);
     void resolveWithFormData(Ref<DeferredPromise>&&, const String& contentType, const FormData&, ScriptExecutionContext*);
     void consumeFormDataAsStream(const FormData&, FetchBodySource&, ScriptExecutionContext*);
 
@@ -84,7 +84,7 @@ public:
 
     void setAsLoading() { m_isLoading = true; }
 
-    static RefPtr<DOMFormData> packageFormData(ScriptExecutionContext*, const String& contentType, const uint8_t* data, size_t length);
+    static RefPtr<DOMFormData> packageFormData(ScriptExecutionContext*, const String& contentType, std::span<const uint8_t> data);
 
 private:
     Ref<Blob> takeAsBlob(ScriptExecutionContext*, const String& contentType);

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -109,7 +109,7 @@ void FetchBodyOwner::arrayBuffer(Ref<DeferredPromise>&& promise)
     }
 
     if (isBodyNullOrOpaque()) {
-        fulfillPromiseWithArrayBuffer(WTFMove(promise), nullptr, 0);
+        fulfillPromiseWithArrayBufferFromSpan(WTFMove(promise), { });
         return;
     }
     if (isDisturbedOrLocked()) {
@@ -190,7 +190,7 @@ void FetchBodyOwner::formData(Ref<DeferredPromise>&& promise)
     if (isBodyNullOrOpaque()) {
         if (isBodyNull()) {
             // If the content-type is 'application/x-www-form-urlencoded', a body is not required and we should package an empty byte sequence as per the specification.
-            if (auto formData = FetchBodyConsumer::packageFormData(promise->scriptExecutionContext(), contentType(), nullptr, 0)) {
+            if (auto formData = FetchBodyConsumer::packageFormData(promise->scriptExecutionContext(), contentType(), { })) {
                 promise->resolve<IDLInterface<DOMFormData>>(*formData);
                 return;
             }

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -210,7 +210,7 @@ void RTCDataChannel::didReceiveRawData(const uint8_t* data, size_t dataLength)
 {
     switch (m_binaryType) {
     case BinaryType::Blob:
-        scheduleDispatchEvent(MessageEvent::create(Blob::create(scriptExecutionContext(), Vector { data, dataLength }, emptyString()), { }));
+        scheduleDispatchEvent(MessageEvent::create(Blob::create(scriptExecutionContext(), Vector(std::span { data, dataLength }), emptyString()), { }));
         return;
     case BinaryType::Arraybuffer:
         scheduleDispatchEvent(MessageEvent::create(ArrayBuffer::create(data, dataLength)));

--- a/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
@@ -27,6 +27,7 @@
 #import "NotificationData.h"
 
 #import "NotificationDirection.h"
+#import <wtf/cocoa/VectorCocoa.h>
 
 static NSString * const WebNotificationDefaultActionURLKey = @"WebNotificationDefaultActionURLKey";
 static NSString * const WebNotificationTitleKey = @"WebNotificationTitleKey";
@@ -89,7 +90,7 @@ std::optional<NotificationData> NotificationData::fromDictionary(NSDictionary *d
         return std::nullopt;
     }
 
-    NotificationData data { URL { String { defaultActionURL } }, title, body, iconURL, tag, language, direction, originString, URL { String { serviceWorkerRegistrationURL } }, *uuid, contextIdentifier, PAL::SessionID { sessionID.unsignedLongLongValue }, { }, { static_cast<const uint8_t*>(notificationData.bytes), notificationData.length }, nsValueToOptionalBool(dictionary[WebNotificationSilentKey]) };
+    NotificationData data { URL { String { defaultActionURL } }, title, body, iconURL, tag, language, direction, originString, URL { String { serviceWorkerRegistrationURL } }, *uuid, contextIdentifier, PAL::SessionID { sessionID.unsignedLongLongValue }, { }, toVector(notificationData), nsValueToOptionalBool(dictionary[WebNotificationSilentKey]) };
     return WTFMove(data);
 }
 

--- a/Source/WebCore/Modules/push-api/PushEvent.cpp
+++ b/Source/WebCore/Modules/push-api/PushEvent.cpp
@@ -41,14 +41,13 @@ static Vector<uint8_t> dataFromPushMessageDataInit(PushMessageDataInit& data)
     return WTF::switchOn(data, [](RefPtr<JSC::ArrayBuffer>& value) -> Vector<uint8_t> {
         if (!value)
             return { };
-        return { reinterpret_cast<const uint8_t*>(value->data()), value->byteLength() };
+        return value->bytes();
     }, [](RefPtr<JSC::ArrayBufferView>& value) -> Vector<uint8_t> {
         if (!value)
             return { };
-        return { reinterpret_cast<const uint8_t*>(value->baseAddress()), value->byteLength() };
+        return value->bytes();
     }, [](String& value) -> Vector<uint8_t> {
-        auto utf8 = value.utf8();
-        return Vector<uint8_t> { reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length() };
+        return value.utf8().bytes();
     });
 }
 

--- a/Source/WebCore/Modules/push-api/PushManager.cpp
+++ b/Source/WebCore/Modules/push-api/PushManager.cpp
@@ -86,13 +86,9 @@ void PushManager::subscribe(ScriptExecutionContext& context, std::optional<PushS
 
         using KeyDataResult = ExceptionOr<Vector<uint8_t>>;
         auto keyDataResult = WTF::switchOn(*options->applicationServerKey, [](RefPtr<JSC::ArrayBuffer>& value) -> KeyDataResult {
-            if (!value)
-                return Vector<uint8_t> { };
-            return Vector<uint8_t> { reinterpret_cast<const uint8_t*>(value->data()), value->byteLength() };
+            return value ? Vector<uint8_t>(value->bytes()) : Vector<uint8_t>();
         }, [](RefPtr<JSC::ArrayBufferView>& value) -> KeyDataResult {
-            if (!value)
-                return Vector<uint8_t> { };
-            return Vector<uint8_t> { reinterpret_cast<const uint8_t*>(value->baseAddress()), value->byteLength() };
+            return value ? Vector<uint8_t>(value->bytes()) : Vector<uint8_t>();
         }, [](String& value) -> KeyDataResult {
             auto decoded = base64URLDecode(value);
             if (!decoded)

--- a/Source/WebCore/Modules/push-api/PushMessageCrypto.cpp
+++ b/Source/WebCore/Modules/push-api/PushMessageCrypto.cpp
@@ -41,12 +41,12 @@ static constexpr size_t sharedAuthSecretLength = 16;
 
 ClientKeys ClientKeys::generate()
 {
-    uint8_t sharedAuthSecret[sharedAuthSecretLength];
-    cryptographicallyRandomValues(sharedAuthSecret, sizeof(sharedAuthSecret));
+    std::array<uint8_t, sharedAuthSecretLength> sharedAuthSecret;
+    cryptographicallyRandomValues(sharedAuthSecret.data(), sharedAuthSecret.size());
 
     return ClientKeys {
         P256DHKeyPair::generate(),
-        Vector<uint8_t> { sharedAuthSecret, sizeof(sharedAuthSecret) }
+        Vector<uint8_t> { sharedAuthSecret }
     };
 }
 
@@ -295,7 +295,7 @@ std::optional<Vector<uint8_t>> decryptAESGCMPayload(const ClientKeys& clientKeys
     if (paddingLength == SIZE_MAX)
         return std::nullopt;
 
-    return Vector<uint8_t> { plainText.data() + paddingLength, plainText.size() - paddingLength };
+    return plainText.subvector(paddingLength);
 }
 
 } // namespace WebCore::PushCrypto

--- a/Source/WebCore/Modules/push-api/PushMessageData.cpp
+++ b/Source/WebCore/Modules/push-api/PushMessageData.cpp
@@ -64,7 +64,7 @@ ExceptionOr<JSC::JSValue> PushMessageData::json(JSDOMGlobalObject& globalObject)
 
 String PushMessageData::text()
 {
-    return TextResourceDecoder::textFromUTF8(m_data.data(), m_data.size());
+    return TextResourceDecoder::textFromUTF8(m_data.span());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/push-api/cocoa/PushCryptoCocoa.cpp
+++ b/Source/WebCore/Modules/push-api/cocoa/PushCryptoCocoa.cpp
@@ -46,20 +46,20 @@ P256DHKeyPair P256DHKeyPair::generate(void)
     CCCryptorStatus status = CCECCryptorGeneratePair(256, &ccPublicKey, &ccPrivateKey);
     RELEASE_ASSERT(status == kCCSuccess);
 
-    uint8_t publicKey[p256dhPublicKeyLength];
-    size_t publicKeyLength = sizeof(publicKey);
-    status = CCECCryptorExportKey(kCCImportKeyBinary, publicKey, &publicKeyLength, ccECKeyPublic, ccPublicKey);
-    RELEASE_ASSERT(status == kCCSuccess && publicKeyLength == sizeof(publicKey));
+    std::array<uint8_t, p256dhPublicKeyLength> publicKey;
+    size_t publicKeyLength = publicKey.size();
+    status = CCECCryptorExportKey(kCCImportKeyBinary, publicKey.data(), &publicKeyLength, ccECKeyPublic, ccPublicKey);
+    RELEASE_ASSERT(status == kCCSuccess && publicKeyLength == p256dhPublicKeyLength);
 
     // CommonCrypto expects the binary format to be 65 byte public key followed by the 32 byte private key, so we want to extract the last 32 bytes from the buffer.
-    uint8_t key[p256dhPublicKeyLength + p256dhPrivateKeyLength];
-    size_t keyLength = sizeof(key);
-    status = CCECCryptorExportKey(kCCImportKeyBinary, key, &keyLength, ccECKeyPrivate, ccPrivateKey);
-    RELEASE_ASSERT(status == kCCSuccess && keyLength == sizeof(key));
+    std::array<uint8_t, p256dhPublicKeyLength + p256dhPrivateKeyLength> key;
+    size_t keyLength = key.size();
+    status = CCECCryptorExportKey(kCCImportKeyBinary, key.data(), &keyLength, ccECKeyPrivate, ccPrivateKey);
+    RELEASE_ASSERT(status == kCCSuccess && keyLength == key.size());
 
     return P256DHKeyPair {
-        Vector<uint8_t> { publicKey, p256dhPublicKeyLength },
-        Vector<uint8_t> { key + p256dhPublicKeyLength, p256dhPrivateKeyLength }
+        Vector<uint8_t> { publicKey },
+        Vector<uint8_t> { std::span { key }.subspan(p256dhPublicKeyLength, p256dhPrivateKeyLength) }
     };
 }
 

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 
 Vector<uint8_t> convertBytesToVector(const uint8_t byteArray[], const size_t length)
 {
-    return { byteArray, length };
+    return { std::span { byteArray, length } };
 }
 
 Vector<uint8_t> produceRpIdHash(const String& rpId)

--- a/Source/WebCore/Modules/webauthn/cbor/CBORValue.cpp
+++ b/Source/WebCore/Modules/webauthn/cbor/CBORValue.cpp
@@ -103,7 +103,7 @@ CBORValue::CBORValue(BinaryValue&& inBytes)
 
 CBORValue::CBORValue(const WebCore::BufferSource& bufferSource)
     : m_type(Type::ByteString)
-    , m_byteStringValue(bufferSource.data(), bufferSource.length())
+    , m_byteStringValue(bufferSource.bytes())
 {
 }
 

--- a/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp
@@ -78,7 +78,7 @@ std::optional<cbor::CBORValue> decodeResponseMap(const Vector<uint8_t>& inBuffer
     if (inBuffer.size() <= kResponseCodeLength || getResponseCode(inBuffer) != CtapDeviceResponseCode::kSuccess)
         return std::nullopt;
 
-    Vector<uint8_t> buffer { inBuffer.data() + 1, inBuffer.size() - 1 };
+    auto buffer = inBuffer.subvector(1);
     std::optional<CBOR> decodedResponse = cbor::CBORReader::read(buffer);
     if (!decodedResponse || !decodedResponse->isMap())
         return std::nullopt;

--- a/Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp
@@ -67,7 +67,7 @@ std::unique_ptr<FidoHidInitPacket> FidoHidInitPacket::createFromSerializedData(c
     // Update remaining size to determine the payload size of follow on packets.
     *remainingSize = payloadSize - dataSize;
 
-    Vector<uint8_t> data { serialized.begin() + index, dataSize };
+    auto data = serialized.subvector(index, dataSize);
     return makeUnique<FidoHidInitPacket>(channelId, command, WTFMove(data), payloadSize);
 }
 
@@ -120,7 +120,7 @@ std::unique_ptr<FidoHidContinuationPacket> FidoHidContinuationPacket::createFrom
     // Check to see if packet payload is less than maximum size and padded with 0s.
     size_t dataSize = std::min(*remainingSize, kHidPacketSize - index);
     *remainingSize -= dataSize;
-    Vector<uint8_t> data { serialized.begin() + index, dataSize };
+    auto data = serialized.subvector(index, dataSize);
     return makeUnique<FidoHidContinuationPacket>(channelId, sequence, WTFMove(data));
 }
 

--- a/Source/WebCore/Modules/webauthn/fido/Pin.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.cpp
@@ -172,8 +172,8 @@ std::optional<KeyAgreementResponse> KeyAgreementResponse::parseFromCOSE(const CB
 cbor::CBORValue::MapValue encodeCOSEPublicKey(const Vector<uint8_t>& rawPublicKey)
 {
     ASSERT(rawPublicKey.size() == 65);
-    Vector<uint8_t> x { rawPublicKey.data() + 1, ES256FieldElementLength };
-    Vector<uint8_t> y { rawPublicKey.data() + 1 + ES256FieldElementLength, ES256FieldElementLength };
+    auto x = rawPublicKey.subvector(1, ES256FieldElementLength);
+    auto y = rawPublicKey.subvector(1 + ES256FieldElementLength, ES256FieldElementLength);
 
     cbor::CBORValue::MapValue publicKeyMap;
     publicKeyMap[cbor::CBORValue(COSE::kty)] = cbor::CBORValue(COSE::EC2);

--- a/Source/WebCore/Modules/webauthn/fido/U2fResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/U2fResponseConverter.cpp
@@ -64,10 +64,10 @@ static Vector<uint8_t> extractECPublicKeyFromU2fRegistrationResponse(const Vecto
     if (u2fData.size() < pos + 2 * ES256FieldElementLength)
         return { };
 
-    Vector<uint8_t> x { u2fData.data() + pos, ES256FieldElementLength };
+    auto x = u2fData.subvector(pos, ES256FieldElementLength);
     pos += ES256FieldElementLength;
 
-    Vector<uint8_t> y { u2fData.data() + pos, ES256FieldElementLength };
+    auto y = u2fData.subvector(pos, ES256FieldElementLength);
     return encodeES256PublicKeyAsCBOR(WTFMove(x), WTFMove(y));
 }
 
@@ -81,7 +81,7 @@ static Vector<uint8_t> extractCredentialIdFromU2fRegistrationResponse(const Vect
 
     if (u2fData.size() < pos + credentialIdLength)
         return { };
-    return { u2fData.data() + pos, credentialIdLength };
+    return u2fData.subvector(pos, credentialIdLength);
 }
 
 static Vector<uint8_t> createAttestedCredentialDataFromU2fRegisterResponse(const Vector<uint8_t>& u2fData, const Vector<uint8_t>& publicKey)
@@ -119,10 +119,10 @@ static cbor::CBORValue::MapValue createFidoAttestationStatementFromU2fRegisterRe
     if (!x509Length || u2fData.size() < offset + x509Length)
         return { };
 
-    Vector<uint8_t> x509 { u2fData.data() + offset, x509Length };
+    auto x509 = u2fData.subvector(offset, x509Length);
     offset += x509Length;
 
-    Vector<uint8_t> signature { u2fData.data() + offset, u2fData.size() - offset };
+    auto signature = u2fData.subvector(offset);
     if (signature.isEmpty())
         return { };
 
@@ -177,8 +177,8 @@ RefPtr<AuthenticatorAssertionResponse> readU2fSignResponse(const String& rpId, c
     auto authData = buildAuthData(rpId, flags, counter, { });
 
     // FIXME: Find a way to remove the need of constructing a vector here.
-    Vector<uint8_t> signature { u2fData.data() + signatureIndex, u2fData.size() - signatureIndex };
-    Vector<uint8_t> keyHandleVector { keyHandle.data(), keyHandle.length() };
+    auto signature = u2fData.subvector(signatureIndex);
+    Vector<uint8_t> keyHandleVector { keyHandle.bytes() };
     return AuthenticatorAssertionResponse::create(keyHandleVector, authData, signature, { }, attachment);
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
@@ -43,7 +43,7 @@ ExceptionOr<Ref<WebCodecsAudioData>> WebCodecsAudioData::create(ScriptExecutionC
     if (!isValidAudioDataInit(init))
         return Exception { ExceptionCode::TypeError, "Invalid init data"_s };
 
-    auto rawData = init.data.span();
+    auto rawData = init.data.bytes();
     auto data = PlatformRawAudioData::create(WTFMove(rawData), init.format, init.sampleRate, init.timestamp, init.numberOfFrames, init.numberOfChannels);
 
     if (!data)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDataAlgorithms.cpp
@@ -54,8 +54,7 @@ bool isValidAudioDataInit(const WebCodecsAudioData::Init& init)
     if (!WTF::safeMultiply(totalSamples, bytesPerSample, totalSize))
         return false;
 
-    auto dataSize = init.data.span().size();
-    return dataSize >= totalSize;
+    return init.data.length() >= totalSize;
 }
 
 bool isAudioSampleFormatInterleaved(const AudioSampleFormat& format)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 WebCodecsEncodedAudioChunk::WebCodecsEncodedAudioChunk(Init&& init)
-    : m_storage { WebCodecsEncodedAudioChunkStorage::create(init.type, init.timestamp, init.duration, std::span<const uint8_t> { init.data.data(), init.data.length() }) }
+    : m_storage { WebCodecsEncodedAudioChunkStorage::create(init.type, init.timestamp, init.duration, init.data.bytes()) }
 {
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 WebCodecsEncodedVideoChunk::WebCodecsEncodedVideoChunk(Init&& init)
-    : m_storage { WebCodecsEncodedVideoChunkStorage::create(init.type, init.timestamp, init.duration, std::span { init.data.data(), init.data.length() }) }
+    : m_storage { WebCodecsEncodedVideoChunkStorage::create(init.type, init.timestamp, init.duration, init.data.bytes()) }
 {
 }
 

--- a/Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp
+++ b/Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp
@@ -88,7 +88,7 @@ Vector<uint8_t> CryptoDigest::computeHash()
     size_t digestLen = gcry_md_get_algo_dlen(m_context->algorithm);
 
     gcry_md_final(m_context->md);
-    Vector<uint8_t> result { gcry_md_read(m_context->md, 0), digestLen };
+    Vector<uint8_t> result(std::span { gcry_md_read(m_context->md, 0), digestLen });
     gcry_md_close(m_context->md);
 
     return result;
@@ -108,7 +108,7 @@ std::optional<Vector<uint8_t>> CryptoDigest::computeHash(CryptoDigest::Algorithm
 
     gcry_md_write(digest->m_context->md, input.data(), input.size());
     gcry_md_final(digest->m_context->md);
-    Vector<uint8_t> result { gcry_md_read(digest->m_context->md, 0), digestLen };
+    Vector<uint8_t> result(std::span { gcry_md_read(digest->m_context->md, 0), digestLen });
     gcry_md_close(digest->m_context->md);
 
     return result;

--- a/Source/WebCore/PAL/pal/text/TextCodec.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodec.cpp
@@ -27,12 +27,18 @@
 #include "config.h"
 #include "TextCodec.h"
 #include <unicode/uchar.h>
+#include <wtf/text/WTFString.h>
 #include <wtf/unicode/CharacterNames.h>
 
 #include <array>
 #include <cstdio>
 
 namespace PAL {
+
+String TextCodec::decode(std::span<const uint8_t> data, bool flush, bool stopOnError, bool& sawError)
+{
+    return decode(reinterpret_cast<const char*>(data.data()), data.size(), flush, stopOnError, sawError);
+}
 
 int TextCodec::getUnencodableReplacement(char32_t codePoint, UnencodableHandling handling, UnencodableReplacementArray& replacement)
 {

--- a/Source/WebCore/PAL/pal/text/TextCodec.h
+++ b/Source/WebCore/PAL/pal/text/TextCodec.h
@@ -29,6 +29,7 @@
 #include "UnencodableHandling.h"
 #include <array>
 #include <memory>
+#include <span>
 #include <unicode/umachine.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
@@ -46,7 +47,8 @@ public:
     virtual ~TextCodec() = default;
 
     virtual void stripByteOrderMark() { }
-    virtual String decode(const char*, size_t length, bool flush, bool stopOnError, bool& sawError) = 0;
+    virtual String decode(const char*, size_t length, bool flush, bool stopOnError, bool& sawError) = 0; // FIXME: We should drop once all call sites start passing a span.
+    String decode(std::span<const uint8_t> data, bool flush, bool stopOnError, bool& sawError);
 
     virtual Vector<uint8_t> encode(StringView, UnencodableHandling) const = 0;
 

--- a/Source/WebCore/PAL/pal/text/TextEncodingDetector.h
+++ b/Source/WebCore/PAL/pal/text/TextEncodingDetector.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include <span>
+
 namespace PAL {
 
 class TextEncoding;
@@ -38,8 +40,6 @@ class TextEncoding;
 // hintEncodingName, detect the most likely character encoding.
 // The way hintEncodingName is used is up to an implementation.
 // Currently, the only caller sets it to the parent frame encoding.
-bool detectTextEncoding(const char* data, size_t len,
-    const char* hintEncodingName,
-    TextEncoding* detectedEncoding);
+bool detectTextEncoding(std::span<const uint8_t> data, const char* hintEncodingName, TextEncoding* detectedEncoding);
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/text/TextEncodingDetectorICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingDetectorICU.cpp
@@ -37,9 +37,7 @@
 
 namespace PAL {
 
-bool detectTextEncoding(const char* data, size_t len,
-    const char* hintEncodingName,
-    TextEncoding* detectedEncoding)
+bool detectTextEncoding(std::span<const uint8_t> data, const char* hintEncodingName, TextEncoding* detectedEncoding)
 {
     *detectedEncoding = TextEncoding();
     int matchesCount = 0; 
@@ -48,7 +46,7 @@ bool detectTextEncoding(const char* data, size_t len,
     if (U_FAILURE(status))
         return false;
     ucsdet_enableInputFilter(detector, true);
-    ucsdet_setText(detector, data, static_cast<int32_t>(len), &status); 
+    ucsdet_setText(detector, reinterpret_cast<const char*>(data.data()), static_cast<int32_t>(data.size()), &status);
     if (U_FAILURE(status))
         return false;
 

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -46,6 +46,7 @@
 #import "TextCheckerClient.h"
 #import "TextCheckingHelper.h"
 #import "TextDecorationPainter.h"
+#import <wtf/cocoa/SpanCocoa.h>
 
 #if PLATFORM(MAC)
 
@@ -798,7 +799,7 @@ std::span<const uint8_t> AXRemoteFrame::generateRemoteToken() const
     if (auto* parent = parentObject()) {
         // We use the parent's wrapper so that the remote frame acts as a pass through for the remote token bridge.
         NSData *data = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:parent->wrapper()];
-        return std::span(static_cast<const uint8_t*>([data bytes]), [data length]);
+        return toSpan(data);
     }
 
     return std::span<const uint8_t> { };

--- a/Source/WebCore/bindings/js/BufferSource.h
+++ b/Source/WebCore/bindings/js/BufferSource.h
@@ -72,7 +72,7 @@ public:
         }, m_variant);
     }
 
-    std::span<const uint8_t> span() const { return { data(), length() }; }
+    std::span<const uint8_t> bytes() const { return { data(), length() }; }
 
 private:
     VariantType m_variant;

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp
@@ -283,9 +283,9 @@ void fulfillPromiseWithArrayBuffer(Ref<DeferredPromise>&& promise, ArrayBuffer* 
     promise->resolve<IDLInterface<ArrayBuffer>>(*arrayBuffer);
 }
 
-void fulfillPromiseWithArrayBuffer(Ref<DeferredPromise>&& promise, const void* data, size_t length)
+void fulfillPromiseWithArrayBufferFromSpan(Ref<DeferredPromise>&& promise, std::span<const uint8_t> data)
 {
-    fulfillPromiseWithArrayBuffer(WTFMove(promise), ArrayBuffer::tryCreate(data, length).get());
+    fulfillPromiseWithArrayBuffer(WTFMove(promise), ArrayBuffer::tryCreate(data).get());
 }
 
 bool DeferredPromise::handleTerminationExceptionIfNeeded(CatchScope& scope, JSDOMGlobalObject& lexicalGlobalObject)

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -336,7 +336,7 @@ public:
 
 void fulfillPromiseWithJSON(Ref<DeferredPromise>&&, const String&);
 void fulfillPromiseWithArrayBuffer(Ref<DeferredPromise>&&, ArrayBuffer*);
-void fulfillPromiseWithArrayBuffer(Ref<DeferredPromise>&&, const void*, size_t);
+void fulfillPromiseWithArrayBufferFromSpan(Ref<DeferredPromise>&&, std::span<const uint8_t>);
 WEBCORE_EXPORT void rejectPromiseWithExceptionIfAny(JSC::JSGlobalObject&, JSDOMGlobalObject&, JSC::JSPromise&, JSC::CatchScope&);
 
 enum class RejectedPromiseWithTypeErrorCause { NativeGetter, InvalidThis };

--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -48,7 +48,7 @@ static void append(Vector<uint8_t>& vector, size_t length)
 
 static void append(Vector<uint8_t>& vector, const CString& string)
 {
-    vector.append(std::span { reinterpret_cast<const uint8_t*>(string.data()), string.length() });
+    vector.append(string.bytes());
 }
 
 static size_t deserializeLength(std::span<const uint8_t> span, size_t offset)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
@@ -44,7 +44,7 @@ static ExceptionOr<Vector<uint8_t>> signEd25519(const Vector<uint8_t>& sk, size_
 #else
     cced25519_sign(di, newSignature, data.size(), data.data(), pk, sk.data());
 #endif
-    return Vector<uint8_t>(newSignature, 64);
+    return Vector<uint8_t>(std::span { newSignature, 64 });
 }
 
 static ExceptionOr<bool> verifyEd25519(const Vector<uint8_t>& key, size_t keyLengthInBytes, const Vector<uint8_t>& signature, const Vector<uint8_t> data)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
@@ -38,7 +38,7 @@ std::optional<Vector<uint8_t>> CryptoAlgorithmX25519::platformDeriveBits(const C
 #else
     cccurve25519(derivedKey, baseKey.platformKey().data(), publicKey.platformKey().data());
 #endif
-    return Vector<uint8_t>(derivedKey, 32);
+    return Vector<uint8_t>(std::span { derivedKey, 32 });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp
@@ -349,7 +349,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportPkcs8(CryptoAlgorithmIdentifier i
     index += bytesUsedToEncodedLength(keyData[index]) + 1; // Read length, InitialOctet
 
     // KeyBinary = uncompressed point + private key
-    Vector<uint8_t> keyBinary { keyData.data() + index, keyData.size() - index };
+    auto keyBinary = keyData.subvector(index);
     if (!doesUncompressedPointMatchNamedCurve(curve, keyBinary.size()))
         return nullptr;
     keyBinary.append(keyData.data() + privateKeyPos, privateKeySize);

--- a/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
+++ b/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
@@ -255,7 +255,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!serialization)
         return false;
 
-    result = vectorFromNSData(serialization);
+    result = toVector(serialization);
     return true;
 }
 
@@ -276,17 +276,17 @@ bool unwrapSerializedCryptoKey(const Vector<uint8_t>& masterKey, const Vector<ui
     id wrappedKEKObject = [dictionary objectForKey:wrappedKEKKey];
     if (![wrappedKEKObject isKindOfClass:[NSData class]])
         return false;
-    Vector<uint8_t> wrappedKEK = vectorFromNSData(wrappedKEKObject);
+    Vector<uint8_t> wrappedKEK = toVector(wrappedKEKObject);
 
     id encryptedKeyObject = [dictionary objectForKey:encryptedKeyKey];
     if (![encryptedKeyObject isKindOfClass:[NSData class]])
         return false;
-    Vector<uint8_t> encryptedKey = vectorFromNSData(encryptedKeyObject);
+    Vector<uint8_t> encryptedKey = toVector(encryptedKeyObject);
 
     id tagObject = [dictionary objectForKey:tagKey];
     if (![tagObject isKindOfClass:[NSData class]])
         return false;
-    Vector<uint8_t> tag = vectorFromNSData(tagObject);
+    Vector<uint8_t> tag = toVector(tagObject);
     if (tag.size() != 16)
         return false;
 

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
@@ -519,8 +519,8 @@ bool CryptoKeyEC::platformAddFieldElements(JsonWebKey& jwk) const
     if (qMPI) {
         auto q = mpiData(qMPI);
         if (q && q->size() == curveUncompressedPointSize(m_curve)) {
-            jwk.x = base64URLEncodeToString(Vector<uint8_t> { q->data() + 1, uncompressedFieldElementSize });
-            jwk.y = base64URLEncodeToString(Vector<uint8_t> { q->data() + 1 + uncompressedFieldElementSize, uncompressedFieldElementSize });
+            jwk.x = base64URLEncodeToString(q->subvector(1, uncompressedFieldElementSize));
+            jwk.y = base64URLEncodeToString(q->subvector(1 + uncompressedFieldElementSize, uncompressedFieldElementSize));
         }
     }
 

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp
@@ -113,7 +113,7 @@ static std::optional<Vector<uint8_t>> cryptDecrypt(const Vector<uint8_t>& key, c
     int cipherTextLen = cipherText.size() - tagLength;
 
     Vector<uint8_t> plainText(cipherText.size());
-    Vector<uint8_t> tag { cipherText.data() + cipherTextLen, tagLength };
+    auto tag = cipherText.subvector(cipherTextLen, tagLength);
 
     // Create and initialize the context
     if (!(ctx = EvpCipherCtxPtr(EVP_CIPHER_CTX_new())))

--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -60,7 +60,7 @@ bool CSSVariableData::operator==(const CSSVariableData& other) const
 }
 
 CSSVariableData::CSSVariableData(const CSSParserTokenRange& range, const CSSParserContext& context)
-    : m_tokens(range.begin(), range.size())
+    : m_tokens(range.span())
     , m_context(context)
 {
     StringBuilder stringBuilder;

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -99,6 +99,7 @@ public:
     String serialize(CSSParserToken::SerializationMode = CSSParserToken::SerializationMode::Normal) const;
 
     const CSSParserToken* begin() const { return m_first; }
+    std::span<const CSSParserToken> span() const { return std::span { begin(), size() }; }
 
     static CSSParserToken& eofToken();
 

--- a/Source/WebCore/dom/ElementData.cpp
+++ b/Source/WebCore/dom/ElementData.cpp
@@ -144,7 +144,7 @@ UniqueElementData::UniqueElementData(const UniqueElementData& other)
 
 UniqueElementData::UniqueElementData(const ShareableElementData& other)
     : ElementData(other, true)
-    , m_attributeVector(other.m_attributeArray, other.length())
+    , m_attributeVector(std::span { other.m_attributeArray, other.length() })
 {
     // An ShareableElementData should never have a mutable inline StyleProperties attached.
     ASSERT(!other.m_inlineStyle || !other.m_inlineStyle->isMutable());

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -515,8 +515,7 @@ static String sanitizeMarkupWithArchive(LocalFrame& frame, Document& destination
             subframeMainResource.releaseNonNull(), subframeArchive.copyRef() };
         auto subframeMarkup = sanitizeMarkupWithArchive(frame, destinationDocument, subframeContent, MSOListQuirks::Disabled, canShowMIMETypeAsHTML);
 
-        CString utf8 = subframeMarkup.utf8();
-        auto blob = Blob::create(&destinationDocument, Vector { utf8.dataAsUInt8Ptr(), utf8.length() }, type);
+        auto blob = Blob::create(&destinationDocument, Vector(subframeMarkup.utf8().bytes()), type);
 
         String subframeBlobURL = DOMURL::createObjectURL(destinationDocument, blob);
         blobURLMap.set(AtomString { subframeURL.string() }, AtomString { subframeBlobURL });

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -64,7 +64,7 @@ Vector<AtomString> AtomStringVectorReader::consumeSubvector(size_t subvectorSize
         return { };
     auto subvectorIndex = index;
     index += subvectorSize;
-    return { vector.data() + subvectorIndex, subvectorSize };
+    return vector.subvector(subvectorIndex, subvectorSize);
 }
 
 // ----------------------------------------------------------------------------

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
@@ -122,7 +122,7 @@ PAL::TextEncoding HTMLMetaCharsetParser::encodingFromMetaAttributes(std::span<co
     return PAL::TextEncoding();
 }
 
-bool HTMLMetaCharsetParser::checkForMetaCharset(const char* data, size_t length)
+bool HTMLMetaCharsetParser::checkForMetaCharset(std::span<const uint8_t> data)
 {
     if (m_doneChecking)
         return true;
@@ -150,7 +150,7 @@ bool HTMLMetaCharsetParser::checkForMetaCharset(const char* data, size_t length)
     constexpr int bytesToCheckUnconditionally = 1024;
 
     bool ignoredSawErrorFlag;
-    m_input.append(m_codec->decode(data, length, false, false, ignoredSawErrorFlag));
+    m_input.append(m_codec->decode(data, false, false, ignoredSawErrorFlag));
 
     while (auto token = m_tokenizer.nextToken(m_input)) {
         bool isEnd = token->type() == HTMLToken::Type::EndTag;

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.h
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.h
@@ -41,7 +41,7 @@ public:
     HTMLMetaCharsetParser();
 
     // Returns true if done checking, regardless whether an encoding is found.
-    bool checkForMetaCharset(const char*, size_t);
+    bool checkForMetaCharset(std::span<const uint8_t>);
 
     const PAL::TextEncoding& encoding() { return m_encoding; }
 

--- a/Source/WebCore/loader/FormSubmission.cpp
+++ b/Source/WebCore/loader/FormSubmission.cpp
@@ -74,8 +74,7 @@ static void appendMailtoPostFormDataToURL(URL& url, const FormData& data, const 
         body = PAL::decodeURLEscapeSequences(makeStringByReplacingAll(makeStringByReplacingAll(body, '&', "\r\n"_s), '+', ' '));
     }
 
-    Vector<char> bodyData;
-    bodyData.append("body=", 5);
+    Vector<uint8_t> bodyData(std::span { "body=", 5 });
     FormDataBuilder::encodeStringAsFormData(bodyData, body.utf8());
     body = makeStringByReplacingAll(String(bodyData.data(), bodyData.size()), '+', "%20"_s);
 
@@ -223,7 +222,7 @@ Ref<FormSubmission> FormSubmission::create(HTMLFormElement& form, HTMLFormContro
 
     if (isMultiPartForm) {
         formData = FormData::createMultiPart(domFormData);
-        boundary = String::fromLatin1(formData->boundary().data());
+        boundary = String(formData->boundary());
     } else {
         formData = FormData::create(domFormData, attributes.method() == Method::Get ? FormData::EncodingType::FormURLEncoded : FormData::parseEncodingType(encodingType));
         if (copiedAttributes.method() == Method::Post && isMailtoForm) {

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -36,13 +36,13 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-static constexpr bool bytesEqual(const char* p, char b)
+static constexpr bool bytesEqual(const uint8_t* p, uint8_t b)
 {
     return *p == b;
 }
 
 template<typename... T>
-static constexpr bool bytesEqual(const char* p, char b, T... bs)
+static constexpr bool bytesEqual(const uint8_t* p, uint8_t b, T... bs)
 {
     return *p == b && bytesEqual(p + 1, bs...);
 }
@@ -51,7 +51,7 @@ static constexpr bool bytesEqual(const char* p, char b, T... bs)
 // similar functions that operate on UChar, but arguably only the decoder has
 // a reason to process strings of char rather than UChar.
 
-static int find(const char* subject, size_t subjectLength, const char* target)
+static int find(const uint8_t* subject, size_t subjectLength, const char* target)
 {
     size_t targetLength = strlen(target);
     if (targetLength > subjectLength)
@@ -70,7 +70,7 @@ static int find(const char* subject, size_t subjectLength, const char* target)
     return -1;
 }
 
-static PAL::TextEncoding findTextEncoding(const char* encodingName, int length)
+static PAL::TextEncoding findTextEncoding(const uint8_t* encodingName, int length)
 {
     Vector<char, 64> buffer(length + 1);
     memcpy(buffer.data(), encodingName, length);
@@ -81,7 +81,7 @@ static PAL::TextEncoding findTextEncoding(const char* encodingName, int length)
 class KanjiCode {
 public:
     enum Type { ASCII, JIS, EUC, SJIS, UTF16, UTF8 };
-    static enum Type judge(const char* str, int length);
+    static enum Type judge(std::span<const uint8_t>);
     static const int ESC = 0x1b;
     static const unsigned char sjisMap[256];
     static int ISkanji(int code)
@@ -137,30 +137,30 @@ const unsigned char KanjiCode::sjisMap[256] = {
  * Special Thanks to Kenichi Tsuchida
  */
 
-enum KanjiCode::Type KanjiCode::judge(const char* str, int size)
+enum KanjiCode::Type KanjiCode::judge(std::span<const uint8_t> str)
 {
     enum Type code;
-    int i;
+    size_t i;
     int bfr = false;            /* Kana Moji */
     int bfk = 0;                /* EUC Kana */
     int sjis = 0;
     int euc = 0;
 
-    const unsigned char* ptr = reinterpret_cast<const unsigned char*>(str);
+    const uint8_t* ptr = str.data();
 
     code = ASCII;
 
     i = 0;
-    while (i < size) {
-        if (ptr[i] == ESC && (size - i >= 3)) {
-            if (bytesEqual(str + i + 1, '$', 'B')
-                    || bytesEqual(str + i + 1, '(', 'B')
-                    || bytesEqual(str + i + 1, '$', '@')
-                    || bytesEqual(str + i + 1, '(', 'J')) {
+    while (i < str.size()) {
+        if (ptr[i] == ESC && (str.size() - i >= 3)) {
+            if (bytesEqual(str.data() + i + 1, '$', 'B')
+                || bytesEqual(str.data() + i + 1, '(', 'B')
+                || bytesEqual(str.data() + i + 1, '$', '@')
+                || bytesEqual(str.data() + i + 1, '(', 'J')) {
                 code = JIS;
                 goto breakBreak;
             }
-            if (bytesEqual(str + i + 1, '(', 'I') || bytesEqual(str + i + 1, ')', 'I')) {
+            if (bytesEqual(str.data() + i + 1, '(', 'I') || bytesEqual(str.data() + i + 1, ')', 'I')) {
                 code = JIS;
                 i += 3;
             } else {
@@ -188,14 +188,14 @@ enum KanjiCode::Type KanjiCode::judge(const char* str, int size)
                 }
             } else {
                 /* ?? check hiragana or katana ?? */
-                if ((size - i > 1) && (ptr[i] == 0x82) && (0xa0 <= ptr[i + 1])) {
+                if ((str.size() - i > 1) && (ptr[i] == 0x82) && (0xa0 <= ptr[i + 1])) {
                     sjis++;     /* hiragana */
-                } else if ((size - i > 1) && (ptr[i] == 0x83)
+                } else if ((str.size() - i > 1) && (ptr[i] == 0x83)
                          && (0x40 <= ptr[i + 1] && ptr[i + 1] <= 0x9f)) {
                     sjis++;     /* katakana */
-                } else if ((size - i > 1) && (ptr[i] == 0xa4) && (0xa0 <= ptr[i + 1])) {
+                } else if ((str.size() - i > 1) && (ptr[i] == 0xa4) && (0xa0 <= ptr[i + 1])) {
                     euc++;      /* hiragana */
-                } else if ((size - i > 1) && (ptr[i] == 0xa5) && (0xa0 <= ptr[i + 1])) {
+                } else if ((str.size() - i > 1) && (ptr[i] == 0xa5) && (0xa0 <= ptr[i + 1])) {
                     euc++;      /* katakana */
                 }
                 if (bfr) {
@@ -233,7 +233,7 @@ enum KanjiCode::Type KanjiCode::judge(const char* str, int size)
                         bfk = 0;
                     }
                 } else if (0x8e == ptr[i]) {
-                    if (size - i <= 1) {
+                    if (str.size() - i <= 1) {
                         ;
                     } else if (0xa1 <= ptr[i + 1] && ptr[i + 1] <= 0xdf) {
                         /* EUC KANA or SJIS KANJI */
@@ -250,7 +250,7 @@ enum KanjiCode::Type KanjiCode::judge(const char* str, int size)
                 } else if (0x81 <= ptr[i] && ptr[i] <= 0x9f) {
                     /* SJIS only */
                     code = SJIS;
-                    if ((size - i >= 1)
+                    if ((str.size() - i >= 1)
                             && ((0x40 <= ptr[i + 1] && ptr[i + 1] <= 0x7e)
                             || (0x80 <= ptr[i + 1] && ptr[i + 1] <= 0xfc))) {
                         goto breakBreak;
@@ -258,7 +258,7 @@ enum KanjiCode::Type KanjiCode::judge(const char* str, int size)
                 } else if (0xfd <= ptr[i] && ptr[i] <= 0xfe) {
                     /* EUC only */
                     code = EUC;
-                    if ((size - i >= 1)
+                    if ((str.size() - i >= 1)
                             && (0xa1 <= ptr[i + 1] && ptr[i + 1] <= 0xfe)) {
                         goto breakBreak;
                     }
@@ -319,20 +319,20 @@ Ref<TextResourceDecoder> TextResourceDecoder::create(const String& mimeType, con
 
 TextResourceDecoder::~TextResourceDecoder() = default;
 
-static inline bool shouldPrependBOM(const unsigned char* data, unsigned length)
+static inline bool shouldPrependBOM(std::span<const uint8_t> data)
 {
-    if (length < 3)
+    if (data.size() < 3)
         return true;
     return data[0] != 0xef || data[1] != 0xbb || data[2] != 0xbf;
 }
 
 // https://encoding.spec.whatwg.org/#utf-8-decode
-String TextResourceDecoder::textFromUTF8(const unsigned char* data, unsigned length)
+String TextResourceDecoder::textFromUTF8(std::span<const uint8_t> data)
 {
     auto decoder = TextResourceDecoder::create("text/plain"_s, "UTF-8");
-    if (shouldPrependBOM(data, length))
+    if (shouldPrependBOM(data))
         decoder->decode("\xef\xbb\xbf", 3);
-    return decoder->decodeAndFlush(data, length);
+    return decoder->decodeAndFlush(data);
 }
 
 void TextResourceDecoder::setEncoding(const PAL::TextEncoding& encoding, EncodingSource source)
@@ -363,7 +363,7 @@ bool TextResourceDecoder::hasEqualEncodingForCharset(const String& charset) cons
 }
 
 // Returns the position of the encoding string.
-static int findXMLEncoding(const char* str, int len, int& encodingLength)
+static int findXMLEncoding(const uint8_t* str, int len, int& encodingLength)
 {
     int pos = find(str, len, "encoding");
     if (pos == -1)
@@ -402,7 +402,7 @@ static int findXMLEncoding(const char* str, int len, int& encodingLength)
     return pos;
 }
 
-size_t TextResourceDecoder::checkForBOM(const char* data, size_t len)
+size_t TextResourceDecoder::checkForBOM(std::span<const uint8_t> data)
 {
     // Check for UTF-16 or UTF-8 BOM mark at the beginning, which is a sure sign of a Unicode encoding.
     // We let it override even a user-chosen encoding.
@@ -415,9 +415,9 @@ size_t TextResourceDecoder::checkForBOM(const char* data, size_t len)
     size_t bufferLength = m_buffer.size();
 
     size_t buf1Len = bufferLength;
-    size_t buf2Len = len;
-    const unsigned char* buf1 = reinterpret_cast<const unsigned char*>(m_buffer.data());
-    const unsigned char* buf2 = reinterpret_cast<const unsigned char*>(data);
+    size_t buf2Len = data.size();
+    const uint8_t* buf1 = m_buffer.data();
+    const uint8_t* buf2 = data.data();
     unsigned char c1 = buf1Len ? (static_cast<void>(--buf1Len), *buf1++) : buf2Len ? (static_cast<void>(--buf2Len), *buf2++) : 0;
     unsigned char c2 = buf1Len ? (static_cast<void>(--buf1Len), *buf1++) : buf2Len ? (static_cast<void>(--buf2Len), *buf2++) : 0;
     unsigned char c3 = buf1Len ? (static_cast<void>(--buf1Len), *buf1++) : buf2Len ? (static_cast<void>(--buf2Len), *buf2++) : 0;
@@ -439,14 +439,14 @@ size_t TextResourceDecoder::checkForBOM(const char* data, size_t len)
         }
     }
 
-    if (lengthOfBOM || bufferLength + len >= maximumBOMLength)
+    if (lengthOfBOM || bufferLength + data.size() >= maximumBOMLength)
         m_checkedForBOM = true;
 
     ASSERT(lengthOfBOM <= maximumBOMLength);
     return lengthOfBOM;
 }
 
-bool TextResourceDecoder::checkForCSSCharset(const char* data, size_t len, bool& movedDataToBuffer)
+bool TextResourceDecoder::checkForCSSCharset(std::span<const uint8_t> data, bool& movedDataToBuffer)
 {
     if (m_source != DefaultEncoding && m_source != EncodingFromParentFrame) {
         m_checkedForCSSCharset = true;
@@ -454,20 +454,20 @@ bool TextResourceDecoder::checkForCSSCharset(const char* data, size_t len, bool&
     }
 
     size_t oldSize = m_buffer.size();
-    m_buffer.grow(oldSize + len);
-    memcpy(m_buffer.data() + oldSize, data, len);
+    m_buffer.grow(oldSize + data.size());
+    memcpy(m_buffer.data() + oldSize, data.data(), data.size());
 
     movedDataToBuffer = true;
 
     if (m_buffer.size() <= 13) // strlen('@charset "x";') == 13
         return false;
 
-    const char* dataStart = m_buffer.data();
-    const char* dataEnd = dataStart + m_buffer.size();
+    const uint8_t* dataStart = m_buffer.data();
+    const uint8_t* dataEnd = dataStart + m_buffer.size();
 
     if (bytesEqual(dataStart, '@', 'c', 'h', 'a', 'r', 's', 'e', 't', ' ', '"')) {
         dataStart += 10;
-        const char* pos = dataStart;
+        const uint8_t* pos = dataStart;
 
         while (pos < dataEnd && *pos != '"')
             ++pos;
@@ -488,7 +488,7 @@ bool TextResourceDecoder::checkForCSSCharset(const char* data, size_t len, bool&
     return true;
 }
 
-bool TextResourceDecoder::checkForHeadCharset(const char* data, size_t len, bool& movedDataToBuffer)
+bool TextResourceDecoder::checkForHeadCharset(std::span<const uint8_t> data, bool& movedDataToBuffer)
 {
     if (m_source != DefaultEncoding && m_source != EncodingFromParentFrame) {
         m_checkedForHeadCharset = true;
@@ -499,17 +499,17 @@ bool TextResourceDecoder::checkForHeadCharset(const char* data, size_t len, bool
     // through the HTML head several times.
 
     size_t oldSize = m_buffer.size();
-    m_buffer.grow(oldSize + len);
-    memcpy(m_buffer.data() + oldSize, data, len);
+    m_buffer.grow(oldSize + data.size());
+    memcpy(m_buffer.data() + oldSize, data.data(), data.size());
 
     movedDataToBuffer = true;
 
     // Continue with checking for an HTML meta tag if we were already doing so.
     if (m_charsetParser)
-        return checkForMetaCharset(data, len);
+        return checkForMetaCharset(data);
 
-    const char* ptr = m_buffer.data();
-    const char* pEnd = ptr + m_buffer.size();
+    const uint8_t* ptr = m_buffer.data();
+    const uint8_t* pEnd = ptr + m_buffer.size();
 
     // Is there enough data available to check for XML declaration?
     if (m_buffer.size() < 8)
@@ -518,7 +518,7 @@ bool TextResourceDecoder::checkForHeadCharset(const char* data, size_t len, bool
     // Handle XML declaration, which can have encoding in it. This encoding is honored even for HTML documents.
     // It is an error for an XML declaration not to be at the start of an XML document, and it is ignored in HTML documents in such case.
     if (bytesEqual(ptr, '<', '?', 'x', 'm', 'l')) {
-        const char* xmlDeclarationEnd = ptr;
+        const uint8_t* xmlDeclarationEnd = ptr;
         while (xmlDeclarationEnd != pEnd && *xmlDeclarationEnd != '>')
             ++xmlDeclarationEnd;
         if (xmlDeclarationEnd == pEnd)
@@ -542,12 +542,12 @@ bool TextResourceDecoder::checkForHeadCharset(const char* data, size_t len, bool
         return true;
 
     m_charsetParser = makeUnique<HTMLMetaCharsetParser>();
-    return checkForMetaCharset(data, len);
+    return checkForMetaCharset(data);
 }
 
-bool TextResourceDecoder::checkForMetaCharset(const char* data, size_t length)
+bool TextResourceDecoder::checkForMetaCharset(std::span<const uint8_t> data)
 {
-    if (!m_charsetParser->checkForMetaCharset(data, length))
+    if (!m_charsetParser->checkForMetaCharset(data))
         return false;
 
     setEncoding(m_charsetParser->encoding(), EncodingFromMetaTag);
@@ -556,9 +556,9 @@ bool TextResourceDecoder::checkForMetaCharset(const char* data, size_t length)
     return true;
 }
 
-void TextResourceDecoder::detectJapaneseEncoding(const char* data, size_t len)
+void TextResourceDecoder::detectJapaneseEncoding(std::span<const uint8_t> data)
 {
-    switch (KanjiCode::judge(data, len)) {
+    switch (KanjiCode::judge(data)) {
         case KanjiCode::JIS:
             setEncoding("ISO-2022-JP", AutoDetectedEncoding);
             break;
@@ -590,29 +590,29 @@ bool TextResourceDecoder::shouldAutoDetect() const
         && (m_source == DefaultEncoding || (m_source == EncodingFromParentFrame && m_parentFrameAutoDetectedEncoding));
 }
 
-String TextResourceDecoder::decode(const char* data, size_t length)
+String TextResourceDecoder::decode(std::span<const uint8_t> data)
 {
     size_t lengthOfBOM = 0;
     if (!m_checkedForBOM)
-        lengthOfBOM = checkForBOM(data, length);
+        lengthOfBOM = checkForBOM(data);
 
     bool movedDataToBuffer = false;
 
     if (m_contentType == CSS && !m_checkedForCSSCharset)
-        if (!checkForCSSCharset(data, length, movedDataToBuffer))
+        if (!checkForCSSCharset(data, movedDataToBuffer))
             return emptyString();
 
     if ((m_contentType == HTML || m_contentType == XML) && !m_checkedForHeadCharset) // HTML and XML
-        if (!checkForHeadCharset(data, length, movedDataToBuffer))
+        if (!checkForHeadCharset(data, movedDataToBuffer))
             return emptyString();
 
     // FIXME: It is wrong to change the encoding downstream after we have already done some decoding.
     if (shouldAutoDetect()) {
         if (m_encoding.isJapanese())
-            detectJapaneseEncoding(data, length); // FIXME: We should use detectTextEncoding() for all languages.
+            detectJapaneseEncoding(data); // FIXME: We should use detectTextEncoding() for all languages.
         else {
             PAL::TextEncoding detectedEncoding;
-            if (detectTextEncoding(data, length, m_parentFrameAutoDetectedEncoding, &detectedEncoding))
+            if (detectTextEncoding(data, m_parentFrameAutoDetectedEncoding, &detectedEncoding))
                 setEncoding(detectedEncoding, AutoDetectedEncoding);
         }
     }
@@ -623,15 +623,15 @@ String TextResourceDecoder::decode(const char* data, size_t length)
         m_codec = newTextCodec(m_encoding);
 
     if (m_buffer.isEmpty())
-        return m_codec->decode(data + lengthOfBOM, length - lengthOfBOM, false, m_contentType == XML, m_sawError);
+        return m_codec->decode(data.subspan(lengthOfBOM), false, m_contentType == XML, m_sawError);
 
     if (!movedDataToBuffer) {
         size_t oldSize = m_buffer.size();
-        m_buffer.grow(oldSize + length);
-        memcpy(m_buffer.data() + oldSize, data, length);
+        m_buffer.grow(oldSize + data.size());
+        memcpy(m_buffer.data() + oldSize, data.data(), data.size());
     }
 
-    String result = m_codec->decode(m_buffer.data() + lengthOfBOM, m_buffer.size() - lengthOfBOM, false, m_contentType == XML && !m_useLenientXMLDecoding, m_sawError);
+    String result = m_codec->decode(m_buffer.span().subspan(lengthOfBOM), false, m_contentType == XML && !m_useLenientXMLDecoding, m_sawError);
     m_buffer.clear();
     return result;
 }
@@ -644,23 +644,23 @@ String TextResourceDecoder::flush()
     if (m_buffer.size() && shouldAutoDetect()
         && ((!m_checkedForHeadCharset && (m_contentType == HTML || m_contentType == XML)) || (!m_checkedForCSSCharset && (m_contentType == CSS)))) {
         PAL::TextEncoding detectedEncoding;
-        if (detectTextEncoding(m_buffer.data(), m_buffer.size(), m_parentFrameAutoDetectedEncoding, &detectedEncoding))
+        if (detectTextEncoding(m_buffer.span(), m_parentFrameAutoDetectedEncoding, &detectedEncoding))
             setEncoding(detectedEncoding, AutoDetectedEncoding);
     }
 
     if (!m_codec)
         m_codec = newTextCodec(m_encoding);
 
-    String result = m_codec->decode(m_buffer.data(), m_buffer.size(), true, m_contentType == XML && !m_useLenientXMLDecoding, m_sawError);
+    String result = m_codec->decode(m_buffer.span(), true, m_contentType == XML && !m_useLenientXMLDecoding, m_sawError);
     m_buffer.clear();
     m_codec = nullptr;
     m_checkedForBOM = false; // Skip BOM again when re-decoding.
     return result;
 }
 
-String TextResourceDecoder::decodeAndFlush(const char* data, size_t length)
+String TextResourceDecoder::decodeAndFlush(std::span<const uint8_t> data)
 {
-    String decoded = decode(data, length);
+    String decoded = decode(data);
     return decoded + flush();
 }
 

--- a/Source/WebCore/loader/TextResourceDecoder.h
+++ b/Source/WebCore/loader/TextResourceDecoder.h
@@ -48,7 +48,7 @@ public:
     WEBCORE_EXPORT static Ref<TextResourceDecoder> create(const String& mimeType, const PAL::TextEncoding& defaultEncoding = { }, bool usesEncodingDetector = false);
     WEBCORE_EXPORT ~TextResourceDecoder();
 
-    static String textFromUTF8(const unsigned char* data, unsigned length);
+    static String textFromUTF8(std::span<const uint8_t>);
 
     void setEncoding(const PAL::TextEncoding&, EncodingSource);
     const PAL::TextEncoding& encoding() const { return m_encoding; }
@@ -56,12 +56,14 @@ public:
 
     bool hasEqualEncodingForCharset(const String& charset) const;
 
-    WEBCORE_EXPORT String decode(const char* data, size_t length);
-    String decode(const uint8_t* data, size_t length) { return decode(reinterpret_cast<const char*>(data), length); }
+    WEBCORE_EXPORT String decode(std::span<const uint8_t>);
+    String decode(const char* data, size_t length) { return decode(std::span { reinterpret_cast<const uint8_t*>(data), length }); }
+    String decode(const uint8_t* data, size_t length) { return decode(std::span { data, length }); }
     WEBCORE_EXPORT String flush();
 
-    WEBCORE_EXPORT String decodeAndFlush(const char* data, size_t length);
-    String decodeAndFlush(const uint8_t* data, size_t length) { return decodeAndFlush(reinterpret_cast<const char*>(data), length); }
+    WEBCORE_EXPORT String decodeAndFlush(std::span<const uint8_t>);
+    String decodeAndFlush(const char* data, size_t length) { return decodeAndFlush(std::span { reinterpret_cast<const uint8_t*>(data), length }); }
+    String decodeAndFlush(const uint8_t* data, size_t length) { return decodeAndFlush(std::span { data, length }); }
 
     void setHintEncoding(const TextResourceDecoder* parentFrameDecoder);
    
@@ -77,11 +79,11 @@ private:
     static ContentType determineContentType(const String& mimeType);
     static const PAL::TextEncoding& defaultEncoding(ContentType, const PAL::TextEncoding& defaultEncoding);
 
-    size_t checkForBOM(const char*, size_t);
-    bool checkForCSSCharset(const char*, size_t, bool& movedDataToBuffer);
-    bool checkForHeadCharset(const char*, size_t, bool& movedDataToBuffer);
-    bool checkForMetaCharset(const char*, size_t);
-    void detectJapaneseEncoding(const char*, size_t);
+    size_t checkForBOM(std::span<const uint8_t>);
+    bool checkForCSSCharset(std::span<const uint8_t>, bool& movedDataToBuffer);
+    bool checkForHeadCharset(std::span<const uint8_t>, bool& movedDataToBuffer);
+    bool checkForMetaCharset(std::span<const uint8_t>);
+    void detectJapaneseEncoding(std::span<const uint8_t>);
     bool shouldAutoDetect() const;
 
     ContentType m_contentType;
@@ -90,7 +92,7 @@ private:
     std::unique_ptr<HTMLMetaCharsetParser> m_charsetParser;
     EncodingSource m_source { DefaultEncoding };
     const char* m_parentFrameAutoDetectedEncoding { nullptr };
-    Vector<char> m_buffer;
+    Vector<uint8_t> m_buffer;
     bool m_checkedForBOM { false };
     bool m_checkedForCSSCharset { false };
     bool m_checkedForHeadCharset { false };

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -275,11 +275,11 @@ void FragmentedSharedBuffer::append(const FragmentedSharedBuffer& data)
     ASSERT(internallyConsistent());
 }
 
-void FragmentedSharedBuffer::append(const uint8_t* data, size_t length)
+void FragmentedSharedBuffer::append(std::span<const uint8_t> data)
 {
     ASSERT(!m_contiguous);
-    m_segments.append({ m_size, DataSegment::create(Vector { data, length }) });
-    m_size += length;
+    m_segments.append({ m_size, DataSegment::create(data) });
+    m_size += data.size();
     ASSERT(internallyConsistent());
 }
 

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -79,6 +79,7 @@ class DataSegment : public ThreadSafeRefCounted<DataSegment> {
 public:
     WEBCORE_EXPORT const uint8_t* data() const;
     WEBCORE_EXPORT size_t size() const;
+    std::span<const uint8_t> bytes() const { return std::span { data(), size() }; }
 
     WEBCORE_EXPORT static Ref<DataSegment> create(Vector<uint8_t>&&);
 
@@ -265,8 +266,8 @@ protected:
 private:
     friend class SharedBufferBuilder;
     WEBCORE_EXPORT void append(const FragmentedSharedBuffer&);
-    WEBCORE_EXPORT void append(const uint8_t*, size_t);
-    void append(std::span<const uint8_t> value) { append(value.data(), value.size()); }
+    WEBCORE_EXPORT void append(std::span<const uint8_t>);
+    void append(const uint8_t* data, size_t length) { append(std::span { data, length }); } // FIXME: Call sites should pass in a span.
     void append(const char* data, size_t length) { append(reinterpret_cast<const uint8_t*>(data), length); }
     WEBCORE_EXPORT void append(Vector<uint8_t>&&);
 #if USE(FOUNDATION)

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -89,8 +89,7 @@ RefPtr<PlatformRawAudioData> PlatformRawAudioData::create(std::span<const uint8_
     auto caps = adoptGRef(gst_audio_info_to_caps(&info));
     GST_TRACE("Creating raw audio wrapper with caps %" GST_PTR_FORMAT, caps.get());
 
-    Vector<uint8_t> dataStorage { sourceData.data(), sourceData.size() };
-    auto data = SharedBuffer::create(WTFMove(dataStorage));
+    Ref data = SharedBuffer::create(Vector<uint8_t>(sourceData));
     gpointer bufferData = const_cast<void*>(static_cast<const void*>(data->data()));
     auto bufferLength = data->size();
     auto buffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, bufferData, bufferLength, 0, bufferLength, reinterpret_cast<gpointer>(&data.leakRef()), [](gpointer data) {

--- a/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
@@ -35,6 +35,7 @@
 #import <pal/spi/cocoa/WebFilterEvaluatorSPI.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/CString.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -86,7 +87,7 @@ Vector<uint8_t> ContentFilterUnblockHandler::webFilterEvaluatorData() const
 {
     NSError *error { nil };
     NSData *data = [NSKeyedArchiver archivedDataWithRootObject:m_webFilterEvaluator.get() requiringSecureCoding:YES error:&error];
-    return { static_cast<const uint8_t*>(data.bytes), data.length };
+    return toVector(data);
 }
 
 RetainPtr<WebFilterEvaluator> ContentFilterUnblockHandler::unpackWebFilterEvaluatorData(Vector<uint8_t>&& vector)

--- a/Source/WebCore/platform/graphics/DecomposedGlyphs.cpp
+++ b/Source/WebCore/platform/graphics/DecomposedGlyphs.cpp
@@ -30,7 +30,7 @@ namespace WebCore {
 
 Ref<DecomposedGlyphs> DecomposedGlyphs::create(const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode mode, RenderingResourceIdentifier renderingResourceIdentifier)
 {
-    return adoptRef(*new DecomposedGlyphs({ { glyphs, count }, { advances, count }, localAnchor, mode }, renderingResourceIdentifier));
+    return adoptRef(*new DecomposedGlyphs({ Vector(std::span { glyphs, count }), Vector(std::span { advances, count }), localAnchor, mode }, renderingResourceIdentifier));
 }
 
 Ref<DecomposedGlyphs> DecomposedGlyphs::create(PositionedGlyphs&& positionedGlyphs, RenderingResourceIdentifier renderingResourceIdentifier)

--- a/Source/WebCore/platform/graphics/ImageBackingStore.h
+++ b/Source/WebCore/platform/graphics/ImageBackingStore.h
@@ -205,7 +205,7 @@ private:
         , m_premultiplyAlpha(other.m_premultiplyAlpha)
     {
         ASSERT(!m_size.isEmpty() && !isOverSize(m_size));
-        Vector<uint8_t> buffer { other.m_pixels->data(), other.m_pixels->size() };
+        Vector<uint8_t> buffer(other.m_pixels->bytes());
         m_pixels = FragmentedSharedBuffer::DataSegment::create(WTFMove(buffer));
         m_pixelsPtr = reinterpret_cast<uint32_t*>(const_cast<uint8_t*>(m_pixels->data()));
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2150,7 +2150,7 @@ bool MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource(AVAssetR
         auto keyURIArray = Uint16Array::create(initDataBuffer.copyRef(), 4, keyURI.length());
         keyURIArray->setRange(reinterpret_cast<const UniChar*>(StringView(keyURI).upconvertedCharacters().get()), keyURI.length() / sizeof(unsigned char), 0);
 
-        auto initData = SharedBuffer::create(Vector<uint8_t> { static_cast<uint8_t*>(initDataBuffer->data()), byteLength });
+        Ref initData = SharedBuffer::create(initDataBuffer->toVector());
         player->keyNeeded(initData);
 #if ENABLE(ENCRYPTED_MEDIA)
         if (!m_shouldContinueAfterKeyNeeded)

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
@@ -103,7 +103,7 @@ Vector<uint8_t> encodeData(cairo_surface_t* image, const String& mimeType, std::
     if (!encodeImage(image, mimeType, quality, buffer, bufferSize))
         return { };
 
-    return { reinterpret_cast<const uint8_t*>(buffer.get()), bufferSize };
+    return std::span { reinterpret_cast<const uint8_t*>(buffer.get()), bufferSize };
 }
 #endif // !PLATFORM(GTK)
 

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
@@ -330,7 +330,7 @@ bool parseOpusPrivateData(size_t codecPrivateSize, const uint8_t* codecPrivateDa
 static Vector<uint8_t> cookieFromOpusCookieContents(const OpusCookieContents& cookie)
 {
 #if HAVE(AUDIOFORMATPROPERTY_VARIABLEPACKET_SUPPORTED)
-    return { cookie.cookieData->data(), cookie.cookieData->size() };
+    return { cookie.cookieData->dataAsSpanForContiguousData() };
 #else
     auto samplesPerPacket = cookie.framesPerPacket * (cookie.frameDuration.seconds() * cookie.sampleRate);
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -296,7 +296,7 @@ DrawGlyphs::DrawGlyphs(RenderingResourceIdentifier fontIdentifier, PositionedGly
 
 DrawGlyphs::DrawGlyphs(const Font& font, const GlyphBufferGlyph* glyphs, const GlyphBufferAdvance* advances, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode smoothingMode)
     : m_fontIdentifier(font.renderingResourceIdentifier())
-    , m_positionedGlyphs { { glyphs, count }, { advances, count }, localAnchor, smoothingMode }
+    , m_positionedGlyphs { Vector(std::span { glyphs, count }), Vector(std::span { advances, count }), localAnchor, smoothingMode }
 {
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -623,7 +623,7 @@ void connectSimpleBusMessageCallback(GstElement* pipeline, Function<void(GstMess
 template<>
 Vector<uint8_t> GstMappedBuffer::createVector() const
 {
-    return { data(), size() };
+    return std::span<const uint8_t> { data(), size() };
 }
 
 Ref<SharedBuffer> GstMappedOwnedBuffer::createSharedBuffer()

--- a/Source/WebCore/platform/graphics/iso/ISOBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOBox.cpp
@@ -98,7 +98,7 @@ bool ISOBox::parse(DataView& view, unsigned& offset)
         if (!checkedRead<ExtendedType>(extendedTypeStruct, view, offset, BigEndian))
             return false;
 
-        m_extendedType = Vector<uint8_t>(extendedTypeStruct.value, std::size(extendedTypeStruct.value));
+        m_extendedType = Vector<uint8_t>(std::span { extendedTypeStruct.value });
     }
 
     return true;

--- a/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp
@@ -123,7 +123,7 @@ Vector<uint8_t> encodeData(SkImage* image, const String& mimeType, std::optional
         if (!data)
             return { };
 
-        return { reinterpret_cast<const uint8_t*>(data->data()), data->size() };
+        return std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(data->data()), data->size() };
     }
 
     SkPixmap pixmap;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp
@@ -97,7 +97,7 @@ void MediaRecorderPrivateMock::fetchData(FetchDataCallback&& completionHandler)
     RefPtr<FragmentedSharedBuffer> buffer;
     {
         Locker locker { m_bufferLock };
-        Vector<uint8_t> value { m_buffer.characters8(), m_buffer.length() };
+        Vector<uint8_t> value(m_buffer.span<uint8_t>());
         m_buffer.clear();
         buffer = SharedBuffer::create(WTFMove(value));
     }

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -50,6 +50,7 @@
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <wtf/Scope.h>
 #import <wtf/WorkQueue.h>
+#include <wtf/cocoa/VectorCocoa.h>
 
 #import "CoreVideoSoftLink.h"
 #import <pal/cocoa/AVFoundationSoftLink.h>
@@ -1151,7 +1152,7 @@ void AVVideoCaptureSource::captureOutputDidFinishProcessingPhoto(RetainPtr<AVCap
     }
 
     NSData* data = [photo fileDataRepresentation];
-    resolvePendingPhotoRequest({ static_cast<const uint8_t*>(data.bytes), data.length }, "image/jpeg"_s);
+    resolvePendingPhotoRequest(toVector(data), "image/jpeg"_s);
 }
 
 void AVVideoCaptureSource::captureSessionIsRunningDidChange(bool state)

--- a/Source/WebCore/platform/network/FormData.h
+++ b/Source/WebCore/platform/network/FormData.h
@@ -124,11 +124,10 @@ public:
     };
 
     WEBCORE_EXPORT static Ref<FormData> create();
-    WEBCORE_EXPORT static Ref<FormData> create(const void*, size_t);
+    WEBCORE_EXPORT static Ref<FormData> create(std::span<const uint8_t>);
     WEBCORE_EXPORT static Ref<FormData> create(const CString&);
     WEBCORE_EXPORT static Ref<FormData> create(Vector<uint8_t>&&);
-    WEBCORE_EXPORT static Ref<FormData> create(Vector<WebCore::FormDataElement>&&, uint64_t identifier, bool alwaysStream, Vector<char>&& boundary);
-    static Ref<FormData> create(const Vector<char>&);
+    WEBCORE_EXPORT static Ref<FormData> create(Vector<WebCore::FormDataElement>&&, uint64_t identifier, bool alwaysStream, Vector<uint8_t>&& boundary);
     static Ref<FormData> create(const Vector<uint8_t>&);
     static Ref<FormData> create(const DOMFormData&, EncodingType = EncodingType::FormURLEncoded);
     static Ref<FormData> createMultiPart(const DOMFormData&);
@@ -139,7 +138,7 @@ public:
     Ref<FormData> copy() const;
     WEBCORE_EXPORT Ref<FormData> isolatedCopy() const;
 
-    WEBCORE_EXPORT void appendData(const void* data, size_t);
+    WEBCORE_EXPORT void appendData(std::span<const uint8_t> data);
     void appendFile(const String& filePath);
     WEBCORE_EXPORT void appendFileRange(const String& filename, long long start, long long length, std::optional<WallTime> expectedModificationTime);
     WEBCORE_EXPORT void appendBlob(const URL& blobURL);
@@ -156,7 +155,7 @@ public:
 
     bool isEmpty() const { return m_elements.isEmpty(); }
     const Vector<FormDataElement>& elements() const { return m_elements; }
-    const Vector<char>& boundary() const { return m_boundary; }
+    const Vector<uint8_t>& boundary() const { return m_boundary; }
 
     WEBCORE_EXPORT RefPtr<SharedBuffer> asSharedBuffer() const;
 
@@ -188,8 +187,8 @@ private:
     FormData() = default;
     FormData(const FormData&);
 
-    void appendMultiPartFileValue(const File&, Vector<char>& header, PAL::TextEncoding&);
-    void appendMultiPartStringValue(const String&, Vector<char>& header, PAL::TextEncoding&);
+    void appendMultiPartFileValue(const File&, Vector<uint8_t>& header, PAL::TextEncoding&);
+    void appendMultiPartStringValue(const String&, Vector<uint8_t>& header, PAL::TextEncoding&);
     void appendMultiPartKeyValuePairItems(const DOMFormData&);
     void appendNonMultiPartKeyValuePairItems(const DOMFormData&, EncodingType);
 
@@ -197,7 +196,7 @@ private:
 
     int64_t m_identifier { 0 };
     bool m_alwaysStream { false };
-    Vector<char> m_boundary;
+    Vector<uint8_t> m_boundary;
     mutable std::optional<uint64_t> m_lengthInBytes;
 };
 

--- a/Source/WebCore/platform/network/FormDataBuilder.cpp
+++ b/Source/WebCore/platform/network/FormDataBuilder.cpp
@@ -38,27 +38,32 @@ namespace WebCore {
 
 namespace FormDataBuilder {
 
-static inline void append(Vector<char>& buffer, char string)
+static inline void append(Vector<uint8_t>& buffer, char string)
 {
     buffer.append(string);
 }
 
-static inline void append(Vector<char>& buffer, const char* string)
+static inline void append(Vector<uint8_t>& buffer, std::span<const uint8_t> bytes)
+{
+    buffer.append(bytes);
+}
+
+static inline void append(Vector<uint8_t>& buffer, const char* string)
 {
     buffer.append(string, strlen(string));
 }
 
-static inline void append(Vector<char>& buffer, const CString& string)
+static inline void append(Vector<uint8_t>& buffer, const CString& string)
 {
-    buffer.append(string.data(), string.length());
+    buffer.append(string.bytes());
 }
 
-static inline void append(Vector<char>& buffer, const Vector<uint8_t>& string)
+static inline void append(Vector<uint8_t>& buffer, const Vector<uint8_t>& string)
 {
     buffer.appendVector(string);
 }
 
-static void appendQuoted(Vector<char>& buffer, const Vector<uint8_t>& string)
+static void appendQuoted(Vector<uint8_t>& buffer, const Vector<uint8_t>& string)
 {
     // Append a string as a quoted value, escaping quotes and line breaks.
     // FIXME: Is it correct to use percent escaping here? When this code was originally written,
@@ -85,7 +90,7 @@ static void appendQuoted(Vector<char>& buffer, const Vector<uint8_t>& string)
 }
 
 // https://url.spec.whatwg.org/#concept-urlencoded-byte-serializer
-static void appendFormURLEncoded(Vector<char>& buffer, const uint8_t* string, size_t length)
+static void appendFormURLEncoded(Vector<uint8_t>& buffer, const uint8_t* string, size_t length)
 {
     static const char safeCharacters[] = "-._*";
     for (size_t i = 0; i < length; ++i) {
@@ -106,14 +111,14 @@ static void appendFormURLEncoded(Vector<char>& buffer, const uint8_t* string, si
     }
 }
 
-static void appendFormURLEncoded(Vector<char>& buffer, const Vector<uint8_t>& string)
+static void appendFormURLEncoded(Vector<uint8_t>& buffer, const Vector<uint8_t>& string)
 {
     appendFormURLEncoded(buffer, string.data(), string.size());
 }
 
-Vector<char> generateUniqueBoundaryString()
+Vector<uint8_t> generateUniqueBoundaryString()
 {
-    Vector<char> boundary;
+    Vector<uint8_t> boundary;
 
     // The RFC 2046 spec says the alphanumeric characters plus the
     // following characters are legal for boundaries:  '()+_,-./:=?
@@ -145,11 +150,10 @@ Vector<char> generateUniqueBoundaryString()
         boundary.append(alphaNumericEncodingMap[randomness & 0x3F]);
     }
 
-    boundary.append(0); // Add a 0 at the end so we can use this as a C-style string.
     return boundary;
 }
 
-void beginMultiPartHeader(Vector<char>& buffer, const CString& boundary, const Vector<uint8_t>& name)
+void beginMultiPartHeader(Vector<uint8_t>& buffer, std::span<const uint8_t> boundary, const Vector<uint8_t>& name)
 {
     addBoundaryToMultiPartHeader(buffer, boundary);
 
@@ -160,7 +164,7 @@ void beginMultiPartHeader(Vector<char>& buffer, const CString& boundary, const V
     append(buffer, '"');
 }
 
-void addBoundaryToMultiPartHeader(Vector<char>& buffer, const CString& boundary, bool isLastBoundary)
+void addBoundaryToMultiPartHeader(Vector<uint8_t>& buffer, std::span<const uint8_t> boundary, bool isLastBoundary)
 {
     append(buffer, "--");
     append(buffer, boundary);
@@ -171,26 +175,26 @@ void addBoundaryToMultiPartHeader(Vector<char>& buffer, const CString& boundary,
     append(buffer, "\r\n");
 }
 
-void addFilenameToMultiPartHeader(Vector<char>& buffer, const PAL::TextEncoding& encoding, const String& filename)
+void addFilenameToMultiPartHeader(Vector<uint8_t>& buffer, const PAL::TextEncoding& encoding, const String& filename)
 {
     append(buffer, "; filename=\"");
     appendQuoted(buffer, encoding.encode(filename, PAL::UnencodableHandling::Entities));
     append(buffer, '"');
 }
 
-void addContentTypeToMultiPartHeader(Vector<char>& buffer, const CString& mimeType)
+void addContentTypeToMultiPartHeader(Vector<uint8_t>& buffer, const CString& mimeType)
 {
     ASSERT(Blob::isNormalizedContentType(mimeType));
     append(buffer, "\r\nContent-Type: ");
     append(buffer, mimeType);
 }
 
-void finishMultiPartHeader(Vector<char>& buffer)
+void finishMultiPartHeader(Vector<uint8_t>& buffer)
 {
     append(buffer, "\r\n\r\n");
 }
 
-void addKeyValuePairAsFormData(Vector<char>& buffer, const Vector<uint8_t>& key, const Vector<uint8_t>& value, FormData::EncodingType encodingType)
+void addKeyValuePairAsFormData(Vector<uint8_t>& buffer, const Vector<uint8_t>& key, const Vector<uint8_t>& value, FormData::EncodingType encodingType)
 {
     if (encodingType == FormData::EncodingType::TextPlain) {
         append(buffer, key);
@@ -206,7 +210,7 @@ void addKeyValuePairAsFormData(Vector<char>& buffer, const Vector<uint8_t>& key,
     }
 }
 
-void encodeStringAsFormData(Vector<char>& buffer, const CString& string)
+void encodeStringAsFormData(Vector<uint8_t>& buffer, const CString& string)
 {
     appendFormURLEncoded(buffer, string.dataAsUInt8Ptr(), string.length());
 }

--- a/Source/WebCore/platform/network/FormDataBuilder.h
+++ b/Source/WebCore/platform/network/FormDataBuilder.h
@@ -33,16 +33,16 @@ namespace WebCore {
 namespace FormDataBuilder {
 
 // Helper functions used by HTMLFormElement for multi-part form data.
-Vector<char> generateUniqueBoundaryString();
-void beginMultiPartHeader(Vector<char>&, const CString& boundary, const Vector<uint8_t>& name);
-void addBoundaryToMultiPartHeader(Vector<char>&, const CString& boundary, bool isLastBoundary = false);
-void addFilenameToMultiPartHeader(Vector<char>&, const PAL::TextEncoding&, const String& filename);
-void addContentTypeToMultiPartHeader(Vector<char>&, const CString& mimeType);
-void finishMultiPartHeader(Vector<char>&);
+Vector<uint8_t> generateUniqueBoundaryString();
+void beginMultiPartHeader(Vector<uint8_t>&, std::span<const uint8_t> boundary, const Vector<uint8_t>& name);
+void addBoundaryToMultiPartHeader(Vector<uint8_t>&, std::span<const uint8_t> boundary, bool isLastBoundary = false);
+void addFilenameToMultiPartHeader(Vector<uint8_t>&, const PAL::TextEncoding&, const String& filename);
+void addContentTypeToMultiPartHeader(Vector<uint8_t>&, const CString& mimeType);
+void finishMultiPartHeader(Vector<uint8_t>&);
 
 // Helper functions used by HTMLFormElement for non-multi-part form data.
-void addKeyValuePairAsFormData(Vector<char>&, const Vector<uint8_t>& key, const Vector<uint8_t>& value, FormData::EncodingType = FormData::EncodingType::FormURLEncoded);
-void encodeStringAsFormData(Vector<char>&, const CString&);
+void addKeyValuePairAsFormData(Vector<uint8_t>&, const Vector<uint8_t>& key, const Vector<uint8_t>& value, FormData::EncodingType = FormData::EncodingType::FormURLEncoded);
+void encodeStringAsFormData(Vector<uint8_t>&, const CString&);
 
 }
 

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -37,6 +37,7 @@
 #import <Foundation/NSURLRequest.h>
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/FileSystem.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/CString.h>
 
@@ -210,7 +211,7 @@ void ResourceRequest::doUpdateResourceRequest()
 void ResourceRequest::doUpdateResourceHTTPBody()
 {
     if (NSData* bodyData = [m_nsRequest HTTPBody])
-        m_httpBody = FormData::create([bodyData bytes], [bodyData length]);
+        m_httpBody = FormData::create(toSpan(bodyData));
     else if (NSInputStream* bodyStream = [m_nsRequest HTTPBodyStream]) {
         FormData* formData = httpBodyFromStream(bodyStream);
         // There is no FormData object if a client provided a custom data stream.

--- a/Source/WebCore/platform/network/curl/OpenSSLHelper.cpp
+++ b/Source/WebCore/platform/network/curl/OpenSSLHelper.cpp
@@ -124,7 +124,7 @@ public:
         if (length < 0)
             return std::nullopt;
 
-        return Vector { data, static_cast<size_t>(length) };
+        return Vector(std::span<const uint8_t> { data, static_cast<size_t>(length) });
     }
 
     String getDataAsString() const

--- a/Source/WebCore/platform/sql/SQLiteStatement.cpp
+++ b/Source/WebCore/platform/sql/SQLiteStatement.cpp
@@ -288,8 +288,7 @@ String SQLiteStatement::columnBlobAsString(int col)
 
 Vector<uint8_t> SQLiteStatement::columnBlob(int col)
 {
-    auto span = columnBlobAsSpan(col);
-    return { span.data(), span.size() };
+    return { columnBlobAsSpan(col) };
 }
 
 std::span<const uint8_t> SQLiteStatement::columnBlobAsSpan(int col)

--- a/Source/WebCore/platform/text/LocaleICU.cpp
+++ b/Source/WebCore/platform/text/LocaleICU.cpp
@@ -188,7 +188,7 @@ std::unique_ptr<Vector<String>> LocaleICU::createLabelVector(const UDateFormat* 
 
 static std::unique_ptr<Vector<String>> createFallbackMonthLabels()
 {
-    return makeUnique<Vector<String>>(WTF::monthFullName, 12);
+    return makeUnique<Vector<String>>(std::span { WTF::monthFullName });
 }
 
 const Vector<String>& LocaleICU::monthLabels()

--- a/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
+++ b/Source/WebCore/platform/text/cocoa/LocaleCocoa.mm
@@ -112,7 +112,7 @@ const Vector<String>& LocaleCocoa::monthLabels()
         m_monthLabels = makeVector<String>(array);
         return m_monthLabels;
     }
-    m_monthLabels = { WTF::monthFullName, std::size(WTF::monthFullName) };
+    m_monthLabels = std::span { WTF::monthFullName };
     return m_monthLabels;
 }
 
@@ -203,7 +203,7 @@ const Vector<String>& LocaleCocoa::shortMonthLabels()
         m_shortMonthLabels = makeVector<String>(array);
         return m_shortMonthLabels;
     }
-    m_shortMonthLabels = { WTF::monthName, std::size(WTF::monthName) };
+    m_shortMonthLabels = std::span { WTF::monthName };
     return m_shortMonthLabels;
 }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4184,8 +4184,7 @@ Ref<ArrayBuffer> Internals::serializeObject(const RefPtr<SerializedScriptValue>&
 
 Ref<SerializedScriptValue> Internals::deserializeBuffer(ArrayBuffer& buffer) const
 {
-    Vector<uint8_t> bytes { static_cast<const uint8_t*>(buffer.data()), buffer.byteLength() };
-    return SerializedScriptValue::createFromWireBytes(WTFMove(bytes));
+    return SerializedScriptValue::createFromWireBytes(buffer.toVector());
 }
 
 bool Internals::isFromCurrentWorld(JSC::JSValue value) const
@@ -7235,12 +7234,7 @@ void Internals::retainTextIteratorForDocumentContent()
 
 RefPtr<PushSubscription> Internals::createPushSubscription(const String& endpoint, std::optional<EpochTimeStamp> expirationTime, const ArrayBuffer& serverVAPIDPublicKey, const ArrayBuffer& clientECDHPublicKey, const ArrayBuffer& auth)
 {
-    auto myEndpoint = endpoint;
-    Vector<uint8_t> myServerVAPIDPublicKey { static_cast<const uint8_t*>(serverVAPIDPublicKey.data()), serverVAPIDPublicKey.byteLength() };
-    Vector<uint8_t> myClientECDHPublicKey { static_cast<const uint8_t*>(clientECDHPublicKey.data()), clientECDHPublicKey.byteLength() };
-    Vector<uint8_t> myAuth { static_cast<const uint8_t*>(auth.data()), auth.byteLength() };
-
-    return PushSubscription::create(PushSubscriptionData { { }, WTFMove(myEndpoint), expirationTime, WTFMove(myServerVAPIDPublicKey), WTFMove(myClientECDHPublicKey), WTFMove(myAuth) });
+    return PushSubscription::create(PushSubscriptionData { { }, { endpoint }, expirationTime, serverVAPIDPublicKey.toVector(), clientECDHPublicKey.toVector(), auth.toVector() });
 }
 
 #if ENABLE(ARKIT_INLINE_PREVIEW_MAC)

--- a/Source/WebCore/testing/ServiceWorkerInternals.cpp
+++ b/Source/WebCore/testing/ServiceWorkerInternals.cpp
@@ -72,7 +72,7 @@ void ServiceWorkerInternals::schedulePushEvent(const String& message, RefPtr<Def
     std::optional<Vector<uint8_t>> data;
     if (!message.isNull()) {
         auto utf8 = message.utf8();
-        data = Vector<uint8_t> { reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length()};
+        data = Vector(utf8.bytes());
     }
     callOnMainThread([identifier = m_identifier, data = WTFMove(data), weakThis = WeakPtr { *this }, counter]() mutable {
         SWContextManager::singleton().firePushEvent(identifier, WTFMove(data), std::nullopt, [identifier, weakThis = WTFMove(weakThis), counter](bool result, std::optional<NotificationPayload>&&) mutable {
@@ -182,12 +182,7 @@ void ServiceWorkerInternals::lastNavigationWasAppInitiated(Ref<DeferredPromise>&
 
 RefPtr<PushSubscription> ServiceWorkerInternals::createPushSubscription(const String& endpoint, std::optional<EpochTimeStamp> expirationTime, const ArrayBuffer& serverVAPIDPublicKey, const ArrayBuffer& clientECDHPublicKey, const ArrayBuffer& auth)
 {
-    auto myEndpoint = endpoint;
-    Vector<uint8_t> myServerVAPIDPublicKey { static_cast<const uint8_t*>(serverVAPIDPublicKey.data()), serverVAPIDPublicKey.byteLength() };
-    Vector<uint8_t> myClientECDHPublicKey { static_cast<const uint8_t*>(clientECDHPublicKey.data()), clientECDHPublicKey.byteLength() };
-    Vector<uint8_t> myAuth { static_cast<const uint8_t*>(auth.data()), auth.byteLength() };
-
-    return PushSubscription::create(PushSubscriptionData { { }, WTFMove(myEndpoint), expirationTime, WTFMove(myServerVAPIDPublicKey), WTFMove(myClientECDHPublicKey), WTFMove(myAuth) });
+    return PushSubscription::create(PushSubscriptionData { { }, { endpoint }, expirationTime, serverVAPIDPublicKey.toVector(), clientECDHPublicKey.toVector(), auth.toVector() });
 }
 
 bool ServiceWorkerInternals::fetchEventIsSameSite(FetchEvent& event)

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
@@ -483,7 +483,7 @@ void BackgroundFetch::doStore(CompletionHandler<void(BackgroundFetchStore::Store
         encoder << record->isCompleted();
     }
 
-    m_store->storeFetch(m_registrationKey, m_identifier, m_options.downloadTotal, m_uploadTotal, responseBodyIndexToClear, { encoder.buffer(), encoder.bufferSize() }, WTFMove(callback));
+    m_store->storeFetch(m_registrationKey, m_identifier, m_options.downloadTotal, m_uploadTotal, responseBodyIndexToClear, { encoder.bytes() }, WTFMove(callback));
 }
 
 std::unique_ptr<BackgroundFetch> BackgroundFetch::createFromStore(std::span<const uint8_t> data, SWServer& server, Ref<BackgroundFetchStore>&& store, NotificationCallback&& notificationCallback)

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -558,7 +558,7 @@ ExceptionOr<void> XMLHttpRequest::send(DOMFormData& body)
     if (m_method != "GET"_s && m_method != "HEAD"_s) {
         m_requestEntityBody = FormData::createMultiPart(body);
         if (!m_requestHeaders.contains(HTTPHeaderName::ContentType))
-            m_requestHeaders.set(HTTPHeaderName::ContentType, makeString("multipart/form-data; boundary=", m_requestEntityBody->boundary().data()));
+            m_requestHeaders.set(HTTPHeaderName::ContentType, makeString("multipart/form-data; boundary=", m_requestEntityBody->boundary()));
     }
 
     return createRequest();
@@ -568,21 +568,21 @@ ExceptionOr<void> XMLHttpRequest::send(ArrayBuffer& body)
 {
     ASCIILiteral consoleMessage { "ArrayBuffer is deprecated in XMLHttpRequest.send(). Use ArrayBufferView instead."_s };
     scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, consoleMessage);
-    return sendBytesData(body.data(), body.byteLength());
+    return sendBytesData(body.bytes());
 }
 
 ExceptionOr<void> XMLHttpRequest::send(ArrayBufferView& body)
 {
-    return sendBytesData(body.baseAddress(), body.byteLength());
+    return sendBytesData(body.bytes());
 }
 
-ExceptionOr<void> XMLHttpRequest::sendBytesData(const void* data, size_t length)
+ExceptionOr<void> XMLHttpRequest::sendBytesData(std::span<const uint8_t> data)
 {
     if (auto result = prepareToSend())
         return WTFMove(result.value());
 
     if (m_method != "GET"_s && m_method != "HEAD"_s) {
-        m_requestEntityBody = FormData::create(data, length);
+        m_requestEntityBody = FormData::create(data);
         if (m_upload)
             m_requestEntityBody->setAlwaysStream(true);
     }

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -178,7 +178,7 @@ private:
     ExceptionOr<void> send(DOMFormData&);
     ExceptionOr<void> send(JSC::ArrayBuffer&);
     ExceptionOr<void> send(JSC::ArrayBufferView&);
-    ExceptionOr<void> sendBytesData(const void*, size_t);
+    ExceptionOr<void> sendBytesData(std::span<const uint8_t>);
 
     void changeState(State);
     void callReadyStateChangeListener();

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -504,7 +504,7 @@ static void* openFunc(const char* uri)
     if (!data)
         return &globalDescriptor;
 
-    return new OffsetBuffer({ data->data(), data->size() });
+    return new OffsetBuffer(Vector(data->dataAsSpanForContiguousData()));
 }
 
 static int readFunc(void* context, char* buffer, int len)

--- a/Source/WebGPU/WebGPU/Adapter.mm
+++ b/Source/WebGPU/WebGPU/Adapter.mm
@@ -117,7 +117,7 @@ void Adapter::requestDevice(const WGPUDeviceDescriptor& descriptor, CompletionHa
     } else
         limits = defaultLimits();
 
-    auto features = Vector { descriptor.requiredFeatures, descriptor.requiredFeatureCount };
+    Vector<WGPUFeatureName> features(std::span { descriptor.requiredFeatures, descriptor.requiredFeatureCount });
     if (includesUnsupportedFeatures(features, m_capabilities.features)) {
         callback(WGPURequestDeviceStatus_Error, Device::createInvalid(*this), "Device does not support requested features"_s);
         return;

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -885,7 +885,7 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
     Vector<id<MTLResource>> stageResources[stagesPlusUndefinedCount][maxResourceUsageValue];
     Vector<BindGroupEntryUsageData> stageResourceUsages[stagesPlusUndefinedCount][maxResourceUsageValue];
     auto& bindGroupLayoutEntries = bindGroupLayout.entries();
-    Vector<WGPUBindGroupEntry> descriptorEntries(descriptor.entries, descriptor.entryCount);
+    Vector<WGPUBindGroupEntry> descriptorEntries(std::span { descriptor.entries, descriptor.entryCount });
     std::sort(descriptorEntries.begin(), descriptorEntries.end(), [](const WGPUBindGroupEntry& a, const WGPUBindGroupEntry& b) {
         return a.binding < b.binding;
     });

--- a/Source/WebGPU/WebGPU/BindGroupLayout.mm
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.mm
@@ -189,7 +189,7 @@ Ref<BindGroupLayout> Device::createBindGroupLayout(const WGPUBindGroupLayoutDesc
         storageTexturesPerStage[shaderStage] = 0;
     }
 
-    Vector<WGPUBindGroupLayoutEntry> descriptorEntries(descriptor.entries, descriptor.entryCount);
+    Vector<WGPUBindGroupLayoutEntry> descriptorEntries(std::span { descriptor.entries, descriptor.entryCount });
     std::sort(descriptorEntries.begin(), descriptorEntries.end(), [](const WGPUBindGroupLayoutEntry& a, const WGPUBindGroupLayoutEntry& b) {
         return a.metalBinding < b.metalBinding;
     });

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -428,7 +428,7 @@ void ComputePassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& grou
     }
 
     if (dynamicOffsetCount)
-        m_bindGroupDynamicOffsets.add(groupIndex, Vector<uint32_t>(dynamicOffsets, dynamicOffsetCount));
+        m_bindGroupDynamicOffsets.add(groupIndex, Vector<uint32_t>(std::span { dynamicOffsets, dynamicOffsetCount }));
 
     Vector<const BindableResources*> resourceList;
     for (const auto& resource : group.resources()) {

--- a/Source/WebGPU/WebGPU/RenderBundle.mm
+++ b/Source/WebGPU/WebGPU/RenderBundle.mm
@@ -51,7 +51,7 @@ RenderBundle::RenderBundle(NSArray<RenderBundleICBWithResources*> *resources, Re
     , m_renderBundleEncoder(encoder)
     , m_renderBundlesResources(resources)
     , m_descriptor(descriptor)
-    , m_descriptorColorFormats(descriptor.colorFormats ? Vector<WGPUTextureFormat>(descriptor.colorFormats, descriptor.colorFormatCount) : Vector<WGPUTextureFormat>())
+    , m_descriptorColorFormats(descriptor.colorFormats ? Vector<WGPUTextureFormat>(std::span { descriptor.colorFormats, descriptor.colorFormatCount }) : Vector<WGPUTextureFormat>())
     , m_commandCount(commandCount)
 {
     if (m_descriptorColorFormats.size())

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -174,7 +174,7 @@ RenderBundleEncoder::RenderBundleEncoder(MTLIndirectCommandBufferDescriptor *ind
     , m_icbDescriptor(indirectCommandBufferDescriptor)
     , m_resources([NSMapTable strongToStrongObjectsMapTable])
     , m_descriptor(descriptor)
-    , m_descriptorColorFormats(descriptor.colorFormats ? Vector<WGPUTextureFormat>(descriptor.colorFormats, descriptor.colorFormatCount) : Vector<WGPUTextureFormat>())
+    , m_descriptorColorFormats(descriptor.colorFormats ? Vector<WGPUTextureFormat>(std::span { descriptor.colorFormats, descriptor.colorFormatCount }) : Vector<WGPUTextureFormat>())
 {
     if (m_descriptorColorFormats.size())
         m_descriptor.colorFormats = &m_descriptorColorFormats[0];

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -59,7 +59,7 @@ RenderPassEncoder::RenderPassEncoder(id<MTLRenderCommandEncoder> renderCommandEn
     , m_parentEncoder(parentEncoder)
     , m_visibilityResultBuffer(visibilityResultBuffer)
     , m_descriptor(descriptor)
-    , m_descriptorColorAttachments(descriptor.colorAttachmentCount ? Vector<WGPURenderPassColorAttachment>(descriptor.colorAttachments, descriptor.colorAttachmentCount) : Vector<WGPURenderPassColorAttachment>())
+    , m_descriptorColorAttachments(descriptor.colorAttachmentCount ? Vector<WGPURenderPassColorAttachment>(std::span { descriptor.colorAttachments, descriptor.colorAttachmentCount }) : Vector<WGPURenderPassColorAttachment>())
     , m_descriptorDepthStencilAttachment(descriptor.depthStencilAttachment ? *descriptor.depthStencilAttachment : WGPURenderPassDepthStencilAttachment())
     , m_descriptorTimestampWrites(descriptor.timestampWrites ? *descriptor.timestampWrites : WGPURenderPassTimestampWrites())
     , m_maxDrawCount(maxDrawCount)
@@ -818,7 +818,7 @@ void RenderPassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& group
 
     m_maxBindGroupSlot = std::max(groupIndex, m_maxBindGroupSlot);
     if (dynamicOffsetCount)
-        m_bindGroupDynamicOffsets.set(groupIndex, Vector<uint32_t>(dynamicOffsets, dynamicOffsetCount));
+        m_bindGroupDynamicOffsets.set(groupIndex, Vector<uint32_t>(std::span { dynamicOffsets, dynamicOffsetCount }));
 
     for (const auto& resource : group.resources()) {
         if (resource.renderStages & (MTLRenderStageVertex | MTLRenderStageFragment))

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -1556,7 +1556,7 @@ RenderPipeline::RenderPipeline(id<MTLRenderPipelineState> renderPipelineState, M
     , m_descriptor(descriptor)
     , m_descriptorDepthStencil(descriptor.depthStencil ? *descriptor.depthStencil : WGPUDepthStencilState())
     , m_descriptorFragment(descriptor.fragment ? *descriptor.fragment : WGPUFragmentState())
-    , m_descriptorTargets(descriptor.fragment && descriptor.fragment->targetCount ? Vector<WGPUColorTargetState>(descriptor.fragment->targets, descriptor.fragment->targetCount) : Vector<WGPUColorTargetState>())
+    , m_descriptorTargets(descriptor.fragment && descriptor.fragment->targetCount ? Vector<WGPUColorTargetState>(std::span { descriptor.fragment->targets, descriptor.fragment->targetCount }) : Vector<WGPUColorTargetState>())
 {
     if (descriptor.depthStencil)
         m_descriptor.depthStencil = &m_descriptorDepthStencil;

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2547,7 +2547,7 @@ Ref<Texture> Device::createTexture(const WGPUTextureDescriptor& descriptor)
 
     // https://gpuweb.github.io/gpuweb/#dom-gpudevice-createtexture
 
-    Vector viewFormats = { descriptor.viewFormats, descriptor.viewFormatCount };
+    Vector viewFormats(std::span { descriptor.viewFormats, descriptor.viewFormatCount });
 
     if (NSString *error = errorValidatingTextureCreation(descriptor, viewFormats)) {
         generateAValidationError(error);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -51,7 +51,7 @@ namespace {
 template<typename S, int I, typename T>
 Vector<S> vectorCopyCast(const T& arrayReference)
 {
-    return { reinterpret_cast<const S*>(arrayReference.template data<I>()), arrayReference.size() };
+    return Vector(std::span { reinterpret_cast<const S*>(arrayReference.template data<I>()), arrayReference.size() });
 }
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
@@ -64,7 +64,7 @@ void RemoteBuffer::mapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore:
 
         auto mappedRange = protectedThis->m_backing->getMappedRange(0, std::nullopt);
         protectedThis->m_mappedRange = mappedRange;
-        callback(Vector<uint8_t>(static_cast<const uint8_t*>(mappedRange.source), mappedRange.byteLength));
+        callback(Vector(std::span { static_cast<const uint8_t*>(mappedRange.source), mappedRange.byteLength }));
     });
 }
 
@@ -75,7 +75,7 @@ void RemoteBuffer::getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<
     m_mapModeFlags = { WebCore::WebGPU::MapMode::Write };
     m_isMapped = true;
 
-    callback(Vector<uint8_t>(static_cast<const uint8_t*>(mappedRange.source), mappedRange.byteLength));
+    callback(Vector(std::span { static_cast<const uint8_t*>(mappedRange.source), mappedRange.byteLength }));
 }
 
 void RemoteBuffer::unmap(Vector<uint8_t>&& data)

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -31,6 +31,7 @@
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <pal/spi/cocoa/NSProgressSPI.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 namespace WebKit {
 
@@ -69,8 +70,7 @@ void Download::platformCancelNetworkLoad(CompletionHandler<void(std::span<const 
     ASSERT(m_downloadTask);
     [m_downloadTask cancelByProducingResumeData:makeBlockPtr([completionHandler = WTFMove(completionHandler)] (NSData *resumeData) mutable {
         ensureOnMainRunLoop([resumeData = retainPtr(resumeData), completionHandler = WTFMove(completionHandler)] () mutable  {
-            auto resumeDataReference = resumeData ? std::span { static_cast<const uint8_t*>([resumeData bytes]), [resumeData length] } : std::span<const uint8_t> { };
-            completionHandler(resumeDataReference);
+            completionHandler(toSpan(resumeData.get()));
         });
     }).get()];
 }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -67,6 +67,7 @@
 #import <wtf/URL.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/darwin/WeakLinking.h>
@@ -923,7 +924,7 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
             }
         }
 
-        auto resumeDataReference = resumeData ? std::span { static_cast<const uint8_t*>(resumeData.bytes), resumeData.length } : std::span<const uint8_t> { };
+        auto resumeDataReference = toSpan(resumeData);
         download->didFail(error, resumeDataReference);
     }
 }

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -467,7 +467,7 @@ static Vector<uint8_t> encodeRecordHeader(CacheStorageRecord&& record)
     encoder << record.responseBodySize;
     encoder.encodeChecksum();
 
-    return { encoder.buffer(), encoder.bufferSize() };
+    return { encoder.bytes() };
 }
 
 static Vector<uint8_t> encodeRecordBody(const CacheStorageRecord& record)
@@ -476,7 +476,7 @@ static Vector<uint8_t> encodeRecordBody(const CacheStorageRecord& record)
         // FIXME: Store form data body.
         return Vector<uint8_t> { };
     }, [&](const Ref<WebCore::SharedBuffer>& buffer) {
-        return Vector<uint8_t> { buffer->data(), buffer->size() };
+        return Vector<uint8_t> { buffer->dataAsSpanForContiguousData() };
     }, [](const std::nullptr_t&) {
         return Vector<uint8_t> { };
     });
@@ -495,9 +495,9 @@ static Vector<uint8_t> encodeRecord(const NetworkCache::Key& key, const Vector<u
     encoder << isBodyInline;
     encoder.encodeChecksum();
 
-    auto metaData = Vector<uint8_t> { encoder.buffer(), encoder.bufferSize() };
+    auto metaData = encoder.bytes();
     Vector<uint8_t> result;
-    result.appendVector(metaData);
+    result.append(metaData);
     result.appendVector(headerData);
 
     StringBuilder sb;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -144,7 +144,7 @@ static bool writeSizeFile(const String& sizeDirectoryPath, uint64_t size)
 
     auto sizeFilePath = FileSystem::pathByAppendingComponent(sizeDirectoryPath, sizeFileName);
     auto value = String::number(size).utf8();
-    return FileSystem::overwriteEntireFile(sizeFilePath, std::span(reinterpret_cast<uint8_t*>(const_cast<char*>(value.data())), value.length())) != -1;
+    return FileSystem::overwriteEntireFile(sizeFilePath, value.bytes()) != -1;
 }
 
 static String saltFilePath(const String& saltDirectory)

--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -109,7 +109,7 @@ void ConnectionToMachService<Traits>::sendWithReply(typename Traits::MessageType
         }
         size_t dataSize { 0 };
         const void* data = xpc_dictionary_get_data(reply, Traits::protocolEncodedMessageKey, &dataSize);
-        completionHandler({ static_cast<const uint8_t*>(data), dataSize });
+        completionHandler(Vector(std::span { static_cast<const uint8_t*>(data), dataSize }));
     });
 }
 

--- a/Source/WebKit/Shared/API/c/WKURLRequest.cpp
+++ b/Source/WebKit/Shared/API/c/WKURLRequest.cpp
@@ -59,7 +59,7 @@ WKStringRef WKURLRequestCopyHTTPMethod(WKURLRequestRef requestRef)
 WKURLRequestRef WKURLRequestCopySettingHTTPBody(WKURLRequestRef requestRef, WKDataRef body)
 {
     WebCore::ResourceRequest requestCopy(WebKit::toImpl(requestRef)->resourceRequest());
-    requestCopy.setHTTPBody(WebCore::FormData::create(WKDataGetBytes(body), WKDataGetSize(body)));
+    requestCopy.setHTTPBody(WebCore::FormData::create(std::span { WKDataGetBytes(body), WKDataGetSize(body) }));
     return WebKit::toAPI(&API::URLRequest::create(requestCopy).leakRef());
 }
 

--- a/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
@@ -27,6 +27,7 @@
 #import "WebPushMessage.h"
 
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 namespace WebKit {
 
@@ -72,10 +73,8 @@ std::optional<WebPushMessage> WebPushMessage::fromDictionary(NSDictionary *dicti
     WebPushMessage message { { }, String { pushPartition }, URL { url }, { } };
 #endif
 
-    if (isData) {
-        NSData *data = (NSData *)pushData;
-        message.pushData = Vector<uint8_t> { static_cast<const uint8_t*>(data.bytes), data.length };
-    }
+    if (isData)
+        message.pushData = toVector((NSData *)pushData);
 
     return message;
 }

--- a/Source/WebKit/Shared/RTCNetwork.cpp
+++ b/Source/WebKit/Shared/RTCNetwork.cpp
@@ -31,8 +31,8 @@
 namespace WebKit {
 
 RTCNetwork::RTCNetwork(const rtc::Network& network)
-    : name(network.name().data(), network.name().length())
-    , description(network.description().data(), network.description().length())
+    : name(std::span { network.name() })
+    , description(std::span { network.description() })
     , prefix(network.prefix())
     , prefixLength(network.prefix_length())
     , type(network.type())
@@ -103,7 +103,7 @@ rtc::SocketAddress SocketAddress::rtcAddress() const
 SocketAddress::SocketAddress(const rtc::SocketAddress& value)
     : port(value.port())
     , scopeID(value.scope_id())
-    , hostname(value.hostname().data(), value.hostname().size())
+    , hostname(std::span { value.hostname() })
     , ipAddress(value.IsUnresolvedIP() ? std::nullopt : std::optional(IPAddress(value.ipaddr()))) { }
 
 IPAddress::IPAddress(const rtc::IPAddress& input)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3956,7 +3956,7 @@ struct WebCore::CookieRequestHeaderFieldProxy {
     Vector<WebCore::FormDataElement> m_elements;
     int64_t m_identifier;
     bool m_alwaysStream;
-    Vector<char> m_boundary;
+    Vector<uint8_t> m_boundary;
     [NotSerialized] std::optional<uint64_t> m_lengthInBytes;
 };
 
@@ -4107,7 +4107,7 @@ enum class WebCore::MediaDecodingType : uint8_t {
 enum class WebCore::MediaEncodingType : bool;
 
 class WebCore::BufferSource {
-    std::span<const uint8_t> span()
+    std::span<const uint8_t> bytes()
 }
 
 struct WebCore::FontShadow {

--- a/Source/WebKit/Shared/WebPushMessage.cpp
+++ b/Source/WebKit/Shared/WebPushMessage.cpp
@@ -53,7 +53,7 @@ WebCore::NotificationData WebPushMessage::notificationPayloadToCoreData() const
         silent = notificationPayload->options->silent;
 
         CString dataCString = notificationPayload->options->dataJSONString.utf8();
-        dataJSON = { dataCString.dataAsUInt8Ptr(), dataCString.length() };
+        dataJSON = dataCString.bytes();
     }
 
     return {

--- a/Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm
+++ b/Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm
@@ -51,7 +51,7 @@ Vector<uint8_t> identifyingDataFromCookieStorage(CFHTTPCookieStorageRef cookieSt
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
 
     auto cfData = adoptCF(CFHTTPCookieStorageCreateIdentifyingData(kCFAllocatorDefault, cookieStorage));
-    return vectorFromCFData(cfData.get());
+    return toVector(cfData.get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -263,14 +263,12 @@ static std::span<const uint8_t> dataFrom(const String& string)
 {
     if (string.isNull() || !string.is8Bit())
         return { reinterpret_cast<const uint8_t*>(string.characters16()), string.length() * sizeof(UChar) };
-    return { string.characters8(), string.length() * sizeof(LChar) };
+    return string.span8();
 }
 
 static Ref<WebCore::DataSegment> dataReferenceFrom(const String& string)
 {
-    if (string.isNull() || !string.is8Bit())
-        return WebCore::DataSegment::create(Vector<uint8_t>(reinterpret_cast<const uint8_t*>(string.characters16()), string.length() * sizeof(UChar)));
-    return WebCore::DataSegment::create(Vector<uint8_t>(string.characters8(), string.length() * sizeof(LChar)));
+    return WebCore::DataSegment::create(dataFrom(string));
 }
 
 static void loadString(WKPageRef pageRef, WKStringRef stringRef, const String& mimeType, const String& baseURL, WKTypeRef userDataRef)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -256,7 +256,7 @@ static RetainPtr<WKProcessPool>& sharedProcessPool()
         [_processPool->ensureBundleParameters() removeObjectForKey:parameter];
 
     auto data = keyedArchiver.get().encodedData;
-    _processPool->sendToAllProcesses(Messages::WebProcess::SetInjectedBundleParameter(parameter, std::span(static_cast<const uint8_t*>([data bytes]), [data length])));
+    _processPool->sendToAllProcesses(Messages::WebProcess::SetInjectedBundleParameter(parameter, toSpan(data)));
 }
 
 - (void)_setObjectsForBundleParametersWithDictionary:(NSDictionary *)dictionary
@@ -274,7 +274,7 @@ static RetainPtr<WKProcessPool>& sharedProcessPool()
     [_processPool->ensureBundleParameters() setValuesForKeysWithDictionary:copy.get()];
 
     auto data = keyedArchiver.get().encodedData;
-    _processPool->sendToAllProcesses(Messages::WebProcess::SetInjectedBundleParameters(std::span(static_cast<const uint8_t*>([data bytes]), [data length])));
+    _processPool->sendToAllProcesses(Messages::WebProcess::SetInjectedBundleParameters(toSpan(data)));
 }
 
 #if !TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -164,6 +164,7 @@
 #import <wtf/SystemTracing.h>
 #import <wtf/UUID.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/spi/darwin/dyldSPI.h>
 #import <wtf/text/StringToIntegerConversion.h>
@@ -3089,7 +3090,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 
     // FIXME: This should not use the legacy session state decoder.
     WebKit::SessionState sessionState;
-    if (!WebKit::decodeLegacySessionState(std::span { static_cast<const uint8_t*>(sessionStateData.bytes), sessionStateData.length }, sessionState))
+    if (!WebKit::decodeLegacySessionState(toSpan(sessionStateData), sessionState))
         return;
 
     _page->restoreFromSessionState(WTFMove(sessionState), true);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -62,6 +62,7 @@
 #import <wtf/Vector.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 #if HAVE(NW_PROXY_CONFIG)
 #import <Network/Network.h>
@@ -99,7 +100,7 @@ private:
         RetainPtr<NSData> result = [m_delegate webCryptoMasterKey];
         if (!result)
             return std::nullopt;
-        return Vector<uint8_t>(static_cast<const uint8_t *>([result.get() bytes]), result.get().length);
+        return toVector(result.get());
     }
 
     void requestStorageSpace(const WebCore::SecurityOriginData& topOrigin, const WebCore::SecurityOriginData& frameOrigin, uint64_t quota, uint64_t currentSize, uint64_t spaceRequired, CompletionHandler<void(std::optional<uint64_t>)>&& completionHandler) final
@@ -505,7 +506,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
         uuid_t proxyIdentifier;
         nw_proxy_config_get_identifier(proxyConfig, proxyIdentifier);
 
-        configDataVector.append({ vectorFromNSData(agentData.get()), WTF::UUID(proxyIdentifier) });
+        configDataVector.append({ toVector(agentData.get()), WTF::UUID(proxyIdentifier) });
     }
     
     _websiteDataStore->setProxyConfigData(WTFMove(configDataVector));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -282,7 +282,7 @@ static RetainPtr<NSArray> getAllLocalAuthenticatorCredentialsImpl(NSString *acce
 
     auto result = adoptNS([[NSMutableArray alloc] init]);
     for (NSDictionary *attributes in (NSArray *)attributesArrayRef) {
-        auto decodedResponse = cbor::CBORReader::read(vectorFromNSData(attributes[bridge_id_cast(kSecAttrApplicationTag)]));
+        auto decodedResponse = cbor::CBORReader::read(toVector(attributes[bridge_id_cast(kSecAttrApplicationTag)]));
         if (!decodedResponse || !decodedResponse->isMap()) {
             ASSERT_NOT_REACHED();
             return nullptr;
@@ -428,7 +428,7 @@ static RetainPtr<NSArray> getAllLocalAuthenticatorCredentialsImpl(NSString *acce
         return;
     }
     auto attributes = adoptNS((__bridge NSDictionary *)attributesArrayRef);
-    auto decodedResponse = cbor::CBORReader::read(vectorFromNSData(attributes.get()[bridge_id_cast(kSecAttrApplicationTag)]));
+    auto decodedResponse = cbor::CBORReader::read(toVector(attributes.get()[bridge_id_cast(kSecAttrApplicationTag)]));
     if (!decodedResponse || !decodedResponse->isMap()) {
         ASSERT_NOT_REACHED();
         return;
@@ -491,7 +491,7 @@ static RetainPtr<NSArray> getAllLocalAuthenticatorCredentialsImpl(NSString *acce
         return;
     }
     auto attributes = adoptNS((__bridge NSDictionary *)attributesArrayRef);
-    auto decodedResponse = cbor::CBORReader::read(vectorFromNSData(attributes.get()[bridge_id_cast(kSecAttrApplicationTag)]));
+    auto decodedResponse = cbor::CBORReader::read(toVector(attributes.get()[bridge_id_cast(kSecAttrApplicationTag)]));
     if (!decodedResponse || !decodedResponse->isMap()) {
         ASSERT_NOT_REACHED();
         return;
@@ -549,7 +549,7 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
 + (NSData *)importLocalAuthenticatorWithAccessGroup:(NSString *)accessGroup credential:(NSData *)credentialBlob error:(NSError **)error
 {
 #if ENABLE(WEB_AUTHN)
-    auto credential = cbor::CBORReader::read(vectorFromNSData(credentialBlob));
+    auto credential = cbor::CBORReader::read(toVector(credentialBlob));
     if (!credential || !credential->isMap()) {
         createNSErrorFromWKErrorIfNecessary(error, WKErrorMalformedCredential);
         return nullptr;
@@ -728,7 +728,7 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
     credentialMap[cbor::CBORValue(WebCore::keyTypeKey)] = cbor::CBORValue(keyType);
     credentialMap[cbor::CBORValue(WebCore::keySizeKey)] = cbor::CBORValue(keySize);
     credentialMap[cbor::CBORValue(WebCore::relyingPartyKey)] = cbor::CBORValue(String(attributes.get()[bridge_id_cast(kSecAttrLabel)]));
-    auto decodedResponse = cbor::CBORReader::read(vectorFromNSData(attributes.get()[bridge_id_cast(kSecAttrApplicationTag)]));
+    auto decodedResponse = cbor::CBORReader::read(toVector(attributes.get()[bridge_id_cast(kSecAttrApplicationTag)]));
     if (!decodedResponse || !decodedResponse->isMap()) {
         createNSErrorFromWKErrorIfNecessary(error, WKErrorMalformedCredential);
         return nullptr;
@@ -1003,7 +1003,7 @@ static RetainPtr<_WKAuthenticatorAttestationResponse> wkAuthenticatorAttestation
             handler(nil, [NSError errorWithDomain:WKErrorDomain code:static_cast<NSInteger>(exception.code) userInfo:@{ NSLocalizedDescriptionKey: exception.message }]);
         });
     };
-    _panel->handleRequest({ vectorFromNSData(clientDataHash), [_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:options], nullptr, WebKit::WebAuthenticationPanelResult::Unavailable, nullptr, std::nullopt, { }, String(), nullptr, toWebCore(mediation), std::nullopt }, WTFMove(callback));
+    _panel->handleRequest({ toVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:options], nullptr, WebKit::WebAuthenticationPanelResult::Unavailable, nullptr, std::nullopt, { }, String(), nullptr, toWebCore(mediation), std::nullopt }, WTFMove(callback));
 #endif
 }
 
@@ -1071,7 +1071,7 @@ static RetainPtr<_WKAuthenticatorAssertionResponse> wkAuthenticatorAssertionResp
             handler(nil, [NSError errorWithDomain:WKErrorDomain code:static_cast<NSInteger>(exception.code) userInfo:@{ NSLocalizedDescriptionKey: exception.message }]);
         });
     };
-    _panel->handleRequest({ vectorFromNSData(clientDataHash), [_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:options], nullptr, WebKit::WebAuthenticationPanelResult::Unavailable, nullptr, std::nullopt, { }, String(), nullptr, toWebCore(mediation), std::nullopt }, WTFMove(callback));
+    _panel->handleRequest({ toVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:options], nullptr, WebKit::WebAuthenticationPanelResult::Unavailable, nullptr, std::nullopt, { }, String(), nullptr, toWebCore(mediation), std::nullopt }, WTFMove(callback));
 #endif
 }
 
@@ -1154,7 +1154,7 @@ static RetainPtr<_WKAuthenticatorAssertionResponse> wkAuthenticatorAssertionResp
 {
     RetainPtr<NSData> encodedCommand;
 #if ENABLE(WEB_AUTHN)
-    auto encodedVector = fido::encodeMakeCredentialRequestAsCBOR(vectorFromNSData(clientDataHash), [_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:options], coreUserVerificationAvailability(userVerificationAvailability), fido::AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, makeVector<String>(authenticatorSupportedExtensions), std::nullopt);
+    auto encodedVector = fido::encodeMakeCredentialRequestAsCBOR(toVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:options], coreUserVerificationAvailability(userVerificationAvailability), fido::AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, makeVector<String>(authenticatorSupportedExtensions), std::nullopt);
     encodedCommand = adoptNS([[NSData alloc] initWithBytes:encodedVector.data() length:encodedVector.size()]);
 #endif
 
@@ -1170,7 +1170,7 @@ static RetainPtr<_WKAuthenticatorAssertionResponse> wkAuthenticatorAssertionResp
 {
     RetainPtr<NSData> encodedCommand;
 #if ENABLE(WEB_AUTHN)
-    auto encodedVector = fido::encodeGetAssertionRequestAsCBOR(vectorFromNSData(clientDataHash), [_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:options], coreUserVerificationAvailability(userVerificationAvailability), makeVector<String>(authenticatorSupportedExtensions), std::nullopt);
+    auto encodedVector = fido::encodeGetAssertionRequestAsCBOR(toVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:options], coreUserVerificationAvailability(userVerificationAvailability), makeVector<String>(authenticatorSupportedExtensions), std::nullopt);
     encodedCommand = adoptNS([[NSData alloc] initWithBytes:encodedVector.data() length:encodedVector.size()]);
 #endif
 

--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
@@ -638,7 +638,7 @@ void IconDatabase::setIconForPageURL(const String& iconURL, const uint8_t* iconD
         return;
     }
 
-    Vector<uint8_t> data { iconData, iconDataSize };
+    Vector<uint8_t> data(std::span { iconData, iconDataSize });
     m_workQueue->dispatch([this, protectedThis = Ref { *this }, iconURL = iconURL.isolatedCopy(), iconData = WTFMove(data), pageURL = pageURL.isolatedCopy(), completionHandler = WTFMove(completionHandler)]() mutable {
         bool result = false;
         if (m_db.isOpen()) {

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -3327,7 +3327,7 @@ void webkit_web_view_load_alternate_html(WebKitWebView* webView, const gchar* co
     g_return_if_fail(content);
     g_return_if_fail(contentURI);
 
-    getPage(webView).loadAlternateHTML(WebCore::DataSegment::create(Vector<uint8_t>(reinterpret_cast<const uint8_t*>(content), content ? strlen(content) : 0)), "UTF-8"_s, URL { String::fromUTF8(baseURI) }, URL { String::fromUTF8(contentURI) });
+    getPage(webView).loadAlternateHTML(WebCore::DataSegment::create(Vector(std::span { reinterpret_cast<const uint8_t*>(content), content ? strlen(content) : 0 })), "UTF-8"_s, URL { String::fromUTF8(baseURI) }, URL { String::fromUTF8(contentURI) });
 }
 
 /**

--- a/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm
@@ -31,6 +31,7 @@
 #import <WebCore/ResourceError.h>
 #import <WebCore/ResourceRequest.h>
 #import <WebCore/ResourceResponse.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 @interface WKCustomProtocolLoader : NSObject <NSURLConnectionDelegate> {
 @private
@@ -108,8 +109,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!_customProtocolManagerProxy)
         return;
 
-    std::span coreData(static_cast<const uint8_t*>([data bytes]), [data length]);
-    _customProtocolManagerProxy->didLoadData(_customProtocolID, coreData);
+    _customProtocolManagerProxy->didLoadData(_customProtocolID, toSpan(data));
 }
 
 - (NSURLRequest *)connection:(NSURLConnection *)connection willSendRequest:(NSURLRequest *)request redirectResponse:(NSURLResponse *)redirectResponse

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -35,6 +35,7 @@
 #import <WebCore/HTTPStatusCodes.h>
 #import <WebCore/ResourceResponse.h>
 #import <wtf/RunLoop.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -71,7 +72,7 @@ void SubFrameSOAuthorizationSession::fallBackToWebPathInternal()
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("fallBackToWebPathInternal: navigationAction=%p", navigationAction());
     ASSERT(navigationAction());
-    appendRequestToLoad(URL(navigationAction()->request().url()), Vector { reinterpret_cast<const uint8_t*>(soAuthorizationPostDidCancelMessageToParent), strlen(soAuthorizationPostDidCancelMessageToParent) });
+    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(std::span { soAuthorizationPostDidCancelMessageToParent, strlen(soAuthorizationPostDidCancelMessageToParent) }));
     appendRequestToLoad(URL(navigationAction()->request().url()), String(navigationAction()->request().httpReferrer()));
 }
 
@@ -88,7 +89,7 @@ void SubFrameSOAuthorizationSession::completeInternal(const WebCore::ResourceRes
         fallBackToWebPathInternal();
         return;
     }
-    appendRequestToLoad(URL(response.url()), Vector { reinterpret_cast<const uint8_t*>(data.bytes), data.length });
+    appendRequestToLoad(URL(response.url()), toVector(data));
 }
 
 void SubFrameSOAuthorizationSession::beforeStart()
@@ -97,7 +98,7 @@ void SubFrameSOAuthorizationSession::beforeStart()
     // Cancelled the current load before loading the data to post SOAuthorizationDidStart to the parent frame.
     invokeCallback(true);
     ASSERT(navigationAction());
-    appendRequestToLoad(URL(navigationAction()->request().url()), Vector { reinterpret_cast<const uint8_t*>(soAuthorizationPostDidStartMessageToParent), strlen(soAuthorizationPostDidStartMessageToParent) });
+    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(std::span { soAuthorizationPostDidStartMessageToParent, strlen(soAuthorizationPostDidStartMessageToParent) }));
 }
 
 void SubFrameSOAuthorizationSession::didFinishLoad()

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm
@@ -51,7 +51,7 @@ static void reportReceived(void* context, IOReturn status, void*, IOHIDReportTyp
     ASSERT(reportID == kHidReportId);
     ASSERT(reportLength == kHidMaxPacketSize);
 
-    connection->receiveReport({ report, static_cast<size_t>(reportLength) });
+    connection->receiveReport(std::span { report, static_cast<size_t>(reportLength) });
 }
 
 HidConnection::HidConnection(IOHIDDeviceRef device)

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
@@ -93,7 +93,7 @@ Vector<uint8_t> NfcConnection::transact(Vector<uint8_t>&& data) const
 {
     // The method will return an empty NSData if the tag is disconnected.
     auto *responseData = [m_session transceive:adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]).get()];
-    return vectorFromNSData(responseData);
+    return toVector(responseData);
 }
 
 void NfcConnection::stop() const

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -836,7 +836,7 @@ static std::optional<AuthenticationExtensionsClientOutputs> toExtensionOutputs(N
 {
     if (!extensionOutputsCBOR)
         return std::nullopt;
-    return AuthenticationExtensionsClientOutputs::fromCBOR(vectorFromNSData(extensionOutputsCBOR));
+    return AuthenticationExtensionsClientOutputs::fromCBOR(toVector(extensionOutputsCBOR));
 }
 
 bool WebAuthenticatorCoordinatorProxy::isASCAvailable()

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
@@ -141,7 +141,7 @@ Vector<uint8_t> signatureForPrivateKey(RetainPtr<SecKeyRef> privateKey, const Ve
         ASSERT(!errorRef);
     }
 
-    return vectorFromNSData((NSData *)signature.get());
+    return toVector((NSData *)signature.get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
+++ b/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
@@ -215,8 +215,7 @@ auto WebURLSchemeTask::didComplete(const ResourceError& error) -> ExceptionType
     m_completed = true;
 
     if (isSync()) {
-        size_t size = m_syncData.size();
-        Vector<uint8_t> data = { m_syncData.takeAsContiguous()->data(), size };
+        Vector<uint8_t> data = m_syncData.takeAsContiguous()->dataAsSpanForContiguousData();
         m_syncCompletionHandler(m_syncResponse, error, WTFMove(data));
     }
 

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -73,6 +73,7 @@
 #import <wtf/Condition.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/TextStream.h>
 #import <wtf/threads/BinarySemaphore.h>
 #import "AppKitSoftLink.h"
@@ -791,7 +792,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
         [self _updateRemoteAccessibilityRegistration:YES];
         storeAccessibilityRemoteConnectionInformation(self, _page->process().processID(), uuid);
 
-        std::span<const uint8_t> elementToken(reinterpret_cast<const uint8_t*>([remoteElementToken bytes]), [remoteElementToken length]);
+        auto elementToken = toSpan(remoteElementToken);
         _page->registerUIProcessAccessibilityTokens(elementToken, elementToken);
     }
 }

--- a/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
+++ b/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
@@ -36,6 +36,7 @@
 #import <WebCore/LegacyNSPasteboardTypes.h>
 #import <pal/spi/mac/NSSharingServicePickerSPI.h>
 #import <pal/spi/mac/NSSharingServiceSPI.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/WTFString.h>
 
 // FIXME: We probably need to hang on the picker itself until the context menu operation is done, and this object will probably do that.
@@ -129,7 +130,7 @@
 
     if ([item isKindOfClass:[NSAttributedString class]]) {
         NSData *data = [item RTFDFromRange:NSMakeRange(0, [item length]) documentAttributes:@{ }];
-        dataReference = std::span(static_cast<const uint8_t*>([data bytes]), [data length]);
+        dataReference = toSpan(data);
 
         types.append(NSPasteboardTypeRTFD);
         types.append(WebCore::legacyRTFDPasteboardType());
@@ -141,7 +142,7 @@
         if (!image)
             return;
 
-        dataReference = std::span(static_cast<const uint8_t*>([data bytes]), [data length]);
+        dataReference = toSpan(data);
         types.append(NSPasteboardTypeTIFF);
     } else if ([item isKindOfClass:[NSItemProvider class]]) {
         NSItemProvider *itemProvider = (NSItemProvider *)item;

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -50,6 +50,7 @@
 #import <pal/spi/mac/NSWindowSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 #if HAVE(UNIFORM_TYPE_IDENTIFIERS_FRAMEWORK)
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
@@ -385,7 +386,7 @@ void WebContextMenuProxyMac::removeBackgroundFromControlledImage()
     if (!data)
         return;
 
-    page()->replaceImageForRemoveBackground(*elementContext, { String(type.get()) }, std::span(static_cast<const uint8_t*>([data bytes]), [data length]));
+    page()->replaceImageForRemoveBackground(*elementContext, { String(type.get()) }, toSpan(data.get()));
 #endif // ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3535,9 +3535,7 @@ void WebViewImpl::accessibilityRegisterUIProcessTokens()
     // Initialize remote accessibility when the window connection has been established.
     NSData *remoteElementToken = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:m_view.getAutoreleased()];
     NSData *remoteWindowToken = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:[m_view window]];
-    std::span elementToken(reinterpret_cast<const uint8_t*>([remoteElementToken bytes]), [remoteElementToken length]);
-    std::span windowToken(reinterpret_cast<const uint8_t*>([remoteWindowToken bytes]), [remoteWindowToken length]);
-    m_page->registerUIProcessAccessibilityTokens(elementToken, windowToken);
+    m_page->registerUIProcessAccessibilityTokens(toSpan(remoteElementToken), toSpan(remoteWindowToken));
 }
 
 id WebViewImpl::accessibilityFocusedUIElement()

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp
@@ -103,7 +103,7 @@ void RemoteComputePassEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index,
     if (!convertedBindGroup)
         return;
 
-    auto sendResult = send(Messages::RemoteComputePassEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart, dynamicOffsetsDataLength)));
+    auto sendResult = send(Messages::RemoteComputePassEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(std::span { dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart, dynamicOffsetsDataLength })));
     UNUSED_VARIABLE(sendResult);
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -81,7 +81,7 @@ void RemoteQueueProxy::writeBuffer(
     if (!convertedBuffer)
         return;
 
-    auto sendResult = send(Messages::RemoteQueue::WriteBuffer(convertedBuffer, bufferOffset, Vector<uint8_t>(static_cast<const uint8_t*>(source) + dataOffset, size.value_or(byteLength - dataOffset))));
+    auto sendResult = send(Messages::RemoteQueue::WriteBuffer(convertedBuffer, bufferOffset, std::span { static_cast<const uint8_t*>(source) + dataOffset, size.value_or(byteLength - dataOffset) }));
     UNUSED_VARIABLE(sendResult);
 }
 
@@ -101,7 +101,7 @@ void RemoteQueueProxy::writeTexture(
     if (!convertedDestination || !convertedDataLayout || !convertedSize)
         return;
 
-    auto sendResult = send(Messages::RemoteQueue::WriteTexture(*convertedDestination, Vector<uint8_t>(static_cast<const uint8_t*>(source), byteLength), *convertedDataLayout, *convertedSize));
+    auto sendResult = send(Messages::RemoteQueue::WriteTexture(*convertedDestination, Vector(std::span { static_cast<const uint8_t*>(source), byteLength }), *convertedDataLayout, *convertedSize));
     UNUSED_VARIABLE(sendResult);
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp
@@ -147,7 +147,7 @@ void RemoteRenderBundleEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index
     if (!convertedBindGroup)
         return;
 
-    auto sendResult = send(Messages::RemoteRenderBundleEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart, dynamicOffsetsDataLength)));
+    auto sendResult = send(Messages::RemoteRenderBundleEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(std::span { dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart, dynamicOffsetsDataLength })));
     UNUSED_VARIABLE(sendResult);
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp
@@ -146,7 +146,7 @@ void RemoteRenderPassEncoderProxy::setBindGroup(WebCore::WebGPU::Index32 index, 
     if (!convertedBindGroup)
         return;
 
-    auto sendResult = send(Messages::RemoteRenderPassEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart, dynamicOffsetsDataLength)));
+    auto sendResult = send(Messages::RemoteRenderPassEncoder::SetBindGroup(index, convertedBindGroup, Vector<WebCore::WebGPU::BufferDynamicOffset>(std::span { dynamicOffsetsArrayBuffer + dynamicOffsetsDataStart, dynamicOffsetsDataLength })));
     UNUSED_VARIABLE(sendResult);
 }
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -803,7 +803,7 @@ void LibWebRTCCodecs::setEncodingConfiguration(WebKit::VideoEncoderIdentifier id
     if (encoder->descriptionCallback) {
         std::optional<Vector<uint8_t>> decoderDescriptionData;
         if (description.size())
-            decoderDescriptionData = Vector<uint8_t> { description.data(), description.size() };
+            decoderDescriptionData = Vector<uint8_t> { description };
         encoder->descriptionCallback(WebCore::VideoEncoderActiveConfiguration { { }, { }, { }, { }, { }, WTFMove(decoderDescriptionData), WTFMove(colorSpace) });
     }
 }

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -64,7 +64,7 @@ NetworkSendQueue WebSocketChannel::createMessageQueue(Document& document, WebSoc
 {
     return { document, [&channel](auto& utf8String) {
         channel.notifySendFrame(WebSocketFrame::OpCode::OpCodeText, utf8String.dataAsUInt8Ptr(), utf8String.length());
-        channel.sendMessage(Messages::NetworkSocketChannel::SendString { std::span { utf8String.dataAsUInt8Ptr(), utf8String.length() } }, utf8String.length());
+        channel.sendMessage(Messages::NetworkSocketChannel::SendString { utf8String.bytes() }, utf8String.length());
     }, [&channel](auto span) {
         channel.notifySendFrame(WebSocketFrame::OpCode::OpCodeBinary, span.data(), span.size());
         channel.sendMessage(Messages::NetworkSocketChannel::SendData { span }, span.size());

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
@@ -226,7 +226,7 @@ void RTCDataChannelRemoteManager::RemoteSourceConnection::didChangeReadyState(We
 void RTCDataChannelRemoteManager::RemoteSourceConnection::didReceiveStringData(WebCore::RTCDataChannelIdentifier identifier, const String& string)
 {
     auto text = string.utf8();
-    m_connection->send(Messages::RTCDataChannelRemoteManagerProxy::ReceiveData { identifier, false, std::span { text.dataAsUInt8Ptr(), text.length() } }, 0);
+    m_connection->send(Messages::RTCDataChannelRemoteManagerProxy::ReceiveData { identifier, false, text.bytes() }, 0);
 }
 
 void RTCDataChannelRemoteManager::RemoteSourceConnection::didReceiveRawData(WebCore::RTCDataChannelIdentifier identifier, const uint8_t* data, size_t size)

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -296,7 +296,7 @@ void WebSWContextManagerConnection::firePushEvent(ServiceWorkerIdentifier identi
 
     std::optional<Vector<uint8_t>> data;
     if (ipcData)
-        data = Vector<uint8_t> { ipcData->data(), ipcData->size() };
+        data = Vector<uint8_t> { *ipcData };
 
     auto inQueueCallback = [queue = m_queue, callback = WTFMove(callback)](bool result, std::optional<NotificationPayload>&& resultPayload) mutable {
         queue->dispatch([result, resultPayload = crossThreadCopy(WTFMove(resultPayload)), callback = WTFMove(callback)]() mutable {

--- a/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
@@ -125,7 +125,7 @@ static Ref<FormData> toFormData(const HTTPBody& httpBody)
 
     for (const auto& element : httpBody.elements) {
         switchOn(element.data, [&] (const Vector<uint8_t>& data) {
-            formData->appendData(data.data(), data.size());
+            formData->appendData(data.span());
         }, [&] (const HTTPBody::Element::FileData& data) {
             formData->appendFileRange(data.filePath, data.fileStart, data.fileLength.value_or(BlobDataItem::toEndOfFile), data.expectedFileModificationTime);
         }, [&] (const String& blobURLString) {

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -79,6 +79,7 @@
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <pal/spi/cocoa/NSAccessibilitySPI.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/spi/darwin/SandboxSPI.h>
 
 #if ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
@@ -421,8 +422,7 @@ void WebPage::clearDictationAlternatives(Vector<DictationContext>&& contexts)
 
 void WebPage::accessibilityTransferRemoteToken(RetainPtr<NSData> remoteToken, FrameIdentifier frameID)
 {
-    std::span dataToken(reinterpret_cast<const uint8_t*>([remoteToken bytes]), [remoteToken length]);
-    send(Messages::WebPageProxy::RegisterWebProcessAccessibilityToken(dataToken, frameID));
+    send(Messages::WebPageProxy::RegisterWebProcessAccessibilityToken(toSpan(remoteToken.get()), frameID));
 }
 
 void WebPage::accessibilityManageRemoteElementStatus(bool registerStatus, int processIdentifier)
@@ -461,9 +461,7 @@ void WebPage::bindRemoteAccessibilityFrames(int processIdentifier, WebCore::Fram
     registerRemoteFrameAccessibilityTokens(processIdentifier, dataToken);
 
     // Get our remote token data and send back to the RemoteFrame.
-    auto remoteToken = accessibilityRemoteTokenData();
-    std::span remoteDataToken(reinterpret_cast<const uint8_t*>([remoteToken bytes]), [remoteToken length]);
-    completionHandler(remoteDataToken, getpid());
+    completionHandler(toSpan(accessibilityRemoteTokenData().get()), getpid());
 }
 
 #if ENABLE(APPLE_PAY)

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -102,6 +102,7 @@
 #import <pal/spi/mac/NSApplicationSPI.h>
 #import <wtf/SetForScope.h>
 #import <wtf/SortedArrayMap.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 #import "MediaPlaybackTargetContextSerialized.h"
@@ -763,7 +764,7 @@ void WebPage::handleSelectionServiceClick(FrameSelection& selection, const Vecto
     NSData *selectionData = [attributedSelection RTFDFromRange:NSMakeRange(0, [attributedSelection length]) documentAttributes:@{ }];
 
     flushPendingEditorStateUpdate();
-    send(Messages::WebPageProxy::ShowContextMenu(ContextMenuContextData(point, Vector { reinterpret_cast<const uint8_t*>(selectionData.bytes), selectionData.length }, phoneNumbers, selection.selection().isContentEditable()), UserData()));
+    send(Messages::WebPageProxy::ShowContextMenu(ContextMenuContextData(point, toVector(selectionData), phoneNumbers, selection.selection().isContentEditable()), UserData()));
 }
 
 void WebPage::handleImageServiceClick(const IntPoint& point, Image& image, HTMLImageElement& element)

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -843,8 +843,8 @@ static void registerLogHook()
             qos = Thread::QOS::UserInteractive;
         }
 
-        Vector<uint8_t> buffer(msg->buffer, msg->buffer_sz);
-        Vector<uint8_t> privdata(msg->privdata, msg->privdata_sz);
+        Vector<uint8_t> buffer(std::span { msg->buffer, msg->buffer_sz });
+        Vector<uint8_t> privdata(std::span { msg->privdata, msg->privdata_sz });
 
         logQueue()->dispatchWithQOS([logFormat = WTFMove(logFormat), logChannel = WTFMove(logChannel), logCategory = WTFMove(logCategory), type = type, buffer = WTFMove(buffer), privdata = WTFMove(privdata), qos] {
             os_log_message_s msg;

--- a/Source/WebKit/webpushd/ApplePushServiceConnection.mm
+++ b/Source/WebKit/webpushd/ApplePushServiceConnection.mm
@@ -51,7 +51,7 @@
     ASSERT(isMainRunLoop());
 
     if (_connection && publicToken.length)
-        _connection->didReceivePublicToken(Vector<uint8_t> { static_cast<const uint8_t*>(publicToken.bytes), publicToken.length });
+        _connection->didReceivePublicToken(toVector(publicToken));
 }
 
 - (void)connection:(APSConnection *)connection didReceiveIncomingMessage:(APSIncomingMessage *)message

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -415,9 +415,9 @@ void WebPushDaemon::getPendingPushMessages(PushClientConnection& connection, Com
         for (auto& message : iterator->value) {
             auto data = message.payload.utf8();
 #if ENABLE(DECLARATIVE_WEB_PUSH)
-            resultMessages.append(WebKit::WebPushMessage { Vector<uint8_t> { reinterpret_cast<const uint8_t*>(data.data()), data.length() }, message.pushPartitionString, message.registrationURL, WTFMove(message.parsedPayload) });
+            resultMessages.append(WebKit::WebPushMessage { Vector(data.bytes()), message.pushPartitionString, message.registrationURL, WTFMove(message.parsedPayload) });
 #else
-            resultMessages.append(WebKit::WebPushMessage { Vector<uint8_t> { reinterpret_cast<const uint8_t*>(data.data()), data.length() }, message.pushPartitionString, message.registrationURL, { } });
+            resultMessages.append(WebKit::WebPushMessage { Vector(data.bytes()), message.pushPartitionString, message.registrationURL, { } });
 #endif
         }
         m_testingPushMessages.remove(iterator);

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
@@ -68,7 +68,7 @@ public:
     static Ref<WebSocketChannel> create(Document& document, WebSocketChannelClient& client, SocketProvider& provider) { return adoptRef(*new WebSocketChannel(document, client, provider)); }
     virtual ~WebSocketChannel();
 
-    bool send(const uint8_t* data, int length);
+    bool send(std::span<const uint8_t> data);
 
     // ThreadableWebSocketChannel functions.
     ConnectStatus connect(const URL&, const String& protocol) final;
@@ -149,7 +149,7 @@ private:
         RefPtr<Blob> blobData;
     };
     void enqueueTextFrame(CString&&);
-    void enqueueRawFrame(WebSocketFrame::OpCode, const uint8_t* data, size_t dataLength);
+    void enqueueRawFrame(WebSocketFrame::OpCode, std::span<const uint8_t> data);
     void enqueueBlobFrame(WebSocketFrame::OpCode, Blob&);
 
     void processOutgoingFrameQueue();

--- a/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp
@@ -1855,7 +1855,7 @@ private:
             // Note that you can resolve a NativePromise on any threads. Unlike with a CompletionHandler it is not the responsibility of the producer to resolve the promise
             // on a particular thread.
             // The consumer specifies the thread on which it wants to be called back.
-            producer.resolve(std::make_pair<Vector<uint8_t>, String>({ image.data(), image.size() }, { mimeType.data(), static_cast<unsigned>(mimeType.size()) }));
+            producer.resolve(std::make_pair<Vector<uint8_t>, String>(std::span { image }, { mimeType.data(), static_cast<unsigned>(mimeType.size()) }));
         }));
 
         // Return the promise which the producer will resolve at a later stage.

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -321,7 +321,7 @@ TEST(WTF_Vector, CopyFromOtherMinCapacity)
 TEST(WTF_Vector, ConstructorOtherRawPointerTypeAndLength)
 {
     const UChar uchars[] = { 'b', 'a', 'r' };
-    Vector<LChar> vector(uchars, 3);
+    Vector<LChar> vector(std::span { uchars });
     EXPECT_EQ(vector.size(), 3U);
     EXPECT_EQ(vector[0], 'b');
     EXPECT_EQ(vector[1], 'a');
@@ -1715,9 +1715,9 @@ TEST(WTF_Vector, HashKeyString)
 TEST(WTF_Vector, ConstructorFromRawPointerAndSize)
 {
     constexpr size_t inputSize = 5;
-    uint8_t input[inputSize] = { 1, 2, 3, 4, 5 };
+    std::array<uint8_t, inputSize> input { 1, 2, 3, 4, 5 };
 
-    Vector<uint8_t> vector { input, inputSize };
+    Vector<uint8_t> vector { input };
     ASSERT_EQ(vector.size(), inputSize);
     EXPECT_EQ(vector[0], 1);
     EXPECT_EQ(vector[1], 2);

--- a/Tools/TestWebKitAPI/Tests/WTF/cf/VectorCF.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/cf/VectorCF.cpp
@@ -155,7 +155,7 @@ TEST(VectorCF, VectorFromCFData)
     EXPECT_EQ(elementCount, byteLength);
     auto cfData = adoptCF(CFDataCreate(nullptr, static_cast<const UInt8*>(&bytes[0]), Checked<CFIndex>(byteLength)));
 
-    auto vectorData = vectorFromCFData(cfData.get());
+    auto vectorData = toVector(cfData.get());
 
     CFIndex cfDataLength = CFDataGetLength(cfData.get());
     EXPECT_EQ(byteLength, Checked<size_t>(cfDataLength));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -48,6 +48,7 @@
 #import <WebKit/_WKFeature.h>
 #import <WebKit/_WKInspector.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
+#import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 #import <wtf/text/StringConcatenateNumbers.h>
 
@@ -259,8 +260,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
         (__bridge id)kSecAttrKeyType: (__bridge id)kSecAttrKeyTypeRSA,
         (__bridge id)kSecAttrKeyClass: (__bridge id)kSecAttrKeyClassPublic
     }, nil));
-    Vector<uint8_t> rawKeyBytes(static_cast<const uint8_t*>(publicKey.get().bytes), publicKey.get().length);
-    auto wrappedKeyBytes = wrapPublicKeyWithRSAPSSOID(WTFMove(rawKeyBytes));
+    auto wrappedKeyBytes = wrapPublicKeyWithRSAPSSOID(toVector(publicKey.get()));
 
     auto keyData = base64URLEncodeToString(wrappedKeyBytes.data(), wrappedKeyBytes.size());
     // The server.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -51,6 +51,7 @@
 #import <wtf/Deque.h>
 #import <wtf/FileSystem.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/StringToIntegerConversion.h>
 #import <wtf/text/WTFString.h>
 
@@ -709,7 +710,7 @@ static void respondToRangeRequests(const TestWebKitAPI::Connection& connection, 
             rangeBegin, rangeEnd, static_cast<uint64_t>(data.get().length), rangeEnd - rangeBegin];
         NSData *responseHeader = [responseHeaderString dataUsingEncoding:NSUTF8StringEncoding];
         NSData *responseBody = [data subdataWithRange:NSMakeRange(rangeBegin, rangeEnd - rangeBegin)];
-        Vector<uint8_t> response { static_cast<const uint8_t*>(responseHeader.bytes), responseHeader.length };
+        auto response = toVector(responseHeader);
         response.append(static_cast<const uint8_t*>(responseBody.bytes), responseBody.length);
         connection.send(WTFMove(response), [=] {
             respondToRangeRequests(connection, data);


### PR DESCRIPTION
#### 7263d3ab568094eb94dd4e9ec859d14a9cd871b0
<pre>
Drop Vector constructor taking a raw pointer and a size
<a href="https://bugs.webkit.org/show_bug.cgi?id=270944">https://bugs.webkit.org/show_bug.cgi?id=270944</a>

Reviewed by Sihui Liu, Mike Wyrzykowski, Justin Michaud and Darin Adler.

Drop Vector constructor taking a raw pointer and a size and port call sites to
the constructor taking a std::span instead.

This is work towards more widespread std::span adoption in WebKit, which has
security benefits.

* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::ArrayBuffer::tryCreate):
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/JavaScriptCore/runtime/ArrayBufferView.h:
(JSC::ArrayBufferView::bytes const):
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::parseTimeZoneBracketedAnnotation):
(JSC::ISO8601::parseCalendar):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::formatRange):
(JSC::IntlDateTimeFormat::formatRangeToParts):
* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::Parser::sourceSpan const):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseInitExpr):
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::StreamingParser::consume):
* Source/JavaScriptCore/yarr/generateYarrUnicodePropertyTables.py:
(PropertyData.convertStringToCppFormat):
* Source/WTF/wtf/Algorithms.h:
(WTF::equalSpans):
* Source/WTF/wtf/Vector.h:
(WTF::Vector::Vector):
(WTF::Vector::subVector const):
* Source/WTF/wtf/cf/VectorCF.h:
(WTF::vectorFromCFData):
* Source/WTF/wtf/cocoa/VectorCocoa.h:
(WTF::vectorFromNSData):
* Source/WTF/wtf/persistence/PersistentEncoder.h:
(WTF::Persistence::Encoder::bytes const):
* Source/WTF/wtf/text/IntegerToStringConversion.h:
* Source/WTF/wtf/text/StringParsingBuffer.h:
* Source/WTF/wtf/text/WTFString.cpp:
(asciiDebug):
* Source/WTF/wtf/text/WTFString.h:
(WTF::String::fromUTF8):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm:
(WebCore::ShapeDetection::convertLandmark):
* Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp:
(WebCore::ClipboardItem::blobFromString):
* Source/WebCore/Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm:
(WebCore::ClipboardImageReader::readBuffer):
* Source/WebCore/Modules/async-clipboard/mac/ClipboardImageReaderMac.mm:
(WebCore::ClipboardImageReader::readBuffer):
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::consumeArrayBuffer):
(WebCore::FetchBody::consumeArrayBufferView):
(WebCore::FetchBody::consumeText):
(WebCore::FetchBody::bodyAsFormData const):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::packageFormData):
(WebCore::resolveWithTypeAndData):
(WebCore::FetchBodyConsumer::resolveWithData):
(WebCore::FetchBodyConsumer::resolveWithFormData):
(WebCore::FetchBodyConsumer::resolve):
(WebCore::FetchBodyConsumer::takeAsText):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.h:
* Source/WebCore/Modules/fetch/FetchBodyOwner.cpp:
(WebCore::FetchBodyOwner::arrayBuffer):
(WebCore::FetchBodyOwner::formData):
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::didReceiveRawData):
* Source/WebCore/Modules/notifications/NotificationDataCocoa.mm:
(WebCore::NotificationData::fromDictionary):
* Source/WebCore/Modules/push-api/PushEvent.cpp:
(WebCore::dataFromPushMessageDataInit):
* Source/WebCore/Modules/push-api/PushManager.cpp:
(WebCore::PushManager::subscribe):
* Source/WebCore/Modules/push-api/PushMessageCrypto.cpp:
(WebCore::PushCrypto::ClientKeys::generate):
(WebCore::PushCrypto::decryptAESGCMPayload):
* Source/WebCore/Modules/push-api/PushMessageData.cpp:
(WebCore::PushMessageData::text):
* Source/WebCore/Modules/push-api/cocoa/PushCryptoCocoa.cpp:
(WebCore::PushCrypto::P256DHKeyPair::generate):
* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp:
(WebCore::convertBytesToVector):
* Source/WebCore/Modules/webauthn/cbor/CBORValue.cpp:
(cbor::CBORValue::CBORValue):
* Source/WebCore/Modules/webauthn/fido/DeviceResponseConverter.cpp:
(fido::decodeResponseMap):
* Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp:
(fido::FidoHidInitPacket::createFromSerializedData):
(fido::FidoHidContinuationPacket::createFromSerializedData):
* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
(fido::pin::encodeCOSEPublicKey):
* Source/WebCore/Modules/webauthn/fido/U2fResponseConverter.cpp:
(fido::WebCore::extractECPublicKeyFromU2fRegistrationResponse):
(fido::WebCore::extractCredentialIdFromU2fRegistrationResponse):
(fido::WebCore::createFidoAttestationStatementFromU2fRegisterResponse):
(fido::readU2fSignResponse):
* Source/WebCore/PAL/pal/text/TextCodec.cpp:
(PAL::TextCodec::decode):
* Source/WebCore/PAL/pal/text/TextCodec.h:
* Source/WebCore/PAL/pal/text/TextEncodingDetector.h:
* Source/WebCore/PAL/pal/text/TextEncodingDetectorICU.cpp:
(PAL::detectTextEncoding):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
(WebCore::fulfillPromiseWithArrayBuffer):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::toKeyData):
(WebCore::copyToVector):
(WebCore::SubtleCrypto::encrypt):
(WebCore::SubtleCrypto::decrypt):
(WebCore::SubtleCrypto::sign):
(WebCore::SubtleCrypto::digest):
(WebCore::SubtleCrypto::deriveBits):
(WebCore::SubtleCrypto::exportKey):
(WebCore::SubtleCrypto::wrapKey):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp:
(WebCore::signEd25519):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp:
(WebCore::CryptoAlgorithmX25519::platformDeriveBits):
* Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp:
(WebCore::CryptoKeyEC::platformImportPkcs8):
* Source/WebCore/css/CSSVariableData.cpp:
(WebCore::CSSVariableData::CSSVariableData):
* Source/WebCore/css/parser/CSSParserTokenRange.h:
(WebCore::CSSParserTokenRange::span const):
* Source/WebCore/dom/ElementData.cpp:
(WebCore::UniqueElementData::UniqueElementData):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::sanitizeMarkupWithArchive):
* Source/WebCore/html/FormController.cpp:
(WebCore::AtomStringVectorReader::consumeSubvector):
* Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp:
(WebCore::HTMLMetaCharsetParser::checkForMetaCharset):
* Source/WebCore/html/parser/HTMLMetaCharsetParser.h:
* Source/WebCore/loader/FormSubmission.cpp:
(WebCore::appendMailtoPostFormDataToURL):
* Source/WebCore/loader/TextResourceDecoder.cpp:
(WebCore::bytesEqual):
(WebCore::find):
(WebCore::findTextEncoding):
(WebCore::KanjiCode::judge):
(WebCore::shouldPrependBOM):
(WebCore::TextResourceDecoder::textFromUTF8):
(WebCore::findXMLEncoding):
(WebCore::TextResourceDecoder::checkForBOM):
(WebCore::TextResourceDecoder::checkForCSSCharset):
(WebCore::TextResourceDecoder::checkForHeadCharset):
(WebCore::TextResourceDecoder::checkForMetaCharset):
(WebCore::TextResourceDecoder::detectJapaneseEncoding):
(WebCore::TextResourceDecoder::decode):
(WebCore::TextResourceDecoder::flush):
(WebCore::TextResourceDecoder::decodeAndFlush):
* Source/WebCore/loader/TextResourceDecoder.h:
(WebCore::TextResourceDecoder::decode):
(WebCore::TextResourceDecoder::decodeAndFlush):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::append):
* Source/WebCore/platform/SharedBuffer.h:
(WebCore::DataSegment::bytes const):
(WebCore::FragmentedSharedBuffer::append):
* Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm:
(WebCore::ContentFilterUnblockHandler::webFilterEvaluatorData const):
* Source/WebCore/platform/graphics/DecomposedGlyphs.cpp:
(WebCore::DecomposedGlyphs::create):
* Source/WebCore/platform/graphics/ImageBackingStore.h:
(WebCore::ImageBackingStore::ImageBackingStore):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource):
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::cookieFromOpusCookieContents):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::DrawGlyphs::DrawGlyphs):
* Source/WebCore/platform/graphics/iso/ISOBox.cpp:
(WebCore::ISOBox::parse):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.cpp:
(WebCore::MediaRecorderPrivateMock::fetchData):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::captureOutputDidFinishProcessingPhoto):
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormData::create):
(WebCore::FormDataElement::isolatedCopy const):
(WebCore::FormData::appendData):
(WebCore::FormData::appendMultiPartFileValue):
(WebCore::FormData::appendMultiPartStringValue):
(WebCore::FormData::appendMultiPartKeyValuePairItems):
(WebCore::FormData::appendNonMultiPartKeyValuePairItems):
(WebCore::appendBlobResolved):
(WebCore::FormData::resolveBlobReferences):
* Source/WebCore/platform/network/FormData.h:
* Source/WebCore/platform/network/FormDataBuilder.cpp:
(WebCore::FormDataBuilder::append):
(WebCore::FormDataBuilder::appendQuoted):
(WebCore::FormDataBuilder::appendFormURLEncoded):
(WebCore::FormDataBuilder::beginMultiPartHeader):
(WebCore::FormDataBuilder::addBoundaryToMultiPartHeader):
(WebCore::FormDataBuilder::addFilenameToMultiPartHeader):
(WebCore::FormDataBuilder::addContentTypeToMultiPartHeader):
(WebCore::FormDataBuilder::finishMultiPartHeader):
(WebCore::FormDataBuilder::addKeyValuePairAsFormData):
(WebCore::FormDataBuilder::encodeStringAsFormData):
* Source/WebCore/platform/network/FormDataBuilder.h:
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdateResourceHTTPBody):
* Source/WebCore/platform/sql/SQLiteStatement.cpp:
(WebCore::SQLiteStatement::columnBlob):
* Source/WebCore/platform/text/cocoa/LocaleCocoa.mm:
(WebCore::LocaleCocoa::monthLabels):
(WebCore::LocaleCocoa::shortMonthLabels):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::deserializeBuffer const):
(WebCore::Internals::createPushSubscription):
* Source/WebCore/testing/ServiceWorkerInternals.cpp:
(WebCore::ServiceWorkerInternals::schedulePushEvent):
(WebCore::ServiceWorkerInternals::createPushSubscription):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
(WebCore::BackgroundFetch::doStore):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::send):
(WebCore::XMLHttpRequest::sendBytesData):
* Source/WebCore/xml/XMLHttpRequest.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::openFunc):
* Source/WebGPU/WebGPU/Adapter.mm:
(WebGPU::Adapter::requestDevice):
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::Device::createBindGroupLayout):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::setBindGroup):
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::RenderBundle):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::RenderBundleEncoder):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::RenderPassEncoder):
(WebGPU::RenderPassEncoder::setBindGroup):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::RenderPipeline):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Device::createTexture):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::WebCore::vectorCopyCast):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::mapAsync):
(WebKit::RemoteBuffer::getMappedRange):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::encodeRecordHeader):
(WebKit::encodeRecordBody):
(WebKit::encodeRecord):
* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::sendWithReply const):
* Source/WebKit/Shared/API/c/WKURLRequest.cpp:
(WKURLRequestCopySettingHTTPBody):
* Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm:
(WebKit::WebPushMessage::fromDictionary):
* Source/WebKit/Shared/RTCNetwork.cpp:
(WebKit::RTCNetwork::RTCNetwork):
(WebKit::description):
(WebKit::RTC::Network::SocketAddress::SocketAddress):
* Source/WebKit/Shared/WebPushMessage.cpp:
(WebKit::WebPushMessage::notificationPayloadToCoreData const):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(dataReferenceFrom):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm:
(WebKit::SubFrameSOAuthorizationSession::fallBackToWebPathInternal):
(WebKit::SubFrameSOAuthorizationSession::completeInternal):
(WebKit::SubFrameSOAuthorizationSession::beforeStart):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm:
(WebKit::CcidConnection::detectContactless):
(WebKit::CcidConnection::trySelectFidoApplet):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/HidConnection.mm:
(WebKit::reportReceived):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::aaguidVector):
* Source/WebKit/UIProcess/WebURLSchemeTask.cpp:
(WebKit::WebURLSchemeTask::didComplete):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteComputePassEncoderProxy::setBindGroup):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::writeBuffer):
(WebKit::WebGPU::RemoteQueueProxy::writeTexture):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderBundleEncoderProxy::setBindGroup):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.cpp:
(WebKit::WebGPU::RemoteRenderPassEncoderProxy::setBindGroup):
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::setEncodingConfiguration):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::firePushEvent):
* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp:
(WebKit::toFormData):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::handleSelectionServiceClick):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::registerLogHook):
* Source/WebKit/webpushd/ApplePushServiceConnection.mm:
(-[_WKAPSConnectionDelegate connection:didReceivePublicToken:]):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::getPendingPushMessages):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::send):
(WebCore::WebSocketChannel::startClosingHandshake):
(WebCore::WebSocketChannel::processFrame):
(WebCore::WebSocketChannel::enqueueRawFrame):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h:
* Tools/TestWebKitAPI/Tests/WTF/NativePromise.cpp:
(TestWebKitAPI::PhotoProducer::takePhotoImpl const):
* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm:
(TestWebKitAPI::signUnlinkableTokenAndSendSecretToken):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(respondToRangeRequests):

Canonical link: <a href="https://commits.webkit.org/276220@main">https://commits.webkit.org/276220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6878e7eb37e7cda7583d5a0630541a56317092f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46700 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40105 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20521 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37948 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39045 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2110 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/37403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48286 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43638 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15612 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20636 "Hash e6878e7e for PR 25854 does not build (failure)") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50699 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6036 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/20048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10228 "Passed tests") | 
<!--EWS-Status-Bubble-End-->