### PR TITLE
[Skia] Add support for font render properties

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1913,6 +1913,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/FontPaletteValues.h
     platform/graphics/FontPlatformData.h
     platform/graphics/FontRanges.h
+    platform/graphics/FontRenderOptions.h
     platform/graphics/FontSelectionAlgorithm.h
     platform/graphics/FontSelector.h
     platform/graphics/FontSelectorClient.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2284,6 +2284,7 @@ platform/graphics/FontFeatureValues.cpp
 platform/graphics/FontGenericFamilies.cpp
 platform/graphics/FontPlatformData.cpp
 platform/graphics/FontRanges.cpp
+platform/graphics/FontRenderOptions.cpp
 platform/graphics/FontSelectionAlgorithm.cpp
 platform/graphics/FontSelector.cpp
 platform/graphics/FontTaggedSettings.cpp

--- a/Source/WebCore/platform/SourcesCairo.txt
+++ b/Source/WebCore/platform/SourcesCairo.txt
@@ -25,6 +25,7 @@ platform/graphics/cairo/CairoOperations.cpp
 platform/graphics/cairo/CairoUtilities.cpp @no-unify
 platform/graphics/cairo/FloatRectCairo.cpp
 platform/graphics/cairo/FontCairo.cpp
+platform/graphics/cairo/FontRenderOptionsCairo.cpp
 platform/graphics/cairo/GradientCairo.cpp
 platform/graphics/cairo/GraphicsContextCairo.cpp
 platform/graphics/cairo/GraphicsContextGLCairo.cpp

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -34,6 +34,7 @@ platform/graphics/skia/FontCascadeSkia.cpp
 platform/graphics/skia/FontCustomPlatformDataSkia.cpp
 platform/graphics/skia/FontDescriptionSkia.cpp
 platform/graphics/skia/FontPlatformDataSkia.cpp
+platform/graphics/skia/FontRenderOptionsSkia.cpp
 platform/graphics/skia/FontSkia.cpp
 platform/graphics/skia/FontVariationsSkia.cpp
 platform/graphics/skia/GlyphPageSkia.cpp

--- a/Source/WebCore/platform/graphics/FontRenderOptions.cpp
+++ b/Source/WebCore/platform/graphics/FontRenderOptions.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FontRenderOptions.h"
+
+#if USE(CAIRO) || USE(SKIA)
+
+namespace WebCore {
+
+FontRenderOptions& FontRenderOptions::singleton()
+{
+    static NeverDestroyed<FontRenderOptions> options;
+    return options;
+}
+
+} // namespace WebCore
+
+#endif // USE(CAIRO) || USE(SKIA)
+

--- a/Source/WebCore/platform/graphics/FontRenderOptions.h
+++ b/Source/WebCore/platform/graphics/FontRenderOptions.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CAIRO) || USE(SKIA)
+#include <optional>
+#include <wtf/NeverDestroyed.h>
+
+#if USE(CAIRO)
+#include "CairoUniquePtr.h"
+#elif USE(SKIA)
+#include <skia/core/SkFont.h>
+#include <skia/core/SkFontTypes.h>
+#include <skia/core/SkSurfaceProps.h>
+#endif
+
+namespace WebCore {
+
+class FontRenderOptions {
+    friend class NeverDestroyed<FontRenderOptions>;
+public:
+    WEBCORE_EXPORT static FontRenderOptions& singleton();
+
+    enum class Hinting {
+        None,
+        Slight,
+        Medium,
+        Full
+    };
+
+    enum class Antialias {
+        None,
+        Normal,
+        Subpixel
+    };
+
+    enum class SubpixelOrder {
+        Unknown,
+        HorizontalRGB,
+        HorizontalBGR,
+        VerticalRGB,
+        VerticalBGR
+    };
+
+    void setHinting(std::optional<Hinting>);
+    void setAntialias(std::optional<Antialias>);
+    void setSubpixelOrder(std::optional<SubpixelOrder>);
+
+#if USE(CAIRO)
+    const cairo_font_options_t* fontOptions() const { return m_fontOptions.get(); }
+#elif USE(SKIA)
+    SkFontHinting hinting() const { return m_hinting; }
+    SkFont::Edging antialias() const { return m_antialias; }
+    SkPixelGeometry subpixelOrder() const { return m_subpixelOrder; }
+#endif
+
+    WEBCORE_EXPORT void disableHintingForTesting();
+
+private:
+    FontRenderOptions();
+    ~FontRenderOptions() = default;
+
+#if USE(CAIRO)
+    CairoUniquePtr<cairo_font_options_t> m_fontOptions;
+#elif USE(SKIA)
+    SkFontHinting m_hinting { SkFontHinting::kNormal };
+    SkFont::Edging m_antialias { SkFont::Edging::kAntiAlias };
+    SkPixelGeometry m_subpixelOrder { kUnknown_SkPixelGeometry };
+#endif
+    bool m_isHintingDisabledForTesting { false };
+};
+
+} // namespace WebCore
+
+#endif // USE(CAIRO) || USE(SKIA)

