### PR TITLE
[iOS] Increase the limit on the canvas size to 8192x8192

### DIFF
--- a/LayoutTests/fast/canvas/canvas-size-minimum-limit-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-size-minimum-limit-expected.txt
@@ -1,0 +1,10 @@
+The limit on the canvas size should be at least 8192x8192.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS pixelColors[0] is 0
+PASS pixelColors[1] is 128
+PASS pixelColors[2] is 0
+PASS pixelColors[3] is 255
+

--- a/LayoutTests/fast/canvas/canvas-size-minimum-limit.html
+++ b/LayoutTests/fast/canvas/canvas-size-minimum-limit.html
@@ -1,0 +1,23 @@
+<head>
+    <script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+    <script>
+        description("The limit on the canvas size should be at least 8192x8192.");
+
+        const canvas = document.createElement('canvas');
+        canvas.width = 8192;
+        canvas.height = 8192;
+
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = "green";
+        ctx.fillRect(0, 0, 8192, 8192);
+
+        pixelColors = ctx.getImageData(8191, 8191, 1, 1).data;
+
+        shouldBe("pixelColors[0]", "0");
+        shouldBe("pixelColors[1]", "128");
+        shouldBe("pixelColors[2]", "0");
+        shouldBe("pixelColors[3]", "255");
+    </script>
+</body>

--- a/LayoutTests/platform/ios/compositing/canvas/accelerated-canvas-compositing-size-limit-expected.txt
+++ b/LayoutTests/platform/ios/compositing/canvas/accelerated-canvas-compositing-size-limit-expected.txt
@@ -1,7 +1,5 @@
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
 Verifies Canvas 2D Context accelerated backing store behavior.
 
 

--- a/LayoutTests/platform/ios/fast/canvas/canvas-toDataURL-crash-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/canvas-toDataURL-crash-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
 PASS
 
 Calling toDataURL() on a huge canvas shouldn't crash. If the text above is "PASS", the test passed.

