### PR TITLE
Further adjustments to the organization storage access prompt

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -208,8 +208,17 @@
 /* Message for user microphone access prompt */
 "Allow “%@” to use your microphone?" = "Allow “%@” to use your microphone?";
 
-/* Informative text for requesting cross-site cookie and website data access. */
-"Allowing access to website data is necessary for the website to work correctly." = "Allowing access to website data is necessary for the website to work correctly.";
+/* Informative text for requesting cross-site cookie and website data access for two sites. */
+"Using the same cookies and website data is required for %s and %s to work correctly, but could make it easier to track your browsing across these websites." = "Using the same cookies and website data is required for %s and %s to work correctly, but could make it easier to track your browsing across these websites.";
+
+/* Informative text for requesting cross-site cookie and website data access for three sites. */
+"Using the same cookies and website data is required for %s, %s, and one more website to work correctly, but could make it easier to track your browsing across these websites." = "Using the same cookies and website data is required for %s, %s, and one more website to work correctly, but could make it easier to track your browsing across these websites.";
+
+/* Informative text for requesting cross-site cookie and website data access for four or more sites. */
+"Using the same cookies and website data is required for %s, %s, and %lu other websites to work correctly, but could make it easier to track your browsing across these websites." = "Using the same cookies and website data is required for %s, %s, and %lu other websites to work correctly, but could make it easier to track your browsing across these websites.";
+
+/* Label describing the list of related websites controlled by the same organization. */
+"Related %@ websites" = "Related %@ websites";
 
 /* WKWebExtensionErrorUnknown description */
 "An unknown error has occurred." = "An unknown error has occurred.";
@@ -230,7 +239,7 @@
 "Apple Pay" = "Apple Pay";
 
 /* Message for requesting cross-site cookie and website data access. */
-"Are you logging in to this website, and do you want to allow other %@ sites access to your website data while browsing the websites listed below?" = "Are you logging in to this website, and do you want to allow other %@ sites access to your website data while browsing the websites listed below?";
+"Allow related %@ websites to share cookies and website data?" = "Allow related %@ websites to share cookies and website data?";
 
 /* Malware confirmation dialog title */
 "Are you sure you wish to go to this site?" = "Are you sure you wish to go to this site?";
@@ -441,12 +450,6 @@
 
 /* Message for requesting cross-site cookie and website data access. */
 "Do you want to allow “%@” to use cookies and website data while browsing “%@”?" = "Do you want to allow “%@” to use cookies and website data while browsing “%@”?";
-
-/* Message for requesting cross-site cookie and website data access. */
-"Do you want to allow %@ websites to access one another's cookies and website data?" = "Do you want to allow %@ websites to access one another's cookies and website data?";
-
-/* Informative text for requesting cross-site cookie and website data access. */
-"Logging into this website requires %s and %s to access one another's cookies and website data. Allowing access is necessary for the website to work correctly." = "Logging into this website requires %s and %s to access one another's cookies and website data. Allowing access is necessary for the website to work correctly.";
 
 /* Codec Strings */
 "Dolby Vision Codec String" = "Dolby Vision";