--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
@@ -33,6 +33,7 @@
 #include "Color.h"
 #include "FloatPoint.h"
 #include "FloatRect.h"
+#include "FontRenderOptions.h"
 #include "IntRect.h"
 #include "Path.h"
 #include "RefPtrCairo.h"
@@ -60,40 +61,9 @@ RecursiveLock& cairoFontLock()
 }
 #endif
 
-static cairo_font_options_t* defaultCairoFontOptions()
-{
-    static cairo_font_options_t* s_defaultCairoFontOptions = cairo_font_options_create();
-    return s_defaultCairoFontOptions;
-}
-
 const cairo_font_options_t* getDefaultCairoFontOptions()
 {
-    return defaultCairoFontOptions();
-}
-
-static bool s_disableCairoFontHintingForTesting = false;
-
-void disableCairoFontHintingForTesting()
-{
-    cairo_font_options_set_hint_metrics(defaultCairoFontOptions(), CAIRO_HINT_METRICS_ON);
-    cairo_font_options_set_hint_style(defaultCairoFontOptions(), CAIRO_HINT_STYLE_NONE);
-
-    s_disableCairoFontHintingForTesting = true;
-}
-
-void setDefaultCairoHintOptions(cairo_hint_metrics_t hintMetrics, cairo_hint_style_t hintStyle)
-{
-    if (s_disableCairoFontHintingForTesting)
-        return;
-
-    cairo_font_options_set_hint_metrics(defaultCairoFontOptions(), hintMetrics);
-    cairo_font_options_set_hint_style(defaultCairoFontOptions(), hintStyle);
-}
-
-void setDefaultCairoAntialiasOptions(cairo_antialias_t antialias, cairo_subpixel_order_t subpixelOrder)
-{
-    cairo_font_options_set_antialias(defaultCairoFontOptions(), antialias);
-    cairo_font_options_set_subpixel_order(defaultCairoFontOptions(), subpixelOrder);
+    return FontRenderOptions::singleton().fontOptions();
 }
 
 void copyContextProperties(cairo_t* srcCr, cairo_t* dstCr)

--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
@@ -77,11 +77,6 @@ private:
 
 const cairo_font_options_t* getDefaultCairoFontOptions();
 
-void setDefaultCairoHintOptions(cairo_hint_metrics_t, cairo_hint_style_t);
-void setDefaultCairoAntialiasOptions(cairo_antialias_t, cairo_subpixel_order_t);
-
-void disableCairoFontHintingForTesting();
-
 void copyContextProperties(cairo_t* srcCr, cairo_t* dstCr);
 void setSourceRGBAFromColor(cairo_t*, const Color&);
 void appendPathToCairoContext(cairo_t* to, cairo_t* from);

