### PR TITLE
[GStreamer] Caps negotiation issue in video encoder for I422 formats

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1229,6 +1229,10 @@ imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker.
 imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html [ Pass DumpJSConsoleLogInStdErr ]
 http/wpt/webcodecs/encoder-task-failing.html [ Pass ]
 
+# H.264 high-4:2:2 encoding is supported in the GStreamer ports, so this test (checking that profile
+# is not supported) is expected to fail.
+http/wpt/webcodecs/H264-422.html [ Failure ]
+
 fast/mediacapturefromelement/CanvasCaptureMediaStream-capture-out-of-DOM-canvas-webgl.html [ Pass Failure ]
 
 webkit.org/b/264665 http/wpt/webcodecs/videoFrame-webglCanvasImageSource.html [ Failure ]

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -687,9 +687,9 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                         pixelFormat = "Y444";
                 } else if (g_str_has_prefix(profileString, "high-4:2:2")) {
                     if (supports10BitsLittleEndian)
-                        pixelFormat = "Y422_10LE";
+                        pixelFormat = "I422_10LE";
                     else if (supports10BitsBigEndian)
-                        pixelFormat = "Y422_10BE";
+                        pixelFormat = "I422_10BE";
                     else
                         pixelFormat = "Y42B";
                 } else if (g_str_has_prefix(profileString, "high-10")) {
@@ -915,9 +915,9 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                             pixelFormat = "Y444";
                     } else if (isY422) {
                         if (supports12BitsLittleEndian)
-                            pixelFormat = "Y422_12LE";
+                            pixelFormat = "I422_12LE";
                         else if (supports12BitsBigEndian)
-                            pixelFormat = "Y422_12BE";
+                            pixelFormat = "I422_12BE";
                         else
                             pixelFormat = "Y42B";
                     }


### PR DESCRIPTION
#### b65e2001a308e3a0a86411c0bf91b802157f934f
<pre>
[GStreamer] Caps negotiation issue in video encoder for I422 formats
<a href="https://bugs.webkit.org/show_bug.cgi?id=271110">https://bugs.webkit.org/show_bug.cgi?id=271110</a>

Reviewed by Xabier Rodriguez-Calvar.

The encoder was being configured to convert input buffers to Y422, which is not a valid GStreamer
video format. Use I422 instead.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(webkit_video_encoder_class_init):

Canonical link: <a href="https://commits.webkit.org/276261@main">https://commits.webkit.org/276261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ea875c32e2ea70834e57a07c2ef80bc978b5867

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46754 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40139 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46417 "Failed to checkout and rebase branch from PR 26007") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36348 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17378 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39088 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2162 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48342 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15661 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43209 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20452 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41932 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9819 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->