### PR TITLE
Feature Policy was renamed to Permissions Policy

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1166,7 +1166,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/DOMTokenList.h
     html/DataListSuggestionInformation.h
     html/EnterKeyHint.h
-    html/FeaturePolicy.h
     html/FormAssociatedCustomElement.h
     html/FormAssociatedElement.h
     html/FormController.h
@@ -1263,6 +1262,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/MediaError.h
     html/OffscreenCanvas.h
     html/PDFDocument.h
+    html/PermissionsPolicy.h
     html/PluginDocument.h
     html/StepRange.h
     html/TimeRanges.h

--- a/Source/WebCore/Modules/applepay/PaymentSession.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentSession.cpp
@@ -30,8 +30,8 @@
 
 #include "Document.h"
 #include "DocumentLoader.h"
-#include "FeaturePolicy.h"
 #include "FrameDestructionObserverInlines.h"
+#include "PermissionsPolicy.h"
 #include "SecurityOrigin.h"
 
 namespace WebCore {
@@ -49,7 +49,7 @@ static bool isSecure(DocumentLoader& documentLoader)
 
 ExceptionOr<void> PaymentSession::canCreateSession(Document& document)
 {
-    if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Payment, document, LogFeaturePolicyFailure::Yes))
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Payment, document, LogPermissionsPolicyFailure::Yes))
         return Exception { ExceptionCode::SecurityError, "Third-party iframes are not allowed to request payments unless explicitly allowed via Feature-Policy (payment)"_s };
 
     if (!document.frame())

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -31,7 +31,7 @@
 #include "AudioSession.h"
 #include "Document.h"
 #include "EventNames.h"
-#include "FeaturePolicy.h"
+#include "PermissionsPolicy.h"
 #include "PlatformMediaSessionManager.h"
 
 namespace WebCore {
@@ -84,7 +84,7 @@ ExceptionOr<void> DOMAudioSession::setType(Type type)
     if (!document)
         return Exception { ExceptionCode::InvalidStateError };
 
-    if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, *document, LogFeaturePolicyFailure::No))
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, *document, LogPermissionsPolicyFailure::No))
         return { };
 
     document->topDocument().setAudioSessionType(type);
@@ -101,7 +101,7 @@ ExceptionOr<void> DOMAudioSession::setType(Type type)
 DOMAudioSession::Type DOMAudioSession::type() const
 {
     RefPtr document = downcast<Document>(scriptExecutionContext());
-    if (document && !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, *document, LogFeaturePolicyFailure::No))
+    if (document && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, *document, LogPermissionsPolicyFailure::No))
         return DOMAudioSession::Type::Auto;
 
     return document ? document->topDocument().audioSessionType() : DOMAudioSession::Type::Auto;
@@ -121,7 +121,7 @@ static DOMAudioSession::State computeAudioSessionState()
 DOMAudioSession::State DOMAudioSession::state() const
 {
     RefPtr document = downcast<Document>(scriptExecutionContext());
-    if (!document || !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, *document, LogFeaturePolicyFailure::No))
+    if (!document || !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, *document, LogPermissionsPolicyFailure::No))
         return DOMAudioSession::State::Inactive;
 
     if (!m_state)
@@ -161,7 +161,7 @@ void DOMAudioSession::audioSessionActiveStateChanged()
 void DOMAudioSession::scheduleStateChangeEvent()
 {
     RefPtr document = downcast<Document>(scriptExecutionContext());
-    if (document && !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, *document, LogFeaturePolicyFailure::No))
+    if (document && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, *document, LogPermissionsPolicyFailure::No))
         return;
 
     if (m_hasScheduleStateChangeEvent)

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp
@@ -28,7 +28,6 @@
 #if ENABLE(ENCRYPTED_MEDIA)
 
 #include "Document.h"
-#include "FeaturePolicy.h"
 #include "HTMLIFrameElement.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -29,12 +29,12 @@
 #if ENABLE(GAMEPAD)
 
 #include "Document.h"
-#include "FeaturePolicy.h"
 #include "Gamepad.h"
 #include "GamepadManager.h"
 #include "GamepadProvider.h"
 #include "LocalDOMWindow.h"
 #include "Navigator.h"
