### PR TITLE
Rename SharedBuffer::dataAsSpanForContiguousData() to SharedBuffer::bytes()

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -260,7 +260,7 @@ RefPtr<FormData> FetchBody::bodyAsFormData() const
     if (isFormData())
         return &const_cast<FormData&>(formDataBody());
     if (auto* data = m_consumer.data())
-        return FormData::create(data->makeContiguous()->dataAsSpanForContiguousData());
+        return FormData::create(data->makeContiguous()->bytes());
 
     ASSERT_NOT_REACHED();
     return nullptr;

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -271,7 +271,7 @@ void FetchBodyConsumer::resolveWithData(Ref<DeferredPromise>&& promise, const St
 void FetchBodyConsumer::resolveWithFormData(Ref<DeferredPromise>&& promise, const String& contentType, const FormData& formData, ScriptExecutionContext* context)
 {
     if (auto sharedBuffer = formData.asSharedBuffer()) {
-        resolveWithData(WTFMove(promise), contentType, sharedBuffer->makeContiguous()->dataAsSpanForContiguousData());
+        resolveWithData(WTFMove(promise), contentType, sharedBuffer->makeContiguous()->bytes());
         return;
     }
 
@@ -289,7 +289,7 @@ void FetchBodyConsumer::resolveWithFormData(Ref<DeferredPromise>&& promise, cons
         if (value.empty()) {
             auto protectedPromise = WTFMove(promise);
             auto buffer = builder.takeAsContiguous();
-            resolveWithData(WTFMove(protectedPromise), contentType, buffer->dataAsSpanForContiguousData());
+            resolveWithData(WTFMove(protectedPromise), contentType, buffer->bytes());
             return;
         }
 
@@ -348,7 +348,7 @@ void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& co
             if (!chunk) {
                 auto protectedPromise = WTFMove(promise);
                 auto buffer = data.takeAsContiguous();
-                resolveWithTypeAndData(WTFMove(protectedPromise), type, contentType, buffer->dataAsSpanForContiguousData());
+                resolveWithTypeAndData(WTFMove(protectedPromise), type, contentType, buffer->bytes());
                 return;
             }
 
@@ -383,7 +383,7 @@ void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& co
         return;
     case FetchBodyConsumer::Type::FormData: {
         auto buffer = takeData();
-        if (auto formData = packageFormData(promise->scriptExecutionContext(), contentType, buffer ? buffer->makeContiguous()->dataAsSpanForContiguousData() : std::span<const uint8_t> { }))
+        if (auto formData = packageFormData(promise->scriptExecutionContext(), contentType, buffer ? buffer->makeContiguous()->bytes() : std::span<const uint8_t> { }))
             promise->resolve<IDLInterface<DOMFormData>>(*formData);
         else
             promise->reject(ExceptionCode::TypeError);
@@ -438,7 +438,7 @@ String FetchBodyConsumer::takeAsText()
         return String();
 
     auto buffer = m_buffer.takeAsContiguous();
-    auto text = TextResourceDecoder::textFromUTF8(buffer->dataAsSpanForContiguousData());
+    auto text = TextResourceDecoder::textFromUTF8(buffer->bytes());
     return text;
 }
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -366,7 +366,7 @@ void FetchResponse::Loader::didReceiveData(const SharedBuffer& buffer)
     ASSERT(m_response.m_readableStreamSource || m_consumeDataCallback);
 
     if (m_consumeDataCallback) {
-        auto chunk = buffer.dataAsSpanForContiguousData();
+        auto chunk = buffer.bytes();
         m_consumeDataCallback(&chunk);
         return;
     }
@@ -422,7 +422,7 @@ void FetchResponse::Loader::consumeDataByChunk(ConsumeDataByChunkCallback&& cons
         return;
 
     auto contiguousBuffer = data->makeContiguous();
-    auto chunk = contiguousBuffer->dataAsSpanForContiguousData();
+    auto chunk = contiguousBuffer->bytes();
     m_consumeDataCallback(&chunk);
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -696,7 +696,7 @@ bool SQLiteIDBBackingStore::addExistingIndex(IDBObjectStoreInfo& objectStoreInfo
             || sql->bindInt64(1, info.identifier()) != SQLITE_OK
             || sql->bindText(2, info.name()) != SQLITE_OK
             || sql->bindInt64(3, info.objectStoreIdentifier()) != SQLITE_OK
-            || sql->bindBlob(4, keyPathBlob->dataAsSpanForContiguousData()) != SQLITE_OK
+            || sql->bindBlob(4, keyPathBlob->bytes()) != SQLITE_OK
             || sql->bindInt(5, info.unique()) != SQLITE_OK
             || sql->bindInt(6, info.multiEntry()) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
@@ -1170,7 +1170,7 @@ IDBError SQLiteIDBBackingStore::createObjectStore(const IDBResourceIdentifier& t
         if (!sql
             || sql->bindInt64(1, info.identifier()) != SQLITE_OK
             || sql->bindText(2, info.name()) != SQLITE_OK
-            || sql->bindBlob(3, keyPathBlob->dataAsSpanForContiguousData()) != SQLITE_OK
+            || sql->bindBlob(3, keyPathBlob->bytes()) != SQLITE_OK
             || sql->bindInt(4, info.autoIncrement()) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
             LOG_ERROR("Could not add object store '%s' to ObjectStoreInfo table (%i) - %s", info.name().utf8().data(), m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
@@ -1384,7 +1384,7 @@ IDBError SQLiteIDBBackingStore::createIndex(const IDBResourceIdentifier& transac
             || sql->bindInt64(1, info.identifier()) != SQLITE_OK
             || sql->bindText(2, info.name()) != SQLITE_OK
             || sql->bindInt64(3, info.objectStoreIdentifier()) != SQLITE_OK
-            || sql->bindBlob(4, keyPathBlob->dataAsSpanForContiguousData()) != SQLITE_OK
+            || sql->bindBlob(4, keyPathBlob->bytes()) != SQLITE_OK
             || sql->bindInt(5, info.unique()) != SQLITE_OK
             || sql->bindInt(6, info.multiEntry()) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
@@ -1458,7 +1458,7 @@ IDBError SQLiteIDBBackingStore::uncheckedHasIndexRecord(const IDBIndexInfo& info
     auto sql = cachedStatement(SQL::HasIndexRecord, "SELECT rowid FROM IndexRecords WHERE indexID = ? AND key = CAST(? AS TEXT);"_s);
     if (!sql
         || sql->bindInt64(1, info.identifier()) != SQLITE_OK
-        || sql->bindBlob(2, indexKeyBuffer->dataAsSpanForContiguousData()) != SQLITE_OK) {
+        || sql->bindBlob(2, indexKeyBuffer->bytes()) != SQLITE_OK) {
         LOG_ERROR("Error checking for index record in database");
         return IDBError { ExceptionCode::UnknownError, "Error checking for index record in database"_s };
     }
@@ -1535,8 +1535,8 @@ IDBError SQLiteIDBBackingStore::uncheckedPutIndexRecord(int64_t objectStoreID, i
         if (!sql
             || sql->bindInt64(1, indexID) != SQLITE_OK
             || sql->bindInt64(2, objectStoreID) != SQLITE_OK
-            || sql->bindBlob(3, indexKeyBuffer->dataAsSpanForContiguousData()) != SQLITE_OK
-            || sql->bindBlob(4, valueBuffer->dataAsSpanForContiguousData()) != SQLITE_OK
+            || sql->bindBlob(3, indexKeyBuffer->bytes()) != SQLITE_OK
+            || sql->bindBlob(4, valueBuffer->bytes()) != SQLITE_OK
             || sql->bindInt64(5, recordID) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
             LOG_ERROR("Could not put index record for index %" PRIi64 " in object store %" PRIi64 " in Records table (%i) - %s", indexID, objectStoreID, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
@@ -1655,7 +1655,7 @@ IDBError SQLiteIDBBackingStore::keyExistsInObjectStore(const IDBResourceIdentifi
     auto sql = cachedStatement(SQL::KeyExistsInObjectStore, "SELECT key FROM Records WHERE objectStoreID = ? AND key = CAST(? AS TEXT) LIMIT 1;"_s);
     if (!sql
         || sql->bindInt64(1, objectStoreID) != SQLITE_OK
-        || sql->bindBlob(2, keyBuffer->dataAsSpanForContiguousData()) != SQLITE_OK) {
+        || sql->bindBlob(2, keyBuffer->bytes()) != SQLITE_OK) {
         LOG_ERROR("Could not get record from object store %" PRIi64 " from Records table (%i) - %s", objectStoreID, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
         return IDBError { ExceptionCode::UnknownError, "Unable to check for existence of IDBKey in object store"_s };
     }
@@ -1741,7 +1741,7 @@ IDBError SQLiteIDBBackingStore::deleteRecord(SQLiteIDBTransaction& transaction, 
 
         if (!sql
             || sql->bindInt64(1, objectStoreID) != SQLITE_OK
-            || sql->bindBlob(2, keyBuffer->dataAsSpanForContiguousData()) != SQLITE_OK) {
+            || sql->bindBlob(2, keyBuffer->bytes()) != SQLITE_OK) {
             LOG_ERROR("Could not delete record from object store %" PRIi64 " (%i) - %s", objectStoreID, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
             return IDBError { ExceptionCode::UnknownError, "Failed to delete record from object store"_s };
         }
@@ -1788,7 +1788,7 @@ IDBError SQLiteIDBBackingStore::deleteRecord(SQLiteIDBTransaction& transaction, 
 
         if (!sql
             || sql->bindInt64(1, objectStoreID) != SQLITE_OK
-            || sql->bindBlob(2, keyBuffer->dataAsSpanForContiguousData()) != SQLITE_OK
+            || sql->bindBlob(2, keyBuffer->bytes()) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
             LOG_ERROR("Could not delete record from object store %" PRIi64 " (%i) - %s", objectStoreID, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
             return IDBError { ExceptionCode::UnknownError, "Failed to delete record from object store"_s };
@@ -1959,7 +1959,7 @@ IDBError SQLiteIDBBackingStore::addRecord(const IDBResourceIdentifier& transacti
         auto sql = cachedStatement(SQL::AddObjectStoreRecord, "INSERT INTO Records VALUES (?, CAST(? AS TEXT), ?, NULL);"_s);
         if (!sql
             || sql->bindInt64(1, objectStoreInfo.identifier()) != SQLITE_OK
-            || sql->bindBlob(2, keyBuffer->dataAsSpanForContiguousData()) != SQLITE_OK
+            || sql->bindBlob(2, keyBuffer->bytes()) != SQLITE_OK
             || sql->bindBlob(3, *value.data().data()) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
             LOG_ERROR("Could not put record for object store %" PRIi64 " in Records table (%i) - %s", objectStoreInfo.identifier(), m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
@@ -1975,7 +1975,7 @@ IDBError SQLiteIDBBackingStore::addRecord(const IDBResourceIdentifier& transacti
         auto sql = cachedStatement(SQL::DeleteObjectStoreRecord, "DELETE FROM Records WHERE objectStoreID = ? AND key = CAST(? AS TEXT);"_s);
         if (!sql
             || sql->bindInt64(1, objectStoreInfo.identifier()) != SQLITE_OK
-            || sql->bindBlob(2, keyBuffer->dataAsSpanForContiguousData()) != SQLITE_OK
+            || sql->bindBlob(2, keyBuffer->bytes()) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
             LOG_ERROR("Indexing new object store record failed, but unable to remove the object store record itself");
             return IDBError { ExceptionCode::UnknownError, "Indexing new object store record failed, but unable to remove the object store record itself"_s };
@@ -2160,8 +2160,8 @@ IDBError SQLiteIDBBackingStore::getRecord(const IDBResourceIdentifier& transacti
 
         if (!sql
             || sql->bindInt64(1, objectStoreID) != SQLITE_OK
-            || sql->bindBlob(2, lowerBuffer->dataAsSpanForContiguousData()) != SQLITE_OK
-            || sql->bindBlob(3, upperBuffer->dataAsSpanForContiguousData()) != SQLITE_OK) {
+            || sql->bindBlob(2, lowerBuffer->bytes()) != SQLITE_OK
+            || sql->bindBlob(3, upperBuffer->bytes()) != SQLITE_OK) {
             LOG_ERROR("Could not get key range record from object store %" PRIi64 " from Records table (%i) - %s", objectStoreID, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
             return IDBError { ExceptionCode::UnknownError, "Failed to look up record in object store by key range"_s };
         }
@@ -2277,8 +2277,8 @@ IDBError SQLiteIDBBackingStore::getAllObjectStoreRecords(const IDBResourceIdenti
     auto sql = cachedStatementForGetAllObjectStoreRecords(getAllRecordsData);
     if (!sql
         || sql->bindInt64(1, getAllRecordsData.objectStoreIdentifier) != SQLITE_OK
-        || sql->bindBlob(2, lowerBuffer->dataAsSpanForContiguousData()) != SQLITE_OK
-        || sql->bindBlob(3, upperBuffer->dataAsSpanForContiguousData()) != SQLITE_OK) {
+        || sql->bindBlob(2, lowerBuffer->bytes()) != SQLITE_OK
+        || sql->bindBlob(3, upperBuffer->bytes()) != SQLITE_OK) {
         LOG_ERROR("Could not get key range record from object store %" PRIi64 " from Records table (%i) - %s", getAllRecordsData.objectStoreIdentifier, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
         return IDBError { ExceptionCode::UnknownError, "Failed to look up record in object store by key range"_s };
     }
@@ -2443,7 +2443,7 @@ IDBError SQLiteIDBBackingStore::uncheckedGetIndexRecordForOneKey(int64_t indexID
 
     if (!sql
         || sql->bindInt64(1, indexID) != SQLITE_OK
-        || sql->bindBlob(2, buffer->dataAsSpanForContiguousData()) != SQLITE_OK) {
+        || sql->bindBlob(2, buffer->bytes()) != SQLITE_OK) {
         LOG_ERROR("Unable to lookup index record in database");
         return IDBError { ExceptionCode::UnknownError, "Unable to lookup index record in database"_s };
     }
@@ -2525,8 +2525,8 @@ IDBError SQLiteIDBBackingStore::getCount(const IDBResourceIdentifier& transactio
         
         if (!statement
             || statement->bindInt64(1, objectStoreIdentifier) != SQLITE_OK
-            || statement->bindBlob(2, lowerBuffer->dataAsSpanForContiguousData()) != SQLITE_OK
-            || statement->bindBlob(3, upperBuffer->dataAsSpanForContiguousData()) != SQLITE_OK) {
+            || statement->bindBlob(2, lowerBuffer->bytes()) != SQLITE_OK
+            || statement->bindBlob(3, upperBuffer->bytes()) != SQLITE_OK) {
             LOG_ERROR("Could not count records in object store %" PRIi64 " from Records table (%i) - %s", objectStoreIdentifier, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
             return IDBError { ExceptionCode::UnknownError, "Unable to count records in object store due to binding failure"_s };
         }
@@ -2542,8 +2542,8 @@ IDBError SQLiteIDBBackingStore::getCount(const IDBResourceIdentifier& transactio
 
         if (!statement
             || statement->bindInt64(1, indexIdentifier) != SQLITE_OK
-            || statement->bindBlob(2, lowerBuffer->dataAsSpanForContiguousData()) != SQLITE_OK
-            || statement->bindBlob(3, upperBuffer->dataAsSpanForContiguousData()) != SQLITE_OK) {
+            || statement->bindBlob(2, lowerBuffer->bytes()) != SQLITE_OK
+            || statement->bindBlob(3, upperBuffer->bytes()) != SQLITE_OK) {
             LOG_ERROR("Could not count records with index %" PRIi64 " from IndexRecords table (%i) - %s", indexIdentifier, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
             return IDBError { ExceptionCode::UnknownError, "Unable to count records for index due to binding failure"_s };
         }

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
@@ -272,13 +272,13 @@ bool SQLiteIDBCursor::bindArguments()
     }
 
     auto buffer = serializeIDBKeyData(m_currentLowerKey);
-    if (m_statement->bindBlob(currentBindArgument++, buffer->dataAsSpanForContiguousData()) != SQLITE_OK) {
+    if (m_statement->bindBlob(currentBindArgument++, buffer->bytes()) != SQLITE_OK) {
         LOG_ERROR("Could not create cursor statement (lower key)");
         return false;
     }
 
     buffer = serializeIDBKeyData(m_currentUpperKey);
-    if (m_statement->bindBlob(currentBindArgument++, buffer->dataAsSpanForContiguousData()) != SQLITE_OK) {
+    if (m_statement->bindBlob(currentBindArgument++, buffer->bytes()) != SQLITE_OK) {
         LOG_ERROR("Could not create cursor statement (upper key)");
         return false;
     }
@@ -318,13 +318,13 @@ bool SQLiteIDBCursor::resetAndRebindPreIndexStatementIfNecessary()
     }
 
     auto buffer = serializeIDBKeyData(key);
-    if (m_preIndexStatement->bindBlob(currentBindArgument++, buffer->dataAsSpanForContiguousData()) != SQLITE_OK) {
+    if (m_preIndexStatement->bindBlob(currentBindArgument++, buffer->bytes()) != SQLITE_OK) {
         LOG_ERROR("Could not bind id argument to pre statement (key)");
         return false;
     }
 
     buffer = serializeIDBKeyData(m_currentIndexRecordValue);
-    if (m_preIndexStatement->bindBlob(currentBindArgument++, buffer->dataAsSpanForContiguousData()) != SQLITE_OK) {
+    if (m_preIndexStatement->bindBlob(currentBindArgument++, buffer->bytes()) != SQLITE_OK) {
         LOG_ERROR("Could not bind id argument to pre statement (value)");
         return false;
     }

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -815,7 +815,7 @@ bool ApplicationCacheStorage::store(ApplicationCacheResource* resource, unsigned
     } else {
         if (resource->data().size()) {
             auto contiguousData = resource->data().makeContiguous();
-            dataStatement->bindBlob(1, contiguousData->dataAsSpanForContiguousData());
+            dataStatement->bindBlob(1, contiguousData->bytes());
         }
     }
     

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -75,7 +75,7 @@ FontParsingPolicy CachedFont::policyForCustomFont(const Ref<SharedBuffer>& data)
     if (!m_loader || !m_loader->frame())
         return FontParsingPolicy::Deny;
 
-    return fontBinaryParsingPolicy(data->dataAsSpanForContiguousData(), m_loader->frame()->settings().downloadableBinaryFontTrustedTypes());
+    return fontBinaryParsingPolicy(data->bytes(), m_loader->frame()->settings().downloadableBinaryFontTrustedTypes());
 }
 
 void CachedFont::finishLoading(const FragmentedSharedBuffer* data, const NetworkLoadMetrics& metrics)

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -313,7 +313,7 @@ public:
     WEBCORE_EXPORT const uint8_t* data() const;
     WEBCORE_EXPORT const uint8_t& operator[](size_t) const;
     const char* dataAsCharPtr() const { return reinterpret_cast<const char*>(data()); }
-    std::span<const uint8_t> dataAsSpanForContiguousData() const { RELEASE_ASSERT(isContiguous()); return std::span(data(), size()); }
+    std::span<const uint8_t> bytes() const { return std::span(data(), size()); }
     WTF::Persistence::Decoder decoder() const;
 
     enum class MayUseFileMapping : bool { No, Yes };

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
@@ -330,7 +330,7 @@ bool parseOpusPrivateData(size_t codecPrivateSize, const uint8_t* codecPrivateDa
 static Vector<uint8_t> cookieFromOpusCookieContents(const OpusCookieContents& cookie)
 {
 #if HAVE(AUDIOFORMATPROPERTY_VARIABLEPACKET_SUPPORTED)
-    return { cookie.cookieData->dataAsSpanForContiguousData() };
+    return { cookie.cookieData->bytes() };
 #else
     auto samplesPerPacket = cookie.framesPerPacket * (cookie.frameDuration.seconds() * cookie.sampleRate);
 

--- a/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
@@ -137,7 +137,7 @@ std::optional<Ref<FontCustomPlatformData>> FontCustomPlatformData::tryMakeFromSe
 
 FontCustomPlatformSerializedData FontCustomPlatformData::serializedData() const
 {
-    return FontCustomPlatformSerializedData { { creationData.fontFaceData->dataAsSpanForContiguousData() }, creationData.itemInCollection, m_renderingResourceIdentifier };
+    return FontCustomPlatformSerializedData { { creationData.fontFaceData->bytes() }, creationData.itemInCollection, m_renderingResourceIdentifier };
 }
 
 bool FontCustomPlatformData::supportsFormat(const String& format)

--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -320,7 +320,7 @@ FontPlatformData::PlatformDataVariant FontPlatformData::platformSerializationDat
 
     const auto& data = creationData();
     if (data)
-        return FontPlatformSerializedCreationData { { data->fontFaceData->dataAsSpanForContiguousData() }, attributes, data->itemInCollection };
+        return FontPlatformSerializedCreationData { { data->fontFaceData->bytes() }, attributes, data->itemInCollection };
 
     auto options = CTFontDescriptorGetOptions(fontDescriptor.get());
     auto referenceURL = adoptCF(static_cast<CFURLRef>(CTFontCopyAttribute(ctFont, kCTFontReferenceURLAttribute)));

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -504,7 +504,7 @@ static void* openFunc(const char* uri)
     if (!data)
         return &globalDescriptor;
 
-    return new OffsetBuffer(Vector(data->dataAsSpanForContiguousData()));
+    return new OffsetBuffer(Vector(data->bytes()));
 }
 
 static int readFunc(void* context, char* buffer, int len)

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -476,7 +476,7 @@ static Vector<uint8_t> encodeRecordBody(const CacheStorageRecord& record)
         // FIXME: Store form data body.
         return Vector<uint8_t> { };
     }, [&](const Ref<WebCore::SharedBuffer>& buffer) {
-        return Vector<uint8_t> { buffer->dataAsSpanForContiguousData() };
+        return Vector<uint8_t> { buffer->bytes() };
     }, [](const std::nullptr_t&) {
         return Vector<uint8_t> { };
     });

--- a/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
+++ b/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
@@ -215,7 +215,7 @@ auto WebURLSchemeTask::didComplete(const ResourceError& error) -> ExceptionType
     m_completed = true;
 
     if (isSync()) {
-        Vector<uint8_t> data = m_syncData.takeAsContiguous()->dataAsSpanForContiguousData();
+        Vector<uint8_t> data = m_syncData.takeAsContiguous()->bytes();
         m_syncCompletionHandler(m_syncResponse, error, WTFMove(data));
     }
 


### PR DESCRIPTION
#### 4c53942002bdfa4c04057293fdf832705b35b487
<pre>
Rename SharedBuffer::dataAsSpanForContiguousData() to SharedBuffer::bytes()
<a href="https://bugs.webkit.org/show_bug.cgi?id=271102">https://bugs.webkit.org/show_bug.cgi?id=271102</a>

Reviewed by Alan Baradlay and Richard Robinson.

Rename SharedBuffer::dataAsSpanForContiguousData() to SharedBuffer::bytes().
This is much shorter and consistent with other types.

Also drop useless `isContiguous()` assertion. SharedBuffer is always
contiguous, that&apos;s what distinguishes it from a FragmentedSharedBuffer.

* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::bodyAsFormData const):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::resolveWithFormData):
(WebCore::FetchBodyConsumer::resolve):
(WebCore::FetchBodyConsumer::takeAsText):
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::Loader::didReceiveData):
(WebCore::FetchResponse::Loader::consumeDataByChunk):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::addExistingIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::createObjectStore):
(WebCore::IDBServer::SQLiteIDBBackingStore::createIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedHasIndexRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedPutIndexRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::keyExistsInObjectStore):
(WebCore::IDBServer::SQLiteIDBBackingStore::deleteRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::addRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::getRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::getAllObjectStoreRecords):
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedGetIndexRecordForOneKey):
(WebCore::IDBServer::SQLiteIDBBackingStore::getCount):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp:
(WebCore::IDBServer::SQLiteIDBCursor::bindArguments):
(WebCore::IDBServer::SQLiteIDBCursor::resetAndRebindPreIndexStatementIfNecessary):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::ApplicationCacheStorage::store):
* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::policyForCustomFont):
* Source/WebCore/platform/SharedBuffer.h:
(WebCore::SharedBuffer::bytes const):
(WebCore::SharedBuffer::dataAsSpanForContiguousData const): Deleted.
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::cookieFromOpusCookieContents):
* Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp:
(WebCore::FontCustomPlatformData::serializedData const):
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::FontPlatformData::platformSerializationData const):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::openFunc):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::encodeRecordBody):
* Source/WebKit/UIProcess/WebURLSchemeTask.cpp:
(WebKit::WebURLSchemeTask::didComplete):

Canonical link: <a href="https://commits.webkit.org/276226@main">https://commits.webkit.org/276226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5da198e4c376d5a17cd853f2e2917c43d17dd438

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46729 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46391 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20547 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20181 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/37963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/39063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2136 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40251 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/39352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48313 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15626 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/41910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20650 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6046 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/20057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->