### PR TITLE
[Text Extraction] Retrieved items should be reported in the coordinate space of the web view

### DIFF
--- a/LayoutTests/fast/text-extraction/text-extraction-when-scrolled-expected.txt
+++ b/LayoutTests/fast/text-extraction/text-extraction-when-scrolled-expected.txt
@@ -1,0 +1,18 @@
+PASS textResults.length is 1
+PASS textResults[0].includes("Bottom link") is true
+PASS rootRect.height is >= 10000
+PASS rootRect.y is <= -5000
+PASS textRect.y is <= 5000
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+Top link
+
+
+Bottom link
+
+
+
+
+

--- a/LayoutTests/fast/text-extraction/text-extraction-when-scrolled.html
+++ b/LayoutTests/fast/text-extraction/text-extraction-when-scrolled.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    white-space: pre-wrap;
+}
+
+.tall-content {
+    height: 10000px;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<div>Top <a href="https://apple.com">link</a></div>
+<div class="tall-content"></div>
+<div>Bottom <a href="https://webkit.org">link</a></div>
+<script>
+jsTestIsAsync = true;
+
+function parseRect(outputString) {
+    const [x, y, width, height] = JSON.parse([...outputString.matchAll(/rect=(\[.*\])/g)][0][1]);
+    return { x, y, width, height };
+}
+
+addEventListener("load", async () => {
+    await UIHelper.renderingUpdate();
+    scrollTo(0, document.scrollingElement.scrollHeight);
+    await UIHelper.renderingUpdate();
+
+    const extractionResult = await UIHelper.requestTextExtraction({
+        clipToBounds: true,
+        includeRects: true
+    });
+
+    rootResult = extractionResult.split("\n").filter(line => line.includes("ROOT"))[0];
+    textResults = extractionResult.split("\n").filter(line => line.includes("TEXT"));
+
+    shouldBe("textResults.length", "1");
+
+    rootRect = parseRect(rootResult);
+    textRect = parseRect(textResults[0]);
+
+    shouldBeTrue(`textResults[0].includes("Bottom link")`);
+    shouldBeGreaterThanOrEqual("rootRect.height", "10000");
+    shouldBeLessThanOrEqual("rootRect.y", "-5000");
+    shouldBeLessThanOrEqual("textRect.y", "5000");
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2141,14 +2141,17 @@ window.UIHelper = class UIHelper {
         return new Promise(resolve => testRunner.getSelectedTextInChromeInputField(resolve));
     }
 
-    static requestTextExtraction()
+    static requestTextExtraction(options)
     {
         if (!this.isWebKit2())
             return Promise.resolve();
 
         return new Promise(resolve => {
             testRunner.runUIScript(`(() => {
-                uiController.requestTextExtraction(result => uiController.uiScriptComplete(result));
+                uiController.requestTextExtraction(
+                    result => uiController.uiScriptComplete(result),
+                    ${JSON.stringify(options)}
+                );
             })()`, resolve);
         });
     }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -4290,8 +4290,14 @@ static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFind
 #endif
     }();
 
-    _page->requestTextExtraction(WTFMove(rectInRootView), [completionHandler = makeBlockPtr(completionHandler)](auto&& item) {
-        completionHandler(WebKit::createItem(item).get());
+    _page->requestTextExtraction(WTFMove(rectInRootView), [completionHandler = makeBlockPtr(completionHandler), weakSelf = WeakObjCPtr<WKWebView>(self)](auto&& item) {
+        completionHandler(WebKit::createItem(item, [strongSelf = weakSelf.get()](auto& rectInRootView) -> WebCore::FloatRect {
+#if PLATFORM(IOS_FAMILY)
+            if (RetainPtr contentView = strongSelf ? strongSelf->_contentView : nil)
+                return { [strongSelf convertRect:rectInRootView fromView:contentView.get()] };
+#endif
+            return rectInRootView;
+        }).get());
     });
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionItem.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionItem.h
@@ -42,11 +42,11 @@ typedef NS_ENUM(NSInteger, WKTextExtractionContainer) {
 
 @interface WKTextExtractionItem : NSObject
 @property (nonatomic, readonly) NSArray<WKTextExtractionItem *> *children;
-@property (nonatomic, readonly) CGRect rectInRootView;
+@property (nonatomic, readonly) CGRect rectInWebView;
 @end
 
 @interface WKTextExtractionContainerItem : WKTextExtractionItem
-- (instancetype)initWithContainer:(WKTextExtractionContainer)container rectInRootView:(CGRect)rectInRootView children:(NSArray<WKTextExtractionItem *> *)children;
+- (instancetype)initWithContainer:(WKTextExtractionContainer)container rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children;
 @property (nonatomic, readonly) WKTextExtractionContainer container;
 @end
 
@@ -65,7 +65,7 @@ typedef NS_ENUM(NSInteger, WKTextExtractionContainer) {
 @end
 
 @interface WKTextExtractionTextItem : WKTextExtractionItem
-- (instancetype)initWithContent:(NSString *)content selectedRange:(NSRange)selectedRange links:(NSArray<WKTextExtractionLink *> *)links editable:(WKTextExtractionEditable *)editable rectInRootView:(CGRect)rectInRootView children:(NSArray<WKTextExtractionItem *> *)children;
+- (instancetype)initWithContent:(NSString *)content selectedRange:(NSRange)selectedRange links:(NSArray<WKTextExtractionLink *> *)links editable:(WKTextExtractionEditable *)editable rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children;
 @property (nonatomic, readonly) NSString *content;
 @property (nonatomic, readonly) NSRange selectedRange;
 @property (nonatomic, readonly) NSArray<WKTextExtractionLink *> *links;
@@ -73,12 +73,12 @@ typedef NS_ENUM(NSInteger, WKTextExtractionContainer) {
 @end
 
 @interface WKTextExtractionScrollableItem : WKTextExtractionItem
-- (instancetype)initWithContentSize:(CGSize)contentSize rectInRootView:(CGRect)rectInRootView children:(NSArray<WKTextExtractionItem *> *)children;
+- (instancetype)initWithContentSize:(CGSize)contentSize rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children;
 @property (nonatomic, readonly) CGSize contentSize;
 @end
 
 @interface WKTextExtractionImageItem : WKTextExtractionItem
-- (instancetype)initWithName:(NSString *)name altText:(NSString *)altText rectInRootView:(CGRect)rectInRootView children:(NSArray<WKTextExtractionItem *> *)children;
+- (instancetype)initWithName:(NSString *)name altText:(NSString *)altText rectInWebView:(CGRect)rectInWebView children:(NSArray<WKTextExtractionItem *> *)children;
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) NSString *altText;
 @end

--- a/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.h
@@ -25,11 +25,14 @@
 
 #pragma once
 
+#import <wtf/Function.h>
 #import <wtf/RetainPtr.h>
 
 OBJC_CLASS WKTextExtractionItem;
 
 namespace WebCore {
+class FloatRect;
+
 namespace TextExtraction {
 struct Item;
 }
@@ -38,6 +41,8 @@ struct Item;
 namespace WebKit {
 
 void prepareTextExtractionSupportIfNeeded();
-RetainPtr<WKTextExtractionItem> createItem(const WebCore::TextExtraction::Item&);
+
+using RootViewToWebViewConverter = Function<WebCore::FloatRect(const WebCore::FloatRect&)>;
+RetainPtr<WKTextExtractionItem> createItem(const WebCore::TextExtraction::Item&, RootViewToWebViewConverter&&);
 
 } // namespace WebKit

--- a/Source/WebKit/WebKitSwift/TextExtraction/WKTextExtractionItem.swift
+++ b/Source/WebKit/WebKitSwift/TextExtraction/WKTextExtractionItem.swift
@@ -25,11 +25,11 @@ import Foundation
 
 @available(iOS 17.0, macOS 12.0, *)
 @objc(WKTextExtractionItem) public class WKTextExtractionItem: NSObject {
-    @objc public let rectInRootView: CGRect
+    @objc public let rectInWebView: CGRect
     @objc public let children: [WKTextExtractionItem]
 
-    public init(with rectInRootView: CGRect, children: [WKTextExtractionItem]) {
-        self.rectInRootView = rectInRootView
+    public init(with rectInWebView: CGRect, children: [WKTextExtractionItem]) {
+        self.rectInWebView = rectInWebView
         self.children = children
     }
 }
@@ -51,9 +51,9 @@ import Foundation
 @objc(WKTextExtractionContainerItem) public class WKTextExtractionContainerItem: WKTextExtractionItem {
     @objc public let container: WKTextExtractionContainer
 
-    @objc public init(container: WKTextExtractionContainer, rectInRootView: CGRect, children: [WKTextExtractionItem]) {
+    @objc public init(container: WKTextExtractionContainer, rectInWebView: CGRect, children: [WKTextExtractionItem]) {
         self.container = container
-        super.init(with: rectInRootView, children: children)
+        super.init(with: rectInWebView, children: children)
     }
 }
 
@@ -90,12 +90,12 @@ import Foundation
     @objc public let links: [WKTextExtractionLink]
     @objc public let editable: WKTextExtractionEditable?
 
-    @objc public init(content: String, selectedRange: NSRange, links: [WKTextExtractionLink], editable: WKTextExtractionEditable?, rectInRootView: CGRect, children: [WKTextExtractionItem]) {
+    @objc public init(content: String, selectedRange: NSRange, links: [WKTextExtractionLink], editable: WKTextExtractionEditable?, rectInWebView: CGRect, children: [WKTextExtractionItem]) {
         self.content = content
         self.selectedRange = selectedRange
         self.links = links
         self.editable = editable
-        super.init(with: rectInRootView, children: children)
+        super.init(with: rectInWebView, children: children)
     }
 }
 
@@ -103,9 +103,9 @@ import Foundation
 @objc(WKTextExtractionScrollableItem) public class WKTextExtractionScrollableItem: WKTextExtractionItem {
     @objc public let contentSize: CGSize
 
-    @objc public init(contentSize: CGSize, rectInRootView: CGRect, children: [WKTextExtractionItem]) {
+    @objc public init(contentSize: CGSize, rectInWebView: CGRect, children: [WKTextExtractionItem]) {
         self.contentSize = contentSize
-        super.init(with: rectInRootView, children: children)
+        super.init(with: rectInWebView, children: children)
     }
 }
 
@@ -114,10 +114,10 @@ import Foundation
     @objc public let name: String
     @objc public let altText: String
 
-    @objc public init(name: String, altText: String, rectInRootView: CGRect, children: [WKTextExtractionItem]) {
+    @objc public init(name: String, altText: String, rectInWebView: CGRect, children: [WKTextExtractionItem]) {
         self.name = name
         self.altText = altText
-        super.init(with: rectInRootView, children: children)
+        super.init(with: rectInWebView, children: children)
     }
 }
 

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -42,6 +42,11 @@ dictionary ScrollToOptions {
     boolean unconstrained = false;
 };
 
+dictionary TextExtractionOptions {
+    boolean clipToBounds = false;
+    boolean includeRects = false;
+};
+
 interface UIScriptController {
 
     undefined doAsyncTask(object callback); // Used to test the harness.
@@ -411,6 +416,6 @@ interface UIScriptController {
     undefined setInlinePrediction(DOMString completion);
     undefined acceptInlinePrediction();
 
-    undefined requestTextExtraction(object callback);
+    undefined requestTextExtraction(object callback, TextExtractionOptions options);
     undefined requestRenderedTextForSelector(DOMString selector, object callback);
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -56,6 +56,13 @@ struct ScrollToOptions {
 
 ScrollToOptions* toScrollToOptions(JSContextRef, JSValueRef);
 
+struct TextExtractionOptions {
+    bool clipToBounds { false };
+    bool includeRects { false };
+};
+
+TextExtractionOptions* toTextExtractionOptions(JSContextRef, JSValueRef);
+
 class UIScriptController : public JSWrappable {
 public:
     static Ref<UIScriptController> create(UIScriptContext&);
@@ -407,7 +414,7 @@ public:
     virtual void installFakeMachineReadableCodeResultsForImageAnalysis() { }
 
     // Text Extraction
-    virtual void requestTextExtraction(JSValueRef) { notImplemented(); }
+    virtual void requestTextExtraction(JSValueRef, TextExtractionOptions*) { notImplemented(); }
     virtual void requestRenderedTextForSelector(JSStringRef, JSValueRef) { notImplemented(); }
 
 protected:

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -64,6 +64,17 @@ ScrollToOptions* toScrollToOptions(JSContextRef context, JSValueRef argument)
     return &options;
 }
 
+TextExtractionOptions* toTextExtractionOptions(JSContextRef context, JSValueRef argument)
+{
+    if (!JSValueIsObject(context, argument))
+        return nullptr;
+
+    static TextExtractionOptions options;
+    options.clipToBounds = booleanProperty(context, (JSObjectRef)argument, "clipToBounds", false);
+    options.includeRects = booleanProperty(context, (JSObjectRef)argument, "includeRects", false);
+    return &options;
+}
+
 UIScriptController::UIScriptController(UIScriptContext& context)
     : m_context(&context)
 {

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -88,7 +88,7 @@ private:
 
     void setSpellCheckerResults(JSValueRef) final;
 
-    void requestTextExtraction(JSValueRef callback) final;
+    void requestTextExtraction(JSValueRef callback, TextExtractionOptions*) final;
     void requestRenderedTextForSelector(JSStringRef selector, JSValueRef callback) final;
 };
 

--- a/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.h
+++ b/Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.h
@@ -35,6 +35,7 @@
 
 namespace WTR {
 
-NSString *recursiveDescription(WKTextExtractionItem *);
+enum class IncludeRects : bool { No, Yes };
+NSString *recursiveDescription(WKTextExtractionItem *, IncludeRects);
 
 }


### PR DESCRIPTION
#### 884b0d2472da61ab72615727088039ab05e998a6
<pre>
[Text Extraction] Retrieved items should be reported in the coordinate space of the web view
<a href="https://bugs.webkit.org/show_bug.cgi?id=270994">https://bugs.webkit.org/show_bug.cgi?id=270994</a>
<a href="https://rdar.apple.com/124557587">rdar://124557587</a>

Reviewed by Abrar Rahman Protyasha.

`WKTextExtractionItem`&apos;s rect should be in web view coordinates, rather than root view coordinates.
Fix this by refactoring the text extraction item conversion code, so that we can pass in a function
to convert from root view coordinates to web view coordinates if needed (i.e. on iOS).

Test: fast/text-extraction/text-extraction-when-scrolled.html

* LayoutTests/fast/text-extraction/text-extraction-when-scrolled-expected.txt: Added.
* LayoutTests/fast/text-extraction/text-extraction-when-scrolled.html: Added.

Add a new layout test to exercise the change:
1.  Only the bottom link should be extracted
2.  The y-offset of the extracted link should be closer to 0 than 10000 (roughly the full height of
    the view).
3.  The y-offset of the root should be a large negative number close to 10000.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.requestTextExtraction):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _requestTextExtraction:completionHandler:]):
* Source/WebKit/UIProcess/Cocoa/WKTextExtractionItem.h:
* Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.h:
* Source/WebKit/UIProcess/Cocoa/WKTextExtractionUtilities.mm:
(WebKit::createWKTextItem):
(WebKit::createItemWithChildren):
(WebKit::createItemRecursive):
(WebKit::createItem):
* Source/WebKit/WebKitSwift/TextExtraction/WKTextExtractionItem.swift:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::requestTextExtraction):
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionOptions):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::requestTextExtraction):

Add new test options to allow layout tests to:
- Clip text extraction to the visible bounds of the web view.
- Additionally print rects for each of the extracted items.

* Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.h:
* Tools/WebKitTestRunner/cocoa/WKTextExtractionTestingHelpers.mm:
(WTR::buildDescriptionIgnoringChildren):
(WTR::buildRecursiveDescription):
(WTR::recursiveDescription):

Canonical link: <a href="https://commits.webkit.org/276133@main">https://commits.webkit.org/276133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f29ec9a98152f0353294f2d37d8f4ffa49ed9a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46467 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39916 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36172 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37747 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17168 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17431 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38826 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1877 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48026 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18843 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15425 "Found 1 new test failure: http/tests/navigation/parsed-iframe-dynamic-form-back-entry.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42981 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41673 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9751 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20440 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->