### PR TITLE
Move more ivars from WKWebViewConfiguration to API::PageConfiguration

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -237,6 +237,24 @@ public:
     bool needsStorageAccessFromFileURLsQuirk() const { return m_data.needsStorageAccessFromFileURLsQuirk; }
     void setNeedsStorageAccessFromFileURLsQuirk(bool needs) { m_data.needsStorageAccessFromFileURLsQuirk = needs; }
 
+    bool legacyEncryptedMediaAPIEnabled() const { return m_data.legacyEncryptedMediaAPIEnabled; }
+    void setLegacyEncryptedMediaAPIEnabled(bool enabled) { m_data.legacyEncryptedMediaAPIEnabled = enabled; }
+
+    bool allowMediaContentTypesRequiringHardwareSupportAsFallback() const { return m_data.allowMediaContentTypesRequiringHardwareSupportAsFallback; }
+    void setAllowMediaContentTypesRequiringHardwareSupportAsFallback(bool allow) { m_data.allowMediaContentTypesRequiringHardwareSupportAsFallback = allow; }
+
+    bool colorFilterEnabled() const { return m_data.colorFilterEnabled; }
+    void setColorFilterEnabled(bool enabled) { m_data.colorFilterEnabled = enabled; }
+
+    bool incompleteImageBorderEnabled() const { return m_data.incompleteImageBorderEnabled; }
+    void setIncompleteImageBorderEnabled(bool enabled) { m_data.incompleteImageBorderEnabled = enabled; }
+
+    bool shouldDeferAsynchronousScriptsUntilAfterDocumentLoad() const { return m_data.shouldDeferAsynchronousScriptsUntilAfterDocumentLoad; }
+    void setShouldDeferAsynchronousScriptsUntilAfterDocumentLoad(bool defer) { m_data.shouldDeferAsynchronousScriptsUntilAfterDocumentLoad = defer; }
+
+    bool undoManagerAPIEnabled() const { return m_data.undoManagerAPIEnabled; }
+    void setUndoManagerAPIEnabled(bool enabled) { m_data.undoManagerAPIEnabled = enabled; }
+
     void setShouldRelaxThirdPartyCookieBlocking(WebCore::ShouldRelaxThirdPartyCookieBlocking value) { m_data.shouldRelaxThirdPartyCookieBlocking = value; }
     WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking() const { return m_data.shouldRelaxThirdPartyCookieBlocking; }
 
@@ -348,6 +366,12 @@ private:
         bool allowUniversalAccessFromFileURLs { false };
         bool allowTopNavigationToDataURLs { false };
         bool needsStorageAccessFromFileURLsQuirk { true };
+        bool legacyEncryptedMediaAPIEnabled { true };
+        bool allowMediaContentTypesRequiringHardwareSupportAsFallback { true };
+        bool colorFilterEnabled { false };
+        bool incompleteImageBorderEnabled { false };
+        bool shouldDeferAsynchronousScriptsUntilAfterDocumentLoad { true };
+        bool undoManagerAPIEnabled { false };
 
         WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
         WTF::String attributedBundleIdentifier { };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -159,13 +159,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
 #if ENABLE(APPLE_PAY)
     BOOL _applePayEnabled;
 #endif
-    BOOL _legacyEncryptedMediaAPIEnabled;
-    BOOL _allowMediaContentTypesRequiringHardwareSupportAsFallback;
-    BOOL _colorFilterEnabled;
-    BOOL _incompleteImageBorderEnabled;
-    BOOL _shouldDeferAsynchronousScriptsUntilAfterDocumentLoad;
-    BOOL _drawsBackground;
-    BOOL _undoManagerAPIEnabled;
 #if ENABLE(APP_HIGHLIGHTS)
     BOOL _appHighlightsEnabled;
 #endif
@@ -207,7 +200,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     _mediaDataLoadsAutomatically = YES;
     _userInterfaceDirectionPolicy = WKUserInterfaceDirectionPolicyContent;
 #endif
-    _legacyEncryptedMediaAPIEnabled = YES;
     _mainContentUserGestureOverrideEnabled = NO;
     _invisibleAutoplayNotPermitted = NO;
     _attachmentElementEnabled = NO;
@@ -234,14 +226,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
 #endif // PLATFORM(IOS_FAMILY)
 
     _mediaContentTypesRequiringHardwareSupport = @"";
