### PR TITLE
Sync `DeviceMotionEvent` as per web specification

### DIFF
--- a/LayoutTests/fast/dom/DeviceMotion/optional-event-properties-expected.txt
+++ b/LayoutTests/fast/dom/DeviceMotion/optional-event-properties-expected.txt
@@ -7,8 +7,8 @@ event = document.createEvent('DeviceMotionEvent')
 PASS event.acceleration == null is true
 PASS event.accelerationIncludingGravity == null is true
 PASS event.rotationRate == null is true
-PASS event.interval == null is true
-event.initDeviceMotionEvent('', false, false, {x: 0, y: 1, z: 2}, {x: 3, y: 4, z: 5}, {alpha: 6, beta: 7, gamma: 8}, 9)
+PASS event.interval == 0 is true
+event = new DeviceMotionEvent('', {acceleration: {x: 0, y: 1, z: 2}, accelerationIncludingGravity: {x: 3, y: 4, z: 5}, rotationRate: {alpha: 6, beta: 7, gamma: 8}, interval: 9})
 PASS event.acceleration.x == 0 is true
 PASS event.acceleration.y == 1 is true
 PASS event.acceleration.z == 2 is true
@@ -19,14 +19,13 @@ PASS event.rotationRate.alpha == 6 is true
 PASS event.rotationRate.beta == 7 is true
 PASS event.rotationRate.gamma == 8 is true
 PASS event.interval == 9 is true
-PASS event.initDeviceMotionEvent('', false, false, objectThrowingException, {x: 3, z: 5}, {gamma: 8, beta: 7}, 9) threw exception Error: x getter exception.
-PASS event.initDeviceMotionEvent('', false, false, {x: 0, y: 1, z: 2}, objectThrowingException, {gamma: 8, beta: 7}, 9) threw exception Error: x getter exception.
-PASS event.initDeviceMotionEvent('', false, false, {x: 0, y: 1, z: 2}, {x: 3, z: 5}, objectThrowingException, 9) threw exception Error: alpha getter exception.
-PASS event.initDeviceMotionEvent('', false, false, {x: objectThrowingException, y: 1, z: 2}, {x: 3, y: 4, z: 5}, {alpha: 6, beta: 7, gamma: 8}, 9) threw exception Error: valueOf threw exception.
-PASS event.initDeviceMotionEvent('', false, false, {x: 0, y: 1, z: 2}, {x: 3, y: objectThrowingException, z: 5}, {alpha: 6, beta: 7, gamma: 8}, 9) threw exception Error: valueOf threw exception.
-PASS event.initDeviceMotionEvent('', false, false, {x: 0, y: 1, z: 2}, {x: 3, y: 4, z: 5}, {alpha: 6, beta: 7, gamma: objectThrowingException}, 9) threw exception Error: valueOf threw exception.
-PASS event.initDeviceMotionEvent('', false, false, '', '', '', '') threw exception TypeError: Type error.
-event.initDeviceMotionEvent('', false, false, {y: 1, x: 0}, {x: 3, z: 5}, {gamma: 8, beta: 7}, 9)
+PASS event = new DeviceMotionEvent('', {acceleration: objectThrowingException, accelerationIncludingGravity: {x: 3, z: 5}, rotationRate: {gamma: 8, beta: 7}, interval: 9}) threw exception Error: x getter exception.
+PASS event = new DeviceMotionEvent('', {acceleration: {x: 0, y: 1, z: 2}, accelerationIncludingGravity: objectThrowingException, rotationRate: {gamma: 8, beta: 7}, interval: 9}) threw exception Error: x getter exception.
+PASS event = new DeviceMotionEvent('', {acceleration: {x: 0, y: 1, z: 2}, accelerationIncludingGravity: {x: 3, z: 5}, rotationRate: objectThrowingException, interval: 9}) threw exception Error: alpha getter exception.
+PASS event = new DeviceMotionEvent('', {acceleration: {x: objectThrowingException, y: 1, z: 2}, accelerationIncludingGravity: {x: 3, y: 4, z: 5}, rotationRate: {alpha: 6, beta: 7, gamma: 8}, interval: 9}) threw exception Error: valueOf threw exception.
+PASS event = new DeviceMotionEvent('', {acceleration: {x: 0, y: 1, z: 2}, accelerationIncludingGravity: {x: 3, y: objectThrowingException, z: 5}, rotationRate: {alpha: 6, beta: 7, gamma: 8}, interval: 9}) threw exception Error: valueOf threw exception.
+PASS event = new DeviceMotionEvent('', {acceleration: {x: 0, y: 1, z: 2}, accelerationIncludingGravity: {x: 3, y: 4, z: 5}, rotationRate: {alpha: 6, beta: 7, gamma: objectThrowingException}, interval: 9}) threw exception Error: valueOf threw exception.
+event = new DeviceMotionEvent('', {acceleration: {y: 1, x: 0}, accelerationIncludingGravity: {x: 3, z: 5}, rotationRate: {gamma: 8, beta: 7}, interval: 9})
 PASS event.acceleration.x == 0 is true
 PASS event.acceleration.y == 1 is true
 PASS event.acceleration.z == null is true
