### PR TITLE
Add ability to sniff media content should we failed to play a file or if the provided content type was invalid.

### DIFF
--- a/LayoutTests/http/tests/media/video-throttled-load-metadata-expected.txt
+++ b/LayoutTests/http/tests/media/video-throttled-load-metadata-expected.txt
@@ -3,8 +3,6 @@ This test case simulates a slow network, and starts a web worker thread to write
 This test case is for https://bugs.webkit.org/show_bug.cgi?id=80978
 
 EXPECTED (video.error == 'null') OK
-Message from worker thread OK
 EVENT(loadedmetadata)
-loaded metadata of media file OK
 END OF TEST
 

--- a/LayoutTests/http/tests/media/video-throttled-load-metadata.html
+++ b/LayoutTests/http/tests/media/video-throttled-load-metadata.html
@@ -4,34 +4,27 @@
     <script src=../../../media-resources/media-file.js></script>
     <script src=../../../media-resources/video-test.js></script>
     <script>
-        function loadedmetadata(e)
-        {
-            logResult(true, "loaded metadata of media file");
-            endTest();
-        }
-
         function error(e)
         {
             logResult(false, "failed to load media file");
             endTest();
         }
 
-        function start()
+        async function start()
         {
             findMediaElement();
 
-            waitForEvent('loadedmetadata', loadedmetadata);
             waitForEvent("error", error);
             testExpected("video.error", null);
 
-            var worker = new Worker("video-throttled-load-metadata-worker.js");
-            worker.onmessage = function (event) {
-                logResult(true, event.data);
-            }
+            var worker = new Worker("video-throttled-load-metadata-worker.js");            
+            const workerPromise = waitFor(worker, 'message', true);
             var movie = findMediaFile("video", "resources/test");
             var type = mimeTypeForExtension(movie.split('.').pop());
             video.src = "http://127.0.0.1:8000/media/video-throttled-load.cgi?name=" + movie + "&throttle=400&type=" + type;
             video.load();
+            await Promise.all([waitFor(video, 'loadedmetadata'), workerPromise]);
+            endTest();
         }
     </script>
 </head>

--- a/LayoutTests/media/video-src-mp4-blob-expected.txt
+++ b/LayoutTests/media/video-src-mp4-blob-expected.txt
@@ -1,0 +1,4 @@
+
+EVENT(loadedmetadata)
+END OF TEST
+

--- a/LayoutTests/media/video-src-mp4-blob.html
+++ b/LayoutTests/media/video-src-mp4-blob.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src=video-test.js></script>
+        <script>
+            async function runTest() {
+                findMediaElement();
+                const file = "content/test.mp4"
+                const resp = await fetch(file);
+                const blob = await resp.blob();
+                const blobUrl = URL.createObjectURL(blob);
+                waitForEventAndEnd('loadedmetadata');
+                waitForEventAndFail('error');
+                video.src = blobUrl;
+            }
+        </script>
+    </head>
+    <body onload="runTest()">
+        <video></video>
+    </body>
+</html>

--- a/LayoutTests/media/video-src-webm-blob-expected.txt
+++ b/LayoutTests/media/video-src-webm-blob-expected.txt
@@ -1,0 +1,4 @@
+
+EVENT(loadedmetadata)
+END OF TEST
+

--- a/LayoutTests/media/video-src-webm-blob.html
+++ b/LayoutTests/media/video-src-webm-blob.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src=video-test.js></script>
+        <script>
+            async function runTest() {
+                findMediaElement();
+                const file = "content/test-vp8.webm"
+                const resp = await fetch(file);
+                const blob = await resp.blob();
+                const blobUrl = URL.createObjectURL(blob);
+                waitForEventAndEnd('loadedmetadata');
+                waitForEventAndFail('error');
+                video.src = blobUrl;
+            }
+        </script>
+    </head>
+    <body onload="runTest()">
+        <video></video>
+    </body>
+</html>

--- a/LayoutTests/media/video-srcobject-mp4-blob-expected.txt
+++ b/LayoutTests/media/video-srcobject-mp4-blob-expected.txt
@@ -1,0 +1,4 @@
+
+EVENT(loadedmetadata)
+END OF TEST
+

--- a/LayoutTests/media/video-srcobject-mp4-blob.html
+++ b/LayoutTests/media/video-srcobject-mp4-blob.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src=video-test.js></script>
+        <script>
+            async function runTest() {
+                findMediaElement();
+                const file = "content/test.mp4"
+                const resp = await fetch(file);
+                const blob = await resp.blob();
+                waitForEventAndEnd('loadedmetadata');
+                waitForEventAndFail('error');
+                video.srcObject = blob;
+            }
+        </script>
+    </head>
+    <body onload="runTest()">
+        <video></video>
+    </body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1057,6 +1057,7 @@ media/W3C/video/canPlayType/canPlayType_two_implies_one_2.html [ Failure ]
 media/media-can-play-webm.html [ Failure ]
 media/media-vp8-webm-error.html [ Failure ]
 media/media-vp8-webm.html [ Skip ]
+media/video-src-webm-blob.html [ Failure ]
 media/track/media-audio-track.html [ Failure ]
 media/media-sources-selection.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -921,8 +921,6 @@ webkit.org/b/140022 http/tests/media/track-in-band-hls-metadata.html [ Pass Time
 http/tests/media/remove-while-loading.html [ Skip ]
 http/tests/media/video-accept-encoding.html [ Failure ]
 http/tests/media/video-cancel-load.html [ Skip ]
-http/tests/media/video-served-as-text.html [ Failure ]
-http/tests/media/video-throttled-load-metadata.html [ Failure ]
 http/tests/security/contentSecurityPolicy/media-src-allowed.html [ Skip ]
 
 webkit.org/b/229101 http/tests/media/modern-media-controls/pip-support/pip-support-live-broadcast.html [ Pass Failure ]

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -1348,7 +1348,12 @@ public:
         assertIsDead();
     }
 