--- a/Source/WebCore/platform/graphics/cairo/FontRenderOptionsCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontRenderOptionsCairo.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FontRenderOptions.h"
+
+#if USE(CAIRO)
+
+namespace WebCore {
+
+FontRenderOptions::FontRenderOptions()
+    : m_fontOptions(cairo_font_options_create())
+{
+}
+
+void FontRenderOptions::setHinting(std::optional<Hinting> hinting)
+{
+    if (m_isHintingDisabledForTesting)
+        return;
+
+    cairo_font_options_set_hint_metrics(m_fontOptions.get(), CAIRO_HINT_METRICS_ON);
+    if (!hinting.has_value()) {
+        cairo_font_options_set_hint_style(m_fontOptions.get(), CAIRO_HINT_STYLE_DEFAULT);
+        return;
+    }
+
+    switch (hinting.value()) {
+    case Hinting::None:
+        cairo_font_options_set_hint_style(m_fontOptions.get(), CAIRO_HINT_STYLE_NONE);
+        break;
+    case Hinting::Slight:
+        cairo_font_options_set_hint_style(m_fontOptions.get(), CAIRO_HINT_STYLE_SLIGHT);
+        break;
+    case Hinting::Medium:
+        cairo_font_options_set_hint_style(m_fontOptions.get(), CAIRO_HINT_STYLE_MEDIUM);
+        break;
+    case Hinting::Full:
+        cairo_font_options_set_hint_style(m_fontOptions.get(), CAIRO_HINT_STYLE_FULL);
+        break;
+    }
+}
+
+void FontRenderOptions::setAntialias(std::optional<Antialias> antialias)
+{
+    if (!antialias.has_value()) {
+        cairo_font_options_set_antialias(m_fontOptions.get(), CAIRO_ANTIALIAS_DEFAULT);
+        return;
+    }
+
+    switch (antialias.value()) {
+    case Antialias::None:
+        cairo_font_options_set_antialias(m_fontOptions.get(), CAIRO_ANTIALIAS_NONE);
+        break;
+    case Antialias::Normal:
+        cairo_font_options_set_antialias(m_fontOptions.get(), CAIRO_ANTIALIAS_GRAY);
+        break;
+    case Antialias::Subpixel:
+        cairo_font_options_set_antialias(m_fontOptions.get(), CAIRO_ANTIALIAS_SUBPIXEL);
+        break;
+    }
+}
+
+void FontRenderOptions::setSubpixelOrder(std::optional<SubpixelOrder> subpixelOrder)
+{
+    if (!subpixelOrder.has_value()) {
+        cairo_font_options_set_subpixel_order(m_fontOptions.get(), CAIRO_SUBPIXEL_ORDER_DEFAULT);
+        return;
+    }
+
+    switch (subpixelOrder.value()) {
+    case SubpixelOrder::Unknown:
+        cairo_font_options_set_subpixel_order(m_fontOptions.get(), CAIRO_SUBPIXEL_ORDER_DEFAULT);
+        break;
+    case SubpixelOrder::HorizontalRGB:
+        cairo_font_options_set_subpixel_order(m_fontOptions.get(), CAIRO_SUBPIXEL_ORDER_RGB);
+        break;
+    case SubpixelOrder::HorizontalBGR:
+        cairo_font_options_set_subpixel_order(m_fontOptions.get(), CAIRO_SUBPIXEL_ORDER_BGR);
+        break;
+    case SubpixelOrder::VerticalRGB:
+        cairo_font_options_set_subpixel_order(m_fontOptions.get(), CAIRO_SUBPIXEL_ORDER_VRGB);
+        break;
+    case SubpixelOrder::VerticalBGR:
+        cairo_font_options_set_subpixel_order(m_fontOptions.get(), CAIRO_SUBPIXEL_ORDER_VBGR);
+        break;
+    }
+}
+
+void FontRenderOptions::disableHintingForTesting()
+{
+    cairo_font_options_set_hint_metrics(m_fontOptions.get(), CAIRO_HINT_METRICS_ON);
+    cairo_font_options_set_hint_style(m_fontOptions.get(), CAIRO_HINT_STYLE_NONE);
+    m_isHintingDisabledForTesting = true;
+}
+
+} // namespace WebCore
+
+#endif // USE(CAIRO)

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
@@ -32,6 +32,7 @@
 #include <wtf/FastMalloc.h>
 
 #if USE(SKIA)
