### PR TITLE
[webkitpy] SingleTestRunner should use expected paths from Test objects

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py
@@ -546,7 +546,6 @@ class TestShard(object):
             is_slow=test_input.is_slow,
             needs_servers=test_input.needs_servers,
             should_dump_jsconsolelog_in_stderr=test_input.should_dump_jsconsolelog_in_stderr,
-            reference_files=test_input.reference_files,
             should_run_pixel_test=test_input.should_run_pixel_test,
         )
 

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -237,9 +237,6 @@ class Manager(object):
 
     def _test_input_for_file(self, test_file, device_type):
         test_is_slow = self._test_is_slow(test_file.test_path, device_type=device_type)
-        reference_files = self._port.reference_files(
-            test_file.test_path, device_type=device_type
-        )
         timeout = (
             self._options.slow_time_out_ms
             if test_is_slow
@@ -251,7 +248,7 @@ class Manager(object):
             )
         )
 
-        if reference_files:
+        if test_file.reference_files:
             should_run_pixel_test = True
         elif not self._options.pixel_tests:
             should_run_pixel_test = False
@@ -269,7 +266,6 @@ class Manager(object):
             is_slow=test_is_slow,
             needs_servers=test_file.needs_any_server,
             should_dump_jsconsolelog_in_stderr=should_dump_jsconsolelog_in_stderr,
-            reference_files=reference_files,
             should_run_pixel_test=should_run_pixel_test,
         )
 

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py
@@ -34,6 +34,7 @@ from collections import deque
 
 from webkitcorepy import string_utils
 
+from webkitpy.common import read_checksum_from_png
 from webkitpy.layout_tests.controllers import test_result_writer
 from webkitpy.layout_tests.models import test_expectations, test_failures
 from webkitpy.layout_tests.models.test_results import TestResult
@@ -66,10 +67,16 @@ class SingleTestRunner(object):
             # For example, if 'foo.html' has two expectation files, 'foo-expected.html' and
             # 'foo-expected.txt', we should warn users. One test file must be used exclusively
             # in either layout tests or reftests, but not in both.
-            for suffix in ('.txt', '.png', '.wav'):
-                expected_filename = self._port.expected_filename(self._test_name, suffix, device_type=self._driver.host.device_type)
-                if self._filesystem.exists(expected_filename):
-                    _log.error('%s is a reftest, but has an unused expectation file. Please remove %s.', self._test_name, expected_filename)
+            test = test_input.test
+            for expected_filename in (
+                test.expected_text_path,
+                test.expected_image_path,
+                test.expected_audio_path,
+            ):
+                if expected_filename is None:
+                    continue
+
+                _log.error('%s is a reftest, but has an unused expectation file. Please remove %s.', self._test_name, expected_filename)
 
     @property
     def _test_name(self):
@@ -85,17 +92,49 @@ class SingleTestRunner(object):
 
     @property
     def _reference_files(self):
-        return self._test_input.reference_files
+        files = self._test_input.test.reference_files
+        if files is not None:
+            return list(files)
+        else:
+            return []
 
     @property
     def _timeout(self):
         return self._test_input.timeout
 
     def _expected_driver_output(self):
-        return DriverOutput(self._port.expected_text(self._test_name, device_type=self._driver.host.device_type),
-                                 self._port.expected_image(self._test_name, device_type=self._driver.host.device_type),
-                                 self._port.expected_checksum(self._test_name, device_type=self._driver.host.device_type),
-                                 self._port.expected_audio(self._test_name, device_type=self._driver.host.device_type))
+        test = self._test_input.test
+        fs = self._filesystem
+
+        text = None
+        image = None
+        checksum = None
+        audio = None
+
+        if test.expected_text_path is not None:
+            # FIXME: DRT output is actually utf-8, but since we don't decode the
+            # output from DRT (instead treating it as a binary string), we read the
+            # baselines as a binary string, too.
+            text = string_utils.decode(
+                fs.read_binary_file(test.expected_text_path),
+                target_type=str,
+            )
+
+            # End-of-line characters are normalized to '\n'.
+            text = text.replace("\r\n", "\n")
+
+        if test.expected_image_path is not None:
+            with fs.open_binary_file_for_reading(
+                test.expected_image_path
+            ) as filehandle:
+                checksum = read_checksum_from_png.read_checksum(filehandle)
+                filehandle.seek(0)
+                image = filehandle.read()
+
+        if test.expected_audio_path is not None:
+            audio = fs.read_binary_file(test.expected_audio_path)
+
+        return DriverOutput(text, image, checksum, audio)
 
     def _should_fetch_expected_checksum(self):
         return self._should_run_pixel_test and not (self._options.new_baseline or self._options.reset_results)
@@ -107,7 +146,13 @@ class SingleTestRunner(object):
         # previous run will be copied into the baseline."""
         image_hash = None
         if self._should_fetch_expected_checksum():
