### PR TITLE
[web-animations] transform animation shows invisible frame on iteration

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2795,4 +2795,24 @@ bool KeyframeEffect::isPropertyAdditiveOrCumulative(KeyframeInterpolation::Prope
     });
 }
 
+void KeyframeEffect::populateStylesAtIterationBoundary(Vector<const RenderStyle*>& styles)
+{
+    if (iterations() <= 1)
+        return;
+
+    auto numberOfKeyframes = m_blendingKeyframes.size();
+    if (!numberOfKeyframes)
+        return;
+
+    auto addKeyframeStyle = [&](const BlendingKeyframe& keyframe) {
+        auto offset = keyframe.offset();
+        if (!offset || offset == 1)
+            styles.append(keyframe.style());
+    };
+
+    addKeyframeStyle(m_blendingKeyframes[0]);
+    if (numberOfKeyframes > 1)
+        addKeyframeStyle(m_blendingKeyframes[numberOfKeyframes - 1]);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -192,6 +192,8 @@ public:
 
     WebAnimationType animationType() const { return m_animationType; }
 
+    void populateStylesAtIterationBoundary(Vector<const RenderStyle*>&);
+
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     const AcceleratedEffect* acceleratedRepresentation() const { return m_acceleratedRepresentation.get(); }
     void setAcceleratedRepresentation(const AcceleratedEffect* acceleratedRepresentation) { m_acceleratedRepresentation = acceleratedRepresentation; }

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -333,4 +333,12 @@ bool KeyframeEffectStack::hasAcceleratedEffects(const Settings& settings) const
     return false;
 }
 
