### PR TITLE
Refactor the text extraction runtime feature flag

### DIFF
--- a/LayoutTests/fast/text-extraction/basic-text-extraction.html
+++ b/LayoutTests/fast/text-extraction/basic-text-extraction.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ textExtractionEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6796,7 +6796,7 @@ TextExtractionEnabled:
   exposed: [ WebKit ]
   defaultValue:
     WebKit:
-      default: false
+      default: true
 
 TextInteractionEnabled:
   type: bool

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -826,12 +826,6 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 
 - (void)_setTextExtractionEnabled:(BOOL)enabled
 {
-    if (enabled) {
-        static std::once_flag onceFlag;
-        std::call_once(onceFlag, [] {
-            WebKit::prepareTextExtractionSupport();
-        });
-    }
     _preferences->setTextExtractionEnabled(enabled);
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.h
@@ -27,7 +27,7 @@
 
 #import <wtf/RetainPtr.h>
 
-@class WKTextExtractionItem;
+OBJC_CLASS WKTextExtractionItem;
 
 namespace WebCore {
 namespace TextExtraction {
@@ -37,7 +37,7 @@ struct Item;
 
 namespace WebKit {
 
-void prepareTextExtractionSupport();
+void prepareTextExtractionSupportIfNeeded();
 RetainPtr<WKTextExtractionItem> createItem(const WebCore::TextExtraction::Item&);
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm
@@ -35,7 +35,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-void prepareTextExtractionSupport()
+void prepareTextExtractionSupportIfNeeded()
 {
     // Preemptively soft link libWebKitSwift if it exists, so that the corresponding Swift extension
     // on WKWebView will be loaded.

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -385,6 +385,10 @@
 #include "WebExtensionController.h"
 #endif
 
+#if ENABLE(TEXT_EXTRACTION)
+#import "WKTextExtractionUtilities.h"
+#endif
+
 #define MESSAGE_CHECK(process, assertion) MESSAGE_CHECK_BASE(assertion, process->connection())
 #define MESSAGE_CHECK_URL(process, url) MESSAGE_CHECK_BASE(checkURLReceivedFromCurrentOrPreviousWebProcess(process, url), process->connection())
 #define MESSAGE_CHECK_COMPLETION(process, assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, process->connection(), completion)
@@ -6319,6 +6323,11 @@ void WebPageProxy::didCommitLoadForFrame(FrameIdentifier frameID, FrameInfoData&
 #if ENABLE(MEDIA_STREAM)
     if (m_userMediaPermissionRequestManager)
         m_userMediaPermissionRequestManager->didCommitLoadForFrame(frameID);
+#endif
+
+#if ENABLE(TEXT_EXTRACTION)
+    if (frame->isMainFrame() && preferences().textExtractionEnabled())
+        prepareTextExtractionSupportIfNeeded();
 #endif
 }
 

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -195,7 +195,6 @@ const TestFeatures& TestOptions::defaults()
             { "showsScrollIndicators", true },
             { "longPressActionsEnabled", true },
             { "enhancedWindowingEnabled", false },
-            { "textExtractionEnabled", false },
         };
         features.doubleTestRunnerFeatures = {
             { "contentInset.top", 0 },
@@ -266,7 +265,6 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "showsScrollIndicators", TestHeaderKeyType::BoolTestRunner },
         { "longPressActionsEnabled", TestHeaderKeyType::BoolTestRunner },
         { "enhancedWindowingEnabled", TestHeaderKeyType::BoolTestRunner },
-        { "textExtractionEnabled", TestHeaderKeyType::BoolTestRunner },
     
         { "contentInset.top", TestHeaderKeyType::DoubleTestRunner },
         { "obscuredInset.top", TestHeaderKeyType::DoubleTestRunner },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -83,7 +83,6 @@ public:
     bool showsScrollIndicators() const { return boolTestRunnerFeatureValue("showsScrollIndicators"); }
     bool longPressActionsEnabled() const { return boolTestRunnerFeatureValue("longPressActionsEnabled"); }
     bool enhancedWindowingEnabled() const { return boolTestRunnerFeatureValue("enhancedWindowingEnabled"); }
-    bool textExtractionEnabled() const { return boolTestRunnerFeatureValue("textExtractionEnabled"); }
     double contentInsetTop() const { return doubleTestRunnerFeatureValue("contentInset.top"); }
     double obscuredInsetTop() const { return doubleTestRunnerFeatureValue("obscuredInset.top"); }
     double horizontalSystemMinimumLayoutMargin() const { return doubleTestRunnerFeatureValue("horizontalSystemMinimumLayoutMargin"); }

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -458,7 +458,6 @@ void TestController::cocoaResetStateToConsistentValues(const TestOptions& option
 
         auto configuration = platformView.configuration;
         configuration.preferences.textInteractionEnabled = options.textInteractionEnabled();
-        configuration.preferences._textExtractionEnabled = options.textExtractionEnabled();
     }
 
     [LayoutTestSpellChecker uninstallAndReset];


### PR DESCRIPTION
#### e8a2ecbc49f8a65ccf25a725f51d6fda11c8d530
<pre>
Refactor the text extraction runtime feature flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=270954">https://bugs.webkit.org/show_bug.cgi?id=270954</a>
<a href="https://rdar.apple.com/124557582">rdar://124557582</a>

Reviewed by Aditya Keerthi.

Flip the text extraction embedder preference to being true by default; see below for more details.

* LayoutTests/fast/text-extraction/basic-text-extraction.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _setTextExtractionEnabled:]):

Loading `libWebKitSwift` when the WebKit client enables text extraction no longer makes sense, now
that it&apos;s enabled by default; instead, defer loading this dylib to when the web view actually
commits a load for the first time.

* Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.h:
* Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm:
(WebKit::prepareTextExtractionSupportIfNeeded):
(WebKit::prepareTextExtractionSupport): Deleted.

Renamed from `prepareTextExtractionSupport()` to reflect that it only loads WebKitSwift the first
time it is called, assuming it hasn&apos;t already been loaded.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):

Call `prepareTextExtractionSupportIfNeeded` when committing a load.

* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::textExtractionEnabled const): Deleted.
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::cocoaResetStateToConsistentValues):

Remove the test option, now that it&apos;s no longer necessary.

Canonical link: <a href="https://commits.webkit.org/276091@main">https://commits.webkit.org/276091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84173a6cc877efb7809ca90d56526a1fffe7e45b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46356 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39818 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46017 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36099 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19778 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37649 "Failed to checkout and rebase branch from PR 25866") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17081 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38717 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1770 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37153 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39869 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [💥 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39022 "An unexpected error occured. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47912 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43332 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42900 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/37920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41585 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9726 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20343 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50345 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19778 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10152 "Passed tests") | 
<!--EWS-Status-Bubble-End-->