@@ -37,32 +36,52 @@ PASS event.rotationRate.alpha == null is true
 PASS event.rotationRate.beta == 7 is true
 PASS event.rotationRate.gamma == 8 is true
 PASS event.interval == 9 is true
-event.initDeviceMotionEvent()
-PASS event.acceleration == null is true
-PASS event.accelerationIncludingGravity == null is true
-PASS event.rotationRate == null is true
-PASS event.interval == null is true
-event.initDeviceMotionEvent('', false, false, [], [], [], [])
+event = new DeviceMotionEvent('')
 PASS event.acceleration == null is true
 PASS event.accelerationIncludingGravity == null is true
 PASS event.rotationRate == null is true
 PASS event.interval == 0 is true
-event.initDeviceMotionEvent('', false, false, undefined, undefined, undefined, undefined)
-PASS event.acceleration == null is true
+event = new DeviceMotionEvent('', {acceleration: [], accelerationIncludingGravity: [], rotationRate: [], interval: []})
+PASS event.acceleration.x == null is true
+PASS event.acceleration.y == null is true
+PASS event.acceleration.z == null is true
+PASS event.accelerationIncludingGravity.x == null is true
+PASS event.accelerationIncludingGravity.y == null is true
+PASS event.accelerationIncludingGravity.z == null is true
+PASS event.rotationRate.alpha == null is true
+PASS event.rotationRate.beta == null is true
+PASS event.rotationRate.gamma == null is true
+PASS event.interval == 0 is true
+event = new DeviceMotionEvent('', {acceleration: [], accelerationIncludingGravity: undefined, rotationRate: undefined, interval: undefined})
+PASS event.acceleration.x == null is true
+PASS event.acceleration.y == null is true
+PASS event.acceleration.z == null is true
 PASS event.accelerationIncludingGravity == null is true
 PASS event.rotationRate == null is true
-PASS event.interval == null is true
-event.initDeviceMotionEvent('', false, false, null, null, null, null)
-PASS event.acceleration == null is true
-PASS event.accelerationIncludingGravity == null is true
-PASS event.rotationRate == null is true
-PASS event.interval == null is true
-event.initDeviceMotionEvent('', false, false, {x: null, y: null, z: null}, {x: null, y: null, z: null}, {alpha: null, beta: null, gamma: null}, null)
-PASS event.acceleration == null is true
-PASS event.accelerationIncludingGravity == null is true
-PASS event.rotationRate == null is true
-PASS event.interval == null is true
-event.initDeviceMotionEvent('', false, false, {x: null, y: null, z: 1}, {x: null, y: null, z: 2}, {alpha: null, beta: null, gamma: 3}, null)
+PASS event.interval == 0 is true
+event = new DeviceMotionEvent('', {acceleration: null, accelerationIncludingGravity: null, rotationRate: null, interval: null})
+PASS event.acceleration.x == null is true
+PASS event.acceleration.y == null is true
+PASS event.acceleration.z == null is true
+PASS event.accelerationIncludingGravity.x == null is true
+PASS event.accelerationIncludingGravity.y == null is true
+PASS event.accelerationIncludingGravity.z == null is true
+PASS event.rotationRate.alpha == null is true
+PASS event.rotationRate.beta == null is true
+PASS event.rotationRate.gamma == null is true
+PASS event.interval == 0 is true
+event = new DeviceMotionEvent('', {acceleration: {x: null, y: null, z: null}, accelerationIncludingGravity: {x: null, y: null, z: null}, rotationRate: {alpha: null, beta: null, gamma: null}, interval: null})
+PASS event.acceleration.x == null is true
+PASS event.acceleration.y == null is true
+PASS event.acceleration.z == null is true
+PASS event.accelerationIncludingGravity.x == null is true
+PASS event.accelerationIncludingGravity.y == null is true
+PASS event.accelerationIncludingGravity.z == null is true
+PASS event.rotationRate.alpha == null is true
+PASS event.rotationRate.beta == null is true
+PASS event.rotationRate.gamma == null is true
+PASS event.interval == 0 is true
+event = new DeviceMotionEvent('', {acceleration: {x: null, y: null, z: 1}, accelerationIncludingGravity: {x: null, y: null, z: 2}, rotationRate: {alpha: null, beta: null, gamma: 3}, interval: null})
 PASS event.acceleration.x == null is true
 PASS event.acceleration.y == null is true
 PASS event.acceleration.z == 1 is true
@@ -72,13 +91,19 @@ PASS event.accelerationIncludingGravity.z == 2 is true
 PASS event.rotationRate.alpha == null is true
 PASS event.rotationRate.beta == null is true
 PASS event.rotationRate.gamma == 3 is true
