### PR TITLE
URL text fragment directives not fully stripped from Javascript

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-same-doc.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-same-doc.html
@@ -38,6 +38,7 @@ function runTest() {
   }).then(position => {
     assert_equals(position, 'text');
     assert_equals(window.location.href.indexOf(':~:'), -1, 'Expected fragment directive to be stripped from the URL.');
+    assert_equals(window.location.href.indexOf('#'), -1, 'Expected hash mark to be stripped from the URL.');
   }), 'Activated for same-document window.location setter');
 
   promise_test(t => new Promise(resolve => {
@@ -49,6 +50,7 @@ function runTest() {
   }).then(position => {
     assert_equals(position, 'text');
     assert_equals(window.location.href.indexOf(':~:'), -1, 'Expected fragment directive to be stripped from the URL.');
+    assert_equals(window.location.href.indexOf('#'), -1, 'Expected hash mark to be stripped from the URL.');
   }), 'Activated for same-document window.location.replace');
 }
 </script>

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -247,7 +247,7 @@ StringView URL::fragmentIdentifier() const
 }
 
 // https://wicg.github.io/scroll-to-text-fragment/#the-fragment-directive
-String URL::consumefragmentDirective()
+String URL::consumeFragmentDirective()
 {
     ASCIILiteral fragmentDirectiveDelimiter = ":~:"_s;
     auto fragment = fragmentIdentifier();
@@ -259,7 +259,11 @@ String URL::consumefragmentDirective()
     
     auto fragmentDirective = fragment.substring(fragmentDirectiveStart + fragmentDirectiveDelimiter.length()).toString();
     
-    setFragmentIdentifier(fragment.left(fragmentDirectiveStart));
+    auto remainingFragment = fragment.left(fragmentDirectiveStart);
+    if (remainingFragment.isEmpty())
+        removeFragmentIdentifier();
+    else
+        setFragmentIdentifier(remainingFragment);
     
     return fragmentDirective;
 }

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -216,7 +216,7 @@ public:
 
     WTF_EXPORT_PRIVATE void setFragmentIdentifier(StringView);
     WTF_EXPORT_PRIVATE void removeFragmentIdentifier();
-    WTF_EXPORT_PRIVATE String consumefragmentDirective();
+    WTF_EXPORT_PRIVATE String consumeFragmentDirective();
     WTF_EXPORT_PRIVATE void removeQueryAndFragmentIdentifier();
 
     WTF_EXPORT_PRIVATE static bool hostIsIPAddress(StringView);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4032,7 +4032,7 @@ void Document::setURL(const URL& url)
     if (newURL == m_url)
         return;
 
-    m_fragmentDirective = newURL.consumefragmentDirective();
+    m_fragmentDirective = newURL.consumeFragmentDirective();
 
     if (SecurityOrigin::shouldIgnoreHost(newURL))
         newURL.setHostAndPort({ });


### PR DESCRIPTION
#### 4a5699e1eec867490b0a1dad99e74b76a2e21029
<pre>
URL text fragment directives not fully stripped from Javascript
<a href="https://bugs.webkit.org/show_bug.cgi?id=271017">https://bugs.webkit.org/show_bug.cgi?id=271017</a>
<a href="https://rdar.apple.com/107326333">rdar://107326333</a>

Reviewed by Ryosuke Niwa.

When re-adding the fragment to the URL after consuming any STTF parts,
we were not testing to see if the fragment was fully consumed or not.
Since empty fragments are used for many cases
there was no testing to see if the fragment was empty before adding the
&apos;#&apos; back with an empty fragment, so we would end up with a URL with a &apos;#&apos;
and an empty fragment when the page was navigated to with a STTF.
In this case, we do not want an empty fragment, so we should clear the
fragment instead of setting it when there is nothing left of the fragment
after consumption.

* LayoutTests/imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-same-doc.html:
* Source/WTF/wtf/URL.cpp:
(WTF::URL::consumeFragmentDirective):
(WTF::URL::setFragmentIdentifier):
(WTF::URL::consumefragmentDirective): Deleted.
* Source/WTF/wtf/URL.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setURL):

Canonical link: <a href="https://commits.webkit.org/276370@main">https://commits.webkit.org/276370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b71b8ea1be12620fffcde34732e8b74bca533b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40278 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27349 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36474 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20422 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17500 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39231 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2301 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/37605 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); jscore-tests (cancelled)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40497 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39516 "Found 1 new test failure: imported/w3c/web-platform-tests/streams/piping/close-propagation-forward.any.worker.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48509 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43810 "Found 1 new JSC stress test failure: wasm.yaml/PerformanceTests/JetStream2/wasm-cli.js.wasm-slow-memory (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43350 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42081 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9893 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20816 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50891 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20218 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10306 "Passed tests") | 
<!--EWS-Status-Bubble-End-->