-            image_hash = self._port.expected_checksum(self._test_name, device_type=self._driver.host.device_type)
+            expected_image_path = self._test_input.test.expected_image_path
+            if expected_image_path is not None:
+                with self._filesystem.open_binary_file_for_reading(
+                    expected_image_path
+                ) as filehandle:
+                    image_hash = read_checksum_from_png.read_checksum(filehandle)
+
         return DriverInput(self._test_name, self._timeout, image_hash, self._should_run_pixel_test, self._should_dump_jsconsolelog_in_stderr, self._options.additional_header)
 
     def run(self):

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_input.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_input.py
@@ -46,7 +46,6 @@ class TestInput(object):
     is_slow = attr.ib(default=None)  # type: Optional[bool]
     needs_servers = attr.ib(default=None)  # type: Optional[bool]
     should_dump_jsconsolelog_in_stderr = attr.ib(default=None)  # type: Optional[bool]
-    reference_files = attr.ib(default=None)  # type: Optional[List[Tuple[str str]]]
     should_run_pixel_test = attr.ib(default=None)  # type: Optional[bool]
 
     @property

--- a/Tools/Scripts/webkitpy/port/base_unittest.py
+++ b/Tools/Scripts/webkitpy/port/base_unittest.py
@@ -225,12 +225,6 @@ class PortTest(unittest.TestCase):
         port._filesystem = MockFileSystem({'/mock-checkout/LayoutTests/platform/foo/TestExpectations': ''})
         self.assertTrue(port.uses_test_expectations_file())
 
-    def test_reference_files(self):
-        port = self.make_port(with_tests=True)
-        self.assertEqual(port.reference_files('passes/svgreftest.svg'), [('==', port.layout_tests_dir() + '/passes/svgreftest-expected.svg')])
-        self.assertEqual(port.reference_files('passes/xhtreftest.svg'), [('==', port.layout_tests_dir() + '/passes/xhtreftest-expected.html')])
-        self.assertEqual(port.reference_files('passes/phpreftest.php'), [('!=', port.layout_tests_dir() + '/passes/phpreftest-expected-mismatch.svg')])
-
     def test_operating_system(self):
         self.assertEqual('mac', self.make_port().operating_system())
 
@@ -298,23 +292,6 @@ class PortTest(unittest.TestCase):
         port._filesystem.maybe_make_directory(jhbuild_path)
         self.assertTrue(port._filesystem.isdir(jhbuild_path))
         self.assertTrue(port._should_use_jhbuild())
-
-    def test_ref_tests_platform_directory(self):
-        port = self.make_port(port_name='foo')
-        port.default_baseline_search_path = lambda **kwargs: ['/mock-checkout/LayoutTests/platform/foo']
-        port._filesystem.write_text_file('/mock-checkout/LayoutTests/fast/ref-expected.html', 'foo')
-
-        # No platform directory
-        self.assertEqual(
-            [('==', '/mock-checkout/LayoutTests/fast/ref-expected.html')],
-            port.reference_files('fast/ref.html'),
-        )
-
-        port._filesystem.write_text_file('/mock-checkout/LayoutTests/platform/foo/fast/ref-expected-mismatch.html', 'foo-plat')
-        self.assertEqual(
-            [('!=', '/mock-checkout/LayoutTests/platform/foo/fast/ref-expected-mismatch.html')],
-            port.reference_files('fast/ref.html'),
-        )
 
     def test_commits_for_upload(self):
         with mocks.local.Svn(path='/'), mocks.local.Git():


### PR DESCRIPTION
#### e74b50bb809762e861795aa960e7a7f6150c2f8d
<pre>
[webkitpy] SingleTestRunner should use expected paths from Test objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=271060">https://bugs.webkit.org/show_bug.cgi?id=271060</a>

Reviewed by Jonathan Bedard.

Now LayoutTestFinder is populating the Test object&apos;s expectation paths,
we should use them in SingleTestRunner.

This doesn&apos;t migrate the other call sites of Port.expected_filename and
Port.expected_baselines to using the Test object&apos;s attributes, as these
aren&apos;t on such commonly used code paths.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py:
(TestShard.pack): TestInput.reference_files is gone.
* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager._test_input_for_file): TestInput.reference_files is gone.
* Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner.py:
(SingleTestRunner.__init__): Use Test paths.
(SingleTestRunner._reference_files): Ditto.
(SingleTestRunner._expected_driver_output): Ditto.
(SingleTestRunner._driver_input): Ditto.
* Tools/Scripts/webkitpy/layout_tests/models/test_input.py:
(TestInput): Remove reference_files, as it is always set to test.reference_files.
* Tools/Scripts/webkitpy/port/base.py:
(Port.expected_checksum): Deleted.
(Port.expected_image): Deleted.
(Port.expected_audio): Deleted.
(Port.expected_text): Deleted.
(Port.reference_files): Deleted.
* Tools/Scripts/webkitpy/port/base_unittest.py:
(PortTest.test_reference_files): Deleted.
(PortTest.test_ref_tests_platform_directory): Deleted.

Canonical link: <a href="https://commits.webkit.org/277720@main">https://commits.webkit.org/277720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f18a6acfbe32b3f3ba56ff46e0d2a8b2b5f15d6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51001 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44378 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39470 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25215 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20613 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/48170 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42910 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6369 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44653 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52905 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23360 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19705 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46805 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45718 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10673 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->