+#include "PermissionsPolicy.h"
 #include "PlatformGamepad.h"
 
 namespace WebCore {
@@ -83,7 +83,7 @@ ExceptionOr<const Vector<RefPtr<Gamepad>>&> NavigatorGamepad::getGamepads(Naviga
         return { emptyGamepads.get() };
     }
 
-    if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Gamepad, *document, LogFeaturePolicyFailure::Yes))
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Gamepad, *document, LogPermissionsPolicyFailure::Yes))
         return Exception { ExceptionCode::SecurityError, "Third-party iframes are not allowed to call getGamepads() unless explicitly allowed via Feature-Policy (gamepad)"_s };
 
     return NavigatorGamepad::from(navigator)->gamepads();

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -32,7 +32,6 @@
 
 #include "Document.h"
 #include "EventLoop.h"
-#include "FeaturePolicy.h"
 #include "GeoNotifier.h"
 #include "GeolocationController.h"
 #include "GeolocationCoordinates.h"
@@ -42,6 +41,7 @@
 #include "LocalFrame.h"
 #include "Navigator.h"
 #include "Page.h"
+#include "PermissionsPolicy.h"
 #include "RuntimeApplicationChecks.h"
 #include "SecurityOrigin.h"
 #include <wtf/IsoMallocInlines.h>
@@ -356,7 +356,7 @@ static void logError(const String& target, const bool isSecure, const bool isMix
     
 bool Geolocation::shouldBlockGeolocationRequests()
 {
-    if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Geolocation, *document(), LogFeaturePolicyFailure::Yes))
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Geolocation, *document(), LogPermissionsPolicyFailure::Yes))
         return true;
 
     bool isSecure = SecurityOrigin::isSecure(document()->url()) || document()->isSecureContext();

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -46,6 +46,7 @@
 #include "LocalFrame.h"
 #include "Logging.h"
 #include "MediaTrackSupportedConstraints.h"
+#include "PermissionsPolicy.h"
 #include "RealtimeMediaSourceSettings.h"
 #include "Settings.h"
 #include "UserGestureIndicator.h"
@@ -275,19 +276,19 @@ void MediaDevices::getDisplayMedia(DisplayMediaStreamConstraints&& constraints, 
 
 static inline bool checkCameraAccess(const Document& document)
 {
-    return isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Camera, document, LogFeaturePolicyFailure::No);
+    return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Camera, document, LogPermissionsPolicyFailure::No);
 }
 
 static inline bool checkMicrophoneAccess(const Document& document)
 {
-    return isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, document, LogFeaturePolicyFailure::No);
+    return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, document, LogPermissionsPolicyFailure::No);
 }
 
 static inline bool checkSpeakerAccess(const Document& document)
 {
     return document.frame()
         && document.frame()->settings().exposeSpeakersEnabled()
-        && isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::SpeakerSelection, document, LogFeaturePolicyFailure::No);
+        && isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::SpeakerSelection, document, LogPermissionsPolicyFailure::No);
 }
 
 void MediaDevices::exposeDevices(Vector<CaptureDeviceWithCapabilities>&& newDevices, MediaDeviceHashSalts&& deviceIDHashSalts, EnumerateDevicesPromise&& promise)
@@ -393,8 +394,8 @@ void MediaDevices::listenForDeviceChanges()
     if (!controller)
         return;
 
-    bool canAccessCamera = isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Camera, *document, LogFeaturePolicyFailure::No);
-    bool canAccessMicrophone = isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, *document, LogFeaturePolicyFailure::No);
+    bool canAccessCamera = isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Camera, *document, LogPermissionsPolicyFailure::No);
+    bool canAccessMicrophone = isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, *document, LogPermissionsPolicyFailure::No);
 
     if (m_listeningForDeviceChanges || (!canAccessCamera && !canAccessMicrophone))
         return;

--- a/Source/WebCore/Modules/mediastream/UserMediaController.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaController.cpp
@@ -30,6 +30,7 @@
 
 #include "Document.h"
 #include "LocalDOMWindow.h"
+#include "PermissionsPolicy.h"
 #include "RealtimeMediaSourceCenter.h"
 #include "UserMediaRequest.h"
 
