### PR TITLE
[Skia] Ensure the correct fill sources are applied for each fill paint used

### DIFF
--- a/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
@@ -51,9 +51,12 @@ void FontCascade::drawGlyphs(GraphicsContext& graphicsContext, const Font& font,
     }
     auto blob = builder.make();
     auto* canvas = graphicsContext.platformContext();
-    SkPaint paint = static_cast<GraphicsContextSkia*>(&graphicsContext)->createFillPaint();
+    auto* skiaGraphicsContext = static_cast<GraphicsContextSkia*>(&graphicsContext);
+    SkPaint paint = skiaGraphicsContext->createFillPaint();
     paint.setAntiAlias(font.allowsAntialiasing());
-    paint.setImageFilter(static_cast<GraphicsContextSkia*>(&graphicsContext)->createDropShadowFilterIfNeeded(GraphicsContextSkia::ShadowStyle::Outset));
+    paint.setImageFilter(skiaGraphicsContext->createDropShadowFilterIfNeeded(GraphicsContextSkia::ShadowStyle::Outset));
+    paint.setColor(SkColor(skiaGraphicsContext->fillColor().colorWithAlphaMultipliedBy(skiaGraphicsContext->alpha())));
+
     canvas->drawTextBlob(blob, SkFloatToScalar(position.x()), SkFloatToScalar(position.y()), paint);
 }
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -102,14 +102,16 @@ public:
     enum class ShadowStyle : uint8_t { Outset, Inset };
     sk_sp<SkImageFilter> createDropShadowFilterIfNeeded(ShadowStyle) const;
 
-    SkPaint createFillPaint(std::optional<Color> fillColor = std::nullopt) const;
-    SkPaint createStrokeStylePaint() const;
-    SkPaint createStrokePaint(std::optional<Color> strokeColor = std::nullopt) const;
+    SkPaint createFillPaint() const;
+    SkPaint createStrokePaint() const;
 
 private:
     SkCanvas& canvas() const;
 
     bool makeGLContextCurrentIfNeeded() const;
+
+    void setupFillSource(SkPaint&) const;
+    void setupStrokeSource(SkPaint&) const;
 
     class SkiaState {
     public:

--- a/Source/WebCore/platform/graphics/skia/PathSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PathSkia.cpp
@@ -292,7 +292,7 @@ bool PathSkia::strokeContains(const FloatPoint& point, const Function<void(Graph
     strokeStyleApplier(graphicsContext);
 
     // FIXME: Compute stroke precision.
-    SkPaint paint = graphicsContext.createStrokeStylePaint();
+    SkPaint paint = graphicsContext.createStrokePaint();
     SkPath strokePath;
     skpathutils::FillPathWithPaint(m_platformPath, paint, &strokePath, nullptr);
     return strokePath.contains(SkScalar(point.x()), SkScalar(point.y()));
@@ -318,7 +318,7 @@ FloatRect PathSkia::strokeBoundingRect(const Function<void(GraphicsContext&)>& s
 
     // Skia stroke resolution scale for reduced-precision requirements.
     constexpr float strokePrecision = 0.3f;
-    SkPaint paint = graphicsContext.createStrokeStylePaint();
+    SkPaint paint = graphicsContext.createStrokePaint();
     SkPath strokePath;
     skpathutils::FillPathWithPaint(m_platformPath, paint, &strokePath, nullptr, strokePrecision);
     return strokePath.computeTightBounds();


### PR DESCRIPTION
#### 459c7fa7db217648a4885d72b971063b30698835
<pre>
[Skia] Ensure the correct fill sources are applied for each fill paint used
<a href="https://bugs.webkit.org/show_bug.cgi?id=271047">https://bugs.webkit.org/show_bug.cgi?id=271047</a>

Reviewed by Carlos Garcia Campos.

Currently, createFillPaint() invoked with clear color may actually pick up a shader instead.
This change separates automatic detection of fill source from createFillPaint() so that it&apos;s not used by mistake.
This change does the same for createStrokePaint().

* Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp:
(WebCore::FontCascade::drawGlyphs):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::drawRect):
(WebCore::GraphicsContextSkia::drawNativeImageInternal):
(WebCore::GraphicsContextSkia::drawLine):
(WebCore::GraphicsContextSkia::drawEllipse):
(WebCore::GraphicsContextSkia::fillPath):
(WebCore::GraphicsContextSkia::createFillPaint const):
(WebCore::GraphicsContextSkia::setFillSource const):
(WebCore::GraphicsContextSkia::fillRect):
(WebCore::GraphicsContextSkia::drawDotsForDocumentMarker):
(WebCore::GraphicsContextSkia::clearRect):
(WebCore::GraphicsContextSkia::fillRoundedRectImpl):
(WebCore::GraphicsContextSkia::fillRectWithRoundedHole):
(WebCore::GraphicsContextSkia::drawPattern):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:

Canonical link: <a href="https://commits.webkit.org/276154@main">https://commits.webkit.org/276154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0bdf9e37bbb083ada0d1ef72abe1432587d3cfb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43929 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46574 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40003 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20381 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17250 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38920 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1985 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40103 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48146 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18933 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15508 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20322 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41783 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20528 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6005 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->