### PR TITLE
Remove non-standard `HashChangeEvent.initHashChangeEvent`

### DIFF
--- a/LayoutTests/fast/events/initEvent-after-dispatching-expected.txt
+++ b/LayoutTests/fast/events/initEvent-after-dispatching-expected.txt
@@ -17,20 +17,6 @@ PASS testEvent.bubbles is false
 PASS testEvent.cancelable is false
 PASS document.body.dispatchEvent(testEvent) is true
 
-* HashChangeEvent.prototype.initHashChangeEvent()
-testEvent = document.createEvent(createEventString)
-PASS testEvent.__proto__ is window[eventType].prototype
-testEvent[initMethodName]('firstType', true, true)
-PASS testEvent.type is "firstType"
-PASS testEvent.bubbles is true
-PASS testEvent.cancelable is true
-PASS document.body.dispatchEvent(testEvent) is true
-testEvent[initMethodName]('secondType', false, false)
-PASS testEvent.type is "secondType"
-PASS testEvent.bubbles is false
-PASS testEvent.cancelable is false
-PASS document.body.dispatchEvent(testEvent) is true
-
 * KeyboardEvent.prototype.initKeyboardEvent()
 testEvent = document.createEvent(createEventString)
 PASS testEvent.__proto__ is window[eventType].prototype

--- a/LayoutTests/fast/events/initEvent-after-dispatching.html
+++ b/LayoutTests/fast/events/initEvent-after-dispatching.html
@@ -28,7 +28,6 @@ function testEventInitFunction(_createEventString, _eventType, _initMethodName)
 }
 
 testEventInitFunction("compositionevent", "CompositionEvent", "initCompositionEvent");
-testEventInitFunction("hashchangeevent", "HashChangeEvent", "initHashChangeEvent");
 testEventInitFunction("keyboardevent", "KeyboardEvent", "initKeyboardEvent");
 testEventInitFunction("messageevent", "MessageEvent", "initMessageEvent");
 testEventInitFunction("textevent", "TextEvent", "initTextEvent");

--- a/Source/WebCore/dom/HashChangeEvent.h
+++ b/Source/WebCore/dom/HashChangeEvent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -46,17 +46,6 @@ public:
     static Ref<HashChangeEvent> create(const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
     {
         return adoptRef(*new HashChangeEvent(type, initializer, isTrusted));
-    }
-
-    void initHashChangeEvent(const AtomString& eventType, bool canBubble, bool cancelable, const String& oldURL, const String& newURL)
-    {
-        if (isBeingDispatched())
-            return;
-
-        initEvent(eventType, canBubble, cancelable);
-
-        m_oldURL = oldURL;
-        m_newURL = newURL;
     }
 
     const String& oldURL() const { return m_oldURL; }

--- a/Source/WebCore/dom/HashChangeEvent.idl
+++ b/Source/WebCore/dom/HashChangeEvent.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -17,17 +17,12 @@
  * Boston, MA 02110-1301, USA.
  */
 
-// Introduced in http://www.whatwg.org/specs/web-apps/current-work/multipage/history.html#event-hashchange
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-hashchangeevent-interface
+
 [
     Exposed=Window
 ] interface HashChangeEvent : Event {
-    constructor([AtomString] DOMString type, optional HashChangeEventInit eventInitDict);
-
-    undefined initHashChangeEvent([AtomString] DOMString type,
-                             optional boolean canBubble = false,
-                             optional boolean cancelable = false,
-                             optional USVString oldURL = "undefined",
-                             optional USVString newURL = "undefined");
+    constructor([AtomString] DOMString type, optional HashChangeEventInit eventInitDict = {});
 
     readonly attribute USVString oldURL;
     readonly attribute USVString newURL;


### PR DESCRIPTION
#### cf053c07242eafb5f2f371db03ce47ac0e261e9d
<pre>
Remove non-standard `HashChangeEvent.initHashChangeEvent`

<a href="https://bugs.webkit.org/show_bug.cgi?id=271094">https://bugs.webkit.org/show_bug.cgi?id=271094</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Blink / Chrome and Web Specification [1]:

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-hashchangeevent-interface">https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-hashchangeevent-interface</a>

By removing `initHashChangeEvent`, WebKit aligns with Web Specification
and Blink also removed it in 2015 via below commit:

Reference: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=202347

* Source/WebCore/dom/HashChangeEvent.idl:
* Source/WebCore/dom/HashChangeEvent.h:
(initHashChangeEvent): Removed
* LayoutTests/fast/events/initEvent-after-dispatching.html: Rebaselined
* LayoutTests/fast/events/initEvent-after-dispatching-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/276232@main">https://commits.webkit.org/276232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a499db62387d51b178efb665136b89fd6a537eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46722 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40114 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46385 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/27106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20541 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17354 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17647 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39053 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2130 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48306 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43178 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41903 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9805 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20652 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20055 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->