### PR TITLE
WKWebExtensionAPITabs.ActiveTab is flaky.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -2197,7 +2197,7 @@ TEST(WKWebExtensionAPITabs, ActiveTab)
         @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
         @"  browser.test.assertEq(tabId, currentTab.id, 'Only the tab we expect should be changing')",
 
-        @"  if ('url' in changeInfo) {",
+        @"  if ('url' in changeInfo && 'title' in changeInfo) {",
         @"    ++updateCount",
 
         @"    if (updateCount === 1) {",
@@ -2297,7 +2297,7 @@ TEST(WKWebExtensionAPITabs, UserGestureWithoutActiveTab)
         @"browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {",
         @"  browser.test.assertEq(tabId, currentTab.id, 'Only the tab we expect should be changing')",
 
-        @"  if ('url' in changeInfo) {",
+        @"  if ('url' in changeInfo && 'title' in changeInfo) {",
         @"    browser.test.assertEq(changeInfo.url, '', 'URL should be empty before user gesture')",
         @"    browser.test.assertEq(changeInfo.title, '', 'Title should be empty before user gesture')",
         @"    browser.test.yield('Perform User Gesture')",

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -397,7 +397,7 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesLoading forTab:self];
 }
 
-- (void)webView:(WKWebView *)webView didCommitNavigation:(WKNavigation *)navigation
+- (void)_webView:(WKWebView *)webView navigationDidFinishDocumentLoad:(WKNavigation *)navigation
 {
     [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesTitle | _WKWebExtensionTabChangedPropertiesURL forTab:self];
 }


### PR DESCRIPTION
#### 3dc776898be47c68845d9931dde1bd94638acaf3
<pre>
WKWebExtensionAPITabs.ActiveTab is flaky.
<a href="https://webkit.org/b/269932">https://webkit.org/b/269932</a>
<a href="https://rdar.apple.com/problem/123457954">rdar://problem/123457954</a>

Reviewed by Alex Christensen and Brian Weinstein.

We need to mark the title as changed after the document has loaded,
not when the navigation is committed, since the &lt;title&gt; wont be parsed yet.
This was causing a race condition for accessing the web view&apos;s title.

To keep things simple in the tests, also fire the URL change with the title,
otherwise it will require rejiggering the tests to be more robust. In practice
these do fire together due to event coalescing, but that coalescing window
is small and we were sometimes firing them separate, and that was causing
flakiness. Fix the tests to expect both &apos;url&apos; and &apos;title&apos; in `changeInfo`.

* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionTab _webView:navigationDidFinishDocumentLoad:]): Added.
(-[TestWebExtensionTab webView:didCommitNavigation:]): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TEST(WKWebExtensionAPITabs, ActiveTab)): Expect both &apos;url&apos; and &apos;title&apos; in `changeInfo`.
(TEST(WKWebExtensionAPITabs, UserGestureWithoutActiveTab)): Ditto.

Canonical link: <a href="https://commits.webkit.org/276217@main">https://commits.webkit.org/276217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a1e2fbdee752acbcb50fcd0088b5635994b67d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44043 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46347 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20503 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37927 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17331 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39023 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2094 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48266 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15598 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41882 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20624 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6034 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/20037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->