### PR TITLE
[JSC] TypedArray sorting methods should have a special-case for comparator returning `false`

### DIFF
--- a/JSTests/stress/sorting-boolean-result-comparator-typedarray.js
+++ b/JSTests/stress/sorting-boolean-result-comparator-typedarray.js
@@ -1,0 +1,16 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Bad value: ${actual}!`);
+}
+
+const makeArray = () => new Int8Array([10, 3, 8, 5, 30, 100, 6, 7, 100, 3]);
+const expected = "100,100,30,10,8,7,6,5,3,3";
+
+const comparator1 = (x, y) => x < y;
+const comparator2 = comparator1.bind();
+const comparator3 = new Proxy(comparator2, {});
+
+shouldBe(makeArray().sort(comparator1).join(), expected);
+shouldBe(makeArray().toSorted(comparator1).join(), expected);
+shouldBe(makeArray().sort(comparator2).join(), expected);
+shouldBe(makeArray().toSorted(comparator3).join(), expected);


### PR DESCRIPTION
#### 798d1789439ab19b30559051cd834481ec7220ac
<pre>
[JSC] TypedArray sorting methods should have a special-case for comparator returning `false`
<a href="https://bugs.webkit.org/show_bug.cgi?id=268075">https://bugs.webkit.org/show_bug.cgi?id=268075</a>
&lt;<a href="https://rdar.apple.com/problem/122093956">rdar://problem/122093956</a>&gt;

Reviewed by Yusuke Suzuki and Justin Michaud.

This change aligns TypedArray sorting methods with Array.prototype.sort() to treat `false`,
returned from comparator function, like smallest negative number rather than zero, which is a long-time
web reality quirk [1] to allow lexicographical comparison: `[&quot;c&quot;, &quot;b&quot;, &quot;a&quot;].sort((a, b) =&gt; a &gt; b)`.

The spec [2] still lacks normative steps on how to handle comparator return value in the common case.

This patch aligns JSC with V8 and SpiderMonkey.
However, it appears that V8 have recently removed the special-case for `false` in Array sorting methods.

[1]: <a href="https://bugs.webkit.org/show_bug.cgi?id=47825">https://bugs.webkit.org/show_bug.cgi?id=47825</a>
[2]: <a href="https://tc39.es/ecma262/#sec-sortindexedproperties">https://tc39.es/ecma262/#sec-sortindexedproperties</a> (step 4)

* JSTests/stress/sorting-boolean-result-comparator-typedarray.js: Added.
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::coerceComparatorResultToBoolean):
(JSC::genericTypedArrayViewProtoFuncSortImpl):

Canonical link: <a href="https://commits.webkit.org/276130@main">https://commits.webkit.org/276130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ef47af0f8df23a29587b04e54f34d76277c6223

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46460 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39911 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/26815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20271 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17164 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17425 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38815 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1870 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/37233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/39991 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39117 "Found 1 new test failure: fonts/font-cache-memory-pressure-crash.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48018 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43429 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18840 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15418 "Found 2 new test failures: http/tests/media/media-stream/get-display-media-iframe-allow-attribute.html, http/tests/navigation/parsed-iframe-dynamic-form-back-entry.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/42980 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20236 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41686 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20436 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50448 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/5993 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19860 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10175 "Passed tests") | 
<!--EWS-Status-Bubble-End-->