### PR TITLE
Migrate more ivars from WKWebViewConfiguration to API::PageConfiguration

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -216,6 +216,27 @@ public:
     void setContextMenuQRCodeDetectionEnabled(bool enabled) { m_data.contextMenuQRCodeDetectionEnabled = enabled; }
 #endif
 
+    double incrementalRenderingSuppressionTimeout() const { return m_data.incrementalRenderingSuppressionTimeout; }
+    void setIncrementalRenderingSuppressionTimeout(double timeout) { m_data.incrementalRenderingSuppressionTimeout = timeout; }
+
+    bool allowsJavaScriptMarkup() const { return m_data.allowsJavaScriptMarkup; }
+    void setAllowsJavaScriptMarkup(bool allows) { m_data.allowsJavaScriptMarkup = allows; }
+
+    bool convertsPositionStyleOnCopy() const { return m_data.convertsPositionStyleOnCopy; }
+    void setConvertsPositionStyleOnCopy(bool converts) { m_data.convertsPositionStyleOnCopy = converts; }
+
+    bool allowsMetaRefresh() const { return m_data.allowsMetaRefresh; }
+    void setAllowsMetaRefresh(bool allows) { m_data.allowsMetaRefresh = allows; }
+
+    bool allowUniversalAccessFromFileURLs() const { return m_data.allowUniversalAccessFromFileURLs; }
+    void setAllowUniversalAccessFromFileURLs(bool allow) { m_data.allowUniversalAccessFromFileURLs = allow; }
+
+    bool allowTopNavigationToDataURLs() const { return m_data.allowTopNavigationToDataURLs; }
+    void setAllowTopNavigationToDataURLs(bool allow) { m_data.allowTopNavigationToDataURLs = allow; }
+
+    bool needsStorageAccessFromFileURLsQuirk() const { return m_data.needsStorageAccessFromFileURLsQuirk; }
+    void setNeedsStorageAccessFromFileURLsQuirk(bool needs) { m_data.needsStorageAccessFromFileURLsQuirk = needs; }
+
     void setShouldRelaxThirdPartyCookieBlocking(WebCore::ShouldRelaxThirdPartyCookieBlocking value) { m_data.shouldRelaxThirdPartyCookieBlocking = value; }
     WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking() const { return m_data.shouldRelaxThirdPartyCookieBlocking; }
 
@@ -319,6 +340,14 @@ private:
         bool imageControlsEnabled { false };
         bool contextMenuQRCodeDetectionEnabled { false };
 #endif
+
+        double incrementalRenderingSuppressionTimeout { 5 };
+        bool allowsJavaScriptMarkup { true };
+        bool convertsPositionStyleOnCopy { false };
+        bool allowsMetaRefresh { true };
+        bool allowUniversalAccessFromFileURLs { false };
+        bool allowTopNavigationToDataURLs { false };
+        bool needsStorageAccessFromFileURLsQuirk { true };
 
         WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
         WTF::String attributedBundleIdentifier { };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -133,12 +133,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     WeakObjCPtr<WKWebView> _alternateWebViewForNavigationGestures;
     RetainPtr<NSString> _groupIdentifier;
     std::optional<RetainPtr<NSString>> _applicationNameForUserAgent;
-    NSTimeInterval _incrementalRenderingSuppressionTimeout;
-    BOOL _allowsJavaScriptMarkup;
-    BOOL _convertsPositionStyleOnCopy;
-    BOOL _allowsMetaRefresh;
-    BOOL _allowUniversalAccessFromFileURLs;
-    BOOL _allowTopNavigationToDataURLs;
 
 #if PLATFORM(IOS_FAMILY)
     LazyInitialized<RetainPtr<WKWebViewContentProviderRegistry>> _contentProviderRegistry;
@@ -165,7 +159,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
 #if ENABLE(APPLE_PAY)
     BOOL _applePayEnabled;
 #endif
-    BOOL _needsStorageAccessFromFileURLsQuirk;
     BOOL _legacyEncryptedMediaAPIEnabled;
     BOOL _allowMediaContentTypesRequiringHardwareSupportAsFallback;
     BOOL _colorFilterEnabled;
@@ -225,14 +218,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     _allowsAirPlayForMediaPlayback = YES;
 #endif
-
-    _incrementalRenderingSuppressionTimeout = 5;
-    _allowsJavaScriptMarkup = YES;
-    _convertsPositionStyleOnCopy = NO;
-    _allowsMetaRefresh = YES;
-    _allowUniversalAccessFromFileURLs = NO;
-    _allowTopNavigationToDataURLs = NO;
-    _needsStorageAccessFromFileURLsQuirk = YES;
 
 #if PLATFORM(IOS_FAMILY)
     _selectionGranularity = WKSelectionGranularityDynamic;
