### PR TITLE
Add data task signposts for _WKDataTask requests

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -2007,7 +2007,7 @@ void NetworkSessionCocoa::dataTaskWithRequest(WebPageProxyIdentifier pageID, Web
     auto nsRequest = request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody);
     auto session = sessionWrapperForTask(pageID, request, WebCore::StoredCredentialsPolicy::Use, std::nullopt).session;
     auto task = [session dataTaskWithRequest:nsRequest];
-    auto delegate = adoptNS([[WKURLSessionTaskDelegate alloc] initWithIdentifier:identifier session:*this]);
+    auto delegate = adoptNS([[WKURLSessionTaskDelegate alloc] initWithTask:task identifier:identifier session:*this]);
 #if HAVE(NSURLSESSION_TASK_DELEGATE)
     task.delegate = delegate.get();
 #endif

--- a/Source/WebKit/NetworkProcess/cocoa/WKURLSessionTaskDelegate.h
+++ b/Source/WebKit/NetworkProcess/cocoa/WKURLSessionTaskDelegate.h
@@ -36,7 +36,7 @@ class NetworkSessionCocoa;
 NS_ASSUME_NONNULL_BEGIN
 
 @interface WKURLSessionTaskDelegate : NSObject<NSURLSessionTaskDelegate>
-- (instancetype)initWithIdentifier:(WebKit::DataTaskIdentifier)identifier session:(WebKit::NetworkSessionCocoa&)session;
+- (instancetype)initWithTask:(NSURLSessionTask *)task identifier:(WebKit::DataTaskIdentifier)identifier session:(WebKit::NetworkSessionCocoa&)session;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### d41c16dc9131e22004d607de6eb609cc83a1a1d4
<pre>
Add data task signposts for _WKDataTask requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=271075">https://bugs.webkit.org/show_bug.cgi?id=271075</a>
<a href="https://rdar.apple.com/124708190">rdar://124708190</a>

Reviewed by Sihui Liu.

We had some power issues that were harder to diagnose than they should have been because data tasks
created by _WKDataTask (which eventually calls down to NetworkProcess::dataTaskWithRequest) don&apos;t
have signposts like other NetworkProcess data tasks. This adds those signposts so future bugs will
be easier to triage.

* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::dataTaskWithRequest):
* Source/WebKit/NetworkProcess/cocoa/WKURLSessionTaskDelegate.h:
* Source/WebKit/NetworkProcess/cocoa/WKURLSessionTaskDelegate.mm:
(-[WKURLSessionTaskDelegate initWithTask:identifier:session:]):
(-[WKURLSessionTaskDelegate dealloc]):
(-[WKURLSessionTaskDelegate URLSession:task:didReceiveChallenge:completionHandler:]):
(-[WKURLSessionTaskDelegate URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:]):
(-[WKURLSessionTaskDelegate URLSession:dataTask:didReceiveResponse:completionHandler:]):
(-[WKURLSessionTaskDelegate URLSession:dataTask:didReceiveData:]):
(-[WKURLSessionTaskDelegate URLSession:task:didCompleteWithError:]):
(-[WKURLSessionTaskDelegate initWithIdentifier:session:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/277338@main">https://commits.webkit.org/277338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a7977268cd0425f4de95b7d0264cb86635398aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50062 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43427 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24019 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47960 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/24091 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40826 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19894 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/21529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5422 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51938 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23684 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10439 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->