### PR TITLE
[UnifiedPDF] Data detector highlight painting should be optimized by specifying dirty rects

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
@@ -78,7 +78,7 @@ private:
     void didScrollFrame(WebCore::PageOverlay&, WebCore::LocalFrame&) final { }
 
     // DataDetectorHighlightClient
-    WebCore::DataDetectorHighlight* activeHighlight() const final { return m_activeDataDetectorHighlight.get(); }
+    WebCore::DataDetectorHighlight* activeHighlight() const final { return m_activeDataDetectorItemWithHighlight.second.get(); }
     void scheduleRenderingUpdate(OptionSet<WebCore::RenderingUpdateStep>) final;
     float deviceScaleFactor() const final;
     RefPtr<WebCore::GraphicsLayer> createGraphicsLayer(WebCore::GraphicsLayerClient&) final;
@@ -99,13 +99,15 @@ private:
     RefPtr<WebCore::PageOverlay> m_overlay;
 
     using PDFDataDetectorItemWithHighlight = std::pair<Ref<PDFDataDetectorItem>, Ref<WebCore::DataDetectorHighlight>>;
+    using PDFDataDetectorItemWithHighlightPtr = std::pair<RefPtr<PDFDataDetectorItem>, RefPtr<WebCore::DataDetectorHighlight>>;
     using PDFDataDetectorItemsWithHighlights = Vector<PDFDataDetectorItemWithHighlight>;
     template <typename Key, typename Value>
     using HashMapWithUnsignedIntegralZeroKeyAllowed = HashMap<Key, Value, WTF::IntHash<Key>, WTF::UnsignedWithZeroKeyHashTraits<Key>>;
     using PDFDataDetectorItemsWithHighlightsMap = HashMapWithUnsignedIntegralZeroKeyAllowed<PDFDocumentLayout::PageIndex, PDFDataDetectorItemsWithHighlights>;
 
     PDFDataDetectorItemsWithHighlightsMap m_pdfDataDetectorItemsWithHighlightsMap;
-    RefPtr<WebCore::DataDetectorHighlight> m_activeDataDetectorHighlight;
+    PDFDataDetectorItemWithHighlightPtr m_activeDataDetectorItemWithHighlight;
+    PDFDataDetectorItemWithHighlightPtr m_staleDataDetectorItemWithHighlight;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -149,6 +149,7 @@ public:
     float deviceScaleFactor() const override;
 
     WebCore::FloatRect rectForSelectionInPluginSpace(PDFSelection *) const;
+    Vector<WebCore::FloatRect> selectionBoundsAcrossDocumentInContentSpace(const PDFSelection *) const;
 
     RetainPtr<PDFPage> pageAtIndex(PDFDocumentLayout::PageIndex) const;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2760,6 +2760,13 @@ Vector<FloatRect> UnifiedPDFPlugin::selectionBoundsAcrossDocument(const PDFSelec
     });
 }
 
+Vector<FloatRect> UnifiedPDFPlugin::selectionBoundsAcrossDocumentInContentSpace(const PDFSelection *selection) const
+{
+    return selectionBoundsAcrossDocument(selection).map([&](const FloatRect& rectInDocumentSpace) {
+        return convertUp(CoordinateSpace::PDFDocumentLayout, CoordinateSpace::Contents, rectInDocumentSpace);
+    });
+}
+
 void UnifiedPDFPlugin::repaintOnSelectionActiveStateChangeIfNeeded(ActiveStateChangeReason reason, const Vector<FloatRect>& additionalDocumentRectsToRepaint)
 {
     switch (reason) {


### PR DESCRIPTION
#### a83a068ce4deea7c97d93f22b98084197cf3367f
<pre>
[UnifiedPDF] Data detector highlight painting should be optimized by specifying dirty rects
<a href="https://bugs.webkit.org/show_bug.cgi?id=271091">https://bugs.webkit.org/show_bug.cgi?id=271091</a>
<a href="https://rdar.apple.com/124719471">rdar://124719471</a>

Reviewed by Sammy Gill.

Currently we paint the entire page overlay when we think a data detector
highlight needs to be painted. Instead, we should specify which rects
(in content space) we want to have painted. This patch:

1. Keeps track of both the active DDHighlight as well as the
   PDFDataDetectorItem it&apos;s paired to. This allows us to be able to read
   the associated PDF selection object.
1. Keeps track of the &quot;just-deactivated&quot; stale highlight data. This
   allows us to ask for the stale data to be (re)painted away, if
   needed.
2. Introduces a helper utility on UnifiedPDFPlugin that returns the
   content space bounds for a PDF Selection.
3. Queries said utility with the selections for both the active and the
   stale highlight, painting the resulting rects as necessary.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm:
(WebKit::PDFDataDetectorOverlayController::handleMouseEvent):
(WebKit::PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::selectionBoundsAcrossDocumentInContentSpace const):

Canonical link: <a href="https://commits.webkit.org/276239@main">https://commits.webkit.org/276239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f348a9ad10335eacf7932ec9c5a1c9edb603c5ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46696 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40103 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20517 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37944 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17341 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17638 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2107 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40228 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48282 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15610 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43170 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20419 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41895 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9807 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20046 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->