### PR TITLE
UnifiedPDF: Find highlights sometimes appear in the wrong place if scrolling was needed

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -344,8 +344,9 @@ private:
     // Package up the data needed to paint a set of pages for the given clip, for use by UnifiedPDFPlugin::paintPDFContent and async rendering.
     PDFPageCoverage pageCoverageForRect(const WebCore::FloatRect& clipRect) const;
 
-    enum class PaintingBehavior : uint8_t { All, PageContentsOnly };
-    void paintPDFContent(WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect, PaintingBehavior = PaintingBehavior::All);
+    enum class PaintingBehavior : bool { All, PageContentsOnly };
+    enum class AllowsAsyncRendering : bool { No, Yes };
+    void paintPDFContent(WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect, PaintingBehavior = PaintingBehavior::All, AllowsAsyncRendering = AllowsAsyncRendering::No);
 
     void ensureLayers();
     void updatePageBackgroundLayers();
@@ -377,6 +378,8 @@ private:
     WebCore::ScrollingCoordinator* scrollingCoordinator();
     void createScrollingNodeIfNecessary();
 
+    void revealRectInContentsSpace(WebCore::FloatRect);
+    void scrollToPointInContentsSpace(WebCore::FloatPoint);
     void scrollToPDFDestination(PDFDestination *);
     void scrollToPointInPage(WebCore::FloatPoint pointInPDFPageSpace, PDFDocumentLayout::PageIndex);
     void scrollToPage(PDFDocumentLayout::PageIndex);


### PR DESCRIPTION
#### b11f283a59bc576ff8212d0fbac2763b20d81787
<pre>
UnifiedPDF: Find highlights sometimes appear in the wrong place if scrolling was needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=271087">https://bugs.webkit.org/show_bug.cgi?id=271087</a>
<a href="https://rdar.apple.com/123462967">rdar://123462967</a>

Reviewed by Abrar Rahman Protyasha and Simon Fraser.

Fix five bugs in one fell swoop:

1) Find highlights were sometimes painted in the wrong location, often overlapping UI

We weren&apos;t treating our programmatic scrolls as programmatic, letting them be
async and then making the TextIndicator in the wrong location (before the scroll
was synchronized).

Fix this by marking the scrolls as programmatic explicitly. Factor this out for
use of the whole plugin.

2) Find highlights were sometimes blank, especially when far from the current scroll position

We can&apos;t use async rendering for text indicator snapshots, because we can&apos;t repaint
them when the tiles come in. Make async rendering opt-in, and only opt-in when we&apos;re
painting the contents layer, not for other calls into painting code.

3) Find highlights didn&apos;t scroll to reveal when their top left corner was visible,
even if most of the match was off screen.

Adopt correct rect-revelation logic, as used to reveal form fields, and share with that code.

4) Software-painted snaphots are often blank
5) Printed PDFs in subframes are rasterized instead of remaining vectors

These are both async rendering regressions that are fixed by the fix for (2).

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::paintContents):
Opt contents layer painting into async rendering.

(WebKit::UnifiedPDFPlugin::paintPDFContent):
Make async rendering opt-in.

(WebKit::UnifiedPDFPlugin::scrollToPointInContentsSpace):
Factor out this somewhat messy code to temporarily change the currentScrollType
on our ScrollableArea to programmatic.

(WebKit::UnifiedPDFPlugin::revealRectInContentsSpace):
Factor out the logic to reveal a rectangle.

(WebKit::UnifiedPDFPlugin::scrollToPointInPage):
(WebKit::UnifiedPDFPlugin::scrollToPage):
Adopt scrollToPointInContentsSpace.

(WebKit::UnifiedPDFPlugin::findString):
(WebKit::UnifiedPDFPlugin::setActiveAnnotation):
Adopt revealRectInContentsSpace. In the find case, this fixes (3).

Canonical link: <a href="https://commits.webkit.org/276216@main">https://commits.webkit.org/276216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/365e792622d8637ea4f022d44111181ad5fcb80f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46686 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20506 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20138 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2097 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/39320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48269 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15600 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9799 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20627 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/20040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->