--- a/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.h
@@ -44,7 +44,7 @@ namespace WebKit {
 void presentStorageAccessAlert(WKWebView *, const WebCore::RegistrableDomain& requestingDomain, const WebCore::RegistrableDomain& currentDomain, CompletionHandler<void(bool)>&&);
 void presentStorageAccessAlertQuirk(WKWebView *, const WebCore::RegistrableDomain& firstRequestingDomain, const WebCore::RegistrableDomain& secondRequestingDomain, const WebCore::RegistrableDomain& current, CompletionHandler<void(bool)>&&);
 void presentStorageAccessAlertSSOQuirk(WKWebView *, const String& organizationName, const HashMap<WebCore::RegistrableDomain, Vector<WebCore::RegistrableDomain>>&, CompletionHandler<void(bool)>&&);
-void displayStorageAccessAlert(WKWebView *, NSString *, NSString *, CompletionHandler<void(bool)>&&);
+void displayStorageAccessAlert(WKWebView *, NSString *, NSString *, NSString *, NSArray<NSString *> *, CompletionHandler<void(bool)>&&);
 
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm
@@ -41,6 +41,67 @@
 #import <WebCore/RegistrableDomain.h>
 #import <wtf/BlockPtr.h>
 
+#if PLATFORM(MAC)
+@interface _WKSSOSiteList : NSObject<NSTableViewDataSource, NSTableViewDelegate>
+- (instancetype)initWithSiteList:(NSArray<NSString *> *)siteList withAlert:(RetainPtr<NSAlert>)alert withTableView:(RetainPtr<NSTableView>)tableView;
+- (IBAction)toggleTableViewContents:(NSButton *)sender;
+@end
+
+@implementation _WKSSOSiteList {
+    RetainPtr<NSArray<NSString *>> _siteList;
+    RetainPtr<NSAlert> _alert;
+    RetainPtr<NSTableView> _tableView;
+}
+
+- (instancetype)initWithSiteList:(NSArray<NSString *> *)siteList withAlert:(RetainPtr<NSAlert>)alert withTableView:(RetainPtr<NSTableView>)tableView
+{
+    if (!(self = [super init]))
+        return self;
+
+    _siteList = adoptNS([[NSArray alloc] initWithArray:siteList copyItems:YES]);
+    _alert = alert;
+    _tableView = tableView;
+    return self;
+}
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView *)aTableView
+{
+    return _siteList.get().count;
+}
+
+- (NSView *)tableView:(NSTableView *)tableView viewForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row
+{
+    NSString *viewIdenfier = [NSString stringWithFormat:@"row%ldIdentifier", (long)row];
+    RetainPtr result = [tableView makeViewWithIdentifier:viewIdenfier owner:self];
+    if (!result) {
+        result = adoptNS([[NSTextView alloc] initWithFrame:NSMakeRect(0, 0, 100, 300)]);
+        result.get().identifier = viewIdenfier;
+    }
+    [result setEditable:NO];
+    [result setDrawsBackground:NO];
+
+    if ((NSUInteger)row < [_siteList count]) {
+        [[result textStorage].mutableString setString:_siteList.get()[row]];
+        [result textStorage].font = [NSFont systemFontOfSize:[NSFont smallSystemFontSize]];
+        [result textStorage].foregroundColor = NSColor.whiteColor;
+    }
+    return result.autorelease();
+}
+
+- (IBAction)toggleTableViewContents:(NSButton *)sender
+{
+    _tableView.get().hidden = (sender.state != NSControlStateValueOn);
+    NSRect frame = _alert.get().window.frame;
+    if (_tableView.get().hidden)
+        frame.size.height -= _tableView.get().frame.size.height;
+    else
+        frame.size.height += _tableView.get().frame.size.height;
+    [_alert.get().window setFrame:frame display:YES];
+    [_alert layout];
+}
+@end
+#endif
+
 namespace WebKit {
 
 void presentStorageAccessAlert(WKWebView *webView, const WebCore::RegistrableDomain& requesting, const WebCore::RegistrableDomain& current, CompletionHandler<void(bool)>&& completionHandler)
@@ -56,7 +117,7 @@ void presentStorageAccessAlert(WKWebView *webView, const WebCore::RegistrableDom
 
     NSString *informativeText = [NSString stringWithFormat:WEB_UI_NSSTRING(@"This will allow “%@” to track your activity.", @"Informative text for requesting cross-site cookie and website data access."), requestingDomain.get()];
 
-    displayStorageAccessAlert(webView, alertTitle, informativeText, WTFMove(completionHandler));
+    displayStorageAccessAlert(webView, alertTitle, informativeText, nil, nil, WTFMove(completionHandler));
 }
 
 void presentStorageAccessAlertQuirk(WKWebView *webView, const WebCore::RegistrableDomain& firstRequesting, const WebCore::RegistrableDomain& secondRequesting, const WebCore::RegistrableDomain& current, CompletionHandler<void(bool)>&& completionHandler)
@@ -72,13 +133,17 @@ void presentStorageAccessAlertQuirk(WKWebView *webView, const WebCore::Registrab
 #endif
 
     NSString *informativeText = [NSString stringWithFormat:WEB_UI_NSSTRING(@"This will allow “%@” and “%@” to track your activity.", @"Informative text for requesting cross-site cookie and website data access."), firstRequestingDomain.get(), secondRequestingDomain.get()];
-    
-    displayStorageAccessAlert(webView, alertTitle, informativeText, WTFMove(completionHandler));
+
+    displayStorageAccessAlert(webView, alertTitle, informativeText, nil, nil, WTFMove(completionHandler));
 }
 
 void presentStorageAccessAlertSSOQuirk(WKWebView *webView, const String& organizationName, const HashMap<WebCore::RegistrableDomain, Vector<WebCore::RegistrableDomain>>& domainPairings, CompletionHandler<void(bool)>&& completionHandler)
 {
-    NSString *alertTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Do you want to allow %@ websites to access one another's cookies and website data?", @"Message for requesting cross-site cookie and website data access."), organizationName.createCFString().get()];
+    NSString *alertTitle = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Allow related %@ websites to share cookies and website data?", @"Message for requesting cross-site cookie and website data access."), organizationName.createCFString().get()];
+
+    NSString *informativeText;;
+    NSString *relatedWebsitesString;
+    NSMutableArray<NSString *> *accessoryTextList;
 
     HashSet<String> allDomains;
     for (auto&& domains : domainPairings) {
@@ -87,18 +152,35 @@ void presentStorageAccessAlertSSOQuirk(WKWebView *webView, const String& organiz
             allDomains.add(subFrameDomain.string());
     }
 
+    if (allDomains.size() < 2)  {
+        completionHandler(true);
+        return;
+    }
+
     Vector<String> uniqueDomainList = copyToVector(allDomains);
-    std::sort(uniqueDomainList.begin(), uniqueDomainList.end());
-    auto lastDomain = uniqueDomainList.takeLast();
+    std::sort(uniqueDomainList.begin(), uniqueDomainList.end(), WTF::codePointCompareLessThan);
 
-    auto initialDomainList = makeStringByJoining(uniqueDomainList.span(), ", "_s);
 
-    NSString *informativeText = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Logging into this website requires %s and %s to access one another's cookies and website data. Allowing access is necessary for the website to work correctly.", @"Informative text for requesting cross-site cookie and website data access."), initialDomainList.utf8().data(), lastDomain.utf8().data()];
+    if (uniqueDomainList.size() == 2) {
+        informativeText = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Using the same cookies and website data is required for %s and %s to work correctly, but could make it easier to track your browsing across these websites.", @"Informative text for requesting cross-site cookie and website data access for two sites"), uniqueDomainList[0].utf8().data(), uniqueDomainList[1].utf8().data()];
+        relatedWebsitesString = nil;
+        accessoryTextList = nil;
+    } else {
+        if (uniqueDomainList.size() == 3)
+            informativeText = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Using the same cookies and website data is required for %s, %s, and one more website to work correctly, but could make it easier to track your browsing across these websites.", @"Informative text for requesting cross-site cookie and website data access for three sites"), uniqueDomainList[0].utf8().data(), uniqueDomainList[1].utf8().data()];
+        else
+            informativeText = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Using the same cookies and website data is required for %s, %s, and %lu other websites to work correctly, but could make it easier to track your browsing across these websites.", @"Informative text for requesting cross-site cookie and website data access for four or more sites."), uniqueDomainList[0].utf8().data(), uniqueDomainList[1].utf8().data(), uniqueDomainList.size() - 2];
 
-    displayStorageAccessAlert(webView, alertTitle, informativeText, WTFMove(completionHandler));
+        relatedWebsitesString = [NSString stringWithFormat:WEB_UI_NSSTRING(@"Related %@ websites", @"Label describing the list of related websites controlled by the same organization"), organizationName.createCFString().get()];
+        accessoryTextList = [NSMutableArray arrayWithCapacity:uniqueDomainList.size()];
+        for (const auto& domains : uniqueDomainList)
+            [accessoryTextList addObject:domains];
+    }
+
+    displayStorageAccessAlert(webView, alertTitle, informativeText, relatedWebsitesString, accessoryTextList, WTFMove(completionHandler));
 }
 
-void displayStorageAccessAlert(WKWebView *webView, NSString *alertTitle, NSString *informativeText, CompletionHandler<void(bool)>&& completionHandler)
+void displayStorageAccessAlert(WKWebView *webView, NSString *alertTitle, NSString *informativeText, NSString *accessoryLabel, NSArray<NSString *> *accessoryTextList, CompletionHandler<void(bool)>&& completionHandler)
 {
     auto completionBlock = makeBlockPtr([completionHandler = WTFMove(completionHandler)](bool shouldAllow) mutable {
         completionHandler(shouldAllow);
@@ -111,12 +193,45 @@ void displayStorageAccessAlert(WKWebView *webView, NSString *alertTitle, NSStrin
     auto alert = adoptNS([NSAlert new]);
     [alert setMessageText:alertTitle];
     [alert setInformativeText:informativeText];
+    RetainPtr<_WKSSOSiteList> ssoSiteList;
+    if (accessoryTextList.count) {
+        RetainPtr disclosureButton = adoptNS([[NSButton alloc] init]);
+        disclosureButton.get().title = @"";
+        disclosureButton.get().bezelStyle = NSBezelStyleDisclosure;
+        [disclosureButton setButtonType:NSButtonTypePushOnPushOff];
+
+        NSTextField *relatedWebsitesLabel = [NSTextField labelWithString:accessoryLabel];
+        NSStackView *disclosureStackView = [NSStackView stackViewWithViews:@[disclosureButton.get(), relatedWebsitesLabel]];
+
+        RetainPtr siteListTableView = adoptNS([[NSTableView alloc] initWithFrame:NSMakeRect(0, 0, 1000, 1000)]);
+        siteListTableView.get().allowsTypeSelect = NO;
+        siteListTableView.get().enabled = NO;
+        siteListTableView.get().usesSingleLineMode = YES;
+        siteListTableView.get().hidden = YES;
+        [siteListTableView addTableColumn:adoptNS([[NSTableColumn alloc] initWithIdentifier:@"columnIdentifier"]).get()];
+
+        ssoSiteList = adoptNS([[_WKSSOSiteList alloc] initWithSiteList:accessoryTextList withAlert:alert withTableView:siteListTableView]);
+        siteListTableView.get().dataSource = ssoSiteList.get();
+        siteListTableView.get().delegate = ssoSiteList.get();
+
+        NSStackView *accessoryStackView = [NSStackView stackViewWithViews:@[disclosureStackView, siteListTableView.get()]];
+        accessoryStackView.orientation = NSUserInterfaceLayoutOrientationVertical;
+        disclosureButton.get().target = ssoSiteList.get();
+        disclosureButton.get().action = @selector(toggleTableViewContents:);
+
+        NSRect frame = alert.get().window.frame;
+        frame.size.width += 100.;
+        [alert.get().window setFrame:frame display:YES];
+
+        [alert setAccessoryView:accessoryStackView];
+        [alert layout];
+    }
     [alert addButtonWithTitle:allowButtonString];
     [alert addButtonWithTitle:doNotAllowButtonString];
-    [alert beginSheetModalForWindow:webView.window completionHandler:[completionBlock](NSModalResponse returnCode) {
+    [alert beginSheetModalForWindow:webView.window completionHandler:makeBlockPtr([ssoSiteList, completionBlock](NSModalResponse returnCode) {
         auto shouldAllow = returnCode == NSAlertFirstButtonReturn;
         completionBlock(shouldAllow);
-    }];
+    }).get()];
 #else
     auto alert = WebKit::createUIAlertController(alertTitle, informativeText);
 


### PR DESCRIPTION
#### 1d87ffb4145cbaff9fc2b97b2bd6d7d2f3dda29a
<pre>
Further adjustments to the organization storage access prompt
<a href="https://bugs.webkit.org/show_bug.cgi?id=271007">https://bugs.webkit.org/show_bug.cgi?id=271007</a>
<a href="https://rdar.apple.com/124640260">rdar://124640260</a>

Reviewed by Wenson Hsieh.

After receiving additional feedback, adjust the wording and add a disclosure
list. If the list of domains is more than 2, then show the domains in a list
via a disclosure button.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.h:
* Source/WebKit/UIProcess/Cocoa/WKStorageAccessAlert.mm:
(-[_WKSSOSiteList initWithSiteList:withAlert:withTableView:]):
(-[_WKSSOSiteList numberOfRowsInTableView:]):
(-[_WKSSOSiteList tableView:viewForTableColumn:row:]):
(-[_WKSSOSiteList toggleTableViewContents:]):
(WebKit::presentStorageAccessAlert):
(WebKit::presentStorageAccessAlertQuirk):
(WebKit::presentStorageAccessAlertSSOQuirk):
(WebKit::displayStorageAccessAlert):

Canonical link: <a href="https://commits.webkit.org/276435@main">https://commits.webkit.org/276435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0259671d6e8a30595cb329171a7d9037d8eb525f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46641 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40060 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36282 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20090 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17302 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38979 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2051 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40170 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48219 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15568 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43126 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20376 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41845 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9945 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20588 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->