-PASS event.interval == null is true
-event.initDeviceMotionEvent('', false, false, {x: undefined, y: undefined, z: undefined}, {x: undefined, y: undefined, z: undefined}, {alpha: undefined, beta: undefined, gamma: undefined}, undefined)
-PASS event.acceleration == null is true
-PASS event.accelerationIncludingGravity == null is true
-PASS event.rotationRate == null is true
-PASS event.interval == null is true
-event.initDeviceMotionEvent('', false, false, {x: undefined, y: undefined, z: 1}, {x: undefined, y: undefined, z: 2}, {alpha: undefined, beta: undefined, gamma: 3}, undefined)
+PASS event.interval == 0 is true
+event = new DeviceMotionEvent('', {acceleration: {x: undefined, y: undefined, z: undefined}, accelerationIncludingGravity: {x: undefined, y: undefined, z: undefined}, rotationRate: {alpha: undefined, beta: undefined, gamma: undefined}, interval: undefined})
+PASS event.acceleration.x == null is true
+PASS event.acceleration.y == null is true
+PASS event.acceleration.z == null is true
+PASS event.accelerationIncludingGravity.x == null is true
+PASS event.accelerationIncludingGravity.y == null is true
+PASS event.accelerationIncludingGravity.z == null is true
+PASS event.rotationRate.alpha == null is true
+PASS event.rotationRate.beta == null is true
+PASS event.rotationRate.gamma == null is true
+PASS event.interval == 0 is true
+event = new DeviceMotionEvent('', {acceleration: {x: undefined, y: undefined, z: 1}, accelerationIncludingGravity: {x: undefined, y: undefined, z: 2}, rotationRate: {alpha: undefined, beta: undefined, gamma: 3}, interval: undefined})
 PASS event.acceleration.x == null is true
 PASS event.acceleration.y == null is true
 PASS event.acceleration.z == 1 is true
@@ -88,7 +113,7 @@ PASS event.accelerationIncludingGravity.z == 2 is true
 PASS event.rotationRate.alpha == null is true
 PASS event.rotationRate.beta == null is true
 PASS event.rotationRate.gamma == 3 is true
-PASS event.interval == null is true
+PASS event.interval == 0 is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/DeviceMotion/optional-event-properties.html
+++ b/LayoutTests/fast/dom/DeviceMotion/optional-event-properties.html
@@ -1,8 +1,7 @@
+<!DOCTYPE html>
 <html>
-<head>
-<script src="../../../resources/js-test-pre.js"></script>
-</head>
 <body>
+<script src="../../../resources/js-test.js"></script>
 <script>
 description("Tests the optional properties of DeviceMotionEvent. Each property should be null if not set, or set to null or undefined.");
 
@@ -23,9 +22,9 @@ evalAndLog("event = document.createEvent('DeviceMotionEvent')");
 shouldBeTrue("event.acceleration == null");
 shouldBeTrue("event.accelerationIncludingGravity == null");
 shouldBeTrue("event.rotationRate == null");
-shouldBeTrue("event.interval == null");
+shouldBeTrue("event.interval == 0");
 
-evalAndLog("event.initDeviceMotionEvent('', false, false, {x: 0, y: 1, z: 2}, {x: 3, y: 4, z: 5}, {alpha: 6, beta: 7, gamma: 8}, 9)");
+evalAndLog("event = new DeviceMotionEvent('', {acceleration: {x: 0, y: 1, z: 2}, accelerationIncludingGravity: {x: 3, y: 4, z: 5}, rotationRate: {alpha: 6, beta: 7, gamma: 8}, interval: 9})");
 shouldBeTrue("event.acceleration.x == 0");
 shouldBeTrue("event.acceleration.y == 1");
 shouldBeTrue("event.acceleration.z == 2");
@@ -36,17 +35,14 @@ shouldBeTrue("event.rotationRate.alpha == 6");
 shouldBeTrue("event.rotationRate.beta == 7");
 shouldBeTrue("event.rotationRate.gamma == 8");
 shouldBeTrue("event.interval == 9");
+testException("event = new DeviceMotionEvent('', {acceleration: objectThrowingException, accelerationIncludingGravity: {x: 3, z: 5}, rotationRate: {gamma: 8, beta: 7}, interval: 9})", "Error: x getter exception");
+testException("event = new DeviceMotionEvent('', {acceleration: {x: 0, y: 1, z: 2}, accelerationIncludingGravity: objectThrowingException, rotationRate: {gamma: 8, beta: 7}, interval: 9})", "Error: x getter exception");
+testException("event = new DeviceMotionEvent('', {acceleration: {x: 0, y: 1, z: 2}, accelerationIncludingGravity: {x: 3, z: 5}, rotationRate: objectThrowingException, interval: 9})", "Error: alpha getter exception");
+testException("event = new DeviceMotionEvent('', {acceleration: {x: objectThrowingException, y: 1, z: 2}, accelerationIncludingGravity: {x: 3, y: 4, z: 5}, rotationRate: {alpha: 6, beta: 7, gamma: 8}, interval: 9})", "Error: valueOf threw exception");
+testException("event = new DeviceMotionEvent('', {acceleration: {x: 0, y: 1, z: 2}, accelerationIncludingGravity: {x: 3, y: objectThrowingException, z: 5}, rotationRate: {alpha: 6, beta: 7, gamma: 8}, interval: 9})", "Error: valueOf threw exception");
+testException("event = new DeviceMotionEvent('', {acceleration: {x: 0, y: 1, z: 2}, accelerationIncludingGravity: {x: 3, y: 4, z: 5}, rotationRate: {alpha: 6, beta: 7, gamma: objectThrowingException}, interval: 9})", "Error: valueOf threw exception");
 
