### PR TITLE
[UnifiedPDF] Can't click-drag the scrollbar

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2009,6 +2009,11 @@ ScrollableArea* EventHandler::enclosingScrollableArea(Node* node)
                 return scrollableArea;
         }
 
+        if (RefPtr plugin = dynamicDowncast<RenderEmbeddedObject>(renderer)) {
+            if (auto* scrollableArea = plugin->scrollableArea())
+                return scrollableArea;
+        }
+
         auto* layer = renderer->enclosingLayer();
         if (!layer)
             return nullptr;
@@ -4614,17 +4619,16 @@ bool EventHandler::startKeyboardScrollAnimationOnRenderBoxAndItsAncestors(Scroll
     return false;
 }
 
-bool EventHandler::startKeyboardScrollAnimationOnPlugin(ScrollDirection direction, ScrollGranularity granularity, RenderEmbeddedObject& plugin, bool isKeyRepeat)
+bool EventHandler::startKeyboardScrollAnimationOnPlugin(ScrollDirection direction, ScrollGranularity granularity, RenderEmbeddedObject& pluginRenderer, bool isKeyRepeat)
 {
-    if (!plugin.usesAsyncScrolling())
-        return false;
-    ScrollingNodeID scroller = plugin.scrollingNodeID();
-    ScrollableArea* scrollableArea = m_frame->view()->scrollableAreaForScrollingNodeID(scroller);
+    auto* scrollableArea = pluginRenderer.scrollableArea();
     if (!scrollableArea)
         return false;
+
     auto* animator = scrollableArea->scrollAnimator().keyboardScrollingAnimator();
     if (!animator)
         return false;
+
     return beginKeyboardScrollGesture(animator, direction, granularity, isKeyRepeat);
 }
 

--- a/Source/WebCore/plugins/PluginViewBase.h
+++ b/Source/WebCore/plugins/PluginViewBase.h
@@ -36,6 +36,7 @@ namespace WebCore {
 
 class Element;
 class GraphicsLayer;
+class ScrollableArea;
 class Scrollbar;
 class VoidCallback;
 
@@ -64,6 +65,7 @@ public:
     virtual bool shouldAllowNavigationFromDrags() const { return false; }
     virtual void willDetachRenderer() { }
 
+    virtual ScrollableArea* scrollableArea() const { return nullptr; }
     virtual bool usesAsyncScrolling() const { return false; }
     virtual ScrollingNodeID scrollingNodeID() const { return { }; }
     virtual void willAttachScrollingNode() { }

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -111,9 +111,18 @@ bool RenderEmbeddedObject::requiresAcceleratedCompositing() const
     return pluginViewBase->layerHostingStrategy() != PluginLayerHostingStrategy::None;
 }
 