@@ -70,8 +71,8 @@ void UserMediaController::logGetDisplayMediaDenial(Document& document)
 void UserMediaController::logEnumerateDevicesDenial(Document& document)
 {
     // We redo the check to print to the console log.
-    isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Camera, document, LogFeaturePolicyFailure::Yes);
-    isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, document, LogFeaturePolicyFailure::Yes);
+    isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Camera, document, LogPermissionsPolicyFailure::Yes);
+    isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, document, LogPermissionsPolicyFailure::Yes);
     if (RefPtr window = document.domWindow())
         window->printErrorMessage(makeString("Not allowed to call enumerateDevices."));
 }

--- a/Source/WebCore/Modules/mediastream/UserMediaController.h
+++ b/Source/WebCore/Modules/mediastream/UserMediaController.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(MEDIA_STREAM)
 
-#include "FeaturePolicy.h"
 #include "Page.h"
 #include "UserMediaClient.h"
 #include <wtf/CompletionHandler.h>

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -115,19 +115,19 @@ void UserMediaRequest::start()
     switch (m_request.type) {
     case MediaStreamRequest::Type::DisplayMedia:
     case MediaStreamRequest::Type::DisplayMediaWithAudio:
-        if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::DisplayCapture, document)) {
+        if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::DisplayCapture, document)) {
             deny(MediaAccessDenialReason::PermissionDenied);
             controller->logGetDisplayMediaDenial(document);
             return;
         }
         break;
     case MediaStreamRequest::Type::UserMedia:
-        if (m_request.audioConstraints.isValid && !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, document)) {
+        if (m_request.audioConstraints.isValid && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, document)) {
             deny(MediaAccessDenialReason::PermissionDenied);
             controller->logGetUserMediaDenial(document);
             return;
         }
-        if (m_request.videoConstraints.isValid && !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Camera, document)) {
+        if (m_request.videoConstraints.isValid && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Camera, document)) {
             deny(MediaAccessDenialReason::PermissionDenied);
             controller->logGetUserMediaDenial(document);
             return;

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -29,7 +29,6 @@
 #include "DedicatedWorkerGlobalScope.h"
 #include "Document.h"
 #include "Exception.h"
-#include "FeaturePolicy.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSPermissionDescriptor.h"
 #include "JSPermissionStatus.h"
@@ -40,6 +39,7 @@
 #include "PermissionDescriptor.h"
 #include "PermissionName.h"
 #include "PermissionQuerySource.h"
+#include "PermissionsPolicy.h"
 #include "ScriptExecutionContext.h"
 #include "SecurityOrigin.h"
 #include "ServiceWorkerGlobalScope.h"
@@ -73,15 +73,15 @@ NavigatorBase* Permissions::navigator()
 
 Permissions::~Permissions() = default;
 
-static bool isAllowedByFeaturePolicy(const Document& document, PermissionName name)
+static bool isAllowedByPermissionsPolicy(const Document& document, PermissionName name)
 {
     switch (name) {
     case PermissionName::Camera:
-        return isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Camera, document, LogFeaturePolicyFailure::No);
+        return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Camera, document, LogPermissionsPolicyFailure::No);
     case PermissionName::Geolocation:
-        return isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Geolocation, document, LogFeaturePolicyFailure::No);
+        return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Geolocation, document, LogPermissionsPolicyFailure::No);
     case PermissionName::Microphone:
-        return isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, document, LogFeaturePolicyFailure::No);
+        return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, document, LogPermissionsPolicyFailure::No);
     default:
         return true;
     }
@@ -154,7 +154,7 @@ void Permissions::query(JSC::Strong<JSC::JSObject> permissionDescriptorValue, DO
             return;
         }
 
-        if (!isAllowedByFeaturePolicy(*document, permissionDescriptor.name)) {
+        if (!isAllowedByPermissionsPolicy(*document, permissionDescriptor.name)) {
             promise.resolve(PermissionStatus::create(*context, PermissionState::Denied, permissionDescriptor, PermissionQuerySource::Window, *page));
             return;
         }

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -29,7 +29,6 @@
 #include "DocumentInlines.h"
 #include "EventLoop.h"
 #include "Exception.h"
-#include "FeaturePolicy.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWakeLockSentinel.h"
 #include "LocalDOMWindow.h"
@@ -37,6 +36,7 @@
 #include "PermissionController.h"
 #include "PermissionQuerySource.h"
 #include "PermissionState.h"
+#include "PermissionsPolicy.h"
 #include "VisibilityState.h"
 #include "WakeLockManager.h"
 #include "WakeLockSentinel.h"
@@ -56,7 +56,7 @@ void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
         promise->reject(Exception { ExceptionCode::NotAllowedError, "Document is not fully active"_s });
         return;
     }
