### PR TITLE
Add a menu item in MiniBrowser to toggle advanced privacy protections

### DIFF
--- a/Tools/MiniBrowser/mac/SettingsController.h
+++ b/Tools/MiniBrowser/mac/SettingsController.h
@@ -65,6 +65,7 @@ typedef NS_ENUM(NSInteger, AttachmentElementEnabledState) {
 @property (nonatomic, readonly) BOOL loadsAllSiteIcons;
 @property (nonatomic, readonly) BOOL usesGameControllerFramework;
 @property (nonatomic, readonly) BOOL networkCacheSpeculativeRevalidationDisabled;
+@property (nonatomic, readonly) BOOL advancedPrivacyProtectionsEnabled;
 
 @property (nonatomic, readonly) NSString *defaultURL;
 @property (nonatomic, readonly) NSString *customUserAgent;

--- a/Tools/MiniBrowser/mac/SettingsController.m
+++ b/Tools/MiniBrowser/mac/SettingsController.m
@@ -68,6 +68,7 @@ static NSString * const UseSystemAppearancePreferenceKey = @"UseSystemAppearance
 static NSString * const DataDetectorsEnabledPreferenceKey = @"DataDetectorsEnabled";
 static NSString * const UseMockCaptureDevicesPreferenceKey = @"UseMockCaptureDevices";
 static NSString * const AttachmentElementEnabledPreferenceKey = @"AttachmentElementEnabled";
+static NSString * const AdvancedPrivacyProtectionsPreferenceKey = @"AdvancedPrivacyProtectionsEnabled";
 
 // This default name intentionally overlaps with the key that WebKit2 checks when creating a view.
 static NSString * const UseRemoteLayerTreeDrawingAreaPreferenceKey = @"WebKit2UseRemoteLayerTreeDrawingArea";
@@ -189,6 +190,7 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
     addItem(@"Use System Appearance", @selector(toggleUseSystemAppearance:));
     addItem(@"Enable Data Detectors", @selector(toggleDataDetectorsEnabled:));
     addItem(@"Use Mock Capture Devices", @selector(toggleUseMockCaptureDevices:));
+    addItem(@"Advanced Privacy Protections", @selector(toggleAdvancedPrivacyProtections:));
 
     NSMenu *attachmentElementMenu = addSubmenu(@"Enable Attachment Element");
     addItemToMenu(attachmentElementMenu, @"Disabled", @selector(changeAttachmentElementEnabled:), NO, AttachmentElementDisabledTag);
@@ -377,6 +379,8 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
         [menuItem setState:[self dataDetectorsEnabled] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(toggleUseMockCaptureDevices:))
         [menuItem setState:[self useMockCaptureDevices] ? NSControlStateValueOn : NSControlStateValueOff];
+    else if (action == @selector(toggleAdvancedPrivacyProtections:))
+        [menuItem setState:[self advancedPrivacyProtectionsEnabled] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(toggleReserveSpaceForBanners:))
         [menuItem setState:[self isSpaceReservedForBanners] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(toggleShowTiledScrollingIndicator:))
@@ -695,6 +699,16 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
 - (BOOL)useMockCaptureDevices
 {
     return [[NSUserDefaults standardUserDefaults] boolForKey:UseMockCaptureDevicesPreferenceKey];
+}
+
+- (void)toggleAdvancedPrivacyProtections:(id)sender
+{
+    [self _toggleBooleanDefault:AdvancedPrivacyProtectionsPreferenceKey];
+}
+
+- (BOOL)advancedPrivacyProtectionsEnabled
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:AdvancedPrivacyProtectionsPreferenceKey];
 }
 
 - (BOOL)nonFastScrollableRegionOverlayVisible


### PR DESCRIPTION
#### a492c4f712b85796979d93d1903fbcc4b3faf935
<pre>
Add a menu item in MiniBrowser to toggle advanced privacy protections
<a href="https://bugs.webkit.org/show_bug.cgi?id=271116">https://bugs.webkit.org/show_bug.cgi?id=271116</a>

Reviewed by Charlie Wolfe.

Add an &quot;Advanced Privacy Protections&quot; toggle in MiniBrowser on macOS, that emulates the WebKit-level
protections that comprise Advanced Tracking and Fingerprinting Protection in Safari 17+.

* Tools/MiniBrowser/mac/AppDelegate.m:
* Tools/MiniBrowser/mac/SettingsController.h:
* Tools/MiniBrowser/mac/SettingsController.m:
(-[SettingsController _populateMenu:]):
(-[SettingsController validateMenuItem:]):
(-[SettingsController toggleAdvancedPrivacyProtections:]):
(-[SettingsController advancedPrivacyProtectionsEnabled]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController webView:decidePolicyForNavigationAction:preferences:decisionHandler:]):
(-[WK2BrowserWindowController webView:decidePolicyForNavigationAction:decisionHandler:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/276245@main">https://commits.webkit.org/276245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6791f85c3257c3e48d6a499abcaea2abcd52b8b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46771 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40156 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20592 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36364 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44707 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/20230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17397 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39106 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2179 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48363 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43228 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20469 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/41951 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9810 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20694 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20095 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->