-testException("event.initDeviceMotionEvent('', false, false, objectThrowingException, {x: 3, z: 5}, {gamma: 8, beta: 7}, 9)", "Error: x getter exception");
-testException("event.initDeviceMotionEvent('', false, false, {x: 0, y: 1, z: 2}, objectThrowingException, {gamma: 8, beta: 7}, 9)", "Error: x getter exception");
-testException("event.initDeviceMotionEvent('', false, false, {x: 0, y: 1, z: 2}, {x: 3, z: 5}, objectThrowingException, 9)", "Error: alpha getter exception");
-
-testException("event.initDeviceMotionEvent('', false, false, {x: objectThrowingException, y: 1, z: 2}, {x: 3, y: 4, z: 5}, {alpha: 6, beta: 7, gamma: 8}, 9)", "Error: valueOf threw exception");
-testException("event.initDeviceMotionEvent('', false, false, {x: 0, y: 1, z: 2}, {x: 3, y: objectThrowingException, z: 5}, {alpha: 6, beta: 7, gamma: 8}, 9)", "Error: valueOf threw exception");
-testException("event.initDeviceMotionEvent('', false, false, {x: 0, y: 1, z: 2}, {x: 3, y: 4, z: 5}, {alpha: 6, beta: 7, gamma: objectThrowingException}, 9)", "Error: valueOf threw exception");
-testException("event.initDeviceMotionEvent('', false, false, '', '', '', '')", "TypeError: Type error");
-
-evalAndLog("event.initDeviceMotionEvent('', false, false, {y: 1, x: 0}, {x: 3, z: 5}, {gamma: 8, beta: 7}, 9)");
+evalAndLog("event = new DeviceMotionEvent('', {acceleration: {y: 1, x: 0}, accelerationIncludingGravity: {x: 3, z: 5}, rotationRate: {gamma: 8, beta: 7}, interval: 9})");
 shouldBeTrue("event.acceleration.x == 0");
 shouldBeTrue("event.acceleration.y == 1");
 shouldBeTrue("event.acceleration.z == null");
@@ -58,37 +54,57 @@ shouldBeTrue("event.rotationRate.beta == 7");
 shouldBeTrue("event.rotationRate.gamma == 8");
 shouldBeTrue("event.interval == 9");
 
-evalAndLog("event.initDeviceMotionEvent()");
-shouldBeTrue("event.acceleration == null");
-shouldBeTrue("event.accelerationIncludingGravity == null");
-shouldBeTrue("event.rotationRate == null");
-shouldBeTrue("event.interval == null");
-
-evalAndLog("event.initDeviceMotionEvent('', false, false, [], [], [], [])");
+evalAndLog("event = new DeviceMotionEvent('')");
 shouldBeTrue("event.acceleration == null");
 shouldBeTrue("event.accelerationIncludingGravity == null");
 shouldBeTrue("event.rotationRate == null");
 shouldBeTrue("event.interval == 0");
 
-evalAndLog("event.initDeviceMotionEvent('', false, false, undefined, undefined, undefined, undefined)");
-shouldBeTrue("event.acceleration == null");
+evalAndLog("event = new DeviceMotionEvent('', {acceleration: [], accelerationIncludingGravity: [], rotationRate: [], interval: []})");
+shouldBeTrue("event.acceleration.x == null");
+shouldBeTrue("event.acceleration.y == null");
+shouldBeTrue("event.acceleration.z == null");
+shouldBeTrue("event.accelerationIncludingGravity.x == null");
+shouldBeTrue("event.accelerationIncludingGravity.y == null");
+shouldBeTrue("event.accelerationIncludingGravity.z == null");
+shouldBeTrue("event.rotationRate.alpha == null");
+shouldBeTrue("event.rotationRate.beta == null");
+shouldBeTrue("event.rotationRate.gamma == null");
+shouldBeTrue("event.interval == 0");
+
+evalAndLog("event = new DeviceMotionEvent('', {acceleration: [], accelerationIncludingGravity: undefined, rotationRate: undefined, interval: undefined})");
+shouldBeTrue("event.acceleration.x == null");
+shouldBeTrue("event.acceleration.y == null");
+shouldBeTrue("event.acceleration.z == null");
 shouldBeTrue("event.accelerationIncludingGravity == null");
 shouldBeTrue("event.rotationRate == null");