-    explicit operator bool() const { return m_promise && m_promise->isSettled(); }
+    bool isSettled() const
+    {
+        ASSERT(m_promise, "used after moved");
+        return m_promise && m_promise->isSettled();
+    }
+    explicit operator bool() const { return isSettled(); }
     bool isNothing() const
     {
         ASSERT(m_promise, "used after moved");

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1981,6 +1981,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/LayoutRect.h
     platform/graphics/LayoutSize.h
     platform/graphics/LegacyCDMSession.h
+    platform/graphics/MIMESniffer.h
     platform/graphics/MIMETypeCache.h
     platform/graphics/MediaPlaybackTarget.h
     platform/graphics/MediaPlaybackTargetClient.h
@@ -1989,6 +1990,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/MediaPlayerEnums.h
     platform/graphics/MediaPlayerIdentifier.h
     platform/graphics/MediaPlayerPrivate.h
+    platform/graphics/MediaResourceSniffer.h
     platform/graphics/MediaSourcePrivate.h
     platform/graphics/MediaSourcePrivateClient.h
     platform/graphics/MediaUsageInfo.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2324,9 +2324,11 @@ platform/graphics/IntSize.cpp
 platform/graphics/LayoutPoint.cpp
 platform/graphics/LayoutRect.cpp
 platform/graphics/LayoutSize.cpp
+platform/graphics/MIMESniffer.cpp
 platform/graphics/MIMETypeCache.cpp
 platform/graphics/MediaPlayer.cpp
 platform/graphics/MediaPlayerPrivate.cpp
+platform/graphics/MediaResourceSniffer.cpp
 platform/graphics/MediaSourcePrivate.cpp
 platform/graphics/Model.cpp
 platform/graphics/NamedImageGeneratedImage.cpp

--- a/Source/WebCore/platform/CommonAtomStrings.h
+++ b/Source/WebCore/platform/CommonAtomStrings.h
@@ -35,6 +35,7 @@ namespace WebCore {
     macro(alternative, "alternative") \
     macro(applicationXHTMLContentType, "application/xhtml+xml") \
     macro(applicationXMLContentType, "application/xml") \
+    macro(applicationOctetStream, "application/octet-stream") \
     macro(auto, "auto") \
     macro(captions, "captions") \
     macro(commentary, "commentary") \

--- a/Source/WebCore/platform/ContentType.h
+++ b/Source/WebCore/platform/ContentType.h
@@ -28,13 +28,20 @@
 
 #include <wtf/text/WTFString.h>
 
+namespace WTF {
+class URL;
+}
+
 namespace WebCore {
 
 class ContentType {
 public:
     WEBCORE_EXPORT explicit ContentType(String&& type);
     WEBCORE_EXPORT explicit ContentType(const String& type);
+    WEBCORE_EXPORT ContentType(const String& type, bool); // Use by the IPC serializer.
     ContentType() = default;
+
+    WEBCORE_EXPORT static ContentType fromURL(const WTF::URL&);
 
     WEBCORE_EXPORT static const String& codecsParameter();
     static const String& profilesParameter();
@@ -46,10 +53,15 @@ public:
     const String& raw() const { return m_type; }
     bool isEmpty() const { return m_type.isEmpty(); }
 
+    bool typeWasInferredFromExtension() const { return m_typeWasInferredFromExtension; }
+
     WEBCORE_EXPORT String toJSONString() const;
+    bool operator==(const ContentType& other) const { return raw() == other.raw(); }
+    bool operator!=(const ContentType& other) const { return !(*this == other); }
 
 private:
     String m_type;
+    bool m_typeWasInferredFromExtension { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/PlatformMediaError.cpp
+++ b/Source/WebCore/platform/PlatformMediaError.cpp
@@ -44,6 +44,7 @@ String convertEnumerationToString(PlatformMediaError enumerationValue)
         MAKE_STATIC_STRING_IMPL("LogicError"),
         MAKE_STATIC_STRING_IMPL("DecoderCreationError"),
         MAKE_STATIC_STRING_IMPL("NotSupportedError"),
+        MAKE_STATIC_STRING_IMPL("NetworkError"),
     };
     static_assert(!static_cast<size_t>(PlatformMediaError::AppendError), "PlatformMediaError::AppendError is not 0 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::ClientDisconnected) == 1, "PlatformMediaError::ClientDisconnected is not 1 as expected");
@@ -56,6 +57,7 @@ String convertEnumerationToString(PlatformMediaError enumerationValue)
     static_assert(static_cast<size_t>(PlatformMediaError::LogicError) == 8, "PlatformMediaError::LogicError is not 8 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::DecoderCreationError) == 9, "PlatformMediaError::DecoderCreationError is not 9 as expected");
     static_assert(static_cast<size_t>(PlatformMediaError::NotSupportedError) == 10, "PlatformMediaError::NotSupportedError is not 10 as expected");
+    static_assert(static_cast<size_t>(PlatformMediaError::NetworkError) == 11, "PlatformMediaError::NetworkError is not 11 as expected");
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }

--- a/Source/WebCore/platform/PlatformMediaError.h
+++ b/Source/WebCore/platform/PlatformMediaError.h
@@ -42,6 +42,7 @@ enum class PlatformMediaError : uint8_t {
     LogicError,
     DecoderCreationError,
     NotSupportedError,
+    NetworkError,
 };
 
 using MediaPromise = NativePromise<void, PlatformMediaError>;
@@ -76,7 +77,8 @@ template<> struct EnumTraits<WebCore::PlatformMediaError> {
         WebCore::PlatformMediaError::Cancelled,
         WebCore::PlatformMediaError::LogicError,
         WebCore::PlatformMediaError::DecoderCreationError,
-        WebCore::PlatformMediaError::NotSupportedError
+        WebCore::PlatformMediaError::NotSupportedError,
+        WebCore::PlatformMediaError::NetworkError
     >;
 };
 

--- a/Source/WebCore/platform/graphics/MIMESniffer.cpp
+++ b/Source/WebCore/platform/graphics/MIMESniffer.cpp
@@ -1,0 +1,347 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MIMESniffer.h"
+
+#include <array>
+
+namespace WebCore {
+
+namespace MIMESniffer {
+
+template<std::size_t N>
+constexpr auto span8(const char(&p)[N])
+{
+    return std::span<const uint8_t, N - 1>(reinterpret_cast<const uint8_t*>(p), N - 1);
+}
+
+static bool hasSignatureForMP4(std::span<const uint8_t> sequence)
+{
+    // To determine whether a byte sequence matches the signature for MP4, use the following steps:
+    // Let sequence be the byte sequence to be matched, where sequence[s] is byte s in sequence and sequence[0] is the first byte in sequence.
+    // Let length be the number of bytes in sequence.
+    size_t length = sequence.size();
+    // If length is less than 12, return false.
+    if (length < 12)
+        return false;
+    // Let box-size be the four bytes from sequence[0] to sequence[3], interpreted as a 32-bit unsigned big-endian integer.
+    uint32_t boxSize = sequence[0] << 24 | sequence[1] << 16 | sequence[2] << 8 | sequence[3] << 0;
+
+    // If length is less than box-size or if box-size modulo 4 is not equal to 0, return false.
+    if (length < boxSize || (boxSize % 4))
+        return false;
+    // If the four bytes from sequence[4] to sequence[7] are not equal to 0x66 0x74 0x79 0x70 ("ftyp"), return false.
+    if (sequence[4] != 0x66 || sequence[5] != 0x74 || sequence[6] != 0x79 || sequence[7] != 0x70)
+        return false;
+    // If the three bytes from sequence[8] to sequence[10] are equal to 0x6D 0x70 0x34 ("mp4"), return true.
+    if (sequence[8] == 0x6d && sequence[9] == 0x70 && sequence[10] == 0x34)
+        return true;
+
+    // Let bytes-read be 16.
+    uint32_t bytesRead = 16;
+
+    // This ignores the four bytes that correspond to the version number of the "major brand".
+    // While bytes-read is less than box-size, continuously loop through these steps:
+    while (bytesRead < boxSize) {
+        // If the three bytes from sequence[bytes-read] to sequence[bytes-read + 2] are equal to 0x6D 0x70 0x34 ("mp4"), return true.
+        if (sequence[bytesRead] == 0x6d && sequence[bytesRead + 1] == 0x70 && sequence[bytesRead + 2] == 0x34)
+            return true;
+        // Increment bytes-read by 4.
+        bytesRead += 4;
+    }
+    // Return false.
+    return false;
+}
+
+static std::optional<std::pair<uint8_t, int64_t>> parseWebMVint(std::span<const uint8_t> sequence)
+{
+    size_t index = 0;
+    // Let mask be 128.
+    uint8_t mask = 128;
+    // Let max vint length be 8.
+    const uint8_t maxVintLength = 8;
+    // Let number size be 1.
+    uint8_t numberSize = 1;
+    // While number size is less than max vint length, and less than length, continuously loop through these steps:
+    while (numberSize < maxVintLength && numberSize < sequence.size()) {
+        // If the sequence[index] & mask is not zero, abort these steps.
+        if (sequence[index] & mask)
+            break;
+        // Let mask be the value of mask >> 1.
+        mask >>= 1;
+        // Increment number size by one.
+        numberSize++;
+    }
+    // Let index be 0.
+    index = 0;
+    // Let parsed number be sequence[index] & ~mask.
+    uint64_t parsedNumber = sequence[index] & ~mask;
+    // Increment index by one.
+    index++;
+    // Let bytes remaining be the value of number size.
+    // TODO: spec is wrong, we've already read the first digit, should be value of number size - 1.
+    uint8_t bytesRemaining = numberSize - 1;
+    // While bytes remaining is not zero, execute there steps:
+    while (bytesRemaining) {
+        // Let parsed number be parsed number << 8.
+        parsedNumber <<= 8;
+        // Let parsed number be parsed number | sequence[index].
+        parsedNumber |= sequence[index];
+        // Increment index by one.
+        index++;
+        // If index is greater or equal than length, abort these steps.
+        if (index >= sequence.size())
+            return { };
+        // Decrement bytes remaining by one.
+        bytesRemaining--;
+    }
+    // Return parsed number and number size
+    return std::make_pair(numberSize, parsedNumber);
+}
+
+static bool hasSignatureForWebM(std::span<const uint8_t> sequence)
+{
+    // To determine whether a byte sequence matches the signature for WebM, use the following steps:
+    //   1. Let sequence be the byte sequence to be matched, where sequence[s] is byte s in sequence and sequence[0] is the first byte in sequence.
+    //   2. Let length be the number of bytes in sequence.
+    auto length = sequence.size();
+    //   3. If length is less than 4, return false.
+    if (length < 4)
+        return false;
+    //   4. If the four bytes from sequence[0] to sequence[3], are not equal to 0x1A 0x45 0xDF 0xA3, return false.
+    if (sequence[0] != 0x1a || sequence[1] != 0x45 || sequence[2] != 0xdf || sequence[3] != 0xa3)
+        return false;
+    //   5. Let iter be 4.
+    size_t iter = 4;
+    //   6. While iter is less than length and iter is less than 38, continuously loop through these steps:
+    while (iter < length && iter < 38) {
+        //  1. If the two bytes from sequence[iter] to sequence[iter + 1] are equal to 0x42 0x82,
+        if (sequence[iter] == 0x42 && sequence[iter + 1] == 0x82) {
+            //  1. Increment iter by 2.
+            iter += 2;
+            //  2. If iter is greater or equal than length, abort these steps.
+            if (iter >= length)
+                break;
+            //  3. Let number size be the result of parsing a vint starting at sequence[iter].
+            auto result = parseWebMVint(sequence.subspan(iter));
+            if (!result)
+                return false;
+            auto numberSize = result->first;
+            //  4. Increment iter by number size.
+            iter += numberSize;
+            //  5. If iter is less than length - 4, abort these steps.
+            // TODO: this is a spec error. It will always be less than length - 4 unless an error occurred.
+            //  6. Let matched be the result of matching a padded sequence 0x77 0x65 0x62 0x6D ("webm") on sequence at offset iter.
+            while (!sequence[iter] && iter < length)
+                iter++;
+            if (iter >= length - 4)
+                break;
+            //  7. If matched is true, abort these steps and return true.
+            if (sequence[iter] == 0x77 && sequence[iter + 1] == 0x65 && sequence[iter + 2] == 0x62 && sequence[iter + 3] == 0x6d)
+                return true;
+        }
+        //  2. Increment iter by 1.
+        iter++;
+    }
+    //   7. Return false.
+    return false;
+}
+
+static bool matchMP3Header(std::span<const uint8_t> sequence)
+{
+    // To match an mp3 header, using a byte sequence sequence of length length at offset s execute these steps:
+
+    // If length is less than 4, return false.
+    if (sequence.size() < 4)
+        return false;
+
+    // If sequence[s] is not equal to 0xff and sequence[s + 1] & 0xe0 is not equal to 0xe0, return false.
+    if (sequence[0] != 0xff || sequence[1] != 0xe0)
+        return false;
+    // Let layer be the result of sequence[s + 1] & 0x06 >> 1.
+    auto layer = sequence[1] & 0x06 >> 1;
+    // If layer is 0, return false.
+    if (!layer)
+        return false;
+    // Let bit-rate be sequence[s + 2] & 0xf0 >> 4.
+    auto bitRate = sequence[2] & 0xf0 >> 4;
+    // If bit-rate is 15, return false.
+    if (bitRate == 15)
+        return false;
+    // Let sample-rate be sequence[s + 2] & 0x0c >> 2.
+    auto sampleRate = sequence[2] & 0x0c >> 2;
+    // If sample-rate is 3, return false.
+    if (sampleRate == 3)
+        return false;
+    // Let freq be the value given by sample-rate in the table sample-rate.
+    // const uint32_t sampleRateTable[] = { 44100, 48000, 32000 };
+    // auto freq = sampleRateTable[sampleRate];
+    // Let final-layer be the result of 4 - (sequence[s + 1]).
+    auto finalLayer = 4 - sequence[1];
+    // If final-layer & 0x06 >> 1 is not 3, return false.
+    if ((finalLayer & 0x06 >> 1) != 3)
+        return false;
+    // Return true.
+    return true;
+}
+
+struct MP3Frame {
+    uint8_t version;
+    uint32_t bitRate;
+    uint32_t sampleRate;
+    uint8_t pad;
+};
+
+static uint32_t mp3FrameSize(const MP3Frame& frame)
+{
+    // To compute an mp3 frame size, execute these steps:
+    // If version is 1, let scale be 72, else, let scale be 144.
+    auto scale = frame.version == 1 ? 72u : 144u;
+    // Let size be bitrate * scale / freq.
+    uint32_t size = frame.bitRate * scale / frame.sampleRate;
+    // If pad is not zero, increment size by 1.
+    if (frame.pad)
+        size += 1;
+    // Return size.
+    return size;
+}
+
+static MP3Frame parseMP3Frame(std::span<const uint8_t> sequence)
+{
+    // Let version be sequence[s + 1] & 0x18 >> 3.
+    uint8_t version = sequence[1] & 0x18 >> 3;
+    // Let bitrate-index be sequence[s + 2] & 0xf0 >> 4.
+    auto bitrateIndex = sequence[2] & 0xf0 >> 4;
+    // If the version & 0x01 is non-zero, let bitrate be the value given by bitrate-index in the table mp2.5-rates
+    constexpr std::array mp25ratesTable { 0u, 8000u, 16000u, 24000u, 32000u, 40000u, 48000u, 56000u, 64000u, 80000u, 96000u, 112000u, 128000u, 144000u, 160000u };
+    // If version & 0x01 is zero, let bitrate be the value given by bitrate-index in the table mp3-rates
+    constexpr std::array mp3ratesTable { 0u, 32000u, 40000u, 48000u, 56000u, 64000u, 80000u, 96000u, 112000u, 128000u, 160000u, 192000u, 224000u, 256000u, 320000u };
+    auto bitRate = (version & 0x1) ? mp25ratesTable[bitrateIndex] : mp3ratesTable[bitrateIndex];
+    // Let samplerate-index be sequence[s + 2] & 0x0c >> 2.
+    auto sampleRateIndex = sequence[2] & 0x0c >> 2;
+    // Let samplerate be the value given by samplerate-index in the sample-rate table.
+    constexpr std::array sampleRateTable { 44100u, 48000u, 32000u };
+    auto sampleRate = sampleRateTable[sampleRateIndex];
+    // Let pad be sequence[s + 2] & 0x02 >> 1.
+    uint8_t pad = sequence[2] & 0x02 >> 1;
+    return { version, bitRate, sampleRate, pad };
+}
+
+static bool hasSignatureForMP3WithoutID3(std::span<const uint8_t> sequence)
+{
+    // To determine whether a byte sequence matches the signature for MP3 without ID3, use the following steps:
+
+    // Let sequence be the byte sequence to be matched, where sequence[s] is byte s in sequence and sequence[0] is the first byte in sequence.
+    //  Let length be the number of bytes in sequence.
+    auto length = sequence.size();
+    // Initialize s to 0.
+    size_t s = 0;
+    // If the result of the operation match mp3 header is false, return false.
+    if (!matchMP3Header(sequence))
+        return false;
+    // Parse an mp3 frame on sequence at offset s
+    auto frame = parseMP3Frame(sequence);
+    // Let skipped-bytes the return value of the execution of mp3 framesize computation
+    auto skippedBytes = mp3FrameSize(frame);
+    //    If skipped-bytes is less than 4, or skipped-bytes is greater than s - length, return false.
+    if (skippedBytes < 4 || skippedBytes > length)
+        return false;
+    // Increment s by skipped-bytes.
+    s += skippedBytes;
+    // If the result of the operation match mp3 header operation is false, return false, else, return true.
+    return matchMP3Header(sequence.subspan(s));
+}
+
+static String mimeTypeFromSnifferEntries(std::span<const uint8_t> sequence)
+{
+    struct MIMESniffEntry {
+        const std::span<const uint8_t> pattern;
+        const std::span<const uint8_t> mask;
+        const ASCIILiteral contentType;
+    };
+
+    static const MIMESniffEntry sSnifferEntries[] = {
+        // The string "FORM" followed by four bytes followed by the string "AIFF", the AIFF signature.
+        { span8("\x46\x4F\x52\x4D\x00\x00\x00\x00\x41\x49\x46\x46"), span8("\xFF\xFF\xFF\xFF\x00\x00\x00\x00\xFF\xFF\xFF\xFF"), "audio/aiff"_s },
+        // The string "ID3", the ID3v2-tagged MP3 signature.
+        { span8("\x49\x44\x33"), span8("\xFF\xFF\xFF"), "audio/mpeg"_s },
+        // The string "OggS" followed by NUL, the Ogg container signature.
+        { span8("\x4F\x67\x67\x53\x00"), span8("\xFF\xFF\xFF\xFF\xFF"), "application/ogg"_s },
+        // The string "MThd" followed by four bytes representing the number 6 in 32 bits (big-endian), the MIDI signature.
+        { span8("\0x4D\x54\x68\x64\x00\x00\x00\x06"), span8("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"), "audio/midi"_s },
+        // The string "RIFF" followed by four bytes followed by the string "AVI ", the AVI signature.
+        { span8("\0x52\x49\x46\x46\x00\x00\x00\x00\x41\x56\x49\x20"), span8("\xFF\xFF\xFF\xFF\x00\x00\x00\x00\xFF\xFF\xFF\xFF"), "video/avi"_s },
+        // The string "RIFF" followed by four bytes followed by the string "WAVE", the WAVE signature.
+        { span8("\x52\x49\x46\x46\x00\x00\x00\x00\x57\x41\x56\x45"), span8("\xFF\xFF\xFF\xFF\x00\x00\x00\x00\xFF\xFF\xFF\xFF"), "audio/wave"_s },
+    };
+
+    // 1. Execute the following steps for each row row in the following table:
+    //   1. Let patternMatched be the result of the pattern matching algorithm given input,
+    //      the value in the first column of row, the value in the second column of row, and the value in the third column of row.
+    //   2. If patternMatched is true, return the value in the fourth column of row.
+    for (const auto& currentEntry : sSnifferEntries) {
+        if (sequence.size() < currentEntry.mask.size() || currentEntry.mask.size() != currentEntry.pattern.size())
+            continue;
+        bool matched = true;
+        for (uint32_t i = 0; i < currentEntry.mask.size(); i++) {
+            if (currentEntry.pattern[i] != (currentEntry.mask[i] & sequence[i])) {
+                matched = false;
+                break;
+            }
+        }
+        if (matched)
+            return currentEntry.contentType;
+    }
+    return nullString();
+}
+
+String getMIMETypeFromContent(std::span<const uint8_t> sequence)
+{
+    // 6.2. Matching an audio or video type pattern
+    // To determine which audio or video MIME type byte pattern a byte sequence input matches, if any, use the following audio or video type pattern matching algorithm:
+
+    if (auto mimeType = mimeTypeFromSnifferEntries(sequence); !mimeType.isNull())
+        return mimeType;
+
+    // 2. If input matches the signature for MP4, return "video/mp4".
+    if (hasSignatureForMP4(sequence))
+        return "video/mp4"_s;
+
+    // 3. If input matches the signature for WebM, return "video/webm".
+    if (hasSignatureForWebM(sequence))
+        return "video/webm"_s;
+
+    // 4. If input matches the signature for MP3 without ID3, return "audio/mpeg".
+    if (hasSignatureForMP3WithoutID3(sequence))
+        return "audio/mpeg"_s;
+
+    // 5. Return undefined.
+    return emptyString();
+}
+
+} // namespace MIMESniffer
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/MIMESniffer.h
+++ b/Source/WebCore/platform/graphics/MIMESniffer.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <span>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+namespace MIMESniffer {
+
+// from https://mimesniff.spec.whatwg.org/#matching-an-audio-or-video-type-pattern
+WEBCORE_EXPORT String getMIMETypeFromContent(std::span<const uint8_t>);
+
+} // namespace MIMESniffer
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -265,7 +265,7 @@ public:
 
     virtual String mediaPlayerElementId() const { return emptyString(); }
 
-    virtual void mediaPlayerEngineFailedToLoad() const { }
+    virtual void mediaPlayerEngineFailedToLoad() { }
 
     virtual double mediaPlayerRequestedPlaybackRate() const { return 0; }
     virtual MediaPlayerEnums::VideoFullscreenMode mediaPlayerFullscreenMode() const { return MediaPlayerEnums::VideoFullscreenModeNone; }
@@ -632,6 +632,7 @@ public:
 #endif
 
     static void resetMediaEngines();
+    void reset();
 
 #if USE(GSTREAMER)
     void simulateAudioInterruption();
@@ -659,9 +660,9 @@ public:
     void setShouldDisableSleep(bool);
     bool shouldDisableSleep() const;
 
-    String contentMIMEType() const { return m_contentType.containerType(); }
-    String contentTypeCodecs() const { return m_contentType.parameter(ContentType::codecsParameter()); }
-    bool contentMIMETypeWasInferredFromExtension() const { return m_contentMIMETypeWasInferredFromExtension; }
+    String contentMIMEType() const;
+    String contentTypeCodecs() const;
+    bool contentMIMETypeWasInferredFromExtension() const;
 
     const Vector<ContentType>& mediaContentTypesRequiringHardwareSupport() const;
     void setShouldCheckHardwareSupport(bool);
@@ -774,7 +775,6 @@ private:
     bool m_inPrivateBrowsingMode { false };
     bool m_shouldPrepareToPlay { false };
     bool m_shouldPrepareToRender { false };
-    bool m_contentMIMETypeWasInferredFromExtension { false };
     bool m_initializingMediaEngine { false };
     DynamicRangeMode m_preferredDynamicRangeMode;
     PitchCorrectionAlgorithm m_pitchCorrectionAlgorithm { PitchCorrectionAlgorithm::BestAllAround };

--- a/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
+++ b/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "MediaResourceSniffer.h"
+
+#include "MIMESniffer.h"
+#include "ResourceRequest.h"
+#include <limits.h>
+
+namespace WebCore {
+
+Ref<MediaResourceSniffer> MediaResourceSniffer::create(PlatformMediaResourceLoader& loader, ResourceRequest&& request, std::optional<size_t> maxSize)
+{
+    if (maxSize)
+        request.addHTTPHeaderField(HTTPHeaderName::Range, makeString("bytes=", 0, '-', *maxSize));
+    auto resource = loader.requestResource(WTFMove(request), PlatformMediaResourceLoader::LoadOption::DisallowCaching);
+    if (!resource)
+        return adoptRef(*new MediaResourceSniffer());
+    Ref sniffer = adoptRef(*new MediaResourceSniffer(*resource , maxSize.value_or(SIZE_MAX)));
+    resource->setClient(sniffer.copyRef());
+    return sniffer;
+}
+
+MediaResourceSniffer::MediaResourceSniffer()
+    : m_maxSize(0)
+{
+    m_producer.reject(PlatformMediaError::NetworkError);
+}
+
+MediaResourceSniffer::MediaResourceSniffer(Ref<PlatformMediaResource>&& resource, size_t maxSize)
+    : m_resource(WTFMove(resource))
+    , m_maxSize(maxSize)
+{
+}
+
+MediaResourceSniffer::~MediaResourceSniffer()
+{
+    cancel();
+}
+
+void MediaResourceSniffer::cancel()
+{
+    if (auto resource = std::exchange(m_resource, { }))
+        resource->shutdown();
+    if (!m_producer.isSettled())
+        m_producer.reject(PlatformMediaError::Cancelled);
+    m_content.reset();
+}
+
+MediaResourceSniffer::Promise& MediaResourceSniffer::promise() const
+{
+    return m_producer.promise().get();
+}
+
+void MediaResourceSniffer::dataReceived(PlatformMediaResource&, const SharedBuffer& buffer)
+{
+    m_received += buffer.size();
+    m_content.append(buffer);
+    auto contiguousBuffer = m_content.get()->makeContiguous();
+    auto mimeType = MIMESniffer::getMIMETypeFromContent(contiguousBuffer->bytes());
+    if (mimeType.isEmpty() && m_received < m_maxSize)
+        return;
+    if (!m_producer.isSettled())
+        m_producer.resolve(ContentType { WTFMove(mimeType) });
+    cancel();
+}
+
+void MediaResourceSniffer::loadFailed(PlatformMediaResource&, const ResourceError&)
+{
+    if (!m_producer.isSettled())
+        m_producer.reject(PlatformMediaError::NetworkError);
+    cancel();
+}
+
+void MediaResourceSniffer::loadFinished(PlatformMediaResource&, const NetworkLoadMetrics&)
+{
+    if (m_producer.isSettled())
+        return;
+    Ref contiguousBuffer = m_content.takeAsContiguous();
+    auto mimeType = MIMESniffer::getMIMETypeFromContent(contiguousBuffer->bytes());
+    m_producer.resolve(ContentType { WTFMove(mimeType) });
+    cancel();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/MediaResourceSniffer.h
+++ b/Source/WebCore/platform/graphics/MediaResourceSniffer.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ContentType.h"
+#include "MediaPromiseTypes.h"
+#include "PlatformMediaResourceLoader.h"
+#include <wtf/NativePromise.h>
+
+namespace WebCore {
+
+class MediaResourceSniffer final : public PlatformMediaResourceClient {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    static Ref<MediaResourceSniffer> create(PlatformMediaResourceLoader&, ResourceRequest&&, std::optional<size_t> maxSize);
+    ~MediaResourceSniffer();
+
+    using Promise = NativePromise<ContentType, PlatformMediaError>;
+    Promise& promise() const;
+    void cancel();
+
+private:
+    MediaResourceSniffer(Ref<PlatformMediaResource>&&, size_t);
+    MediaResourceSniffer();
+
+    void dataReceived(PlatformMediaResource&, const SharedBuffer&) final;
+    void loadFailed(PlatformMediaResource&, const ResourceError&) final;
+    void loadFinished(PlatformMediaResource&, const NetworkLoadMetrics&) final;
+
+    RefPtr<PlatformMediaResource> m_resource;
+    const size_t m_maxSize;
+    size_t m_received { 0 };
+    Promise::Producer m_producer;
+    SharedBufferBuilder m_content;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -527,11 +527,8 @@ void MediaPlayerPrivateAVFoundation::updateStates()
                     } else
                         newNetworkState = MediaPlayer::NetworkState::Idle;
                 }
-            } else {
-                // FIX ME: fetch the error associated with the @"playable" key to distinguish between format 
-                // and network errors.
-                newNetworkState = MediaPlayer::NetworkState::FormatError;
-            }
+            } else
+                newNetworkState = assetStatus == MediaPlayerAVAssetStatusNetworkError ? MediaPlayer::NetworkState::NetworkError : MediaPlayer::NetworkState::FormatError;
         }
 
         if (!hasAvailableVideoFrame())

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -239,6 +239,7 @@ protected:
         MediaPlayerAVAssetStatusLoading,
         MediaPlayerAVAssetStatusFailed,
         MediaPlayerAVAssetStatusCancelled,
+        MediaPlayerAVAssetStatusNetworkError,
         MediaPlayerAVAssetStatusLoaded,
         MediaPlayerAVAssetStatusPlayable,
     };

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -485,7 +485,7 @@ void RemoteMediaPlayerProxy::mediaPlayerRateChanged()
     m_webProcessConnection->send(Messages::MediaPlayerPrivateRemote::RateChanged(m_player->effectiveRate(), timeUpdateData(*m_player, m_player->currentTime())), m_id);
 }
 
-void RemoteMediaPlayerProxy::mediaPlayerEngineFailedToLoad() const
+void RemoteMediaPlayerProxy::mediaPlayerEngineFailedToLoad()
 {
     m_webProcessConnection->send(Messages::MediaPlayerPrivateRemote::EngineFailedToLoad(m_player->platformErrorCode()), m_id);
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -254,7 +254,7 @@ private:
     void mediaPlayerRateChanged() final;
     void mediaPlayerPlaybackStateChanged() final;
     void mediaPlayerResourceNotSupported() final;
-    void mediaPlayerEngineFailedToLoad() const final;
+    void mediaPlayerEngineFailedToLoad() final;
     void mediaPlayerActiveSourceBuffersChanged() final;
     void mediaPlayerBufferedTimeRangesChanged() final;
     void mediaPlayerSeekableTimeRangesChanged() final;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2261,7 +2261,8 @@ header: <WebCore/NetworkLoadInformation.h>
 [Nested] enum class WebCore::NetworkTransactionInformation::Type : bool
 
 class WebCore::ContentType {
-    String raw()
+    String raw();
+    bool typeWasInferredFromExtension();
 }
 
 #if ENABLE(DATE_AND_TIME_INPUT_TYPES)

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -205,6 +205,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/IntSizeTests.cpp
         Tests/WebCore/KeyedCoding.cpp
         Tests/WebCore/LayoutUnitTests.cpp
+        Tests/WebCore/MIMESniffer.cpp
         Tests/WebCore/MIMETypeRegistry.cpp
         Tests/WebCore/MonospaceFontTests.cpp
         Tests/WebCore/NowPlayingInfoTests.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -327,6 +327,7 @@
 		5110FCF91E01CD8A006F8D0B /* IndexUpgrade.blob in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5110FCF21E01CD77006F8D0B /* IndexUpgrade.blob */; };
 		5120C83E1E67678F0025B250 /* WebsiteDataStoreCustomPaths.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5120C83B1E674E350025B250 /* WebsiteDataStoreCustomPaths.html */; };
 		512C4C9E20EAA40D004945EA /* ResponsivenessTimerCrash.mm in Sources */ = {isa = PBXBuildFile; fileRef = 512C4C9D20EAA405004945EA /* ResponsivenessTimerCrash.mm */; };
+		512F29102BA1D03100F1C326 /* MIMESniffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 512F290F2BA1D03100F1C326 /* MIMESniffer.cpp */; };
 		51393E221523952D005F39C5 /* DOMWindowExtensionBasic_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51393E1D1523944A005F39C5 /* DOMWindowExtensionBasic_Bundle.cpp */; };
 		5142B2731517C8C800C32B19 /* ContextMenuCanCopyURL.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 5142B2721517C89100C32B19 /* ContextMenuCanCopyURL.html */; };
 		514958BE1F7427AC00E87BAD /* WKWebViewAutofillTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 514958BD1F7427AC00E87BAD /* WKWebViewAutofillTests.mm */; };