--- a/LayoutTests/platform/ios/fast/canvas/image-buffer-backend-variants-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/image-buffer-backend-variants-expected.txt
@@ -1,105 +1,66 @@
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
 Test enumerates the behavior of canvas with respect to dimensions and backends
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
@@ -148,9 +109,11 @@ Testing 1000x16384 (area: 16384000)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 1000x32768 (area: 32768000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 1000x32769 (area: 32769000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 2048x1 (area: 2048)
 PASS imageData.data is red
 Effective renderingMode: Accelerated
@@ -167,9 +130,11 @@ Testing 2048x8192 (area: 16777216)
 PASS imageData.data is red
 Effective renderingMode: Accelerated
 Testing 2048x16384 (area: 33554432)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 2048x32768 (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 2048x32769 (area: 67110912)
 PASS Context was lost
 Testing 4096x1 (area: 4096)
@@ -185,9 +150,11 @@ Testing 4096x4096 (area: 16777216)
 PASS imageData.data is red
 Effective renderingMode: Accelerated
 Testing 4096x8192 (area: 33554432)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Accelerated
 Testing 4096x16384 (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 4096x32768 (area: 134217728)
 PASS Context was lost
 Testing 4096x32769 (area: 134221824)
@@ -202,9 +169,11 @@ Testing 8192x2048 (area: 16777216)
 PASS imageData.data is red
 Effective renderingMode: Accelerated
 Testing 8192x4096 (area: 33554432)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Accelerated
 Testing 8192x8192 (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Accelerated
 Testing 8192x16384 (area: 134217728)
 PASS Context was lost
 Testing 8192x32768 (area: 268435456)
@@ -218,9 +187,11 @@ Testing 16384x1000 (area: 16384000)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 16384x2048 (area: 33554432)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 16384x4096 (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 16384x8192 (area: 134217728)
 PASS Context was lost
 Testing 16384x16384 (area: 268435456)
@@ -233,9 +204,11 @@ Testing 32768x1 (area: 32768)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 32768x1000 (area: 32768000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32768x2048 (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32768x4096 (area: 134217728)
 PASS Context was lost
 Testing 32768x8192 (area: 268435456)
@@ -250,7 +223,8 @@ Testing 32769x1 (area: 32769)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 32769x1000 (area: 32769000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32769x2048 (area: 67110912)
 PASS Context was lost
 Testing 32769x4096 (area: 134221824)
@@ -312,9 +286,11 @@ Testing 1000x16384 forced 'Accelerated' (area: 16384000)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 1000x32768 forced 'Accelerated' (area: 32768000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 1000x32769 forced 'Accelerated' (area: 32769000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 2048x1 forced 'Accelerated' (area: 2048)
 PASS imageData.data is red
 Effective renderingMode: Accelerated
@@ -331,9 +307,11 @@ Testing 2048x8192 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
 Effective renderingMode: Accelerated
 Testing 2048x16384 forced 'Accelerated' (area: 33554432)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 2048x32768 forced 'Accelerated' (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 2048x32769 forced 'Accelerated' (area: 67110912)
 PASS Context was lost
 Testing 4096x1 forced 'Accelerated' (area: 4096)
@@ -349,9 +327,11 @@ Testing 4096x4096 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
 Effective renderingMode: Accelerated
 Testing 4096x8192 forced 'Accelerated' (area: 33554432)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Accelerated
 Testing 4096x16384 forced 'Accelerated' (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 4096x32768 forced 'Accelerated' (area: 134217728)
 PASS Context was lost
 Testing 4096x32769 forced 'Accelerated' (area: 134221824)
@@ -366,9 +346,11 @@ Testing 8192x2048 forced 'Accelerated' (area: 16777216)
 PASS imageData.data is red
 Effective renderingMode: Accelerated
 Testing 8192x4096 forced 'Accelerated' (area: 33554432)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Accelerated
 Testing 8192x8192 forced 'Accelerated' (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Accelerated
 Testing 8192x16384 forced 'Accelerated' (area: 134217728)
 PASS Context was lost
 Testing 8192x32768 forced 'Accelerated' (area: 268435456)
@@ -382,9 +364,11 @@ Testing 16384x1000 forced 'Accelerated' (area: 16384000)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 16384x2048 forced 'Accelerated' (area: 33554432)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 16384x4096 forced 'Accelerated' (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 16384x8192 forced 'Accelerated' (area: 134217728)
 PASS Context was lost
 Testing 16384x16384 forced 'Accelerated' (area: 268435456)
@@ -397,9 +381,11 @@ Testing 32768x1 forced 'Accelerated' (area: 32768)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 32768x1000 forced 'Accelerated' (area: 32768000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32768x2048 forced 'Accelerated' (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32768x4096 forced 'Accelerated' (area: 134217728)
 PASS Context was lost
 Testing 32768x8192 forced 'Accelerated' (area: 268435456)
@@ -414,7 +400,8 @@ Testing 32769x1 forced 'Accelerated' (area: 32769)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 32769x1000 forced 'Accelerated' (area: 32769000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32769x2048 forced 'Accelerated' (area: 67110912)
 PASS Context was lost
 Testing 32769x4096 forced 'Accelerated' (area: 134221824)
@@ -476,9 +463,11 @@ Testing 1000x16384 forced 'Unaccelerated' (area: 16384000)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 1000x32768 forced 'Unaccelerated' (area: 32768000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 1000x32769 forced 'Unaccelerated' (area: 32769000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 2048x1 forced 'Unaccelerated' (area: 2048)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
@@ -495,9 +484,11 @@ Testing 2048x8192 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 2048x16384 forced 'Unaccelerated' (area: 33554432)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 2048x32768 forced 'Unaccelerated' (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 2048x32769 forced 'Unaccelerated' (area: 67110912)
 PASS Context was lost
 Testing 4096x1 forced 'Unaccelerated' (area: 4096)
@@ -513,9 +504,11 @@ Testing 4096x4096 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 4096x8192 forced 'Unaccelerated' (area: 33554432)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 4096x16384 forced 'Unaccelerated' (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 4096x32768 forced 'Unaccelerated' (area: 134217728)
 PASS Context was lost
 Testing 4096x32769 forced 'Unaccelerated' (area: 134221824)
@@ -530,9 +523,11 @@ Testing 8192x2048 forced 'Unaccelerated' (area: 16777216)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 8192x4096 forced 'Unaccelerated' (area: 33554432)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 8192x8192 forced 'Unaccelerated' (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 8192x16384 forced 'Unaccelerated' (area: 134217728)
 PASS Context was lost
 Testing 8192x32768 forced 'Unaccelerated' (area: 268435456)
@@ -546,9 +541,11 @@ Testing 16384x1000 forced 'Unaccelerated' (area: 16384000)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 16384x2048 forced 'Unaccelerated' (area: 33554432)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 16384x4096 forced 'Unaccelerated' (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 16384x8192 forced 'Unaccelerated' (area: 134217728)
 PASS Context was lost
 Testing 16384x16384 forced 'Unaccelerated' (area: 268435456)
@@ -561,9 +558,11 @@ Testing 32768x1 forced 'Unaccelerated' (area: 32768)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 32768x1000 forced 'Unaccelerated' (area: 32768000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32768x2048 forced 'Unaccelerated' (area: 67108864)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32768x4096 forced 'Unaccelerated' (area: 134217728)
 PASS Context was lost
 Testing 32768x8192 forced 'Unaccelerated' (area: 268435456)
@@ -578,7 +577,8 @@ Testing 32769x1 forced 'Unaccelerated' (area: 32769)
 PASS imageData.data is red
 Effective renderingMode: Unaccelerated
 Testing 32769x1000 forced 'Unaccelerated' (area: 32769000)
-PASS Context was lost
+PASS imageData.data is red
+Effective renderingMode: Unaccelerated
 Testing 32769x2048 forced 'Unaccelerated' (area: 67110912)
 PASS Context was lost
 Testing 32769x4096 forced 'Unaccelerated' (area: 134221824)

--- a/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,2 +1,2 @@
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
 

--- a/LayoutTests/platform/ios/fast/canvas/pattern-too-large-to-create-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/pattern-too-large-to-create-expected.txt
@@ -1,2 +1,2 @@
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
 PASS: Saw exception.

--- a/LayoutTests/platform/ios/fast/canvas/resize-to-large-canvas-and-convert-to-blog-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/resize-to-large-canvas-and-convert-to-blog-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 16777216).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
 This test passes if it doesn't crash.
 
 

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -139,7 +139,7 @@ static inline size_t maxCanvasArea()
     // reaches that limit. We limit by area instead, giving us larger maximum dimensions,
     // in exchange for a smaller maximum canvas size. The maximum canvas size is in device pixels.
 #if PLATFORM(IOS_FAMILY)
-    return 4096 * 4096;
+    return 8192 * 8192;
 #else
     return 16384 * 16384;
 #endif


### PR DESCRIPTION
#### d1f63c061eadee6c83dc9fa06a2725c3d099a86b
<pre>
[iOS] Increase the limit on the canvas size to 8192x8192
<a href="https://bugs.webkit.org/show_bug.cgi?id=271002">https://bugs.webkit.org/show_bug.cgi?id=271002</a>
<a href="https://rdar.apple.com/122230873">rdar://122230873</a>

Reviewed by Chris Dumez.

The maximum size of the canvas on iOS has been 4096x4096. The jetsam limit on iOS
has been raised. So we can safely double the limit on the canvas size on iOS.

* LayoutTests/fast/canvas/canvas-size-minimum-limit-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-size-minimum-limit.html: Added.
* LayoutTests/platform/ios/compositing/canvas/accelerated-canvas-compositing-size-limit-expected.txt:
* LayoutTests/platform/ios/fast/canvas/canvas-toDataURL-crash-expected.txt:
* LayoutTests/platform/ios/fast/canvas/image-buffer-backend-variants-expected.txt:
* LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt:
* LayoutTests/platform/ios/fast/canvas/pattern-too-large-to-create-expected.txt:
* LayoutTests/platform/ios/fast/canvas/resize-to-large-canvas-and-convert-to-blog-expected.txt:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::maxCanvasArea):

Canonical link: <a href="https://commits.webkit.org/276145@main">https://commits.webkit.org/276145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f56c14a410952945abb1529ba7df89a75435e26e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46521 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39960 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36204 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37783 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17206 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38862 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1933 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40077 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39162 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48082 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18887 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15461 "Found 1 new test failure: http/tests/navigation/parsed-iframe-dynamic-form-back-entry.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43017 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41719 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9763 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20484 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19904 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->