-shouldBeTrue("event.interval == null");
+shouldBeTrue("event.interval == 0");
 
-evalAndLog("event.initDeviceMotionEvent('', false, false, null, null, null, null)");
-shouldBeTrue("event.acceleration == null");
-shouldBeTrue("event.accelerationIncludingGravity == null");
-shouldBeTrue("event.rotationRate == null");
-shouldBeTrue("event.interval == null");
+evalAndLog("event = new DeviceMotionEvent('', {acceleration: null, accelerationIncludingGravity: null, rotationRate: null, interval: null})");
+shouldBeTrue("event.acceleration.x == null");
+shouldBeTrue("event.acceleration.y == null");
+shouldBeTrue("event.acceleration.z == null");
+shouldBeTrue("event.accelerationIncludingGravity.x == null");
+shouldBeTrue("event.accelerationIncludingGravity.y == null");
+shouldBeTrue("event.accelerationIncludingGravity.z == null");
+shouldBeTrue("event.rotationRate.alpha == null");
+shouldBeTrue("event.rotationRate.beta == null");
+shouldBeTrue("event.rotationRate.gamma == null");
+shouldBeTrue("event.interval == 0");
 
-evalAndLog("event.initDeviceMotionEvent('', false, false, {x: null, y: null, z: null}, {x: null, y: null, z: null}, {alpha: null, beta: null, gamma: null}, null)");
-shouldBeTrue("event.acceleration == null");
-shouldBeTrue("event.accelerationIncludingGravity == null");
-shouldBeTrue("event.rotationRate == null");
-shouldBeTrue("event.interval == null");
+evalAndLog("event = new DeviceMotionEvent('', {acceleration: {x: null, y: null, z: null}, accelerationIncludingGravity: {x: null, y: null, z: null}, rotationRate: {alpha: null, beta: null, gamma: null}, interval: null})");
+shouldBeTrue("event.acceleration.x == null");
+shouldBeTrue("event.acceleration.y == null");
+shouldBeTrue("event.acceleration.z == null");
+shouldBeTrue("event.accelerationIncludingGravity.x == null");
+shouldBeTrue("event.accelerationIncludingGravity.y == null");
+shouldBeTrue("event.accelerationIncludingGravity.z == null");
+shouldBeTrue("event.rotationRate.alpha == null");
+shouldBeTrue("event.rotationRate.beta == null");
+shouldBeTrue("event.rotationRate.gamma == null");
+shouldBeTrue("event.interval == 0");
 
-evalAndLog("event.initDeviceMotionEvent('', false, false, {x: null, y: null, z: 1}, {x: null, y: null, z: 2}, {alpha: null, beta: null, gamma: 3}, null)");
+evalAndLog("event = new DeviceMotionEvent('', {acceleration: {x: null, y: null, z: 1}, accelerationIncludingGravity: {x: null, y: null, z: 2}, rotationRate: {alpha: null, beta: null, gamma: 3}, interval: null})");
 shouldBeTrue("event.acceleration.x == null");
 shouldBeTrue("event.acceleration.y == null");
 shouldBeTrue("event.acceleration.z == 1");
@@ -98,15 +114,21 @@ shouldBeTrue("event.accelerationIncludingGravity.z == 2");
 shouldBeTrue("event.rotationRate.alpha == null");
 shouldBeTrue("event.rotationRate.beta == null");
 shouldBeTrue("event.rotationRate.gamma == 3");
-shouldBeTrue("event.interval == null");
+shouldBeTrue("event.interval == 0");
 
-evalAndLog("event.initDeviceMotionEvent('', false, false, {x: undefined, y: undefined, z: undefined}, {x: undefined, y: undefined, z: undefined}, {alpha: undefined, beta: undefined, gamma: undefined}, undefined)");
-shouldBeTrue("event.acceleration == null");
-shouldBeTrue("event.accelerationIncludingGravity == null");
-shouldBeTrue("event.rotationRate == null");
-shouldBeTrue("event.interval == null");
+evalAndLog("event = new DeviceMotionEvent('', {acceleration: {x: undefined, y: undefined, z: undefined}, accelerationIncludingGravity: {x: undefined, y: undefined, z: undefined}, rotationRate: {alpha: undefined, beta: undefined, gamma: undefined}, interval: undefined})");
+shouldBeTrue("event.acceleration.x == null");
+shouldBeTrue("event.acceleration.y == null");
+shouldBeTrue("event.acceleration.z == null");
+shouldBeTrue("event.accelerationIncludingGravity.x == null");
+shouldBeTrue("event.accelerationIncludingGravity.y == null");
+shouldBeTrue("event.accelerationIncludingGravity.z == null");
+shouldBeTrue("event.rotationRate.alpha == null");
+shouldBeTrue("event.rotationRate.beta == null");
+shouldBeTrue("event.rotationRate.gamma == null");
+shouldBeTrue("event.interval == 0");
 