-    if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::ScreenWakeLock, *document, LogFeaturePolicyFailure::Yes)) {
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::ScreenWakeLock, *document, LogPermissionsPolicyFailure::Yes)) {
         promise->reject(Exception { ExceptionCode::NotAllowedError, "'screen-wake-lock' is not allowed by Feature-Policy"_s });
         return;
     }

--- a/Source/WebCore/Modules/speech/SpeechRecognition.cpp
+++ b/Source/WebCore/Modules/speech/SpeechRecognition.cpp
@@ -29,9 +29,9 @@
 #include "ClientOrigin.h"
 #include "Document.h"
 #include "EventNames.h"
-#include "FeaturePolicy.h"
 #include "FrameDestructionObserverInlines.h"
 #include "Page.h"
+#include "PermissionsPolicy.h"
 #include "SpeechRecognitionError.h"
 #include "SpeechRecognitionErrorEvent.h"
 #include "SpeechRecognitionEvent.h"
@@ -78,7 +78,7 @@ ExceptionOr<void> SpeechRecognition::startRecognition()
         return Exception { ExceptionCode::UnknownError, "Recognition is not in a valid frame"_s };
 
     auto optionalFrameIdentifier = document->frameID();
-    if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Microphone, document.get(), LogFeaturePolicyFailure::No)) {
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Microphone, document.get(), LogPermissionsPolicyFailure::No)) {
         didError({ SpeechRecognitionErrorType::NotAllowed, "Permission is denied"_s });
         return { };
     }

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -34,12 +34,12 @@
 #include "AuthenticatorCoordinatorClient.h"
 #include "AuthenticatorResponseData.h"
 #include "Document.h"
-#include "FeaturePolicy.h"
 #include "FrameDestructionObserverInlines.h"
 #include "JSBasicCredential.h"
 #include "JSCredentialCreationOptions.h"
 #include "JSCredentialRequestOptions.h"
 #include "JSDOMPromiseDeferred.h"
+#include "PermissionsPolicy.h"
 #include "PublicKeyCredential.h"
 #include "PublicKeyCredentialCreationOptions.h"
 #include "PublicKeyCredentialRequestOptions.h"
@@ -235,7 +235,7 @@ void AuthenticatorCoordinator::discoverFromExternalSource(const Document& docume
     // Step 1, 3, 13 are handled by the caller.
     // Step 2.
     // This implements https://www.w3.org/TR/webauthn-2/#sctn-permissions-policy
-    if (scopeAndCrossOriginParent.first != WebAuthn::Scope::SameOrigin && !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::PublickeyCredentialsGetRule, document, LogFeaturePolicyFailure::No)) {
+    if (scopeAndCrossOriginParent.first != WebAuthn::Scope::SameOrigin && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::PublickeyCredentialsGetRule, document, LogPermissionsPolicyFailure::No)) {
         promise.reject(Exception { ExceptionCode::NotAllowedError, "The origin of the document is not the same as its ancestors."_s });
         return;
     }

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -32,7 +32,6 @@
 #include "Chrome.h"
 #include "ChromeClient.h"
 #include "Document.h"
-#include "FeaturePolicy.h"
 #include "IDLTypes.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSWebXRSession.h"
@@ -40,6 +39,7 @@
 #include "LocalDOMWindow.h"
 #include "Navigator.h"
 #include "Page.h"
+#include "PermissionsPolicy.h"
 #include "RequestAnimationFrameCallback.h"
 #include "SecurityOrigin.h"
 #include "UserGestureIndicator.h"
