### PR TITLE
Move some WKWebViewConfiguration ivars to API::PageConfiguration

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -202,6 +202,20 @@ public:
     void setHTTPSUpgradeEnabled(bool enabled) { m_data.httpsUpgradeEnabled = enabled; }
     bool httpsUpgradeEnabled() const { return m_data.httpsUpgradeEnabled; }
 
+#if PLATFORM(MAC)
+    bool showsURLsInToolTips() const { return m_data.showsURLsInToolTips; }
+    void setShowsURLsInToolTips(bool shows) { m_data.showsURLsInToolTips = shows; }
+
+    bool serviceControlsEnabled() const { return m_data.serviceControlsEnabled; }
+    void setServiceControlsEnabled(bool enabled) { m_data.serviceControlsEnabled = enabled; }
+
+    bool imageControlsEnabled() const { return m_data.imageControlsEnabled; }
+    void setImageControlsEnabled(bool enabled) { m_data.imageControlsEnabled = enabled; }
+
+    bool contextMenuQRCodeDetectionEnabled() const { return m_data.contextMenuQRCodeDetectionEnabled; }
+    void setContextMenuQRCodeDetectionEnabled(bool enabled) { m_data.contextMenuQRCodeDetectionEnabled = enabled; }
+#endif
+
     void setShouldRelaxThirdPartyCookieBlocking(WebCore::ShouldRelaxThirdPartyCookieBlocking value) { m_data.shouldRelaxThirdPartyCookieBlocking = value; }
     WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking() const { return m_data.shouldRelaxThirdPartyCookieBlocking; }
 
@@ -298,6 +312,13 @@ private:
 
         bool mediaCaptureEnabled { false };
         bool httpsUpgradeEnabled { true };
+
+#if PLATFORM(MAC)
+        bool showsURLsInToolTips { false };
+        bool serviceControlsEnabled { false };
+        bool imageControlsEnabled { false };
+        bool contextMenuQRCodeDetectionEnabled { false };
+#endif
 
         WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
         WTF::String attributedBundleIdentifier { };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -159,12 +159,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     Class _attachmentFileWrapperClass;
     BOOL _mainContentUserGestureOverrideEnabled;
 
-#if PLATFORM(MAC)
-    BOOL _showsURLsInToolTips;
-    BOOL _serviceControlsEnabled;
-    BOOL _imageControlsEnabled;
-    BOOL _contextMenuQRCodeDetectionEnabled;
-#endif
     BOOL _waitsForPaintAfterViewDidMoveToWindow;
     BOOL _controlledByAutomation;
 
@@ -226,12 +220,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     _attachmentElementEnabled = NO;
     _attachmentWideLayoutEnabled = NO;
 
-#if PLATFORM(MAC)
-    _showsURLsInToolTips = NO;
-    _serviceControlsEnabled = NO;
-    _imageControlsEnabled = NO;
-    _contextMenuQRCodeDetectionEnabled = NO;
-#endif
     _waitsForPaintAfterViewDidMoveToWindow = YES;
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
@@ -437,13 +425,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     configuration->_longPressActionsEnabled = self->_longPressActionsEnabled;
     configuration->_systemPreviewEnabled = self->_systemPreviewEnabled;
     configuration->_shouldDecidePolicyBeforeLoadingQuickLookPreview = self->_shouldDecidePolicyBeforeLoadingQuickLookPreview;
-#endif
-#if PLATFORM(MAC)
-    configuration->_userInterfaceDirectionPolicy = self->_userInterfaceDirectionPolicy;
-    configuration->_showsURLsInToolTips = self->_showsURLsInToolTips;
-    configuration->_serviceControlsEnabled = self->_serviceControlsEnabled;
-    configuration->_imageControlsEnabled = self->_imageControlsEnabled;
-    configuration->_contextMenuQRCodeDetectionEnabled = self->_contextMenuQRCodeDetectionEnabled;
 #endif
 #if ENABLE(DATA_DETECTION) && PLATFORM(IOS_FAMILY)
     configuration->_dataDetectorTypes = self->_dataDetectorTypes;
