### PR TITLE
Expose more type metadata to IPC test API

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
@@ -23,8 +23,8 @@
 #if USE(LIBWEBRTC)
 
 messages -> NetworkRTCProvider {
-    CreateUDPSocket(WebCore::LibWebRTCSocketIdentifier identifier, WebKit::RTCNetwork::SocketAddress localAddress, uint16_t minPort, uint16_t maxPort, WebKit::WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain domain)
-    CreateClientTCPSocket(WebCore::LibWebRTCSocketIdentifier identifier, WebKit::RTCNetwork::SocketAddress localAddress, WebKit::RTCNetwork::SocketAddress remoteAddress, String userAgent, int options, WebKit::WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain domain)
+    CreateUDPSocket(WebCore::LibWebRTCSocketIdentifier identifier, WebKit::RTC::Network::SocketAddress localAddress, uint16_t minPort, uint16_t maxPort, WebKit::WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain domain)
+    CreateClientTCPSocket(WebCore::LibWebRTCSocketIdentifier identifier, WebKit::RTC::Network::SocketAddress localAddress, WebKit::RTC::Network::SocketAddress remoteAddress, String userAgent, int options, WebKit::WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain domain)
     WrapNewTCPConnection(WebCore::LibWebRTCSocketIdentifier identifier, WebCore::LibWebRTCSocketIdentifier newConnectionSocketIdentifier)
 
     void SetPlatformTCPSocketsEnabled(bool enabled)
@@ -33,7 +33,7 @@ messages -> NetworkRTCProvider {
     CreateResolver(WebKit::LibWebRTCResolverIdentifier identifier, String address)
     StopResolver(WebKit::LibWebRTCResolverIdentifier identifier)
 
-    void SendToSocket(WebCore::LibWebRTCSocketIdentifier identifier, std::span<const uint8_t> data, WebKit::RTCNetwork::SocketAddress address, struct WebKit::RTCPacketOptions options)
+    void SendToSocket(WebCore::LibWebRTCSocketIdentifier identifier, std::span<const uint8_t> data, WebKit::RTC::Network::SocketAddress address, struct WebKit::RTCPacketOptions options)
     void CloseSocket(WebCore::LibWebRTCSocketIdentifier identifier)
     void SetSocketOption(WebCore::LibWebRTCSocketIdentifier identifier, int option, int value)
 }

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -173,6 +173,8 @@ class SerializedType(object):
         return self.namespace + '::' + self.name
 
     def name_declaration_for_serialized_type_info(self):
+        if self.cf_type is not None:
+            return self.cf_type + 'Ref'
         if self.namespace == 'WTF':
             if self.name != "UUID":
                 return self.name
@@ -199,43 +201,6 @@ class SerializedType(object):
 
     def members_for_serialized_type_info(self):
         return self.serialized_members()
-
-        result = []
-        for member in self.dictionary_members:
-            member = copy.copy(member)
-            outer_type = None
-            collection_key_type = None
-            collection_value_type = None
-            optional = False
-            if member.name.endswith('?'):
-                optional = True
-            match = re.search(r'(.*)<(.*), (.*)>', member.name)
-            if match:
-                outer_type, collection_key_type, collection_value_type = match.groups()
-            else:
-                match = re.search(r'(.*)<(.*)>', member.name)
-                if match:
-                    outer_type, collection_value_type = match.groups()
-                else:
-                    outer_type = member.name
-
-            outer_type = 'WebKit::CoreIPC' + outer_type
-            if outer_type.endswith('?'):
-                outer_type = outer_type[:-1]
-
-            if collection_key_type is not None:
-                member.name = outer_type + '<WebKit::CoreIPC' + collection_key_type + ', WebKit::CoreIPC' + collection_value_type + '>'
-            elif collection_value_type is not None:
-                member.name = outer_type + '<WebKit::CoreIPC' + collection_value_type + '>'
-            else:
-                member.name = outer_type
-
-            if optional:
-                member.name = member.name + '?'
-            result.append(member)
-
-        return result
-
 
     def serialized_members(self):
         return list(filter(lambda member: 'NotSerialized' not in member.attributes, self.members))
@@ -482,6 +447,13 @@ class UsingStatement(object):
     def __init__(self, name, alias, condition):
         self.name = name
         self.alias = alias
+        self.condition = condition
+
+
+class ObjCWrappedType(object):
+    def __init__(self, ns_type, wrapper, condition):
+        self.ns_type = ns_type
+        self.wrapper = wrapper
         self.condition = condition
 
 
@@ -1093,7 +1065,7 @@ def generate_one_impl(type, template_argument):
     return result
 
 
-def generate_impl(serialized_types, serialized_enums, headers, generating_webkit_platform_impl):
+def generate_impl(serialized_types, serialized_enums, headers, generating_webkit_platform_impl, objc_wrapped_types):
     result = []
     result.append(_license_header)
     result.append('#include "config.h"')
@@ -1141,6 +1113,26 @@ def generate_impl(serialized_types, serialized_enums, headers, generating_webkit
     result.append('')
     result.append('namespace IPC {')
     result.append('')
+
+    for type in objc_wrapped_types:
+        if type.condition is not None:
+            result.append('#if ' + type.condition)
+        result.append('template<> void encodeObjectDirectly<' + type.ns_type + '>(IPC::Encoder& encoder, ' + type.ns_type + ' *instance)')
+        result.append('{')
+        result.append('    encoder << (instance ? std::optional(WebKit::' + type.wrapper + '(instance)) : std::nullopt);')
+        result.append('}')
+        result.append('')
+        result.append('template<> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringAllowedClasses<' + type.ns_type + '>(IPC::Decoder& decoder)')
+        result.append('{')
+        result.append('    auto result = decoder.decode<std::optional<WebKit::' + type.wrapper + '>>();')
+        result.append('    if (!result)')
+        result.append('        return std::nullopt;')
+        result.append('    return *result ? (*result)->toID() : nullptr;')
+        result.append('}')
+        if type.condition is not None:
+            result.append('#endif // ' + type.condition)
+        result.append('')
+
     if not generating_webkit_platform_impl:
         result = result + argument_coder_declarations(serialized_types, False)
         result.append('')
@@ -1336,7 +1328,7 @@ def output_sorted_headers(sorted_headers):
     return result
 
 
-def generate_serialized_type_info(serialized_types, serialized_enums, headers, using_statements):
+def generate_serialized_type_info(serialized_types, serialized_enums, headers, using_statements, objc_wrapped_types):
     result = []
     result.append(_license_header)
     result.append('#include "config.h"')
@@ -1367,6 +1359,14 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, u
     for type in serialized_types:
         result.extend(generate_one_serialized_type_info(type))
 
+    for type in objc_wrapped_types:
+        if type.condition is not None:
+            result.append('#if ' + type.condition)
+        result.append('        { "' + type.ns_type + '"_s, {')
+        result.append('            { "WebKit::' + type.wrapper + '"_s, "wrapper"_s }')
+        result.append('        } },')
+        if type.condition is not None:
+            result.append('#endif // ' + type.condition)
     for using_statement in using_statements:
         if using_statement.condition is not None:
             result.append('#if ' + using_statement.condition)
@@ -1436,6 +1436,7 @@ def parse_serialized_types(file):
     serialized_types = []
     serialized_enums = []
     using_statements = []
+    objc_wrapped_types = []
     additional_forward_declarations = []
     headers = []
 
@@ -1588,6 +1589,11 @@ def parse_serialized_types(file):
         if match:
             cf_type, namespace, name = match.groups()
             continue
+        match = re.search(r'(.*) wrapped by (.*)', line)
+        if match:
+            objc_wrapped_type, objc_wrapper = match.groups()
+            objc_wrapped_types.append(ObjCWrappedType(objc_wrapped_type, objc_wrapper, type_condition))
+            continue
         match = re.search(r'additional_forward_declaration: (.*)', line)
         if match:
             declaration = match.groups()[0]
@@ -1641,7 +1647,7 @@ def parse_serialized_types(file):
                     dictionary_members.append(MemberVariable(member_type, member_name, member_condition, []))
                 else:
                     members.append(MemberVariable(member_type, member_name, member_condition, []))
-    return [serialized_types, serialized_enums, headers, using_statements, additional_forward_declarations]
+    return [serialized_types, serialized_enums, headers, using_statements, additional_forward_declarations, objc_wrapped_types]
 
 
 def generate_webkit_secure_coding_impl(serialized_types, headers):
@@ -1880,6 +1886,7 @@ def main(argv):
     serialized_types = []
     serialized_enums = []
     using_statements = []
+    objc_wrapped_types = []
     headers = []
     header_set = set()
     header_set.add(ConditionalHeader('"FormDataReference.h"', None))
@@ -1897,7 +1904,7 @@ def main(argv):
             continue
         path = os.path.sep.join([directory, argv[i]])
         with open(path) as file:
-            new_types, new_enums, new_headers, new_using_statements, new_additional_forward_declarations = parse_serialized_types(file)
+            new_types, new_enums, new_headers, new_using_statements, new_additional_forward_declarations, new_objc_wrapped_types = parse_serialized_types(file)
             for type in new_types:
                 serialized_types.append(type)
             for enum in new_enums:
@@ -1908,6 +1915,8 @@ def main(argv):
                 header_set.add(header)
             for declaration in new_additional_forward_declarations:
                 additional_forward_declarations_list.append(declaration)
+            for objc_wrapped_type in new_objc_wrapped_types:
+                objc_wrapped_types.append(objc_wrapped_type)
     headers = sorted(header_set)
 
     serialized_types = resolve_inheritance(serialized_types)
@@ -1915,11 +1924,11 @@ def main(argv):
     with open('GeneratedSerializers.h', "w+") as output:
         output.write(generate_header(serialized_types, serialized_enums, additional_forward_declarations_list))
     with open('GeneratedSerializers.%s' % file_extension, "w+") as output:
-        output.write(generate_impl(serialized_types, serialized_enums, headers, False))
+        output.write(generate_impl(serialized_types, serialized_enums, headers, False, []))
     with open('WebKitPlatformGeneratedSerializers.%s' % file_extension, "w+") as output:
-        output.write(generate_impl(serialized_types, serialized_enums, headers, True))
+        output.write(generate_impl(serialized_types, serialized_enums, headers, True, objc_wrapped_types))
     with open('SerializedTypeInfo.%s' % file_extension, "w+") as output:
-        output.write(generate_serialized_type_info(serialized_types, serialized_enums, headers, using_statements))
+        output.write(generate_serialized_type_info(serialized_types, serialized_enums, headers, using_statements, objc_wrapped_types))
     with open('GeneratedWebKitSecureCoding.h', "w+") as output:
         output.write(generate_webkit_secure_coding_header(serialized_types))
     with open('GeneratedWebKitSecureCoding.%s' % file_extension, "w+") as output:

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -998,6 +998,8 @@ def headers_for_type(type):
         'WebKit::PaymentSetupFeatures': ['"ApplePayPaymentSetupFeaturesWebKit.h"'],
         'WebKit::ImageBufferSetPrepareBufferForDisplayInputData': ['"PrepareBackingStoreBuffersData.h"'],
         'WebKit::ImageBufferSetPrepareBufferForDisplayOutputData': ['"PrepareBackingStoreBuffersData.h"'],
+        'WebKit::RTC::Network::IPAddress': ['"RTCNetwork.h"'],
+        'WebKit::RTC::Network::SocketAddress': ['"RTCNetwork.h"'],
         'WebKit::RemoteVideoFrameReadReference': ['"RemoteVideoFrameIdentifier.h"'],
         'WebKit::RemoteVideoFrameWriteReference': ['"RemoteVideoFrameIdentifier.h"'],
         'WebKit::RespectSelectionAnchor': ['"GestureTypes.h"'],

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -341,6 +341,24 @@ template<> struct ArgumentCoder<RetainPtr<CFBarRef>> {
 };
 #endif
 
+#if USE(CFSTRING)
+template<> struct ArgumentCoder<CFStringRef> {
+    static void encode(Encoder&, CFStringRef);
+    static void encode(StreamConnectionEncoder&, CFStringRef);
+};
+template<> struct ArgumentCoder<RetainPtr<CFStringRef>> {
+    static void encode(Encoder& encoder, const RetainPtr<CFStringRef>& retainPtr)
+    {
+        ArgumentCoder<CFStringRef>::encode(encoder, retainPtr.get());
+    }
+    static void encode(StreamConnectionEncoder& encoder, const RetainPtr<CFStringRef>& retainPtr)
+    {
+        ArgumentCoder<CFStringRef>::encode(encoder, retainPtr.get());
+    }
+    static std::optional<RetainPtr<CFStringRef>> decode(Decoder&);
+};
+#endif
+
 template<> struct ArgumentCoder<WebKit::RValueWithFunctionCalls> {
     static void encode(Encoder&, WebKit::RValueWithFunctionCalls&&);
     static std::optional<WebKit::RValueWithFunctionCalls> decode(Decoder&);

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -417,6 +417,11 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             { "WebKit::BarWrapper"_s, "wrapper"_s }
         } },
 #endif // USE(CFBAR)
+#if USE(CFSTRING)
+        { "CFStringRef"_s, {
+            { "String"_s, "wrapper"_s }
+        } },
+#endif // USE(CFSTRING)
         { "WebKit::RValueWithFunctionCalls"_s, {
             {
                 "SandboxExtensionHandle"_s,
@@ -471,6 +476,14 @@ Vector<SerializedTypeInfo> allSerializedTypes()
             },
         } },
 #endif // USE(APPKIT)
+#if USE(PASSKIT)
+        { "PKPaymentMethod"_s, {
+            { "WebKit::CoreIPCPKPaymentMethod"_s, "wrapper"_s }
+        } },
+#endif // USE(PASSKIT)
+        { "NSNull"_s, {
+            { "WebKit::CoreIPCNull"_s, "wrapper"_s }
+        } },
         { "WebCore::SharedStringHash"_s, {
             { "uint32_t"_s, "alias"_s }
         } },

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -273,6 +273,11 @@ additional_forward_declaration: typedef struct __CFBar * CFBarRef
 }
 #endif
 
