### PR TITLE
[Legacy line layout removal] Remove float and pagination support

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h
@@ -76,8 +76,8 @@ public:
 
     const RenderBlockFlow& formattingContextRoot() const { return m_rootInlineBox->blockFlow(); }
 
-    RenderFragmentContainer* containingFragment() const { return m_rootInlineBox->containingFragment(); }
-    bool isFirstAfterPageBreak() const { return m_rootInlineBox->isFirstAfterPageBreak(); }
+    RenderFragmentContainer* containingFragment() const { return nullptr; }
+    bool isFirstAfterPageBreak() const { return false; }
 
     size_t lineIndex() const
     {

--- a/Source/WebCore/rendering/FloatingObjects.cpp
+++ b/Source/WebCore/rendering/FloatingObjects.cpp
@@ -35,7 +35,6 @@ namespace WebCore {
 
 struct SameSizeAsFloatingObject {
     SingleThreadWeakPtr<RenderBox> renderer;
-    WeakPtr<LegacyRootInlineBox> originatingLine;
     LayoutRect rect;
     int paginationStrut;
     LayoutSize size;
@@ -276,15 +275,6 @@ FloatingObjects::FloatingObjects(const RenderBlockFlow& renderer)
 
 FloatingObjects::~FloatingObjects() = default;
 
-void FloatingObjects::clearLineBoxTreePointers()
-{
-    // Clear references to originating lines, since the lines are being deleted
-    for (auto it = m_set.begin(), end = m_set.end(); it != end; ++it) {
-        ASSERT(!((*it)->originatingLine()) || &((*it)->originatingLine()->renderer()) == &renderer());
-        (*it)->clearOriginatingLine();
-    }
-}
-
 void FloatingObjects::clear()
 {
     m_set.clear();
@@ -372,7 +362,6 @@ void FloatingObjects::remove(FloatingObject* floatingObject)
     ASSERT(floatingObject->isPlaced() || !floatingObject->isInPlacedTree());
     if (floatingObject->isPlaced())
         removePlacedObject(floatingObject);
-    ASSERT(!floatingObject->originatingLine());
     m_set.remove(floatingObject);
 }
 

--- a/Source/WebCore/rendering/FloatingObjects.h
+++ b/Source/WebCore/rendering/FloatingObjects.h
@@ -90,11 +90,6 @@ public:
     bool isDescendant() const { return m_isDescendant; }
     void setIsDescendant(bool isDescendant) { m_isDescendant = isDescendant; }
 
-    // FIXME: Callers of these methods are dangerous and should be allowed explicitly or removed.
-    LegacyRootInlineBox* originatingLine() const { return m_originatingLine.get(); }
-    void clearOriginatingLine() { m_originatingLine = nullptr; }
-    void setOriginatingLine(LegacyRootInlineBox& line) { m_originatingLine = line; }
-
     LayoutSize locationOffsetOfBorderBox() const
     {
         ASSERT(isPlaced());
@@ -107,7 +102,6 @@ private:
     friend FloatingObjects;
 
     SingleThreadWeakPtr<RenderBox> m_renderer;
-    WeakPtr<LegacyRootInlineBox> m_originatingLine;
     LayoutRect m_frameRect;
     LayoutUnit m_paginationStrut;
     LayoutSize m_marginOffset;
@@ -168,7 +162,6 @@ public:
     bool hasLeftObjects() const { return m_leftObjectsCount > 0; }
     bool hasRightObjects() const { return m_rightObjectsCount > 0; }
     const FloatingObjectSet& set() const { return m_set; }
-    void clearLineBoxTreePointers();
 
     LayoutUnit logicalLeftOffset(LayoutUnit fixedOffset, LayoutUnit logicalTop, LayoutUnit logicalHeight);
     LayoutUnit logicalRightOffset(LayoutUnit fixedOffset, LayoutUnit logicalTop, LayoutUnit logicalHeight);

--- a/Source/WebCore/rendering/LegacyInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineBox.cpp
@@ -133,9 +133,6 @@ float LegacyInlineBox::logicalHeight() const
     if (hasVirtualLogicalHeight())
         return virtualLogicalHeight();
 
-    if (auto* inlineBox = dynamicDowncast<LegacyRootInlineBox>(*this); inlineBox && inlineBox->isForTrailingFloats())
-        return 0;
-
     const RenderStyle& lineStyle = this->lineStyle();
     if (renderer().isRenderTextOrLineBreak())
         return lineStyle.metricsOfPrimaryFont().intHeight();

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.h
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.h
@@ -46,8 +46,6 @@ public:
         , m_baselineType(AlphabeticBaseline)
         , m_hasAnnotationsBefore(false)
         , m_hasAnnotationsAfter(false)
-        , m_isFirstAfterPageBreak(false)
-        , m_isForTrailingFloats(false)
         , m_hasSelfPaintInlineBox(false)
 #if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
         , m_hasBadChildList(false)
@@ -254,8 +252,6 @@ protected:
     unsigned m_lineBreakBidiStatusLastStrong : 5; // UCharDirection
     unsigned m_lineBreakBidiStatusLast : 5; // UCharDirection
 
-    unsigned m_isFirstAfterPageBreak : 1;
-    unsigned m_isForTrailingFloats : 1;
     unsigned m_hasSelfPaintInlineBox : 1;
 
     // End of RootInlineBox-specific members.

--- a/Source/WebCore/rendering/LegacyLineLayout.h
+++ b/Source/WebCore/rendering/LegacyLineLayout.h
@@ -65,7 +65,6 @@ public:
     void layoutLineBoxes(bool relayoutChildren, LayoutUnit& repaintLogicalTop, LayoutUnit& repaintLogicalBottom);
 
     LegacyRootInlineBox* constructLine(BidiRunList<BidiRun>&, const LineInfo&);
-    bool positionNewFloatOnLine(const FloatingObject& newFloat, FloatingObject* lastFloatFromPreviousLine, LineInfo&, LineWidth&);
     void addOverflowFromInlineChildren();
 
     size_t lineCount() const;
@@ -82,20 +81,13 @@ private:
     void removeInlineBox(BidiRun&, const LegacyRootInlineBox&) const;
     void removeEmptyTextBoxesAndUpdateVisualReordering(LegacyRootInlineBox*, BidiRun* firstRun);
     inline BidiRun* handleTrailingSpaces(BidiRunList<BidiRun>& bidiRuns, BidiContext* currentContext);
-    void appendFloatingObjectToLastLine(FloatingObject&);
     LegacyRootInlineBox* createLineBoxesFromBidiRuns(unsigned bidiLevel, BidiRunList<BidiRun>& bidiRuns, const LegacyInlineIterator& end, LineInfo&);
     void layoutRunsAndFloats(LineLayoutState&, bool hasInlineChild);
-    inline const LegacyInlineIterator& restartLayoutRunsAndFloatsInRange(LayoutUnit oldLogicalHeight, LayoutUnit newLogicalHeight, FloatingObject* lastFloatFromPreviousLine, InlineBidiResolver&,  const LegacyInlineIterator& oldEnd);
-    void layoutRunsAndFloatsInRange(LineLayoutState&, InlineBidiResolver&, const LegacyInlineIterator& cleanLineStart, const BidiStatus& cleanLineBidiStatus, unsigned consecutiveHyphenatedLines);
-    void reattachCleanLineFloats(LegacyRootInlineBox& cleanLine, LayoutUnit delta, bool isFirstCleanLine);
+    void layoutRunsAndFloatsInRange(LineLayoutState&, InlineBidiResolver&, const LegacyInlineIterator& cleanLineStart, unsigned consecutiveHyphenatedLines);
     void linkToEndLineIfNeeded(LineLayoutState&);
-    void checkFloatInCleanLine(LegacyRootInlineBox& cleanLine, RenderBox& floatBoxOnCleanLine, FloatWithRect& matchingFloatWithRect, bool& encounteredNewFloat, bool& dirtiedByFloat);
     LegacyRootInlineBox* determineStartPosition(LineLayoutState&, InlineBidiResolver&);
-    void determineEndPosition(LineLayoutState&, LegacyRootInlineBox* startLine, LegacyInlineIterator& cleanLineStart, BidiStatus& cleanLineBidiStatus);
-    bool checkPaginationAndFloatsAtEndLine(LineLayoutState&);
-    bool lineWidthForPaginatedLineChanged(LegacyRootInlineBox* rootBox, LayoutUnit lineDelta, RenderFragmentedFlow*) const;
-    bool matchedEndLine(LineLayoutState&, const InlineBidiResolver&, const LegacyInlineIterator& endLineStart, const BidiStatus& endLineStatus);
-    void updateFragmentForLine(LegacyRootInlineBox*) const;
+    void determineEndPosition(LineLayoutState&, LegacyRootInlineBox* startLine, LegacyInlineIterator& cleanLineStart);
+    bool matchedEndLine(LineLayoutState&, const InlineBidiResolver&, const LegacyInlineIterator& endLineStart);
 
     const RenderStyle& style() const;
     const LocalFrameViewLayoutContext& layoutContext() const;

--- a/Source/WebCore/rendering/LegacyRootInlineBox.h
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.h
@@ -30,7 +30,6 @@ namespace WebCore {
 class HitTestResult;
 class LogicalSelectionOffsetCaches;
 class RenderBlockFlow;
-class RenderFragmentContainer;
 
 struct BidiStatus;
 struct GapRects;
@@ -55,21 +54,6 @@ public:
     LayoutUnit lineBoxTop() const { return m_lineBoxTop; }
     LayoutUnit lineBoxBottom() const { return m_lineBoxBottom; }
     LayoutUnit lineBoxHeight() const { return lineBoxBottom() - lineBoxTop(); }
-    
-    LayoutUnit paginationStrut() const { return m_paginationStrut; }
-    void setPaginationStrut(LayoutUnit strut) { m_paginationStrut = strut; }
-
-    bool isFirstAfterPageBreak() const { return m_isFirstAfterPageBreak; }
-    void setIsFirstAfterPageBreak(bool isFirstAfterPageBreak) { m_isFirstAfterPageBreak = isFirstAfterPageBreak; }
-
-    LayoutUnit paginatedLineWidth() const { return m_paginatedLineWidth; }
-    void setPaginatedLineWidth(LayoutUnit width) { m_paginatedLineWidth = width; }
-
-    // It should not be assumed the containingFragment() is always valid.
-    // It can also be nullptr if the flow has no fragment chain.
-    RenderFragmentContainer* containingFragment() const;
-    void setContainingFragment(RenderFragmentContainer&);
-    void clearContainingFragment();
 
     LayoutUnit selectionTop() const;
     LayoutUnit selectionBottom() const;
@@ -93,9 +77,6 @@ public:
     unsigned lineBreakPos() const { return m_lineBreakPos; }
     void setLineBreakPos(unsigned p) { m_lineBreakPos = p; }
 
-    bool isForTrailingFloats() const { return m_isForTrailingFloats; }
-    void setIsForTrailingFloats() { m_isForTrailingFloats = true; }
-
     using LegacyInlineBox::endsWithBreak;
     using LegacyInlineBox::setEndsWithBreak;
 
@@ -109,25 +90,6 @@ public:
     RenderObject::HighlightState selectionState() const final;
     const LegacyInlineBox* firstSelectedBox() const;
     const LegacyInlineBox* lastSelectedBox() const;
-
-    using CleanLineFloatList = Vector<SingleThreadWeakPtr<RenderBox>>;
-    void appendFloat(RenderBox& floatingBox)
-    {
-        ASSERT(!isDirty());
-        if (m_floats)
-            m_floats->append(floatingBox);
-        else
-            m_floats = makeUnique<CleanLineFloatList>(1, floatingBox);
-    }
-
-    void removeFloat(RenderBox& floatingBox)
-    {
-        ASSERT(m_floats);
-        ASSERT(m_floats->contains(&floatingBox));
-        m_floats->remove(m_floats->find(&floatingBox));
-    }
-
-    CleanLineFloatList* floatsPtr() { ASSERT(!isDirty()); return m_floats.get(); }
 
     void extractLineBoxFromRenderObject() final;
     void attachLineBoxToRenderObject() final;
@@ -175,13 +137,6 @@ private:
 
     LayoutUnit m_lineBoxTop;
     LayoutUnit m_lineBoxBottom;
-
-    LayoutUnit m_paginationStrut;
-    LayoutUnit m_paginatedLineWidth;
-
-    // Floats hanging off the line are pushed into this vector during layout. It is only
-    // good for as long as the line has not been marked dirty.
-    std::unique_ptr<CleanLineFloatList> m_floats;
 };
 
 inline LegacyRootInlineBox* LegacyRootInlineBox::nextRootBox() const

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -282,11 +282,6 @@ void RenderBlockFlow::rebuildFloatingObjectSetFromIntrudingFloats()
                             changeLogicalBottom = std::max(changeLogicalBottom, std::max(logicalTop, oldLogicalTop));
                         }
                     }
-
-                    if (oldFloatingObject->originatingLine() && !selfNeedsLayout()) {
-                        ASSERT(&oldFloatingObject->originatingLine()->renderer() == this);
-                        oldFloatingObject->originatingLine()->markDirty();
-                    }
                 } else {
                     changeLogicalTop = 0;
                     changeLogicalBottom = std::max(changeLogicalBottom, logicalBottom);
@@ -1985,16 +1980,6 @@ static void clearShouldBreakAtLineToAvoidWidowIfNeeded(RenderBlockFlow& blockFlo
     blockFlow.setDidBreakAtLineToAvoidWidow();
 }
 
-void RenderBlockFlow::adjustLinePositionForPagination(LegacyRootInlineBox* rootInlineBox, LayoutUnit& delta)
-{
-    auto adjustment = computeLineAdjustmentForPagination(rootInlineBox, delta);
-
-    rootInlineBox->setPaginationStrut(adjustment.strut);
-    rootInlineBox->setIsFirstAfterPageBreak(adjustment.isFirstAfterPageBreak);
-
-    delta += adjustment.strut;
-}
-
 RenderBlockFlow::LinePaginationAdjustment RenderBlockFlow::computeLineAdjustmentForPagination(const InlineIterator::LineBoxIterator& lineBox, LayoutUnit delta, LayoutUnit floatMinimumBottom)
 {
     // FIXME: For now we paginate using line overflow. This ensures that lines don't overlap at all when we
@@ -2688,16 +2673,6 @@ void RenderBlockFlow::removeFloatingObject(RenderBox& floatBox)
                     // the line that they're on, but it still needs to be dirtied. This is
                     // accomplished by pretending they have a height of 1.
                     logicalBottom = std::max(logicalBottom, logicalTop + 1);
-                }
-                if (floatingObject.originatingLine()) {
-                    floatingObject.originatingLine()->removeFloat(floatBox);
-                    if (!selfNeedsLayout()) {
-                        ASSERT(&floatingObject.originatingLine()->renderer() == this);
-                        floatingObject.originatingLine()->markDirty();
-                    }
-#if ASSERT_ENABLED
-                    floatingObject.clearOriginatingLine();
-#endif
                 }
                 markLinesDirtyInBlockRange(0, logicalBottom);
             }

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -534,9 +534,6 @@ private:
     std::optional<LayoutUnit> selfCollapsingMarginBeforeWithClear(RenderObject* candidate);
 
 public:
-    // Computes a deltaOffset value that put a line at the top of the next page if it doesn't fit on the current page.
-    void adjustLinePositionForPagination(LegacyRootInlineBox*, LayoutUnit& deltaOffset);
-
     struct LinePaginationAdjustment {
         LayoutUnit strut { 0_lu };
         bool isFirstAfterPageBreak { false };

--- a/Source/WebCore/rendering/RenderFragmentContainer.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainer.cpp
@@ -494,21 +494,13 @@ void RenderFragmentContainer::addVisualOverflowForBox(const RenderBox& box, cons
     fragmentOverflow->addVisualOverflow(flippedRect);
 }
 
-LayoutRect RenderFragmentContainer::visualOverflowRectForBox(const RenderBoxModelObject& box) const
+LayoutRect RenderFragmentContainer::visualOverflowRectForBox(const RenderBox& box) const
 {
-    if (CheckedPtr inlineBox = dynamicDowncast<RenderInline>(box))
-        return inlineBox->linesVisualOverflowBoundingBoxInFragment(this);
+    RefPtr<RenderOverflow> overflow;
+    ensureOverflowForBox(box, overflow, true);
 
-    if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(box)) {
-        RefPtr<RenderOverflow> overflow;
-        ensureOverflowForBox(*renderBox, overflow, true);
-
-        ASSERT(overflow);
-        return overflow->visualOverflowRect();
-    }
-
-    ASSERT_NOT_REACHED();
-    return LayoutRect();
+    ASSERT(overflow);
+    return overflow->visualOverflowRect();
 }
 
 // FIXME: This doesn't work for writing modes.
@@ -536,7 +528,7 @@ LayoutRect RenderFragmentContainer::layoutOverflowRectForBoxForPropagation(const
     return rect;
 }
 
-LayoutRect RenderFragmentContainer::visualOverflowRectForBoxForPropagation(const RenderBoxModelObject& box)
+LayoutRect RenderFragmentContainer::visualOverflowRectForBoxForPropagation(const RenderBox& box)
 {
     LayoutRect rect = visualOverflowRectForBox(box);
     fragmentedFlow()->flipForWritingModeLocalCoordinates(rect);

--- a/Source/WebCore/rendering/RenderFragmentContainer.h
+++ b/Source/WebCore/rendering/RenderFragmentContainer.h
@@ -104,9 +104,9 @@ public:
 
     void addLayoutOverflowForBox(const RenderBox&, const LayoutRect&);
     void addVisualOverflowForBox(const RenderBox&, const LayoutRect&);
-    LayoutRect visualOverflowRectForBox(const RenderBoxModelObject&) const;
+    LayoutRect visualOverflowRectForBox(const RenderBox&) const;
     LayoutRect layoutOverflowRectForBoxForPropagation(const RenderBox&);
-    LayoutRect visualOverflowRectForBoxForPropagation(const RenderBoxModelObject&);
+    LayoutRect visualOverflowRectForBoxForPropagation(const RenderBox&);
 
     LayoutRect rectFlowPortionForBox(const RenderBox&, const LayoutRect&) const;
     

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -575,49 +575,6 @@ LayoutRect RenderInline::linesVisualOverflowBoundingBox() const
     return rect;
 }
 
-LayoutRect RenderInline::linesVisualOverflowBoundingBoxInFragment(const RenderFragmentContainer* fragment) const
-{
-    ASSERT(fragment);
-
-    if (!firstLineBox() || !lastLineBox())
-        return LayoutRect();
-
-    // Return the width of the minimal left side and the maximal right side.
-    LayoutUnit logicalLeftSide = LayoutUnit::max();
-    LayoutUnit logicalRightSide = LayoutUnit::min();
-    LayoutUnit logicalTop;
-    LayoutUnit logicalHeight;
-    LegacyInlineFlowBox* lastInlineInFragment = 0;
-    for (auto* curr = firstLineBox(); curr; curr = curr->nextLineBox()) {
-        const LegacyRootInlineBox& root = curr->root();
-        if (root.containingFragment() != fragment) {
-            if (lastInlineInFragment)
-                break;
-            continue;
-        }
-
-        if (!lastInlineInFragment)
-            logicalTop = curr->logicalTopVisualOverflow(root.lineTop());
-
-        lastInlineInFragment = curr;
-
-        logicalLeftSide = std::min(logicalLeftSide, curr->logicalLeftVisualOverflow());
-        logicalRightSide = std::max(logicalRightSide, curr->logicalRightVisualOverflow());
-    }
-
-    if (!lastInlineInFragment)
-        return LayoutRect();
-
-    logicalHeight = lastInlineInFragment->logicalBottomVisualOverflow(lastInlineInFragment->root().lineBottom()) - logicalTop;
-    
-    LayoutUnit logicalWidth = logicalRightSide - logicalLeftSide;
-    
-    LayoutRect rect(logicalLeftSide, logicalTop, logicalWidth, logicalHeight);
-    if (!style().isHorizontalWritingMode())
-        rect = rect.transposedRect();
-    return rect;
-}
-
 LayoutRect RenderInline::clippedOverflowRect(const RenderLayerModelObject* repaintContainer, VisibleRectContext context) const
 {
     // Only first-letter renderers are allowed in here during layout. They mutate the tree triggering repaints.

--- a/Source/WebCore/rendering/RenderInline.h
+++ b/Source/WebCore/rendering/RenderInline.h
@@ -60,7 +60,6 @@ public:
 
     WEBCORE_EXPORT IntRect linesBoundingBox() const;
     LayoutRect linesVisualOverflowBoundingBox() const;
-    LayoutRect linesVisualOverflowBoundingBoxInFragment(const RenderFragmentContainer*) const;
 
     LegacyInlineFlowBox* createAndAppendInlineFlowBox();
 

--- a/Source/WebCore/rendering/RenderLineBoxList.cpp
+++ b/Source/WebCore/rendering/RenderLineBoxList.cpp
@@ -369,17 +369,8 @@ void RenderLineBoxList::dirtyLinesFromChangedChild(RenderBoxModelObject& contain
 
         // FIXME: We shouldn't need to always dirty the next line. This is only strictly 
         // necessary some of the time, in situations involving BRs.
-        if (LegacyRootInlineBox* nextBox = box->nextRootBox()) {
+        if (LegacyRootInlineBox* nextBox = box->nextRootBox())
             nextBox->markDirty();
-            // Dedicated linebox for floats may be added as the last rootbox. If this occurs with BRs inside inlines that propagte their lineboxes to
-            // the parent flow, we need to invalidate it explicitly.
-            // FIXME: We should be able to figure out the actual "changed child" even when we are calling through empty inlines recursively.
-            if (auto* renderInline = dynamicDowncast<RenderInline>(child); renderInline && !renderInline->firstLineBox()) {
-                auto* lastRootBox = nextBox->blockFlow().lastRootBox();
-                if (lastRootBox->isForTrailingFloats() && !lastRootBox->isDirty())
-                    lastRootBox->markDirty();
-            }
-        }
     }
 }
 

--- a/Source/WebCore/rendering/line/LineBreaker.cpp
+++ b/Source/WebCore/rendering/line/LineBreaker.cpp
@@ -32,42 +32,20 @@ namespace WebCore {
 
 void LineBreaker::reset()
 {
-    m_positionedObjects.clear();
     m_hyphenated = false;
-    m_clear = UsedClear::None;
 }
 
-// FIXME: The entire concept of the skipTrailingWhitespace function is flawed, since we really need to be building
-// line boxes even for containers that may ultimately collapse away. Otherwise we'll never get positioned
-// elements quite right. In other words, we need to build this function's work into the normal line
-// object iteration process.
-// NB. this function will insert any floating elements that would otherwise
-// be skipped but it will not position them.
 void LineBreaker::skipTrailingWhitespace(LegacyInlineIterator& iterator, const LineInfo& lineInfo)
 {
-    while (!iterator.atEnd() && !requiresLineBox(iterator, lineInfo, TrailingWhitespace)) {
-        RenderObject& object = *iterator.renderer();
-        if (object.isOutOfFlowPositioned())
-            setStaticPositions(m_block, downcast<RenderBox>(object), DoNotIndentText);
-        else if (object.isFloating())
-            m_block.insertFloatingObject(downcast<RenderBox>(object));
+    while (!iterator.atEnd() && !requiresLineBox(iterator, lineInfo, TrailingWhitespace))
         iterator.increment();
-    }
 }
 
-void LineBreaker::skipLeadingWhitespace(InlineBidiResolver& resolver, LineInfo& lineInfo, FloatingObject* lastFloatFromPreviousLine, LineWidth& width)
+void LineBreaker::skipLeadingWhitespace(InlineBidiResolver& resolver, LineInfo& lineInfo)
 {
     while (!resolver.position().atEnd() && !requiresLineBox(resolver.position(), lineInfo, LeadingWhitespace)) {
         RenderObject& object = *resolver.position().renderer();
-        if (object.isOutOfFlowPositioned()) {
-            setStaticPositions(m_block, downcast<RenderBox>(object), width.shouldIndentText());
-            if (object.style().isOriginalDisplayInlineType()) {
-                resolver.runs().appendRun(makeUnique<BidiRun>(0, 1, object, resolver.context(), resolver.dir()));
-                lineInfo.incrementRunsFromLeadingWhitespace();
-            }
-        } else if (object.isFloating())
-            m_block.legacyLineLayout()->positionNewFloatOnLine(*m_block.insertFloatingObject(downcast<RenderBox>(object)), lastFloatFromPreviousLine, lineInfo, width);
-        else if (object.style().hasTextCombine()) {
+        if (object.style().hasTextCombine()) {
             if (CheckedPtr combineText = dynamicDowncast<RenderCombineText>(object)) {
                 combineText->combineTextIfNeeded();
                 if (combineText->isCombined())
@@ -79,7 +57,7 @@ void LineBreaker::skipLeadingWhitespace(InlineBidiResolver& resolver, LineInfo& 
     resolver.commitExplicitEmbedding();
 }
 
-LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, LineInfo& lineInfo, RenderTextInfo& renderTextInfo, FloatingObject* lastFloatFromPreviousLine, unsigned consecutiveHyphenatedLines, WordMeasurements& wordMeasurements)
+LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, LineInfo& lineInfo, RenderTextInfo& renderTextInfo, unsigned consecutiveHyphenatedLines, WordMeasurements& wordMeasurements)
 {
     reset();
 
@@ -89,25 +67,17 @@ LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, Li
 
     LineWidth width(m_block, lineInfo.isFirstLine(), requiresIndent(lineInfo.isFirstLine(), lineInfo.previousLineBrokeCleanly(), m_block.style()));
 
-    skipLeadingWhitespace(resolver, lineInfo, lastFloatFromPreviousLine, width);
+    skipLeadingWhitespace(resolver, lineInfo);
 
     if (resolver.position().atEnd())
         return resolver.position();
 
-    BreakingContext context(*this, resolver, lineInfo, width, renderTextInfo, lastFloatFromPreviousLine, appliedStartWidth, m_block);
+    BreakingContext context(*this, resolver, lineInfo, width, renderTextInfo, appliedStartWidth, m_block);
 
     while (context.currentObject()) {
         context.initializeForCurrentObject();
-        if (context.currentObject()->isBR()) {
-            context.handleBR(m_clear);
-        } else if (context.currentObject()->isOutOfFlowPositioned()) {
-            context.handleOutOfFlowPositioned(m_positionedObjects);
-        } else if (context.currentObject()->isFloating()) {
-            context.handleFloat();
-        } else if (context.currentObject()->isRenderInline()) {
+        if (context.currentObject()->isRenderInline()) {
             context.handleEmptyInline();
-        } else if (context.currentObject()->isReplacedOrInlineBlock()) {
-            context.handleReplaced();
         } else if (context.currentObject()->isRenderText()) {
             if (context.handleText(wordMeasurements, m_hyphenated, consecutiveHyphenatedLines)) {
                 // We've hit a hard text line break. Our line break iterator is updated, so early return.

--- a/Source/WebCore/rendering/line/LineBreaker.h
+++ b/Source/WebCore/rendering/line/LineBreaker.h
@@ -50,28 +50,18 @@ public:
         reset();
     }
 
-    LegacyInlineIterator nextLineBreak(InlineBidiResolver&, LineInfo&, RenderTextInfo&, FloatingObject* lastFloatFromPreviousLine, unsigned consecutiveHyphenatedLines, WordMeasurements&);
+    LegacyInlineIterator nextLineBreak(InlineBidiResolver&, LineInfo&, RenderTextInfo&, unsigned consecutiveHyphenatedLines, WordMeasurements&);
 
     bool lineWasHyphenated() { return m_hyphenated; }
-    const Vector<RenderBox*>& positionedObjects() { return m_positionedObjects; }
-    UsedClear usedClear() { return m_clear; }
 
 private:
     void reset();
 
     void skipTrailingWhitespace(LegacyInlineIterator&, const LineInfo&);
-    void skipLeadingWhitespace(InlineBidiResolver&, LineInfo&, FloatingObject* lastFloatFromPreviousLine, LineWidth&);
-
-    FloatingObject* insertFloatingObject(RenderBox& floatBox) { return m_block.insertFloatingObject(floatBox); }
-    bool positionNewFloatOnLine(const FloatingObject& newFloat, FloatingObject* lastFloatFromPreviousLine, LineInfo& lineInfo, LineWidth& width)
-    {
-        return m_block.legacyLineLayout()->positionNewFloatOnLine(newFloat, lastFloatFromPreviousLine, lineInfo, width);
-    }
+    void skipLeadingWhitespace(InlineBidiResolver&, LineInfo&);
 
     RenderBlockFlow& m_block;
     bool m_hyphenated;
-    UsedClear m_clear;
-    Vector<RenderBox*> m_positionedObjects;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/line/LineLayoutState.h
+++ b/Source/WebCore/rendering/line/LineLayoutState.h
@@ -35,77 +35,19 @@
 
 #include "LayoutRect.h"
 #include "RenderBlockFlow.h"
-#include "RenderFragmentedFlow.h"
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
-
-class FloatWithRect : public RefCounted<FloatWithRect> {
-    WTF_MAKE_FAST_ALLOCATED;
-public:
-    static Ref<FloatWithRect> create(RenderBox& renderer)
-    {
-        return adoptRef(*new FloatWithRect(renderer));
-    }
-    
-    RenderBox& renderer() const { return m_renderer; }
-    LayoutRect rect() const { return m_rect; }
-    bool everHadLayout() const { return m_everHadLayout; }
-
-    void adjustRect(const LayoutRect& rect) { m_rect = rect; }
-
-private:
-    FloatWithRect(RenderBox& renderer)
-        : m_renderer(renderer)
-        , m_rect(LayoutRect(renderer.x() - renderer.marginLeft(), renderer.y() - renderer.marginTop(), renderer.width() + renderer.horizontalMarginExtent(), renderer.height() + renderer.verticalMarginExtent()))
-        , m_everHadLayout(renderer.everHadLayout())
-    {
-    }
-    
-    RenderBox& m_renderer;
-    LayoutRect m_rect;
-    bool m_everHadLayout { false };
-};
 
 // Like LayoutState for layout(), LineLayoutState keeps track of global information
 // during an entire linebox tree layout pass (aka layoutInlineChildren).
 class LineLayoutState {
 public:
-    class FloatList {
-    public:
-        void append(Ref<FloatWithRect>&& floatWithRect)
-        {
-            m_floats.add(floatWithRect.copyRef());
-            m_floatWithRectMap.add(floatWithRect->renderer(), WTFMove(floatWithRect));
-        }
-        void setLastFloat(FloatingObject* lastFloat) { m_lastFloat = lastFloat; }
-        FloatingObject* lastFloat() const { return m_lastFloat; }
-
-        void setLastCleanFloat(RenderBox& floatBox) { m_lastCleanFloat = &floatBox; }
-        RenderBox* lastCleanFloat() const { return m_lastCleanFloat; }
-
-        FloatWithRect* floatWithRect(RenderBox& floatBox) const { return m_floatWithRectMap.get(floatBox); }
-
-        using Iterator = ListHashSet<Ref<FloatWithRect>>::iterator;
-        Iterator begin() { return m_floats.begin(); }
-        Iterator end() { return m_floats.end(); }
-        Iterator find(FloatWithRect& floatBoxWithRect) { return m_floats.find(floatBoxWithRect); }
-        bool isEmpty() const { return m_floats.isEmpty(); }
-
-    private:
-        ListHashSet<Ref<FloatWithRect>> m_floats;
-        HashMap<SingleThreadWeakRef<RenderBox>, Ref<FloatWithRect>> m_floatWithRectMap;
-        FloatingObject* m_lastFloat { nullptr };
-        RenderBox* m_lastCleanFloat { nullptr };
-    };
-
-    LineLayoutState(const RenderBlockFlow& blockFlow, bool fullLayout, LayoutUnit& repaintLogicalTop, LayoutUnit& repaintLogicalBottom, RenderFragmentedFlow* fragmentedFlow)
-        : m_fragmentedFlow(fragmentedFlow)
-        , m_repaintLogicalTop(repaintLogicalTop)
+    LineLayoutState(const RenderBlockFlow& blockFlow, bool fullLayout, LayoutUnit& repaintLogicalTop, LayoutUnit& repaintLogicalBottom)
+        : m_repaintLogicalTop(repaintLogicalTop)
         , m_repaintLogicalBottom(repaintLogicalBottom)
         , m_marginInfo(blockFlow, blockFlow.borderAndPaddingBefore(), blockFlow.borderAndPaddingAfter() + blockFlow.scrollbarLogicalHeight())
         , m_endLineMatched(false)
-        , m_checkForFloatsFromLastLine(false)
         , m_isFullLayout(fullLayout)
         , m_usesRepaintBounds(false)
     {
@@ -123,13 +65,8 @@ public:
     LayoutUnit adjustedLogicalLineTop() const { return m_adjustedLogicalLineTop; }
     void setAdjustedLogicalLineTop(LayoutUnit value) { m_adjustedLogicalLineTop = value; }
 
-    RenderFragmentedFlow* fragmentedFlow() const { return m_fragmentedFlow.get(); }
-
     bool endLineMatched() const { return m_endLineMatched; }
     void setEndLineMatched(bool endLineMatched) { m_endLineMatched = endLineMatched; }
-
-    bool checkForFloatsFromLastLine() const { return m_checkForFloatsFromLastLine; }
-    void setCheckForFloatsFromLastLine(bool check) { m_checkForFloatsFromLastLine = check; }
 
     void markForFullLayout() { m_isFullLayout = true; }
     bool isFullLayout() const { return m_isFullLayout; }
@@ -151,8 +88,6 @@ public:
 
     RenderBlockFlow::MarginInfo& marginInfo() { return m_marginInfo; }
 
-    FloatList& floatList() { return m_floatList; }
-
 private:
     LineInfo m_lineInfo;
     LayoutUnit m_endLineLogicalTop;
@@ -160,9 +95,6 @@ private:
 
     LayoutUnit m_adjustedLogicalLineTop;
 
-    SingleThreadWeakPtr<RenderFragmentedFlow> m_fragmentedFlow;
-
-    FloatList m_floatList;
     // FIXME: Should this be a range object instead of two ints?
     LayoutUnit& m_repaintLogicalTop;
     LayoutUnit& m_repaintLogicalBottom;
@@ -170,7 +102,6 @@ private:
     RenderBlockFlow::MarginInfo m_marginInfo;
 
     bool m_endLineMatched : 1;
-    bool m_checkForFloatsFromLastLine : 1;
     bool m_isFullLayout : 1;
     bool m_usesRepaintBounds : 1;
 };


### PR DESCRIPTION
#### 1a03c1187459057ba2b479f620dc17f53ec252ab
<pre>
[Legacy line layout removal] Remove float and pagination support
<a href="https://bugs.webkit.org/show_bug.cgi?id=271056">https://bugs.webkit.org/show_bug.cgi?id=271056</a>
<a href="https://rdar.apple.com/problem/124691392">rdar://problem/124691392</a>

Reviewed by Alan Baradlay.

Neither is used or needed anymore.

* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxLegacyPath.h:
(WebCore::InlineIterator::LineBoxIteratorLegacyPath::containingFragment const):
(WebCore::InlineIterator::LineBoxIteratorLegacyPath::isFirstAfterPageBreak const):
* Source/WebCore/rendering/FloatingObjects.cpp:
(WebCore::FloatingObjects::remove):
(WebCore::FloatingObjects::clearLineBoxTreePointers): Deleted.
* Source/WebCore/rendering/FloatingObjects.h:
(WebCore::FloatingObjects::set const):
(WebCore::FloatingObject::originatingLine const): Deleted.
(WebCore::FloatingObject::clearOriginatingLine): Deleted.
(WebCore::FloatingObject::setOriginatingLine): Deleted.
* Source/WebCore/rendering/LegacyInlineBox.cpp:
(WebCore::LegacyInlineBox::logicalHeight const):
* Source/WebCore/rendering/LegacyInlineFlowBox.h:
(WebCore::LegacyInlineFlowBox::LegacyInlineFlowBox):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::~LegacyLineLayout):
(WebCore::LegacyLineLayout::layoutRunsAndFloats):
(WebCore::LegacyLineLayout::layoutRunsAndFloatsInRange):
(WebCore::LegacyLineLayout::linkToEndLineIfNeeded):
(WebCore::LegacyLineLayout::layoutLineBoxes):
(WebCore::LegacyLineLayout::determineStartPosition):
(WebCore::LegacyLineLayout::determineEndPosition):
(WebCore::LegacyLineLayout::matchedEndLine):
(WebCore::LegacyLineLayout::addOverflowFromInlineChildren):
(WebCore::LegacyLineLayout::appendFloatingObjectToLastLine): Deleted.
(WebCore::repaintDirtyFloats): Deleted.
(WebCore::LegacyLineLayout::restartLayoutRunsAndFloatsInRange): Deleted.
(WebCore::LegacyLineLayout::reattachCleanLineFloats): Deleted.
(WebCore::LegacyLineLayout::checkFloatInCleanLine): Deleted.
(WebCore::LegacyLineLayout::checkPaginationAndFloatsAtEndLine): Deleted.
(WebCore::LegacyLineLayout::lineWidthForPaginatedLineChanged const): Deleted.
(WebCore::LegacyLineLayout::positionNewFloatOnLine): Deleted.
(WebCore::LegacyLineLayout::updateFragmentForLine const): Deleted.
* Source/WebCore/rendering/LegacyLineLayout.h:
* Source/WebCore/rendering/LegacyRootInlineBox.cpp:
(WebCore::LegacyRootInlineBox::~LegacyRootInlineBox):
(WebCore::containingFragmentMap): Deleted.
(WebCore::LegacyRootInlineBox::containingFragment const): Deleted.
(WebCore::LegacyRootInlineBox::clearContainingFragment): Deleted.
(WebCore::LegacyRootInlineBox::setContainingFragment): Deleted.
* Source/WebCore/rendering/LegacyRootInlineBox.h:
(WebCore::LegacyRootInlineBox::lineBoxHeight const):
(WebCore::LegacyRootInlineBox::paginationStrut const): Deleted.
(WebCore::LegacyRootInlineBox::setPaginationStrut): Deleted.
(WebCore::LegacyRootInlineBox::isFirstAfterPageBreak const): Deleted.
(WebCore::LegacyRootInlineBox::setIsFirstAfterPageBreak): Deleted.
(WebCore::LegacyRootInlineBox::paginatedLineWidth const): Deleted.
(WebCore::LegacyRootInlineBox::setPaginatedLineWidth): Deleted.
(WebCore::LegacyRootInlineBox::isForTrailingFloats const): Deleted.
(WebCore::LegacyRootInlineBox::setIsForTrailingFloats): Deleted.
(WebCore::LegacyRootInlineBox::appendFloat): Deleted.
(WebCore::LegacyRootInlineBox::removeFloat): Deleted.
(WebCore::LegacyRootInlineBox::floatsPtr): Deleted.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::rebuildFloatingObjectSetFromIntrudingFloats):
(WebCore::RenderBlockFlow::removeFloatingObject):
(WebCore::RenderBlockFlow::adjustLinePositionForPagination): Deleted.
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderFragmentContainer.cpp:
(WebCore::RenderFragmentContainer::visualOverflowRectForBox const):
(WebCore::RenderFragmentContainer::visualOverflowRectForBoxForPropagation):

Tighten RenderBoxModelObject -&gt; RenderBox making it clear
RenderInline::linesVisualOverflowBoundingBoxInFragment is unneeded.

* Source/WebCore/rendering/RenderFragmentContainer.h:
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::linesVisualOverflowBoundingBoxInFragment const): Deleted.
* Source/WebCore/rendering/RenderInline.h:
(WebCore::RenderInline::linesVisualOverflowBoundingBoxInFragment const):
* Source/WebCore/rendering/RenderLineBoxList.cpp:
(WebCore::RenderLineBoxList::dirtyLinesFromChangedChild):
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::BreakingContext):
(WebCore::shouldSkipWhitespaceAfterStartObject):
(WebCore::BreakingContext::handleFloat): Deleted.
* Source/WebCore/rendering/line/LineBreaker.cpp:
(WebCore::LineBreaker::reset):
(WebCore::LineBreaker::skipTrailingWhitespace):
(WebCore::LineBreaker::skipLeadingWhitespace):
(WebCore::LineBreaker::nextLineBreak):
* Source/WebCore/rendering/line/LineBreaker.h:
(WebCore::LineBreaker::lineWasHyphenated):
(WebCore::LineBreaker::usedClear): Deleted.
(WebCore::LineBreaker::insertFloatingObject): Deleted.
(WebCore::LineBreaker::positionNewFloatOnLine): Deleted.
* Source/WebCore/rendering/line/LineLayoutState.h:
(WebCore::LineLayoutState::LineLayoutState):
(WebCore::FloatWithRect::create): Deleted.
(WebCore::FloatWithRect::renderer const): Deleted.
(WebCore::FloatWithRect::rect const): Deleted.
(WebCore::FloatWithRect::everHadLayout const): Deleted.
(WebCore::FloatWithRect::adjustRect): Deleted.
(WebCore::FloatWithRect::FloatWithRect): Deleted.
(): Deleted.
(WebCore::LineLayoutState::FloatList::append): Deleted.
(WebCore::LineLayoutState::FloatList::setLastFloat): Deleted.
(WebCore::LineLayoutState::FloatList::lastFloat const): Deleted.
(WebCore::LineLayoutState::FloatList::setLastCleanFloat): Deleted.
(WebCore::LineLayoutState::FloatList::lastCleanFloat const): Deleted.
(WebCore::LineLayoutState::FloatList::floatWithRect const): Deleted.
(WebCore::LineLayoutState::FloatList::begin): Deleted.
(WebCore::LineLayoutState::FloatList::end): Deleted.
(WebCore::LineLayoutState::FloatList::find): Deleted.
(WebCore::LineLayoutState::FloatList::isEmpty const): Deleted.
(WebCore::LineLayoutState::fragmentedFlow const): Deleted.
(WebCore::LineLayoutState::checkForFloatsFromLastLine const): Deleted.
(WebCore::LineLayoutState::setCheckForFloatsFromLastLine): Deleted.
(WebCore::LineLayoutState::floatList): Deleted.

Canonical link: <a href="https://commits.webkit.org/276188@main">https://commits.webkit.org/276188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58bddc79520fe6984210c4412a169bba19b02a10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46614 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20425 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20056 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17284 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38959 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2024 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48189 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15544 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41820 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9777 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20564 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->