### PR TITLE
[Legacy line layout removal] Remove horizontal inline box positioning

### DIFF
--- a/Source/WebCore/rendering/LegacyInlineFlowBox.h
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.h
@@ -41,8 +41,6 @@ class LegacyInlineFlowBox : public LegacyInlineBox {
 public:
     explicit LegacyInlineFlowBox(RenderBoxModelObject& renderer)
         : LegacyInlineBox(renderer)
-        , m_includeLogicalLeftEdge(false)
-        , m_includeLogicalRightEdge(false)
         , m_hasHardLinebreak(false)
         , m_descendantsHaveSameLineHeightAndBaseline(true)
         , m_baselineType(AlphabeticBaseline)
@@ -118,41 +116,16 @@ public:
     inline LayoutUnit marginBorderPaddingLogicalRight() const;
     LayoutUnit marginLogicalLeft() const
     {
-        if (!includeLogicalLeftEdge())
-            return 0;
-        return isHorizontal() ? renderer().marginLeft() : renderer().marginTop();
+        return 0;
     }
     LayoutUnit marginLogicalRight() const
     {
-        if (!includeLogicalRightEdge())
-            return 0;
-        return isHorizontal() ? renderer().marginRight() : renderer().marginBottom();
+        return 0;
     }
     inline float borderLogicalLeft() const;
     inline float borderLogicalRight() const;
     inline float paddingLogicalLeft() const;
     inline float paddingLogicalRight() const;
-
-    bool includeLogicalLeftEdge() const { return m_includeLogicalLeftEdge; }
-    bool includeLogicalRightEdge() const { return m_includeLogicalRightEdge; }
-    void setEdges(bool includeLeft, bool includeRight)
-    {
-        m_includeLogicalLeftEdge = includeLeft;
-        m_includeLogicalRightEdge = includeRight;
-    }
-
-    // Helper functions used during line construction and placement.
-    void determineSpacingForFlowBoxes(bool lastLine, bool isLogicallyLastRunWrapped, RenderObject* logicallyLastRunRenderer);
-    LayoutUnit getFlowSpacingLogicalWidth();
-    float placeBoxesInInlineDirection(float logicalLeft, bool& needsWordSpacing);
-    float placeBoxRangeInInlineDirection(LegacyInlineBox* firstChild, LegacyInlineBox* lastChild, float& logicalLeft, float& minLogicalLeft, float& maxLogicalRight, bool& needsWordSpacing);
-    void beginPlacingBoxRangesInInlineDirection(float logicalLeft) { setLogicalLeft(logicalLeft); }
-    void endPlacingBoxRangesInInlineDirection(float logicalLeft, float logicalRight, float minLogicalLeft, float maxLogicalRight)
-    {
-        setLogicalWidth(logicalRight - logicalLeft);
-        if (knownToHaveNoOverflow() && (minLogicalLeft < logicalLeft || maxLogicalRight > logicalRight))
-            clearKnownToHaveNoOverflow();
-    }
 
     LayoutUnit computeOverAnnotationAdjustment(LayoutUnit allowedPosition) const;
     LayoutUnit computeUnderAnnotationAdjustment(LayoutUnit allowedPosition) const;
@@ -262,8 +235,6 @@ private:
     void addReplacedChildOverflow(const LegacyInlineBox*, LayoutRect& logicalLayoutOverflow, LayoutRect& logicalVisualOverflow);
 
 private:
-    unsigned m_includeLogicalLeftEdge : 1;
-    unsigned m_includeLogicalRightEdge : 1;
     unsigned m_hasTextChildren : 1;
     unsigned m_hasTextDescendants : 1;
     unsigned m_hasHardLinebreak : 1;

--- a/Source/WebCore/rendering/LegacyInlineFlowBoxInlines.h
+++ b/Source/WebCore/rendering/LegacyInlineFlowBoxInlines.h
@@ -29,30 +29,22 @@ inline LayoutUnit LegacyInlineFlowBox::marginBorderPaddingLogicalRight() const {
 
 inline float LegacyInlineFlowBox::borderLogicalLeft() const
 {
-    if (!includeLogicalLeftEdge())
-        return 0;
-    return isHorizontal() ? lineStyle().borderLeftWidth() : lineStyle().borderTopWidth();
+    return 0;
 }
 
 inline float LegacyInlineFlowBox::borderLogicalRight() const
 {
-    if (!includeLogicalRightEdge())
-        return 0;
-    return isHorizontal() ? lineStyle().borderRightWidth() : lineStyle().borderBottomWidth();
+    return 0;
 }
 
 inline float LegacyInlineFlowBox::paddingLogicalLeft() const
 {
-    if (!includeLogicalLeftEdge())
-        return 0;
-    return isHorizontal() ? renderer().paddingLeft() : renderer().paddingTop();
+    return 0;
 }
 
 inline float LegacyInlineFlowBox::paddingLogicalRight() const
 {
-    if (!includeLogicalRightEdge())
-        return 0;
-    return isHorizontal() ? renderer().paddingRight() : renderer().paddingBottom();
+    return 0;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/LegacyLineLayout.h
+++ b/Source/WebCore/rendering/LegacyLineLayout.h
@@ -79,15 +79,11 @@ private:
     LegacyRootInlineBox* createAndAppendRootInlineBox();
     LegacyInlineBox* createInlineBoxForRenderer(RenderObject*);
     LegacyInlineFlowBox* createLineBoxes(RenderObject*, const LineInfo&, LegacyInlineBox*);
-    TextAlignMode textAlignmentForLine(bool endsWithSoftBreak) const;
-    void computeExpansionForJustifiedText(BidiRun* firstRun, BidiRun* trailingSpaceRun, const Vector<unsigned, 16>& expansionOpportunities, unsigned expansionOpportunityCount, float totalLogicalWidth, float availableLogicalWidth);
-    void computeInlineDirectionPositionsForLine(LegacyRootInlineBox*, const LineInfo&, BidiRun* firstRun, BidiRun* trailingSpaceRun, bool reachedEnd, GlyphOverflowAndFallbackFontsMap&, WordMeasurements&);
-    BidiRun* computeInlineDirectionPositionsForSegment(LegacyRootInlineBox*, const LineInfo&, TextAlignMode, float& logicalLeft, float& availableLogicalWidth, BidiRun* firstRun, BidiRun* trailingSpaceRun, GlyphOverflowAndFallbackFontsMap&, WordMeasurements&);
     void removeInlineBox(BidiRun&, const LegacyRootInlineBox&) const;
     void removeEmptyTextBoxesAndUpdateVisualReordering(LegacyRootInlineBox*, BidiRun* firstRun);
     inline BidiRun* handleTrailingSpaces(BidiRunList<BidiRun>& bidiRuns, BidiContext* currentContext);
     void appendFloatingObjectToLastLine(FloatingObject&);
-    LegacyRootInlineBox* createLineBoxesFromBidiRuns(unsigned bidiLevel, BidiRunList<BidiRun>& bidiRuns, const LegacyInlineIterator& end, LineInfo&, BidiRun* trailingSpaceRun, WordMeasurements&);
+    LegacyRootInlineBox* createLineBoxesFromBidiRuns(unsigned bidiLevel, BidiRunList<BidiRun>& bidiRuns, const LegacyInlineIterator& end, LineInfo&);
     void layoutRunsAndFloats(LineLayoutState&, bool hasInlineChild);
     inline const LegacyInlineIterator& restartLayoutRunsAndFloatsInRange(LayoutUnit oldLogicalHeight, LayoutUnit newLogicalHeight, FloatingObject* lastFloatFromPreviousLine, InlineBidiResolver&,  const LegacyInlineIterator& oldEnd);
     void layoutRunsAndFloatsInRange(LineLayoutState&, InlineBidiResolver&, const LegacyInlineIterator& cleanLineStart, const BidiStatus& cleanLineBidiStatus, unsigned consecutiveHyphenatedLines);

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -508,10 +508,6 @@ private:
     VisiblePosition positionForPointWithInlineChildren(const LayoutPoint& pointInLogicalContents, const RenderFragmentContainer*) override;
     void addFocusRingRectsForInlineChildren(Vector<LayoutRect>& rects, const LayoutPoint& additionalOffset, const RenderLayerModelObject*) const override;
 
-public:
-    virtual std::optional<TextAlignMode> overrideTextAlignmentForLine(bool /* endsWithSoftBreak */) const { return { }; }
-    virtual void adjustInlineDirectionLineBounds(int /* expansionOpportunityCount */, float& /* logicalLeft */, float& /* logicalWidth */) const { }
-
 private:
     bool hasLineLayout() const;
     bool hasLegacyLineLayout() const;


### PR DESCRIPTION
#### ff763d9dead40a6ce11cc71d1aed464dbc0045f9
<pre>
[Legacy line layout removal] Remove horizontal inline box positioning
<a href="https://bugs.webkit.org/show_bug.cgi?id=271036">https://bugs.webkit.org/show_bug.cgi?id=271036</a>
<a href="https://rdar.apple.com/124660457">rdar://124660457</a>

Reviewed by Alan Baradlay.

SVG is the last user of LegacyInlineBoxes but it does its own inline layout and does not use this code.

* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::LegacyInlineFlowBox::addBorderOutsetVisualOverflow):
(WebCore::LegacyInlineFlowBox::getFlowSpacingLogicalWidth): Deleted.
(WebCore::isLastChildForRenderer): Deleted.
(WebCore::isAncestorAndWithinBlock): Deleted.
(WebCore::LegacyInlineFlowBox::determineSpacingForFlowBoxes): Deleted.
(WebCore::LegacyInlineFlowBox::placeBoxesInInlineDirection): Deleted.
(WebCore::LegacyInlineFlowBox::placeBoxRangeInInlineDirection): Deleted.
* Source/WebCore/rendering/LegacyInlineFlowBox.h:
(WebCore::LegacyInlineFlowBox::LegacyInlineFlowBox):
(WebCore::LegacyInlineFlowBox::marginLogicalLeft const):
(WebCore::LegacyInlineFlowBox::marginLogicalRight const):
(WebCore::LegacyInlineFlowBox::includeLogicalLeftEdge const): Deleted.
(WebCore::LegacyInlineFlowBox::includeLogicalRightEdge const): Deleted.
(WebCore::LegacyInlineFlowBox::setEdges): Deleted.
(WebCore::LegacyInlineFlowBox::beginPlacingBoxRangesInInlineDirection): Deleted.
(WebCore::LegacyInlineFlowBox::endPlacingBoxRangesInInlineDirection): Deleted.
* Source/WebCore/rendering/LegacyInlineFlowBoxInlines.h:
(WebCore::LegacyInlineFlowBox::borderLogicalLeft const):
(WebCore::LegacyInlineFlowBox::borderLogicalRight const):
(WebCore::LegacyInlineFlowBox::paddingLogicalLeft const):
(WebCore::LegacyInlineFlowBox::paddingLogicalRight const):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::constructLine):
(WebCore::LegacyLineLayout::updateLogicalWidthForAlignment):
(WebCore::LegacyLineLayout::createLineBoxesFromBidiRuns):
(WebCore::LegacyLineLayout::layoutRunsAndFloatsInRange):
(WebCore::endsWithHTMLSpaces): Deleted.
(WebCore::reachedEndOfTextRenderer): Deleted.
(WebCore::LegacyLineLayout::textAlignmentForLine const): Deleted.
(WebCore::setLogicalWidthForTextRun): Deleted.
(WebCore::LegacyLineLayout::computeExpansionForJustifiedText): Deleted.
(WebCore::updateLogicalInlinePositions): Deleted.
(WebCore::LegacyLineLayout::computeInlineDirectionPositionsForLine): Deleted.
(WebCore::expansionBehaviorForInlineTextBox): Deleted.
(WebCore::applyExpansionBehavior): Deleted.
(WebCore::inlineAncestorHasStartBorderPaddingOrMargin): Deleted.
(WebCore::inlineAncestorHasEndBorderPaddingOrMargin): Deleted.
(WebCore::isLastInFlowRun): Deleted.
(WebCore::LegacyLineLayout::computeInlineDirectionPositionsForSegment): Deleted.
* Source/WebCore/rendering/LegacyLineLayout.h:
* Source/WebCore/rendering/RenderBlockFlow.h:
(WebCore::RenderBlockFlow::overrideTextAlignmentForLine const): Deleted.
(WebCore::RenderBlockFlow::adjustInlineDirectionLineBounds const): Deleted.

Canonical link: <a href="https://commits.webkit.org/276152@main">https://commits.webkit.org/276152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abaa691ada7d426cd3660c40e309547b3a1b28aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46553 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/39984 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20361 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/19986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17231 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38901 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1965 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40073 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48120 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43048 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20304 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41755 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9765 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20508 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->