### PR TITLE
[WebCore] Use fast bitset iteration for Style Builder::applyPropertiesImpl

### DIFF
--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -130,9 +130,8 @@ void PropertyCascade::set(CSSPropertyID id, CSSValue& cssValue, const MatchedPro
     }
 
     auto& property = m_properties[id];
-    if (!m_propertyIsPresent[id])
+    if (!m_propertyIsPresent.testAndSet(id))
         property.cssValue = { };
-    m_propertyIsPresent.set(id);
     setPropertyInternal(property, id, cssValue, matchedProperties, cascadeLevel);
 }
 

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -28,7 +28,7 @@
 #include "CascadeLevel.h"
 #include "MatchResult.h"
 #include "WebAnimationTypes.h"
-#include <bitset>
+#include <wtf/BitSet.h>
 
 namespace WebCore {
 
@@ -39,6 +39,8 @@ namespace Style {
 class PropertyCascade {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    using PropertyBitSet = WTF::BitSet<lastLowPriorityProperty + 1>;
+
     enum class PropertyType : uint8_t {
         NonInherited = 1 << 0,
         Inherited = 1 << 1,
@@ -64,7 +66,7 @@ public:
         std::array<CSSValue*, 3> cssValue; // Values for link match states MatchDefault, MatchLink and MatchVisited
     };
 
-    bool isEmpty() const { return m_propertyIsPresent.none() && !m_seenDeferredPropertyCount; }
+    bool isEmpty() const { return m_propertyIsPresent.isEmpty() && !m_seenDeferredPropertyCount; }
 
     bool hasNormalProperty(CSSPropertyID) const;
     const Property& normalProperty(CSSPropertyID) const;
@@ -80,6 +82,9 @@ public:
     const HashMap<AtomString, Property>& customProperties() const { return m_customProperties; }
 
     const HashSet<AnimatableCSSProperty> overriddenAnimatedProperties() const;
+
+    PropertyBitSet& propertyIsPresent() { return m_propertyIsPresent; }
+    const PropertyBitSet& propertyIsPresent() const { return m_propertyIsPresent; }
 
 private:
     void buildCascade();
@@ -125,7 +130,7 @@ private:
     // It could actually be 2 units smaller, but then we would have to subtract 'firstCSSProperty', which may not be worth it.
     // 'm_propertyIsPresent' is not used for deferred properties, so we only need to cover up to the last low priority one.
     std::array<Property, lastDeferredProperty + 1> m_properties;
-    std::bitset<lastLowPriorityProperty + 1> m_propertyIsPresent;
+    PropertyBitSet m_propertyIsPresent;
 
     static constexpr unsigned deferredPropertyCount = lastDeferredProperty - firstDeferredProperty + 1;
     std::array<unsigned, deferredPropertyCount> m_deferredPropertyIndices { };
@@ -141,7 +146,7 @@ private:
 inline bool PropertyCascade::hasNormalProperty(CSSPropertyID id) const
 {
     ASSERT(id < firstDeferredProperty);
-    return m_propertyIsPresent[id];
+    return m_propertyIsPresent.get(id);
 }
 
 inline const PropertyCascade::Property& PropertyCascade::normalProperty(CSSPropertyID id) const

--- a/Tools/TestWebKitAPI/Tests/WTF/BitSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BitSet.cpp
@@ -763,6 +763,68 @@ void testBitSetForEachSetBit()
 }
 
 template<typename WordType>
+void testBitSetForEachSetBitWithStartIndex()
+{
+    DECLARE_AND_INIT_BITMAPS_FOR_TEST();
+
+    size_t count = 0;
+    ASSERT_TRUE(bitSetZeroes.isEmpty());
+    bitSetZeroes.forEachSetBit(0, [&](size_t i) {
+        constexpr bool notReached = false;
+        ASSERT_TRUE(notReached);
+        count++;
+    });
+    ASSERT_EQ(count, zeroSize);
+
+    bitSetZeroes.forEachSetBit(10, [&](size_t i) {
+        constexpr bool notReached = false;
+        ASSERT_TRUE(notReached);
+        count++;
+    });
+    ASSERT_EQ(count, zeroSize);
+
+    count = 0;
+    bitSet1.forEachSetBit(0, [&](size_t i) {
+        ASSERT_TRUE(bitSet1.get(i));
+        ASSERT_EQ(bitSet1.get(i), expectedBits1[i]);
+        count++;
+    });
+    ASSERT_EQ(count, expectedNumberOfSetBits1);
+
+    count = 0;
+    bitSet1.forEachSetBit(2, [&](size_t i) {
+        ASSERT_TRUE(bitSet1.get(i));
+        ASSERT_EQ(bitSet1.get(i), expectedBits1[i]);
+        count++;
+    });
+    ASSERT_EQ(count, expectedNumberOfSetBits1);
+
+    count = 0;
+    bitSet1.forEachSetBit(3, [&](size_t i) {
+        ASSERT_TRUE(bitSet1.get(i));
+        ASSERT_EQ(bitSet1.get(i), expectedBits1[i]);
+        count++;
+    });
+    ASSERT_EQ(count, expectedNumberOfSetBits1 - 1);
+
+    count = 0;
+    bitSet1.forEachSetBit(16, [&](size_t i) {
+        ASSERT_TRUE(bitSet1.get(i));
+        ASSERT_EQ(bitSet1.get(i), expectedBits1[i]);
+        count++;
+    });
+    ASSERT_EQ(count, expectedNumberOfSetBits1 - 2);
+
+    count = 0;
+    bitSet1.forEachSetBit(125, [&](size_t i) {
+        ASSERT_TRUE(bitSet1.get(i));
+        ASSERT_EQ(bitSet1.get(i), expectedBits1[i]);
+        count++;
+    });
+    ASSERT_EQ(count, 3U);
+}
+
+template<typename WordType>
 void testBitSetFindBit()
 {
     DECLARE_AND_INIT_BITMAPS_FOR_TEST();
@@ -1415,6 +1477,7 @@ TEST(WTF_BitSet, Exclude_uint32_t) { testBitSetExclude<uint32_t>(); }
 TEST(WTF_BitSet, ConcurrentFilter_uint32_t) { testBitSetConcurrentFilter<uint32_t>(); }
 TEST(WTF_BitSet, Subsumes_uint32_t) { testBitSetSubsumes<uint32_t>(); }
 TEST(WTF_BitSet, ForEachSetBit_uint32_t) { testBitSetForEachSetBit<uint32_t>(); }
+TEST(WTF_BitSet, ForEachSetBitWithStartIndex_uint32_t) { testBitSetForEachSetBitWithStartIndex<uint32_t>(); }
 TEST(WTF_BitSet, FindBit_uint32_t) { testBitSetFindBit<uint32_t>(); }
 TEST(WTF_BitSet, Iteration_uint32_t) { testBitSetIteration<uint32_t>(); }
 TEST(WTF_BitSet, MergeAndClear_uint32_t) { testBitSetMergeAndClear<uint32_t>(); }
@@ -1451,6 +1514,7 @@ TEST(WTF_BitSet, Exclude_uint64_t) { testBitSetExclude<uint64_t>(); }
 TEST(WTF_BitSet, ConcurrentFilter_uint64_t) { testBitSetConcurrentFilter<uint64_t>(); }
 TEST(WTF_BitSet, Subsumes_uint64_t) { testBitSetSubsumes<uint64_t>(); }
 TEST(WTF_BitSet, ForEachSetBit_uint64_t) { testBitSetForEachSetBit<uint64_t>(); }
+TEST(WTF_BitSet, ForEachSetBitWithStartIndex_uint64_t) { testBitSetForEachSetBitWithStartIndex<uint64_t>(); }
 TEST(WTF_BitSet, FindBit_uint64_t) { testBitSetFindBit<uint64_t>(); }
 TEST(WTF_BitSet, Iteration_uint64_t) { testBitSetIteration<uint64_t>(); }
 TEST(WTF_BitSet, MergeAndClear_uint64_t) { testBitSetMergeAndClear<uint64_t>(); }


### PR DESCRIPTION
#### 6f670174ddc808f8b33835f906a779b27236e8a4
<pre>
[WebCore] Use fast bitset iteration for Style Builder::applyPropertiesImpl
<a href="https://bugs.webkit.org/show_bug.cgi?id=271100">https://bugs.webkit.org/show_bug.cgi?id=271100</a>
<a href="https://rdar.apple.com/124722402">rdar://124722402</a>

Reviewed by Antti Koivisto.

While top-priority / high-priority CSS properties are limited, more than 300 low-priority CSS properties exist.
And we are doing very naive iteration for that in Builder::applyPropertiesImpl. Given that only low-priority CSS properties
are huge and it is placed at the end of bitset, let&apos;s just use super fast bitset iteration instead of doing naive loop.

* Source/WTF/wtf/BitSet.h:
(WTF::WordType&gt;::forEachSetBit const):
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::set):
* Source/WebCore/style/PropertyCascade.h:
(WebCore::Style::PropertyCascade::isEmpty const):
(WebCore::Style::PropertyCascade::propertyIsPresent):
(WebCore::Style::PropertyCascade::propertyIsPresent const):
(WebCore::Style::PropertyCascade::hasNormalProperty const):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyPropertiesImpl):
* Tools/TestWebKitAPI/Tests/WTF/BitSet.cpp:
(TestWebKitAPI::testBitSetForEachSetBitWithStartIndex):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/276280@main">https://commits.webkit.org/276280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee7f3d6f4b277f887769e4b05ab9701790584c6e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46734 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40120 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36341 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44670 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17367 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39070 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2142 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37416 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40256 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48327 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43652 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43203 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20434 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41922 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20656 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50731 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6071 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20061 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10238 "Passed tests") | 
<!--EWS-Status-Bubble-End-->