### PR TITLE
[visionOS] Attempting to fullscreen a portrait video on twitter.com displays the feed

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1493,6 +1493,17 @@ bool Quirks::allowLayeredFullscreenVideos() const
 }
 #endif
 
+#if PLATFORM(VISION)
+// twitter.com: rdar://124180748
+bool Quirks::shouldDisableFullscreenVideoAspectRatioAdaptiveSizing() const
+{
+    if (!needsQuirks())
+        return false;
+
+    return isDomain("twitter.com"_s);
+}
+#endif
+
 bool Quirks::shouldEnableApplicationCacheQuirk() const
 {
     // FIXME: Remove this when deleting ApplicationCache APIs.

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -160,6 +160,10 @@ public:
     bool shouldEnableFontLoadingAPIQuirk() const;
     bool needsVideoShouldMaintainAspectRatioQuirk() const;
 
+#if PLATFORM(VISION)
+    WEBCORE_EXPORT bool shouldDisableFullscreenVideoAspectRatioAdaptiveSizing() const;
+#endif
+
     bool shouldDisableLazyIframeLoadingQuirk() const;
 
     bool shouldDisableFetchMetadata() const;

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -267,9 +267,17 @@ void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element, 
 
 #if PLATFORM(VISION)
     if (m_mainVideoElement) {
+        bool fullscreenElementIsVideoElement = is<HTMLVideoElement>(element);
+
+        auto mainVideoElementSize = [&]() -> FloatSize {
+            if (!fullscreenElementIsVideoElement && element->document().quirks().shouldDisableFullscreenVideoAspectRatioAdaptiveSizing())
+                return { };
+            return FloatSize(m_mainVideoElement->videoWidth(), m_mainVideoElement->videoHeight());
+        }();
+
         mediaDetails = {
-            is<HTMLVideoElement>(element) ? FullScreenMediaDetails::Type::Video : FullScreenMediaDetails::Type::ElementWithVideo,
-            FloatSize(m_mainVideoElement->videoWidth(), m_mainVideoElement->videoHeight())
+            fullscreenElementIsVideoElement ? FullScreenMediaDetails::Type::Video : FullScreenMediaDetails::Type::ElementWithVideo,
+            mainVideoElementSize
         };
     }
 #endif


### PR DESCRIPTION
#### 12aecd5743e3ac7c3a20903dadd971251ca4e6e2
<pre>
[visionOS] Attempting to fullscreen a portrait video on twitter.com displays the feed
<a href="https://bugs.webkit.org/show_bug.cgi?id=270958">https://bugs.webkit.org/show_bug.cgi?id=270958</a>
<a href="https://rdar.apple.com/124180748">rdar://124180748</a>

Reviewed by Abrar Rahman Protyasha.

Fullscreen video on visionOS is intended to be presented at the aspect ratio of
the video element. However, twitter.com tears down its video player if the
fullscreen window has a portrait size, when the original window has a landscape
size. This results in the video disappearing in fullscreen, leaving behind the
feed.

Add a quirk to disable the aspect-ratio based fullscreen window sizing behavior
for twitter.com.

This issue was not caught earlier due to a crash when entering fullscreen on
twitter.com (fixed in 273885@main), and an issue with fullscreen event
ordering (fixed in 275115@main) that resulted in the same bug happening for
*all* videos on twitter.com. Additionally, the issue was temporarily hidden
until a recent regression which accidentally disabled the aspect ratio based
sizing behavior was fixed by 276059@main.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDisableFullscreenVideoAspectRatioAdaptiveSizing const):
* Source/WebCore/page/Quirks.h:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):

Canonical link: <a href="https://commits.webkit.org/276121@main">https://commits.webkit.org/276121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca0d491b9ced47a44e145f5efd3887b9783cbca7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46361 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39821 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46021 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36103 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19788 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37654 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17085 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17326 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38722 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1774 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39880 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47922 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42908 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20155 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41593 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9743 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19781 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->