@@ -165,7 +165,7 @@ void WebXRSystem::isSessionSupported(XRSessionMode mode, IsSessionSupportedPromi
     // 3. If the requesting document's origin is not allowed to use the "xr-spatial-tracking" feature policy,
     //    reject promise with a "SecurityError" DOMException and return it.
     auto document = downcast<Document>(scriptExecutionContext());
-    if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::XRSpatialTracking, *document, LogFeaturePolicyFailure::Yes)) {
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::XRSpatialTracking, *document, LogPermissionsPolicyFailure::Yes)) {
         promise.reject(Exception { ExceptionCode::SecurityError });
         return;
     }

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1349,7 +1349,6 @@ html/DirectoryFileListCreator.cpp
 html/EmailInputType.cpp
 html/EnterKeyHint.cpp
 html/FTPDirectoryDocument.cpp
-html/FeaturePolicy.cpp
 html/FileInputType.cpp
 html/FormAssociatedElement.cpp
 html/FormAssociatedCustomElement.cpp
@@ -1470,8 +1469,9 @@ html/MonthInputType.cpp
 html/NavigatorUserActivation.cpp
 html/NumberInputType.cpp
 html/OffscreenCanvas.cpp
-html/PasswordInputType.cpp
 html/PDFDocument.cpp
+html/PasswordInputType.cpp
+html/PermissionsPolicy.cpp
 html/PluginDocument.cpp
 html/PublicURLManager.cpp
 html/RadioInputType.cpp

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -220,7 +220,7 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
 
         // The context object's node document, or an ancestor browsing context's document does not have
         // the fullscreen enabled flag set.
-        if (checkType == EnforceIFrameAllowFullscreenRequirement && !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Fullscreen, document)) {
+        if (checkType == EnforceIFrameAllowFullscreenRequirement && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Fullscreen, document)) {
             ERROR_LOG(identifier, "task - ancestor document does not enable fullscreen; failing.");
             failedPreflights(WTFMove(element), WTFMove(promise));
             return;
@@ -476,7 +476,7 @@ bool FullscreenManager::isFullscreenEnabled() const
     // browsing context's documents have their fullscreen enabled flag set, or false otherwise.
 
     // Top-level browsing contexts are implied to have their allowFullscreen attribute set.
-    return isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Fullscreen, protectedDocument());
+    return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Fullscreen, protectedDocument());
 }
 
 static void markRendererDirtyAfterTopLayerChange(RenderElement* renderer, RenderBlock* containingBlockBeforeStyleResolution)

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -130,7 +130,7 @@ void HTMLIFrameElement::attributeChanged(const QualifiedName& name, const AtomSt
     case AttributeNames::allowAttr:
     case AttributeNames::allowfullscreenAttr:
     case AttributeNames::webkitallowfullscreenAttr:
-        m_featurePolicy = std::nullopt;
+        m_permissionsPolicy = std::nullopt;
         break;
     case AttributeNames::loadingAttr:
         // Allow loading=eager to load the frame immediately if the lazy load was started, but
@@ -173,11 +173,11 @@ ReferrerPolicy HTMLIFrameElement::referrerPolicy() const
     return parseReferrerPolicy(attributeWithoutSynchronization(referrerpolicyAttr), ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString);
 }
 
-const FeaturePolicy& HTMLIFrameElement::featurePolicy() const
+const PermissionsPolicy& HTMLIFrameElement::permissionsPolicy() const
 {
-    if (!m_featurePolicy)
-        m_featurePolicy = FeaturePolicy::parse(document(), *this, attributeWithoutSynchronization(allowAttr));
-    return *m_featurePolicy;
+    if (!m_permissionsPolicy)
+        m_permissionsPolicy = PermissionsPolicy::parse(document(), *this, attributeWithoutSynchronization(allowAttr));
+    return *m_permissionsPolicy;
 }
 
 const AtomString& HTMLIFrameElement::loadingForBindings() const

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -23,8 +23,8 @@
 
 #pragma once
 
-#include "FeaturePolicy.h"
 #include "HTMLFrameElementBase.h"