+#include "FontRenderOptions.h"
 #include "PlatformDisplay.h"
 #include <skia/core/SkCanvas.h>
 #include <skia/core/SkImage.h>
@@ -90,7 +91,8 @@ UnacceleratedBuffer::UnacceleratedBuffer(const WebCore::IntSize& size, Flags fla
 #if USE(SKIA)
     auto imageInfo = SkImageInfo::MakeN32Premul(size.width(), size.height());
     // FIXME: ref buffer and unref on release proc?
-    m_surface = SkSurfaces::WrapPixels(imageInfo, m_data.get(), imageInfo.minRowBytes64(), nullptr);
+    SkSurfaceProps properties = { 0, WebCore::FontRenderOptions::singleton().subpixelOrder() };
+    m_surface = SkSurfaces::WrapPixels(imageInfo, m_data.get(), imageInfo.minRowBytes64(), &properties);
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontPlatformDataSkia.cpp
@@ -28,6 +28,7 @@
 
 #include "FontCache.h"
 #include "FontCustomPlatformData.h"
+#include "FontRenderOptions.h"
 #include "FontVariationsSkia.h"
 #include "NotImplemented.h"
 #include "OpenTypeTypes.h"
@@ -45,6 +46,8 @@ FontPlatformData::FontPlatformData(sk_sp<SkTypeface>&& typeface, float size, boo
     m_font = SkFont(typeface, m_size);
     m_font.setEmbolden(m_syntheticBold);
     m_font.setSkewX(m_syntheticOblique ? -SK_Scalar1 / 4 : 0);
+    m_font.setEdging(FontRenderOptions::singleton().antialias());
+    m_font.setHinting(FontRenderOptions::singleton().hinting());
 
     m_hbFont = SkiaHarfBuzzFont::getOrCreate(*m_font.getTypeface());
 

--- a/Source/WebCore/platform/graphics/skia/FontRenderOptionsSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontRenderOptionsSkia.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FontRenderOptions.h"
+
+#if USE(SKIA)
+
+namespace WebCore {
+
+FontRenderOptions::FontRenderOptions() = default;
+
+void FontRenderOptions::setHinting(std::optional<Hinting> hinting)
+{
+    if (m_isHintingDisabledForTesting)
+        return;
+
+    switch (hinting.value_or(Hinting::Medium)) {
+    case Hinting::None:
+        m_hinting = SkFontHinting::kNone;
+        break;
+    case Hinting::Slight:
+        m_hinting = SkFontHinting::kSlight;
+        break;
+    case Hinting::Medium:
+        m_hinting = SkFontHinting::kNormal;
+        break;
+    case Hinting::Full:
+        m_hinting = SkFontHinting::kFull;
+        break;
+    }
+}
+
+void FontRenderOptions::setAntialias(std::optional<Antialias> antialias)
+{
+    switch (antialias.value_or(Antialias::Normal)) {
+    case Antialias::None:
+        m_antialias = SkFont::Edging::kAlias;
+        break;
+    case Antialias::Normal:
+        m_antialias = SkFont::Edging::kAntiAlias;
+        break;
+    case Antialias::Subpixel:
+        m_antialias = SkFont::Edging::kSubpixelAntiAlias;
+        break;
+    }
+}
+
+void FontRenderOptions::setSubpixelOrder(std::optional<SubpixelOrder> subpixelOrder)
+{
+    switch (subpixelOrder.value_or(SubpixelOrder::Unknown)) {
+    case SubpixelOrder::Unknown:
+        m_subpixelOrder = kUnknown_SkPixelGeometry;
+        break;
+    case SubpixelOrder::HorizontalRGB:
+        m_subpixelOrder = kRGB_H_SkPixelGeometry;
+        break;
+    case SubpixelOrder::HorizontalBGR:
+        m_subpixelOrder = kBGR_H_SkPixelGeometry;
+        break;
+    case SubpixelOrder::VerticalRGB:
+        m_subpixelOrder = kRGB_V_SkPixelGeometry;
+        break;
+    case SubpixelOrder::VerticalBGR:
+        m_subpixelOrder = kBGR_V_SkPixelGeometry;
+        break;
+    }
+}
+
+void FontRenderOptions::disableHintingForTesting()
+{
+    m_hinting = SkFontHinting::kNone;
+    m_isHintingDisabledForTesting = true;
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -27,7 +27,7 @@
 #include "ImageBufferSkiaAcceleratedBackend.h"
 
 #if USE(SKIA)
-
+#include "FontRenderOptions.h"
 #include "GLContext.h"
 #include "IntRect.h"
 #include "PixelBuffer.h"
@@ -55,7 +55,8 @@ std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBac
     auto* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
     RELEASE_ASSERT(grContext);
     auto imageInfo = SkImageInfo::MakeN32Premul(backendSize.width(), backendSize.height());
-    auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, nullptr);
+    SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
+    auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, &properties);
     if (!surface)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
@@ -27,7 +27,7 @@
 #include "ImageBufferSkiaUnacceleratedBackend.h"
 
 #if USE(SKIA)
-
+#include "FontRenderOptions.h"
 #include "IntRect.h"
 #include "PixelBuffer.h"
 #include <skia/core/SkPixmap.h>
@@ -44,7 +44,8 @@ std::unique_ptr<ImageBufferSkiaUnacceleratedBackend> ImageBufferSkiaUnaccelerate
         return nullptr;
 
     auto imageInfo = SkImageInfo::MakeN32Premul(backendSize.width(), backendSize.height());
-    auto surface = SkSurfaces::Raster(imageInfo, nullptr);
+    SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
+    auto surface = SkSurfaces::Raster(imageInfo, &properties);
     return std::unique_ptr<ImageBufferSkiaUnacceleratedBackend>(new ImageBufferSkiaUnacceleratedBackend(parameters, WTFMove(surface)));
 }
 

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -28,6 +28,7 @@
 
 #if USE(SKIA)
 
+#include "GLContext.h"
 #include "GraphicsContextSkia.h"
 #include "NotImplemented.h"
 #include "PlatformDisplay.h"

--- a/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
@@ -27,6 +27,7 @@
 #include "ShareableBitmap.h"
 
 #include "BitmapImage.h"
+#include "FontRenderOptions.h"
 #include "GraphicsContextSkia.h"
 #include "NotImplemented.h"
 #include <skia/core/SkSurface.h>
@@ -51,9 +52,10 @@ CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerRow(const IntSize& 
 std::unique_ptr<GraphicsContext> ShareableBitmap::createGraphicsContext()
 {
     ref();
+    SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
     auto surface = SkSurfaces::WrapPixels(m_configuration.imageInfo(), data(), bytesPerRow(), [](void*, void* context) {
         static_cast<ShareableBitmap*>(context)->deref();
-    }, this);
+    }, this, &properties);
     return makeUnique<GraphicsContextSkia>(WTFMove(surface), RenderingMode::Unaccelerated, RenderingPurpose::ShareableSnapshot);
 }
 

