### PR TITLE
Scoped Arguments needs to alias between named and unnamed accesses and across nested scopes

### DIFF
--- a/JSTests/stress/arrow-function-captured-arguments-aliased.js
+++ b/JSTests/stress/arrow-function-captured-arguments-aliased.js
@@ -1,0 +1,66 @@
+function createOptAll(count) {
+    count = 0;
+
+    return () => {
+        arguments[0]++;
+
+        return count;
+    };
+}
+
+function createOpt500(count) {
+    count = 0;
+
+    return () => {
+        arguments[0]++;
+
+        if (arguments[0] < 500)
+            return arguments[0];
+
+        return count;
+    };
+}
+
+function createOpt2000(count) {
+    count = 0;
+
+    return () => {
+        arguments[0]++;
+
+        if (arguments[0] < 2000)
+            return arguments[0];
+
+        return count;
+    };
+}
+
+function createOpt5000(count) {
+    count = 0;
+
+    return () => {
+        arguments[0]++;
+
+        if (arguments[0] < 5000)
+            return arguments[0];
+
+        return count;
+    };
+}
+
+function main() {
+    const testCount = 10000;
+    const createOptFuncs = [createOptAll, createOpt500, createOpt2000, createOpt5000];
+    for (createOptFunc of createOptFuncs) {
+    const opt = createOptFunc(0);
+        for (let i = 0; i < testCount; i++) {
+            opt();
+        }
+
+        const expectedResult = testCount+1;
+        let actualResult = opt();
+        if (actualResult != expectedResult)
+            print("Expected " + expectedResult + ", got " + actualResult);
+    }
+}
+
+main();

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -592,7 +592,12 @@ bool CodeBlock::finishCreation(VM& vm, ScriptExecutable* ownerExecutable, Unlink
                     ConcurrentJSLocker locker(symbolTable->m_lock);
                     auto iter = symbolTable->find(locker, ident.impl());
                     ASSERT(iter != symbolTable->end(locker));
-                    iter->value.prepareToWatch();
+                    if (bytecode.m_getPutInfo.initializationMode() == InitializationMode::ScopedArgumentInitialization) {
+                        ASSERT(bytecode.m_value.isArgument());
+                        unsigned argumentIndex = bytecode.m_value.toArgument() - 1;
+                        symbolTable->prepareToWatchScopedArgument(iter->value, argumentIndex);
+                    } else
+                        iter->value.prepareToWatch();
                     metadata.m_watchpointSet = iter->value.watchpointSet();
                 } else
                     metadata.m_watchpointSet = nullptr;

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -599,17 +599,23 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, FunctionNode* functionNode, Unlinke
                     m_outOfMemoryDuringConstruction = true;
                     return;
                 }
+
+                unsigned varOrAnonymous = UINT_MAX;
+
                 if (UniquedStringImpl* name = visibleNameForParameter(parameters.at(i).first)) {
                     VarOffset varOffset(offset);
                     SymbolTableEntry entry(varOffset);
-                    // Stores to these variables via the ScopedArguments object will not do
-                    // notifyWrite(), since that would be cumbersome. Also, watching formal
-                    // parameters when "arguments" is in play is unlikely to be super profitable.
-                    // So, we just disable it.
-                    entry.disableWatching(m_vm);
                     functionSymbolTable->set(NoLockingNecessary, name, entry);
+
+IGNORE_GCC_WARNINGS_BEGIN("dangling-reference")
+                    const Identifier& ident =
+                        static_cast<const BindingNode*>(parameters.at(i).first)->boundProperty();
+IGNORE_GCC_WARNINGS_END
+
+                    varOrAnonymous = addConstant(ident);
                 }
