### PR TITLE
[WTF] Make Assertion inlined

### DIFF
--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -650,35 +650,6 @@ void WTFReleaseLogStackTrace(WTFLogChannel* channel)
 } // extern "C"
 
 #if (OS(DARWIN) || PLATFORM(PLAYSTATION)) && (CPU(X86_64) || CPU(ARM64))
-#if CPU(X86_64)
-
-#define CRASH_INST "int3"
-
-// This ordering was chosen to be consistent with JSC's JIT asserts. We probably shouldn't change this ordering
-// since it would make tooling crash reports much harder. If, for whatever reason, we decide to change the ordering
-// here we should update the abortWithuint64_t functions.
-#define CRASH_GPR0 "r11"
-#define CRASH_GPR1 "r10"
-#define CRASH_GPR2 "r9"
-#define CRASH_GPR3 "r8"
-#define CRASH_GPR4 "r15"
-#define CRASH_GPR5 "r14"
-#define CRASH_GPR6 "r13"
-
-#elif CPU(ARM64) // CPU(X86_64)
-
-#define CRASH_INST "brk #0xc471"
-
-// See comment above on the ordering.
-#define CRASH_GPR0 "x16"
-#define CRASH_GPR1 "x17"
-#define CRASH_GPR2 "x19" // We skip x18, which is reserved on ARM64 for platform use.
-#define CRASH_GPR3 "x20"
-#define CRASH_GPR4 "x21"
-#define CRASH_GPR5 "x22"
-#define CRASH_GPR6 "x23"
-
-#endif // CPU(ARM64)
 
 void WTFCrashWithInfoImpl(int, const char*, const char*, int, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5, uint64_t misc6)
 {

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -248,16 +248,56 @@ WTF_EXPORT_PRIVATE void WTFReleaseLogStackTrace(WTFLogChannel*);
 
 WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
 
+#if CPU(X86_64)
+
+#define CRASH_INST "int3"
+
+// This ordering was chosen to be consistent with JSC's JIT asserts. We probably shouldn't change this ordering
+// since it would make tooling crash reports much harder. If, for whatever reason, we decide to change the ordering
+// here we should update the abortWithuint64_t functions.
+#define CRASH_ARG_GPR0 "rdi"
+#define CRASH_ARG_GPR1 "rsi"
+#define CRASH_ARG_GPR2 "rdx"
+#define CRASH_ARG_GPR3 "rcx"
+
+#define CRASH_GPR0 "r11"
+#define CRASH_GPR1 "r10"
+#define CRASH_GPR2 "r9"
+#define CRASH_GPR3 "r8"
+#define CRASH_GPR4 "r15"
+#define CRASH_GPR5 "r14"
+#define CRASH_GPR6 "r13"
+
+#elif CPU(ARM64) // CPU(X86_64)
+
+#define CRASH_INST "brk #0xc471"
+
+// See comment above on the ordering.
+#define CRASH_ARG_GPR0 "x0"
+#define CRASH_ARG_GPR1 "x1"
+#define CRASH_ARG_GPR2 "x2"
+#define CRASH_ARG_GPR3 "x3"
+
+#define CRASH_GPR0 "x16"
+#define CRASH_GPR1 "x17"
+#define CRASH_GPR2 "x19" // We skip x18, which is reserved on ARM64 for platform use.
+#define CRASH_GPR3 "x20"
+#define CRASH_GPR4 "x21"
+#define CRASH_GPR5 "x22"
+#define CRASH_GPR6 "x23"
+
+#endif // CPU(ARM64)
+
 #if COMPILER(MSVC)
 #define WTFBreakpointTrap()  __debugbreak()
 #elif ASAN_ENABLED
 #define WTFBreakpointTrap()  __builtin_trap()
 #elif CPU(X86_64) || CPU(X86)
-#define WTFBreakpointTrap()  asm volatile ("int3")
+#define WTFBreakpointTrap()  asm volatile (CRASH_INST)
 #elif CPU(ARM_THUMB2)
 #define WTFBreakpointTrap()  asm volatile ("bkpt #0")
 #elif CPU(ARM64)
-#define WTFBreakpointTrap()  asm volatile ("brk #0xc471")
+#define WTFBreakpointTrap()  asm volatile (CRASH_INST)
 #else
 #define WTFBreakpointTrap() WTFCrash() // Not implemented.
 #endif
@@ -722,7 +762,11 @@ WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoI
 WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, int counter, uint64_t reason, uint64_t misc1, uint64_t misc2);
 WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, int counter, uint64_t reason, uint64_t misc1);
 WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, int counter, uint64_t reason);