+#if USE(CFSTRING)
+[WebKitPlatform, CustomHeader, AdditionalEncoder=StreamConnectionEncoder, ToCFMethod=result->createCFString()] CFStringRef wrapped by WTF::String {
+}
+#endif
+
 [RValue] class WebKit::RValueWithFunctionCalls {
     SandboxExtensionHandle callFunction()
 }
@@ -325,3 +330,8 @@ header: <WebCore/ScrollbarTrackCornerSystemImageMac.h>
     bool m_useDarkAppearance;
 }
 #endif // USE(APPKIT)
+
+#if USE(PASSKIT)
+PKPaymentMethod wrapped by CoreIPCPKPaymentMethod
+#endif
+NSNull wrapped by CoreIPCNull

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -671,21 +671,6 @@ template<> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringAllowedClas
 #endif
 #endif
 
-#define ENCODE_WITH_COREIPC_WRAPPER_NAMED(c, wrapper) \
-template<> void encodeObjectDirectly<c>(IPC::Encoder& encoder, c *instance) \
-{ \
-    encoder << (instance ? std::optional(WebKit::wrapper(instance)) : std::nullopt); \
-} \
-template<> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringAllowedClasses<c>(IPC::Decoder& decoder) \
-{ \
-    auto result = decoder.decode<std::optional<WebKit::wrapper>>(); \
-    if (!result) \
-        return std::nullopt; \
-    return *result ? (*result)->toID() : nullptr; \
-}
-
-#define ENCODE_WITH_COREIPC_WRAPPER(c) ENCODE_WITH_COREIPC_WRAPPER_NAMED(c, CoreIPC##c)
-
 #define ENCODE_AS_SECURE_CODING(c) \
 template<> void encodeObjectDirectly<c>(IPC::Encoder& encoder, c *instance) \
 { \
@@ -699,49 +684,12 @@ template<> std::optional<RetainPtr<id>> decodeObjectDirectlyRequiringAllowedClas
     return *result ? (*result)->toID() : nullptr; \
 }
 
