### PR TITLE
[Gardening]: REGRESSION (275888@main): [ Sonoma+ iOS ] imported/w3c/web-platform-tests/svg/text/visualtests/text-inline-size-003-visual.svg is a consistent failure

### DIFF
--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/text/visualtests/text-inline-size-003-visual-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/text/visualtests/text-inline-size-003-visual-expected.txt
@@ -15,7 +15,7 @@ layer at (0,0) size 800x600
     RenderSVGContainer {g} at (90,166) size 620x232
       RenderSVGContainer {g} at (90,166) size 577x32
         RenderSVGText {text} at (54,100) size 346x19 contains 1 chunk(s)
-          RenderSVGTSpan {tspan} at (0,0) size 224x19
+          RenderSVGTSpan {tspan} at (122,0) size 224x19
             RenderSVGInlineText {#text} at (122,0) size 224x19
               chunk 1 text run 1 at (176.88,114.80) startOffset 0 endOffset 38 width 223.12 RTL: "\x{644}\x{643}\x{646} \x{644}\x{627} \x{628}\x{62F} \x{623}\x{646} \x{623}\x{648}\x{636}\x{62D} \x{644}\x{643} \x{623}\x{646} \x{643}\x{644} \x{647}\x{630}\x{647} \x{627}\x{644}\x{623}\x{641}\x{643}\x{627}\x{631}"
           RenderSVGInlineText {#text} at (117,0) size 5x19
@@ -26,7 +26,7 @@ layer at (0,0) size 800x600
           RenderSVGInlineText {#text} at (0,0) size 0x0
       RenderSVGContainer {g} at (112,266) size 576x32 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,60.00)}]
         RenderSVGText {text} at (67,100) size 346x19 contains 1 chunk(s)
-          RenderSVGTSpan {tspan} at (0,0) size 224x19
+          RenderSVGTSpan {tspan} at (122,0) size 224x19
             RenderSVGInlineText {#text} at (122,0) size 224x19
               chunk 1 (middle anchor) text run 1 at (189.60,114.80) startOffset 0 endOffset 38 width 223.12 RTL: "\x{644}\x{643}\x{646} \x{644}\x{627} \x{628}\x{62F} \x{623}\x{646} \x{623}\x{648}\x{636}\x{62D} \x{644}\x{643} \x{623}\x{646} \x{643}\x{644} \x{647}\x{630}\x{647} \x{627}\x{644}\x{623}\x{641}\x{643}\x{627}\x{631}"
           RenderSVGInlineText {#text} at (117,0) size 5x19
@@ -37,7 +37,7 @@ layer at (0,0) size 800x600
           RenderSVGInlineText {#text} at (0,0) size 0x0
       RenderSVGContainer {g} at (133,366) size 577x32 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,120.00)}]
         RenderSVGText {text} at (80,100) size 346x19 contains 1 chunk(s)
-          RenderSVGTSpan {tspan} at (0,0) size 224x19
+          RenderSVGTSpan {tspan} at (122,0) size 224x19
             RenderSVGInlineText {#text} at (122,0) size 224x19
               chunk 1 (end anchor) text run 1 at (202.32,114.80) startOffset 0 endOffset 38 width 223.12 RTL: "\x{644}\x{643}\x{646} \x{644}\x{627} \x{628}\x{62F} \x{623}\x{646} \x{623}\x{648}\x{636}\x{62D} \x{644}\x{643} \x{623}\x{646} \x{643}\x{644} \x{647}\x{630}\x{647} \x{627}\x{644}\x{623}\x{641}\x{643}\x{627}\x{631}"
           RenderSVGInlineText {#text} at (117,0) size 5x19


### PR DESCRIPTION
#### defcd231dacafd45fd68c3b28a53f9030100d90a
<pre>
[Gardening]: REGRESSION (275888@main): [ Sonoma+ iOS ] imported/w3c/web-platform-tests/svg/text/visualtests/text-inline-size-003-visual.svg is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=270881">https://bugs.webkit.org/show_bug.cgi?id=270881</a>
<a href="https://rdar.apple.com/124490034">rdar://124490034</a>

Unreviewed test gardening.

Adding test rebaseline

* LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/text/visualtests/text-inline-size-003-visual-expected.txt:

Canonical link: <a href="https://commits.webkit.org/276072@main">https://commits.webkit.org/276072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5164bb290ec16f630e56c42ea1fecd85e2db865e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43719 "Failed to checkout and rebase branch from PR 25872") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46158 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/46363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/39823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26611 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/20175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/46363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44293 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/19783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/46363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1776 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/39874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/39029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/47918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/18749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/20175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/47918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/47918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5963 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->