### PR TITLE
rdar://119489615 ([CoreIPC] SEGV in WebKit::RemoteSourceBufferProxy::addTrackBuffer)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5363,8 +5363,9 @@ webkit.org/b/239959 ipc/stream-sync-crash-no-timeout.html [ Skip ]
 # The test invokes random messages, potentially produces random results.
 ipc/start-message-testing.html [ Skip ]
 
-# Test is slow
+# Fixing timeouts is tracked by https://bugs.webkit.org/show_bug.cgi?id=267714 (rdar://120486467)
 ipc/invalid-fullscreen-enum.html [ Pass Timeout ]
+ipc/invalid-message-to-addTrackBuffer.html [ Pass Timeout ]
 
 # Test is crashing in Debug builds since import.
 webkit.org/b/234977 [ Debug ] imported/w3c/web-platform-tests/dom/events/focus-event-document-move.html [ Skip ]

--- a/LayoutTests/ipc/invalid-message-to-addTrackBuffer-expected.txt
+++ b/LayoutTests/ipc/invalid-message-to-addTrackBuffer-expected.txt
@@ -1,0 +1,1 @@
+This test should not crash

--- a/LayoutTests/ipc/invalid-message-to-addTrackBuffer.html
+++ b/LayoutTests/ipc/invalid-message-to-addTrackBuffer.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<head>
+<script>
+function fuzz() {
+  if (window.testRunner) {
+      testRunner.waitUntilDone();
+  }
+
+  if (window.IPC) {
+    var calledParseMessage = false;
+    IPC.addOutgoingMessageListener("GPU", (msg) => {
+      if (!calledParseMessage && msg.name == IPC.messages.RemoteMediaPlayerProxy_PlayerContentBoxRectChanged.name) {
+        calledParseMessage = true;
+        parseMessage(msg);
+      }
+    });
+  }
+  video=document.createElement('video');
+  video.src='test.gif';
+}
+function parseMessage(msg) {
+  o58=msg.destinationID;
+  o65=2219;
+  IPC.sendMessage('GPU',o58,IPC.messages.RemoteMediaPlayerManagerProxy_CreateMediaPlayer.name,[{type: 'uint64_t',value: o65},{type: 'uint8_t',value: 1},{type: 'String',value: 'undefined'},{type: 'String',value: "video/mpeg"},{type: 'String',value: "page-6"},{type: 'String',value: "/tmp/ipcfuzz"},{type: 'Vector',value: [[{type: 'String',value: 'undefined'}],[{type: 'String',value: "com.apple.fps"}],[{type: 'String',value: "org.w3.clearkey"}],[{type: 'String',value: "/tmp/ipcfuzz"}],[{type: 'String',value: "image/wepb"}],[{type: 'String',value: 'undefined'}],[{type: 'String',value: "video/mp4"}],[{type: 'String',value: 'undefined'}],[{type: 'String',value: 'undefined'}],[{type: 'String',value: 'undefined'}],[{type: 'String',value: "com.apple.pasteboard.clipboard"}],[{type: 'String',value: "InsertTab"}],[{type: 'String',value: "image/wepb"}]]},{type: 'bool',value: 1},{type: 'Vector',value: [[{type: 'String',value: 'undefined'}],[{type: 'String',value: 'undefined'}],[{type: 'String',value: 'undefined'}],[{type: 'String',value: 'undefined'}],[{type: 'String',value: 'undefined'}],[{type: 'String',value: "Apple CFPasteboard general"}],[{type: 'String',value: 'undefined'}],[{type: 'String',value: "page-6"}],[{type: 'String',value: 'undefined'}],[{type: 'String',value: "com.apple.fps."}],[{type: 'String',value: "page-9"}]]},{type: 'bool',value: 1},{type: 'Vector',value: [[{type: 'String',value: 'undefined'}],[{type: 'String',value: "de-DE"}],[{type: 'String',value: 'undefined'}]]},{type: 'bool',value: 1},{type: 'Vector',value: [[{type: 'uint32_t',value: 946}],[{type: 'uint32_t',value: 845}],[{type: 'uint32_t',value: 854}],[{type: 'uint32_t',value: 633}],[{type: 'uint32_t',value: 199}],[{type: 'uint32_t',value: 429}],[{type: 'uint32_t',value: 939}],[{type: 'uint32_t',value: 3473215}],[{type: 'uint32_t',value: 323}],[{type: 'uint32_t',value: 865}],[{type: 'uint32_t',value: 308}],[{type: 'uint32_t',value: 780}],[{type: 'uint32_t',value: 950}]]},{type: 'bool',value: 1},{type: 'Vector',value: [[{type: 'uint32_t',value: 441}],[{type: 'uint32_t',value: 493}],[{type: 'uint32_t',value: 474}],[{type: 'uint32_t',value: 47}],[{type: 'uint32_t',value: 287}]]},{type: 'bool',value: 0},{type: 'uint32_t',value: 113},{type: 'uint32_t',value: 215},{type: 'uint32_t',value: 733},{type: 'uint32_t',value: 864},{type: 'Vector',value: [[{type: 'String',value: 'undefined'}],[{type: 'String',value: "video/webm"}]]},{type: 'Vector',value: [[{type: 'String',value: "Apple CFPasteboard general"},{type: 'String',value: "file:///tmp/ipcfuzz"},{type: 'String',value: "video/mp4"},{type: 'uint8_t',value: 1},{type: 'uint8_t',value: 4},{type: 'uint8_t',value: 2},{type: 'uint32_t',value: 962},{type: 'bool',value: 1}],[{type: 'String',value: 'undefined'},{type: 'String',value: "image/wepb"},{type: 'String',value: "InsertTab"},{type: 'uint8_t',value: 0},{type: 'uint8_t',value: 1},{type: 'uint8_t',value: 1},{type: 'uint32_t',value: 277},{type: 'bool',value: 0}],[{type: 'String',value: 'undefined'},{type: 'String',value: 'undefined'},{type: 'String',value: "video/webm"},{type: 'uint8_t',value: 2},{type: 'uint8_t',value: 5},{type: 'uint8_t',value: 2},{type: 'uint32_t',value: 418},{type: 'bool',value: 1}],[{type: 'String',value: "video/mpeg"},{type: 'String',value: 'undefined'},{type: 'String',value: 'undefined'},{type: 'uint8_t',value: 0},{type: 'uint8_t',value: 3},{type: 'uint8_t',value: 1},{type: 'uint32_t',value: 722},{type: 'bool',value: 0}],[{type: 'String',value: 'undefined'},{type: 'String',value: 'undefined'},{type: 'String',value: "cancelOperation"},{type: 'uint8_t',value: 2},{type: 'uint8_t',value: 0},{type: 'uint8_t',value: 0},{type: 'uint32_t',value: 335},{type: 'bool',value: 1}],[{type: 'String',value: 'undefined'},{type: 'String',value: 'undefined'},{type: 'String',value: 'undefined'},{type: 'uint8_t',value: 1},{type: 'uint8_t',value: 3},{type: 'uint8_t',value: 1},{type: 'uint32_t',value: 785},{type: 'bool',value: 1}],[{type: 'String',value: 'undefined'},{type: 'String',value: 'undefined'},{type: 'String',value: 'undefined'},{type: 'uint8_t',value: 0},{type: 'uint8_t',value: 3},{type: 'uint8_t',value: 1},{type: 'uint32_t',value: 2932851},{type: 'bool',value: 1}],[{type: 'String',value: "cancelOperation"},{type: 'String',value: 'undefined'},{type: 'String',value: 'undefined'},{type: 'uint8_t',value: 2},{type: 'uint8_t',value: 5},{type: 'uint8_t',value: 2},{type: 'uint32_t',value: 762},{type: 'bool',value: 1}],[{type: 'String',value: 'undefined'},{type: 'String',value: "en-US"},{type: 'String',value: 'undefined'},{type: 'uint8_t',value: 0},{type: 'uint8_t',value: 4},{type: 'uint8_t',value: 1},{type: 'uint32_t',value: 1019},{type: 'bool',value: 0}],[{type: 'String',value: 'undefined'},{type: 'String',value: "de-DE"},{type: 'String',value: "a"},{type: 'uint8_t',value: 0},{type: 'uint8_t',value: 0},{type: 'uint8_t',value: 0},{type: 'uint32_t',value: 284},{type: 'bool',value: 0}],[{type: 'String',value: 'undefined'},{type: 'String',value: 'undefined'},{type: 'String',value: 'undefined'},{type: 'uint8_t',value: 0},{type: 'uint8_t',value: 3},{type: 'uint8_t',value: 1},{type: 'uint32_t',value: 822},{type: 'bool',value: 0}],[{type: 'String',value: "text/html"},{type: 'String',value: 'undefined'},{type: 'String',value: "cancelOperation"},{type: 'uint8_t',value: 0},{type: 'uint8_t',value: 2},{type: 'uint8_t',value: 2},{type: 'uint32_t',value: 773},{type: 'bool',value: 0}],[{type: 'String',value: 'undefined'},{type: 'String',value: 'undefined'},{type: 'String',value: "Apple CFPasteboard general"},{type: 'uint8_t',value: 2},{type: 'uint8_t',value: 2},{type: 'uint8_t',value: 1},{type: 'uint32_t',value: 209},{type: 'bool',value: 0}],[{type: 'String',value: 'undefined'},{type: 'String',value: "video/webm"},{type: 'String',value: "video/mp4"},{type: 'uint8_t',value: 0},{type: 'uint8_t',value: 1},{type: 'uint8_t',value: 0},{type: 'uint32_t',value: 775},{type: 'bool',value: 0}],[{type: 'String',value: "org.w3.clearkey"},{type: 'String',value: "image/jpeg"},{type: 'String',value: "com.apple.fps"},{type: 'uint8_t',value: 2},{type: 'uint8_t',value: 4},{type: 'uint8_t',value: 0},{type: 'uint32_t',value: 685},{type: 'bool',value: 1}]]},[{type: 'String', value: 'http'}, {type: 'String', value: 'localhost'}, {type: 'bool', value: 0}],{type: 'uint32_t',value: 777},{type: 'uint32_t',value: 490},{type: 'float',value: 774},{type: 'float',value: 865},{type: 'uint64_t',value: 39},{type: 'bool',value: 1},{type: 'bool',value: 1},{type: 'bool',value: 1},{type: 'bool',value: 1},{type: 'bool',value: 1}]);
+  o131=3032;
+  IPC.sendMessage("GPU", o65, IPC.messages.RemoteMediaPlayerProxy_LoadMediaSource.name, [{type:"String", value: "insertText:"},{type:"String", value: "image/jpeg"},{type: "bool", value: 0},{type: "uint64_t", value: 3032}]);
+  reply=IPC.sendSyncMessage('GPU',o131,IPC.messages.RemoteMediaSourceProxy_AddSourceBuffer.name,0.1,[{type: 'String',value: "video/mp4"}]);
+  parseResults=parseMessageFromReply(IPC.messages.RemoteMediaSourceProxy_AddSourceBuffer.replyArguments, reply.buffer);
+  o188=parseResults['WebKit::RemoteSourceBufferIdentifier'];
+  IPC.sendMessage('GPU',o188,IPC.messages.RemoteSourceBufferProxy_AddTrackBuffer.name,[{type: 'uint64_t', value: 0x414141414141}]);
+  if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.notifyDone();
+  }
+}
+
+let knownSizes = {
+    "unsigned": 4,
+    "int": 4,
+    "uint8_t": 1,
+    "int8_t": 1,
+    "uint64_t": 8,
+    "int64_t": 8,
+    "uint32_t": 4,
+    "int32_t": 4,
+    "uint16_t": 2,
+    "int16_t": 2,
+    "double": 8,
+    "float": 4,
+    "bool": 1,
+    "size_t": 8,
+    "unsigned short": 2,
+    "long long": 8,
+    "UUID": 16
+};
+function parseMessageFromReply(args, buffer) {
+  buffer = new Uint8Array(buffer);
+  let results = {};
+  try {
+    parse(buffer, args, 0x10/*skip message header*/, results);
+  } catch (e) {
+    console.log("Exception: " + e);
+  }
+  return results;
+}
+function align(pos, granularity) {
+  if (pos%granularity) {
+    pos = pos + granularity-(pos%granularity);
+  }
+  return pos;
+}
+function parse(buf, args, pos, results) {
+  if (args == null) return -1;
+  if (args.length == 0) return pos;
+  let arg = args.shift();
+  let t = arg['type'];
+  if (arg['optional']) {
+    let haz = !!buf[pos];
+    pos += 1
+    if (!haz) {
+      return parse(buf, args, pos, results);
+    }
+  }
+  if (t == "WebKit::RemoteSourceBufferIdentifier") {
+    pos = align(pos, 8);
+    if (pos + 8 > buf.length) {
+      return -1;
+    }
+    let view = new DataView(buf.buffer, pos);
+    let id = view.getBigUint64(0, true);
+    results[t] = id;
+    return parse(buf, args, pos + 8, results);
+  } else if (knownSizes[t]) {
+    pos = align(pos, knownSizes[t]);
+    pos += knownSizes[t];
+    return parse(buf, args, pos, results);
+  } else {
+    console.log("could not parse '"+t+"'");
+  }
+  return -1;
+}
+</script>
+</head>
+<body onload='fuzz()'>
+<div>This test should not crash</div>
+</body>
+</html>

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -41,6 +41,8 @@
 #include <WebCore/VideoTrackPrivate.h>
 #include <wtf/Scope.h>
 
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, &m_connectionToWebProcess.get()->connection())
+
 namespace WebKit {
 
 using namespace WebCore;
@@ -247,7 +249,7 @@ void RemoteSourceBufferProxy::asyncEvictCodedFrames(uint64_t newDataSize, const 
 
 void RemoteSourceBufferProxy::addTrackBuffer(TrackID trackId)
 {
-    ASSERT(m_mediaDescriptions.contains(trackId));
+    MESSAGE_CHECK(m_mediaDescriptions.contains(trackId));
     m_sourceBufferPrivate->addTrackBuffer(trackId, m_mediaDescriptions.find(trackId)->second.ptr());
 }
 


### PR DESCRIPTION
#### 09eff921fc9a28f36ed936bbfcb56d5f5d722cfe
<pre>
<a href="https://rdar.apple.com/119489615">rdar://119489615</a> ([CoreIPC] SEGV in WebKit::RemoteSourceBufferProxy::addTrackBuffer)

Checks that the TrackPrivateRemoteIdentifier argument for the IPC call RemoteSourceBufferProxy::addTrackBuffer() is valid and invalidates the IPC message if not.

Reviewed by David Kilzer.

If the TrackPrivateRemoteIdentifier value is not a known value, the IPC message will be marked as invalid, which is supposed
to crash the content process thereby thwarting any attempted attack through this mechanism.

* LayoutTests/TestExpectations:
* LayoutTests/ipc/invalid-message-to-addTrackBuffer-expected.txt: Added.
* LayoutTests/ipc/invalid-message-to-addTrackBuffer.html: Added.
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::addTrackBuffer):

Originally-landed-as: 272448.259@safari-7618-branch (60f8c4667d7a). <a href="https://rdar.apple.com/124555372">rdar://124555372</a>
Canonical link: <a href="https://commits.webkit.org/276351@main">https://commits.webkit.org/276351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bce6126d4eaa805016b39460bbd0b18844e77246

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46887 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40265 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36450 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17490 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17837 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39247 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2288 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40431 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48493 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15791 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43337 "Found 1 new test failure: http/tests/inspector/network/har/har-page.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42062 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9879 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20803 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->