### PR TITLE
Fix crash when `Device::generateAnOutOfMemoryError` is repeatedly invoked

### DIFF
--- a/LayoutTests/fast/webgpu/repeated-out-of-memory-error-expected.txt
+++ b/LayoutTests/fast/webgpu/repeated-out-of-memory-error-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/repeated-out-of-memory-error.html
+++ b/LayoutTests/fast/webgpu/repeated-out-of-memory-error.html
@@ -1,0 +1,83 @@
+This test passes if it does not crash.
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+
+    onload = async () => {
+        try {
+            let adapter0 = await navigator.gpu.requestAdapter(
+                {
+                    powerPreference: 'high-performance',
+                }
+            );
+            let device0 = await adapter0.requestDevice(
+                {
+                    label: '\u{1fc7e}',
+                    requiredFeatures: [
+                        'depth-clip-control',
+                        'shader-f16',
+                        'bgra8unorm-storage'
+                    ],
+                    requiredLimits: {
+                        maxColorAttachmentBytesPerSample: 60,
+                        maxVertexAttributes: 30,
+                        maxVertexBufferArrayStride: 11348,
+                        maxStorageTexturesPerShaderStage: 42,
+                        maxBindingsPerBindGroup: 7372,
+                        maxTextureArrayLayers: 2011
+                    },
+                }
+            );
+            let bindGroupLayout0 = device0.createBindGroupLayout(
+                {
+                    entries: [
+                        {
+                            binding: 5869,
+                            visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+                            texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+                        }
+                    ],
+                }
+            );
+            device0.addEventListener('uncapturederror', e => { e.label = device0.label; });
+            device0.createTexture(
+                {
+                    label: '\u04ab',
+                    size: {
+                        width: 7798,
+                        height: 7120,
+                        depthOrArrayLayers: 377,
+                    },
+                    format: 'stencil8',
+                    usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+                }
+            );
+            let sampler5 = device0.createSampler(
+                {
+                    addressModeU: 'repeat',
+                    addressModeV: 'mirror-repeat',
+                    addressModeW: 'mirror-repeat',
+                    minFilter: 'nearest',
+                    lodMinClamp: 45.683,
+                    lodMaxClamp: 77.763,
+                    compare: 'always',
+                }
+            );
+            let bindGroup0 = device0.createBindGroup(
+                {
+                    layout: bindGroupLayout0,
+                    entries: [
+                        {
+                            binding: 646,
+                            resource: sampler5,
+                        }
+                    ],
+                }
+            );
+        } catch (e) { }
+        if (window.testRunner)
+            testRunner.notifyDone();
+    };
+</script>

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -323,8 +323,10 @@ void Device::generateAnOutOfMemoryError(String&& message)
         return;
     }
 
-    if (m_uncapturedErrorCallback)
+    if (m_uncapturedErrorCallback) {
         m_uncapturedErrorCallback(WGPUErrorType_OutOfMemory, WTFMove(message));
+        m_uncapturedErrorCallback = nullptr;
+    }
 }
 
 void Device::generateAnInternalError(String&& message)
@@ -339,8 +341,10 @@ void Device::generateAnInternalError(String&& message)
         return;
     }
 
-    if (m_uncapturedErrorCallback)
+    if (m_uncapturedErrorCallback) {
         m_uncapturedErrorCallback(WGPUErrorType_Internal, WTFMove(message));
+        m_uncapturedErrorCallback = nullptr;
+    }
 }
 
 uint32_t Device::maxBuffersPlusVertexBuffersForVertexStage() const


### PR DESCRIPTION
#### 56e388b8f65480d64712ebd2f65f837c95f7057d
<pre>
Fix crash when `Device::generateAnOutOfMemoryError` is repeatedly invoked
<a href="https://bugs.webkit.org/show_bug.cgi?id=270991">https://bugs.webkit.org/show_bug.cgi?id=270991</a>
<a href="https://rdar.apple.com/124475321">rdar://124475321</a>

Reviewed by Mike Wyrzykowski.

`m_uncapturedErrorCallback` can only be called once, so it should always be cleared after calling it.

* LayoutTests/fast/webgpu/repeated-out-of-memory-error-expected.txt: Added.
* LayoutTests/fast/webgpu/repeated-out-of-memory-error.html: Added.
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::generateAnOutOfMemoryError):
(WebGPU::Device::generateAnInternalError):

Canonical link: <a href="https://commits.webkit.org/276135@main">https://commits.webkit.org/276135@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dc89bce47e5356c2971773b6f541b5f077b62c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46468 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39917 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26755 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20277 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36173 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17169 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38819 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1878 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39121 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48027 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18844 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15423 "Found 3 new test failures: http/tests/media/modern-media-controls/overflow-support/playback-speed-live-broadcast.html, http/tests/navigation/parsed-iframe-dynamic-form-back-entry.html, http/tests/referrer-policy-script/origin-when-cross-origin/cross-origin-http.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42982 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41674 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20441 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5995 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19864 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->