### PR TITLE
Fix assertion failure in pas_enumerator_create due to wrong alignment

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_enumerator_region.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerator_region.h
@@ -37,7 +37,7 @@ struct pas_enumerator_region {
     pas_enumerator_region* previous;
     size_t size;
     size_t offset;
-    uint64_t payload[1];
+    PAS_ALIGNED(PAS_INTERNAL_MIN_ALIGN) uint64_t payload[1];
 };
 
 PAS_API void* pas_enumerator_region_allocate(pas_enumerator_region** region_ptr,


### PR DESCRIPTION
#### 5aa139649dd7649acd4451228d56cc0ea8b0e8c9
<pre>
Fix assertion failure in pas_enumerator_create due to wrong alignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=270993">https://bugs.webkit.org/show_bug.cgi?id=270993</a>
<a href="https://rdar.apple.com/124562475">rdar://124562475</a>

Reviewed by Yusuke Suzuki.

In pas_enumerator_create, we assert that the payload of a pas_enumerator_region
is aligned to PAS_INTERNAL_MIN_ALIGN. This patch adds that alignment requirement
to the type definition of pas_enumerator_region so we always respect this
requirement.

* Source/bmalloc/libpas/src/libpas/pas_enumerator_region.h:

Canonical link: <a href="https://commits.webkit.org/276187@main">https://commits.webkit.org/276187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5af1bb16ec923c0d191e17cd4242ff63a0e193a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46427 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39882 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26769 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36152 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37710 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38782 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1838 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37216 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/simple-inline-stacktrace-with-catch.js.wasm-agressive-inline (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/47984 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43399 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18811 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15396 "Found 2 new test failures: http/tests/navigation/parsed-iframe-dynamic-form-back-entry.html, imported/w3c/web-platform-tests/html/dom/idlharness.https.html?exclude=(Document|Window|HTML.*) (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42969 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20216 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41659 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9782 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20410 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50414 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19841 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10164 "Passed tests") | 
<!--EWS-Status-Bubble-End-->