### PR TITLE
(2) Adopt com.apple.developer.cs.allow-jit entitlement for iOS.

### DIFF
--- a/Source/JavaScriptCore/Scripts/process-entitlements.sh
+++ b/Source/JavaScriptCore/Scripts/process-entitlements.sh
@@ -115,16 +115,22 @@ function maccatalyst_process_testapi_entitlements()
 function ios_family_process_jsc_entitlements()
 {
     plistbuddy Add :com.apple.private.pac.exception bool YES
-    plistbuddy Add :com.apple.private.verified-jit bool YES
-    plistbuddy Add :dynamic-codesigning bool YES
+    if [[ "${PLATFORM_NAME}" != watchos ]]; then
+        plistbuddy Add :com.apple.private.verified-jit bool YES
+        if [[ "${PLATFORM_NAME}" == iphoneos ]]; then
+            if (( $(( ${SDK_VERSION_ACTUAL} )) >= 170400 )); then
+                plistbuddy Add :com.apple.developer.cs.allow-jit bool YES
+                plistbuddy Add :com.apple.developer.web-browser-engine.webcontent bool YES
+            else
+                plistbuddy Add :dynamic-codesigning bool YES
+            fi
+        else
+            plistbuddy Add :dynamic-codesigning bool YES
+        fi
+    fi
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
     plistbuddy Add :com.apple.security.fatal-exceptions array
     plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
-}
-
-function ios_family_process_testapi_entitlements()
-{
-    ios_family_process_jsc_entitlements
 }
 
 rm -f "${WK_PROCESSED_XCENT_FILE}"
@@ -172,13 +178,13 @@ then
     if [[ "${PRODUCT_NAME}" == jsc ||
           "${PRODUCT_NAME}" == dynbench ||
           "${PRODUCT_NAME}" == minidom ||
+          "${PRODUCT_NAME}" == testapi ||
           "${PRODUCT_NAME}" == testair ||
           "${PRODUCT_NAME}" == testb3 ||
           "${PRODUCT_NAME}" == testdfg ||
           "${PRODUCT_NAME}" == testmasm ||
           "${PRODUCT_NAME}" == testmem ||
           "${PRODUCT_NAME}" == testRegExp ]]; then ios_family_process_jsc_entitlements
-    elif [[ "${PRODUCT_NAME}" == testapi ]]; then ios_family_process_testapi_entitlements
     else echo "Unsupported/unknown product: ${PRODUCT_NAME}"
     fi
 else

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -164,7 +164,7 @@ static bool isJITEnabled()
 {
     bool jitEnabled = !g_jscConfig.jitDisabled;
 #if HAVE(IOS_JIT_RESTRICTIONS)
-    jitEnabled = jitEnabled && processHasEntitlement("dynamic-codesigning"_s);
+    jitEnabled = jitEnabled && (processHasEntitlement("dynamic-codesigning"_s) || processHasEntitlement("com.apple.developer.cs.allow-jit"_s));
 #elif HAVE(MAC_JIT_RESTRICTIONS) && USE(APPLE_INTERNAL_SDK)
     jitEnabled = jitEnabled && processHasEntitlement("com.apple.security.cs.allow-jit"_s);
 #endif
@@ -184,7 +184,7 @@ void ExecutableAllocator::disableJIT()
 
 #if HAVE(IOS_JIT_RESTRICTIONS) || HAVE(MAC_JIT_RESTRICTIONS) && USE(APPLE_INTERNAL_SDK)
 #if HAVE(IOS_JIT_RESTRICTIONS)
-    bool shouldDisableJITMemory = processHasEntitlement("dynamic-codesigning"_s);
+    bool shouldDisableJITMemory = processHasEntitlement("dynamic-codesigning"_s) || processHasEntitlement("com.apple.developer.cs.allow-jit"_s);
 #else
     bool shouldDisableJITMemory = processHasEntitlement("com.apple.security.cs.allow-jit"_s) && !isKernOpenSource();
 #endif

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -399,10 +399,17 @@ fi
 
 function ios_family_process_webcontent_entitlements()
 {
-    if [[ "${WK_PLATFORM_NAME}" != watchos ]]
-    then
+    if [[ "${PLATFORM_NAME}" != watchos ]]; then
         plistbuddy Add :com.apple.private.verified-jit bool YES
-        plistbuddy Add :dynamic-codesigning bool YES
+        if [[ "${PLATFORM_NAME}" == iphoneos ]]; then
+            if (( $(( ${SDK_VERSION_ACTUAL} )) >= 170400 )); then
+                plistbuddy Add :com.apple.developer.cs.allow-jit bool YES
+            else
+                plistbuddy Add :dynamic-codesigning bool YES
+            fi
+        else
+            plistbuddy Add :dynamic-codesigning bool YES
+        fi
     fi
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES
 

--- a/Tools/WebKitTestRunner/Configurations/WebKitTestRunner-internal.entitlements
+++ b/Tools/WebKitTestRunner/Configurations/WebKitTestRunner-internal.entitlements
@@ -8,6 +8,8 @@
 	</array>
 	<key>com.apple.private.webkit.adattributiond.testing</key>
 	<true/>
+	<key>com.apple.developer.web-browser-engine.webcontent</key>
+	<true/>
 	<key>com.apple.security.temporary-exception.sbpl</key>
 	<array>
 		<string>(allow mach-issue-extension (require-all (extension-class &quot;com.apple.webkit.extension.mach&quot;)))</string>

--- a/Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp-iOS.entitlements
+++ b/Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp-iOS.entitlements
@@ -14,5 +14,7 @@
 	<true/>
 	<key>com.apple.runningboard.launch_extensions</key>
 	<true/>
+	<key>com.apple.developer.web-browser-engine.webcontent</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
#### b1d861f1f579588da2b6d8b13ba5aa138a7afc46
<pre>
(2) Adopt com.apple.developer.cs.allow-jit entitlement for iOS.
<a href="https://rdar.apple.com/122841355">rdar://122841355</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=270723">https://bugs.webkit.org/show_bug.cgi?id=270723</a>

Reviewed by Keith Miller.

* Source/JavaScriptCore/Scripts/process-entitlements.sh:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::isJITEnabled):
(JSC::ExecutableAllocator::disableJIT):
* Source/WebKit/Scripts/process-entitlements.sh:
* Tools/WebKitTestRunner/Configurations/WebKitTestRunner-internal.entitlements:
* Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp-iOS.entitlements:

Canonical link: <a href="https://commits.webkit.org/276913@main">https://commits.webkit.org/276913@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/271160386b3dba08aea3496fe9f2387a286b93d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48782 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42151 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22684 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37701 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46689 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18894 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/45976 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19731 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40885 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4155 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39344 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42430 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50575 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45585 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44867 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22407 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43775 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10219 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52736 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22101 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10790 "Passed tests") | 
<!--EWS-Status-Bubble-End-->