### PR TITLE
[Unified Text Replacement] Replacing text with non-trivial attributed string attributes can sometimes cause a crash

### DIFF
--- a/Source/WebCore/editing/cocoa/HTMLConverter.h
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.h
@@ -30,13 +30,11 @@ namespace WebCore {
 
 WEBCORE_EXPORT AttributedString attributedString(const SimpleRange&);
 
-#if PLATFORM(MAC)
 // This alternate implementation of HTML conversion doesn't handle as many advanced features,
 // such as tables, and doesn't produce document attributes, but it does use TextIterator so
 // text offsets will exactly match plain text and other editing machinery.
 // FIXME: This function and the one above should be merged.
 enum class IncludeImages : bool { No, Yes };
 WEBCORE_EXPORT AttributedString editingAttributedString(const SimpleRange&, IncludeImages = IncludeImages::Yes);
-#endif
 
 } // namespace WebCore


### PR DESCRIPTION
#### 2fd8f81aac4e867ffe107c0e1b3e34b1628c0953
<pre>
[Unified Text Replacement] Replacing text with non-trivial attributed string attributes can sometimes cause a crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=271105">https://bugs.webkit.org/show_bug.cgi?id=271105</a>
<a href="https://rdar.apple.com/123712304">rdar://123712304</a>

Reviewed by Aditya Keerthi.

Currently, the original selected range isn&apos;t guaranteed to fit within the context attributed string,
due to the slight differences between HTMLConverter and TextIterator. To fix, `editingAttributedString`
will now be used, which uses TextIterator itself. Also add an assertion to ensure this postcondition
is true.

The replaced, expanded selection range was also being formed incorrectly, impacting subsequent calls
of the function. A partial fix is done by using the context string instead of the replaced string,
since the range is relative to the former. Additionally, the `extendedBoundaryPoint` method is altered
to use a slightly different mechanism of expanding based on the number of characters, to completely
fix this issue.

Also add a precondition check to ensure the range passed in as the parameter is a valid range within
the context range.

* Source/WebCore/editing/cocoa/HTMLConverter.h:
* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(WebCore::editingAttributedString):
* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm:
(WebKit::extendedBoundaryPoint):
(WebKit::UnifiedTextReplacementController::willBeginTextReplacementSession):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithReplacementRange):

Canonical link: <a href="https://commits.webkit.org/276313@main">https://commits.webkit.org/276313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b7329e5dc5f0e77e8cf48fbb8f99c8cffdc1ca3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46966 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20781 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38162 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39275 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2365 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40504 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/39557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48574 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19295 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9850 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->