@@ -2488,6 +2489,7 @@
 		51242CD42374E61E00EED9C1 /* FindInPageAPI.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FindInPageAPI.mm; sourceTree = "<group>"; };
 		51242CDA237B791E00EED9C1 /* PageZoom.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PageZoom.mm; sourceTree = "<group>"; };
 		512C4C9D20EAA405004945EA /* ResponsivenessTimerCrash.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ResponsivenessTimerCrash.mm; sourceTree = "<group>"; };
+		512F290F2BA1D03100F1C326 /* MIMESniffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MIMESniffer.cpp; sourceTree = "<group>"; };
 		51393E1D1523944A005F39C5 /* DOMWindowExtensionBasic_Bundle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DOMWindowExtensionBasic_Bundle.cpp; sourceTree = "<group>"; };
 		51393E1E1523944A005F39C5 /* DOMWindowExtensionBasic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DOMWindowExtensionBasic.cpp; sourceTree = "<group>"; };
 		51396E19222E4E8600A42FCE /* LoadFileURL.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LoadFileURL.mm; sourceTree = "<group>"; };
@@ -4439,6 +4441,7 @@
 				6BF4A682239ED4CD00E2F45B /* LoggedInStatus.cpp */,
 				076E507E1F45031E006E9F5A /* Logging.cpp */,
 				CE1866471F72E8F100A0CAB6 /* MarkedText.cpp */,