+#include "PermissionsPolicy.h"
 
 namespace WebCore {
 
@@ -43,7 +43,7 @@ public:
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const final;
 
-    const FeaturePolicy& featurePolicy() const;
+    const PermissionsPolicy& permissionsPolicy() const;
 
     const AtomString& loadingForBindings() const;
     void setLoadingForBindings(const AtomString&);
@@ -74,7 +74,7 @@ private:
     bool isLazyLoadObserverActive() const final;
 
     std::unique_ptr<DOMTokenList> m_sandbox;
-    mutable std::optional<FeaturePolicy> m_featurePolicy;
+    mutable std::optional<PermissionsPolicy> m_permissionsPolicy;
 #if ENABLE(FULLSCREEN_API)
     bool m_IFrameFullscreenFlag { false };
 #endif

--- a/Source/WebCore/html/PermissionsPolicy.h
+++ b/Source/WebCore/html/PermissionsPolicy.h
@@ -34,10 +34,10 @@ namespace WebCore {
 class Document;
 class HTMLIFrameElement;
 
-class FeaturePolicy {
+class PermissionsPolicy {
 public:
-    static FeaturePolicy defaultPolicy(Document& document) { return parse(document, nullptr, { }); }
-    static FeaturePolicy parse(Document& document, const HTMLIFrameElement& frame, StringView allow) { return parse(document, &frame, allow); }
+    static PermissionsPolicy defaultPolicy(Document& document) { return parse(document, nullptr, { }); }
+    static PermissionsPolicy parse(Document& document, const HTMLIFrameElement& frame, StringView allow) { return parse(document, &frame, allow); }
 
     enum class Type {
         Camera,
@@ -73,7 +73,7 @@ public:
     };
 
 private:
-    static FeaturePolicy parse(Document&, const HTMLIFrameElement*, StringView);
+    static PermissionsPolicy parse(Document&, const HTMLIFrameElement*, StringView);
 
     AllowRule m_cameraRule;
     AllowRule m_microphoneRule;
@@ -101,7 +101,7 @@ private:
     AllowRule m_privateTokenRule;
 };
 
-enum class LogFeaturePolicyFailure : bool { No, Yes };
-extern bool isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type, const Document&, LogFeaturePolicyFailure = LogFeaturePolicyFailure::Yes);
+enum class LogPermissionsPolicyFailure : bool { No, Yes };
+extern bool isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type, const Document&, LogPermissionsPolicyFailure = LogPermissionsPolicyFailure::Yes);
 
 } // namespace WebCore

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -63,7 +63,6 @@
 #include "Event.h"
 #include "EventHandler.h"
 #include "EventNames.h"
-#include "FeaturePolicy.h"
 #include "FloatRect.h"
 #include "FormState.h"
 #include "FormSubmission.h"
@@ -102,6 +101,7 @@
 #include "PageTransitionEvent.h"
 #include "Performance.h"
 #include "PerformanceLogging.h"
+#include "PermissionsPolicy.h"
 #include "PlatformStrategies.h"
 #include "PluginData.h"
 #include "PluginDocument.h"
@@ -3250,7 +3250,7 @@ void FrameLoader::updateRequestAndAddExtraFields(ResourceRequest& request, IsMai
         request.setHTTPHeaderField(HTTPHeaderName::Accept, CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type::MainResource));
 
     if (RefPtr document = m_frame->document(); document && frame().settings().privateTokenUsageByThirdPartyEnabled() && !frame().loader().client().isRemoteWorkerFrameLoaderClient())
-        request.setIsPrivateTokenUsageByThirdPartyAllowed(isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::PrivateToken, *document, LogFeaturePolicyFailure::No));
+        request.setIsPrivateTokenUsageByThirdPartyAllowed(isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::PrivateToken, *document, LogPermissionsPolicyFailure::No));
 
     // Only set fallback array if it's still empty (later attempts may be incorrect, see bug 117818).
     if (request.responseContentDispositionEncodingFallbackArray().isEmpty()) {

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -63,7 +63,6 @@
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "EventPath.h"
-#include "FeaturePolicy.h"
 #include "FloatRect.h"
 #include "FocusController.h"
 #include "FrameLoadRequest.h"
@@ -95,6 +94,7 @@
 #include "PageTransitionEvent.h"
 #include "Performance.h"
 #include "PerformanceNavigationTiming.h"
+#include "PermissionsPolicy.h"
 #include "Quirks.h"
 #include "RemoteFrame.h"
 #include "RequestAnimationFrameCallback.h"
@@ -2085,8 +2085,8 @@ bool LocalDOMWindow::isAllowedToUseDeviceMotion(String& message) const
         return false;
 
     Ref document = *this->document();
-    if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Gyroscope, document, LogFeaturePolicyFailure::No)
-        || !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Accelerometer, document, LogFeaturePolicyFailure::No)) {
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Gyroscope, document, LogPermissionsPolicyFailure::No)
+        || !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Accelerometer, document, LogPermissionsPolicyFailure::No)) {
         message = "Third-party iframes are not allowed access to device motion unless explicitly allowed via Feature-Policy (gyroscope & accelerometer)"_s;
         return false;
     }