-    _allowMediaContentTypesRequiringHardwareSupportAsFallback = YES;
-
-    _colorFilterEnabled = NO;
-    _incompleteImageBorderEnabled = NO;
-    _shouldDeferAsynchronousScriptsUntilAfterDocumentLoad = YES;
-    _drawsBackground = YES;
-
-    _undoManagerAPIEnabled = NO;
 
 #if ENABLE(APPLE_PAY)
     _applePayEnabled = DEFAULT_VALUE_FOR_ApplePayEnabled;
@@ -416,16 +400,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     configuration->_mediaContentTypesRequiringHardwareSupport = adoptNS([self._mediaContentTypesRequiringHardwareSupport copyWithZone:zone]);
     configuration->_additionalSupportedImageTypes = adoptNS([self->_additionalSupportedImageTypes copyWithZone:zone]);
-    configuration->_legacyEncryptedMediaAPIEnabled = self->_legacyEncryptedMediaAPIEnabled;
-    configuration->_allowMediaContentTypesRequiringHardwareSupportAsFallback = self->_allowMediaContentTypesRequiringHardwareSupportAsFallback;
 
     configuration->_groupIdentifier = adoptNS([self->_groupIdentifier copyWithZone:zone]);
-    configuration->_colorFilterEnabled = self->_colorFilterEnabled;
-    configuration->_incompleteImageBorderEnabled = self->_incompleteImageBorderEnabled;
-    configuration->_shouldDeferAsynchronousScriptsUntilAfterDocumentLoad = self->_shouldDeferAsynchronousScriptsUntilAfterDocumentLoad;
-    configuration->_drawsBackground = self->_drawsBackground;
 
-    configuration->_undoManagerAPIEnabled = self->_undoManagerAPIEnabled;
 #if ENABLE(APP_HIGHLIGHTS)
     configuration->_appHighlightsEnabled = self->_appHighlightsEnabled;
 #endif
@@ -987,32 +964,32 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (BOOL)_colorFilterEnabled
 {
-    return _colorFilterEnabled;
+    return _pageConfiguration->colorFilterEnabled();
 }
 
 - (void)_setColorFilterEnabled:(BOOL)colorFilterEnabled
 {
-    _colorFilterEnabled = colorFilterEnabled;
+    _pageConfiguration->setColorFilterEnabled(colorFilterEnabled);
 }
 
 - (BOOL)_incompleteImageBorderEnabled
 {
-    return _incompleteImageBorderEnabled;
+    return _pageConfiguration->incompleteImageBorderEnabled();
 }
 
 - (void)_setIncompleteImageBorderEnabled:(BOOL)incompleteImageBorderEnabled
 {
-    _incompleteImageBorderEnabled = incompleteImageBorderEnabled;
+    _pageConfiguration->setIncompleteImageBorderEnabled(incompleteImageBorderEnabled);
 }
 
 - (BOOL)_shouldDeferAsynchronousScriptsUntilAfterDocumentLoad
 {
-    return _shouldDeferAsynchronousScriptsUntilAfterDocumentLoad;
+    return _pageConfiguration->shouldDeferAsynchronousScriptsUntilAfterDocumentLoad();
 }
 
 - (void)_setShouldDeferAsynchronousScriptsUntilAfterDocumentLoad:(BOOL)shouldDeferAsynchronousScriptsUntilAfterDocumentLoad
 {
-    _shouldDeferAsynchronousScriptsUntilAfterDocumentLoad = shouldDeferAsynchronousScriptsUntilAfterDocumentLoad;
+    _pageConfiguration->setShouldDeferAsynchronousScriptsUntilAfterDocumentLoad(shouldDeferAsynchronousScriptsUntilAfterDocumentLoad);
 }
 
 - (WKWebsiteDataStore *)_websiteDataStoreIfExists
@@ -1110,12 +1087,12 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (BOOL)_drawsBackground
 {
-    return _drawsBackground;
+    return _pageConfiguration->drawsBackground();
 }
 
 - (void)_setDrawsBackground:(BOOL)drawsBackground
 {
-    _drawsBackground = drawsBackground;
+    _pageConfiguration->setDrawsBackground(drawsBackground);
 }
 
 - (BOOL)_requiresUserActionForVideoPlayback