-                OpPutToScope::emit(this, m_lexicalEnvironmentRegister, UINT_MAX, virtualRegisterForArgumentIncludingThis(1 + i), GetPutInfo(ThrowIfNotFound, ResolvedClosureVar, InitializationMode::NotInitialization, ecmaMode), SymbolTableOrScopeDepth::symbolTable(VirtualRegister { symbolTableConstantIndex }), offset.offset());
+
+                OpPutToScope::emit(this, m_lexicalEnvironmentRegister, varOrAnonymous, virtualRegisterForArgumentIncludingThis(1 + i), GetPutInfo(ThrowIfNotFound, ResolvedClosureVar, InitializationMode::ScopedArgumentInitialization, ecmaMode), SymbolTableOrScopeDepth::symbolTable(VirtualRegister { symbolTableConstantIndex }), offset.offset());
             }
             
             // This creates a scoped arguments object and copies the overflow arguments into the

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -8857,6 +8857,9 @@ void ByteCodeParser::parseBlock(unsigned limit)
                     // Must happen after the store. See comment for GetGlobalVar.
                     addToGraph(NotifyWrite, OpInfo(watchpoints));
                 }
+
+                // Keep scope alive until after put.
+                addToGraph(Phantom, scopeNode);
                 break;
             }
 

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm
@@ -2917,7 +2917,7 @@ llintOpWithMetadata(op_put_to_scope, OpPutToScope, macro (size, get, dispatch, m
         loadi OpPutToScope::Metadata::m_getPutInfo + GetPutInfo::m_operand[t5], t0
         andi InitializationModeMask, t0
         rshifti InitializationModeShift, t0
-        bineq t0, NotInitialization, .noNeedForTDZCheck
+        bilt t0, NotInitialization, .noNeedForTDZCheck
         loadp OpPutToScope::Metadata::m_operand[t5], t0
         loadi TagOffset[t0], t0
         bieq t0, EmptyValueTag, .pDynamic

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -3093,7 +3093,7 @@ llintOpWithMetadata(op_put_to_scope, OpPutToScope, macro (size, get, dispatch, m
         loadi OpPutToScope::Metadata::m_getPutInfo + GetPutInfo::m_operand[t5], t0
         andi InitializationModeMask, t0
         rshifti InitializationModeShift, t0
-        bineq t0, NotInitialization, .noNeedForTDZCheck
+        bilt t0, NotInitialization, .noNeedForTDZCheck
         loadp OpPutToScope::Metadata::m_operand[t5], t0
         loadq [t0], t0
         bqeq t0, ValueEmpty, .pDynamic

--- a/Source/JavaScriptCore/runtime/GetPutInfo.h
+++ b/Source/JavaScriptCore/runtime/GetPutInfo.h
@@ -83,7 +83,8 @@ enum ResolveType : unsigned {
 enum class InitializationMode : unsigned {
     Initialization,      // "let x = 20;"
     ConstInitialization, // "const x = 20;"
-    NotInitialization    // "x = 20;"
+    NotInitialization,   // "x = 20;"
+    ScopedArgumentInitialization // Assign to scoped argument, which also has NotInitialization semantics.
 };
 
 ALWAYS_INLINE const char* resolveModeName(ResolveMode resolveMode)
@@ -120,7 +121,8 @@ ALWAYS_INLINE const char* initializationModeName(InitializationMode initializati
     static const char* const names[] = {
         "Initialization",
         "ConstInitialization",
-        "NotInitialization"
+        "NotInitialization",
+        "ScopedArgumentInitialization"
     };
     return names[static_cast<unsigned>(initializationMode)];
 }
@@ -132,6 +134,7 @@ ALWAYS_INLINE bool isInitialization(InitializationMode initializationMode)
     case InitializationMode::ConstInitialization:
         return true;
     case InitializationMode::NotInitialization:
+    case InitializationMode::ScopedArgumentInitialization:
         return false;
     }
     ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/runtime/ScopedArguments.cpp
+++ b/Source/JavaScriptCore/runtime/ScopedArguments.cpp
@@ -150,6 +150,7 @@ void ScopedArguments::unmapArgument(JSGlobalObject* globalObject, uint32_t i)
             return;
         }
         m_table.set(vm, this, maybeCloned);
+        m_table->clearWatchpointSet(i);
     } else
         storage()[i - namedLength].clear();
 }

--- a/Source/JavaScriptCore/runtime/ScopedArguments.h
+++ b/Source/JavaScriptCore/runtime/ScopedArguments.h
@@ -27,6 +27,7 @@
 
 #include "GenericArguments.h"
 #include "JSLexicalEnvironment.h"
+#include "Watchpoint.h"
 
 namespace JSC {
 
@@ -110,9 +111,13 @@ public:
     {
         ASSERT_WITH_SECURITY_IMPLICATION(isMappedArgument(i));
         unsigned namedLength = m_table->length();
-        if (i < namedLength)
+        if (i < namedLength) {
             m_scope->variableAt(m_table->get(i)).set(vm, m_scope.get(), value);
-        else
+
+            auto* watchpointSet = m_table->getWatchpointSet(i);
+            if (watchpointSet)
+                watchpointSet->touch(vm, "Write to ScopedArgument.");
+        } else
             storage()[i - namedLength].set(vm, this, value);
     }
 

--- a/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
+++ b/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
@@ -70,6 +70,7 @@ ScopedArgumentsTable* ScopedArgumentsTable::tryCreate(VM& vm, uint32_t length)
     result->m_arguments = ArgumentsPtr::tryCreate(length);
     if (UNLIKELY(!result->m_arguments))
         return nullptr;
+    result->m_watchpointSets.fill(nullptr, length);
     return result;
 }
 
@@ -80,6 +81,7 @@ ScopedArgumentsTable* ScopedArgumentsTable::tryClone(VM& vm)
         return nullptr;
     for (unsigned i = m_length; i--;)
         result->at(i) = this->at(i);
+    result->m_watchpointSets = this->m_watchpointSets;
     return result;
 }
 