@@ -1239,42 +1220,42 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 #if PLATFORM(MAC)
 - (BOOL)_showsURLsInToolTips
 {
-    return _showsURLsInToolTips;
+    return _pageConfiguration->showsURLsInToolTips();
 }
 
 - (void)_setShowsURLsInToolTips:(BOOL)showsURLsInToolTips
 {
-    _showsURLsInToolTips = showsURLsInToolTips;
+    _pageConfiguration->setShowsURLsInToolTips(showsURLsInToolTips);
 }
 
 - (BOOL)_serviceControlsEnabled
 {
-    return _serviceControlsEnabled;
+    return _pageConfiguration->serviceControlsEnabled();
 }
 
 - (void)_setServiceControlsEnabled:(BOOL)serviceControlsEnabled
 {
-    _serviceControlsEnabled = serviceControlsEnabled;
+    _pageConfiguration->setServiceControlsEnabled(serviceControlsEnabled);
 }
 
 - (BOOL)_imageControlsEnabled
 {
-    return _imageControlsEnabled;
+    return _pageConfiguration->imageControlsEnabled();
 }
 
 - (void)_setImageControlsEnabled:(BOOL)imageControlsEnabled
 {
-    _imageControlsEnabled = imageControlsEnabled;
+    _pageConfiguration->setImageControlsEnabled(imageControlsEnabled);
 }
 
 - (BOOL)_contextMenuQRCodeDetectionEnabled
 {
-    return _contextMenuQRCodeDetectionEnabled;
+    return _pageConfiguration->contextMenuQRCodeDetectionEnabled();
 }
 
 - (void)_setContextMenuQRCodeDetectionEnabled:(BOOL)contextMenuQRCodeDetectionEnabled
 {
-    _contextMenuQRCodeDetectionEnabled = contextMenuQRCodeDetectionEnabled;
+    _pageConfiguration->setContextMenuQRCodeDetectionEnabled(contextMenuQRCodeDetectionEnabled);
 }
 
 - (BOOL)_requiresUserActionForEditingControlsManager


### PR DESCRIPTION
#### 7c93bf95a3d4107ef243dbfe98fba8207de3bb09
<pre>
Move some WKWebViewConfiguration ivars to API::PageConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=270957">https://bugs.webkit.org/show_bug.cgi?id=270957</a>
<a href="https://rdar.apple.com/124574976">rdar://124574976</a>

Reviewed by Charlie Wolfe.

This is needed so we can move the configuration construction into
platform-independent code in WebPageProxy::createNewPage.

Explicit copy code is no longer needed because API::PageConfiguration::copy
uses API::PageConfiguration::Data&apos;s default copy assignment operator.

* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::showsURLsInToolTips const):
(API::PageConfiguration::setShowsURLsInToolTips):
(API::PageConfiguration::serviceControlsEnabled const):
(API::PageConfiguration::setServiceControlsEnabled):
(API::PageConfiguration::imageControlsEnabled const):
(API::PageConfiguration::setImageControlsEnabled):
(API::PageConfiguration::contextMenuQRCodeDetectionEnabled const):
(API::PageConfiguration::setContextMenuQRCodeDetectionEnabled):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration init]):
(-[WKWebViewConfiguration copyWithZone:]):
(-[WKWebViewConfiguration _showsURLsInToolTips]):
(-[WKWebViewConfiguration _setShowsURLsInToolTips:]):
(-[WKWebViewConfiguration _serviceControlsEnabled]):
(-[WKWebViewConfiguration _setServiceControlsEnabled:]):
(-[WKWebViewConfiguration _imageControlsEnabled]):
(-[WKWebViewConfiguration _setImageControlsEnabled:]):
(-[WKWebViewConfiguration _contextMenuQRCodeDetectionEnabled]):
(-[WKWebViewConfiguration _setContextMenuQRCodeDetectionEnabled:]):

Canonical link: <a href="https://commits.webkit.org/276075@main">https://commits.webkit.org/276075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/299d408ee33a90c8e5d05f325ab40ba660f232a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46351 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39815 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20164 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44282 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17078 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1765 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47907 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18740 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42898 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20149 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41580 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20340 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5965 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19775 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->