+				512F290F2BA1D03100F1C326 /* MIMESniffer.cpp */,
 				A5B149DD1F5A19DC00C6DAFF /* MIMETypeRegistry.cpp */,
 				E38EDC2F2B1D673A00963F9B /* MonospaceFontTests.cpp */,
 				5159F266260D43E300B2DA3C /* NowPlayingInfoTests.cpp */,
@@ -6646,6 +6649,7 @@
 				7C83E0B71D0A64B800FEBCF3 /* MenuTypesForMouseEvents.cpp in Sources */,
 				5C0BF8941DD599C900B00328 /* MenuTypesForMouseEvents.mm in Sources */,
 				51EB126224CA6B66000CB030 /* MicrosoftXboxOne.mm in Sources */,
+				512F29102BA1D03100F1C326 /* MIMESniffer.cpp in Sources */,
 				A5B149DE1F5A19EA00C6DAFF /* MIMETypeRegistry.cpp in Sources */,
 				1CF087D825ED7F73004148CB /* MobileAssetSandboxCheck.mm in Sources */,
 				7C83E0B61D0A64B300FEBCF3 /* ModalAlertsSPI.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/MIMESniffer.h>
+
+namespace TestWebKitAPI {
+
+using namespace WebCore;
+
+TEST(MIMESniffer, MIMETypes)
+{
+    constexpr std::array<const uint8_t, 11> oggData = { 'O', 'g', 'g', 'S', 0, 'm', 'e', 'e', 'e', 'h', '.' };
+    ASSERT_EQ(MIMESniffer::getMIMETypeFromContent({ oggData.data(), oggData.size()}), String("application/ogg"_s));
+
+    constexpr std::array<const uint8_t, 41> webmData = { 0x1A, 0x45, 0xDF, 0xA3, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1F, 0x42, 0x86, 0x81, 0x01, 0x42, 0xF7, 0x81, 0x01, 0x42, 0xF2, 0x81, 0x04, 0x42, 0xF3, 0x81, 0x08, 0x42, 0x82, 0x84, 0x77, 0x65, 0x62, 0x6D, 0x42, 0x87, 0x81, 0x04, 0x42, 0x85 };
+    ASSERT_EQ(MIMESniffer::getMIMETypeFromContent({ webmData.data(), webmData.size() }), String("video/webm"_s));
+
+    constexpr std::array<const uint8_t, 29> mp4data = { 0x00, 0x00, 0x00, 0x1C, 0x66, 0x74, 0x79, 0x70, 0x6D, 0x70, 0x34, 0x32, 0x00, 0x00, 0x00, 0x01, 0x69, 0x73, 0x6F, 0x6D, 0x6D, 0x70, 0x34, 0x31, 0x6D, 0x70, 0x34, 0x32, 0x00 };
+    ASSERT_EQ(MIMESniffer::getMIMETypeFromContent({ mp4data.data(), mp4data.size() }), String("video/mp4"_s));
+
+    constexpr std::array<const uint8_t, 32> mp3id3data = { 0x49, 0x44, 0x33, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x22, 0x54, 0x53, 0x53, 0x45, 0x00, 0x00, 0x00, 0x0E, 0x00, 0x00, 0x03, 0x4C, 0x61, 0x76, 0x66, 0x36, 0x30, 0x2E, 0x35, 0x2E, 0x31, 0x30 };
+    ASSERT_EQ(MIMESniffer::getMIMETypeFromContent({ mp3id3data.data(), mp3id3data.size() }), String("audio/mpeg"_s));
+
+    static std::array<const uint8_t, 32> wavedata = { 0x52, 0x49, 0x46, 0x46, 0x30, 0x13, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45, 0x66, 0x6D, 0x74, 0x20, 0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x44, 0xAC, 0x00, 0x00, 0x10, 0xB1, 0x02, 0x00 };
+    ASSERT_EQ(MIMESniffer::getMIMETypeFromContent({ wavedata.data(), wavedata.size() }), String("audio/wave"_s));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 93f6303ff83e5c20dbd79f5e6ae7c8a801ee519d
<pre>
Add ability to sniff media content should we failed to play a file or if the provided content type was invalid.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270975">https://bugs.webkit.org/show_bug.cgi?id=270975</a>
<a href="https://rdar.apple.com/problem/124614908">rdar://problem/124614908</a>

Reviewed by Jer Noble.

We have always relied on the server to provide a valid content-type and if that failed
we always used the URL&apos;s file name extension instead.
While the HTML5 specs clearly states that determining the type of a resource
should be done through sniffing, this is however a too significant change
to enable right away. There are also performance advantages in using the provided
content-type: it&apos;s typically immediately available.
Should the provided content-type be invalid or non-existent (such as with some blobs)
playback would have failed.

We add a MIMEtype sniffer for media content as per HTML5 specs.
Should we fail to play a media using the older content type detection rather
than immediately fail, we will also sniff the type as a last attempt before
retrying.

In order to not unnecessarily retry following a sniffing, we needed to
distinguish a format error from a network error which the MediaPlayerPrivateAVFoundationObjC
didn&apos;t do. As a fly-by fix, we add a way to distinguish the two errors by
recording in the WebCoreNSURLSession any network failures.

For now will limit sniffing to media element where the src attribute is set
(and so exclude element where alternative sources are defined)

Added API tests for the mimetype sniffer and tests for webm and mp4 in a blob.

* LayoutTests/media/video-src-mp4-blob-expected.txt: Added.
* LayoutTests/media/video-src-mp4-blob.html: Added.
* LayoutTests/media/video-src-webm-blob-expected.txt: Added.
* LayoutTests/media/video-src-webm-blob.html: Added.
* LayoutTests/media/video-srcobject-mp4-blob-expected.txt: Added.
* LayoutTests/media/video-srcobject-mp4-blob.html: Added.
* LayoutTests/http/tests/media/video-throttled-load-metadata-expected.txt:
* LayoutTests/http/tests/media/video-throttled-load-metadata.html: The test was racy and could
caused the loadedmetadata message to have been received before the worker&apos;s message.
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac/TestExpectations: Remove failure expectations. Tests were failing as an incorrect
content-type was provided. Now that we sniff if the provided content-type was incorrect
files can properly play again.
* Source/WTF/wtf/NativePromise.h:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp: Move all the logic from MediaPlayer related
to guessing the ContentType if missing into the HTMLMediaElement.
If all have failed, we will sniff the content.
(WebCore::HTMLMediaElement::~HTMLMediaElement):
(WebCore::HTMLMediaElement::loadResource): If the content is blocked, signal it as a network error rather than content error.
Otherwise we will attempt to load the content twice (once for sniffing and once for playing) causing test failures.
(WebCore::HTMLMediaElement::needsContentTypeToPlay const): Add methods to determine if sniffing is ultimately required.
(WebCore::HTMLMediaElement::sniffForContentType):
(WebCore::HTMLMediaElement::mediaLoadingFailed): Add one ultimate attempt if we failed to decode and
didn&apos;t encounter a network error and didn&apos;t attempt to previously sniff content.
(WebCore::HTMLMediaElement::cancelPendingTasks):
(WebCore::HTMLMediaElement::cancelSniffer):
(WebCore::HTMLMediaElement::mediaPlayerEngineFailedToLoad): Save if a network error was encountered.
If so, we won&apos;t attempt to sniff later on. This is required as multiple tests are
relying on the network being accessed only once, doing one extra access for sniffing
made the tests fail.
(WebCore::HTMLMediaElement::mediaPlayerEngineFailedToLoad const): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/CommonAtomStrings.h:
* Source/WebCore/platform/ContentType.cpp:
(WebCore::ContentType::ContentType):
(WebCore::ContentType::fromURL):
* Source/WebCore/platform/ContentType.h:
(WebCore::ContentType::typeWasInferredFromExtension const):
* Source/WebCore/platform/PlatformMediaError.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/PlatformMediaError.h:
* Source/WebCore/platform/graphics/MIMESniffer.cpp: Added.
(WebCore::MIMESniffer::span8):
(WebCore::MIMESniffer::hasSignatureForMP4):
(WebCore::MIMESniffer::parseWebMVint):
(WebCore::MIMESniffer::hasSignatureForWebM):
(WebCore::MIMESniffer::matchMP3Header):
(WebCore::MIMESniffer::mp3FrameSize):
(WebCore::MIMESniffer::parseMP3Frame):
(WebCore::MIMESniffer::hasSignatureForMP3WithoutID3):
(WebCore::MIMESniffer::mimeTypeFromSnifferEntries):
(WebCore::MIMESniffer::getMIMETypeFromContent):
* Source/WebCore/platform/graphics/MIMESniffer.h: Added.
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::applicationOctetStream):
(WebCore::MediaPlayer::load):
(WebCore::MediaPlayer::loadWithNextMediaEngine):
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaPlayerClient::mediaPlayerEngineFailedToLoad):
(WebCore::MediaPlayerClient::mediaPlayerEngineFailedToLoad const): Deleted.
* Source/WebCore/platform/graphics/MediaResourceSniffer.cpp: Added.
(WebCore::MediaResourceSniffer::create):
(WebCore::MediaResourceSniffer::MediaResourceSniffer):
(WebCore::MediaResourceSniffer::~MediaResourceSniffer):
(WebCore::MediaResourceSniffer::cancel):
(WebCore::MediaResourceSniffer::promise const):
(WebCore::MediaResourceSniffer::dataReceived):
(WebCore::MediaResourceSniffer::loadFailed):
(WebCore::MediaResourceSniffer::loadFinished):
* Source/WebCore/platform/graphics/MediaResourceSniffer.h: Added.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::updateStates): We needed to be able
to distinguish FormatError vs NetworkError so that we don&apos;t unnecessarily retry
playback following sniffing.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::assetStatus const): Distinguish
load failure due to decoding error vs networking error.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerEngineFailedToLoad):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerEngineFailedToLoad const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/MIMESniffer.cpp: Added.
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/276258@main">https://commits.webkit.org/276258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85db953a3a8f96126cbdcdfc2d80c1697c1f6b24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44184 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36404 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17438 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17780 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39164 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2234 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37506 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40373 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48429 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/43742 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43278 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42003 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9816 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20749 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50824 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20151 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10279 "Passed tests") | 
<!--EWS-Status-Bubble-End-->