-#if USE(AVFOUNDATION)
-ENCODE_WITH_COREIPC_WRAPPER(AVOutputContext);
-#endif
-#if USE(PASSKIT)
-ENCODE_WITH_COREIPC_WRAPPER(PKPaymentMethod);
-ENCODE_WITH_COREIPC_WRAPPER(PKPaymentMerchantSession);
-ENCODE_WITH_COREIPC_WRAPPER(PKContact);
-ENCODE_WITH_COREIPC_WRAPPER(PKPayment);
-ENCODE_WITH_COREIPC_WRAPPER(PKPaymentToken);
-ENCODE_WITH_COREIPC_WRAPPER(PKShippingMethod);
-ENCODE_WITH_COREIPC_WRAPPER(PKDateComponentsRange);
-ENCODE_WITH_COREIPC_WRAPPER(CNContact);
-ENCODE_WITH_COREIPC_WRAPPER(CNPhoneNumber);
-ENCODE_WITH_COREIPC_WRAPPER(CNPostalAddress);
-#endif
-ENCODE_WITH_COREIPC_WRAPPER(NSURLProtectionSpace);
-ENCODE_WITH_COREIPC_WRAPPER(NSShadow);
-ENCODE_WITH_COREIPC_WRAPPER(NSValue);
-ENCODE_WITH_COREIPC_WRAPPER(NSURLCredential);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSPersonNameComponents, CoreIPCPersonNameComponents);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSDateComponents, CoreIPCDateComponents);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(PlatformColor, CoreIPCColor);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSData, CoreIPCData);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSURL, CoreIPCURL);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSNull, CoreIPCNull);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(WebCore::CocoaFont, CoreIPCFont);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSDate, CoreIPCDate);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSArray, CoreIPCArray);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSError, CoreIPCError);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSLocale, CoreIPCLocale);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSNumber, CoreIPCNumber);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSString, CoreIPCString);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSDictionary, CoreIPCDictionary);
-ENCODE_WITH_COREIPC_WRAPPER_NAMED(NSPresentationIntent, CoreIPCPresentationIntent);
-
 ENCODE_AS_SECURE_CODING(NSURLRequest);
 ENCODE_AS_SECURE_CODING(NSParagraphStyle);
 #if USE(PASSKIT)
 ENCODE_AS_SECURE_CODING(PKSecureElementPass);
 #endif
 
