### PR TITLE
Skip gb18030 table correction on platforms with ICU 74

### DIFF
--- a/Source/WebCore/PAL/pal/text/EncodingTables.cpp
+++ b/Source/WebCore/PAL/pal/text/EncodingTables.cpp
@@ -28,6 +28,7 @@
 
 #include "TextCodecICU.h"
 #include <mutex>
+#include <wtf/unicode/icu/ICUHelpers.h>
 
 namespace PAL {
 
@@ -8626,11 +8627,11 @@ const std::array<UChar, 23940>& gb18030()
             (*array)[pointer] = icuOutput;
         }
         
-#if U_ICU_VERSION_MAJOR_NUM < 74
-        // This is a difference between ICU and the encoding specification.
-        ASSERT((*array)[6555] == 0xe5e5);
-        (*array)[6555] = 0x3000;
-#endif
+        if (WTF::ICU::majorVersion() < 74) {
+            // This is a difference between ICU and the encoding specification.
+            ASSERT((*array)[6555] == 0xe5e5);
+            (*array)[6555] = 0x3000;
+        }
 
 #if !HAVE(GB_18030_2022)
         static std::array<std::pair<size_t, UChar>, 18> gb18030_2022Differences { {


### PR DESCRIPTION
#### 6e7fffdeac955986ee20f2a860d754e7f494ec00
<pre>
Skip gb18030 table correction on platforms with ICU 74
<a href="https://bugs.webkit.org/show_bug.cgi?id=271101">https://bugs.webkit.org/show_bug.cgi?id=271101</a>
<a href="https://rdar.apple.com/124720057">rdar://124720057</a>

Reviewed by Yusuke Suzuki.

On the Sonoma 23E214 build released last week, ICU 74 is present as indicated by
the updated gb18030 table.  However, uvernum.h is not in the public SDK so open
source builds use the definition of U_ICU_VERSION_MAJOR_NUM in our copy of uvernum.h
in Source/WTF/icu/unicode/uvernum.h which has U_ICU_VERSION_MAJOR_NUM defined to 70.
Change the compile check to a runtime check.

* Source/WTF/wtf/PlatformHave.h:
* Source/WebCore/PAL/pal/text/EncodingTables.cpp:
(PAL::gb18030):

Canonical link: <a href="https://commits.webkit.org/276229@main">https://commits.webkit.org/276229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/434714bc91d982c8294aeab64f5ad4bde07baa34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20548 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44665 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20179 "Found 1 new test failure: requestidlecallback/requestidlecallback-deadline-shortened-by-rendering-update.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17359 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39064 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2137 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48314 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15629 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20431 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41909 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20651 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6048 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/20058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->