### PR TITLE
[visionOS] Video fails to render after returning from LinearMediaPlayer fullscreen

### DIFF
--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -182,14 +182,12 @@
 
 - (void)linearMediaPlayerToggleInlineMode:(WKSLinearMediaPlayer *)player
 {
-    if (auto model = _model.get())
-        model->toggleFullscreen();
-}
+    auto model = _model.get();
+    if (!model)
+        return;
 
-- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player didExitFullscreenWithError:(NSError * _Nullable)error
-{
-    if (auto model = _model.get())
-        model->setVideoReceiverEndpoint(nullptr);
+    model->toggleFullscreen();
+    model->setVideoReceiverEndpoint(nullptr);
 }
 
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setVideoReceiverEndpoint:(xpc_object_t)videoReceiverEndpoint

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -70,8 +70,8 @@ void VideoPresentationInterfaceLMK::setupPlayerViewController()
     linearMediaPlayer().allowFullScreenFromInline = YES;
     linearMediaPlayer().contentType = WKSLinearMediaContentTypePlanar;
     linearMediaPlayer().presentationMode = WKSLinearMediaPresentationModeInline;
-    linearMediaPlayer().captionLayer = captionsLayer();
-    linearMediaPlayer().videoLayer = [m_playerLayerView playerLayer];
+    // FIXME: pass a valid caption layer (rdar://124223292)
+    linearMediaPlayer().captionLayer = CALayer.layer;
 
     m_playerViewController = [linearMediaPlayer() makeViewController];
 }


### PR DESCRIPTION
#### 2464f16d3d6d11f34c0991d00dbf205af7ac0031
<pre>
[visionOS] Video fails to render after returning from LinearMediaPlayer fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=271024">https://bugs.webkit.org/show_bug.cgi?id=271024</a>
<a href="https://rdar.apple.com/123333859">rdar://123333859</a>

Reviewed by Eric Carlson.

When returning from LinearMediaPlayer fullscreen we failed to clear the video receiver endpoint from
MediaPlayer, leaving it in a state where it was rendering to an endpoint that no longer existed. We
attempted to clear the endpoint in PlaybackSessionInterfaceLMK&apos;s implementation of
-linearMediaPlayer:didExitFullscreenWithError:, but it turns out this delegate method isn&apos;t called
when using `allowFullScreenFromInline`. Instead, clear the entpoint in -linearMediaPlayerToggleInlineMode:.

With this bug fixed, there is a second issue where the inline controls do not appear. This ended up
being a side effect of setting VideoPresentationInterface&apos;s captionsLayer on the LinearMediaPlayer.
Since there is still outstanding work for supporting captions (see <a href="https://rdar.apple.com/124223292">rdar://124223292</a>), for now just
pass an empty layer to LinearMediaPlayer.

* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
(-[WKLinearMediaPlayerDelegate linearMediaPlayerToggleInlineMode:]):
(-[WKLinearMediaPlayerDelegate linearMediaPlayer:didExitFullscreenWithError:]): Deleted.
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::setupPlayerViewController):

Canonical link: <a href="https://commits.webkit.org/276179@main">https://commits.webkit.org/276179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7ad7f4f6b621a5697a6df12858dc86a80ce1dae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46516 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39955 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36199 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17200 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17470 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1928 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48097 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18882 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15456 "Found 1 new test failure: http/tests/navigation/parsed-iframe-dynamic-form-back-entry.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43029 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20275 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41733 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9779 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->