### PR TITLE
Permissions check in WebExtensionAPINamespace::isPropertyAllowed should be better.

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -2209,6 +2209,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionPermissionPrivate {
+    header "_WKWebExtensionPermissionPrivate.h"
+    export *
+  }
+
   explicit module _WKWebExtensionPrivate {
     header "_WKWebExtensionPrivate.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -3111,6 +3111,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module _WKWebExtensionPermissionPrivate {
+    header "_WKWebExtensionPermissionPrivate.h"
+    export *
+  }
+
   explicit module _WKWebExtensionPrivate {
     header "_WKWebExtensionPrivate.h"
     export *

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
@@ -28,6 +28,8 @@ struct WebKit::WebExtensionContextParameters {
     URL baseURL;
     String uniqueIdentifier;
 
+    HashMap<String, WallTime> grantedPermissions;
+
     Ref<API::Data> localizationJSON;
     Ref<API::Data> manifestJSON;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.mm
@@ -28,7 +28,7 @@
 #endif
 
 #import "config.h"
-#import "_WKWebExtensionPermission.h"
+#import "_WKWebExtensionPermissionPrivate.h"
 
 _WKWebExtensionPermission const _WKWebExtensionPermissionActiveTab = @"activeTab";
 _WKWebExtensionPermission const _WKWebExtensionPermissionAlarms = @"alarms";
@@ -40,6 +40,7 @@ _WKWebExtensionPermission const _WKWebExtensionPermissionDeclarativeNetRequestFe
 _WKWebExtensionPermission const _WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess = @"declarativeNetRequestWithHostAccess";
 _WKWebExtensionPermission const _WKWebExtensionPermissionMenus = @"menus";
 _WKWebExtensionPermission const _WKWebExtensionPermissionNativeMessaging = @"nativeMessaging";
+_WKWebExtensionPermission const _WKWebExtensionPermissionNotifications = @"notifications";
 _WKWebExtensionPermission const _WKWebExtensionPermissionScripting = @"scripting";
 _WKWebExtensionPermission const _WKWebExtensionPermissionStorage = @"storage";
 _WKWebExtensionPermission const _WKWebExtensionPermissionTabs = @"tabs";

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermissionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermissionPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,42 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#import <WebKit/_WKWebExtensionPermission.h>
 
-#if ENABLE(WK_WEB_EXTENSIONS)
-
-#include "APIData.h"
-#include "WebExtensionContext.h"
-#include "WebExtensionContextIdentifier.h"
-#include "WebExtensionTabIdentifier.h"
-#include "WebExtensionWindowIdentifier.h"
-#include <wtf/URL.h>
-
-namespace WebKit {
-
-struct WebExtensionContextParameters {
-    WebExtensionContextIdentifier identifier;
-
-    URL baseURL;
-    String uniqueIdentifier;
-
-    HashMap<String, WallTime> grantedPermissions;
-
-    Ref<API::Data> localizationJSON;
-    Ref<API::Data> manifestJSON;
-
-    double manifestVersion { 0 };
-    bool isSessionStorageAllowedInContentScripts { false };
-
-    std::optional<WebCore::PageIdentifier> backgroundPageIdentifier;
-#if ENABLE(INSPECTOR_EXTENSIONS)
-    Vector<WebExtensionContext::PageIdentifierTuple> inspectorPageIdentifiers;
-    Vector<WebExtensionContext::PageIdentifierTuple> inspectorBackgroundPageIdentifiers;
-#endif
-    Vector<WebExtensionContext::PageIdentifierTuple> popupPageIdentifiers;
-    Vector<WebExtensionContext::PageIdentifierTuple> tabPageIdentifiers;
-};
-
-} // namespace WebKit
-
-#endif // ENABLE(WK_WEB_EXTENSIONS)
+/*! @abstract The `notifications` permission requests access to the `browser.notifications` APIs. */
+WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
+WK_EXTERN _WKWebExtensionPermission const _WKWebExtensionPermissionNotifications;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm
@@ -243,10 +243,8 @@ void WebExtensionContext::declarativeNetRequestGetMatchedRules(std::optional<Web
     }
 
     if (!hasPermission(_WKWebExtensionPermissionDeclarativeNetRequestFeedback)) {
-        ASSERT(hasPermission(_WKWebExtensionPermissionActiveTab));
-
-        if (!hasPermission(_WKWebExtensionPermissionTabs, tab.get())) {
-            completionHandler(toWebExtensionError(apiName, nil, @"The 'activeTab' permission has not been granted by the user for the specified tab."));
+        if (!tab->extensionHasTemporaryPermission()) {
+            completionHandler(toWebExtensionError(apiName, nil, @"the 'activeTab' permission has not been granted by the user for the tab"));
             return;
         }
     }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -40,7 +40,7 @@
 #import "WebExtensionUtilities.h"
 #import "_WKWebExtensionInternal.h"
 #import "_WKWebExtensionLocalization.h"
-#import "_WKWebExtensionPermission.h"
+#import "_WKWebExtensionPermissionPrivate.h"
 #import <CoreFoundation/CFBundle.h>
 #import <UniformTypeIdentifiers/UTCoreTypes.h>
 #import <UniformTypeIdentifiers/UTType.h>
@@ -1985,7 +1985,7 @@ const WebExtension::PermissionsSet& WebExtension::supportedPermissions()
 {
     static MainThreadNeverDestroyed<PermissionsSet> permissions = std::initializer_list<String> { _WKWebExtensionPermissionActiveTab, _WKWebExtensionPermissionAlarms, _WKWebExtensionPermissionClipboardWrite,
         _WKWebExtensionPermissionContextMenus, _WKWebExtensionPermissionCookies, _WKWebExtensionPermissionDeclarativeNetRequest, _WKWebExtensionPermissionDeclarativeNetRequestFeedback,
-        _WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess, _WKWebExtensionPermissionMenus, _WKWebExtensionPermissionNativeMessaging, _WKWebExtensionPermissionScripting,
+        _WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess, _WKWebExtensionPermissionMenus, _WKWebExtensionPermissionNativeMessaging, _WKWebExtensionPermissionNotifications, _WKWebExtensionPermissionScripting,
         _WKWebExtensionPermissionStorage, _WKWebExtensionPermissionTabs, _WKWebExtensionPermissionUnlimitedStorage, _WKWebExtensionPermissionWebNavigation, _WKWebExtensionPermissionWebRequest };
     return permissions;
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -736,6 +736,8 @@ void WebExtensionContext::permissionsDidChange(const PermissionsSet& changedPerm
     if (!isLoaded())
         return;
 
+    extensionController()->sendToAllProcesses(Messages::WebExtensionContextProxy::UpdateGrantedPermissions(m_grantedPermissions), identifier());
+
     if (changedPermissions.contains(_WKWebExtensionPermissionClipboardWrite)) {
         bool granted = hasPermission(_WKWebExtensionPermissionClipboardWrite);
 
@@ -1366,8 +1368,7 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
     ASSERT(!permission.isEmpty());
 
     if (tab && permission == String(_WKWebExtensionPermissionTabs)) {
-        RefPtr temporaryPattern = tab->temporaryPermissionMatchPattern();
-        if (temporaryPattern && temporaryPattern->matchesURL(tab->url()))
+        if (tab->extensionHasTemporaryPermission())
             return PermissionState::GrantedExplicitly;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -257,6 +257,13 @@ bool WebExtensionTab::extensionHasPermission() const
     return extensionContext()->hasPermission(url(), const_cast<WebExtensionTab*>(this));
 }
 
+bool WebExtensionTab::extensionHasTemporaryPermission() const
+{
+    ASSERT(extensionHasAccess());
+    RefPtr temporaryPattern = temporaryPermissionMatchPattern();
+    return temporaryPattern && temporaryPattern->matchesURL(url());
+}
+
 RefPtr<WebExtensionWindow> WebExtensionTab::window() const
 {
     if (!isValid() || !m_respondsToWindow)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -62,6 +62,7 @@ WebExtensionContextParameters WebExtensionContext::parameters() const
         identifier(),
         baseURL(),
         uniqueIdentifier(),
+        m_grantedPermissions,
         extension().serializeLocalization(),
         extension().serializeManifest(),
         extension().manifestVersion(),

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -113,11 +113,12 @@ public:
 
     bool extensionHasAccess() const;
     bool extensionHasPermission() const;
+    bool extensionHasTemporaryPermission() const;
 
-    bool hasActiveUserGesture() { return m_activeUserGesture; }
+    bool hasActiveUserGesture() const { return m_activeUserGesture; }
     void setActiveUserGesture(bool activeUserGesture) { m_activeUserGesture = activeUserGesture; }
 
-    RefPtr<WebExtensionMatchPattern> temporaryPermissionMatchPattern() { return m_temporaryPermissionMatchPattern; }
+    RefPtr<WebExtensionMatchPattern> temporaryPermissionMatchPattern() const { return m_temporaryPermissionMatchPattern; }
     void setTemporaryPermissionMatchPattern(RefPtr<WebExtensionMatchPattern>&& matchPattern) { m_temporaryPermissionMatchPattern = WTFMove(matchPattern); }
 
     OptionSet<ChangedProperties> changedProperties() const { return m_changedProperties; }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -514,6 +514,7 @@
 		1C6BE79F2B0A910200D01D93 /* WebExtensionMenuItemParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C6BE79E2B0A910200D01D93 /* WebExtensionMenuItemParameters.h */; };
 		1C6BE7A32B0A94E500D01D93 /* WebExtensionMenuItemType.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C6BE7A22B0A94E500D01D93 /* WebExtensionMenuItemType.h */; };
 		1C6BE7A52B0A955700D01D93 /* WebExtensionMenuItemContextType.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C6BE7A42B0A955700D01D93 /* WebExtensionMenuItemContextType.h */; };
+		1C6C665F2BA4030F001CAB38 /* _WKWebExtensionPermissionPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C6C665E2BA4030E001CAB38 /* _WKWebExtensionPermissionPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C7308822B33580D00B341DE /* WebExtensionContextAPICookiesCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C7308812B33580D00B341DE /* WebExtensionContextAPICookiesCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		1C7316732AC1D647007FADA4 /* _WKWebExtensionMessagePort.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C7316722AC1D647007FADA4 /* _WKWebExtensionMessagePort.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C7316752AC1D658007FADA4 /* _WKWebExtensionMessagePort.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C7316742AC1D658007FADA4 /* _WKWebExtensionMessagePort.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -3926,6 +3927,7 @@
 		1C6BE7A02B0A911B00D01D93 /* WebExtensionMenuItem.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = WebExtensionMenuItem.serialization.in; sourceTree = "<group>"; };
 		1C6BE7A22B0A94E500D01D93 /* WebExtensionMenuItemType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionMenuItemType.h; sourceTree = "<group>"; };
 		1C6BE7A42B0A955700D01D93 /* WebExtensionMenuItemContextType.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionMenuItemContextType.h; sourceTree = "<group>"; };
+		1C6C665E2BA4030E001CAB38 /* _WKWebExtensionPermissionPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionPermissionPrivate.h; sourceTree = "<group>"; };
 		1C7308812B33580D00B341DE /* WebExtensionContextAPICookiesCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionContextAPICookiesCocoa.mm; sourceTree = "<group>"; };
 		1C7316722AC1D647007FADA4 /* _WKWebExtensionMessagePort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionMessagePort.h; sourceTree = "<group>"; };
 		1C7316742AC1D658007FADA4 /* _WKWebExtensionMessagePort.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionMessagePort.mm; sourceTree = "<group>"; };
@@ -11409,6 +11411,7 @@
 				1C7316782AC1DFED007FADA4 /* _WKWebExtensionMessagePortPrivate.h */,
 				1C8B2362289AE89400020CDC /* _WKWebExtensionPermission.h */,
 				1C049837289AF5AD0010308B /* _WKWebExtensionPermission.mm */,
+				1C6C665E2BA4030E001CAB38 /* _WKWebExtensionPermissionPrivate.h */,
 				1C3BEB6F288883E300E66E38 /* _WKWebExtensionPrivate.h */,
 				1C04983C289AFF9B0010308B /* _WKWebExtensionTab.h */,
 				1C5ACF8F2A955CB000C041C0 /* _WKWebExtensionTabCreationOptions.h */,
@@ -15876,6 +15879,7 @@
 				1C7316772AC1DFDF007FADA4 /* _WKWebExtensionMessagePortInternal.h in Headers */,
 				1C7316792AC1DFED007FADA4 /* _WKWebExtensionMessagePortPrivate.h in Headers */,
 				1C8B2363289AE89400020CDC /* _WKWebExtensionPermission.h in Headers */,
+				1C6C665F2BA4030F001CAB38 /* _WKWebExtensionPermissionPrivate.h in Headers */,
 				1C3BEB712888842A00E66E38 /* _WKWebExtensionPrivate.h in Headers */,
 				B6D75B1E2B1FD0BF00BC932E /* _WKWebExtensionRegisteredScriptsSQLiteStore.h in Headers */,
 				B6A2923D2B193ED50061930E /* _WKWebExtensionSQLiteDatabase.h in Headers */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
@@ -206,13 +206,6 @@ void WebExtensionAPIDeclarativeNetRequest::getSessionRules(Ref<WebExtensionCallb
     }, extensionContext().identifier());
 }
 
-static bool extensionHasPermission(WebExtensionContextProxy& extensionContext, NSString *permission)
-{
-    // FIXME: https://webkit.org/b/259914 This should be a hasPermission: call to extensionContext() and updated with actually granted permissions from the UI process.
-    auto *permissions = objectForKey<NSArray>(extensionContext.manifest(), @"permissions", true, NSString.class);
-    return [permissions containsObject:permission];
-}
-
 static NSDictionary *toWebAPI(const Vector<WebExtensionMatchedRuleParameters>& matchedRules)
 {
     NSMutableArray *matchedRuleArray = [NSMutableArray arrayWithCapacity:matchedRules.size()];
@@ -230,11 +223,11 @@ static NSDictionary *toWebAPI(const Vector<WebExtensionMatchedRuleParameters>& m
 
 void WebExtensionAPIDeclarativeNetRequest::getMatchedRules(NSDictionary *filter, Ref<WebExtensionCallbackHandler>&& callback, NSString **outExceptionString)
 {
-    bool hasFeedbackPermission = extensionHasPermission(extensionContext(), _WKWebExtensionPermissionDeclarativeNetRequestFeedback);
-    bool hasActiveTabPermission = extensionHasPermission(extensionContext(), _WKWebExtensionPermissionActiveTab);
+    bool hasFeedbackPermission = extensionContext().hasPermission("declarativeNetRequestFeedback"_s);
+    bool hasActiveTabPermission = extensionContext().hasPermission("activeTab"_s);
 
     if (!hasFeedbackPermission && !hasActiveTabPermission) {
-        *outExceptionString = @"Invalid call to declarativeNetRequest.getMatchedRules(). The 'declarativeNetRequestFeedback' or 'activeTab' permission is required.";
+        *outExceptionString = toErrorString(nil, nil, @"either the 'declarativeNetRequestFeedback' or 'activeTab' permission is required");
         return;
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -46,6 +46,9 @@ bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPa
     if (name == "commands"_s)
         return objectForKey<NSDictionary>(extensionContext().manifest(), @"commands");
 
+    if (name == "declarativeNetRequest"_s)
+        return extensionContext().hasPermission(name) || extensionContext().hasPermission("declarativeNetRequestWithHostAccess"_s);
+
     if (name == "browserAction"_s)
         return !extensionContext().supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext().manifest(), @"browser_action", false);
 
@@ -62,18 +65,22 @@ bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPa
         // Notifications are currently only available in test mode as an empty stub.
         if (!extensionContext().inTestingMode())
             return false;
-        // Fall through to the permissions check below.
+        goto finish;
     }
 
     if (name == "pageAction"_s)
         return !extensionContext().supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext().manifest(), @"page_action", false);
 
+    if (name == "storage"_s)
+        return extensionContext().hasPermission(name) || extensionContext().hasPermission("unlimitedStorage"_s);
+
     if (name == "test"_s)
         return extensionContext().inTestingMode();
 
-    // FIXME: https://webkit.org/b/259914 This should be a hasPermission: call to extensionContext() and updated with actually granted permissions from the UI process.
-    auto *permissions = objectForKey<NSArray>(extensionContext().manifest(), @"permissions", true, NSString.class);
-    return [permissions containsObject:name.createNSString().get()];
+finish:
+    // The rest of the property names marked dynamic in WebExtensionAPINamespace.idl match permission names.
+    // Check for the permission to determine if the property is allowed to be accessed.
+    return extensionContext().hasPermission(name);
 }
 
 WebExtensionAPIAction& WebExtensionAPINamespace::action()

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -153,11 +153,8 @@ bool WebExtensionAPIRuntime::parseConnectOptions(NSDictionary *options, std::opt
 
 bool WebExtensionAPIRuntime::isPropertyAllowed(const ASCIILiteral& name, WebPage&)
 {
-    if (name == "connectNative"_s || name == "sendNativeMessage"_s) {
-        // FIXME: https://webkit.org/b/259914 This should be a hasPermission: call to extensionContext() and updated with actually granted permissions from the UI process.
-        auto *permissions = objectForKey<NSArray>(extensionContext().manifest(), @"permissions", true, NSString.class);
-        return [permissions containsObject:@"nativeMessaging"];
-    }
+    if (name == "connectNative"_s || name == "sendNativeMessage"_s)
+        return extensionContext().hasPermission("nativeMessaging"_s);
 
     ASSERT_NOT_REACHED();
     return false;

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -77,6 +77,7 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(const WebExt
         context.m_extensionControllerProxy = extensionControllerProxy;
         context.m_baseURL = parameters.baseURL;
         context.m_uniqueIdentifier = parameters.uniqueIdentifier;
+        context.m_grantedPermissions = parameters.grantedPermissions;
         context.m_localization = parseLocalization(parameters.localizationJSON.get(), parameters.baseURL);
         context.m_manifest = parseJSON(parameters.manifestJSON.get());
         context.m_manifestVersion = parameters.manifestVersion;
@@ -125,6 +126,36 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(const WebExt
     Ref result = adoptRef(*new WebExtensionContextProxy(parameters));
     updateProperties(result);
     return result;
+}
+
+bool WebExtensionContextProxy::hasPermission(const String& permission) const
+{
+    WallTime currentTime = WallTime::now();
+
+    // If the next expiration date hasn't passed yet, there is nothing to remove.
+    if (m_nextGrantedPermissionsExpirationDate != WallTime::nan() && m_nextGrantedPermissionsExpirationDate > currentTime)
+        goto finish;
+
+    m_nextGrantedPermissionsExpirationDate = WallTime::infinity();
+
+    m_grantedPermissions.removeIf([&](auto& entry) {
+        if (entry.value <= currentTime)
+            return true;
+
+        if (entry.value < m_nextGrantedPermissionsExpirationDate)
+            m_nextGrantedPermissionsExpirationDate = entry.value;
+
+        return false;
+    });
+
+finish:
+    return m_grantedPermissions.contains(permission);
+}
+
+void WebExtensionContextProxy::updateGrantedPermissions(PermissionsMap&& permissions)
+{
+    m_grantedPermissions = WTFMove(permissions);
+    m_nextGrantedPermissionsExpirationDate = WallTime::nan();
 }
 
 _WKWebExtensionLocalization *WebExtensionContextProxy::parseLocalization(API::Data& json, const URL& baseURL)

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -67,6 +67,7 @@ public:
     using WeakPageSet = WeakHashSet<WebPage>;
     using TabWindowIdentifierPair = std::pair<std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>>;
     using WeakPageTabWindowMap = WeakHashMap<WebPage, TabWindowIdentifierPair>;
+    using PermissionsMap = WebExtensionContext::PermissionsMap;
 
     WebExtensionContextIdentifier identifier() const { return m_identifier; }
     WebExtensionControllerProxy* extensionControllerProxy() const;
@@ -102,6 +103,8 @@ public:
 
     RefPtr<WebPage> backgroundPage() const;
     void setBackgroundPage(WebPage&);
+
+    bool hasPermission(const String& permission) const;
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     void addInspectorPage(WebPage&, std::optional<WebExtensionTabIdentifier>, std::optional<WebExtensionWindowIdentifier>);
@@ -162,6 +165,7 @@ private:
     void dispatchMenusClickedEvent(const WebExtensionMenuItemParameters&, bool wasChecked, const WebExtensionMenuItemContextParameters&, const std::optional<WebExtensionTabParameters>&);
 
     // Permissions
+    void updateGrantedPermissions(PermissionsMap&&);
     void dispatchPermissionsEvent(WebExtensionEventListenerType, HashSet<String> permissions, HashSet<String> origins);
 
     // Port
@@ -215,6 +219,8 @@ private:
     RetainPtr<NSDictionary> m_manifest;
     double m_manifestVersion { 0 };
     bool m_isSessionStorageAllowedInContentScripts { false };
+    mutable PermissionsMap m_grantedPermissions;
+    mutable WallTime m_nextGrantedPermissionsExpirationDate { WallTime::nan() };
     RefPtr<WebCore::DOMWrapperWorld> m_contentScriptWorld;
     WeakFrameSet m_extensionContentFrames;
     WeakPtr<WebPage> m_backgroundPage;

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in
@@ -58,6 +58,7 @@ messages -> WebExtensionContextProxy {
     DispatchMenusClickedEvent(struct WebKit::WebExtensionMenuItemParameters menuItemParameters, bool wasChecked, struct WebKit::WebExtensionMenuItemContextParameters contextParameters, std::optional<WebKit::WebExtensionTabParameters> tabParameters)
 
     // Permissions
+    UpdateGrantedPermissions(HashMap<String, WallTime> permissions)
     DispatchPermissionsEvent(WebKit::WebExtensionEventListenerType type, HashSet<String> permissions, HashSet<String> origins)
 
     // Ports


### PR DESCRIPTION
#### a0d65e89085b46a9aabbb405df0181fc5c1e3ce6
<pre>
Permissions check in WebExtensionAPINamespace::isPropertyAllowed should be better.
<a href="https://webkit.org/b/259914">https://webkit.org/b/259914</a>
<a href="https://rdar.apple.com/problem/113537360">rdar://problem/113537360</a>

Reviewed by Brian Weinstein.

Send the granted permissions map to the web processes, so the checks in isPropertyAllowed() are
accurate if the permissions have not been granted by the app.

* Source/WebKit/Modules/OSX_Private.modulemap: Added _WKWebExtensionPermissionPrivate.h.
* Source/WebKit/Modules/iOS_Private.modulemap: Ditto.
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h: Added grantedPermissions.
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in: Ditto.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermission.mm: Import _WKWebExtensionPermissionPrivate.h.
Added notifications permission, since it is needed to prevent it from being filtered out as an unsupported permission.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionPermissionPrivate.h: Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionContext::declarativeNetRequestGetMatchedRules): Use new extensionHasTemporaryPermission() helper.
The old check would have been true if the &apos;tabs&apos; permission was granted for the whole extension too.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::supportedPermissions): Added notifications.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::permissionsDidChange): Send UpdateGrantedPermissions message to all processes.
(WebKit::WebExtensionContext::permissionState): Use new extensionHasTemporaryPermission() helper.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::extensionHasTemporaryPermission const): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const): Set grantedPermissions.
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
(WebKit::WebExtensionTab::hasActiveUserGesture const): Made const.
(WebKit::WebExtensionTab::temporaryPermissionMatchPattern const): Ditto.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj: Added _WKWebExtensionPermissionPrivate.h.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
(WebKit::WebExtensionAPIDeclarativeNetRequest::getMatchedRules): Use hasPermission(), and toErrorString().
(WebKit::extensionHasPermission): Deleted.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed): Use hasPermission().
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::isPropertyAllowed): Use hasPermission().
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::getOrCreate): Set m_grantedPermissions.
(WebKit::WebExtensionContextProxy::hasPermission const): Added.
(WebKit::WebExtensionContextProxy::updateGrantedPermissions): Added.
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm:
(TEST(WKWebExtensionAPINamespace, NoWebNavigationObjectWithoutPermission)): Deny permission since it is auto granted now.
(TEST(WKWebExtensionAPINamespace, WebNavigationObjectWithPermission)): Added a comment.
(TEST(WKWebExtensionAPINamespace, NoNotificationsObjectWithoutPermission)): Deny permission since it is auto granted now.
(TEST(WKWebExtensionAPINamespace, NotificationsObjectWithPermission)): Added a comment.

Canonical link: <a href="https://commits.webkit.org/276194@main">https://commits.webkit.org/276194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87992045652151d3d3f4cd48ac6b027b640bb016

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46436 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/46646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20461 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/46646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/44576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/20096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/46646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/38988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2056 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/39277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/48225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/19001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/48225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/48225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6018 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/20008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->