--- a/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
@@ -27,6 +27,7 @@
 #include "SkiaAcceleratedBufferPool.h"
 
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "FontRenderOptions.h"
 #include "GLContext.h"
 #include "PlatformDisplay.h"
 #include <skia/gpu/GrBackendSurface.h>
@@ -79,7 +80,8 @@ RefPtr<Nicosia::Buffer> SkiaAcceleratedBufferPool::createAcceleratedBuffer(const
     auto* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
     RELEASE_ASSERT(grContext);
     auto imageInfo = SkImageInfo::MakeN32Premul(size.width(), size.height());
-    auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, nullptr);
+    SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
+    auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, &properties);
     if (!surface)
         return nullptr;
     return Nicosia::AcceleratedBuffer::create(WTFMove(surface), supportsAlpha ? Nicosia::Buffer::SupportsAlpha : Nicosia::Buffer::NoFlags);

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -33,6 +33,7 @@
 #include "WebProcessCreationParameters.h"
 #include "WebProcessExtensionManager.h"
 
+#include <WebCore/FontRenderOptions.h>
 #include <WebCore/PlatformScreen.h>
 #include <WebCore/ScreenProperties.h>
 
@@ -195,10 +196,8 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     AccessibilityAtspi::singleton().connect(parameters.accessibilityBusAddress);
 #endif
 
