### PR TITLE
[results.webkit.org] Parameterize limits on UI endpoints

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/commits.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/commits.html
@@ -31,6 +31,7 @@
 import {REF, DOM} from '/library/js/Ref.js';
 import {ErrorDisplay} from '/assets/js/common.js';
 import {Commit, CommitTable} from '/assets/js/commit.js';
+import {COMMITS_LIMITS} from '/assets/js/constants.js';
 import {Drawer, BranchSelector, LimitSlider, CommitRepresentation} from '/assets/js/drawer.js';
 
 var oneLine = true;
@@ -100,7 +101,7 @@ function OneLineSwitch() {
 
 var table = new Table();
 DOM.inject(document.getElementById('app'), `${Drawer([
-    LimitSlider(() => {table.reload()}, 10000, 1000),
+    LimitSlider(() => {table.reload()}, COMMITS_LIMITS.max, COMMITS_LIMITS.default),
     OneLineSwitch(),
     BranchSelector(() => {table.reload()}),
     CommitRepresentation(() => {table.reload()}),

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/constants.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/constants.js
@@ -25,5 +25,8 @@ const XCODE_CLOUD_SUITES = [{% for suite in XcodeCloud %}
     '{{ suite }}',
 {% endfor %}];
 const DEFAULT_ARCHITECTURE = {{ default_architecture }};
+const TESTS_LIMITS = JSON.parse('{{ tests_limits|safe }}');
+const SUITES_LIMITS = JSON.parse('{{ suites_limits|safe }}');
+const COMMITS_LIMITS = JSON.parse('{{ commits_limits|safe }}');
 
-export {XCODE_CLOUD_SUITES, DEFAULT_ARCHITECTURE}
+export {XCODE_CLOUD_SUITES, DEFAULT_ARCHITECTURE, TESTS_LIMITS, SUITES_LIMITS, COMMITS_LIMITS}

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
@@ -33,6 +33,7 @@
 import {CommitBank} from '/assets/js/commit.js';
 import {deepCompare, ErrorDisplay, queryToParams, paramsToQuery, escapeHTML} from '/assets/js/common.js';
 import {Configuration} from '/assets/js/configuration.js';
+import {TESTS_LIMITS} from '/assets/js/constants.js';
 import {Drawer, BranchSelector, ConfigurationSelectors, LimitSlider, CommitRepresentation, CommitSearchBar} from '/assets/js/drawer.js';
 import {InvestigateDrawer} from '/assets/js/investigate.js';
 import {SearchBar} from '/assets/js/search.js';
@@ -252,7 +253,7 @@ DOM.inject(
                 child.timeline.update();
             });
         }, false, false, true, false),
-        LimitSlider(() => {view.reload()}),
+        LimitSlider(() => {view.reload()}, TESTS_LIMITS.max, TESTS_LIMITS.default),
         BranchSelector(() => {
             CommitBank.reload();
             view.reload();

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/suite_results.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/suite_results.html
@@ -33,6 +33,7 @@
 import {CommitBank} from '/assets/js/commit.js';
 import {deepCompare, ErrorDisplay, queryToParams, paramsToQuery, escapeHTML} from '/assets/js/common.js';
 import {Configuration} from '/assets/js/configuration.js';
+import {SUITES_LIMITS} from '/assets/js/constants.js';
 import {Drawer, BranchSelector, ConfigurationSelectors, LimitSlider, CommitRepresentation, CommitSearchBar} from '/assets/js/drawer.js';
 import {InvestigateDrawer} from '/assets/js/investigate.js';
 import {Legend, TimelineFromEndpoint} from '/assets/js/timeline.js';
@@ -184,7 +185,7 @@ ${Drawer([
             view.children[suite].update();
         }
     }, true, true, false, true),
-    LimitSlider(() => {view.reload()}),
+    LimitSlider(() => {view.reload()}, SUITES_LIMITS.max, SUITES_LIMITS.default),
     BranchSelector(() => {
         CommitBank.reload();
         view.reload();

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes.py
@@ -45,6 +45,9 @@ class ViewRoutes(AuthedBlueprint):
         archive_routes=None,
         suite_types=None,
         default_architecture=None,
+        tests_limits=None,
+        suites_limits=None,
+        commits_limits=None,
     ):
         super(ViewRoutes, self).__init__('view', import_name, url_prefix=None, auth_decorator=auth_decorator)
         self._cache = {}
@@ -57,6 +60,9 @@ class ViewRoutes(AuthedBlueprint):
 
         self.suite_types = suite_types or {}
         self.default_architecture = default_architecture
+        self.tests_limits = tests_limits or dict(max=50000, default=5000)
+        self.suites_limits = suites_limits or dict(max=10000, default=1000)
+        self.commits_limits = commits_limits or dict(max=10000, default=1000)
 
         # Protecting js and css with auth doesn't make sense
         self.add_url_rule('/library/<path:path>', 'library', self.library, authed=False, methods=('GET',))
@@ -174,5 +180,8 @@ class ViewRoutes(AuthedBlueprint):
             self.environment.get_template('constants.js').render(
                 XcodeCloud=self.suite_types.get('XcodeCloud') or [],
                 default_architecture=json.dumps(self.default_architecture) if self.default_architecture else 'null',
+                tests_limits=json.dumps(self.tests_limits),
+                suites_limits=json.dumps(self.suites_limits),
+                commits_limits=json.dumps(self.commits_limits),
             ), mimetype='application/javascript',
         )


### PR DESCRIPTION
#### 35d904abb4460c7f1654dbc7c26cc67583f9f6fd
<pre>
[results.webkit.org] Parameterize limits on UI endpoints
<a href="https://bugs.webkit.org/show_bug.cgi?id=271081">https://bugs.webkit.org/show_bug.cgi?id=271081</a>
<a href="https://rdar.apple.com/124712805">rdar://124712805</a>

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/commits.html:
Use parameterized limits.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/constants.js:
Add limit constants for tests, suites and commits.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html:
Use parameterized limits.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/suite_results.html:
Ditto.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes.py:
(ViewRoutes.__init__): Set default tests, suites and commits limits.
(ViewRoutes.constants): Parameterize endpoint limits.

Canonical link: <a href="https://commits.webkit.org/276212@main">https://commits.webkit.org/276212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15b50ddd9558f1e97eaae13361205b90ee520767

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44044 "Failed to checkout and rebase branch from PR 25978") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23112 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/46478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/46684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20504 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/46684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44622 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/20135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/46478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/46684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/43922 "Failed to checkout and rebase branch from PR 25978") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/46478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/2095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/46478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/48267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/19035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/48267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/44094 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/46478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/48267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/9798 "The change is no longer eligible for processing.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6031 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/20038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->