+ScrollableArea* RenderEmbeddedObject::scrollableArea() const
+{
+    RefPtr pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
+    if (!pluginViewBase)
+        return nullptr;
+
+    return pluginViewBase->scrollableArea();
+}
+
 bool RenderEmbeddedObject::usesAsyncScrolling() const
 {
-    auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
+    RefPtr pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
     if (!pluginViewBase)
         return false;
     return pluginViewBase->usesAsyncScrolling();
@@ -121,7 +130,7 @@ bool RenderEmbeddedObject::usesAsyncScrolling() const
 
 ScrollingNodeID RenderEmbeddedObject::scrollingNodeID() const
 {
-    auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
+    RefPtr pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
     if (!pluginViewBase)
         return { };
     return pluginViewBase->scrollingNodeID();
@@ -129,7 +138,7 @@ ScrollingNodeID RenderEmbeddedObject::scrollingNodeID() const
 
 void RenderEmbeddedObject::willAttachScrollingNode()
 {
-    auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
+    RefPtr pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
     if (!pluginViewBase)
         return;
     pluginViewBase->willAttachScrollingNode();
@@ -137,7 +146,7 @@ void RenderEmbeddedObject::willAttachScrollingNode()
 
 void RenderEmbeddedObject::didAttachScrollingNode()
 {
-    auto* pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
+    RefPtr pluginViewBase = dynamicDowncast<PluginViewBase>(widget());
     if (!pluginViewBase)
         return;
     pluginViewBase->didAttachScrollingNode();

--- a/Source/WebCore/rendering/RenderEmbeddedObject.h
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.h
@@ -61,6 +61,7 @@ public:
 
     const String& pluginReplacementTextIfUnavailable() const { return m_unavailablePluginReplacementText; }
 
+    ScrollableArea* scrollableArea() const;
     bool usesAsyncScrolling() const;
     ScrollingNodeID scrollingNodeID() const;
     void willAttachScrollingNode();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -297,6 +297,7 @@ protected:
     // ScrollableArea functions.
     WebCore::IntRect scrollCornerRect() const final;
     WebCore::ScrollableArea* enclosingScrollableArea() const final;
+    bool scrollAnimatorEnabled() const final { return true; }
     bool isScrollableOrRubberbandable() final { return true; }
     bool hasScrollableOrRubberbandableAncestor() final { return true; }
     WebCore::IntRect scrollableAreaBoundingBox(bool* = nullptr) const final;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -59,6 +59,9 @@
 #import <WebCore/LocalizedStrings.h>
 #import <WebCore/MouseEvent.h>
 #import <WebCore/PluginDocument.h>
+#import <WebCore/RenderEmbeddedObject.h>
+#import <WebCore/RenderLayer.h>
+#import <WebCore/RenderLayerScrollableArea.h>
 #import <WebCore/ResourceResponse.h>
 #import <WebCore/ScrollAnimator.h>
 #import <WebCore/SharedBuffer.h>
@@ -663,8 +666,22 @@ IntRect PDFPluginBase::scrollCornerRect() const
 
 ScrollableArea* PDFPluginBase::enclosingScrollableArea() const
 {
-    // FIXME: Walk up the frame tree and look for a scrollable parent frame or RenderLayer.
-    return nullptr;
+    if (!m_element)
+        return nullptr;
+
+    RefPtr renderer = dynamicDowncast<RenderEmbeddedObject>(m_element->renderer());
+    if (!renderer)
+        return nullptr;
+
+    CheckedPtr layer = renderer->enclosingLayer();
+    if (!layer)
+        return nullptr;
+
+    CheckedPtr enclosingScrollableLayer = layer->enclosingScrollableLayer(IncludeSelfOrNot::ExcludeSelf, CrossFrameBoundaries::No);
+    if (!enclosingScrollableLayer)
+        return nullptr;
+
+    return enclosingScrollableLayer->scrollableArea();
 }
 
 IntRect PDFPluginBase::scrollableAreaBoundingBox(bool*) const

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -714,6 +714,14 @@ void PluginView::willDetachRenderer()
     protectedPlugin()->willDetachRenderer();
 }
 
+ScrollableArea* PluginView::scrollableArea() const
+{
+    if (!m_isInitialized)
+        return nullptr;
+
+    return m_plugin.ptr();
+}
+
 bool PluginView::usesAsyncScrolling() const
 {
     if (!m_isInitialized)
@@ -721,7 +729,6 @@ bool PluginView::usesAsyncScrolling() const
 
     return protectedPlugin()->usesAsyncScrolling();
 }
-
 
 ScrollingNodeID PluginView::scrollingNodeID() const
 {

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -159,6 +159,7 @@ private:
     bool shouldAllowNavigationFromDrags() const final;
     void willDetachRenderer() final;
 
+    WebCore::ScrollableArea* scrollableArea() const final;
     bool usesAsyncScrolling() const final;
     WebCore::ScrollingNodeID scrollingNodeID() const final;
     void willAttachScrollingNode() final;


### PR DESCRIPTION
#### 5dce1764e0a3228c2260c1797276d4ac1fba2158
<pre>
[UnifiedPDF] Can&apos;t click-drag the scrollbar
<a href="https://bugs.webkit.org/show_bug.cgi?id=271115">https://bugs.webkit.org/show_bug.cgi?id=271115</a>
<a href="https://rdar.apple.com/124785551">rdar://124785551</a>

Reviewed by Abrar Rahman Protyasha.

For mouse interaction with the PDFPlugin&apos;s scrollbars to work, `EventHandler::enclosingScrollableArea()`
has to be able to find the plugin node&apos;s ScrollableArea. Add an easy way to get to the ScrollableArea
from RenderEmbeddedObject, which calls through the PluginView. Replace the odd code in `startKeyboardScrollAnimationOnPlugin()`
with this cleaner code.

Oddly that broke keyboard scrolling, which is fixed by implementing `scrollAnimatorEnabled()` in
PDFPluginBase to return true.

Also implement `PDFPluginBase::enclosingScrollableArea()`; this isn&apos;t called on macOS at this point, but
is implemented for completeness.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::enclosingScrollableArea):
(WebCore::EventHandler::startKeyboardScrollAnimationOnPlugin):
* Source/WebCore/plugins/PluginViewBase.h:
(WebCore::PluginViewBase::scrollableArea const):
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::RenderEmbeddedObject::scrollableArea const):
(WebCore::RenderEmbeddedObject::usesAsyncScrolling const):
(WebCore::RenderEmbeddedObject::scrollingNodeID const):
(WebCore::RenderEmbeddedObject::willAttachScrollingNode):
(WebCore::RenderEmbeddedObject::didAttachScrollingNode):
* Source/WebCore/rendering/RenderEmbeddedObject.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::enclosingScrollableArea const):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::scrollableArea const):
* Source/WebKit/WebProcess/Plugins/PluginView.h:

Canonical link: <a href="https://commits.webkit.org/276244@main">https://commits.webkit.org/276244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfed86f3741641b650e3a9c63081ab88d22c2fda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46769 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40154 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36361 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17394 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39105 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2177 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48364 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15679 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43232 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20467 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41955 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9809 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20692 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->