-#if USE(CAIRO)
     if (parameters.disableFontHintingForTesting)
-        disableCairoFontHintingForTesting();
-#endif
+        FontRenderOptions::singleton().disableHintingForTesting();
 
 #if PLATFORM(GTK)
     GtkSettingsManagerProxy::singleton().applySettings(WTFMove(parameters.gtkSettings));

--- a/Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.cpp
+++ b/Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.cpp
@@ -28,13 +28,10 @@
 
 #include "GtkSettingsManagerProxyMessages.h"
 #include "WebProcess.h"
+#include <WebCore/FontRenderOptions.h>
 #include <WebCore/NotImplemented.h>
 #include <WebCore/Page.h>
 #include <WebCore/RenderTheme.h>
-
-#if USE(CAIRO)
-#include <WebCore/CairoUtilities.h>
-#endif
 
 namespace WebKit {
 using namespace WebCore;
@@ -58,17 +55,17 @@ void GtkSettingsManagerProxy::settingsDidChange(GtkSettingsState&& state)
 
 void GtkSettingsManagerProxy::applySettings(GtkSettingsState&& state)
 {
+    bool shouldUpdateStyle = false;
     if (state.themeName) {
         g_object_set(m_settings, "gtk-theme-name", state.themeName->utf8().data(), nullptr);
         RenderTheme::singleton().platformColorsDidChange();
-        Page::updateStyleForAllPagesAfterGlobalChangeInEnvironment();
+        shouldUpdateStyle = true;
     }
 
     if (state.fontName)
         g_object_set(m_settings, "gtk-font-name", state.fontName->utf8().data(), nullptr);
 
     bool hintingSettingsDidChange = false;
-
     if (state.xftHinting) {
         g_object_set(m_settings, "gtk-xft-hinting", *state.xftHinting, nullptr);
         hintingSettingsDidChange = true;
@@ -79,23 +76,26 @@ void GtkSettingsManagerProxy::applySettings(GtkSettingsState&& state)
         hintingSettingsDidChange = true;
     }
 
-    if (hintingSettingsDidChange)
+    if (hintingSettingsDidChange) {
         applyHintingSettings();
+        shouldUpdateStyle = true;
+    }
 
-    bool antialiasSettingsDidChagne = false;
-
+    bool antialiasSettingsDidChange = false;
     if (state.xftAntialias) {
         g_object_set(m_settings, "gtk-xft-antialias", *state.xftAntialias, nullptr);
-        antialiasSettingsDidChagne = true;
+        antialiasSettingsDidChange = true;
     }
 
     if (state.xftRGBA) {
         g_object_set(m_settings, "gtk-xft-rgba", state.xftRGBA->utf8().data(), nullptr);
-        antialiasSettingsDidChagne = true;
+        antialiasSettingsDidChange = true;
     }
 
-    if (antialiasSettingsDidChagne)
+    if (antialiasSettingsDidChange) {
         applyAntialiasSettings();
+        shouldUpdateStyle = true;
+    }
 
     if (state.xftDPI)
         g_object_set(m_settings, "gtk-xft-dpi", *state.xftDPI, nullptr);
@@ -114,86 +114,70 @@ void GtkSettingsManagerProxy::applySettings(GtkSettingsState&& state)
 
     if (state.enableAnimations)
         g_object_set(m_settings, "gtk-enable-animations", *state.enableAnimations, nullptr);
+
+    if (shouldUpdateStyle)
+        Page::updateStyleForAllPagesAfterGlobalChangeInEnvironment();
 }
 
 void GtkSettingsManagerProxy::applyHintingSettings()
 {
-#if USE(CAIRO)
     gint hinting;
     GUniqueOutPtr<char> hintStyleString;
-    
-    g_object_get(m_settings,
-        "gtk-xft-hinting", &hinting,
-        "gtk-xft-hintstyle", &hintStyleString.outPtr(),
-        nullptr);
+    g_object_get(m_settings, "gtk-xft-hinting", &hinting, "gtk-xft-hintstyle", &hintStyleString.outPtr(), nullptr);
 
-    cairo_hint_metrics_t hintMetrics = CAIRO_HINT_METRICS_ON;
-
-    cairo_hint_style_t hintStyle = CAIRO_HINT_STYLE_DEFAULT;
+    std::optional<FontRenderOptions::Hinting> hintStyle;
     switch (hinting) {
     case 0:
-        hintStyle = CAIRO_HINT_STYLE_NONE;
+        hintStyle = FontRenderOptions::Hinting::None;
         break;
     case 1:
         if (hintStyleString) {
             if (!strcmp(hintStyleString.get(), "hintnone"))
-                hintStyle = CAIRO_HINT_STYLE_NONE;
+                hintStyle = FontRenderOptions::Hinting::None;
             else if (!strcmp(hintStyleString.get(), "hintslight"))
-                hintStyle = CAIRO_HINT_STYLE_SLIGHT;
+                hintStyle = FontRenderOptions::Hinting::Slight;
             else if (!strcmp(hintStyleString.get(), "hintmedium"))
-                hintStyle = CAIRO_HINT_STYLE_MEDIUM;
+                hintStyle = FontRenderOptions::Hinting::Medium;
             else if (!strcmp(hintStyleString.get(), "hintfull"))
-                hintStyle = CAIRO_HINT_STYLE_FULL;
+                hintStyle = FontRenderOptions::Hinting::Full;
         }
         break;
     }
-
-    setDefaultCairoHintOptions(hintMetrics, hintStyle);
-#elif USE(SKIA)
-    notImplemented();
-#endif
+    FontRenderOptions::singleton().setHinting(hintStyle);
 }
 
 void GtkSettingsManagerProxy::applyAntialiasSettings()
 {
-#if USE(CAIRO)
     gint antialias;
     GUniqueOutPtr<char> rgbaString;
+    g_object_get(m_settings, "gtk-xft-antialias", &antialias, "gtk-xft-rgba", &rgbaString.outPtr(), nullptr);
 
-    g_object_get(m_settings,
-        "gtk-xft-antialias", &antialias,
-        "gtk-xft-rgba", &rgbaString.outPtr(),
-        nullptr);
-
-    cairo_subpixel_order_t subpixelOrder = CAIRO_SUBPIXEL_ORDER_DEFAULT;
+    std::optional<FontRenderOptions::SubpixelOrder> subpixelOrder;
     if (rgbaString) {
         if (!strcmp(rgbaString.get(), "rgb"))
-            subpixelOrder = CAIRO_SUBPIXEL_ORDER_RGB;
+            subpixelOrder = FontRenderOptions::SubpixelOrder::HorizontalRGB;
         else if (!strcmp(rgbaString.get(), "bgr"))
-            subpixelOrder = CAIRO_SUBPIXEL_ORDER_BGR;
+            subpixelOrder = FontRenderOptions::SubpixelOrder::HorizontalBGR;
         else if (!strcmp(rgbaString.get(), "vrgb"))
-            subpixelOrder = CAIRO_SUBPIXEL_ORDER_VRGB;
+            subpixelOrder = FontRenderOptions::SubpixelOrder::VerticalRGB;
         else if (!strcmp(rgbaString.get(), "vbgr"))
-            subpixelOrder = CAIRO_SUBPIXEL_ORDER_VBGR;
+            subpixelOrder = FontRenderOptions::SubpixelOrder::VerticalBGR;
     }
+    FontRenderOptions::singleton().setSubpixelOrder(subpixelOrder);
 
-    cairo_antialias_t antialiasMode = CAIRO_ANTIALIAS_DEFAULT;
+    std::optional<FontRenderOptions::Antialias> antialiasMode;
     switch (antialias) {
     case 0:
-        antialiasMode = CAIRO_ANTIALIAS_NONE;
+        antialiasMode = FontRenderOptions::Antialias::None;
         break;
     case 1:
-        if (subpixelOrder != CAIRO_SUBPIXEL_ORDER_DEFAULT)
-            antialiasMode = CAIRO_ANTIALIAS_SUBPIXEL;
+        if (subpixelOrder.has_value())
+            antialiasMode = FontRenderOptions::Antialias::Subpixel;
         else
-            antialiasMode = CAIRO_ANTIALIAS_GRAY;
+            antialiasMode = FontRenderOptions::Antialias::Normal;
         break;
     }
-
-    setDefaultCairoAntialiasOptions(antialiasMode, subpixelOrder);
-#elif USE(SKIA)
-    notImplemented();
-#endif
+    FontRenderOptions::singleton().setAntialias(antialiasMode);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 1e5efc33fac0f5a7214e55db7af541d8f6523260
<pre>
[Skia] Add support for font render properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=271112">https://bugs.webkit.org/show_bug.cgi?id=271112</a>

Reviewed by Michael Catanzaro.

Set hinting, antialias and pixel geometry.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/platform/SourcesCairo.txt:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/FontRenderOptions.cpp: Added.
(WebCore::FontRenderOptions::singleton):
* Source/WebCore/platform/graphics/FontRenderOptions.h: Added.
(WebCore::FontRenderOptions::fontOptions const):
(WebCore::FontRenderOptions::hinting const):
(WebCore::FontRenderOptions::antialias const):
(WebCore::FontRenderOptions::subpixelOrder const):
* Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp:
(WebCore::getDefaultCairoFontOptions):
(WebCore::defaultCairoFontOptions): Deleted.
(WebCore::disableCairoFontHintingForTesting): Deleted.
(WebCore::setDefaultCairoHintOptions): Deleted.
(WebCore::setDefaultCairoAntialiasOptions): Deleted.
* Source/WebCore/platform/graphics/cairo/CairoUtilities.h:
* Source/WebCore/platform/graphics/cairo/FontRenderOptionsCairo.cpp: Added.
(WebCore::FontRenderOptions::FontRenderOptions):
(WebCore::FontRenderOptions::setHinting):
(WebCore::FontRenderOptions::setAntialias):
(WebCore::FontRenderOptions::setSubpixelOrder):
(WebCore::FontRenderOptions::disableHintingForTesting):
* Source/WebCore/platform/graphics/skia/FontRenderOptionsSkia.cpp: Added.
(WebCore::FontRenderOptions::setHinting):
(WebCore::FontRenderOptions::setAntialias):
(WebCore::FontRenderOptions::setSubpixelOrder):
(WebCore::FontRenderOptions::disableHintingForTesting):
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):
* Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.cpp:
(WebKit::GtkSettingsManagerProxy::applyHintingSettings):
(WebKit::GtkSettingsManagerProxy::applyAntialiasSettings):

Canonical link: <a href="https://commits.webkit.org/276255@main">https://commits.webkit.org/276255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fdb6072e24fda693c8f58c78ca482aa5b8f211b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46757 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40142 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36351 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/37991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17382 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17693 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39095 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2165 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40285 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48357 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15667 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43223 "") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20455 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41946 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20680 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6061 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->