+Vector<const RenderStyle*> KeyframeEffectStack::stylesAtIterationBoundary() const
+{
+    Vector<const RenderStyle*> styles;
+    for (auto& effect : m_effects)
+        effect->populateStylesAtIterationBoundary(styles);
+    return styles;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffectStack.h
+++ b/Source/WebCore/animation/KeyframeEffectStack.h
@@ -89,6 +89,8 @@ public:
     void setAcceleratedEffects(WeakListHashSet<AcceleratedEffect>&& acceleratedEffects) { m_acceleratedEffects = WTFMove(acceleratedEffects); }
 #endif
 
+    Vector<const RenderStyle*> stylesAtIterationBoundary() const;
+
 private:
     void ensureEffectsAreSorted();
     bool hasMatchingEffect(const Function<bool(const KeyframeEffect&)>&) const;

--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -98,6 +98,9 @@ public:
     // initialized to identity already. Returns false if the layer has no transform.
     virtual bool getCurrentTransform(const GraphicsLayer*, TransformationMatrix&) const { return false; }
 
+    // Provides animated transforms, if any, for the first and last keyframe of transform-related animations set to iterate.
+    virtual Vector<TransformationMatrix> transformsAtAnimationIterationBoundary(const GraphicsLayer*) const { return { }; }
+
     // Allows the client to modify a layer position used during the visibleRect calculation, for example to ignore
     // scroll overhang.
     virtual void customPositionForVisibleRectComputation(const GraphicsLayer*, FloatPoint&) const { }

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1639,56 +1639,81 @@ void GraphicsLayerCA::setContentsScaleLimitingFactor(float factor)
 
 GraphicsLayerCA::VisibleAndCoverageRects GraphicsLayerCA::computeVisibleAndCoverageRect(TransformState& state, bool preserves3D, ComputeVisibleRectFlags flags) const
 {
-    FloatPoint position = approximatePosition();
+    auto computeVisibleAndCoverageRects = [&](TransformState& state, TransformationMatrix& transform) -> std::pair<FloatRect, FloatRect> {
+        bool applyWasClamped;
+        TransformState::TransformAccumulation accumulation = preserves3D ? TransformState::AccumulateTransform : TransformState::FlattenTransform;
+        state.applyTransform(transform, accumulation, &applyWasClamped);
+
+        bool mapWasClamped;
+        auto clipRectFromParent = state.mappedQuad(&mapWasClamped).boundingBox();
+
+        auto clipRectForSelf = FloatRect { { }, m_size };
+        if (!applyWasClamped && !mapWasClamped)
+            clipRectForSelf.intersect(clipRectFromParent);
+
+        if (masksToBounds()) {
+            ASSERT(accumulation == TransformState::FlattenTransform);
+            // Flatten, and replace the quad in the TransformState with one that is clipped to this layer's bounds.
+            state.flatten();
+            state.setQuad(clipRectForSelf);
+            if (state.isMappingSecondaryQuad())
+                state.setSecondaryQuad(FloatQuad { clipRectForSelf });
+        }
+
+        auto boundsOrigin = m_boundsOrigin;
+#if PLATFORM(IOS_FAMILY)
+        // In WK1, UIKit may be changing layer bounds behind our back in overflow-scroll layers, so use the layer's origin.
+        if (m_layer->type() == PlatformCALayer::Type::Cocoa)
+            boundsOrigin = m_layer->bounds().location();
+#endif
+
+        auto coverageRect = clipRectForSelf;
+        auto quad = state.mappedSecondaryQuad(&mapWasClamped);
+        if (quad && !mapWasClamped && !applyWasClamped)
+            coverageRect = (*quad).boundingBox();
+
+        if (!boundsOrigin.isZero()) {
+            state.move(LayoutSize { toFloatSize(-boundsOrigin) }, accumulation);
+            clipRectForSelf.moveBy(boundsOrigin);
+            coverageRect.moveBy(boundsOrigin);
+        }
+
+        return { clipRectForSelf, coverageRect };
+    };
+
+    auto position = approximatePosition();
     client().customPositionForVisibleRectComputation(this, position);
 
+    // If this graphics layer is targeted by a repeating transform animation, we want to compute a set of
+    // secondary coverage rectangles that will cover the initial and final states of the iterating animation.
+    // This will let us pre-populate tiles for the start and end states and avoid flashing when we reach the
+    // iteration boundary due to the animated transform, computed through WebCore's timing, and the animated
+    // value computed by Core Animation's accelerated animation resolving on different sides of that boundary.
+    auto secondaryCoverageRects = [&]() -> std::optional<Vector<FloatRect>> {
+        if (!(flags & RespectAnimatingTransforms) || m_transformsAtAnimationIterationBoundary.isEmpty())
+            return std::nullopt;
+
+        TransformState transformStateCopy(state);
+        auto secondaryCoverageRects = m_transformsAtAnimationIterationBoundary.map([&](auto& transform) {
+            TransformState startTransformState(transformStateCopy);
+            TransformationMatrix computedTransform = layerTransform(position, &transform);
+            return computeVisibleAndCoverageRects(startTransformState, computedTransform).second;
+        });
+
+        return secondaryCoverageRects;
+    }();
+
+    // First, let's get the live transform.
     TransformationMatrix currentTransform;
     auto transform = [&]() {
         if ((flags & RespectAnimatingTransforms) && client().getCurrentTransform(this, currentTransform))
             return layerTransform(position, &currentTransform);
-
         return layerTransform(position);
     }();
 
-    bool applyWasClamped;
-    TransformState::TransformAccumulation accumulation = preserves3D ? TransformState::AccumulateTransform : TransformState::FlattenTransform;
-    state.applyTransform(transform, accumulation, &applyWasClamped);
+    auto [visibleRect, coverageRect] = computeVisibleAndCoverageRects(state, transform);
 
-    bool mapWasClamped;
-    auto clipRectFromParent = state.mappedQuad(&mapWasClamped).boundingBox();
-
-    auto clipRectForSelf = FloatRect { { }, m_size };
-    if (!applyWasClamped && !mapWasClamped)
-        clipRectForSelf.intersect(clipRectFromParent);
-
-    if (masksToBounds()) {
-        ASSERT(accumulation == TransformState::FlattenTransform);
-        // Flatten, and replace the quad in the TransformState with one that is clipped to this layer's bounds.
-        state.flatten();
-        state.setQuad(clipRectForSelf);
-        if (state.isMappingSecondaryQuad())
-            state.setSecondaryQuad(FloatQuad { clipRectForSelf });
-    }
-
-    auto boundsOrigin = m_boundsOrigin;
-#if PLATFORM(IOS_FAMILY)
-    // In WK1, UIKit may be changing layer bounds behind our back in overflow-scroll layers, so use the layer's origin.
-    if (m_layer->type() == PlatformCALayer::Type::Cocoa)
-        boundsOrigin = m_layer->bounds().location();
-#endif
-
-    auto coverageRect = clipRectForSelf;
-    auto quad = state.mappedSecondaryQuad(&mapWasClamped);
-    if (quad && !mapWasClamped && !applyWasClamped)
-        coverageRect = (*quad).boundingBox();
-
-    if (!boundsOrigin.isZero()) {
-        state.move(LayoutSize { toFloatSize(-boundsOrigin) }, accumulation);
-        clipRectForSelf.moveBy(boundsOrigin);
-        coverageRect.moveBy(boundsOrigin);
-    }
-
-    return { clipRectForSelf, coverageRect, currentTransform };
+    return { visibleRect, coverageRect, secondaryCoverageRects, currentTransform };
 }
 
 bool GraphicsLayerCA::adjustCoverageRect(VisibleAndCoverageRects& rects, const FloatRect& oldVisibleRect) const
@@ -1757,6 +1782,8 @@ void GraphicsLayerCA::setVisibleAndCoverageRects(const VisibleAndCoverageRects& 
     if (coverageRectChanged) {
         addUncommittedChanges(CoverageRectChanged);
         m_coverageRect = rects.coverageRect;
+        if (auto secondaryCoverageRects = rects.secondaryCoverageRects)
+            m_secondaryCoverageRects = *secondaryCoverageRects;
     }
 
     adjustContentsScaleLimitingFactor();
@@ -1848,8 +1875,11 @@ void GraphicsLayerCA::recursiveCommitChanges(CommitState& commitState, const Tra
     commitLayerChangesBeforeSublayers(childCommitState, pageScaleFactor, baseRelativePosition, layerTypeChanged);
 
     bool nowRunningTransformAnimation = wasRunningTransformAnimation;
-    if (m_uncommittedChanges & AnimationChanged)
+    if (m_uncommittedChanges & AnimationChanged) {
         nowRunningTransformAnimation = isRunningTransformAnimation();
+        if (tiledBacking())
+            m_transformsAtAnimationIterationBoundary = client().transformsAtAnimationIterationBoundary(this);
+    }
 
     if (wasRunningTransformAnimation != nowRunningTransformAnimation)
         childCommitState.ancestorStartedOrEndedTransformAnimation = true;
@@ -2774,6 +2804,8 @@ void GraphicsLayerCA::updateCoverage(const CommitState& commitState)
     if (TiledBacking* backing = tiledBacking()) {
         backing->setVisibleRect(m_visibleRect);
         backing->setCoverageRect(m_coverageRect);
+        for (auto& rect : m_secondaryCoverageRects)
+            backing->prepopulateRect(rect);
     }
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -357,6 +357,7 @@ private:
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
         FloatRect visibleRect;
         FloatRect coverageRect;
+        std::optional<Vector<FloatRect>> secondaryCoverageRects;
         TransformationMatrix animatingTransform;
     };
     
@@ -666,6 +667,9 @@ private:
     FloatRect m_coverageRect; // Area for which we should maintain backing store, in the coordinate space of this layer.
     FloatSize m_sizeAtLastCoverageRectUpdate;
     FloatSize m_pixelAlignmentOffset;
+
+    Vector<FloatRect> m_secondaryCoverageRects;
+    Vector<TransformationMatrix> m_transformsAtAnimationIterationBoundary;
 
     Color m_contentsSolidColor;
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1363,6 +1363,8 @@ TransformationMatrix RenderLayer::currentTransform(OptionSet<RenderStyle::Transf
     // Query the animatedStyle() to obtain the current transformation, when accelerated transform animations are running.
     auto styleable = Styleable::fromRenderer(renderer());
     if ((styleable && styleable->isRunningAcceleratedTransformAnimation()) || !options.contains(RenderStyle::TransformOperationOption::TransformOrigin)) {
+        // FIXME: we should filter this call to only account for transforms
+        // such that we don't bother with non-transform related animation resolution.
         std::unique_ptr<RenderStyle> animatedStyle = renderer().animatedStyle();
 
         TransformationMatrix transform;
@@ -1390,6 +1392,25 @@ TransformationMatrix RenderLayer::renderableTransform(OptionSet<PaintBehavior> p
     }
 
     return *m_transform;
+}
+
+Vector<TransformationMatrix> RenderLayer::transformsAtAnimationIterationBoundary() const
+{
+    Vector<TransformationMatrix> transforms;
+
+    auto styleable = Styleable::fromRenderer(renderer());
+    if (styleable && styleable->isRunningAcceleratedTransformAnimation()) {
+        ASSERT(styleable->keyframeEffectStack());
+        for (auto* style : styleable->keyframeEffectStack()->stylesAtIterationBoundary()) {
+            if (!style->hasTransformRelatedProperty())
+                continue;
+            TransformationMatrix transform;
+            updateTransformFromStyle(transform, *style, RenderStyle::individualTransformOperations());
+            transforms.append(transform);
+        }
+    }
+
+    return transforms;
 }
 
 RenderLayer* RenderLayer::enclosingOverflowClipLayer(IncludeSelfOrNot includeSelf) const

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -744,7 +744,8 @@ public:
     TransformationMatrix currentTransform(OptionSet<RenderStyle::TransformOperationOption>) const;
     TransformationMatrix currentTransform() const;
     TransformationMatrix renderableTransform(OptionSet<PaintBehavior>) const;
-    
+    Vector<TransformationMatrix> transformsAtAnimationIterationBoundary() const;
+
     // Get the children transform (to apply a perspective on children), which is applied to transformed sublayers, but not this layer.
     // Returns true if the layer has a perspective.
     // Note that this transform has the perspective-origin baked in.

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3891,6 +3891,11 @@ bool RenderLayerBacking::getCurrentTransform(const GraphicsLayer* graphicsLayer,
     return false;
 }
 
+Vector<TransformationMatrix> RenderLayerBacking::transformsAtAnimationIterationBoundary(const GraphicsLayer*) const
+{
+    return m_owningLayer.transformsAtAnimationIterationBoundary();
+}
+
 bool RenderLayerBacking::isTrackingRepaints() const
 {
     return static_cast<GraphicsLayerClient&>(compositor()).isTrackingRepaints();

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -237,6 +237,7 @@ public:
 
     void didChangePlatformLayerForLayer(const GraphicsLayer*) override;
     bool getCurrentTransform(const GraphicsLayer*, TransformationMatrix&) const override;
+    Vector<TransformationMatrix> transformsAtAnimationIterationBoundary(const GraphicsLayer*) const override;
 
     bool isTrackingRepaints() const override;
     bool shouldSkipLayerInDump(const GraphicsLayer*, OptionSet<LayerTreeAsTextOptions>) const override;


### PR DESCRIPTION
#### 6d4fb9c98fe5e0341c7731688781aa6b713064e3
<pre>
[web-animations] transform animation shows invisible frame on iteration
<a href="https://bugs.webkit.org/show_bug.cgi?id=269284">https://bugs.webkit.org/show_bug.cgi?id=269284</a>
<a href="https://rdar.apple.com/123301944">rdar://123301944</a>

Reviewed by NOBODY (OOPS!).

When tiled content is targeted by a transform animation, we compute tile coverage rectangles on
each rendering frame and provide those to the tile grid such that it may ensure the correct tiles
are visible to account for the transformed state.

The animated transform is computed based on WebCore&apos;s timing, while the actual transform rendered
is computed by Core Animation using its own timing. In the general case, the difference in computed
transform is minimal and, considering the size of tiles, doesn&apos;t manifest itself visually.

However, if the transform animation targeting the tiled layer is set to iterate, that minimal difference
can have a very real visual effect where the displayed tiles are computed using the animated transform
on one side of the iteration boundary (for instance at progress 0.999) while the rendered transform
computed by Core Animation will resolve to the other side of the boundary (for instance 0.001). When
that happens, the tile grid will not display all the required tiles.

We now identify the situation where a transform animation is targeting a tiled layer and will iterate.
In that situation, we gather the transform values at the boundaries whenever the animation data changes,
which likely will be just once as the animation is created, and compute secondary coverage rectangles
under GraphicsLayerCA::computeVisibleAndCoverageRect(). Then, under GraphicsLayerCA::updateCoverage()
we will call prepopulateRect() on the tiled backing with the secondary coverage rectangles, which will
ensure that tiles that should be visible at the animation iteration boundaries are displayed.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::populateStylesAtIterationBoundary):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore:: const):
* Source/WebCore/animation/KeyframeEffectStack.h:
* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
(WebCore::GraphicsLayerClient::transformsAtAnimationIterationBoundary const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::computeVisibleAndCoverageRect const):
(WebCore::GraphicsLayerCA::setVisibleAndCoverageRects):
(WebCore::GraphicsLayerCA::recursiveCommitChanges):
(WebCore::GraphicsLayerCA::updateCoverage):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::currentTransform const):
(WebCore::RenderLayer::transformsAtAnimationIterationBoundary const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::transformsAtAnimationIterationBoundary const):
* Source/WebCore/rendering/RenderLayerBacking.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d4fb9c98fe5e0341c7731688781aa6b713064e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46592 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40021 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36253 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17265 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17591 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38953 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2004 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48167 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43089 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20340 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41822 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20545 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/19966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->