@@ -93,14 +95,18 @@ ScopedArgumentsTable* ScopedArgumentsTable::trySetLength(VM& vm, uint32_t newLen
             newArguments.at(i) = this->at(i);
         m_length = newLength;
         m_arguments = WTFMove(newArguments);
+        m_watchpointSets.resize(newLength);
         return this;
     }
     
     ScopedArgumentsTable* result = tryCreate(vm, newLength);
     if (UNLIKELY(!result))
         return nullptr;
-    for (unsigned i = std::min(m_length, newLength); i--;)
+    m_watchpointSets.resize(newLength);
+    for (unsigned i = std::min(m_length, newLength); i--;) {
         result->at(i) = this->at(i);
+        result->m_watchpointSets[i] = this->m_watchpointSets[i];
+    }
     return result;
 }
 
@@ -117,6 +123,15 @@ ScopedArgumentsTable* ScopedArgumentsTable::trySet(VM& vm, uint32_t i, ScopeOffs
         result = this;
     result->at(i) = value;
     return result;
+}
+
+void ScopedArgumentsTable::trySetWatchpointSet(uint32_t i, WatchpointSet* watchpoints)
+{
+    ASSERT(watchpoints);
+    if (i >= m_watchpointSets.size())
+        return;
+
+    m_watchpointSets[i] = watchpoints;
 }
 
 Structure* ScopedArgumentsTable::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)

--- a/Source/JavaScriptCore/runtime/ScopedArgumentsTable.h
+++ b/Source/JavaScriptCore/runtime/ScopedArgumentsTable.h
@@ -33,6 +33,8 @@
 
 namespace JSC {
 
+class WatchpointSet;
+
 // This class's only job is to hold onto the list of ScopeOffsets for each argument that a
 // function has. Most of the time, the BytecodeGenerator will create one of these and it will
 // never be modified subsequently. There is a rare case where a ScopedArguments object is created
@@ -67,6 +69,7 @@ public:
     ScopedArgumentsTable* trySetLength(VM&, uint32_t newLength);
     
     ScopeOffset get(uint32_t i) const { return at(i); }
+    WatchpointSet* getWatchpointSet(uint32_t i) const { return m_watchpointSets.at(i); }
     
     void lock()
     {
@@ -74,7 +77,9 @@ public:
     }
     
     ScopedArgumentsTable* trySet(VM&, uint32_t index, ScopeOffset);
-    
+    void trySetWatchpointSet(uint32_t index, WatchpointSet* watchpoints);
+    void clearWatchpointSet(uint32_t index) { m_watchpointSets[index] = nullptr; }
+
     DECLARE_INFO;
     
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
@@ -96,6 +101,7 @@ private:
     uint32_t m_length;
     bool m_locked; // Being locked means that there are multiple references to this object and none of them expect to see the others' modifications. This means that modifications need to make a copy first.
     ArgumentsPtr m_arguments;
+    Vector<WatchpointSet*> m_watchpointSets;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -677,6 +677,7 @@ public:
                 return false;
             m_arguments.set(vm, this, table);
         }
