### PR TITLE
Invalidate extension's reference to database after it's been deleted.

### DIFF
--- a/Source/WebKit/Platform/spi/Cocoa/FoundationSPI.h
+++ b/Source/WebKit/Platform/spi/Cocoa/FoundationSPI.h
@@ -29,10 +29,26 @@
 
 #include <Foundation/NSPrivateDecls.h>
 
+#if PLATFORM(IOS_FAMILY)
+#include <Foundation/NSDistributedNotificationCenter.h>
+#endif
+
 #else
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSBundle ()
-- (CFBundleRef)_cfBundle;
+- (null_unspecified CFBundleRef)_cfBundle;
 @end
+
+#if PLATFORM(IOS_FAMILY)
+@interface NSDistributedNotificationCenter : NSNotificationCenter
++ (NSDistributedNotificationCenter *)defaultCenter;
+- (void)addObserver:(id)observer selector:(SEL)aSelector name:(nullable NSNotificationName)aName object:(nullable NSString *)anObject;
+- (void)postNotificationName:(NSNotificationName)aName object:(nullable NSString *)anObject userInfo:(nullable NSDictionary *)aUserInfo;
+@end
+#endif
+
+NS_ASSUME_NONNULL_END
 
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionControllerConfigurationPrivate.h
@@ -25,6 +25,9 @@
 
 #import <WebKit/_WKWebExtensionControllerConfiguration.h>
 
+// FIXME: Remove once https://commits.webkit.org/275999@main is in the SDK.
+#define HAVE_UPDATED_WEB_EXTENSION_CONTROLLER_STORAGE_DIRECTORY_PATH 1
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface _WKWebExtensionControllerConfiguration ()

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -56,6 +56,8 @@ WebExtensionController::WebExtensionController(Ref<WebExtensionControllerConfigu
     ASSERT(!get(identifier()));
     webExtensionControllers().add(identifier(), *this);
 
+    initializePlatform();
+
     // A freshly created extension controller will be used to determine if the startup event
     // should be fired for any loaded extensions during a brief time window. Start a timer
     // when the first extension is about to be loaded.

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -49,6 +49,7 @@
 OBJC_CLASS NSError;
 OBJC_CLASS NSMenu;
 OBJC_CLASS _WKWebExtensionStorageSQLiteStore;
+OBJC_CLASS _WKWebExtensionControllerHelper;
 OBJC_PROTOCOL(_WKWebExtensionControllerDelegatePrivate);
 
 #ifdef __OBJC__
@@ -174,6 +175,8 @@ private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
+    void initializePlatform();
+
     void addProcessPool(WebProcessPool&);
     void removeProcessPool(WebProcessPool&);
 
@@ -226,6 +229,7 @@ private:
 
     Ref<WebExtensionControllerConfiguration> m_configuration;
 
+    RetainPtr<_WKWebExtensionControllerHelper> m_webExtensionControllerHelper;
     WebExtensionContextSet m_extensionContexts;
     WebExtensionContextBaseURLMap m_extensionContextBaseURLMap;
     WebPageProxySet m_pages;


### PR DESCRIPTION
#### 5ac28a0be1efce40c52c3f3a87aec2f2ebed6fe9
<pre>
Invalidate extension&apos;s reference to database after it&apos;s been deleted.
<a href="https://bugs.webkit.org/show_bug.cgi?id=271020">https://bugs.webkit.org/show_bug.cgi?id=271020</a>
<a href="https://rdar.apple.com/124037961">rdar://124037961</a>

Reviewed by Sihui Liu and Timothy Hatcher.

When an extension&apos;s SQL database is deleted, send a notification to the WebExtensionController to
invalidate the extension context&apos;s reference to the database. A distrubuted notification here
is important since this deletion may happen from a process where the WebExtensionContext isn&apos;t
loaded.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(-[_WKWebExtensionControllerHelper initWithWebExtensionController:]):
(-[_WKWebExtensionControllerHelper _didDeleteLocalStorage:]):
(WebKit::WebExtensionController::createWebExtensionControllerHelper):
(WebKit::WebExtensionController::removeData):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::WebExtensionController):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:

Canonical link: <a href="https://commits.webkit.org/276202@main">https://commits.webkit.org/276202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04280287db100af21939564146ae790445bafe27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40066 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20463 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44578 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20097 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37898 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17306 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2058 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48227 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15572 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20594 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6024 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/20010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->