-evalAndLog("event.initDeviceMotionEvent('', false, false, {x: undefined, y: undefined, z: 1}, {x: undefined, y: undefined, z: 2}, {alpha: undefined, beta: undefined, gamma: 3}, undefined)");
+evalAndLog("event = new DeviceMotionEvent('', {acceleration: {x: undefined, y: undefined, z: 1}, accelerationIncludingGravity: {x: undefined, y: undefined, z: 2}, rotationRate: {alpha: undefined, beta: undefined, gamma: 3}, interval: undefined})");
 shouldBeTrue("event.acceleration.x == null");
 shouldBeTrue("event.acceleration.y == null");
 shouldBeTrue("event.acceleration.z == 1");
@@ -116,8 +138,7 @@ shouldBeTrue("event.accelerationIncludingGravity.z == 2");
 shouldBeTrue("event.rotationRate.alpha == null");
 shouldBeTrue("event.rotationRate.beta == null");
 shouldBeTrue("event.rotationRate.gamma == 3");
-shouldBeTrue("event.interval == null");
+shouldBeTrue("event.interval == 0");
 </script>
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/dom/DeviceMotionData.cpp
+++ b/Source/WebCore/dom/DeviceMotionData.cpp
@@ -33,12 +33,12 @@ Ref<DeviceMotionData> DeviceMotionData::create()
     return adoptRef(*new DeviceMotionData);
 }
 
-Ref<DeviceMotionData> DeviceMotionData::create(RefPtr<Acceleration>&& acceleration, RefPtr<Acceleration>&& accelerationIncludingGravity, RefPtr<RotationRate>&& rotationRate, std::optional<double> interval)
+Ref<DeviceMotionData> DeviceMotionData::create(RefPtr<Acceleration>&& acceleration, RefPtr<Acceleration>&& accelerationIncludingGravity, RefPtr<RotationRate>&& rotationRate, double interval)
 {
     return adoptRef(*new DeviceMotionData(WTF::move(acceleration), WTF::move(accelerationIncludingGravity), WTF::move(rotationRate), interval));
 }
 
-DeviceMotionData::DeviceMotionData(RefPtr<Acceleration>&& acceleration, RefPtr<Acceleration>&& accelerationIncludingGravity, RefPtr<RotationRate>&& rotationRate, std::optional<double> interval)
+DeviceMotionData::DeviceMotionData(RefPtr<Acceleration>&& acceleration, RefPtr<Acceleration>&& accelerationIncludingGravity, RefPtr<RotationRate>&& rotationRate, double interval)
     : m_acceleration(WTF::move(acceleration))
     , m_accelerationIncludingGravity(WTF::move(accelerationIncludingGravity))
     , m_rotationRate(WTF::move(rotationRate))

--- a/Source/WebCore/dom/DeviceMotionData.h
+++ b/Source/WebCore/dom/DeviceMotionData.h
@@ -92,22 +92,22 @@ public:
     };
 
     WEBCORE_EXPORT static Ref<DeviceMotionData> NODELETE create();
-    WEBCORE_EXPORT static Ref<DeviceMotionData> NODELETE create(RefPtr<Acceleration>&&, RefPtr<Acceleration>&& accelerationIncludingGravity, RefPtr<RotationRate>&&, std::optional<double> interval);
+    WEBCORE_EXPORT static Ref<DeviceMotionData> NODELETE create(RefPtr<Acceleration>&&, RefPtr<Acceleration>&& accelerationIncludingGravity, RefPtr<RotationRate>&&, double interval);
 
     const Acceleration* acceleration() const { return m_acceleration.get(); }
     const Acceleration* accelerationIncludingGravity() const { return m_accelerationIncludingGravity.get(); }
     const RotationRate* rotationRate() const { return m_rotationRate.get(); }
     
-    std::optional<double> interval() const { return m_interval; }
+    double interval() const { return m_interval; }
 
 private:
     DeviceMotionData() = default;
-    DeviceMotionData(RefPtr<Acceleration>&&, RefPtr<Acceleration>&& accelerationIncludingGravity, RefPtr<RotationRate>&&, std::optional<double> interval);
+    DeviceMotionData(RefPtr<Acceleration>&&, RefPtr<Acceleration>&& accelerationIncludingGravity, RefPtr<RotationRate>&&, double interval);
 
     const RefPtr<Acceleration> m_acceleration;
     const RefPtr<Acceleration> m_accelerationIncludingGravity;
     const RefPtr<RotationRate> m_rotationRate;