+
         return true;
     }
 
@@ -696,6 +697,16 @@ public:
         return true;
     }
     
+    void prepareToWatchScopedArgument(SymbolTableEntry& entry, uint32_t i)
+    {
+        entry.prepareToWatch();
+        if (!m_arguments)
+            return;
+
+        WatchpointSet* watchpoints = entry.watchpointSet();
+        m_arguments->trySetWatchpointSet(i, watchpoints);
+    }
+
     ScopedArgumentsTable* arguments() const
     {
         if (!m_arguments)


### PR DESCRIPTION
#### 09c434a6e6c752650beb946b01d9894e3212374c
<pre>
Scoped Arguments needs to alias between named and unnamed accesses and across nested scopes
<a href="https://bugs.webkit.org/show_bug.cgi?id=261934">https://bugs.webkit.org/show_bug.cgi?id=261934</a>
<a href="https://rdar.apple.com/114925088">rdar://114925088</a>
<a href="https://rdar.apple.com/117838992">rdar://117838992</a>

Reviewed by Yusuke Suzuki.

Fixed issue where an access to a named argument and a seperate access via its argument[i] counterpart weren&apos;t recognized throughout
all JIT tiers as accesses to the same scoped value.  The DFG bytecode parser can unknowingly constant fold the read access.
Added aliasing via the SymbolTable and its ScopedArgumentsTable for both types of accesses of such values.
related objects

Added watchpoints for scoped arguments, and shared the watchpoint from the SymbolTableEntry for the named parameter with the
ScopedArgument entry for the matching index.  Tagged op_put_to_scope bytecodes with a new ScopedArgumentInitialization
initialization type in GetPutInfo to signify this shared watchpoint case.  Since currently all tiers write to scoped arguments
via ScopedArguments::setIndexQuickly(), that is where we fire its watchpoint.

Added a new test.

* JSTests/stress/arrow-function-captured-arguments-aliased.js: Added.
(createOptAll):
(createOpt500):
(createOpt2000):
(createOpt5000):
(main):
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::finishCreation):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::BytecodeGenerator):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/llint/LowLevelInterpreter32_64.asm:
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/runtime/GetPutInfo.h:
(JSC::initializationModeName):
(JSC::isInitialization):
* Source/JavaScriptCore/runtime/ScopedArguments.cpp:
(JSC::ScopedArguments::unmapArgument):
* Source/JavaScriptCore/runtime/ScopedArguments.h:
* Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp:
(JSC::ScopedArgumentsTable::tryCreate):
(JSC::ScopedArgumentsTable::tryClone):
(JSC::ScopedArgumentsTable::trySetLength):
(JSC::ScopedArgumentsTable::trySetWatchpointSet):
* Source/JavaScriptCore/runtime/ScopedArgumentsTable.h:
* Source/JavaScriptCore/runtime/SymbolTable.cpp:
(JSC::SymbolTable::cloneScopePart):
* Source/JavaScriptCore/runtime/SymbolTable.h:

Originally-landed-as: 272448.5@safari-7618-branch (97894699773c). <a href="https://rdar.apple.com/124557495">rdar://124557495</a>
Canonical link: <a href="https://commits.webkit.org/276437@main">https://commits.webkit.org/276437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e123ecb374088453e6e8782ec363a49e8225875

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44450 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47104 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40472 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36573 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17624 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18161 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39392 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2500 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37677 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40781 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48722 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43929 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15958 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43489 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20780 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42225 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9949 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21107 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51086 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20413 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10352 "Passed tests") | 
<!--EWS-Status-Bubble-End-->