-#undef ENCODE_WITH_COREIPC_WRAPPER
-#undef ENCODE_WITH_COREIPC_WRAPPER_NAMED
 #undef ENCODE_AS_SECURE_CODING
 
 #pragma mark - CF

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -30,7 +30,7 @@ headers: "ArgumentCodersCocoa.h"
     WebCore::TextRenderingMode textRenderingMode();
     bool syntheticBold();
     bool syntheticOblique();
-    std::variant<WebCore::FontPlatformSerializedData,WebCore::FontPlatformSerializedCreationData> platformSerializationData();
+    std::variant<WebCore::FontPlatformSerializedData, WebCore::FontPlatformSerializedCreationData> platformSerializationData();
 }
 
 header: <WebCore/FontPlatformData.h>
@@ -313,3 +313,38 @@ enum class WebCore::PlatformCALayerLayerType : uint8_t {
         LayerTypeCustom,
         LayerTypeHost,
 };
+
+#if USE(AVFOUNDATION)
+AVOutputContext wrapped by CoreIPCAVOutputContext
+#endif
+#if USE(PASSKIT)
+PKPaymentMethod wrapped by CoreIPCPKPaymentMethod
+PKPaymentMerchantSession wrapped by CoreIPCPKPaymentMerchantSession
+PKContact wrapped by CoreIPCPKContact
+PKPayment wrapped by CoreIPCPKPayment
+PKPaymentToken wrapped by CoreIPCPKPaymentToken
+PKShippingMethod wrapped by CoreIPCPKShippingMethod
+PKDateComponentsRange wrapped by CoreIPCPKDateComponentsRange
+CNContact wrapped by CoreIPCCNContact
+CNPhoneNumber wrapped by CoreIPCCNPhoneNumber
+CNPostalAddress wrapped by CoreIPCCNPostalAddress
+#endif
+NSURLProtectionSpace wrapped by CoreIPCNSURLProtectionSpace
+NSShadow wrapped by CoreIPCNSShadow
+NSValue wrapped by CoreIPCNSValue
+NSURLCredential wrapped by CoreIPCNSURLCredential
+NSPersonNameComponents wrapped by CoreIPCPersonNameComponents
+NSDateComponents wrapped by CoreIPCDateComponents
+PlatformColor wrapped by CoreIPCColor
+NSData wrapped by CoreIPCData
+NSURL wrapped by CoreIPCURL
+NSNull wrapped by CoreIPCNull
+WebCore::CocoaFont wrapped by CoreIPCFont
+NSDate wrapped by CoreIPCDate
+NSArray wrapped by CoreIPCArray
+NSError wrapped by CoreIPCError
+NSLocale wrapped by CoreIPCLocale
+NSNumber wrapped by CoreIPCNumber
+NSString wrapped by CoreIPCString
+NSDictionary wrapped by CoreIPCDictionary
+NSPresentationIntent wrapped by CoreIPCPresentationIntent

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1518,6 +1518,8 @@ enum class WebCore::WebLockMode : bool;
 
 using WebCore::AuthenticatorResponseDataSerializableForm = std::variant<std::nullptr_t, WebCore::AuthenticatorResponseBaseData, WebCore::AuthenticatorAttestationResponseData, WebCore::AuthenticatorAssertionResponseData>;
 
