### PR TITLE
Web Inspector: If a style sheet is modified by CSSOM, all rules in it can't be edited anymore from style details panel

### DIFF
--- a/LayoutTests/inspector/css/modify-with-cssom-expected.txt
+++ b/LayoutTests/inspector/css/modify-with-cssom-expected.txt
@@ -1,0 +1,259 @@
+Test that the CSS.getMatchedStylesForNode command works with CSSOM modified styles.
+
+
+== Running test suite: ModifyWithCSSOM
+-- Running test case: CSS.getMatchedStylesForNode with CSSOM modifications
+After modifying a style rule in place:
+[
+  {
+    "selectorList": {
+      "selectors": [
+        {
+          "text": "body",
+          "specificity": [
+            0,
+            0,
+            1
+          ]
+        }
+      ],
+      "text": "body",
+      "range": {
+        "startLine": 0,
+        "startColumn": 0,
+        "endLine": 0,
+        "endColumn": 4
+      }
+    },
+    "sourceLine": 0,
+    "origin": "author",
+    "style": {
+      "cssProperties": [
+        {
+          "name": "color",
+          "value": "blue",
+          "text": "color: blue;",
+          "range": {
+            "startLine": 0,
+            "startColumn": 7,
+            "endLine": 0,
+            "endColumn": 19
+          },
+          "implicit": false,
+          "status": "active"
+        },
+        {
+          "name": "background-color",
+          "value": "azure",
+          "text": "background-color: azure;",
+          "range": {
+            "startLine": 0,
+            "startColumn": 20,
+            "endLine": 0,
+            "endColumn": 44
+          },
+          "implicit": false,
+          "status": "active"
+        }
+      ],
+      "shorthandEntries": [],
+      "styleId": "<filtered>",
+      "width": "",
+      "height": "",
+      "range": {
+        "startLine": 0,
+        "startColumn": 6,
+        "endLine": 0,
+        "endColumn": 45
+      },
+      "cssText": " color: blue; background-color: azure; "
+    },
+    "sourceURL": "<filtered>",
+    "ruleId": "<filtered>",
+    "isImplicitlyNested": false
+  }
+]
+
+After adding a style rule:
+[
+  {
+    "selectorList": {
+      "selectors": [
+        {
+          "text": "body",
+          "specificity": [
+            0,
+            0,
+            1
+          ]
+        }
+      ],
+      "text": "body",
+      "range": {
+        "startLine": 0,
+        "startColumn": 0,
+        "endLine": 0,
+        "endColumn": 4
+      }
+    },
+    "sourceLine": 0,
+    "origin": "author",
+    "style": {
+      "cssProperties": [
+        {
+          "name": "font-size",
+          "value": "17px",
+          "text": "font-size: 17px;",
+          "range": {
+            "startLine": 0,
+            "startColumn": 7,
+            "endLine": 0,
+            "endColumn": 23
+          },
+          "implicit": false,
+          "status": "active"
+        }
+      ],
+      "shorthandEntries": [],
+      "styleId": "<filtered>",
+      "width": "",
+      "height": "",
+      "range": {
+        "startLine": 0,
+        "startColumn": 6,
+        "endLine": 0,
+        "endColumn": 24
+      },
+      "cssText": " font-size: 17px; "
+    },
+    "sourceURL": "<filtered>",
+    "ruleId": "<filtered>",
+    "isImplicitlyNested": false
+  },
+  {
+    "selectorList": {
+      "selectors": [
+        {
+          "text": "body",
+          "specificity": [
+            0,
+            0,
+            1
+          ]
+        }
+      ],
+      "text": "body",
+      "range": {
+        "startLine": 1,
+        "startColumn": 0,
+        "endLine": 1,
+        "endColumn": 4
+      }
+    },
+    "sourceLine": 1,
+    "origin": "author",
+    "style": {
+      "cssProperties": [
+        {
+          "name": "color",
+          "value": "blue",
+          "text": "color: blue;",
+          "range": {
+            "startLine": 1,
+            "startColumn": 7,
+            "endLine": 1,
+            "endColumn": 19
+          },
+          "implicit": false,
+          "status": "active"
+        },
+        {
+          "name": "background-color",
+          "value": "azure",
+          "text": "background-color: azure;",
+          "range": {
+            "startLine": 1,
+            "startColumn": 20,
+            "endLine": 1,
+            "endColumn": 44
+          },
+          "implicit": false,
+          "status": "active"
+        }
+      ],
+      "shorthandEntries": [],
+      "styleId": "<filtered>",
+      "width": "",
+      "height": "",
+      "range": {
+        "startLine": 1,
+        "startColumn": 6,
+        "endLine": 1,
+        "endColumn": 45
+      },
+      "cssText": " color: blue; background-color: azure; "
+    },
+    "sourceURL": "<filtered>",
+    "ruleId": "<filtered>",
+    "isImplicitlyNested": false
+  }
+]
+
+After removing a style rule:
+[
+  {
+    "selectorList": {
+      "selectors": [
+        {
+          "text": "body",
+          "specificity": [
+            0,
+            0,
+            1
+          ]
+        }
+      ],
+      "text": "body",
+      "range": {
+        "startLine": 0,
+        "startColumn": 0,
+        "endLine": 0,
+        "endColumn": 4
+      }
+    },
+    "sourceLine": 0,
+    "origin": "author",
+    "style": {
+      "cssProperties": [
+        {
+          "name": "font-size",
+          "value": "17px",
+          "text": "font-size: 17px;",
+          "range": {
+            "startLine": 0,
+            "startColumn": 7,
+            "endLine": 0,
+            "endColumn": 23
+          },
+          "implicit": false,
+          "status": "active"
+        }
+      ],
+      "shorthandEntries": [],
+      "styleId": "<filtered>",
+      "width": "",
+      "height": "",
+      "range": {
+        "startLine": 0,
+        "startColumn": 6,
+        "endLine": 0,
+        "endColumn": 24
+      },
+      "cssText": " font-size: 17px; "
+    },
+    "sourceURL": "<filtered>",
+    "ruleId": "<filtered>",
+    "isImplicitlyNested": false
+  }
+]
+

