### PR TITLE
Use "= default" for constructors and destructors in more places

### DIFF
--- a/Source/WTF/wtf/AutomaticThread.cpp
+++ b/Source/WTF/wtf/AutomaticThread.cpp
@@ -38,13 +38,9 @@ Ref<AutomaticThreadCondition> AutomaticThreadCondition::create()
     return adoptRef(*new AutomaticThreadCondition);
 }
 
-AutomaticThreadCondition::AutomaticThreadCondition()
-{
-}
+AutomaticThreadCondition::AutomaticThreadCondition() = default;
 
-AutomaticThreadCondition::~AutomaticThreadCondition()
-{
-}
+AutomaticThreadCondition::~AutomaticThreadCondition() = default;
 
 void AutomaticThreadCondition::notifyOne(const AbstractLocker& locker)
 {

--- a/Source/WTF/wtf/ConcurrentPtrHashSet.cpp
+++ b/Source/WTF/wtf/ConcurrentPtrHashSet.cpp
@@ -33,9 +33,7 @@ ConcurrentPtrHashSet::ConcurrentPtrHashSet()
     initialize();
 }
 
-ConcurrentPtrHashSet::~ConcurrentPtrHashSet()
-{
-}
+ConcurrentPtrHashSet::~ConcurrentPtrHashSet() = default;
 
 void ConcurrentPtrHashSet::deleteOldTables()
 {

--- a/Source/WTF/wtf/FunctionDispatcher.cpp
+++ b/Source/WTF/wtf/FunctionDispatcher.cpp
@@ -28,12 +28,8 @@
 
 namespace WTF {
 
-FunctionDispatcher::FunctionDispatcher()
-{
-}
+FunctionDispatcher::FunctionDispatcher() = default;
 
-FunctionDispatcher::~FunctionDispatcher()
-{
-}
+FunctionDispatcher::~FunctionDispatcher() = default;
 
 } // namespace WTF

--- a/Source/WTF/wtf/LockedPrintStream.cpp
+++ b/Source/WTF/wtf/LockedPrintStream.cpp
@@ -33,9 +33,7 @@ LockedPrintStream::LockedPrintStream(std::unique_ptr<PrintStream> target)
 {
 }
 
-LockedPrintStream::~LockedPrintStream()
-{
-}
+LockedPrintStream::~LockedPrintStream() = default;
 
 void LockedPrintStream::vprintf(const char* format, va_list args)
 {

--- a/Source/WTF/wtf/PrintStream.cpp
+++ b/Source/WTF/wtf/PrintStream.cpp
@@ -32,8 +32,8 @@
 
 namespace WTF {
 
-PrintStream::PrintStream() { }
-PrintStream::~PrintStream() { } // Force the vtable to be in this module
+PrintStream::PrintStream() = default;
+PrintStream::~PrintStream() = default; // Force the vtable to be in this module
 
 void PrintStream::printf(const char* format, ...)
 {

--- a/Source/WTF/wtf/RefCountedLeakCounter.cpp
+++ b/Source/WTF/wtf/RefCountedLeakCounter.cpp
@@ -30,7 +30,7 @@ void RefCountedLeakCounter::suppressMessages(const char*) { }
 void RefCountedLeakCounter::cancelMessageSuppression(const char*) { }
 
 RefCountedLeakCounter::RefCountedLeakCounter(const char*) { }
-RefCountedLeakCounter::~RefCountedLeakCounter() { }
+RefCountedLeakCounter::~RefCountedLeakCounter() = default;
 
 void RefCountedLeakCounter::increment() { }
 void RefCountedLeakCounter::decrement() { }

--- a/Source/WTF/wtf/glib/SocketConnection.cpp
+++ b/Source/WTF/wtf/glib/SocketConnection.cpp
@@ -57,9 +57,7 @@ SocketConnection::SocketConnection(GRefPtr<GSocketConnection>&& connection, cons
     });
 }
 
-SocketConnection::~SocketConnection()
-{
-}
+SocketConnection::~SocketConnection() = default;
 
 bool SocketConnection::read()
 {

--- a/Source/WTF/wtf/persistence/PersistentDecoder.cpp
+++ b/Source/WTF/wtf/persistence/PersistentDecoder.cpp
@@ -36,9 +36,7 @@ Decoder::Decoder(std::span<const uint8_t> span)
 {
 }
 
-Decoder::~Decoder()
-{
-}
+Decoder::~Decoder() = default;
 
 bool Decoder::bufferIsLargeEnoughToContain(size_t size) const
 {

--- a/Source/WTF/wtf/persistence/PersistentEncoder.cpp
+++ b/Source/WTF/wtf/persistence/PersistentEncoder.cpp
@@ -30,13 +30,9 @@
 
 namespace WTF::Persistence {
 
-Encoder::Encoder()
-{
-}
+Encoder::Encoder() = default;
 
-Encoder::~Encoder()
-{
-}
+Encoder::~Encoder() = default;
 
 uint8_t* Encoder::grow(size_t size)
 {

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -83,9 +83,7 @@
 
 namespace WTF {
 
-Thread::~Thread()
-{
-}
+Thread::~Thread() = default;
 
 #if !OS(DARWIN)
 class Semaphore final {

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -244,9 +244,7 @@ StringView::GraphemeClusters::Iterator::Iterator(StringView stringView, unsigned
 {
 }
 
-StringView::GraphemeClusters::Iterator::~Iterator()
-{
-}
+StringView::GraphemeClusters::Iterator::~Iterator() = default;
 
 StringView::GraphemeClusters::Iterator::Iterator(Iterator&& other)
     : m_impl(WTFMove(other.m_impl))

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -329,9 +329,7 @@ void Thread::SpecificStorage::destroySlots()
     }
 }
 
-Mutex::~Mutex()
-{
-}
+Mutex::~Mutex() = default;
 
 void Mutex::lock()
 {
@@ -370,9 +368,7 @@ static DWORD absoluteTimeToWaitTimeoutInterval(WallTime absoluteTime)
     return static_cast<DWORD>((absoluteTime - currentTime).milliseconds());
 }
 
-ThreadCondition::~ThreadCondition()
-{
-}
+ThreadCondition::~ThreadCondition() = default;
 
 void ThreadCondition::wait(Mutex& mutex)
 {

--- a/Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp
@@ -33,13 +33,9 @@
 
 namespace WebCore {
 
-NavigatorAudioSession::NavigatorAudioSession()
-{
-}
+NavigatorAudioSession::NavigatorAudioSession() = default;
 
-NavigatorAudioSession::~NavigatorAudioSession()
-{
-}
+NavigatorAudioSession::~NavigatorAudioSession() = default;
 
 RefPtr<DOMAudioSession> NavigatorAudioSession::audioSession(Navigator& navigator)
 {

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -351,9 +351,7 @@ FetchResponse::Loader::Loader(FetchResponse& response, NotificationCallback&& re
 {
 }
 
-FetchResponse::Loader::~Loader()
-{
-}
+FetchResponse::Loader::~Loader() = default;
 
 void FetchResponse::Loader::didReceiveResponse(const ResourceResponse& resourceResponse)
 {

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp
@@ -48,9 +48,7 @@ RTCDataChannelRemoteHandler::RTCDataChannelRemoteHandler(RTCDataChannelIdentifie
 {
 }
 
-RTCDataChannelRemoteHandler::~RTCDataChannelRemoteHandler()
-{
-}
+RTCDataChannelRemoteHandler::~RTCDataChannelRemoteHandler() = default;
 
 void RTCDataChannelRemoteHandler::didChangeReadyState(RTCDataChannelState state)
 {

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.cpp
@@ -42,9 +42,7 @@ RTCDataChannelRemoteSource::RTCDataChannelRemoteSource(RTCDataChannelIdentifier 
     m_handler->setClient(*this, { });
 }
 
-RTCDataChannelRemoteSource::~RTCDataChannelRemoteSource()
-{
-}
+RTCDataChannelRemoteSource::~RTCDataChannelRemoteSource() = default;
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -68,9 +68,7 @@ RTCRtpSFrameTransform::RTCRtpSFrameTransform(ScriptExecutionContext& context, Op
     m_transformer->setAuthenticationSize(options.authenticationSize);
 }
 
-RTCRtpSFrameTransform::~RTCRtpSFrameTransform()
-{
-}
+RTCRtpSFrameTransform::~RTCRtpSFrameTransform() = default;
 
 void RTCRtpSFrameTransform::setEncryptionKey(CryptoKey& key, std::optional<uint64_t> keyId, DOMPromiseDeferred<void>&& promise)
 {

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
@@ -153,9 +153,7 @@ RTCRtpSFrameTransformer::RTCRtpSFrameTransformer(CompatibilityMode mode)
 {
 }
 
-RTCRtpSFrameTransformer::~RTCRtpSFrameTransformer()
-{
-}
+RTCRtpSFrameTransformer::~RTCRtpSFrameTransformer() = default;
 
 ExceptionOr<void> RTCRtpSFrameTransformer::setEncryptionKey(const Vector<uint8_t>& rawKey, std::optional<uint64_t> keyId)
 {

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -79,9 +79,7 @@ RTCRtpScriptTransformer::RTCRtpScriptTransformer(ScriptExecutionContext& context
 {
 }
 
-RTCRtpScriptTransformer::~RTCRtpScriptTransformer()
-{
-}
+RTCRtpScriptTransformer::~RTCRtpScriptTransformer() = default;
 
 ReadableStream& RTCRtpScriptTransformer::readable()
 {

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
@@ -93,9 +93,7 @@ VideoTrackGenerator::VideoTrackGenerator(Ref<Sink>&& sink, Ref<WritableStream>&&
 {
 }
 
-VideoTrackGenerator::~VideoTrackGenerator()
-{
-}
+VideoTrackGenerator::~VideoTrackGenerator() = default;
 
 void VideoTrackGenerator::setMuted(ScriptExecutionContext& context, bool muted)
 {

--- a/Source/WebCore/Modules/notifications/NotificationEvent.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationEvent.cpp
@@ -54,9 +54,7 @@ NotificationEvent::NotificationEvent(const AtomString& type, NotificationEventIn
 {
 }
 
-NotificationEvent::~NotificationEvent()
-{
-}
+NotificationEvent::~NotificationEvent() = default;
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/push-api/PushEvent.cpp
+++ b/Source/WebCore/Modules/push-api/PushEvent.cpp
@@ -78,8 +78,6 @@ PushEvent::PushEvent(const AtomString& type, ExtendableEventInit&& eventInit, st
 {
 }
 
-PushEvent::~PushEvent()
-{
-}
+PushEvent::~PushEvent() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
@@ -62,9 +62,7 @@ RemotePlayback::RemotePlayback(HTMLMediaElement& element)
 {
 }
 
-RemotePlayback::~RemotePlayback()
-{
-}
+RemotePlayback::~RemotePlayback() = default;
 
 WebCoreOpaqueRoot RemotePlayback::opaqueRootConcurrently() const
 {

--- a/Source/WebCore/Modules/speech/SpeechRecognition.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.cpp
@@ -212,9 +212,7 @@ void SpeechRecognition::didEnd()
     queueTaskToDispatchEvent(*this, TaskSource::Speech, Event::create(eventNames().endEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
-SpeechRecognition::~SpeechRecognition()
-{
-}
+SpeechRecognition::~SpeechRecognition() = default;
 
 bool SpeechRecognition::virtualHasPendingActivity() const
 {

--- a/Source/WebCore/Modules/streams/TransformStream.cpp
+++ b/Source/WebCore/Modules/streams/TransformStream.cpp
@@ -73,9 +73,7 @@ TransformStream::TransformStream(JSC::JSValue internalTransformStream, Ref<Reada
 {
 }
 
-TransformStream::~TransformStream()
-{
-}
+TransformStream::~TransformStream() = default;
 
 static ExceptionOr<JSC::JSValue> invokeTransformStreamFunction(JSC::JSGlobalObject& globalObject, const JSC::Identifier& identifier, const JSC::MarkedArgumentBuffer& arguments)
 {

--- a/Source/WebCore/Modules/webauthn/cbor/CBORWriter.cpp
+++ b/Source/WebCore/Modules/webauthn/cbor/CBORWriter.cpp
@@ -36,9 +36,7 @@
 
 namespace cbor {
 
-CBORWriter::~CBORWriter()
-{
-}
+CBORWriter::~CBORWriter() = default;
 
 // static
 std::optional<Vector<uint8_t>> CBORWriter::write(const CBORValue& node, size_t maxNestingLevel)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -60,9 +60,7 @@ WebCodecsAudioDecoder::WebCodecsAudioDecoder(ScriptExecutionContext& context, In
 {
 }
 
-WebCodecsAudioDecoder::~WebCodecsAudioDecoder()
-{
-}
+WebCodecsAudioDecoder::~WebCodecsAudioDecoder() = default;
 
 static bool isValidDecoderConfig(const WebCodecsAudioDecoderConfig& config)
 {

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -68,9 +68,7 @@ WebCodecsAudioEncoder::WebCodecsAudioEncoder(ScriptExecutionContext& context, In
 {
 }
 
-WebCodecsAudioEncoder::~WebCodecsAudioEncoder()
-{
-}
+WebCodecsAudioEncoder::~WebCodecsAudioEncoder() = default;
 
 static bool isSupportedEncoderCodec(const StringView& codec)
 {

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -60,9 +60,7 @@ WebCodecsVideoDecoder::WebCodecsVideoDecoder(ScriptExecutionContext& context, In
 {
 }
 
-WebCodecsVideoDecoder::~WebCodecsVideoDecoder()
-{
-}
+WebCodecsVideoDecoder::~WebCodecsVideoDecoder() = default;
 
 static bool isSupportedDecoderCodec(const String& codec, const Settings::Values& settings)
 {

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp
@@ -64,9 +64,7 @@ WebCodecsVideoEncoder::WebCodecsVideoEncoder(ScriptExecutionContext& context, In
 {
 }
 
-WebCodecsVideoEncoder::~WebCodecsVideoEncoder()
-{
-}
+WebCodecsVideoEncoder::~WebCodecsVideoEncoder() = default;
 
 static bool isSupportedEncoderCodec(const String& codec, const Settings::Values& settings)
 {

--- a/Source/WebCore/PAL/pal/crypto/openssl/CryptoDigestOpenSSL.cpp
+++ b/Source/WebCore/PAL/pal/crypto/openssl/CryptoDigestOpenSSL.cpp
@@ -103,13 +103,9 @@ private:
     SHAContext m_context;
 };
 
-CryptoDigest::CryptoDigest()
-{
-}
+CryptoDigest::CryptoDigest() = default;
 
-CryptoDigest::~CryptoDigest()
-{
-}
+CryptoDigest::~CryptoDigest() = default;
 
 static std::unique_ptr<CryptoDigestContext> createCryptoDigest(CryptoDigest::Algorithm algorithm)
 {

--- a/Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb
+++ b/Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb
@@ -145,9 +145,7 @@ Settings::Values Settings::Values::isolatedCopy() const
     };
 }
 
-Settings::~Settings()
-{
-}
+Settings::~Settings() = default;
 
 void Settings::disableUnstableFeaturesForModernWebKit()
 {

--- a/Source/WebCore/animation/AnimationEffect.cpp
+++ b/Source/WebCore/animation/AnimationEffect.cpp
@@ -39,13 +39,9 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(AnimationEffect);
 
-AnimationEffect::AnimationEffect()
-{
-}
+AnimationEffect::AnimationEffect() = default;
 
-AnimationEffect::~AnimationEffect()
-{
-}
+AnimationEffect::~AnimationEffect() = default;
 
 void AnimationEffect::setAnimation(WebAnimation* animation)
 {

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -45,13 +45,9 @@
 namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(KeyframeEffectStack);
 
-KeyframeEffectStack::KeyframeEffectStack()
-{
-}
+KeyframeEffectStack::KeyframeEffectStack() = default;
 
-KeyframeEffectStack::~KeyframeEffectStack()
-{
-}
+KeyframeEffectStack::~KeyframeEffectStack() = default;
 
 bool KeyframeEffectStack::addEffect(KeyframeEffect& effect)
 {

--- a/Source/WebCore/animation/StyleOriginatedAnimation.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.cpp
@@ -51,9 +51,7 @@ StyleOriginatedAnimation::StyleOriginatedAnimation(const Styleable& styleable, c
 {
 }
 
-StyleOriginatedAnimation::~StyleOriginatedAnimation()
-{
-}
+StyleOriginatedAnimation::~StyleOriginatedAnimation() = default;
 
 const std::optional<const Styleable> StyleOriginatedAnimation::owningElement() const
 {

--- a/Source/WebCore/css/FontFaceSet.cpp
+++ b/Source/WebCore/css/FontFaceSet.cpp
@@ -85,9 +85,7 @@ FontFaceSet::FontFaceSet(ScriptExecutionContext& context, CSSFontFaceSet& backin
     m_backing->addFontEventClient(*this);
 }
 
-FontFaceSet::~FontFaceSet()
-{
-}
+FontFaceSet::~FontFaceSet() = default;
 
 FontFaceSet::Iterator::Iterator(FontFaceSet& set)
     : m_target(set)

--- a/Source/WebCore/html/HTMLPictureElement.cpp
+++ b/Source/WebCore/html/HTMLPictureElement.cpp
@@ -43,9 +43,7 @@ HTMLPictureElement::HTMLPictureElement(const QualifiedName& tagName, Document& d
 {
 }
 
-HTMLPictureElement::~HTMLPictureElement()
-{
-}
+HTMLPictureElement::~HTMLPictureElement() = default;
 
 Ref<HTMLPictureElement> HTMLPictureElement::create(const QualifiedName& tagName, Document& document)
 {

--- a/Source/WebCore/html/shadow/DataListButtonElement.cpp
+++ b/Source/WebCore/html/shadow/DataListButtonElement.cpp
@@ -51,7 +51,7 @@ DataListButtonElement::DataListButtonElement(Document& document, DataListButtonO
 {
 }
 
-DataListButtonElement::~DataListButtonElement() { }
+DataListButtonElement::~DataListButtonElement() = default;
 
 void DataListButtonElement::defaultEventHandler(Event& event)
 {


### PR DESCRIPTION
#### 0cc86c22fc251208e801b2eeadaf23c326995557
<pre>
Use &quot;= default&quot; for constructors and destructors in more places

<a href="https://bugs.webkit.org/show_bug.cgi?id=271031">https://bugs.webkit.org/show_bug.cgi?id=271031</a>

Reviewed by Michael Catanzaro and Chris Dumez.

Similar to other patches, this extends our &quot;= default&quot; usage across
constructors and destructors in WebKit code.

* Source/WebCore/animation/AnimationEffect.cpp:
(AnimationEffect::AnimationEffect):
(AnimationEffect::~AnimationEffect):
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(KeyframeEffectStack::KeyframeEffectStack):
(KeyframeEffectStack::~KeyframeEffectStack):
* Source/WebCore/animation/StyleOriginatedAnimation.cpp:
(StyleOriginatedAnimation::~StyleOriginatedAnimation):
* Source/WebCore/css/FontFaceSet.cpp:
(FontFaceSet::~FontFaceSet):
* Source/WebCore/html/HTMLPictureElement.cpp:
(HTMLPictureElement::~HTMLPictureElement):
* Source/WebCore/html/shadow/DataListButtonElement.cpp:
(DataListButtonElement::~DataListButtonElement):
* Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp:
(NavigatorAudioSession::NavigatorAudioSession):
(NavigatorAudioSession::~NavigatorAudioSession):
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(FetchResponse::Loader::~Loader):
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp:
(RTCDataChannelRemoteHandler::~RTCDataChannelRemoteHandler):
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.cpp:
(RTCDataChannelRemoteSource::~RTCDataChannelRemoteSource):
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp:
(RTCRtpScriptTransformer::~RTCRtpScriptTransformer):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
(RTCRtpSFrameTransform::~RTCRtpSFrameTransform):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp:
(RTCRtpSFrameTransformer::~RTCRtpSFrameTransformer):
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp:
(VideoTrackGenerator::~VideoTrackGenerator):
* Source/WebCore/Modules/notifications/NotificationEvent.cpp:
(NotificationEvent::~NotificationEvent):
* Source/WebCore/Modules/push-api/PushEvent.cpp:
(PushEvent::~PushEvent):
* Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp:
(RemotePlayback::~RemotePlayback):
* Source/WebCore/Modules/speech/SpeechRecognition.cpp:
(SpeechRecognition::~SpeechRecognition):
* Source/WebCore/Modules/streams/TransformStream.cpp:
(
TransformStream::~TransformStream):
* Source/WebCore/Modules/webauthn/cbor/CBORWriter.cpp:
(CBORWriter::~CBORWriter):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCodecsAudioDecoder::~WebCodecsAudioDecoder):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCodecsAudioEncoder::~WebCodecsAudioEncoder):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCodecsVideoDecoder::~WebCodecsVideoDecoder):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCodecsVideoEncoder::~WebCodecsVideoEncoder):
* Source/WebCore/PAL/pal/crypto/openssl/CryptoDigestOpenSSL.cpp:
(CryptoDigest::CryptoDigest):
(CryptoDigest::~CryptoDigest():
* Source/WebCore/Scripts/SettingsTemplates/Settings.cpp.erb:
(Settings::~Settings):
* Source/WTF/wtf/AutomaticThread.cpp:
(AutomaticThreadCondition::AutomaticThreadCondition):
(AutomaticThreadCondition::~AutomaticThreadCondition):
* Source/WTF/wtf/ConcurrentPtrHashSet.cpp:
(ConcurrentPtrHashSet::~ConcurrentPtrHashSet):
* Source/WTF/wtf/FunctionDispatcher.cpp:
(FunctionDispatcher::FunctionDispatcher):
(FunctionDispatcher::~FunctionDispatcher):
* Source/WTF/wtf/glib/SocketConnection.cpp:
(SocketConnection::~SocketConnection):
* Source/WTF/wtf/LockedPrintStream.cpp:
(LockedPrintStream::~LockedPrintStream):
* Source/WTF/wtf/persistence/PersistentDecoder.cpp:
(Decoder::~Decoder):
* Source/WTF/wtf/persistence/PersistentEncoder.cpp:
(Encoder::Encoder):
(Encoder::~Encoder):
* Source/WTF/wtf/posix/ThreadingPOSIX.cpp:
(Thread::~Thread):
* Source/WTF/wtf/PrintStream.cpp:
(PrintStream::PrintStream):
(PrintStream::~PrintStream):
* Source/WTF/wtf/RefCountedLeakCounter.cpp:
(RefCountedLeakCounter::~RefCountedLeakCounter):
* Source/WTF/wtf/text/StringView.cpp:
(StringView::GraphemeClusters::Iterator::~Iterator):
* Source/WTF/wtf/win/ThreadingWin.cpp:
(Mutex::~Mutex):
(ThreadCondition::~ThreadCondition):

Canonical link: <a href="https://commits.webkit.org/276159@main">https://commits.webkit.org/276159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7f94f5ab89cb85e522ed76cac5c730e557b6f57

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46532 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39969 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36215 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17217 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17515 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38880 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1944 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37284 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48098 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43488 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15474 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43031 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20289 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41735 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9768 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20493 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50520 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19913 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10196 "Passed tests") | 
<!--EWS-Status-Bubble-End-->