+using WebCore::PointerID = uint32_t;
+
 struct WebCore::AuthenticatorResponseData {
     WebCore::AuthenticatorResponseDataSerializableForm getSerializableForm();
 };

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.messages.in
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.messages.in
@@ -23,9 +23,9 @@
 #if USE(LIBWEBRTC)
 
 messages -> LibWebRTCNetwork NotRefCounted {
-    SignalReadPacket(WebCore::LibWebRTCSocketIdentifier socketIdentifier, std::span<const uint8_t> data, WebKit::RTCNetwork::IPAddress address, uint16_t port, int64_t timestamp)
+    SignalReadPacket(WebCore::LibWebRTCSocketIdentifier socketIdentifier, std::span<const uint8_t> data, WebKit::RTC::Network::IPAddress address, uint16_t port, int64_t timestamp)
     SignalSentPacket(WebCore::LibWebRTCSocketIdentifier socketIdentifier, int packetSize, int64_t timestamp)
-    SignalAddressReady(WebCore::LibWebRTCSocketIdentifier socketIdentifier, WebKit::RTCNetwork::SocketAddress address)
+    SignalAddressReady(WebCore::LibWebRTCSocketIdentifier socketIdentifier, WebKit::RTC::Network::SocketAddress address)
     SignalConnect(WebCore::LibWebRTCSocketIdentifier socketIdentifier)
     SignalClose(WebCore::LibWebRTCSocketIdentifier socketIdentifier, int error)
     SignalUsedInterface(WebCore::LibWebRTCSocketIdentifier socketIdentifier, String interfaceName)

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.messages.in
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.messages.in
@@ -23,7 +23,7 @@
 #if USE(LIBWEBRTC)
 
 messages -> WebRTCMonitor NotRefCounted {
-    void NetworksChanged(Vector<WebKit::RTCNetwork> networks, WebKit::RTCNetwork::IPAddress defaultIPV4Address, WebKit::RTCNetwork::IPAddress defaultIPV6Address)
+    void NetworksChanged(Vector<WebKit::RTCNetwork> networks, WebKit::RTC::Network::IPAddress defaultIPV4Address, WebKit::RTC::Network::IPAddress defaultIPV6Address)
 }
 
 #endif // USE(LIBWEBRTC)

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.messages.in
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.messages.in
@@ -23,7 +23,7 @@
 #if USE(LIBWEBRTC)
 
 messages -> WebRTCResolver NotRefCounted {
-    void SetResolvedAddress(Vector<WebKit::RTCNetwork::IPAddress> addresses)
+    void SetResolvedAddress(Vector<WebKit::RTC::Network::IPAddress> addresses)
     void ResolvedAddressError(int error)
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -642,6 +642,7 @@ TEST(IPCTestingAPI, SerializedTypeInfo)
         @"float",
         @"bool",
         @"NSUInteger",
+        @"NSInteger",
         @"size_t",
         @"std::nullptr_t",
         @"uint32_t",
@@ -672,7 +673,7 @@ TEST(IPCTestingAPI, SerializedTypeInfo)
 
     [typesNeedingDescriptions minusSet:typesHavingDescriptions];
     [typesNeedingDescriptions minusSet:fundamentalTypes];
-    EXPECT_LT(typesNeedingDescriptions.count, 200u); // FIXME: This should eventually be 0.
+    EXPECT_LT(typesNeedingDescriptions.count, 175u); // FIXME: This should eventually be 0.
 }
 
 #endif


### PR DESCRIPTION
#### 129e6466acb1ebebfb9b62b5c21956aa9950a716
<pre>
Expose more type metadata to IPC test API
<a href="https://bugs.webkit.org/show_bug.cgi?id=270985">https://bugs.webkit.org/show_bug.cgi?id=270985</a>
<a href="https://rdar.apple.com/124626429">rdar://124626429</a>

Reviewed by Sihui Liu.

This exposes type metadata for ObjC types wrapped by CoreIPC types,
and fixes up a few other types so their contents are consistently exposed.

* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in:
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.name_declaration_for_serialized_type_info):
(SerializedType.members_for_serialized_type_info):
(ObjCWrappedType):
(ObjCWrappedType.__init__):
(generate_impl):
(generate_serialized_type_info):
(parse_serialized_types):
(main):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFStringRef&gt;&gt;::encode):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::allSerializedTypes):
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Scripts/webkit/tests/WebKitPlatformGeneratedSerializers.cpp:
(IPC::encodeObjectDirectly&lt;PKPaymentMethod&gt;):
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;PKPaymentMethod&gt;):
(IPC::encodeObjectDirectly&lt;NSNull&gt;):
(IPC::decodeObjectDirectlyRequiringAllowedClasses&lt;NSNull&gt;):
(IPC::ArgumentCoder&lt;CFStringRef&gt;::encode):
(IPC::ArgumentCoder&lt;RetainPtr&lt;CFStringRef&gt;&gt;::decode):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetwork.messages.in:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCMonitor.messages.in:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:

Canonical link: <a href="https://commits.webkit.org/276118@main">https://commits.webkit.org/276118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db9db7b66508f3a9ffffbdbd6cd5fe56850a01da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46428 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20241 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37716 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17144 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/43652 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17404 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38789 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1839 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39091 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/48009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18812 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15399 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42958 "layout-tests (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20219 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41648 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20411 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5984 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19842 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->