@@ -2100,9 +2100,9 @@ bool LocalDOMWindow::isAllowedToUseDeviceOrientation(String& message) const
         return false;
 
     Ref document = *this->document();
-    if (!isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Gyroscope, document, LogFeaturePolicyFailure::No)
-        || !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Accelerometer, document, LogFeaturePolicyFailure::No)
-        || !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::Magnetometer, document, LogFeaturePolicyFailure::No)) {
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Gyroscope, document, LogPermissionsPolicyFailure::No)
+        || !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Accelerometer, document, LogPermissionsPolicyFailure::No)
+        || !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::Magnetometer, document, LogPermissionsPolicyFailure::No)) {
         message = "Third-party iframes are not allowed access to device orientation unless explicitly allowed via Feature-Policy (gyroscope & accelerometer & magnetometer)"_s;
         return false;
     }

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -32,7 +32,6 @@
 #include "DOMPluginArray.h"
 #include "Document.h"
 #include "DocumentInlines.h"
-#include "FeaturePolicy.h"
 #include "FrameLoader.h"
 #include "GPU.h"
 #include "Geolocation.h"
@@ -43,6 +42,7 @@
 #include "LocalFrameLoaderClient.h"
 #include "LocalizedStrings.h"
 #include "Page.h"
+#include "PermissionsPolicy.h"
 #include "PlatformStrategies.h"
 #include "PluginData.h"
 #include "PushStrategy.h"
@@ -141,7 +141,7 @@ static std::optional<URL> shareableURLForShareData(ScriptExecutionContext& conte
 
 static bool validateWebSharePolicy(Document& document)
 {
-    return isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::WebShare, document, LogFeaturePolicyFailure::Yes);
+    return isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::WebShare, document, LogPermissionsPolicyFailure::Yes);
 }
 
 bool Navigator::canShare(Document& document, const ShareData& data)

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1675,16 +1675,16 @@ bool Quirks::needsResettingTransitionCancelsRunningTransitionQuirk() const
 #endif
 }
 
-bool Quirks::shouldStarBeFeaturePolicyDefaultValue() const
+bool Quirks::shouldStarBePermissionsPolicyDefaultValue() const
 {
     if (!needsQuirks())
         return false;
 
-    if (!m_shouldStarBeFeaturePolicyDefaultValueQuirk) {
+    if (!m_shouldStarBePermissionsPolicyDefaultValueQuirk) {
         auto domain = m_document->securityOrigin().domain().convertToASCIILowercase();
-        m_shouldStarBeFeaturePolicyDefaultValueQuirk = domain == "jsfiddle.net"_s;
+        m_shouldStarBePermissionsPolicyDefaultValueQuirk = domain == "jsfiddle.net"_s;
     }
-    return *m_shouldStarBeFeaturePolicyDefaultValueQuirk;
+    return *m_shouldStarBePermissionsPolicyDefaultValueQuirk;
 }
 
 // Microsoft office online generates data URLs with incorrect padding on Safari only (rdar://114573089).

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -183,7 +183,7 @@ public:
 
     bool needsResettingTransitionCancelsRunningTransitionQuirk() const;
 
-    bool shouldStarBeFeaturePolicyDefaultValue() const;
+    bool shouldStarBePermissionsPolicyDefaultValue() const;
     bool shouldDisableDataURLPaddingValidation() const;
 
     bool needsDisableDOMPasteAccessQuirk() const;
@@ -260,7 +260,7 @@ private:
     mutable std::optional<bool> m_shouldDisableLazyIframeLoadingQuirk;
     bool m_needsConfigurableIndexedPropertiesQuirk { false };
     bool m_needsToCopyUserSelectNoneQuirk { false };
-    mutable std::optional<bool> m_shouldStarBeFeaturePolicyDefaultValueQuirk;
+    mutable std::optional<bool> m_shouldStarBePermissionsPolicyDefaultValueQuirk;
     mutable std::optional<bool> m_shouldDisableDataURLPaddingValidation;
     mutable std::optional<bool> m_needsDisableDOMPasteAccessQuirk;
     mutable std::optional<bool> m_shouldDisableElementFullscreen;

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -661,7 +661,7 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
         // Either loader is null or some error was synchronously sent to us.
         ASSERT(m_loadingActivity || !m_sendFlag);
     } else {
-        if (scriptExecutionContext()->isDocument() && !isFeaturePolicyAllowedByDocumentAndAllOwners(FeaturePolicy::Type::SyncXHR, *document()))
+        if (scriptExecutionContext()->isDocument() && !isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::SyncXHR, *document()))
             return Exception { ExceptionCode::NetworkError };
 
         request.setDomainForCachePartition(scriptExecutionContext()->domainForCachePartition());


