### PR TITLE
Expand SUPPORTED_PLATFORMS to include visionOS in Tools and various other places

### DIFF
--- a/Source/ThirdParty/gmock/Configurations/Base.xcconfig
+++ b/Source/ThirdParty/gmock/Configurations/Base.xcconfig
@@ -85,7 +85,7 @@ GCC_WARN_UNUSED_VARIABLE = YES;
 PREBINDING = NO;
 WARNING_CFLAGS = $(inherited) -Wcast-qual -Wchar-subscripts -Wextra-tokens -Winit-self -Wmissing-noreturn -Wpacked -Wpointer-arith -Wredundant-decls -Wwrite-strings -Wexit-time-destructors -Wglobal-constructors -Wtautological-compare -Wimplicit-fallthrough -Wvla -Wliteral-conversion -Wthread-safety -Wno-comma -Wno-exit-time-destructors -Wno-global-constructors -Wno-inconsistent-missing-override -Wno-missing-prototypes -Wno-undef;
 
-SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator;
+SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator;
 SUPPORTS_MACCATALYST = YES;
 
 DEAD_CODE_STRIPPING = NO;

--- a/Tools/DumpRenderTree/mac/Configurations/Base.xcconfig
+++ b/Tools/DumpRenderTree/mac/Configurations/Base.xcconfig
@@ -83,7 +83,7 @@ ADDITIONAL_SDKS = $(WK_ADDITIONAL_SDKS);
 AD_HOC_CODE_SIGNING_ALLOWED = YES;
 CODE_SIGN_IDENTITY = -;
 
-SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator;
+SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator;
 SUPPORTS_MACCATALYST = YES;
 
 OTHER_CFLAGS = $(inherited) -isystem $(SDKROOT)/System/Library/Frameworks/System.framework/PrivateHeaders;

--- a/Tools/ImageDiff/cg/Configurations/Base.xcconfig
+++ b/Tools/ImageDiff/cg/Configurations/Base.xcconfig
@@ -72,5 +72,5 @@ ADDITIONAL_SDKS = $(WK_ADDITIONAL_SDKS);
 
 AD_HOC_CODE_SIGNING_ALLOWED = YES;
 
-SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator;
+SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator;
 SUPPORTS_MACCATALYST = YES;

--- a/Tools/MobileMiniBrowser/Configurations/MobileMiniBrowser.xcconfig
+++ b/Tools/MobileMiniBrowser/Configurations/MobileMiniBrowser.xcconfig
@@ -23,4 +23,4 @@
 
 PRODUCT_NAME = MiniBrowser
 STRIP_STYLE=debugging
-SUPPORTED_PLATFORMS = iphoneos iphonesimulator;
+SUPPORTED_PLATFORMS = iphoneos iphonesimulator xros xrsimulator;

--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m
@@ -34,8 +34,11 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     UIStoryboard *frameworkMainStoryboard = [UIStoryboard storyboardWithName:@"Main" bundle:[NSBundle bundleForClass:[AppDelegate class]]];
     WebViewController *viewController = [frameworkMainStoryboard instantiateInitialViewController];
+#pragma clang diagnostic pop
     if (!viewController)
         return NO;
 

--- a/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m
@@ -75,11 +75,17 @@ void* URLContext = &URLContext;
 {
     [super viewDidLoad];
     self.webViews = [[NSMutableArray alloc] initWithCapacity:1];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     self.tabViewController = [self.storyboard instantiateViewControllerWithIdentifier:@"idTabViewController"];
+#pragma clang diagnostic pop
     self.tabViewController.parent = self;
     self.tabViewController.modalPresentationStyle = UIModalPresentationPopover;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     self.settingsViewController = [self.storyboard instantiateViewControllerWithIdentifier:@"idSettingsViewController"];
+#pragma clang diagnostic pop
     self.settingsViewController.parent = self;
     self.settingsViewController.modalPresentationStyle = UIModalPresentationPopover;
 

--- a/Tools/lldb/lldbWebKitTester/Configurations/Base.xcconfig
+++ b/Tools/lldb/lldbWebKitTester/Configurations/Base.xcconfig
@@ -85,7 +85,7 @@ WK_FIXME_WARNING_CFLAGS = -Wno-unused-parameter -Wno-unused-private-field -Wno-u
 
 HEADER_SEARCH_PATHS = ${BUILT_PRODUCTS_DIR}/usr/local/include;
 
-SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator;
+SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator;
 
 DEAD_CODE_STRIPPING = YES;
 DEAD_CODE_STRIPPING[config=Debug] = NO;


### PR DESCRIPTION
#### 2a2314baa31b7ae11d81e5caff77328a78b54e7c
<pre>
Expand SUPPORTED_PLATFORMS to include visionOS in Tools and various other places
<a href="https://bugs.webkit.org/show_bug.cgi?id=271067">https://bugs.webkit.org/show_bug.cgi?id=271067</a>
<a href="https://rdar.apple.com/124702757">rdar://124702757</a>

Reviewed by Richard Robinson and Megan Gardner.

* Source/ThirdParty/gmock/Configurations/Base.xcconfig:
* Tools/DumpRenderTree/mac/Configurations/Base.xcconfig:
* Tools/ImageDiff/cg/Configurations/Base.xcconfig:
* Tools/MobileMiniBrowser/Configurations/MobileMiniBrowser.xcconfig:
* Tools/lldb/lldbWebKitTester/Configurations/Base.xcconfig:
Some ways of building depend on SUPPORTED_PLATFORMS being correct, or they
fall back to building into iOS directories (which then fails because the
dependencies are missing).

* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/AppDelegate.m:
(-[AppDelegate application:didFinishLaunchingWithOptions:]):
* Tools/MobileMiniBrowser/MobileMiniBrowserFramework/WebViewController.m:
(-[WebViewController viewDidLoad]):
Wrap some deprecation warnings.

Canonical link: <a href="https://commits.webkit.org/276192@main">https://commits.webkit.org/276192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/272aa80ffd1a794dab005552d1c1c6f49a9438d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46625 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20438 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20069 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/38970 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2035 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48203 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/18980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15555 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9784 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20574 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/19992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->