--- a/LayoutTests/inspector/css/modify-with-cssom.html
+++ b/LayoutTests/inspector/css/modify-with-cssom.html
@@ -1,0 +1,71 @@
+<html>
+<head>
+<link rel="stylesheet" href="resources/modify-with-cssom.css">
+<script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<script>
+function test() {
+    let suite = ProtocolTest.createAsyncSuite("ModifyWithCSSOM");
+
+    const dumpAuthorStylesForBodyElement = async () => {
+        // Due to https://webkit.org/b/270864, CSSOM modifications aren't reflected until the CSS agent is re-enabled.
+        // (After re-enabling, the styles must still be in the latest state, matching the CSSOM modifications.)
+        await InspectorProtocol.awaitCommand({ method: "CSS.disable" });
+        await InspectorProtocol.awaitCommand({ method: "CSS.enable" });
+
+        let { root } = await InspectorProtocol.awaitCommand({ method: "DOM.getDocument" });
+        let body = await InspectorProtocol.awaitCommand({
+            method: "DOM.querySelector",
+            params: { nodeId: root.nodeId, selector: "body" },
+        });
+
+        const getAuthorRulesForElement = async (element) => {
+            let { matchedCSSRules } = await InspectorProtocol.awaitCommand({
+                method: "CSS.getMatchedStylesForNode",
+                params: { nodeId: element.nodeId },
+            });
+            return matchedCSSRules
+                .map(({ rule }) => rule)
+                .filter((rule) => rule.origin === "author");
+        };
+
+        const filteredValueReplacer = (key, value) => {
+            if (["ruleId", "styleId", "sourceURL"].includes(key))
+                return "<filtered>";
+            return value;
+        };
+
+        ProtocolTest.json(await getAuthorRulesForElement(body), filteredValueReplacer);
+    };
+
+    suite.addTestCase({
+        name: "CSS.getMatchedStylesForNode with CSSOM modifications",
+        description: "Test that CSS.getMatchedStylesForNode works after CSSOM modifies an existing style sheet, by editing, adding, or removing a style rule",
+        test: async () => {
+            await InspectorProtocol.awaitCommand({ method: "Page.enable" });
+
+            await ProtocolTest.evaluateInPage(`document.styleSheets[0].cssRules[0].style.color = "blue";`);
+            ProtocolTest.log("After modifying a style rule in place:")
+            await dumpAuthorStylesForBodyElement();
+
+            ProtocolTest.log("");
+            await ProtocolTest.evaluateInPage(`document.styleSheets[0].insertRule("body { font-size: 17px; }", 0)`);
+            ProtocolTest.log("After adding a style rule:");
+            await dumpAuthorStylesForBodyElement();
+
+            ProtocolTest.log("");
+            await ProtocolTest.evaluateInPage(`document.styleSheets[0].deleteRule(1);`);
+            ProtocolTest.log("After removing a style rule:");
+            await dumpAuthorStylesForBodyElement();
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+
+<body onload="runTest()">
+    <p>Test that the CSS.getMatchedStylesForNode command works with CSSOM modified styles.</p>
+</body>
+
+</html>

--- a/LayoutTests/inspector/css/resources/modify-with-cssom.css
+++ b/LayoutTests/inspector/css/resources/modify-with-cssom.css
@@ -1,0 +1,4 @@
+body {
+    color: red;
+    background-color: azure;
+}

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -249,14 +249,16 @@ void CSSStyleSheet::didMutateRules(RuleMutationType mutationType, ContentsCloned
 
         scope.didChangeStyleSheetContents();
 
-        m_mutatedRules = true;
+        m_wasMutated = true;
     });
 }
 
 void CSSStyleSheet::didMutate()
 {
-    forEachStyleScope([](auto& scope) {
+    forEachStyleScope([&](auto& scope) {
         scope.didChangeStyleSheetContents();
+
+        m_wasMutated = true;
     });
 }
 

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -93,6 +93,7 @@ public:
     void replace(String&&, Ref<DeferredPromise>&&);
     ExceptionOr<void> replaceSync(String&&);
 
+    bool wasMutated() const { return m_wasMutated; }
     bool wasConstructedByJS() const { return m_wasConstructedByJS; }
     Document* constructorDocument() const;
 
@@ -119,8 +120,6 @@ public:
     void setMediaQueries(MQ::MediaQueryList&&);
     void setTitle(const String& title) { m_title = title; }
 
-    bool hadRulesMutation() const { return m_mutatedRules; }
-    void clearHadRulesMutation() { m_mutatedRules = false; }
     RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&);
 
     enum RuleMutationType { OtherMutation, RuleInsertion, KeyframesRuleMutation, RuleReplace };
@@ -180,7 +179,7 @@ private:
     Ref<StyleSheetContents> m_contents;
     bool m_isInlineStylesheet { false };
     bool m_isDisabled { false };
-    bool m_mutatedRules { false };
+    bool m_wasMutated { false };
     bool m_wasConstructedByJS { false }; // constructed flag in the spec.
     std::optional<bool> m_isOriginClean;
     String m_title;

--- a/Source/WebCore/inspector/InspectorStyleSheet.h
+++ b/Source/WebCore/inspector/InspectorStyleSheet.h
@@ -127,16 +127,16 @@ public:
     ~InspectorStyle();
 
     CSSStyleDeclaration& cssStyle() const { return m_style.get(); }
-    Ref<Inspector::Protocol::CSS::CSSStyle> buildObjectForStyle() const;
-    Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSComputedStyleProperty>> buildArrayForComputedStyle() const;
+    Ref<Inspector::Protocol::CSS::CSSStyle> buildObjectForStyle();
+    Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSComputedStyleProperty>> buildArrayForComputedStyle();
 
-    ExceptionOr<String> text() const;
+    ExceptionOr<String> text();
 
 private:
     InspectorStyle(const InspectorCSSId& styleId, Ref<CSSStyleDeclaration>&&, InspectorStyleSheet* parentStyleSheet);
 
-    Vector<InspectorStyleProperty> collectProperties(bool includeAll) const;
-    Ref<Inspector::Protocol::CSS::CSSStyle> styleWithProperties() const;
+    Vector<InspectorStyleProperty> collectProperties(bool includeAll);
+    Ref<Inspector::Protocol::CSS::CSSStyle> styleWithProperties();
     RefPtr<CSSRuleSourceData> extractSourceData() const;
     String shorthandValue(const String& shorthandProperty) const;
     String shorthandPriority(const String& shorthandProperty) const;
@@ -181,7 +181,7 @@ public:
 
     virtual ExceptionOr<void> setRuleStyleText(const InspectorCSSId&, const String& newStyleDeclarationText, String* outOldStyleDeclarationText, const String* newRuleText, String* outOldRuleText);
 
-    virtual ExceptionOr<String> text() const;
+    virtual ExceptionOr<String> text();
     virtual CSSStyleDeclaration* styleForId(const InspectorCSSId&) const;
     void fireStyleSheetChanged();
 
@@ -206,14 +206,14 @@ private:
     friend class InspectorStyle;
 
     static void collectFlatRules(RefPtr<CSSRuleList>&&, Vector<RefPtr<CSSRule>>* result);
-    bool styleSheetMutated() const;
-    bool ensureText() const;
+    bool ensureText();
     bool ensureSourceData();
     void ensureFlatRules() const;
     bool originalStyleSheetText(String* result) const;
     bool resourceStyleSheetText(String* result) const;
     bool inlineStyleSheetText(String* result) const;
     bool extensionStyleSheetText(String* result) const;
+    bool styleSheetTextFromCSSRuleSerialization(String* result) const;
     Ref<JSON::ArrayOf<Inspector::Protocol::CSS::Grouping>> buildArrayForGroupings(CSSRule&);
     Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSRule>> buildArrayForRuleList(CSSRuleList*);
     Ref<Inspector::Protocol::CSS::CSSSelector> buildObjectForSelector(const CSSSelector*);
@@ -237,7 +237,7 @@ public:
     static Ref<InspectorStyleSheetForInlineStyle> create(InspectorPageAgent*, const String& id, Ref<StyledElement>&&, Inspector::Protocol::CSS::StyleSheetOrigin, Listener*);
 
     void didModifyElementAttribute();
-    ExceptionOr<String> text() const final;
+    ExceptionOr<String> text() final;
     CSSStyleDeclaration* styleForId(const InspectorCSSId& id) const final { ASSERT_UNUSED(id, !id.ordinal()); return &inlineStyle(); }
     ExceptionOr<void> setRuleStyleText(const InspectorCSSId&, const String& newStyleDeclarationText, String* outOldStyleDeclarationText, const String* newRuleText, String* outOldRuleText);
 


### PR DESCRIPTION
#### 5f3043fef76f4cf00455056627f4cfea814101ef
<pre>
Web Inspector: If a style sheet is modified by CSSOM, all rules in it can&apos;t be edited anymore from style details panel
<a href="https://bugs.webkit.org/show_bug.cgi?id=271026">https://bugs.webkit.org/show_bug.cgi?id=271026</a>
<a href="https://rdar.apple.com/124650808">rdar://124650808</a>

Reviewed by BJ Burg.

To execute a `CSS.setStyleText` command for a style edit, in order
to know where in the style sheet&apos;s text to apply a style modification,
InspectorStyleSheet records of a list of source ranges -- the
start and end locations of each CSS rule in the static source.
However, when CSSOM in JavaScript modifies a style sheet, whether it&apos;s
adding, removing, or mutating a rule, that style sheet in memory no
longer matches its source text, resulting its list of source ranges
getting out of sync with the static source.

To bypass the outdating of source ranges, what we currently do is
restrict the editing of any CSSOM-modified style sheets. This is done by
setting a mutation flag for a style sheet when it&apos;s CSSOM-modified and
returning null for any of its styles&apos; source range. The frontend then
renders any style declaration without a source range as non-editable.

This commit enables editing to CSSOM-modified style sheets. As a
CSSOM-modified style sheet does not match its static source text, we
reconstruct its text by serializing all of its CSS rules and
concatenating them. This is possible because the `cssText` property
is well-defined for any CSS, style or non-style, nested or non-nested
rules. With this change, we will then be able to provide source ranges
for any style from its newly-constructed source text, keeping them
editable as if it&apos;s from an unmodified style sheet.

There&apos;s one side effect of this patch and the reconstruction of style
sheet text: CSSOM&apos;s modifications to a style sheet will now also be
reflected in the Sources tab in the frontend. I think this is reasonable
as it&apos;s consistent with the Sources tab reflecting style edits in the
style details panel. However, the original style sheet&apos;s text will be
completely overridden by the reconstructed text, along with any comments
or white spaces it had. We can follow up this commit by coming up with
some display in the frontend to indicate a style sheet viewed in the
Sources tab currently contains CSSOM-related styles. Nonetheless, I
think this patch by itself is still valuable enough to have without
the frontend improvement, as it solves a more immediate problem that
is confusing and frequently occurred.

* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::didMutateRules):
(WebCore::CSSStyleSheet::didMutate):
   - The flag `m_wasMutated` now indicates to InspectorStyleSheet
     whether it should reconstruct its source text. Therefore, it also
     needs to be set on `didMutate`, which is called when mutating
     a CSSRule in-place
     (e.g. via PropertySetCSSStyleDeclaration::setProperty).
   - Remove the `clearHadRulesMutation()` method because `m_wasMutated`
     is the useful flag now, and there&apos;s no need to clear that flag
     because if the user edits from the styles panel a CSSOM-modified
     style, the text still needs to be reconstructed.

* Source/WebCore/inspector/InspectorStyleSheet.h:
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyleSheet::ensureText):
(WebCore::InspectorStyleSheet::styleSheetTextFromCSSRuleSerialization const):
   - If the style sheet has been mutated, reconstruct its source text
     by concatenating its CSS rules&apos; serializations. Also call
     `fireStyleSheetChanged` to make sure the frontend reflects all
     CSSOM-modifications on first fetch.

(WebCore::InspectorStyle::buildObjectForStyle):
(WebCore::InspectorStyle::buildArrayForComputedStyle):
(WebCore::InspectorStyle::text):
(WebCore::InspectorStyle::collectProperties):
(WebCore::InspectorStyle::styleWithProperties):
(WebCore::InspectorStyleSheet::setRuleHeaderText):
(WebCore::InspectorStyleSheet::text):
(WebCore::InspectorStyleSheet::ensureParsedDataReady):
(WebCore::InspectorStyleSheet::ensureText):
(WebCore::InspectorStyleSheetForInlineStyle::text):
(WebCore::InspectorStyle::buildObjectForStyle const): Deleted.
(WebCore::InspectorStyle::buildArrayForComputedStyle const): Deleted.
(WebCore::InspectorStyle::text const): Deleted.
(WebCore::InspectorStyle::collectProperties const): Deleted.
(WebCore::InspectorStyle::styleWithProperties const): Deleted.
(WebCore::InspectorStyleSheet::text const): Deleted.
(WebCore::InspectorStyleSheet::ensureText const): Deleted.
(WebCore::InspectorStyleSheetForInlineStyle::text const): Deleted.
   - Adapt to `ensureText` no longer being `const`.

(WebCore::InspectorStyleSheet::reparseStyleSheet):
(WebCore::InspectorStyleSheet::setRuleStyleText):
   - Adapt to the removal of `CSSStyleSheet::clearHadRulesMutation()`.

(WebCore::InspectorStyleSheet::styleSheetMutated const): Deleted.
   - Not used anywhere.

* LayoutTests/inspector/css/modify-with-cssom-expected.txt: Added.
* LayoutTests/inspector/css/modify-with-cssom.html: Added.
* LayoutTests/inspector/css/resources/modify-with-cssom.css: Added.
(body):
   - Add a simple test that the CSS.getMatchedStylesForNode command
     can return style rules with non-empty source ranges, pointed into
     the generated style text, for CSSOM-related styles. (Without my
     changes from this commit, CSS.getMatchedStylesForNode always
     returned style rules without source ranges, whenever the style
     sheet is CSSOM-modified, and thus preventing editing in the
     frontend.)
   - I put this test in a new file rather than in the existing
     modify-css-property.html as that test suite is currently skipped: <a href="https://github.com/WebKit/WebKit/blob/586aa00275b46a60eca5c692d81de42e51882171/LayoutTests/platform/mac/TestExpectations#L1948">https://github.com/WebKit/WebKit/blob/586aa00275b46a60eca5c692d81de42e51882171/LayoutTests/platform/mac/TestExpectations#L1948</a>

Canonical link: <a href="https://commits.webkit.org/288948@main">https://commits.webkit.org/288948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ee002263d739aa15d580040a264c4cb6ea3dd7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85543 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32000 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/83124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8340 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63243 "Found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21011 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43541 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/220 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27889 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30458 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86978 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/8244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71548 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8421 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70783 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18225 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14822 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13744 "Passed tests") | [⏳ 🛠 playstation ](https://ews-build.webkit.org/#/builders/PlayStation-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8205 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13728 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8042 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->