-    std::optional<double> m_interval;
+    double m_interval;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DeviceMotionEvent.cpp
+++ b/Source/WebCore/dom/DeviceMotionEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -86,10 +86,6 @@ static RefPtr<DeviceMotionData::Acceleration> convert(std::optional<DeviceMotion
 {
     if (!acceleration)
         return nullptr;
-
-    if (!acceleration->x && !acceleration->y && !acceleration->z)
-        return nullptr;
-
     return DeviceMotionData::Acceleration::create(acceleration->x, acceleration->y, acceleration->z);
 }
 
@@ -97,10 +93,6 @@ static RefPtr<DeviceMotionData::RotationRate> convert(std::optional<DeviceMotion
 {
     if (!rotationRate)
         return nullptr;
-
-    if (!rotationRate->alpha && !rotationRate->beta && !rotationRate->gamma)
-        return nullptr;
-
     return DeviceMotionData::RotationRate::create(rotationRate->alpha, rotationRate->beta, rotationRate->gamma);
 }
 
@@ -122,18 +114,24 @@ std::optional<DeviceMotionEvent::RotationRate> DeviceMotionEvent::rotationRate()
     return convert(rotationRate.get());
 }
 
-std::optional<double> DeviceMotionEvent::interval() const
+double DeviceMotionEvent::interval() const
 {
     return m_deviceMotionData->interval();
 }
 
-void DeviceMotionEvent::initDeviceMotionEvent(const AtomString& type, bool bubbles, bool cancelable, std::optional<DeviceMotionEvent::Acceleration>&& acceleration, std::optional<DeviceMotionEvent::Acceleration>&& accelerationIncludingGravity, std::optional<DeviceMotionEvent::RotationRate>&& rotationRate, std::optional<double> interval)
+Ref<DeviceMotionEvent> DeviceMotionEvent::create(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
 {
-    if (isBeingDispatched())
-        return;
+    return adoptRef(*new DeviceMotionEvent(type, WTF::move(initializer), isTrusted));
+}
 
-    initEvent(type, bubbles, cancelable);
-    m_deviceMotionData = DeviceMotionData::create(convert(WTF::move(acceleration)), convert(WTF::move(accelerationIncludingGravity)), convert(WTF::move(rotationRate)), interval);
+DeviceMotionEvent::DeviceMotionEvent(const AtomString& type, Init&& initializer, IsTrusted isTrusted)
+#if ENABLE(DEVICE_ORIENTATION)
+    : Event(EventInterfaceType::DeviceMotionEvent, type, initializer, isTrusted)
+#else
+    : Event(EventInterfaceType::Event, type, initializer, isTrusted)
+#endif
+    , m_deviceMotionData(DeviceMotionData::create(convert(WTF::move(initializer.acceleration)), convert(WTF::move(initializer.accelerationIncludingGravity)), convert(WTF::move(initializer.rotationRate)), initializer.interval))
+{
 }
 
 #if ENABLE(DEVICE_ORIENTATION)

--- a/Source/WebCore/dom/DeviceMotionEvent.h
+++ b/Source/WebCore/dom/DeviceMotionEvent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #include "DeviceOrientationOrMotionPermissionState.h"
 #include "Document.h"
 #include "Event.h"
+#include "EventInit.h"
 #include "IDLTypes.h"
 
 namespace WebCore {
@@ -64,12 +65,18 @@ public:
         return adoptRef(*new DeviceMotionEvent);
     }
 
+    struct Init : EventInit {
+        std::optional<Acceleration> acceleration;
+        std::optional<Acceleration> accelerationIncludingGravity;
+        std::optional<RotationRate> rotationRate;
+        double interval { 0 };
+    };
+
+
     std::optional<Acceleration> NODELETE acceleration() const;
     std::optional<Acceleration> NODELETE accelerationIncludingGravity() const;
     std::optional<RotationRate> NODELETE rotationRate() const;
-    std::optional<double> NODELETE interval() const;
-
-    void initDeviceMotionEvent(const AtomString& type, bool bubbles, bool cancelable, std::optional<Acceleration>&&, std::optional<Acceleration>&&, std::optional<RotationRate>&&, std::optional<double>);
+    double NODELETE interval() const;
 
 #if ENABLE(DEVICE_ORIENTATION)
     using PermissionState = DeviceOrientationOrMotionPermissionState;
@@ -80,6 +87,7 @@ public:
 private:
     DeviceMotionEvent();
     DeviceMotionEvent(const AtomString& eventType, DeviceMotionData*);
+    DeviceMotionEvent(const AtomString& type, Init&&, IsTrusted);
 
     RefPtr<DeviceMotionData> m_deviceMotionData;
 };

--- a/Source/WebCore/dom/DeviceMotionEvent.idl
+++ b/Source/WebCore/dom/DeviceMotionEvent.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,23 +29,14 @@
     Exposed=Window,
     SecureContext
 ] interface DeviceMotionEvent : Event {
-    // FIXME: Add support for `DeviceMotionEvent` constructor.
-    // constructor(DOMString type, optional DeviceMotionEventInit eventInitDict = {});
+    constructor([AtomString] DOMString type, optional DeviceMotionEventInit eventInitDict = {});
 
     readonly attribute Acceleration? acceleration;
     readonly attribute Acceleration? accelerationIncludingGravity;
     readonly attribute RotationRate? rotationRate;
-    readonly attribute unrestricted double? interval;
+    readonly attribute unrestricted double interval;
 
     [CallWith=CurrentDocument, EnabledBySetting=DeviceOrientationPermissionAPIEnabled] static Promise<DeviceOrientationOrMotionPermissionState> requestPermission();
-
-    undefined initDeviceMotionEvent(optional [AtomString] DOMString type = "",
-                               optional boolean bubbles = false,
-                               optional boolean cancelable = false,
-                               optional Acceleration? acceleration = null,
-                               optional Acceleration? accelerationIncludingGravity = null,
-                               optional RotationRate? rotationRate = null,
-                               optional unrestricted double? interval = null);
 };
 
 // https://w3c.github.io/deviceorientation/#dictdef-devicemotioneventaccelerationinit