@@ -396,13 +381,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     configuration->_suppressesIncrementalRendering = self->_suppressesIncrementalRendering;
     configuration->_applicationNameForUserAgent = self->_applicationNameForUserAgent;
 
-    configuration->_incrementalRenderingSuppressionTimeout = self->_incrementalRenderingSuppressionTimeout;
-    configuration->_allowsJavaScriptMarkup = self->_allowsJavaScriptMarkup;
-    configuration->_convertsPositionStyleOnCopy = self->_convertsPositionStyleOnCopy;
-    configuration->_allowsMetaRefresh = self->_allowsMetaRefresh;
-    configuration->_allowUniversalAccessFromFileURLs = self->_allowUniversalAccessFromFileURLs;
-    configuration->_allowTopNavigationToDataURLs = self->_allowTopNavigationToDataURLs;
-
     configuration->_invisibleAutoplayNotPermitted = self->_invisibleAutoplayNotPermitted;
     configuration->_mediaDataLoadsAutomatically = self->_mediaDataLoadsAutomatically;
     configuration->_attachmentElementEnabled = self->_attachmentElementEnabled;
@@ -435,7 +413,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if ENABLE(APPLE_PAY)
     configuration->_applePayEnabled = self->_applePayEnabled;
 #endif
-    configuration->_needsStorageAccessFromFileURLsQuirk = self->_needsStorageAccessFromFileURLsQuirk;
 
     configuration->_mediaContentTypesRequiringHardwareSupport = adoptNS([self._mediaContentTypesRequiringHardwareSupport copyWithZone:zone]);
     configuration->_additionalSupportedImageTypes = adoptNS([self->_additionalSupportedImageTypes copyWithZone:zone]);
@@ -735,62 +712,62 @@ static NSString *defaultApplicationNameForUserAgent()
 
 - (NSTimeInterval)_incrementalRenderingSuppressionTimeout
 {
-    return _incrementalRenderingSuppressionTimeout;
+    return _pageConfiguration->incrementalRenderingSuppressionTimeout();
 }
 
 - (void)_setIncrementalRenderingSuppressionTimeout:(NSTimeInterval)incrementalRenderingSuppressionTimeout
 {
-    _incrementalRenderingSuppressionTimeout = incrementalRenderingSuppressionTimeout;
+    _pageConfiguration->setIncrementalRenderingSuppressionTimeout(incrementalRenderingSuppressionTimeout);
 }
 
 - (BOOL)_allowsJavaScriptMarkup
 {
-    return _allowsJavaScriptMarkup;
+    return _pageConfiguration->allowsJavaScriptMarkup();
 }
 
 - (void)_setAllowsJavaScriptMarkup:(BOOL)allowsJavaScriptMarkup
 {
-    _allowsJavaScriptMarkup = allowsJavaScriptMarkup;
+    _pageConfiguration->setAllowsJavaScriptMarkup(allowsJavaScriptMarkup);
 }
 
 - (BOOL)_allowUniversalAccessFromFileURLs
 {
-    return _allowUniversalAccessFromFileURLs;
+    return _pageConfiguration->allowUniversalAccessFromFileURLs();
 }
 
 - (void)_setAllowUniversalAccessFromFileURLs:(BOOL)allowUniversalAccessFromFileURLs
 {
-    _allowUniversalAccessFromFileURLs = allowUniversalAccessFromFileURLs;
+    _pageConfiguration->setAllowUniversalAccessFromFileURLs(allowUniversalAccessFromFileURLs);
 }
 
 - (BOOL)_allowTopNavigationToDataURLs
 {
-    return _allowTopNavigationToDataURLs;
+    return _pageConfiguration->allowTopNavigationToDataURLs();
 }
 
 - (void)_setAllowTopNavigationToDataURLs:(BOOL)allowTopNavigationToDataURLs
 {
-    _allowTopNavigationToDataURLs = allowTopNavigationToDataURLs;
+    _pageConfiguration->setAllowTopNavigationToDataURLs(allowTopNavigationToDataURLs);
 }
 
 - (BOOL)_convertsPositionStyleOnCopy
 {
-    return _convertsPositionStyleOnCopy;
+    return _pageConfiguration->convertsPositionStyleOnCopy();
 }
 
 - (void)_setConvertsPositionStyleOnCopy:(BOOL)convertsPositionStyleOnCopy
 {
-    _convertsPositionStyleOnCopy = convertsPositionStyleOnCopy;
+    _pageConfiguration->setConvertsPositionStyleOnCopy(convertsPositionStyleOnCopy);
 }
 
 - (BOOL)_allowsMetaRefresh
 {
-    return _allowsMetaRefresh;
+    return _pageConfiguration->allowsMetaRefresh();
 }
 
 - (void)_setAllowsMetaRefresh:(BOOL)allowsMetaRefresh
 {
-    _allowsMetaRefresh = allowsMetaRefresh;
+    _pageConfiguration->setAllowsMetaRefresh(allowsMetaRefresh);
 }
 
 - (BOOL)_clientNavigationsRunAtForegroundPriority