@@ -1324,22 +1301,22 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (void)_setLegacyEncryptedMediaAPIEnabled:(BOOL)enabled
 {
-    _legacyEncryptedMediaAPIEnabled = enabled;
+    _pageConfiguration->setLegacyEncryptedMediaAPIEnabled(enabled);
 }
 
 - (BOOL)_legacyEncryptedMediaAPIEnabled
 {
-    return _legacyEncryptedMediaAPIEnabled;
+    return _pageConfiguration->legacyEncryptedMediaAPIEnabled();
 }
 
 - (void)_setAllowMediaContentTypesRequiringHardwareSupportAsFallback:(BOOL)allow
 {
-    _allowMediaContentTypesRequiringHardwareSupportAsFallback = allow;
+    _pageConfiguration->setAllowMediaContentTypesRequiringHardwareSupportAsFallback(allow);
 }
 
 - (BOOL)_allowMediaContentTypesRequiringHardwareSupportAsFallback
 {
-    return _allowMediaContentTypesRequiringHardwareSupportAsFallback;
+    return _pageConfiguration->allowMediaContentTypesRequiringHardwareSupportAsFallback();
 }
 
 - (BOOL)_mediaCaptureEnabled
@@ -1354,12 +1331,12 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (void)_setUndoManagerAPIEnabled:(BOOL)enabled
 {
-    _undoManagerAPIEnabled = enabled;
+    _pageConfiguration->setUndoManagerAPIEnabled(enabled);
 }
 
 - (BOOL)_undoManagerAPIEnabled
 {
-    return _undoManagerAPIEnabled;
+    return _pageConfiguration->undoManagerAPIEnabled();
 }
 
 - (void)_setAppHighlightsEnabled:(BOOL)enabled


### PR DESCRIPTION
#### 55126806e72c760b8a83b281576adbd54931d6b1
<pre>
Move more ivars from WKWebViewConfiguration to API::PageConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=271034">https://bugs.webkit.org/show_bug.cgi?id=271034</a>
<a href="https://rdar.apple.com/124659985">rdar://124659985</a>

Reviewed by Sihui Liu.

This is in preparation for moving PageConfiguration initialization to platform-independent
WebPageProxy::createNewPage.

* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::legacyEncryptedMediaAPIEnabled const):
(API::PageConfiguration::setLegacyEncryptedMediaAPIEnabled):
(API::PageConfiguration::allowMediaContentTypesRequiringHardwareSupportAsFallback const):
(API::PageConfiguration::setAllowMediaContentTypesRequiringHardwareSupportAsFallback):
(API::PageConfiguration::colorFilterEnabled const):
(API::PageConfiguration::setColorFilterEnabled):
(API::PageConfiguration::incompleteImageBorderEnabled const):
(API::PageConfiguration::setIncompleteImageBorderEnabled):
(API::PageConfiguration::shouldDeferAsynchronousScriptsUntilAfterDocumentLoad const):
(API::PageConfiguration::setShouldDeferAsynchronousScriptsUntilAfterDocumentLoad):
(API::PageConfiguration::undoManagerAPIEnabled const):
(API::PageConfiguration::setUndoManagerAPIEnabled):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration init]):
(-[WKWebViewConfiguration copyWithZone:]):
(-[WKWebViewConfiguration _colorFilterEnabled]):
(-[WKWebViewConfiguration _setColorFilterEnabled:]):
(-[WKWebViewConfiguration _incompleteImageBorderEnabled]):
(-[WKWebViewConfiguration _setIncompleteImageBorderEnabled:]):
(-[WKWebViewConfiguration _shouldDeferAsynchronousScriptsUntilAfterDocumentLoad]):
(-[WKWebViewConfiguration _setShouldDeferAsynchronousScriptsUntilAfterDocumentLoad:]):
(-[WKWebViewConfiguration _drawsBackground]):
(-[WKWebViewConfiguration _setDrawsBackground:]):
(-[WKWebViewConfiguration _setLegacyEncryptedMediaAPIEnabled:]):
(-[WKWebViewConfiguration _legacyEncryptedMediaAPIEnabled]):
(-[WKWebViewConfiguration _setAllowMediaContentTypesRequiringHardwareSupportAsFallback:]):
(-[WKWebViewConfiguration _allowMediaContentTypesRequiringHardwareSupportAsFallback]):
(-[WKWebViewConfiguration _setUndoManagerAPIEnabled:]):
(-[WKWebViewConfiguration _undoManagerAPIEnabled]):

Canonical link: <a href="https://commits.webkit.org/276178@main">https://commits.webkit.org/276178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/929111c645589e5c5f3532371f08f62aa1025758

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46538 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39972 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36219 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17221 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17519 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1949 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40090 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48124 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43050 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20292 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41758 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20496 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6014 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19916 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->