### PR TITLE
NULL pointer :  crash under RenderLayerCompositor::scrollableAreaForScrollingNodeID()

### DIFF
--- a/LayoutTests/fast/rendering/render-compositor-null-layer-crash-expected.txt
+++ b/LayoutTests/fast/rendering/render-compositor-null-layer-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it doesn't crash.
+
+

--- a/LayoutTests/fast/rendering/render-compositor-null-layer-crash.html
+++ b/LayoutTests/fast/rendering/render-compositor-null-layer-crash.html
@@ -1,0 +1,35 @@
+<script>
+function gc() {
+ {
+ }
+}
+function main() {
+var x29 = document.getElementById("x29");
+try { x22.selectionEnd = 87; } catch { }
+try { x29.prepend(x7); } catch { }
+}
+function f4() {
+var x37 = document.getElementById("x37");
+try { v30 = x7.contentDocument; } catch { }
+try { v30.all[98 % v30.all.length].appendChild(x3); } catch { }
+try { x7.data = "x"; } catch { }
+try { x37.height = "1em"; } catch { }
+}
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<body onload="main()">
+    <p>This test passes if it doesn't crash.</p>
+<h4 onfocusin="f4()" part="part0">
+<input id="x22" type="url">
+<small id="x3" itemscope="">
+<a id="x29" href="x">
+<h2 webkitdropzone="link">
+</h2>
+<object id="x37" standby="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA">
+</object>
+</small>
+</style>
+</details>
+<object id="x7" data="x">
+</body>

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -5512,7 +5512,10 @@ ScrollableArea* RenderLayerCompositor::scrollableAreaForScrollingNodeID(Scrollin
     if (nodeID == m_renderView.frameView().scrollingNodeID())
         return &m_renderView.frameView();
 
-    return m_scrollingNodeToLayerMap.get(nodeID)->scrollableArea();
+    if (auto weakLayer = m_scrollingNodeToLayerMap.get(nodeID))
+        return weakLayer->scrollableArea();
+
+    return nullptr;
 }
 
 void RenderLayerCompositor::willRemoveScrollingLayerWithBacking(RenderLayer& layer, RenderLayerBacking& backing)


### PR DESCRIPTION
#### f382be44f6ec4f9d5a719a183c70b2e9aaa41254
<pre>
NULL pointer :  crash under RenderLayerCompositor::scrollableAreaForScrollingNodeID()
<a href="https://bugs.webkit.org/show_bug.cgi?id=265820">https://bugs.webkit.org/show_bug.cgi?id=265820</a>
<a href="https://rdar.apple.com/118424482">rdar://118424482</a>.

Reviewed by Simon Fraser.

Null RenderLayer pointer in RenderLayerCompositor::scrollableAreaForScrollingNodeID().
As the RenderLayerCompositor has a HashMap which provides a WeakPtr to RenderLayer but the validity
of this object is not checked before using.

* LayoutTests/fast/rendering/render-compositor-null-layer-crash-expected.txt: Added test expected file.
* LayoutTests/fast/rendering/render-compositor-null-layer-crash.html: Added test case.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::scrollableAreaForScrollingNodeID const): Checked validity of WeakPtr to RenderLayer before accessing it.

Originally-landed-as: 272448.252@safari-7618-branch (a7977801dff3). <a href="https://rdar.apple.com/124556059">rdar://124556059</a>
Canonical link: <a href="https://commits.webkit.org/276701@main">https://commits.webkit.org/276701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c5a417f813a14eaa7dd3fe3b127ecb822dfdcf7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48031 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41375 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21884 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39133 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18324 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40216 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3414 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41654 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49750 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16871 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44249 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21657 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43067 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10100 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21345 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->