### PR TITLE
Media Capability may not be created for a web page after process swap

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -968,6 +968,7 @@ bool AVVideoCaptureSource::setupSession()
 
 #if ENABLE(EXTENSION_CAPABILITIES)
     String mediaEnvironment = RealtimeMediaSourceCenter::singleton().currentMediaEnvironment();
+    WARNING_LOG_IF(loggerPtr() && mediaEnvironment.isEmpty(), "Media environment is empty");
     // FIXME (119325252): Remove staging code for -[AVCaptureSession initWithMediaEnvironment:]
     if (!mediaEnvironment.isEmpty() && [PAL::getAVCaptureSessionClass() instancesRespondToSelector:@selector(initWithMediaEnvironment:)])
         m_session = adoptNS([PAL::allocAVCaptureSessionInstance() initWithMediaEnvironment:mediaEnvironment]);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6326,6 +6326,11 @@ void WebPageProxy::didCommitLoadForFrame(FrameIdentifier frameID, FrameInfoData&
         m_userMediaPermissionRequestManager->didCommitLoadForFrame(frameID);
 #endif
 
+#if ENABLE(EXTENSION_CAPABILITIES)
+    if (frame->isMainFrame())
+        resetMediaCapability();
+#endif
+
 #if ENABLE(TEXT_EXTRACTION)
     if (frame->isMainFrame() && preferences().textExtractionEnabled())
         prepareTextExtractionSupportIfNeeded();
@@ -6601,15 +6606,13 @@ void WebPageProxy::didSameDocumentNavigationForFrameViaJSHistoryAPI(SameDocument
 
 void WebPageProxy::didChangeMainDocument(FrameIdentifier frameID)
 {
-    RefPtr frame = WebFrameProxy::webFrame(frameID);
-
 #if ENABLE(MEDIA_STREAM)
     if (m_userMediaPermissionRequestManager) {
         m_userMediaPermissionRequestManager->resetAccess(frameID);
 
 #if ENABLE(GPU_PROCESS)
         if (RefPtr gpuProcess = m_process->processPool().gpuProcess()) {
-            if (frame)
+            if (RefPtr frame = WebFrameProxy::webFrame(frameID))
                 gpuProcess->updateCaptureOrigin(SecurityOriginData::fromURLWithoutStrictOpaqueness(frame->url()), m_process->coreProcessIdentifier());
         }
 #endif
@@ -6619,11 +6622,6 @@ void WebPageProxy::didChangeMainDocument(FrameIdentifier frameID)
     m_isQuotaIncreaseDenied = false;
 
     m_speechRecognitionPermissionManager = nullptr;
-
-#if ENABLE(EXTENSION_CAPABILITIES)
-    if (frame && frame->isMainFrame())
-        resetMediaCapability();
-#endif
 }
 
 #if ENABLE(GPU_PROCESS)


### PR DESCRIPTION
#### 58512c972d46ac24ddc87a330fcb6894b200e53c
<pre>
Media Capability may not be created for a web page after process swap
<a href="https://bugs.webkit.org/show_bug.cgi?id=270999">https://bugs.webkit.org/show_bug.cgi?id=270999</a>
<a href="https://rdar.apple.com/124491466">rdar://124491466</a>

Reviewed by Eric Carlson.

We used to recrete a media capability in WebPageProxy::didChangeMainDocument.
In case of process swap, the WebPageProxy has sent its media capability to the previous web page, but not the new web page in the new process.
WebPageProxy::didChangeMainDocument is not called so the media capability is not recreated for the new web page.

We move back the potential recreation of the media capbility to WebPageProxy::didCommitLoadForFrame where it was before <a href="https://rdar.apple.com/problem/123381737">rdar://problem/123381737</a>.
This is ok since we are preserving media capabilities over navigation for same origin navigations, instead of recreating a media capability for each new main document.

Manually tested by doing the following in iOS:
1. Load a web page say <a href="https://webkit.org.">https://webkit.org.</a>
2. Via web inspector, load another page, for instance: &apos;window.location = &quot;<a href="https://webrtc.github.io/samples/src/content/getusermedia/gum/&quot">https://webrtc.github.io/samples/src/content/getusermedia/gum/&quot</a>;&apos;
3. Start capturing on the new web page and verify camera capture is working properly.

I also validated that same document navigations are still working using <a href="https://bugs.webkit.org/attachment.cgi?id=470000.">https://bugs.webkit.org/attachment.cgi?id=470000.</a>

After the fix in <a href="https://bugs.webkit.org/show_bug.cgi?id=270995">https://bugs.webkit.org/show_bug.cgi?id=270995</a>, capture would not longer fail but would use identity instead of media capability.
We add a warning logging in AVVideoCaptureSource to catch the case of media capability being empty, which should not happen for safari.

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::setupSession):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didChangeMainDocument):

Canonical link: <a href="https://commits.webkit.org/276211@main">https://commits.webkit.org/276211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/152c8eb6b40f559e755f8ab12e8447d353ef8bcb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22969 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46560 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39989 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46219 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36234 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44490 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17240 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17544 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38906 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1971 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48131 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43058 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20308 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41766 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9792 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20514 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->