### PR TITLE
[CSS] Fix wrong proximity calculation for implicit @scope

### DIFF
--- a/LayoutTests/fast/css/scope-at-rule-expected.html
+++ b/LayoutTests/fast/css/scope-at-rule-expected.html
@@ -1,5 +1,6 @@
 <style>
 .green { color: green; }
+.italic { font-style: italic; }
 </style>
 
 <div class="a">
@@ -77,4 +78,13 @@
 </div>
 <div>
   <span>should not be green</span>
+</div>
+<div>
+  <span class="green italic">should be green and italic</span>
+</div>
+<div>
+  <span class="green italic">should be green and italic</span>
+</div>
+<div>
+  <span class="green italic">should be green and italic</span>
 </div>

--- a/LayoutTests/fast/css/scope-at-rule.html
+++ b/LayoutTests/fast/css/scope-at-rule.html
@@ -86,11 +86,13 @@ div {
 
 @scope (.root) to (.limit) {
   :scope.outer .green-17 {
-      color: green;
-    }
+    color: green;
   }
 }
 
+@scope (#green-18) {
+  * { color: red; font-style: italic; }
+}
 </style>
 
 <div class="a">
@@ -203,4 +205,41 @@ div {
       <span class="green-17">should not be green</span>
     </div>
   </div>
+</div>
+
+<div id="green-18">
+ <div>
+  <style>
+    @scope {
+      * { color: green; }
+    }
+  </style>
+  <span>should be green and italic</span>
+</div>
+</div>
+
+<div id="green-19">
+ <div>
+  <style>
+    @scope {
+    * { color: green; }
+    }
+    @scope (#green-19) {
+    * { color: red; font-style: italic}
+    }
+  </style>
+  <span>should be green and italic</span>
+</div>
+</div>
+
+<div id="green-20">
+  <style>
+    @scope (#green-20) {
+    * { color: red; font-style: italic; }
+    }
+    @scope {
+    * { color: green; }
+    }
+  </style>
+<span>should be green and italic</span>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit-expected.txt
@@ -7,4 +7,5 @@ PASS Implicit @scope has implicitly added :scope descendant combinator
 PASS Implicit @scope with inner relative selector
 PASS Implicit @scope with inner nesting selector
 PASS Implicit @scope with limit
+PASS Proximity calculation of multiple implicit @scope
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit.html
@@ -197,3 +197,35 @@ test((t) => {
   assert_equals(getComputedStyle(outside_limit).zIndex, 'auto');
 }, 'Implicit @scope with limit');
 </script>
+
+<template id=test_concurrent_scope_proximity>
+<style>
+@scope {
+  * { z-index: 1;}
+}
+</style>
+  <div>
+    <style>
+      @scope {
+        * { z-index:2; }
+      }
+    </style>
+    <div id=inner>
+    </div>
+  </div>
+  <div id=outer></div>
+<style>
+@scope {
+  * { z-index: 3;}
+}
+</style>
+</template>
+<script>
+test((t) => {
+  t.add_cleanup(() => main.replaceChildren());
+  main.append(test_concurrent_scope_proximity.content.cloneNode(true));
+
+  assert_equals(getComputedStyle(inner).zIndex, '2');
+  assert_equals(getComputedStyle(outer).zIndex, '3');
+}, 'Proximity calculation of multiple implicit @scope');
+</script>

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -702,16 +702,17 @@ std::pair<bool, std::optional<Vector<ElementRuleCollector::ScopingRootWithDistan
                 // Verify that the node is in the current document
                 if (client->ownerDocument() != &this->element().document())
                     return;
-                // Find the implicit parent node
+                // The owner node should be the <style> node
                 const auto* owner = client->ownerNode();
                 if (!owner)
                     return;
+                // Find the parent node of the <style>
                 const auto* implicitParentNode = owner->parentNode();
                 const auto* implicitParentContainerNode = dynamicDowncast<ContainerNode>(implicitParentNode);
                 const auto* ancestor = &element();
                 unsigned distance = 0;
                 while (ancestor) {
-                    if (ancestor == owner)
+                    if (ancestor == implicitParentNode)
                         break;
                     ancestor = ancestor->parentElement();
                     ++distance;


### PR DESCRIPTION
#### 7b99ea4ee24459026a3b0b8d11414d6ce8bfd9e1
<pre>
[CSS] Fix wrong proximity calculation for implicit @scope
<a href="https://bugs.webkit.org/show_bug.cgi?id=270900">https://bugs.webkit.org/show_bug.cgi?id=270900</a>
<a href="https://rdar.apple.com/124640124">rdar://124640124</a>

Reviewed by Antti Koivisto.

The previous code was wrongly trying to locate the distance
of the element to the @scope owner node (the &lt;style&gt; node),
while it should locate the distance to the parent of the owner node.

* LayoutTests/fast/css/scope-at-rule-expected.html:
* LayoutTests/fast/css/scope-at-rule.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-implicit.html:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):

Canonical link: <a href="https://commits.webkit.org/276345@main">https://commits.webkit.org/276345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1eb3051584b9e802f83465b1cd145747eefa17c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46947 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40331 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36487 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38152 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17521 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/44173 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39264 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2346 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48555 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19276 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15829 "Found 1 new test failure: imported/w3c/web-platform-tests/streams/transform-streams/reentrant-strategies.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43373 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/44347 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42112 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9876 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20966 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50936 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20263 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10312 "Passed tests") | 
<!--EWS-Status-Bubble-End-->