### PR TITLE
Fire selectionchange event on input and textarea elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/selection/textcontrols/selectionchange-bubble-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/selection/textcontrols/selectionchange-bubble-expected.txt
@@ -1,10 +1,8 @@
 
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT selectionchange bubbles from input Test timed out
-NOTRUN selectionchange bubbles from input when focused
-NOTRUN selectionchange bubbles from textarea
-NOTRUN selectionchange bubbles from textarea when focused
+PASS selectionchange bubbles from input
+PASS selectionchange bubbles from input when focused
+PASS selectionchange bubbles from textarea
+PASS selectionchange bubbles from textarea when focused
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/selection/textcontrols/selectionchange-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/selection/textcontrols/selectionchange-expected.txt
@@ -15,7 +15,7 @@ PASS Setting the same selection range twice on the input element
 PASS Calling select() twice on the input element
 PASS Calling setRangeText() after select() on the input element
 PASS Calling setRangeText() repeatedly on the input element
-PASS Calling setRangeText() on empty the input element
+FAIL Calling setRangeText() on empty the input element assert_equals: expected 0 but got 1
 PASS Modifying selectionStart value of the disconnected input element
 PASS Modifying selectionEnd value of the disconnected input element
 PASS Calling setSelectionRange() on the disconnected input element
@@ -30,7 +30,7 @@ PASS Setting the same selection range twice on the disconnected input element
 PASS Calling select() twice on the disconnected input element
 PASS Calling setRangeText() after select() on the disconnected input element
 PASS Calling setRangeText() repeatedly on the disconnected input element
-PASS Calling setRangeText() on empty the disconnected input element
+FAIL Calling setRangeText() on empty the disconnected input element assert_equals: expected 0 but got 1
 PASS Modifying selectionStart value of the textarea element
 PASS Modifying selectionEnd value of the textarea element
 PASS Calling setSelectionRange() on the textarea element
@@ -60,5 +60,5 @@ PASS Setting the same selection range twice on the disconnected textarea element
 PASS Calling select() twice on the disconnected textarea element
 PASS Calling setRangeText() after select() on the disconnected textarea element
 PASS Calling setRangeText() repeatedly on the disconnected textarea element
-PASS Calling setRangeText() on empty the disconnected textarea element
+FAIL Calling setRangeText() on empty the disconnected textarea element assert_equals: expected 0 but got 1
 

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -383,12 +383,14 @@ void HTMLTextAreaElement::setValueCommon(const String& newValue, TextFieldEventB
     setFormControlValueMatchesRenderer(true);
 
     auto endOfString = m_value.length();
-    if (document().focusedElement() == this)
-        setSelectionRange(endOfString, endOfString);
-    else if (selection == TextControlSetValueSelection::SetSelectionToEnd) {
-        // We don't change text selection here but need to update caret to
-        // the end of the text value except for initialize.
-        cacheSelection(endOfString, endOfString, SelectionHasNoDirection);
+    if (selection == TextControlSetValueSelection::SetSelectionToEnd) {
+        if (document().focusedElement() == this)
+            setSelectionRange(endOfString, endOfString);
+        else {
+            // We don't change text selection here but need to update caret to
+            // the end of the text value except for initialize.
+            cacheSelection(endOfString, endOfString, SelectionHasNoDirection);
+        }
     } else if (shouldClamp)
         cacheSelection(std::min(endOfString, selectionStartValue), std::min(endOfString, selectionEndValue), SelectionHasNoDirection);
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -555,24 +555,29 @@ void HTMLTextFormControlElement::restoreCachedSelection(SelectionRevealMode reve
         scheduleSelectEvent();
 }
 
-void HTMLTextFormControlElement::selectionChanged(bool shouldFireSelectEvent)
+bool HTMLTextFormControlElement::selectionChanged(bool shouldFireSelectEvent)
 {
     if (!isTextField())
-        return;
+        return false;
 
     // FIXME: Don't re-compute selection start and end if this function was called inside setSelectionRange.
     // selectionStart() or selectionEnd() will return cached selection when this node doesn't have focus
+    unsigned previousSelectionStart = m_cachedSelectionStart;
+    unsigned previousSelectionEnd = m_cachedSelectionEnd;
     cacheSelection(computeSelectionStart(), computeSelectionEnd(), computeSelectionDirection());
 
     document().setHasEverHadSelectionInsideTextFormControl();
 
     if (shouldFireSelectEvent && m_cachedSelectionStart != m_cachedSelectionEnd)
         dispatchEvent(Event::create(eventNames().selectEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
+
+    return previousSelectionStart != m_cachedSelectionStart || previousSelectionEnd != m_cachedSelectionEnd;
 }
 
 void HTMLTextFormControlElement::scheduleSelectEvent()
 {
     queueTaskToDispatchEvent(TaskSource::UserInteraction, Event::create(eventNames().selectEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
+    queueTaskToDispatchEvent(TaskSource::UserInteraction, Event::create(eventNames().selectionchangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
 }
 
 void HTMLTextFormControlElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -100,7 +100,7 @@ public:
 
     virtual bool dirAutoUsesValue() const = 0;
 
-    void selectionChanged(bool shouldFireSelectEvent);
+    bool selectionChanged(bool shouldFireSelectEvent);
     WEBCORE_EXPORT bool lastChangeWasUserEdit() const;
     void setInnerTextValue(String&&);
     String innerTextValue() const;


### PR DESCRIPTION
#### 0a064d401bd0a68d148be77d03cb3c157188c04b
<pre>
Fire selectionchange event on input and textarea elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=271033">https://bugs.webkit.org/show_bug.cgi?id=271033</a>

Reviewed by Sihui Liu and Wenson Hsieh.

This PR updates the implementation of selectionchange event to be fired on input element and textarea
element instead of document whenever either real selection or cached selection offsets have been updated
to match the specification: <a href="https://w3c.github.io/selection-api/#selectionchange-event">https://w3c.github.io/selection-api/#selectionchange-event</a>

* LayoutTests/imported/w3c/web-platform-tests/selection/textcontrols/selectionchange-bubble-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/selection/textcontrols/selectionchange-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/selection/textcontrols/selectionchange-expected.txt: Added.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::setSelectionWithoutUpdatingAppearance): Fire selectionchange event on input
element and textarea element when the selection resides within those elements.

* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::setValueCommon): Fixed a bug that this code was always updating selection
even when TextControlSetValueSelection::DoNotSet is passed in.

* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::selectionChanged): Made this function return a boolean indicating
whether the selection end points have changed or not.

(WebCore::HTMLTextFormControlElement::scheduleSelectEvent):
* Source/WebCore/html/HTMLTextFormControlElement.h:

Canonical link: <a href="https://commits.webkit.org/276238@main">https://commits.webkit.org/276238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb6dce60706f2a12359e0882525301191c96e9cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46742 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40127 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20562 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44678 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17369 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39084 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2150 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40266 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48336 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15643 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43199 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20440 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41926 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20664 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6051 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->