### PR TITLE
Use std::span more in WebSocket code

### DIFF
--- a/Source/WTF/wtf/StreamBuffer.h
+++ b/Source/WTF/wtf/StreamBuffer.h
@@ -52,21 +52,22 @@ public:
 
     bool isEmpty() const { return !size(); }
 
-    void append(const T* data, size_t size)
+    void append(std::span<const T> data)
     {
-        if (!size)
+        if (!data.size())
             return;
 
-        m_size += size;
-        while (size) {
+        m_size += data.size();
+        while (data.size()) {
             if (!m_buffer.size() || m_buffer.last()->size() == BlockSize)
                 m_buffer.append(makeUnique<Block>());
-            size_t appendSize = std::min(BlockSize - m_buffer.last()->size(), size);
-            m_buffer.last()->append(data, appendSize);
-            data += appendSize;
-            size -= appendSize;
+            size_t appendSize = std::min(BlockSize - m_buffer.last()->size(), data.size());
+            m_buffer.last()->append(data.subspan(0, appendSize));
+            data = data.subspan(appendSize);
         }
     }
+
+    void append(const T* data, size_t size) { append(std::span { data, size }); }
 
     // This function consume data in the fist block.
     // Specified size must be less than over equal to firstBlockSize().
@@ -103,6 +104,8 @@ public:
         ASSERT(m_buffer.size() > 0);
         return m_buffer.first()->size() - m_readOffset;
     }
+
+    std::span<const T> firstBlockSpan() const { return std::span { firstBlockData(), firstBlockSize() }; }
 
 private:
     size_t m_size;

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -529,13 +529,13 @@ String String::fromUTF8(const CString& s)
     return fromUTF8(s.data());
 }
 
-String String::fromUTF8WithLatin1Fallback(const LChar* string, size_t size)
+String String::fromUTF8WithLatin1Fallback(std::span<const LChar> string)
 {
-    String utf8 = fromUTF8(string, size);
+    String utf8 = fromUTF8(string);
     if (!utf8) {
         // Do this assertion before chopping the size_t down to unsigned.
-        RELEASE_ASSERT(size <= String::MaxLength);
-        return String(string, size);
+        RELEASE_ASSERT(string.size() <= String::MaxLength);
+        return String(string);
     }
     return utf8;
 }

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -276,8 +276,11 @@ public:
     static String fromUTF8ReplacingInvalidSequences(const LChar*, size_t);
 
     // Tries to convert the passed in string to UTF-8, but will fall back to Latin-1 if the string is not valid UTF-8.
-    WTF_EXPORT_PRIVATE static String fromUTF8WithLatin1Fallback(const LChar*, size_t);
-    static String fromUTF8WithLatin1Fallback(const char* characters, size_t length) { return fromUTF8WithLatin1Fallback(reinterpret_cast<const LChar*>(characters), length); }
+    WTF_EXPORT_PRIVATE static String fromUTF8WithLatin1Fallback(std::span<const LChar>);
+
+    // FIXME: Update all call sites to pass a span and remove these 2 overloads.
+    static String fromUTF8WithLatin1Fallback(const LChar* characters, size_t length) { return fromUTF8WithLatin1Fallback(std::span { characters, length }); }
+    static String fromUTF8WithLatin1Fallback(const char* characters, size_t length) { return fromUTF8WithLatin1Fallback(std::span { reinterpret_cast<const LChar*>(characters), length }); }
 
     WTF_EXPORT_PRIVATE static String fromCodePoint(char32_t codePoint);
 

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -560,7 +560,7 @@ void WebSocket::didReceiveMessage(String&& message)
         if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
             if (auto* inspector = m_channel->channelInspector()) {
                 auto utf8Message = message.utf8();
-                inspector->didReceiveWebSocketFrame(WebSocketChannelInspector::createFrame(utf8Message.dataAsUInt8Ptr(), utf8Message.length(), WebSocketFrame::OpCode::OpCodeText));
+                inspector->didReceiveWebSocketFrame(WebSocketChannelInspector::createFrame(utf8Message.bytes(), WebSocketFrame::OpCode::OpCodeText));
             }
         }
         ASSERT(scriptExecutionContext());
@@ -577,7 +577,7 @@ void WebSocket::didReceiveBinaryData(Vector<uint8_t>&& binaryData)
 
         if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
             if (auto* inspector = m_channel->channelInspector())
