### PR TITLE
[visionOS] Video briefly resizes to full-window when entering LinearMediaPlayer fullscreen

### DIFF
--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -143,10 +143,8 @@ public:
     WEBCORE_EXPORT void setMode(HTMLMediaElementEnums::VideoFullscreenMode, bool shouldNotifyModel);
     void clearMode(HTMLMediaElementEnums::VideoFullscreenMode, bool shouldNotifyModel);
     bool hasMode(HTMLMediaElementEnums::VideoFullscreenMode mode) const { return m_currentMode.hasMode(mode); }
-#if PLATFORM(WATCHOS) || PLATFORM(APPLETV)
     WEBCORE_EXPORT UIViewController *presentingViewController();
     UIViewController *fullscreenViewController() const { return m_viewController.get(); }
-#endif
     WEBCORE_EXPORT virtual bool pictureInPictureWasStartedWhenEnteringBackground() const = 0;
 
     WEBCORE_EXPORT std::optional<MediaPlayerIdentifier> playerIdentifier() const;


### PR DESCRIPTION
#### 1294f70d6126f5642f5293fe3298e83f1551cd89
<pre>
[visionOS] Video briefly resizes to full-window when entering LinearMediaPlayer fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=271032">https://bugs.webkit.org/show_bug.cgi?id=271032</a>
<a href="https://rdar.apple.com/123315074">rdar://123315074</a>

Reviewed by Jer Noble.

Prior to this change, VideoPresentationInterfaceIOS would create a new UIWindow in which the player
view controller would be presented. However, LinearMediaKit would immediately hide this window and
present the fullscreen video in a new UIScene. When entering LinearMediaPlayer fullscreen, this
resulted in the UIWindow briefly appearing then being hidden prior to the LinearMediaKit scene being
presented.

To avoid this, skip creating the UIWindow for LinearMediaPlayer fullscreen. Instead, embed the
LMPlayableViewController in WKWebView&apos;s presenting view controller with its root view sized to match
the inline video element. Then, allow LinearMediaKit to hide the WKWebView&apos;s UIWindowScene and
present its own scene. This results in a less flashy, more direct transition from inline to
fullscreen.

* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
(WebCore::VideoPresentationInterfaceIOS::hasMode const):
(WebCore::VideoPresentationInterfaceIOS::fullscreenViewController const):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::presentingViewController):
(WebCore::VideoPresentationInterfaceIOS::doSetup):
(WebCore::VideoPresentationInterfaceIOS::cleanupFullscreen):

Canonical link: <a href="https://commits.webkit.org/276177@main">https://commits.webkit.org/276177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af9b1f9ad2cce568673b2e38729728ec5f68e4ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46533 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39970 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46197 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20339 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36214 "Failure limit exceed. At least found 1 new test failure: http/tests/xmlhttprequest/cors-non-standard-safelisted-headers-should-trigger-preflight.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19966 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37800 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17216 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38883 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1945 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48099 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43032 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20290 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41750 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9780 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20494 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19914 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->