### PR TITLE
[UnifiedPDF] Data detector page overlay tiles should not be repainted when there is no active highlight

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
@@ -66,7 +66,8 @@ public:
     RefPtr<PageOverlay> protectedOverlay() const { return m_overlay; }
 
     enum class ShouldUpdatePlatformHighlightData : bool { No, Yes };
-    void didInvalidateHighlightOverlayRects(ShouldUpdatePlatformHighlightData = ShouldUpdatePlatformHighlightData::Yes);
+    enum class ActiveHighlightChanged : bool { No, Yes };
+    void didInvalidateHighlightOverlayRects(ShouldUpdatePlatformHighlightData = ShouldUpdatePlatformHighlightData::Yes, ActiveHighlightChanged = ActiveHighlightChanged::No);
 
 private:
     // PageOverlay::Client

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
@@ -162,8 +162,7 @@ bool PDFDataDetectorOverlayController::handleMouseEvent(const WebMouseEvent& eve
             m_activeDataDetectorHighlight->fadeIn();
         }
 
-        overlay->setNeedsDisplay();
-        didInvalidateHighlightOverlayRects(ShouldUpdatePlatformHighlightData::No);
+        didInvalidateHighlightOverlayRects(ShouldUpdatePlatformHighlightData::No, ActiveHighlightChanged::Yes);
     }
 
     if (event.type() == WebEventType::MouseDown && mouseIsOverActiveHighlightButton)
@@ -234,13 +233,16 @@ void PDFDataDetectorOverlayController::updatePlatformHighlightData(PDFDocumentLa
     });
 }
 
-void PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects(ShouldUpdatePlatformHighlightData shouldUpdatePlatformHighlightData)
+void PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects(ShouldUpdatePlatformHighlightData shouldUpdatePlatformHighlightData, ActiveHighlightChanged activeHighlightChanged)
 {
     if (shouldUpdatePlatformHighlightData == ShouldUpdatePlatformHighlightData::Yes) {
         WTF::forEach(m_pdfDataDetectorItemsWithHighlightsMap.keys(), [&](auto pageIndex) {
             updatePlatformHighlightData(pageIndex);
         });
     }
+
+    if (activeHighlightChanged == ActiveHighlightChanged::No && !m_activeDataDetectorHighlight)
+        return;
 
     RefPtr overlay = protectedOverlay();
 


### PR DESCRIPTION
#### 3aad301970ab258e0c20ac22b43ea2c271897ca6
<pre>
[UnifiedPDF] Data detector page overlay tiles should not be repainted when there is no active highlight
<a href="https://bugs.webkit.org/show_bug.cgi?id=271074">https://bugs.webkit.org/show_bug.cgi?id=271074</a>
<a href="https://rdar.apple.com/124707729">rdar://124707729</a>

Reviewed by Simon Fraser.

Currently, we unconditionally call PageOverlay::setNeedsDisplay()
whenever we scroll the PDF plugin. This is incredibly inefficient
because we&apos;re repainting all the tiles even when there is no need to do
so.

This patch teaches teh data detector overlay controller to better reason
about when a repaint is necessary, and only calls setNeedsDisplay() when
those conditions are met. Namely, we no longer repaint if there is no
active highlight or if the active highlight instance has not changed.

In a future patch, we will further optimize this by clipping the repaint
to only the bounds of the active (and just-deactivated) highlight.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm:
(WebKit::PDFDataDetectorOverlayController::handleMouseEvent):
(WebKit::PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects):

Canonical link: <a href="https://commits.webkit.org/276200@main">https://commits.webkit.org/276200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99c4737aa3e632afad54089a4de6c1d6d8f424db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/43997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46645 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/26975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20460 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37892 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2055 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40175 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48224 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15571 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9788 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20591 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/20007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->