-                inspector->didReceiveWebSocketFrame(WebSocketChannelInspector::createFrame(binaryData.data(), binaryData.size(), WebSocketFrame::OpCode::OpCodeBinary));
+                inspector->didReceiveWebSocketFrame(WebSocketChannelInspector::createFrame(binaryData.span(), WebSocketFrame::OpCode::OpCodeBinary));
         }
 
         switch (m_binaryType) {

--- a/Source/WebCore/Modules/websockets/WebSocketChannelInspector.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketChannelInspector.cpp
@@ -103,14 +103,13 @@ WebSocketChannelIdentifier WebSocketChannelInspector::progressIdentifier() const
     return m_progressIdentifier;
 }
 
-WebSocketFrame WebSocketChannelInspector::createFrame(const uint8_t* data, size_t length, WebSocketFrame::OpCode opCode)
+WebSocketFrame WebSocketChannelInspector::createFrame(std::span<const uint8_t> data, WebSocketFrame::OpCode opCode)
 {
     // This is an approximation since frames can be merged on a single message.
     WebSocketFrame frame;
     frame.opCode = opCode;
     frame.masked = false;
     frame.payload = data;
-    frame.payloadLength = length;
 
     // WebInspector does not use them.
     frame.final = false;

--- a/Source/WebCore/Modules/websockets/WebSocketChannelInspector.h
+++ b/Source/WebCore/Modules/websockets/WebSocketChannelInspector.h
@@ -56,7 +56,7 @@ public:
     
     WebSocketChannelIdentifier progressIdentifier() const;
 
-    static WebSocketFrame createFrame(const uint8_t* data, size_t length, WebSocketFrame::OpCode);
+    static WebSocketFrame createFrame(std::span<const uint8_t> data, WebSocketFrame::OpCode);
 
 private:
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;

--- a/Source/WebCore/Modules/websockets/WebSocketDeflateFramer.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflateFramer.cpp
@@ -158,15 +158,14 @@ void WebSocketDeflateFramer::enableDeflate(int windowBits, WebSocketDeflater::Co
 std::unique_ptr<DeflateResultHolder> WebSocketDeflateFramer::deflate(WebSocketFrame& frame)
 {
     auto result = makeUnique<DeflateResultHolder>(*this);
-    if (!enabled() || !WebSocketFrame::isNonControlOpCode(frame.opCode) || !frame.payloadLength)
+    if (!enabled() || !WebSocketFrame::isNonControlOpCode(frame.opCode) || !frame.payload.size())
         return result;
-    if (!m_deflater->addBytes(frame.payload, frame.payloadLength) || !m_deflater->finish()) {
+    if (!m_deflater->addBytes(frame.payload) || !m_deflater->finish()) {
         result->fail("Failed to compress frame"_s);
         return result;
     }
     frame.compress = true;
-    frame.payload = m_deflater->data();
-    frame.payloadLength = m_deflater->size();
+    frame.payload = m_deflater->bytes();
     return result;
 }
 
@@ -189,13 +188,12 @@ std::unique_ptr<InflateResultHolder> WebSocketDeflateFramer::inflate(WebSocketFr
         result->fail("Received unexpected compressed frame"_s);
         return result;
     }
-    if (!m_inflater->addBytes(frame.payload, frame.payloadLength) || !m_inflater->finish()) {
+    if (!m_inflater->addBytes(frame.payload) || !m_inflater->finish()) {
         result->fail("Failed to decompress frame"_s);
         return result;
     }
     frame.compress = false;
-    frame.payload = m_inflater->data();
-    frame.payloadLength = m_inflater->size();
+    frame.payload = m_inflater->bytes();
     return result;
 }
 

--- a/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
@@ -64,20 +64,20 @@ WebSocketDeflater::~WebSocketDeflater()
         LOG(Network, "WebSocketDeflater %p Destructor deflateEnd() failed: %d is returned", this, result);
 }
 
-static void setStreamParameter(z_stream* stream, const uint8_t* inputData, size_t inputLength, uint8_t* outputData, size_t outputLength)
+static void setStreamParameter(z_stream* stream, std::span<const uint8_t> inputData, uint8_t* outputData, size_t outputLength)
 {
-    stream->next_in = const_cast<uint8_t*>(inputData);
-    stream->avail_in = inputLength;
+    stream->next_in = const_cast<uint8_t*>(inputData.data());
+    stream->avail_in = inputData.size();
     stream->next_out = outputData;
     stream->avail_out = outputLength;
 }
 
-bool WebSocketDeflater::addBytes(const uint8_t* data, size_t length)
+bool WebSocketDeflater::addBytes(std::span<const uint8_t> data)
 {
-    if (!length)
+    if (!data.size())
         return false;
 
-    size_t maxLength = deflateBound(m_stream.get(), length);
+    size_t maxLength = deflateBound(m_stream.get(), data.size());
     size_t writePosition = m_buffer.size();
     CheckedSize bufferSize = maxLength;
     bufferSize += writePosition; 
@@ -85,7 +85,7 @@ bool WebSocketDeflater::addBytes(const uint8_t* data, size_t length)
         return false;
 
     m_buffer.grow(bufferSize.value());
-    setStreamParameter(m_stream.get(), data, length, m_buffer.data() + writePosition, maxLength);
+    setStreamParameter(m_stream.get(), data, m_buffer.data() + writePosition, maxLength);
     int result = deflate(m_stream.get(), Z_NO_FLUSH);
     if (result != Z_OK || m_stream->avail_in > 0)
         return false;
@@ -105,7 +105,7 @@ bool WebSocketDeflater::finish()
 
         m_buffer.grow(bufferSize.value());
         size_t availableCapacity = m_buffer.size() - writePosition;
-        setStreamParameter(m_stream.get(), 0, 0, m_buffer.data() + writePosition, availableCapacity);
+        setStreamParameter(m_stream.get(), { }, m_buffer.data() + writePosition, availableCapacity);
         int result = deflate(m_stream.get(), Z_SYNC_FLUSH);
         if (m_stream->avail_out) {
             m_buffer.shrink(writePosition + availableCapacity - m_stream->avail_out);
@@ -148,13 +148,13 @@ WebSocketInflater::~WebSocketInflater()
         LOG(Network, "WebSocketInflater %p Destructor inflateEnd() failed: %d is returned", this, result);
 }
 
-bool WebSocketInflater::addBytes(const uint8_t* data, size_t length)
+bool WebSocketInflater::addBytes(std::span<const uint8_t> data)
 {
-    if (!length)
+    if (!data.size())
         return false;
 
     size_t consumedSoFar = 0;
-    while (consumedSoFar < length) {
+    while (consumedSoFar < data.size()) {
         size_t writePosition = m_buffer.size();
         CheckedSize bufferSize = writePosition;
         bufferSize += bufferIncrementUnit; 
@@ -163,8 +163,8 @@ bool WebSocketInflater::addBytes(const uint8_t* data, size_t length)
 
         m_buffer.grow(bufferSize.value());
         size_t availableCapacity = m_buffer.size() - writePosition;
-        size_t remainingLength = length - consumedSoFar;
-        setStreamParameter(m_stream.get(), data + consumedSoFar, remainingLength, m_buffer.data() + writePosition, availableCapacity);
+        size_t remainingLength = data.size() - consumedSoFar;
+        setStreamParameter(m_stream.get(), data.subspan(consumedSoFar, remainingLength), m_buffer.data() + writePosition, availableCapacity);
         int result = inflate(m_stream.get(), Z_NO_FLUSH);
         consumedSoFar += remainingLength - m_stream->avail_in;
         m_buffer.shrink(writePosition + availableCapacity - m_stream->avail_out);
@@ -180,18 +180,17 @@ bool WebSocketInflater::addBytes(const uint8_t* data, size_t length)
             return false;
         ASSERT(remainingLength > m_stream->avail_in);
     }
-    ASSERT(consumedSoFar == length);
+    ASSERT(consumedSoFar == data.size());
     return true;
 }
 
 bool WebSocketInflater::finish()
 {
-    constexpr uint8_t strippedFields[] = { 0, 0, 0xFF, 0xFF };
-    constexpr auto strippedLength = std::size(strippedFields);
+    constexpr std::array<uint8_t, 4> strippedFields { 0, 0, 0xFF, 0xFF };
 
     // Appends 4 octests of 0x00 0x00 0xff 0xff
     size_t consumedSoFar = 0;
-    while (consumedSoFar < strippedLength) {
+    while (consumedSoFar < strippedFields.size()) {
         size_t writePosition = m_buffer.size();
         CheckedSize bufferSize = writePosition;
         bufferSize += bufferIncrementUnit; 
@@ -200,8 +199,8 @@ bool WebSocketInflater::finish()
 
         m_buffer.grow(bufferSize.value());
         size_t availableCapacity = m_buffer.size() - writePosition;
-        size_t remainingLength = strippedLength - consumedSoFar;
-        setStreamParameter(m_stream.get(), strippedFields + consumedSoFar, remainingLength, m_buffer.data() + writePosition, availableCapacity);
+        size_t remainingLength = strippedFields.size() - consumedSoFar;
+        setStreamParameter(m_stream.get(), std::span { strippedFields.data() + consumedSoFar, remainingLength }, m_buffer.data() + writePosition, availableCapacity);
         int result = inflate(m_stream.get(), Z_FINISH);
         consumedSoFar += remainingLength - m_stream->avail_in;
         m_buffer.shrink(writePosition + availableCapacity - m_stream->avail_out);
@@ -211,7 +210,7 @@ bool WebSocketInflater::finish()
             return false;
         ASSERT(remainingLength > m_stream->avail_in);
     }
-    ASSERT(consumedSoFar == strippedLength);
+    ASSERT(consumedSoFar == strippedFields.size());
 
     return true;
 }

--- a/Source/WebCore/Modules/websockets/WebSocketDeflater.h
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflater.h
@@ -49,10 +49,11 @@ public:
     WEBCORE_EXPORT ~WebSocketDeflater();
 
     bool initialize();
-    bool addBytes(const uint8_t*, size_t);
+    bool addBytes(std::span<const uint8_t>);
     bool finish();
     const uint8_t* data() { return m_buffer.data(); }
     size_t size() const { return m_buffer.size(); }
+    std::span<const uint8_t> bytes() const { return m_buffer.span(); }
     void reset();
 
 private:
@@ -69,10 +70,11 @@ public:
     WEBCORE_EXPORT ~WebSocketInflater();
 
     bool initialize();
-    bool addBytes(const uint8_t*, size_t);
+    bool addBytes(std::span<const uint8_t>);
     bool finish();
-    const uint8_t* data() { return m_buffer.data(); }
+    const uint8_t* data() const { return m_buffer.data(); }
     size_t size() const { return m_buffer.size(); }
+    std::span<const uint8_t> bytes() const { return m_buffer.span(); }
     void reset();
 
 private:

--- a/Source/WebCore/Modules/websockets/WebSocketFrame.h
+++ b/Source/WebCore/Modules/websockets/WebSocketFrame.h
@@ -58,7 +58,7 @@ struct WebSocketFrame {
     WEBCORE_EXPORT static bool needsExtendedLengthField(size_t payloadLength);
     WEBCORE_EXPORT static ParseFrameResult parseFrame(uint8_t* data, size_t dataLength, WebSocketFrame&, const uint8_t*& frameEnd, String& errorString); // May modify part of data to unmask the frame.
 
-    WEBCORE_EXPORT WebSocketFrame(OpCode = OpCodeInvalid, bool final = false, bool compress = false, bool masked = false, const uint8_t* payload = nullptr, size_t payloadLength = 0);
+    WEBCORE_EXPORT WebSocketFrame(OpCode = OpCodeInvalid, bool final = false, bool compress = false, bool masked = false, std::span<const uint8_t> payload = { });
     WEBCORE_EXPORT void makeFrameData(Vector<uint8_t>& frameData);
 
     OpCode opCode;
@@ -67,8 +67,7 @@ struct WebSocketFrame {
     bool reserved2;
     bool reserved3;
     bool masked;
-    const uint8_t* payload;
-    size_t payloadLength;
+    std::span<const uint8_t> payload;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -175,8 +175,8 @@ Ref<Inspector::Protocol::Network::WebSocketFrame> buildWebSocketMessage(const We
     return Inspector::Protocol::Network::WebSocketFrame::create()
         .setOpcode(frame.opCode)
         .setMask(frame.masked)
-        .setPayloadData(frame.opCode == 1 ? String::fromUTF8WithLatin1Fallback(frame.payload, frame.payloadLength) : base64EncodeToString(frame.payload, frame.payloadLength))
-        .setPayloadLength(frame.payloadLength)
+        .setPayloadData(frame.opCode == 1 ? String::fromUTF8WithLatin1Fallback(frame.payload) : base64EncodeToString(frame.payload))
+        .setPayloadLength(frame.payload.size())
         .release();
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
@@ -114,9 +114,9 @@ void NetworkSocketChannel::didReceiveText(const String& text)
     send(Messages::WebSocketChannel::DidReceiveText { text });
 }
 
-void NetworkSocketChannel::didReceiveBinaryData(const uint8_t* data, size_t length)
+void NetworkSocketChannel::didReceiveBinaryData(std::span<const uint8_t> data)
 {
-    send(Messages::WebSocketChannel::DidReceiveBinaryData { { data, length } });
+    send(Messages::WebSocketChannel::DidReceiveBinaryData { data });
 }
 
 void NetworkSocketChannel::didClose(unsigned short code, const String& reason)

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
@@ -72,7 +72,7 @@ public:
 private:
     void didConnect(const String& subprotocol, const String& extensions);
     void didReceiveText(const String&);
-    void didReceiveBinaryData(const uint8_t* data, size_t length);
+    void didReceiveBinaryData(std::span<const uint8_t>);
     void didClose(unsigned short code, const String& reason);
     void didReceiveMessageError(String&&);
     void didSendHandshakeRequest(WebCore::ResourceRequest&&);

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -34,6 +34,7 @@
 #import <WebCore/ResourceResponse.h>
 #import <WebCore/ThreadableWebSocketChannel.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 namespace WebKit {
 
@@ -91,7 +92,7 @@ void WebSocketTask::readNextMessage()
         if (message.type == NSURLSessionWebSocketMessageTypeString)
             m_channel.didReceiveText(message.string);
         else
-            m_channel.didReceiveBinaryData(static_cast<const uint8_t*>(message.data.bytes), message.data.length);
+            m_channel.didReceiveBinaryData(toSpan(message.data));
 
         readNextMessage();
     }).get()];

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
@@ -86,10 +86,10 @@ private:
     void skipReceivedBuffer(size_t len);
 
     Expected<bool, String> validateOpeningHandshake();
-    std::optional<String> receiveFrames(Function<void(WebCore::WebSocketFrame::OpCode, const uint8_t*, size_t)>&&);
+    std::optional<String> receiveFrames(Function<void(WebCore::WebSocketFrame::OpCode, std::span<const uint8_t>)>&&);
     std::optional<String> validateFrame(const WebCore::WebSocketFrame&);
 
-    bool sendFrame(WebCore::WebSocketFrame::OpCode, const uint8_t* data, size_t dataLength);
+    bool sendFrame(WebCore::WebSocketFrame::OpCode, std::span<const uint8_t> data);
     void sendClosingHandshakeIfNeeded(int32_t, const String& reason);
 
     void didFail(String&& reason);

--- a/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp
@@ -175,13 +175,14 @@ void WebSocketTask::didReceiveMessageCallback(WebSocketTask* task, SoupWebsocket
 
     gsize dataSize;
     const auto* data = g_bytes_get_data(message, &dataSize);
+    std::span dataSpan { static_cast<const uint8_t*>(data), dataSize };
 
     switch (dataType) {
     case SOUP_WEBSOCKET_DATA_TEXT:
-        task->m_channel.didReceiveText(String::fromUTF8(static_cast<const char*>(data), dataSize));
+        task->m_channel.didReceiveText(String::fromUTF8(dataSpan));
         break;
     case SOUP_WEBSOCKET_DATA_BINARY:
-        task->m_channel.didReceiveBinaryData(static_cast<const uint8_t*>(data), dataSize);
+        task->m_channel.didReceiveBinaryData(dataSpan);
         break;
     }
 }

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.h
@@ -80,7 +80,7 @@ private:
     void refThreadableWebSocketChannel() final { ref(); }
     void derefThreadableWebSocketChannel() final { deref(); }
 
-    void notifySendFrame(WebCore::WebSocketFrame::OpCode, const uint8_t* data, size_t length);
+    void notifySendFrame(WebCore::WebSocketFrame::OpCode, std::span<const uint8_t> data);
     void logErrorMessage(const String&);
 
     // Message receivers

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp
@@ -49,18 +49,18 @@ SocketStreamHandle::SocketStreamState SocketStreamHandle::state() const
     return m_state;
 }
 
-void SocketStreamHandle::sendData(const uint8_t* data, size_t length, Function<void(bool)> completionHandler)
+void SocketStreamHandle::sendData(std::span<const uint8_t> data, Function<void(bool)> completionHandler)
 {
     if (m_state == Connecting || m_state == Closing)
         return completionHandler(false);
-    platformSend(data, length, WTFMove(completionHandler));
+    platformSend(data, WTFMove(completionHandler));
 }
 
 void SocketStreamHandle::sendHandshake(CString&& handshake, std::optional<CookieRequestHeaderFieldProxy>&& headerFieldProxy, Function<void(bool, bool)> completionHandler)
 {
     if (m_state == Connecting || m_state == Closing)
         return completionHandler(false, false);
-    platformSendHandshake(handshake.dataAsUInt8Ptr(), handshake.length(), WTFMove(headerFieldProxy), WTFMove(completionHandler));
+    platformSendHandshake(handshake.bytes(), WTFMove(headerFieldProxy), WTFMove(completionHandler));
 }
 
 void SocketStreamHandle::close()

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.h
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.h
@@ -53,7 +53,7 @@ public:
     virtual ~SocketStreamHandle() = default;
     SocketStreamState state() const;
 
-    void sendData(const uint8_t* data, size_t length, Function<void(bool)>);
+    void sendData(std::span<const uint8_t> data, Function<void(bool)>);
     void sendHandshake(CString&& handshake, std::optional<CookieRequestHeaderFieldProxy>&&, Function<void(bool, bool)>);
     void close(); // Disconnect after all data in buffer are sent.
     void disconnect();
@@ -62,8 +62,8 @@ public:
 protected:
     WEBCORE_EXPORT SocketStreamHandle(const URL&, SocketStreamHandleClient&);
 
-    virtual void platformSend(const uint8_t* data, size_t length, Function<void(bool)>&&) = 0;
-    virtual void platformSendHandshake(const uint8_t* data, size_t length, const std::optional<CookieRequestHeaderFieldProxy>&, Function<void(bool, bool)>&&) = 0;
+    virtual void platformSend(std::span<const uint8_t> data, Function<void(bool)>&&) = 0;
+    virtual void platformSendHandshake(std::span<const uint8_t> data, const std::optional<CookieRequestHeaderFieldProxy>&, Function<void(bool, bool)>&&) = 0;
     virtual void platformClose() = 0;
 
     URL m_url;

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.cpp
@@ -35,47 +35,47 @@
 
 namespace WebCore {
 
-void SocketStreamHandleImpl::platformSend(const uint8_t* data, size_t length, Function<void(bool)>&& completionHandler)
+void SocketStreamHandleImpl::platformSend(std::span<const uint8_t> data, Function<void(bool)>&& completionHandler)
 {
     if (!m_buffer.isEmpty()) {
-        if (m_buffer.size() + length > maxBufferSize) {
+        if (m_buffer.size() + data.size() > maxBufferSize) {
             // FIXME: report error to indicate that buffer has no more space.
             return completionHandler(false);
         }
-        m_buffer.append(data, length);
+        m_buffer.append(data);
         m_client.didUpdateBufferedAmount(*this, bufferedAmount());
         return completionHandler(true);
     }
     size_t bytesWritten = 0;
     if (m_state == Open) {
-        if (auto result = platformSendInternal(data, length))
+        if (auto result = platformSendInternal(data))
             bytesWritten = result.value();
         else
             return completionHandler(false);
     }
-    if (m_buffer.size() + length - bytesWritten > maxBufferSize) {
+    if (m_buffer.size() + data.size() - bytesWritten > maxBufferSize) {
         // FIXME: report error to indicate that buffer has no more space.
         return completionHandler(false);
     }
-    if (bytesWritten < length) {
-        m_buffer.append(data + bytesWritten, length - bytesWritten);
+    if (bytesWritten < data.size()) {
+        m_buffer.append(data.subspan(bytesWritten));
         m_client.didUpdateBufferedAmount(static_cast<SocketStreamHandle&>(*this), bufferedAmount());
     }
     return completionHandler(true);
 }
 
-static size_t removeTerminationCharacters(const uint8_t* data, size_t dataLength)
+static std::span<const uint8_t> removeTerminationCharacters(std::span<const uint8_t> data)
 {
 #ifndef NDEBUG
-    ASSERT(dataLength > 2);
-    ASSERT(data[dataLength - 2] == '\r');
-    ASSERT(data[dataLength - 1] == '\n');
+    ASSERT(data.size() > 2);
+    ASSERT(data[data.size() - 2] == '\r');
+    ASSERT(data[data.size() - 1] == '\n');
 #else
     UNUSED_PARAM(data);
 #endif
 
     // Remove the terminating '\r\n'
-    return dataLength - 2;
+    return data.subspan(0, data.size() - 2);
 }
 
 static std::optional<std::pair<Vector<uint8_t>, bool>> cookieDataForHandshake(const NetworkStorageSession* networkStorageSession, const CookieRequestHeaderFieldProxy& headerFieldProxy)
@@ -96,7 +96,7 @@ static std::optional<std::pair<Vector<uint8_t>, bool>> cookieDataForHandshake(co
     return std::pair<Vector<uint8_t>, bool> { data, secureCookiesAccessed };
 }
 
-void SocketStreamHandleImpl::platformSendHandshake(const uint8_t* data, size_t length, const std::optional<CookieRequestHeaderFieldProxy>& headerFieldProxy, Function<void(bool, bool)>&& completionHandler)
+void SocketStreamHandleImpl::platformSendHandshake(std::span<const uint8_t> data, const std::optional<CookieRequestHeaderFieldProxy>& headerFieldProxy, Function<void(bool, bool)>&& completionHandler)
 {
     Vector<uint8_t> cookieData;
     bool secureCookiesAccessed = false;
@@ -110,15 +110,15 @@ void SocketStreamHandleImpl::platformSendHandshake(const uint8_t* data, size_t l
 
         std::tie(cookieData, secureCookiesAccessed) = *cookieDataFromNetworkSession;
         if (cookieData.size())
-            length = removeTerminationCharacters(data, length);
+            data = removeTerminationCharacters(data);
     }
 
     if (!m_buffer.isEmpty()) {
-        if (m_buffer.size() + length + cookieData.size() > maxBufferSize) {
+        if (m_buffer.size() + data.size() + cookieData.size() > maxBufferSize) {
             // FIXME: report error to indicate that buffer has no more space.
             return completionHandler(false, secureCookiesAccessed);
         }
-        m_buffer.append(data, length);
+        m_buffer.append(data);
         m_buffer.append(cookieData.data(), cookieData.size());
         m_client.didUpdateBufferedAmount(*this, bufferedAmount());
         return completionHandler(true, secureCookiesAccessed);
@@ -127,25 +127,25 @@ void SocketStreamHandleImpl::platformSendHandshake(const uint8_t* data, size_t l
     if (m_state == Open) {
         // Unfortunately, we need to send the data in one buffer or else the handshake fails.
         Vector<uint8_t> sendData;
-        sendData.reserveInitialCapacity(length + cookieData.size());
-        sendData.append(data, length);
+        sendData.reserveInitialCapacity(data.size() + cookieData.size());
+        sendData.append(data);
         sendData.append(cookieData.data(), cookieData.size());
 
-        if (auto result = platformSendInternal(sendData.data(), sendData.size()))
+        if (auto result = platformSendInternal(sendData.span()))
             bytesWritten = result.value();
         else
             return completionHandler(false, secureCookiesAccessed);
     }
-    if (m_buffer.size() + length + cookieData.size() - bytesWritten > maxBufferSize) {
+    if (m_buffer.size() + data.size() + cookieData.size() - bytesWritten > maxBufferSize) {
         // FIXME: report error to indicate that buffer has no more space.
         return completionHandler(false, secureCookiesAccessed);
     }
-    if (bytesWritten < length + cookieData.size()) {
+    if (bytesWritten < data.size() + cookieData.size()) {
         size_t cookieBytesWritten = 0;
-        if (bytesWritten < length)
-            m_buffer.append(data + bytesWritten, length - bytesWritten);
+        if (bytesWritten < data.size())
+            m_buffer.append(data.subspan(bytesWritten));
         else
-            cookieBytesWritten = bytesWritten - length;
+            cookieBytesWritten = bytesWritten - data.size();
         m_buffer.append(cookieData.data() + cookieBytesWritten, cookieData.size() - cookieBytesWritten);
         m_client.didUpdateBufferedAmount(static_cast<SocketStreamHandle&>(*this), bufferedAmount());
     }
@@ -166,7 +166,7 @@ bool SocketStreamHandleImpl::sendPendingData()
     }
     bool pending;
     do {
-        auto result = platformSendInternal(m_buffer.firstBlockData(), m_buffer.firstBlockSize());
+        auto result = platformSendInternal(m_buffer.firstBlockSpan());
         if (!result)
             return false;
         size_t bytesWritten = result.value();

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.h
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.h
@@ -51,17 +51,17 @@ public:
 
     virtual ~SocketStreamHandleImpl();
 
-    WEBCORE_EXPORT static void setLegacyTLSEnabled(bool);
+    static void setLegacyTLSEnabled(bool);
 
-    WEBCORE_EXPORT void platformSend(const uint8_t* data, size_t length, Function<void(bool)>&&) final;
-    WEBCORE_EXPORT void platformSendHandshake(const uint8_t* data, size_t length, const std::optional<CookieRequestHeaderFieldProxy>&, Function<void(bool, bool)>&&) final;
-    WEBCORE_EXPORT void platformClose() final;
+    void platformSend(std::span<const uint8_t> data, Function<void(bool)>&&) final;
+    void platformSendHandshake(std::span<const uint8_t> data, const std::optional<CookieRequestHeaderFieldProxy>&, Function<void(bool, bool)>&&) final;
+    void platformClose() final;
 private:
     size_t bufferedAmount() final;
-    std::optional<size_t> platformSendInternal(const uint8_t*, size_t);
+    std::optional<size_t> platformSendInternal(std::span<const uint8_t>);
     bool sendPendingData();
 
-    WEBCORE_EXPORT SocketStreamHandleImpl(const URL&, SocketStreamHandleClient&, PAL::SessionID, const String& credentialPartition, SourceApplicationAuditToken&&, const StorageSessionProvider*, bool shouldAcceptInsecureCertificates);
+    SocketStreamHandleImpl(const URL&, SocketStreamHandleClient&, PAL::SessionID, const String& credentialPartition, SourceApplicationAuditToken&&, const StorageSessionProvider*, bool shouldAcceptInsecureCertificates);
     void createStreams();
     void scheduleStreams();
     void chooseProxy();

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
@@ -677,7 +677,7 @@ SocketStreamHandleImpl::~SocketStreamHandleImpl()
     ASSERT(!m_pacRunLoopSource);
 }
 
-std::optional<size_t> SocketStreamHandleImpl::platformSendInternal(const uint8_t* data, size_t length)
+std::optional<size_t> SocketStreamHandleImpl::platformSendInternal(std::span<const uint8_t> data)
 {
     if (!m_writeStream)
         return 0;
@@ -685,7 +685,7 @@ std::optional<size_t> SocketStreamHandleImpl::platformSendInternal(const uint8_t
     if (!CFWriteStreamCanAcceptBytes(m_writeStream.get()))
         return 0;
 
-    CFIndex result = CFWriteStreamWrite(m_writeStream.get(), data, length);
+    CFIndex result = CFWriteStreamWrite(m_writeStream.get(), data.data(), data.size());
     if (result == -1)
         return std::nullopt;
 

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
@@ -169,7 +169,7 @@ private:
 
     // If you are going to send a hybi-10 frame, you need to use the outgoing frame queue
     // instead of call sendFrame() directly.
-    void sendFrame(WebSocketFrame::OpCode, const uint8_t* data, size_t dataLength, Function<void(bool)> completionHandler);
+    void sendFrame(WebSocketFrame::OpCode, std::span<const uint8_t> data, Function<void(bool)> completionHandler);
 
     enum BlobLoaderStatus {
         BlobLoaderNotStarted,


### PR DESCRIPTION
#### de69356648cfb170e76b2e42d567049156356a71
<pre>
Use std::span more in WebSocket code
<a href="https://bugs.webkit.org/show_bug.cgi?id=271035">https://bugs.webkit.org/show_bug.cgi?id=271035</a>

Reviewed by Brent Fulgham.

Use std::span more in WebSocket code. This is work towards more widespread
std::span adoption in WebKit, which has security benefits.

* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/WTF/wtf/StreamBuffer.h:
(WTF::StreamBuffer::append):
(WTF::StreamBuffer::firstBlockSpan const):
* Source/WTF/wtf/text/WTFString.h:
(WTF::String::fromUTF8):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::didReceiveMessage):
(WebCore::WebSocket::didReceiveBinaryData):
* Source/WebCore/Modules/websockets/WebSocketChannelInspector.cpp:
(WebCore::WebSocketChannelInspector::createFrame):
* Source/WebCore/Modules/websockets/WebSocketChannelInspector.h:
* Source/WebCore/Modules/websockets/WebSocketDeflateFramer.cpp:
(WebCore::WebSocketDeflateFramer::deflate):
(WebCore::WebSocketDeflateFramer::inflate):
* Source/WebCore/Modules/websockets/WebSocketDeflater.cpp:
(WebCore::setStreamParameter):
(WebCore::WebSocketDeflater::addBytes):
(WebCore::WebSocketDeflater::finish):
(WebCore::WebSocketInflater::addBytes):
(WebCore::WebSocketInflater::finish):
* Source/WebCore/Modules/websockets/WebSocketDeflater.h:
(WebCore::WebSocketDeflater::bytes const):
(WebCore::WebSocketInflater::data const):
(WebCore::WebSocketInflater::bytes const):
(WebCore::WebSocketInflater::data): Deleted.
* Source/WebCore/Modules/websockets/WebSocketFrame.cpp:
(WebCore::WebSocketFrame::parseFrame):
(WebCore::appendFramePayload):
(WebCore::WebSocketFrame::makeFrameData):
(WebCore::WebSocketFrame::WebSocketFrame):
* Source/WebCore/Modules/websockets/WebSocketFrame.h:
(WebCore::WebSocketFrame::WebSocketFrame):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::Inspector::buildWebSocketMessage):
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::notifySendFrame):
(WebKit::WebSocketChannel::createMessageQueue):
* Source/WebKit/WebProcess/Network/WebSocketChannel.h:
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp:
(WebCore::SocketStreamHandle::sendData):
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.h:
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.cpp:
(WebCore::SocketStreamHandleImpl::platformSend):
(WebCore::SocketStreamHandleImpl::platformSendHandshake):
(WebCore::SocketStreamHandleImpl::sendPendingData):
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.h:
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp:
(WebCore::SocketStreamHandleImpl::platformSendInternal):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::send):
(WebCore::WebSocketChannel::startClosingHandshake):
(WebCore::WebSocketChannel::processFrame):
(WebCore::WebSocketChannel::enqueueRawFrame):
(WebCore::WebSocketChannel::processOutgoingFrameQueue):
(WebCore::WebSocketChannel::sendFrame):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h:

Canonical link: <a href="https://commits.webkit.org/276224@main">https://commits.webkit.org/276224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cf636e1cea74965d4cb89b5de8c983dabd4e88f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46728 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20546 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20174 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/39062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2135 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/37411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/39351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48312 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/43647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15628 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50724 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6041 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/20056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10237 "Passed tests") | 
<!--EWS-Status-Bubble-End-->