@@ -70,4 +61,14 @@
     double? alpha = null;
     double? beta = null;
     double? gamma = null;
+};
+
+// https://w3c.github.io/deviceorientation/#dictdef-devicemotioneventinit
+[
+    Conditional=DEVICE_ORIENTATION,
+] dictionary DeviceMotionEventInit : EventInit {
+    Acceleration acceleration;
+    Acceleration accelerationIncludingGravity;
+    RotationRate rotationRate;
+    double interval = 0;
 };


### PR DESCRIPTION
#### b75a96c8dc729226d94e528f614e6b7c96a914c7
<pre>
Sync `DeviceMotionEvent` as per web specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=271098">https://bugs.webkit.org/show_bug.cgi?id=271098</a>
<a href="https://rdar.apple.com/problem/125271931">rdar://problem/125271931</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Blink / Chrome and Web Specification [1]:

[1] <a href="https://w3c.github.io/deviceorientation/#device-motion-event-api">https://w3c.github.io/deviceorientation/#device-motion-event-api</a>

By removing `initDeviceMotionEvent`, WebKit aligns with Web Specification
and Blink also removed it in 2017 via below commit:

Reference: <a href="https://chromium.googlesource.com/chromium/src.git/+/0921e8319f228e406019b434701ac9f181ee8ea1">https://chromium.googlesource.com/chromium/src.git/+/0921e8319f228e406019b434701ac9f181ee8ea1</a>

Additionally, it also make &apos;interval&apos; non-nullable. Also adding &apos;=null&apos;
values for &apos;Accelerate&apos; and &apos;Rotate&apos; dictonaries.

Additionally, we now also add `constructor`, which had FIXME.

* Source/WebCore/dom/DeviceMotionData.cpp:
(WebCore::DeviceMotionData::create):
(WebCore::DeviceMotionData::DeviceMotionData):
* Source/WebCore/dom/DeviceMotionData.h:
(WebCore::DeviceMotionData::interval const):
* Source/WebCore/dom/DeviceMotionEvent.cpp:
(WebCore::convert):
(WebCore::DeviceMotionEvent::interval const):
(WebCore::DeviceMotionEvent::create):
(WebCore::DeviceMotionEvent::DeviceMotionEvent):
(WebCore::DeviceMotionEvent::initDeviceMotionEvent): Deleted.
* Source/WebCore/dom/DeviceMotionEvent.h:
* Source/WebCore/dom/DeviceMotionEvent.idl:
* LayoutTests/fast/dom/DeviceMotion/optional-event-properties.html: Rebaselined
* LayoutTests/fast/dom/DeviceMotion/optional-event-properties-expected.txt: Rebaselined
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b75a96c8dc729226d94e528f614e6b7c96a914c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148809 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21522 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15091 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157494 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102239 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e80220cb-88a6-472d-8257-4dc8e94a6522) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150682 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21974 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21400 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/157494 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/102239 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1467338e-cbb7-49b8-8481-978637d023c6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151769 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/21974 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/15091 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/157494 "Hash b75a96c8 for PR 26001 does not build (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c726ac8c-cef8-4fa4-b74d-71152f3bf21b) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/21974 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/168/builds/15091 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5259 "Hash b75a96c8 for PR 26001 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/21974 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/15091 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159832 "Hash b75a96c8 for PR 26001 does not build (failure)") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2969 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/15091 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/159832 "Hash b75a96c8 for PR 26001 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21324 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/21400 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/159832 "Hash b75a96c8 for PR 26001 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21332 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/15091 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77520 "Hash b75a96c8 for PR 26001 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/15091 "Hash b75a96c8 for PR 26001 does not build (failure)") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20934 "Hash b75a96c8 for PR 26001 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84736 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20666 "Hash b75a96c8 for PR 26001 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20813 "Hash b75a96c8 for PR 26001 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20722 "Hash b75a96c8 for PR 26001 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->