### PR TITLE
[JSC] Extend JSBigInt::compare and JSBigInt::compareToDouble for Int64 and Int32

### DIFF
--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -164,20 +164,47 @@ public:
     static ComparisonResult compare(JSBigInt* x, JSBigInt* y);
     static ComparisonResult compare(int32_t x, JSBigInt* y);
     static ComparisonResult compare(JSBigInt* x, int32_t y);
-    static ComparisonResult compare(int32_t x, int32_t y)
-    {
-        if (x == y)
-            return JSBigInt::ComparisonResult::Equal;
-        if (x < y)
-            return JSBigInt::ComparisonResult::LessThan;
-        return JSBigInt::ComparisonResult::GreaterThan;
-    }
+    static ComparisonResult compare(JSBigInt* x, int64_t y);
+    static ComparisonResult compare(JSValue x, int64_t y);
+    static ComparisonResult compare(JSBigInt* x, uint64_t y);
+    static ComparisonResult compare(JSValue x, uint64_t y);
+    static ComparisonResult compare(JSValue x, JSValue y);
 
     double toNumber(JSGlobalObject*) const;
     JSObject* toObject(JSGlobalObject*) const;
     inline bool toBoolean() const { return !isZero(); }
 
-    ComparisonResult static compareToDouble(JSBigInt* x, double y);
+    static ComparisonResult compareToDouble(JSBigInt* x, double y);
+    static ComparisonResult compareToDouble(double x, JSBigInt* y);
+    template<typename BigIntImpl>
+    static ComparisonResult compareToDouble(BigIntImpl x, double y);
+    template <typename BigIntImpl>
+    static ComparisonResult compareToDouble(double x, BigIntImpl y) { return flip(compareToDouble(y, x)); }
+    static ComparisonResult compareToDouble(int32_t x, double y);
+    static ComparisonResult compareToDouble(double x, int32_t y) { return flip(compareToDouble(y, x)); }
+    static ComparisonResult compareToDouble(int64_t x, double y);
+    static ComparisonResult compareToDouble(double x, int64_t y) { return flip(compareToDouble(y, x)); }
+    static ComparisonResult compareToDouble(uint64_t x, double y);
+    static ComparisonResult compareToDouble(double x, uint64_t y) { return flip(compareToDouble(y, x)); }
+    static ComparisonResult compareToDouble(JSValue x, double y);
+    static ComparisonResult compareToDouble(double x, JSValue y) { return flip(compareToDouble(y, x)); }
+
+private:
+    ALWAYS_INLINE static ComparisonResult flip(ComparisonResult result)
+    {
+        switch (result) {
+        case JSBigInt::ComparisonResult::LessThan:
+            return JSBigInt::ComparisonResult::GreaterThan;
+        case JSBigInt::ComparisonResult::GreaterThan:
+            return JSBigInt::ComparisonResult::LessThan;
+        case JSBigInt::ComparisonResult::Equal:
+        case JSBigInt::ComparisonResult::Undefined:
+            return result;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            return JSBigInt::ComparisonResult::Undefined;
+        }
+    }
 
 private:
     friend class HeapBigIntImpl;

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -781,6 +781,13 @@ template<typename T> constexpr T fabsConstExpr(T value)
     return value;
 }
 
+// For use in places where we could negate std::numeric_limits<T>::min and would like to avoid UB.
+template<std::integral T>
+constexpr T negate(T v)
+{
+    return ~static_cast<std::make_unsigned_t<T>>(v) + 1;
+}
+
 } // namespace WTF
 
 using WTF::shuffleVector;


### PR DESCRIPTION
#### f706066e1e24e20a84f82374480a7b33e1de2d10
<pre>
[JSC] Extend JSBigInt::compare and JSBigInt::compareToDouble for Int64 and Int32
<a href="https://bugs.webkit.org/show_bug.cgi?id=271073">https://bugs.webkit.org/show_bug.cgi?id=271073</a>
<a href="https://rdar.apple.com/124706111">rdar://124706111</a>

Reviewed by Keith Miller.

This patch extends JSBigInt::compare and JSBigInt::compareToDouble
for Int64 and Int32.

* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::Int64BigIntImpl::Int64BigIntImpl):
(JSC::Int64BigIntImpl::isZero):
(JSC::Int64BigIntImpl::sign):
(JSC::Int64BigIntImpl::length):
(JSC::Int64BigIntImpl::digit):
(JSC::JSBigInt::compare):
(JSC::JSBigInt::compareToDouble):
* Source/JavaScriptCore/runtime/JSBigInt.h:

Canonical link: <a href="https://commits.webkit.org/276417@main">https://commits.webkit.org/276417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ad48fda6671634adc01e4dd689f8935e9e2a345

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6152 "Built successfully and passed tests") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->