### PR TITLE
[Xcode] Simplify code coverage builds

### DIFF
--- a/Makefile.shared
+++ b/Makefile.shared
@@ -96,6 +96,14 @@ XCODE_OPTIONS += CC=$(CC)
 endif
 endif
 
+ifeq ($(CODE_COVERAGE),YES)
+CONFIG_OPTIONS += --coverage
+else
+ifeq ($(CODE_COVERAGE),NO)
+CONFIG_OPTIONS += --no-coverage
+endif
+endif
+
 ifneq ($(CPLUSPLUS),)
 XCODE_OPTIONS += CPLUSPLUS=$(CPLUSPLUS)
 endif

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -1364,7 +1364,7 @@ sub XcodeOptionStringNoConfig
 
 sub XcodeCoverageSupportOptions()
 {
-    return ("-xcconfig", sourceDir() . "/Tools/coverage/coverage.xcconfig");
+    return ("CLANG_COVERAGE_MAPPING=YES");
 }
 
 sub XcodeExportCompileCommandsOptions()

--- a/Tools/coverage/coverage.xcconfig
+++ b/Tools/coverage/coverage.xcconfig
@@ -1,2 +1,0 @@
-OTHER_CFLAGS = $(inherited) -fprofile-instr-generate -fcoverage-mapping;
-OTHER_LDFLAGS = $(inherited) -fprofile-instr-generate;


### PR DESCRIPTION
#### ee7e9fa115013e7be28a5ba2f52c16f486d4e55a
<pre>
[Xcode] Simplify code coverage builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=271055">https://bugs.webkit.org/show_bug.cgi?id=271055</a>
&lt;<a href="https://rdar.apple.com/124086420">rdar://124086420</a>&gt;

Reviewed by Alex Christensen.

This change simplifies code coverage builds of WebKit using Xcode.
Instead of specifying `-xcconfig Tools/coverage/coverage.xcconfig` on
the command-line, the CLANG_COVERAGE_MAPPING=YES Xcode variable now
enables code coverage builds.

* Makefile.shared:
- Add support for `CODE_COVERAGE=YES` when using `make` to build.
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
(WebCoreTestSupport: InternalSettingsGenerated.cpp):
- This file causes clang to hang indefinitely when compiled with code
  coverage enabled, so add
  &quot;-fno-profile-instr-generate -fno-coverage-mapping&quot; to COMPILER_FLAGS
  for just this file.  (Has no effect on non-code-coverage builds.)  The
  issue is tracked by &lt;<a href="https://rdar.apple.com/124640196">rdar://124640196</a>&gt;.
* Tools/Scripts/webkitdirs.pm:
(XcodeCoverageSupportOptions):
- Use &quot;CLANG_COVERAGE_MAPPING=YES&quot; instead of specifying a path to
  Tools/coverage/coverage.xcconfig.
* Tools/coverage/coverage.xcconfig: Remove.

Canonical link: <a href="https://commits.webkit.org/276273@main">https://commits.webkit.org/276273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a8a67cde4085014a8088ff1b24d0e1440a553a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/22992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40017 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27103 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36248 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38933 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/1994 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37315 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48157 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43531 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15519 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43080 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20331 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41803 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20537 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50572 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6068 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19960 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10206 "Passed tests") | 
<!--EWS-Status-Bubble-End-->