### PR TITLE
Resolve non-replaced URLs in style sheets when saving web page resources

### DIFF
--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -128,11 +128,13 @@ void CSSFontFaceSrcResourceValue::customSetReplacementURLForSubresources(const H
     auto replacementURLString = replacementURLStrings.get(m_location.resolvedURL.string());
     if (!replacementURLString.isNull())
         m_replacementURLString = replacementURLString;
+    m_shouldUseResolvedURLInCSSText = true;
 }
 
 void CSSFontFaceSrcResourceValue::customClearReplacementURLForSubresources()
 {
     m_replacementURLString = { };
+    m_shouldUseResolvedURLInCSSText = false;
 }
 
 bool CSSFontFaceSrcResourceValue::customMayDependOnBaseURL() const
@@ -145,8 +147,12 @@ String CSSFontFaceSrcResourceValue::customCSSText() const
     StringBuilder builder;
     if (!m_replacementURLString.isEmpty())
         builder.append(serializeURL(m_replacementURLString));
-    else
-        builder.append(serializeURL(m_location.specifiedURLString));
+    else {
+        if (m_shouldUseResolvedURLInCSSText)
+            builder.append(serializeURL(m_location.resolvedURL.string()));
+        else
+            builder.append(serializeURL(m_location.specifiedURLString));
+    }
     if (!m_format.isEmpty())
         builder.append(" format("_s, serializeString(m_format), ')');
     if (!m_technologies.isEmpty()) {

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -130,6 +130,7 @@ private:
     LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
     CachedResourceHandle<CachedFont> m_cachedFont;
     String m_replacementURLString;
+    bool m_shouldUseResolvedURLInCSSText { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -128,6 +128,7 @@ void CSSImageValue::customSetReplacementURLForSubresources(const HashMap<String,
     auto replacementURLString = replacementURLStrings.get(m_location.resolvedURL.string());
     if (!replacementURLString.isNull())
         m_replacementURLString = replacementURLString;
+    m_shouldUseResolvedURLInCSSText = true;
 }
 
 bool CSSImageValue::customMayDependOnBaseURL() const
@@ -138,6 +139,7 @@ bool CSSImageValue::customMayDependOnBaseURL() const
 void CSSImageValue::customClearReplacementURLForSubresources()
 {
     m_replacementURLString = { };
+    m_shouldUseResolvedURLInCSSText = false;
 }
 
 bool CSSImageValue::equals(const CSSImageValue& other) const
@@ -152,6 +154,9 @@ String CSSImageValue::customCSSText() const
 
     if (!m_replacementURLString.isEmpty())
         return serializeURL(m_replacementURLString);
+
+    if (m_shouldUseResolvedURLInCSSText)
+        return serializeURL(m_location.resolvedURL.string());
 
     return serializeURL(m_location.specifiedURLString);
 }

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -93,6 +93,7 @@ private:
     RefPtr<CSSImageValue> m_unresolvedValue;
     bool m_isInvalid { false };
     String m_replacementURLString;
+    bool m_shouldUseResolvedURLInCSSText { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 563c795b80f1c0de51382050f74087012e70b4db
<pre>
Resolve non-replaced URLs in style sheets when saving web page resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=270960">https://bugs.webkit.org/show_bug.cgi?id=270960</a>
<a href="https://rdar.apple.com/120498768">rdar://120498768</a>

Reviewed by Ryosuke Niwa.

Some CSS rules allow developers to specify multiple resources so that browser could pick the most suitable one to use
(e.g. @font-face). In our current implementation, when saving web page resources, we only save the resource that is
loaded. That means, URLs of other candidate resources will not be replaced with local file path in saved web page. It is
common that style sheets use relative path for subresource URL, and the result is the relative paths in saved style
sheets now point to non-existent files (as the candidate resources are not saved). To fix that problem, we now resolve
the non-replaced URLs in saved style sheets. With this change, when browser loads the saved web page and decides to load
candidate resource, it could send the request to correct server.

API test: WebArchive.SaveResourcesStyle

* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcResourceValue::customSetReplacementURLForSubresources):
(WebCore::CSSFontFaceSrcResourceValue::customClearReplacementURLForSubresources):
(WebCore::CSSFontFaceSrcResourceValue::customCSSText const):
* Source/WebCore/css/CSSFontFaceSrcValue.h:
* Source/WebCore/css/CSSImageValue.cpp:
(WebCore::CSSImageValue::customSetReplacementURLForSubresources):
(WebCore::CSSImageValue::customClearReplacementURLForSubresources):
(WebCore::CSSImageValue::customCSSText const):
* Source/WebCore/css/CSSImageValue.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:
(TestWebKitAPI::(WebArchive, SaveResourcesStyleWithUnloadedResources)):

Canonical link: <a href="https://commits.webkit.org/279168@main">https://commits.webkit.org/279168@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52e8a8c3a283e7354e6a497d015277cd8317007c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52672 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55950 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3395 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/54977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3096 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/42780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2182 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23880 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/26815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2760 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1554 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/48707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57542 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2912 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45600 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/49445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11502 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->