### PR DESCRIPTION
#### be2c477e55841581bd9cd9f573b5ec5b1a52c738
<pre>
Feature Policy was renamed to Permissions Policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=241952">https://bugs.webkit.org/show_bug.cgi?id=241952</a>
<a href="https://rdar.apple.com/96260775">rdar://96260775</a>

Reviewed by Chris Dumez.

This is a non-functional change to align our code with the terminology
used by the standard. It also updates a couple URLs.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/applepay/PaymentSession.cpp:
(WebCore::PaymentSession::canCreateSession):
* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
(WebCore::DOMAudioSession::setType):
(WebCore::DOMAudioSession::type const):
(WebCore::DOMAudioSession::state const):
(WebCore::DOMAudioSession::scheduleStateChangeEvent):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemController.cpp:
* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::Geolocation::shouldBlockGeolocationRequests):
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::checkCameraAccess):
(WebCore::checkMicrophoneAccess):
(WebCore::checkSpeakerAccess):
(WebCore::MediaDevices::listenForDeviceChanges):
* Source/WebCore/Modules/mediastream/UserMediaController.cpp:
(WebCore::UserMediaController::logEnumerateDevicesDenial):
* Source/WebCore/Modules/mediastream/UserMediaController.h:
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::start):
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::isAllowedByPermissionsPolicy):
(WebCore::Permissions::query):
(WebCore::isAllowedByFeaturePolicy): Deleted.
* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp:
(WebCore::WakeLock::request):
* Source/WebCore/Modules/speech/SpeechRecognition.cpp:
(WebCore::SpeechRecognition::startRecognition):
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::discoverFromExternalSource):
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::isSessionSupported):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):
(WebCore::FullscreenManager::isFullscreenEnabled const):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::attributeChanged):
(WebCore::HTMLIFrameElement::permissionsPolicy const):
(WebCore::HTMLIFrameElement::featurePolicy const): Deleted.
* Source/WebCore/html/HTMLIFrameElement.h:
* Source/WebCore/html/PermissionsPolicy.cpp: Renamed from Source/WebCore/html/FeaturePolicy.cpp.
(WebCore::policyTypeName):
(WebCore::isPermissionsPolicyAllowedByDocumentAndAllOwners):
(WebCore::isAllowedByPermissionsPolicy):
(WebCore::processOriginItem):
(WebCore::updateList):
(WebCore::PermissionsPolicy::parse):
(WebCore::PermissionsPolicy::allows const):
* Source/WebCore/html/PermissionsPolicy.h: Renamed from Source/WebCore/html/FeaturePolicy.h.
(WebCore::PermissionsPolicy::defaultPolicy):
(WebCore::PermissionsPolicy::parse):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::isAllowedToUseDeviceMotion const):
(WebCore::LocalDOMWindow::isAllowedToUseDeviceOrientation const):
* Source/WebCore/page/Navigator.cpp:
(WebCore::validateWebSharePolicy):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldStarBePermissionsPolicyDefaultValue const):
(WebCore::Quirks::shouldStarBeFeaturePolicyDefaultValue const): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::createRequest):

Canonical link: <a href="https://commits.webkit.org/276174@main">https://commits.webkit.org/276174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4685653ab4ed8a238d4ba0ba179e1d2fdaab91f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46577 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40006 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36245 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37837 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17255 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17532 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38924 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1988 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48149 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43075 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20325 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41786 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9778 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20531 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->