@@ -1307,12 +1284,12 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (BOOL)_needsStorageAccessFromFileURLsQuirk
 {
-    return _needsStorageAccessFromFileURLsQuirk;
+    return _pageConfiguration->needsStorageAccessFromFileURLsQuirk();
 }
 
 - (void)_setNeedsStorageAccessFromFileURLsQuirk:(BOOL)needsLocalStorageQuirk
 {
-    _needsStorageAccessFromFileURLsQuirk = needsLocalStorageQuirk;
+    _pageConfiguration->setNeedsStorageAccessFromFileURLsQuirk(needsLocalStorageQuirk);
 }
 
 - (NSString *)_overrideContentSecurityPolicy


### PR DESCRIPTION
#### e7bb5f0f51c631f0fdfbdfeab27b4b7e559c6ea2
<pre>
Migrate more ivars from WKWebViewConfiguration to API::PageConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=270990">https://bugs.webkit.org/show_bug.cgi?id=270990</a>
<a href="https://rdar.apple.com/124627697">rdar://124627697</a>

Reviewed by Charlie Wolfe.

This is another step towards moving the PageConfiguration creation to
platform-independent code in WebPageProxy::createNewPage.

* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::incrementalRenderingSuppressionTimeout const):
(API::PageConfiguration::setIncrementalRenderingSuppressionTimeout):
(API::PageConfiguration::allowsJavaScriptMarkup const):
(API::PageConfiguration::setAllowsJavaScriptMarkup):
(API::PageConfiguration::convertsPositionStyleOnCopy const):
(API::PageConfiguration::setConvertsPositionStyleOnCopy):
(API::PageConfiguration::allowsMetaRefresh const):
(API::PageConfiguration::setAllowsMetaRefresh):
(API::PageConfiguration::allowUniversalAccessFromFileURLs const):
(API::PageConfiguration::setAllowUniversalAccessFromFileURLs):
(API::PageConfiguration::allowTopNavigationToDataURLs const):
(API::PageConfiguration::setAllowTopNavigationToDataURLs):
(API::PageConfiguration::needsStorageAccessFromFileURLsQuirk const):
(API::PageConfiguration::setNeedsStorageAccessFromFileURLsQuirk):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration init]):
(-[WKWebViewConfiguration copyWithZone:]):
(-[WKWebViewConfiguration _incrementalRenderingSuppressionTimeout]):
(-[WKWebViewConfiguration _setIncrementalRenderingSuppressionTimeout:]):
(-[WKWebViewConfiguration _allowsJavaScriptMarkup]):
(-[WKWebViewConfiguration _setAllowsJavaScriptMarkup:]):
(-[WKWebViewConfiguration _allowUniversalAccessFromFileURLs]):
(-[WKWebViewConfiguration _setAllowUniversalAccessFromFileURLs:]):
(-[WKWebViewConfiguration _allowTopNavigationToDataURLs]):
(-[WKWebViewConfiguration _setAllowTopNavigationToDataURLs:]):
(-[WKWebViewConfiguration _convertsPositionStyleOnCopy]):
(-[WKWebViewConfiguration _setConvertsPositionStyleOnCopy:]):
(-[WKWebViewConfiguration _allowsMetaRefresh]):
(-[WKWebViewConfiguration _setAllowsMetaRefresh:]):
(-[WKWebViewConfiguration _needsStorageAccessFromFileURLsQuirk]):
(-[WKWebViewConfiguration _setNeedsStorageAccessFromFileURLsQuirk:]):

Canonical link: <a href="https://commits.webkit.org/276117@main">https://commits.webkit.org/276117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a40ea28d01c7543b55958cc019e9326424bfb7f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46418 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39874 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20229 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37711 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17396 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1829 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39957 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47975 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18802 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/42950 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20208 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41640 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20401 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5983 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->