+#if (OS(DARWIN) || PLATFORM(PLAYSTATION)) && (CPU(X86_64) || CPU(ARM64))
+NO_RETURN_DUE_TO_CRASH ALWAYS_INLINE void WTFCrashWithInfo(int line, const char* file, const char* function, int counter);
+#else
 NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfo(int line, const char* file, const char* function, int counter);
+#endif
 
 template<typename T>
 ALWAYS_INLINE uint64_t wtfCrashArg(T* arg) { return reinterpret_cast<uintptr_t>(arg); }
@@ -772,6 +816,24 @@ NO_RETURN_DUE_TO_CRASH ALWAYS_INLINE void WTFCrashWithInfo(int line, const char*
     WTFCrashWithInfoImpl(line, file, function, counter, wtfCrashArg(reason), wtfCrashArg(misc1), wtfCrashArg(misc2), wtfCrashArg(misc3), wtfCrashArg(misc4), wtfCrashArg(misc5), wtfCrashArg(misc6));
 }
 
+#if (OS(DARWIN) || PLATFORM(PLAYSTATION)) && (CPU(X86_64) || CPU(ARM64))
+
+NO_RETURN_DUE_TO_CRASH ALWAYS_INLINE void WTFCrashWithInfo(int line, const char* file, const char* function, int counter)
+{
+    uint64_t x0Value = static_cast<uint64_t>(static_cast<int64_t>(line));
+    uint64_t x1Value = reinterpret_cast<uintptr_t>(file);
+    uint64_t x2Value = reinterpret_cast<uintptr_t>(function);
+    uint64_t x3Value = static_cast<uint64_t>(static_cast<int64_t>(counter));
+    register uint64_t x0GPR asm(CRASH_ARG_GPR0) = x0Value;
+    register uint64_t x1GPR asm(CRASH_ARG_GPR1) = x1Value;
+    register uint64_t x2GPR asm(CRASH_ARG_GPR2) = x2Value;
+    register uint64_t x3GPR asm(CRASH_ARG_GPR3) = x3Value;
+    __asm__ volatile (CRASH_INST : : "r"(x0GPR), "r"(x1GPR), "r"(x2GPR), "r"(x3GPR));
+    __builtin_trap();
+}
+
+#else
+
 inline void WTFCrashWithInfo(int, const char*, const char*, int)
 #if COMPILER(CLANG)
     __attribute__((optnone))
@@ -779,6 +841,8 @@ inline void WTFCrashWithInfo(int, const char*, const char*, int)
 {
     CRASH();
 }
+
+#endif
 
 namespace WTF {
 inline void isIntegralOrPointerType() { }


### PR DESCRIPTION
#### c5e2f6fceb7fa508c026286a412a8b3b01c7f0c0
<pre>
[WTF] Make Assertion inlined
<a href="https://bugs.webkit.org/show_bug.cgi?id=270952">https://bugs.webkit.org/show_bug.cgi?id=270952</a>
<a href="https://rdar.apple.com/124569636">rdar://124569636</a>

Reviewed by Keith Miller.

This inlined function with optnone is originally introduced in 203263@main to fix internal build failures.
But these affected code no longer exists. This patch makes WTFCrashWithInfo completely inlined function with
appropriate inline asm so that we can make caller of them optimized.

* Source/WTF/wtf/Assertions.h:

Canonical link: <a href="https://commits.webkit.org/276095@main">https://commits.webkit.org/276095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f5faac4781c47fe1d333ae02672a6d533ddd79b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43706 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46145 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46349 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39814 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36097 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17079 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17307 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38711 "Found 1 new test failure: imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1763 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37149 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47905 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43328 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42899 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20148 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41581 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20339 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50338 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5975 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19774 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10148 "Passed tests") | 
<!--EWS-Status-Bubble-End-->