### PR TITLE
[UnifiedPDF] Prepare for thread-safe access to loaded PDF data

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -50,6 +50,8 @@ enum class ByteRangeRequestIdentifierType { };
 using ByteRangeRequestIdentifier = ObjectIdentifier<ByteRangeRequestIdentifierType>;
 using DataRequestCompletionHandler = Function<void(const uint8_t*, size_t count)>;
 
+enum class CheckValidRanges : bool;
+
 class PDFIncrementalLoader : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PDFIncrementalLoader> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(PDFIncrementalLoader);
@@ -86,10 +88,9 @@ private:
 
     bool documentFinishedLoading() const;
 
-    void ensureDataBufferLength(uint64_t);
     void appendAccumulatedDataToDataBuffer(ByteRangeRequest&);
 
-    const uint8_t* dataPtrForRange(uint64_t position, size_t count) const;
+    const uint8_t* dataPtrForRange(uint64_t position, size_t count, CheckValidRanges) const;
     uint64_t availableDataSize() const;
 
     void getResourceBytesAtPosition(size_t count, off_t position, DataRequestCompletionHandler&&);


### PR DESCRIPTION
#### 51537ed487c6c33534b9aa748d8419ddbe07e355
<pre>
[UnifiedPDF] Prepare for thread-safe access to loaded PDF data
<a href="https://bugs.webkit.org/show_bug.cgi?id=271019">https://bugs.webkit.org/show_bug.cgi?id=271019</a>
<a href="https://rdar.apple.com/124644460">rdar://124644460</a>

Reviewed by Tim Horton.

In a future patch I will be attempting to read loaded PDF data off the main thread, rather than
using the semaphore-driven hops to the main thread.

In preparation for this, make accessing the various data members related to loaded PDF data
thread-safe. In particular, add a Lock to protect `m_data` and `m_streamedBytes`, and move
the `RangeSet&lt;Range&gt;&gt;` (which represents ranges of loaded data beyond m_streamedBytes) into
PDFPluginBase to be protected by the same lock.

Now we need the &quot;check data availability and return data pointer&quot; blocks to be thread-safe,
so remove `haveDataForRange()`, and make callers just try to call `dataPtrForRange()` which
internally takes the lock for both the checks and the data access.

There are code paths that want to avoid checking m_validRanges (the &quot;complete unconditionally&quot; code path);
for them, add a CheckValidRanges enum to `dataPtrForRange()`.

* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::ByteRangeRequest::completeUnconditionally):
(WebKit::PDFIncrementalLoader::dataPtrForRange const):
(WebKit::PDFIncrementalLoader::incrementalPDFStreamDidReceiveData):
(WebKit::PDFIncrementalLoader::requestCompleteIfPossible):
(WebKit::PDFIncrementalLoader::requestDidCompleteWithAccumulatedData):
(WebKit::PDFIncrementalLoader::ensureDataBufferLength): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::WTF_GUARDED_BY_LOCK):
(WebKit::PDFPluginBase::streamedBytes const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::teardown):
(WebKit::PDFPluginBase::originalData const):
(WebKit::PDFPluginBase::streamedBytes const):
(WebKit::PDFPluginBase::haveStreamedDataForRange const):
(WebKit::PDFPluginBase::copyDataAtPosition const):
(WebKit::PDFPluginBase::dataPtrForRange const):
(WebKit::PDFPluginBase::insertRangeRequestData):
(WebKit::PDFPluginBase::streamDidReceiveData):
(WebKit::PDFPluginBase::streamDidFail):
(WebKit::PDFPluginBase::addArchiveResource):
(WebKit::PDFPluginBase::incrementalLoaderLog):
(WebKit::PDFPluginBase::haveDataForRange const): Deleted.

Canonical link: <a href="https://commits.webkit.org/276171@main">https://commits.webkit.org/276171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c360b0c0f5cdfdd50de4cfcc1c895965032b88f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46519 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39958 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20325 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36201 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37794 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17202 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17471 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48080 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18885 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15463 "Found 1 new test failure: http/tests/navigation/parsed-iframe-dynamic-form-back-entry.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43015 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20278 "Built successfully") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41717 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9774 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20482 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->