### PR TITLE
Adding layout tests for postMessage CryptoKey for ServiceWorkers.

### DIFF
--- a/LayoutTests/http/tests/workers/service/indexeddb-cryptokey-put-get.https-expected.txt
+++ b/LayoutTests/http/tests/workers/service/indexeddb-cryptokey-put-get.https-expected.txt
@@ -1,2 +1,6 @@
+AES-GCM exported key matches original.
+AES-CBC exported key matches original.
+ECDSA public key matches original
+HMAC exported key matches original.
 Test Passed
 

--- a/LayoutTests/http/tests/workers/service/resources/indexeddb-cryptokey-put-get-worker.js
+++ b/LayoutTests/http/tests/workers/service/resources/indexeddb-cryptokey-put-get-worker.js
@@ -1,18 +1,5 @@
-const asymmetricUsage = ['sign', 'verify'];
-const symmetricUsage = ['decrypt', 'encrypt'];
 const dbName = "cryptoKeyWrapUnwrap";
 const objstoreName = "cryptoKeys";
-
-async function createKeys() {
-    const extractable = true;
-    var keys = {
-        "AES-GCM": await self.crypto.subtle.generateKey({name: 'AES-GCM', length: 256}, extractable, symmetricUsage),
-        "AES-CBC": await self.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, extractable, symmetricUsage),
-        "ECDSA": await self.crypto.subtle.generateKey({name: "ECDSA", namedCurve: "P-384"}, extractable, asymmetricUsage),
-        "HMAC": await self.crypto.subtle.generateKey({name: "HMAC", hash: {name: "SHA-512"}, }, extractable, asymmetricUsage),
-    };
-    return keys;
-}
 
 function openDB() {
     return new Promise(
@@ -75,108 +62,26 @@ async function getValue(key) {
 
 }
 
-function checkKeys(key, algorithm, length, usages) {
-    if (!key)
-        return {result: false, message: 'key is ' + key, type: algorithm};
-    if (algorithm === "HMAC" || algorithm === "ECDSA") {
-        if (algorithm === "HMAC") {
-            if (key.usages.toString() != usages)
-                return {result: false, message: 'key.usages should be ' + usages, type: algorithm};
-            if (key.type != "secret")
-                return {result: false, message: 'key.type should be "secret"', type: algorithm};
-            if (key.algorithm.hash.name != 'SHA-512')
-                return {result: false, message: 'key.algorithm.hash.name should be SHA-512', type: algorithm};
-            if (!key.extractable)
-                return {result: false, message: 'key.extractable should be true', type: algorithm};
-        }
-        if (algorithm === "ECDSA") {
-            if (key.privateKey.type != "private" || key.publicKey.type != "public") {
-                return {result: false, message: 'key.type should either be public or private', type: algorithm};
-            }
-            if (key.privateKey.algorithm.namedCurve != 'P-384' || key.publicKey.algorithm.namedCurve != 'P-384')
-                return {result: false, message: 'key.algorithm.name should be P-384', type: algorithm};
-            if (!key.privateKey.extractable)
-                return {result: false, message: 'key.extractable should be true for privateKey', type: algorithm};
-            if (!key.publicKey.extractable)
-                return {result: false, message: 'key.extractable should be true for publicKey', type: algorithm};
-            if (key.publicKey.usages.toString() != "verify" || key.privateKey.usages.toString() != "sign")
-                return {result: false, message: 'key.privateKey.usages or key.publicKey.usages is not correct', type: algorithm};
-
-        }
-        return {result: true, key: key};
-    }
-    else if (key.algorithm.name != algorithm)
-        return {result: false, message: 'key.algorithm.name should be ' + algorithm, type: algorithm};
-    else if (!key.extractable)
-        return {result: false, message: 'key.extractable should be true', type: algorithm};
-    else if (key.algorithm.length != length)
-        return {result: false, message: 'key.algorithm.length should be 128', type: algorithm};
-    else if (key.usages.toString() != usages)
-        return {result: false, message: 'key.usages should be ' + usages, type: algorithm + " " + key.usages.toString()};
-    else if (key.type != 'secret')
-        return {result: false, message: 'key.type should be "secret"', type: algorithm};
-    else
-        return {result: true, key: key};
-}
-
-async function testFetchedKeys(algorithm, key) {
+async function runTest(keys) {
     try {
-        let data = self.crypto.getRandomValues(new Uint8Array(100));
-        let iv = self.crypto.getRandomValues(new Uint8Array(16));
-        switch (algorithm) {
-            case "AES-GCM":
-                var ciphertext = new Uint8Array(await self.crypto.subtle.encrypt({name: algorithm, iv: iv}, key, data));
-                if (!ciphertext.length) {
-                    return {result: false, message: 'Cannot Encrypt with ' + key};
-                }
-                return checkKeys(key, algorithm, 256, symmetricUsage.toString())
-            case "AES-CBC":
-                var ciphertext = new Uint8Array(await self.crypto.subtle.encrypt({name: algorithm, iv: iv}, key, data));
-                if (!ciphertext.length) {
-                    return {result: false, message: 'Cannot Encrypt with ' + key};
-                }
-                return checkKeys(key, algorithm, 256, symmetricUsage.toString())
-            case "ECDSA":
-                var signature = new Uint8Array(await self.crypto.subtle.sign({name: algorithm, hash: "SHA-384"}, key.privateKey, data));
-                if (!signature.length) {
-                    return {result: false, message: 'Cannot sign with ' + key};
-                }
-                return checkKeys(key, algorithm, 0, asymmetricUsage.toString())
-            case "HMAC":
-                signature = new Uint8Array(await self.crypto.subtle.sign(algorithm, key, data));
-                if (!signature.length) {
-                    return {result: false, message: 'Cannot sign with ' + key};
-                }
-                return checkKeys(key, algorithm, 512, asymmetricUsage.toString())
-        }
-    } catch (e) {
-        return {result: false, message: "Exception: " + e};
-    }
-    return {result: true, message: "Key verified"};
-}
-
-async function runTest() {
-    try {
-        let keys = await createKeys();
         db = await openDB();
+        var fetchedKeys = {};
         for (let [algorithm, value] of Object.entries(keys)) {
             await addValue(algorithm, value);
             let fetchedKey = await getValue(algorithm)
-            let check = await testFetchedKeys(algorithm, fetchedKey)
-            if (!check.result)
-                return check
+            fetchedKeys[algorithm] = fetchedKey;
         }
-        return {result: true, message: "Keys verified"};
+        return {result: true, message: "Completed fetching and getting keys", keys: fetchedKeys};
     } catch (e) {
         return {result: false, message: "Test Failed:Exception: " + e.name + " message: " + e.message + JSON.stringify(e)};
     }
 }
 
 self.addEventListener("message", (event) => {
-    runTest().then((e) => {
+    runTest(event.data).then((e) => {
         try {
             if (e.result) {
-                event.source.postMessage({result: true, message: "runTest Passed"});
+                event.source.postMessage({result: true, message: "runTest Passed", keys: e.keys});
             } else {
                 if (e.type)
                     event.source.postMessage({result: false, message: "runTest failed: " + e.message + " key type: " + e.type});

--- a/LayoutTests/http/tests/workers/service/resources/indexeddb-cryptokey-put-get.js
+++ b/LayoutTests/http/tests/workers/service/resources/indexeddb-cryptokey-put-get.js
@@ -1,18 +1,125 @@
+let createdKeys;
+window.jsTestAsync = true;
+
 async function test() {
     try {
         var registeration = await registerAndWaitForActive("resources/indexeddb-cryptokey-put-get-worker.js", "/workers/service/resources/");
         let worker = registeration.active;
-        worker.postMessage("send keys");
+        let keys = await createKeys();
+        createdKeys = keys;
+        worker.postMessage(keys);
     } catch (e) {
         log("Got exception: " + e);
         finishSWTest();
     }
 }
 
+async function checkKey(key, algorithm, length, usages) {
+    if (!key)
+        return {result: false, message: 'key is ' + key, type: algorithm};
+    if (algorithm === "ECDSA") {
+        exportedKey = await self.crypto.subtle.exportKey("raw", key.publicKey);
+        originalKey = await self.crypto.subtle.exportKey("raw", createdKeys[algorithm].publicKey);
+        if (bytesToHexString(exportedKey) === bytesToHexString(originalKey)) {
+            log("ECDSA public key matches original");
+        } else {
+            return {result: false, message: "exportedKey and originalKey are not the same", type: algorithm};
+        }
+    } else {
 
-navigator.serviceWorker.addEventListener("message", (event) => {
+        let exportedKey = await self.crypto.subtle.exportKey("raw", key);
+        let originalKey = await self.crypto.subtle.exportKey("raw", createdKeys[algorithm]);
+        if (bytesToHexString(exportedKey) === bytesToHexString(originalKey)) {
+            log(algorithm + " exported key matches original.");
+        } else {
+            return {result: false, message: "exportedKey and originalKey are not the same", type: algorithm};
+        }
+    }
+    if (algorithm === "HMAC" || algorithm === "ECDSA") {
+        if (algorithm === "HMAC") {
+            if (key.usages.toString() != usages)
+                return {result: false, message: 'key.usages should be ' + usages, type: algorithm};
+            if (key.type != "secret")
+                return {result: false, message: 'key.type should be "secret"', type: algorithm};
+            if (key.algorithm.hash.name != 'SHA-512')
+                return {result: false, message: 'key.algorithm.hash.name should be SHA-512', type: algorithm};
+            if (!key.extractable)
+                return {result: false, message: 'key.extractable should be true', type: algorithm};
+        }
+        if (algorithm === "ECDSA") {
+            if (key.privateKey.type != "private" || key.publicKey.type != "public") {
+                return {result: false, message: 'key.type should either be public or private', type: algorithm};
+            }
+            if (key.privateKey.algorithm.namedCurve != 'P-384' || key.publicKey.algorithm.namedCurve != 'P-384')
+                return {result: false, message: 'key.algorithm.name should be P-384', type: algorithm};
+            if (!key.privateKey.extractable)
+                return {result: false, message: 'key.extractable should be true for privateKey', type: algorithm};
+            if (!key.publicKey.extractable)
+                return {result: false, message: 'key.extractable should be true for publicKey', type: algorithm};
+            if (key.publicKey.usages.toString() != "verify" || key.privateKey.usages.toString() != "sign")
+                return {result: false, message: 'key.privateKey.usages or key.publicKey.usages is not correct', type: algorithm};
+
+        }
+        return {result: true, key: key};
+    }
+    else if (key.algorithm.name != algorithm)
+        return {result: false, message: 'key.algorithm.name should be ' + algorithm, type: algorithm};
+    else if (!key.extractable)
+        return {result: false, message: 'key.extractable should be true', type: algorithm};
+    else if (key.algorithm.length != length)
+        return {result: false, message: 'key.algorithm.length should be 128', type: algorithm};
+    else if (key.usages.toString() != usages)
+        return {result: false, message: 'key.usages should be ' + usages, type: algorithm + " " + key.usages.toString()};
+    else if (key.type != 'secret')
+        return {result: false, message: 'key.type should be "secret"', type: algorithm};
+    else
+        return {result: true, key: key};
+}
+
+const asymmetricUsage = ['sign', 'verify'];
+const symmetricUsage = ['decrypt', 'encrypt'];
+
+
+async function createKeys() {
+    const extractable = true;
+    var keys = {
+        "AES-GCM": await self.crypto.subtle.generateKey({name: 'AES-GCM', length: 256}, extractable, symmetricUsage),
+        "AES-CBC": await self.crypto.subtle.generateKey({name: "AES-CBC", length: 256}, extractable, symmetricUsage),
+        "ECDSA": await self.crypto.subtle.generateKey({name: "ECDSA", namedCurve: "P-384"}, extractable, asymmetricUsage),
+        "HMAC": await self.crypto.subtle.generateKey({name: "HMAC", hash: {name: "SHA-512"}, }, extractable, asymmetricUsage),
+    };
+    return keys;
+}
+async function testKey(algorithm, key) {
+    try {
+        switch (algorithm) {
+            case "AES-GCM":
+                return await checkKey(key, algorithm, 256, symmetricUsage.toString())
+            case "AES-CBC":
+                return await checkKey(key, algorithm, 256, symmetricUsage.toString())
+            case "ECDSA":
+                return await checkKey(key, algorithm, 0, asymmetricUsage.toString())
+            case "HMAC":
+                return await checkKey(key, algorithm, 512, asymmetricUsage.toString())
+        }
+    } catch (e) {
+        return {result: false, message: "Exception: " + e};
+    }
+    return {result: true, message: "Key verified"};
+}
+
+
+navigator.serviceWorker.addEventListener("message", async (event) => {
     try {
         if (event.data.result) {
+            let fetchedKeys = event.data.keys;
+            for (const [algorithm, key] of Object.entries(fetchedKeys)) {
+                let r = await testKey(algorithm, key);
+                if (!r.result) {
+                    log("Test Failed: key verification failed for " + algorithm + " " + r.message);
+                    finishSWTest();
+                }
+            }
             log("Test Passed");
             finishSWTest();
         } else {

--- a/LayoutTests/http/tests/workers/service/resources/sw-test-pre.js
+++ b/LayoutTests/http/tests/workers/service/resources/sw-test-pre.js
@@ -86,3 +86,24 @@ function gc() {
     }
 }
 
+// Builds a hex string representation for an array-like input.
+// "bytes" can be an Array of bytes, an ArrayBuffer, or any TypedArray.
+// The output looks like this:
+//    ab034c99
+function bytesToHexString(bytes)
+{
+    if (!bytes)
+        return null;
+
+    bytes = new Uint8Array(bytes);
+    var hexBytes = [];
+
+    for (var i = 0; i < bytes.length; ++i) {
+        var byteString = bytes[i].toString(16);
+        if (byteString.length < 2)
+            byteString = "0" + byteString;
+        hexBytes.push(byteString);
+    }
+
+    return hexBytes.join("");
+}

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -91,21 +91,15 @@ public:
 
 private:
 
-    Vector<uint8_t> webCryptoMasterKey() final
+    std::optional<Vector<uint8_t>> webCryptoMasterKey() final
     {
-        if (!m_hasWebCryptoMasterKeySelector || !m_delegate) {
-            auto masterKey = WebCore::defaultWebCryptoMasterKey();
-            if (!masterKey)
-                return { };
-            return *masterKey;
-        }
+        if (!m_hasWebCryptoMasterKeySelector || !m_delegate)
+            return std::nullopt;
 
         RetainPtr<NSData> result = [m_delegate webCryptoMasterKey];
         if (!result)
-            return  { };
-        Vector<uint8_t> key;
-        key.append(static_cast<const uint8_t *>([result.get() bytes]), result.get().length);
-        return key;
+            return std::nullopt;
+        return Vector<uint8_t>(static_cast<const uint8_t *>([result.get() bytes]), result.get().length);
     }
 
     void requestStorageSpace(const WebCore::SecurityOriginData& topOrigin, const WebCore::SecurityOriginData& frameOrigin, uint64_t quota, uint64_t currentSize, uint64_t spaceRequired, CompletionHandler<void(std::optional<uint64_t>)>&& completionHandler) final

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2405,6 +2405,7 @@ public:
     bool hasAllowedToRunInTheBackgroundActivity() const;
 
 private:
+    std::optional<Vector<uint8_t>> getWebCryptoMasterKey();
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -537,6 +537,7 @@ protected:
     void validateFreezerStatus();
 
 private:
+    std::optional<Vector<uint8_t>> getWebCryptoMasterKey();
     using WebProcessProxyMap = HashMap<WebCore::ProcessIdentifier, CheckedRef<WebProcessProxy>>;
     static WebProcessProxyMap& allProcessMap();
     static Vector<Ref<WebProcessProxy>> allProcesses();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
@@ -122,9 +122,9 @@ public:
     virtual void didExceedMemoryFootprintThreshold(size_t, const String&, unsigned, Seconds, bool inForeground, WebCore::WasPrivateRelayed, CanSuspend)
     {
     }
-    virtual Vector<uint8_t> webCryptoMasterKey()
+    virtual std::optional<Vector<uint8_t>> webCryptoMasterKey()
     {
-        return { };
+        return std::nullopt;
     }
 };
 

--- a/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm
@@ -155,7 +155,7 @@
 {
     // Not so random key
     constexpr size_t keyLength = 16;
-    uint8_t keyBytes[keyLength] = { 1 };
+    uint8_t keyBytes[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf };
     NSData *key = [NSData dataWithBytes:keyBytes length:(keyLength)];
     return key;
 }


### PR DESCRIPTION
#### fdb77ba046f0ffbbf952879f1f6c7c0c5c4d63e9
<pre>
Adding layout tests for postMessage CryptoKey for ServiceWorkers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=183167">https://bugs.webkit.org/show_bug.cgi?id=183167</a>
<a href="https://rdar.apple.com/124393477">rdar://124393477</a>

Reviewed by Sihui Liu and Alex Christensen.

webCryptoMasterkey in WkWebsiteDataStoreDelegate and webCryptoMasterKeyforWebView in
WKNavigationDelegatePrivate both need to return the same masterKey. This is essential for
both postMessage from MainPage to ServiceWorker and vice versa to work for CryptoKeys.
Here we demonstrate it working via a test.

We can remove the webCryptoMasterKeyForWebView and only have the new one once
Safari can implement webCryptoMasterKey.(Just like in the
test implementation here).

Also, WebKitTestRunner is using the V3Navigation client which is actually using a hardcoded
value for the key for deterministic tests. So Setting the same value for WKWebsiteDataStoreDelegate.

Essentially, ServiceWorkers were enable to do PostMessage of a key but it&apos;s just that after
276088@main it just so happened that the ServiceWorker was using the default key but the main Page
had a hardcoded key. This patch also fixes that.

* LayoutTests/http/tests/workers/service/indexeddb-cryptokey-put-get.https-expected.txt:
* LayoutTests/http/tests/workers/service/resources/indexeddb-cryptokey-put-get-worker.js:
(async runTest):
(async createKeys): Deleted.
(async testFetchedKeys): Deleted.
* LayoutTests/http/tests/workers/service/resources/indexeddb-cryptokey-put-get.js:
(async test):
(async checkKey):
(async createKeys):
(async testKey):
(async event):
(event.catch): Deleted.
* LayoutTests/http/tests/workers/service/resources/sw-test-pre.js:
(bytesToHexString):
* Tools/WebKitTestRunner/cocoa/TestWebsiteDataStoreDelegate.mm:
(-[TestWebsiteDataStoreDelegate webCryptoMasterKey]):

Canonical link: <a href="https://commits.webkit.org/276197@main">https://commits.webkit.org/276197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f1711639bc84a988f00f55de3583966454c792e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40038 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46269 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20426 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17282 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38956 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2025 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48222 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18971 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15545 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20356 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20565 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6022 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->