### PR TITLE
[Legacy line layout removal] Remove hyphenation

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h
@@ -56,7 +56,7 @@ public:
 
     unsigned char bidiLevel() const { return m_inlineBox->bidiLevel(); }
 
-    bool hasHyphen() const { return inlineTextBox()->hasHyphen(); }
+    bool hasHyphen() const { return false; }
     StringView originalText() const { return StringView(inlineTextBox()->renderer().text()).substring(inlineTextBox()->start(), inlineTextBox()->len()); }
     size_t lineIndex() const
     {
@@ -74,9 +74,8 @@ public:
     TextRun textRun(TextRunMode mode = TextRunMode::Painting) const
     {
         bool ignoreCombinedText = mode == TextRunMode::Editing;
-        bool ignoreHyphen = mode == TextRunMode::Editing;
         if (isText())
-            return inlineTextBox()->createTextRun(ignoreCombinedText, ignoreHyphen);
+            return inlineTextBox()->createTextRun(ignoreCombinedText);
         ASSERT_NOT_REACHED();
         return TextRun { emptyString() };
     }

--- a/Source/WebCore/platform/text/BidiResolver.h
+++ b/Source/WebCore/platform/text/BidiResolver.h
@@ -174,7 +174,6 @@ public:
     unsigned m_stop;
     unsigned char m_level;
     bool m_override : 1;
-    bool m_hasHyphen : 1; // Used by BidiRun subclass which is a layering violation but enables us to save 8 bytes per object on 64-bit.
 };
 
 enum VisualDirectionOverride {

--- a/Source/WebCore/rendering/BidiRun.cpp
+++ b/Source/WebCore/rendering/BidiRun.cpp
@@ -40,8 +40,6 @@ BidiRun::BidiRun(unsigned start, unsigned stop, RenderObject& renderer, BidiCont
     bidiRunCounter.increment();
 #endif
     ASSERT(!is<RenderText>(m_renderer) || static_cast<unsigned>(stop) <= downcast<RenderText>(m_renderer).text().length());
-    // Stored in base class to save space.
-    m_hasHyphen = false;
 }
 
 BidiRun::~BidiRun()

--- a/Source/WebCore/rendering/LegacyInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineBox.cpp
@@ -45,7 +45,7 @@ struct SameSizeAsLegacyInlineBox {
     void* a[3];
     SingleThreadWeakPtr<RenderObject> r;
     FloatPoint b;
-    float c[2];
+    float c[1];
     unsigned d : 23;
 #if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
     unsigned s;
@@ -136,8 +136,6 @@ float LegacyInlineBox::logicalHeight() const
     const RenderStyle& lineStyle = this->lineStyle();
     if (renderer().isRenderTextOrLineBreak())
         return lineStyle.metricsOfPrimaryFont().intHeight();
-    if (auto* box = dynamicDowncast<RenderBox>(renderer()); box && parent())
-        return isHorizontal() ? box->height() : box->width();
 
     ASSERT(isInlineFlowBox());
     RenderBoxModelObject* flowObject = boxModelObject();
@@ -178,12 +176,6 @@ void LegacyInlineBox::dirtyLineBoxes()
 void LegacyInlineBox::adjustPosition(float dx, float dy)
 {
     m_topLeft.move(dx, dy);
-
-    if (renderer().isOutOfFlowPositioned())
-        return;
-
-    if (renderer().isReplacedOrInlineBlock())
-        downcast<RenderBox>(renderer()).move(LayoutUnit(dx), LayoutUnit(dy));
 }
 
 const LegacyRootInlineBox& LegacyInlineBox::root() const

--- a/Source/WebCore/rendering/LegacyInlineBox.h
+++ b/Source/WebCore/rendering/LegacyInlineBox.h
@@ -242,25 +242,6 @@ public:
     bool knownToHaveNoOverflow() const { return m_bitfields.knownToHaveNoOverflow(); }
     void clearKnownToHaveNoOverflow();
 
-    void setExpansion(float newExpansion)
-    {
-        m_logicalWidth -= m_expansion;
-        m_expansion = newExpansion;
-        m_logicalWidth += m_expansion;
-    }
-    void setExpansionWithoutGrowing(float newExpansion)
-    {
-        ASSERT(!m_expansion);
-        m_expansion = newExpansion;
-    }
-    float expansion() const { return m_expansion; }
-
-    void setHasHyphen(bool hasHyphen) { m_bitfields.setHasEllipsisBoxOrHyphen(hasHyphen); }
-    void setCanHaveLeftExpansion(bool canHaveLeftExpansion) { m_bitfields.setCanHaveLeftExpansion(canHaveLeftExpansion); }
-    void setCanHaveRightExpansion(bool canHaveRightExpansion) { m_bitfields.setCanHaveRightExpansion(canHaveRightExpansion); }
-    void setForceRightExpansion() { m_bitfields.setForceRightExpansion(true); }
-    void setForceLeftExpansion() { m_bitfields.setForceLeftExpansion(true); }
-
 private:
     LegacyInlineBox* m_nextOnLine { nullptr }; // The next element on the same line as us.
     LegacyInlineBox* m_previousOnLine { nullptr }; // The previous element on the same line as us.
@@ -271,7 +252,6 @@ private:
 
 private:
     float m_logicalWidth { 0 };
-    float m_expansion { 0 };
     FloatPoint m_topLeft;
 
 #define ADD_BOOLEAN_BITFIELD(name, Name) \
@@ -292,12 +272,7 @@ private:
             , m_hasVirtualLogicalHeight(false)
             , m_isHorizontal(isHorizontal)
             , m_endsWithBreak(false)
-            , m_canHaveLeftExpansion(false)
-            , m_canHaveRightExpansion(false)
-            , m_knownToHaveNoOverflow(true)  
-            , m_hasEllipsisBoxOrHyphen(false)
-            , m_forceRightExpansion(false)
-            , m_forceLeftExpansion(false)
+            , m_knownToHaveNoOverflow(true)
             , m_determinedIfNextOnLineExists(false)
             , m_nextOnLineExists(false)
         {
@@ -322,13 +297,8 @@ private:
         // for RootInlineBox
         ADD_BOOLEAN_BITFIELD(endsWithBreak, EndsWithBreak); // Whether the line ends with a <br>.
         // shared between RootInlineBox and LegacyInlineTextBox
-        ADD_BOOLEAN_BITFIELD(canHaveLeftExpansion, CanHaveLeftExpansion);
-        ADD_BOOLEAN_BITFIELD(canHaveRightExpansion, CanHaveRightExpansion);
         ADD_BOOLEAN_BITFIELD(knownToHaveNoOverflow, KnownToHaveNoOverflow);
-        ADD_BOOLEAN_BITFIELD(hasEllipsisBoxOrHyphen, HasEllipsisBoxOrHyphen);
         // for LegacyInlineTextBox
-        ADD_BOOLEAN_BITFIELD(forceRightExpansion, ForceRightExpansion);
-        ADD_BOOLEAN_BITFIELD(forceLeftExpansion, ForceLeftExpansion);
         ADD_BOOLEAN_BITFIELD(isInGlyphDisplayListCache, IsInGlyphDisplayListCache);
 
     private:
@@ -371,11 +341,6 @@ protected:
     void setEndsWithBreak(bool endsWithBreak) { m_bitfields.setEndsWithBreak(endsWithBreak); }
 
     // For LegacyInlineTextBox
-    bool hasHyphen() const { return m_bitfields.hasEllipsisBoxOrHyphen(); }
-    bool canHaveLeftExpansion() const { return m_bitfields.canHaveLeftExpansion(); }
-    bool canHaveRightExpansion() const { return m_bitfields.canHaveRightExpansion(); }
-    bool forceRightExpansion() const { return m_bitfields.forceRightExpansion(); }
-    bool forceLeftExpansion() const { return m_bitfields.forceLeftExpansion(); }
     bool isInGlyphDisplayListCache() const { return m_bitfields.isInGlyphDisplayListCache(); }
     void setIsInGlyphDisplayListCache(bool inCache = true) { m_bitfields.setIsInGlyphDisplayListCache(inCache); }
     

--- a/Source/WebCore/rendering/LegacyInlineTextBox.h
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.h
@@ -75,16 +75,6 @@ public:
 
     void markDirty(bool dirty = true) final;
 
-    using LegacyInlineBox::hasHyphen;
-    using LegacyInlineBox::setHasHyphen;
-    using LegacyInlineBox::canHaveLeftExpansion;
-    using LegacyInlineBox::setCanHaveLeftExpansion;
-    using LegacyInlineBox::canHaveRightExpansion;
-    using LegacyInlineBox::setCanHaveRightExpansion;
-    using LegacyInlineBox::forceRightExpansion;
-    using LegacyInlineBox::setForceRightExpansion;
-    using LegacyInlineBox::forceLeftExpansion;
-    using LegacyInlineBox::setForceLeftExpansion;
     using LegacyInlineBox::setIsInGlyphDisplayListCache;
 
     LayoutUnit baselinePosition(FontBaseline) const final;
@@ -149,10 +139,8 @@ private:
     const RenderCombineText* combinedText() const;
     const FontCascade& lineFont() const;
 
-    String text(bool ignoreCombinedText = false, bool ignoreHyphen = false) const; // The effective text for the run.
-    TextRun createTextRun(bool ignoreCombinedText = false, bool ignoreHyphen = false) const;
-
-    ExpansionBehavior expansionBehavior() const;
+    String text(bool ignoreCombinedText = false) const; // The effective text for the run.
+    TextRun createTextRun(bool ignoreCombinedText = false) const;
 
     LegacyInlineTextBox* m_prevTextBox { nullptr }; // The previous box that also uses our RenderObject
     LegacyInlineTextBox* m_nextTextBox { nullptr }; // The next box that also uses our RenderObject

--- a/Source/WebCore/rendering/LegacyLineLayout.h
+++ b/Source/WebCore/rendering/LegacyLineLayout.h
@@ -83,7 +83,7 @@ private:
     inline BidiRun* handleTrailingSpaces(BidiRunList<BidiRun>& bidiRuns, BidiContext* currentContext);
     LegacyRootInlineBox* createLineBoxesFromBidiRuns(unsigned bidiLevel, BidiRunList<BidiRun>& bidiRuns, const LegacyInlineIterator& end, LineInfo&);
     void layoutRunsAndFloats(LineLayoutState&, bool hasInlineChild);
-    void layoutRunsAndFloatsInRange(LineLayoutState&, InlineBidiResolver&, const LegacyInlineIterator& cleanLineStart, unsigned consecutiveHyphenatedLines);
+    void layoutRunsAndFloatsInRange(LineLayoutState&, InlineBidiResolver&, const LegacyInlineIterator& cleanLineStart);
     void linkToEndLineIfNeeded(LineLayoutState&);
     LegacyRootInlineBox* determineStartPosition(LineLayoutState&, InlineBidiResolver&);
     void determineEndPosition(LineLayoutState&, LegacyRootInlineBox* startLine, LegacyInlineIterator& cleanLineStart);

--- a/Source/WebCore/rendering/LegacyRootInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.cpp
@@ -64,16 +64,6 @@ LegacyRootInlineBox::~LegacyRootInlineBox()
 {
 }
 
-bool LegacyRootInlineBox::isHyphenated() const
-{
-    for (auto* box = firstLeafDescendant(); box; box = box->nextLeafOnLine()) {
-        auto* textBox = dynamicDowncast<LegacyInlineTextBox>(*box);
-        if (textBox && textBox->hasHyphen())
-            return true;
-    }
-    return false;
-}
-
 LayoutUnit LegacyRootInlineBox::baselinePosition(FontBaseline baselineType) const
 {
     return renderer().baselinePosition(baselineType, isFirstLine(), isHorizontal() ? HorizontalLine : VerticalLine, PositionOfInteriorLineBoxes);

--- a/Source/WebCore/rendering/LegacyRootInlineBox.h
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.h
@@ -82,8 +82,6 @@ public:
 
     void childRemoved(LegacyInlineBox*);
 
-    bool isHyphenated() const;
-
     LayoutUnit baselinePosition(FontBaseline baselineType) const final;
     LayoutUnit lineHeight() const final;
 

--- a/Source/WebCore/rendering/line/LineBreaker.cpp
+++ b/Source/WebCore/rendering/line/LineBreaker.cpp
@@ -30,11 +30,6 @@
 
 namespace WebCore {
 
-void LineBreaker::reset()
-{
-    m_hyphenated = false;
-}
-
 void LineBreaker::skipTrailingWhitespace(LegacyInlineIterator& iterator, const LineInfo& lineInfo)
 {
     while (!iterator.atEnd() && !requiresLineBox(iterator, lineInfo, TrailingWhitespace))
@@ -57,10 +52,8 @@ void LineBreaker::skipLeadingWhitespace(InlineBidiResolver& resolver, LineInfo& 
     resolver.commitExplicitEmbedding();
 }
 
-LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, LineInfo& lineInfo, RenderTextInfo& renderTextInfo, unsigned consecutiveHyphenatedLines, WordMeasurements& wordMeasurements)
+LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, LineInfo& lineInfo, RenderTextInfo& renderTextInfo, WordMeasurements& wordMeasurements)
 {
-    reset();
-
     ASSERT(resolver.position().root() == &m_block);
 
     bool appliedStartWidth = resolver.position().offset();
@@ -79,7 +72,7 @@ LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, Li
         if (context.currentObject()->isRenderInline()) {
             context.handleEmptyInline();
         } else if (context.currentObject()->isRenderText()) {
-            if (context.handleText(wordMeasurements, m_hyphenated, consecutiveHyphenatedLines)) {
+            if (context.handleText(wordMeasurements)) {
                 // We've hit a hard text line break. Our line break iterator is updated, so early return.
                 return context.lineBreak();
             }

--- a/Source/WebCore/rendering/line/LineBreaker.h
+++ b/Source/WebCore/rendering/line/LineBreaker.h
@@ -47,21 +47,15 @@ public:
     explicit LineBreaker(RenderBlockFlow& block)
         : m_block(block)
     {
-        reset();
     }
 
-    LegacyInlineIterator nextLineBreak(InlineBidiResolver&, LineInfo&, RenderTextInfo&, unsigned consecutiveHyphenatedLines, WordMeasurements&);
-
-    bool lineWasHyphenated() { return m_hyphenated; }
+    LegacyInlineIterator nextLineBreak(InlineBidiResolver&, LineInfo&, RenderTextInfo&, WordMeasurements&);
 
 private:
-    void reset();
-
     void skipTrailingWhitespace(LegacyInlineIterator&, const LineInfo&);
     void skipLeadingWhitespace(InlineBidiResolver&, LineInfo&);
 
     RenderBlockFlow& m_block;
-    bool m_hyphenated;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 9ac555f80a69415b0d9e2743ab50a5fda4487c0d
<pre>
[Legacy line layout removal] Remove hyphenation
<a href="https://bugs.webkit.org/show_bug.cgi?id=271106">https://bugs.webkit.org/show_bug.cgi?id=271106</a>
<a href="https://rdar.apple.com/problem/124730805">rdar://problem/124730805</a>

Reviewed by Alan Baradlay.

SVG does not hyphenate, or break lines in general.

* Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h:
(WebCore::InlineIterator::BoxLegacyPath::hasHyphen const):
(WebCore::InlineIterator::BoxLegacyPath::textRun const):
* Source/WebCore/platform/text/BidiResolver.h:
* Source/WebCore/rendering/BidiRun.cpp:
(WebCore::BidiRun::BidiRun):
* Source/WebCore/rendering/LegacyInlineBox.cpp:
(WebCore::LegacyInlineBox::logicalHeight const):
(WebCore::LegacyInlineBox::adjustPosition):
* Source/WebCore/rendering/LegacyInlineBox.h:
(WebCore::LegacyInlineBox::InlineBoxBitfields::InlineBoxBitfields):
(WebCore::LegacyInlineBox::setExpansion): Deleted.
(WebCore::LegacyInlineBox::setExpansionWithoutGrowing): Deleted.
(WebCore::LegacyInlineBox::expansion const): Deleted.
(WebCore::LegacyInlineBox::setHasHyphen): Deleted.
(WebCore::LegacyInlineBox::setCanHaveLeftExpansion): Deleted.
(WebCore::LegacyInlineBox::setCanHaveRightExpansion): Deleted.
(WebCore::LegacyInlineBox::setForceRightExpansion): Deleted.
(WebCore::LegacyInlineBox::setForceLeftExpansion): Deleted.
(WebCore::LegacyInlineBox::hasHyphen const): Deleted.
(WebCore::LegacyInlineBox::canHaveLeftExpansion const): Deleted.
(WebCore::LegacyInlineBox::canHaveRightExpansion const): Deleted.
(WebCore::LegacyInlineBox::forceRightExpansion const): Deleted.
(WebCore::LegacyInlineBox::forceLeftExpansion const): Deleted.

Also remove some other unused leftovers.

* Source/WebCore/rendering/LegacyInlineTextBox.cpp:
(WebCore::LegacyInlineTextBox::selectableRange const):
(WebCore::LegacyInlineTextBox::createTextRun const):
(WebCore::LegacyInlineTextBox::text const):
(WebCore::LegacyInlineTextBox::expansionBehavior const): Deleted.
* Source/WebCore/rendering/LegacyInlineTextBox.h:
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::constructLine):
(WebCore::LegacyLineLayout::layoutRunsAndFloats):
(WebCore::LegacyLineLayout::layoutRunsAndFloatsInRange):
* Source/WebCore/rendering/LegacyLineLayout.h:
* Source/WebCore/rendering/LegacyRootInlineBox.cpp:
(WebCore::LegacyRootInlineBox::isHyphenated const): Deleted.
* Source/WebCore/rendering/LegacyRootInlineBox.h:
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::handleText):
(WebCore::BreakingContext::handleBR): Deleted.
(WebCore::BreakingContext::handleOutOfFlowPositioned): Deleted.
(WebCore::BreakingContext::handleReplaced): Deleted.
(WebCore::measureHyphenWidth): Deleted.
(WebCore::tryHyphenating): Deleted.
* Source/WebCore/rendering/line/LineBreaker.cpp:
(WebCore::LineBreaker::nextLineBreak):
(WebCore::LineBreaker::reset): Deleted.
* Source/WebCore/rendering/line/LineBreaker.h:
(WebCore::LineBreaker::LineBreaker):
(WebCore::LineBreaker::lineWasHyphenated): Deleted.

Canonical link: <a href="https://commits.webkit.org/276241@main">https://commits.webkit.org/276241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1535fef3a6d06bf7f73bf628b248f815bb8d8b33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46765 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40150 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20586 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17390 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17701 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39101 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2173 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40293 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48356 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43222 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20463 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41945 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9808 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20688 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->