### PR TITLE
Drop Vector::append(T*, size_t) and use Vector::append(std::span<const T>) instead

### DIFF
--- a/Source/JavaScriptCore/API/ObjcRuntimeExtras.h
+++ b/Source/JavaScriptCore/API/ObjcRuntimeExtras.h
@@ -60,7 +60,7 @@ inline void forEachProtocolImplementingProtocol(Class cls, Protocol *target, voi
     {
         unsigned protocolsCount;
         auto protocols = adoptSystem<__unsafe_unretained Protocol*[]>(class_copyProtocolList(cls, &protocolsCount));
-        worklist.append(protocols.get(), protocolsCount);
+        worklist.append(std::span { protocols.get(), protocolsCount });
     }
 
     bool stop = false;
@@ -83,7 +83,7 @@ inline void forEachProtocolImplementingProtocol(Class cls, Protocol *target, voi
         {
             unsigned protocolsCount;
             auto protocols = adoptSystem<__unsafe_unretained Protocol*[]>(protocol_copyProtocolList(protocol, &protocolsCount));
-            worklist.append(protocols.get(), protocolsCount);
+            worklist.append(std::span { protocols.get(), protocolsCount });
         }
     }
 }

--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -813,7 +813,7 @@ public:
         
         void append(const JumpList& other)
         {
-            m_jumps.append(other.m_jumps.begin(), other.m_jumps.size());
+            m_jumps.appendVector(other.m_jumps);
         }
 
         bool empty() const

--- a/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
+++ b/Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp
@@ -107,7 +107,7 @@ ObjectPropertyConditionSet ObjectPropertyConditionSet::mergedWith(
     Vector<ObjectPropertyCondition, 16> result;
     
     if (!isEmpty())
-        result.append(m_data->begin(), m_data->size());
+        result.append(m_data->span());
     
     for (const ObjectPropertyCondition& newCondition : other) {
         bool foundMatch = false;

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorConnectionClient.cpp
@@ -82,7 +82,7 @@ void RemoteInspectorConnectionClient::didReceive(RemoteInspectorSocketEndpoint&,
             }
         });
     });
-    result.iterator->value.pushReceivedData(data.data(), data.size());
+    result.iterator->value.pushReceivedData(data.span());
 }
 
 std::optional<RemoteInspectorConnectionClient::Event> RemoteInspectorConnectionClient::extractEvent(ConnectionID clientID, Vector<uint8_t>&& data)

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.cpp
@@ -59,12 +59,12 @@ Vector<uint8_t> MessageParser::createMessage(const uint8_t* data, size_t size)
     return messageBuffer;
 }
 
-void MessageParser::pushReceivedData(const uint8_t* data, size_t size)
+void MessageParser::pushReceivedData(std::span<const uint8_t> data)
 {
-    if (!data || !size || !m_listener)
+    if (data.empty() || !m_listener)
         return;
 
-    m_buffer.append(data, size);
+    m_buffer.append(data);
 
     if (!parse())
         clearReceivedData();

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.h
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorMessageParser.h
@@ -39,7 +39,7 @@ public:
 
     MessageParser() { }
     MessageParser(Function<void(Vector<uint8_t>&&)>&&);
-    void pushReceivedData(const uint8_t*, size_t);
+    void pushReceivedData(std::span<const uint8_t>);
     void clearReceivedData();
 
 private:

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3697,7 +3697,7 @@ static void runWithOptions(GlobalObject* globalObject, CommandLine& options, boo
         case Script::CodeSource::File: {
             fileName = String::fromLatin1(scripts[i].argument);
             if (scripts[i].strictMode == Script::StrictMode::Strict)
-                scriptBuffer.append("\"use strict\";\n", strlen("\"use strict\";\n"));
+                scriptBuffer.append("\"use strict\";\n"_span);
 
             if (isModule) {
                 // If necessary, prepend "./" so the module loader doesn't think this is a bare-name specifier.

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -1095,7 +1095,7 @@ JSTokenType Lexer<CharacterType>::parseIdentifierSlowCase(JSTokenData* tokenData
     auto fillBuffer = [&] (bool isStart = false) {
         // \uXXXX unicode characters or Surrogate pairs.
         if (identifierStart != currentSourcePtr())
-            m_buffer16.append(identifierStart, currentSourcePtr() - identifierStart);
+            m_buffer16.append(std::span(identifierStart, currentSourcePtr() - identifierStart));
 
         if (m_current == '\\') {
             tokenData->escaped = true;
@@ -1150,7 +1150,7 @@ JSTokenType Lexer<CharacterType>::parseIdentifierSlowCase(JSTokenData* tokenData
     const Identifier* ident = nullptr;
     if (shouldCreateIdentifier) {
         if (identifierStart != currentSourcePtr())
-            m_buffer16.append(identifierStart, currentSourcePtr() - identifierStart);
+            m_buffer16.append(std::span(identifierStart, currentSourcePtr() - identifierStart));
         ident = makeIdentifier(m_buffer16.data(), m_buffer16.size());
 
         tokenData->ident = ident;
@@ -1431,7 +1431,7 @@ typename Lexer<T>::StringParseResult Lexer<T>::parseTemplateLiteral(JSTokenData*
                     ASSERT_WITH_MESSAGE(rawStringStart != currentSourcePtr(), "We should have at least shifted the escape.");
 
                     if (rawStringsBuildMode == RawStringsBuildMode::BuildRawStrings) {
-                        m_bufferForRawTemplateString16.append(rawStringStart, currentSourcePtr() - rawStringStart);
+                        m_bufferForRawTemplateString16.append(std::span(rawStringStart, currentSourcePtr() - rawStringStart));
                         m_bufferForRawTemplateString16.append('\n');
                     }
 
@@ -1474,7 +1474,7 @@ typename Lexer<T>::StringParseResult Lexer<T>::parseTemplateLiteral(JSTokenData*
                     if (stringStart != currentSourcePtr())
                         append16(stringStart, currentSourcePtr() - stringStart);
                     if (rawStringStart != currentSourcePtr() && rawStringsBuildMode == RawStringsBuildMode::BuildRawStrings)
-                        m_bufferForRawTemplateString16.append(rawStringStart, currentSourcePtr() - rawStringStart);
+                        m_bufferForRawTemplateString16.append(std::span(rawStringStart, currentSourcePtr() - rawStringStart));
 
                     record16('\n');
                     if (rawStringsBuildMode == RawStringsBuildMode::BuildRawStrings)
@@ -1497,7 +1497,7 @@ typename Lexer<T>::StringParseResult Lexer<T>::parseTemplateLiteral(JSTokenData*
     if (currentSourcePtr() != stringStart)
         append16(stringStart, currentSourcePtr() - stringStart);
     if (rawStringStart != currentSourcePtr() && rawStringsBuildMode == RawStringsBuildMode::BuildRawStrings)
-        m_bufferForRawTemplateString16.append(rawStringStart, currentSourcePtr() - rawStringStart);
+        m_bufferForRawTemplateString16.append(std::span(rawStringStart, currentSourcePtr() - rawStringStart));
 
     if (!parseCookedFailed)
         tokenData->cooked = makeIdentifier(m_buffer16.data(), m_buffer16.size());

--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -134,8 +134,9 @@ private:
     void record16(int);
     void record16(T);
     void recordUnicodeCodePoint(char32_t);
+    // FIXME: These should take in spans.
     void append16(const LChar*, size_t);
-    void append16(const UChar* characters, size_t length) { m_buffer16.append(characters, length); }
+    void append16(const UChar* characters, size_t length) { m_buffer16.append(std::span { characters, length }); }
 
     static constexpr char32_t errorCodePoint = 0xFFFFFFFFu;
     char32_t currentCodePoint() const;

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -154,9 +154,9 @@ void LocaleIDBuilder::overrideLanguageScriptRegion(StringView language, StringVi
 
         ASSERT(subtag.containsOnlyASCII());
         if (subtag.is8Bit())
-            buffer.append(subtag.characters8(), subtag.length());
+            buffer.append(subtag.span8());
         else
-            buffer.append(subtag.characters16(), subtag.length());
+            buffer.append(subtag.span16());
     }
 
     if (endOfLanguageScriptRegionVariant != length) {
@@ -164,9 +164,9 @@ void LocaleIDBuilder::overrideLanguageScriptRegion(StringView language, StringVi
 
         ASSERT(rest.containsOnlyASCII());
         if (rest.is8Bit())
-            buffer.append(rest.characters8(), rest.length());
+            buffer.append(rest.span8());
         else
-            buffer.append(rest.characters16(), rest.length());
+            buffer.append(rest.span16());
     }
 
     buffer.append('\0');

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -354,8 +354,7 @@ Vector<char, 32> canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization(Vec
         end++;
     }
 
-    Vector<char, 32> result;
-    result.append(buffer.data(), extensionIndex + 2); // "-u" is included.
+    Vector<char, 32> result(buffer.subspan(0, extensionIndex + 2)); // "-u" is included.
     StringView extension = locale.substring(extensionIndex, extensionLength);
     ASSERT(extension.is8Bit());
     auto subtags = unicodeExtensionComponents(extension);
@@ -363,7 +362,7 @@ Vector<char, 32> canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization(Vec
         auto subtag = subtags[index];
         ASSERT(subtag.is8Bit());
         result.append('-');
-        result.append(subtag.characters8(), subtag.length());
+        result.append(subtag.span8());
 
         if (subtag.length() != 2) {
             ++index;
@@ -384,15 +383,13 @@ Vector<char, 32> canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization(Vec
             auto value = subtags[valueIndex];
             if (value != "true"_s) {
                 result.append('-');
-                result.append(value.characters8(), value.length());
+                result.append(value.span8());
             }
         }
         index = valueIndexEnd;
     }
 
-    unsigned remainingStart = extensionIndex + extensionLength;
-    unsigned remainingLength = buffer.size() - remainingStart;
-    result.append(buffer.data() + remainingStart, remainingLength);
+    result.append(buffer.subspan(extensionIndex + extensionLength));
     return result;
 }
 
@@ -432,10 +429,10 @@ static void addScriptlessLocaleIfNeeded(LocaleSet& availableLocales, StringView 
 
     Vector<char, 12> buffer;
     ASSERT(subtags[0].is8Bit() && subtags[0].containsOnlyASCII());
-    buffer.append(reinterpret_cast<const char*>(subtags[0].characters8()), subtags[0].length());
+    buffer.append(subtags[0].span8());
     buffer.append('-');
     ASSERT(subtags[2].is8Bit() && subtags[2].containsOnlyASCII());
-    buffer.append(reinterpret_cast<const char*>(subtags[2].characters8()), subtags[2].length());
+    buffer.append(subtags[2].span8());
 
     availableLocales.add(StringImpl::createStaticStringImpl(buffer.data(), buffer.size()));
 }

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2012,7 +2012,7 @@ JSC_DEFINE_HOST_FUNCTION(functionWasmStreamingParserAddBytes, (JSGlobalObject* g
 
     auto data = getWasmBufferFromValue(globalObject, value, guard);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsNumber(static_cast<int32_t>(thisObject->streamingParser().addBytes(bitwise_cast<const uint8_t*>(data.first), data.second)))));
+    RELEASE_AND_RETURN(scope, JSValue::encode(jsNumber(static_cast<int32_t>(thisObject->streamingParser().addBytes(std::span { bitwise_cast<const uint8_t*>(data.first), data.second })))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionWasmStreamingParserFinalize, (JSGlobalObject*, CallFrame* callFrame))
@@ -2112,7 +2112,7 @@ JSC_DEFINE_HOST_FUNCTION(functionWasmStreamingCompilerAddBytes, (JSGlobalObject*
 
     auto data = getWasmBufferFromValue(globalObject, value, guard);
     RETURN_IF_EXCEPTION(scope, { });
-    thisObject->streamingCompiler().addBytes(bitwise_cast<const uint8_t*>(data.first), data.second);
+    thisObject->streamingCompiler().addBytes(std::span { bitwise_cast<const uint8_t*>(data.first), data.second });
     return JSValue::encode(jsUndefined());
 }
 

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.h
@@ -72,7 +72,7 @@ public:
 
     bool parseAndValidateModule()
     {
-        return Base::parseAndValidateModule(m_source.data(), m_source.size());
+        return Base::parseAndValidateModule(m_source.span());
     }
 
     static FunctionAllowlist& ensureGlobalBBQAllowlist();

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.cpp
@@ -78,7 +78,7 @@ void EntryPlan::moveToState(State state)
     m_state = state;
 }
 
-bool EntryPlan::parseAndValidateModule(const uint8_t* source, size_t sourceLength)
+bool EntryPlan::parseAndValidateModule(std::span<const uint8_t> source)
 {
     if (m_state != State::Initial)
         return true;
@@ -88,7 +88,7 @@ bool EntryPlan::parseAndValidateModule(const uint8_t* source, size_t sourceLengt
     if (WasmEntryPlanInternal::verbose || Options::reportCompileTimes())
         startTime = MonotonicTime::now();
 
-    m_streamingParser.addBytes(source, sourceLength);
+    m_streamingParser.addBytes(source);
     {
         Locker locker { m_lock };
         if (failed())

--- a/Source/JavaScriptCore/wasm/WasmEntryPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmEntryPlan.h
@@ -91,7 +91,7 @@ protected:
     // For some reason friendship doesn't extend to parent classes...
     using Base::m_lock;
 
-    bool parseAndValidateModule(const uint8_t*, size_t);
+    bool parseAndValidateModule(std::span<const uint8_t>);
 
     const char* stateString(State);
     void moveToState(State);

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -46,7 +46,7 @@ namespace JSC { namespace Wasm {
 IPIntPlan::IPIntPlan(VM& vm, Vector<uint8_t>&& source, CompilerMode compilerMode, CompletionTask&& task)
     : Base(vm, WTFMove(source), compilerMode, WTFMove(task))
 {
-    if (parseAndValidateModule(m_source.data(), m_source.size()))
+    if (parseAndValidateModule(m_source.span()))
         prepare();
 }
 

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -46,7 +46,7 @@ namespace JSC { namespace Wasm {
 LLIntPlan::LLIntPlan(VM& vm, Vector<uint8_t>&& source, CompilerMode compilerMode, CompletionTask&& task)
     : Base(vm, WTFMove(source), compilerMode, WTFMove(task))
 {
-    if (parseAndValidateModule(m_source.data(), m_source.size()))
+    if (parseAndValidateModule(m_source.span()))
         prepare();
 }
 

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
@@ -51,7 +51,7 @@ public:
 
     JS_EXPORT_PRIVATE ~StreamingCompiler();
 
-    void addBytes(const uint8_t* bytes, size_t length) { m_parser.addBytes(bytes, length); }
+    void addBytes(std::span<const uint8_t> bytes) { m_parser.addBytes(bytes); }
     JS_EXPORT_PRIVATE void finalize(JSGlobalObject*);
     JS_EXPORT_PRIVATE void fail(JSGlobalObject*, JSValue);
     JS_EXPORT_PRIVATE void cancel();

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -215,7 +215,7 @@ auto StreamingParser::parseSectionPayload(Vector<uint8_t>&& data) -> State
     return State::SectionID;
 }
 
-auto StreamingParser::consume(const uint8_t* bytes, size_t bytesSize, size_t& offsetInBytes, size_t requiredSize) -> std::optional<Vector<uint8_t>>
+auto StreamingParser::consume(std::span<const uint8_t> bytes, size_t& offsetInBytes, size_t requiredSize) -> std::optional<Vector<uint8_t>>
 {
     if (m_remaining.size() == requiredSize) {
         Vector<uint8_t> result = WTFMove(m_remaining);
@@ -231,35 +231,35 @@ auto StreamingParser::consume(const uint8_t* bytes, size_t bytesSize, size_t& of
     }
 
     ASSERT(m_remaining.size() < requiredSize);
-    size_t bytesRemainingSize = bytesSize - offsetInBytes;
+    size_t bytesRemainingSize = bytes.size() - offsetInBytes;
     size_t totalDataSize = m_remaining.size() + bytesRemainingSize;
     if (totalDataSize < requiredSize) {
-        m_remaining.append(bytes + offsetInBytes, bytesRemainingSize);
-        offsetInBytes = bytesSize;
+        m_remaining.append(bytes.subspan(offsetInBytes, bytesRemainingSize));
+        offsetInBytes = bytes.size();
         return std::nullopt;
     }
 
     size_t usedSize = requiredSize - m_remaining.size();
-    m_remaining.append(bytes + offsetInBytes, usedSize);
+    m_remaining.append(bytes.subspan(offsetInBytes, usedSize));
     offsetInBytes += usedSize;
     Vector<uint8_t> result = WTFMove(m_remaining);
     m_nextOffset += requiredSize;
     return result;
 }
 
-auto StreamingParser::consumeVarUInt32(const uint8_t* bytes, size_t bytesSize, size_t& offsetInBytes, IsEndOfStream isEndOfStream) -> Expected<uint32_t, State>
+auto StreamingParser::consumeVarUInt32(std::span<const uint8_t> bytes, size_t& offsetInBytes, IsEndOfStream isEndOfStream) -> Expected<uint32_t, State>
 {
     constexpr size_t maxSize = WTF::LEBDecoder::maxByteLength<uint32_t>();
-    size_t bytesRemainingSize = bytesSize - offsetInBytes;
+    size_t bytesRemainingSize = bytes.size() - offsetInBytes;
     size_t totalDataSize = m_remaining.size() + bytesRemainingSize;
     if (m_remaining.size() >= maxSize) {
         // Do nothing.
     } else if (totalDataSize >= maxSize) {
         size_t usedSize = maxSize - m_remaining.size();
-        m_remaining.append(bytes + offsetInBytes, usedSize);
+        m_remaining.append(bytes.subspan(offsetInBytes, usedSize));
         offsetInBytes += usedSize;
     } else {
-        m_remaining.append(bytes + offsetInBytes, bytesRemainingSize);
+        m_remaining.append(bytes.subspan(offsetInBytes, bytesRemainingSize));
         offsetInBytes += bytesRemainingSize;
         // If the given bytes are the end of the stream, we try to parse VarUInt32
         // with the current remaining data since VarUInt32 may not require `maxSize`.
@@ -277,12 +277,11 @@ auto StreamingParser::consumeVarUInt32(const uint8_t* bytes, size_t bytesSize, s
     return result;
 }
 
-auto StreamingParser::addBytes(const uint8_t* bytes, size_t bytesSize, IsEndOfStream isEndOfStream) -> State
+auto StreamingParser::addBytes(std::span<const uint8_t> bytes, IsEndOfStream isEndOfStream) -> State
 {
 #if ASSERT_ENABLED
     if (Options::dumpWasmSourceFileName()) {
-        for (unsigned i = 0; i < bytesSize; ++i)
-            m_buffer.append(bytes[i]);
+        m_buffer.append(bytes);
 
         if (isEndOfStream == IsEndOfStream::Yes) {
             dataLogLn("Streaming parser reached end of stream.");
@@ -293,21 +292,21 @@ auto StreamingParser::addBytes(const uint8_t* bytes, size_t bytesSize, IsEndOfSt
     if (m_state == State::FatalError)
         return m_state;
 
-    m_totalSize += bytesSize;
+    m_totalSize += bytes.size();
     if (UNLIKELY(m_totalSize.hasOverflowed() || m_totalSize > maxModuleSize)) {
         m_state = fail("module size is too large, maximum ", maxModuleSize);
         return m_state;
     }
 
     if (UNLIKELY(Options::useEagerWebAssemblyModuleHashing()))
-        m_hasher.addBytes(bytes, bytesSize);
+        m_hasher.addBytes(bytes);
 
     size_t offsetInBytes = 0;
     while (true) {
-        ASSERT(offsetInBytes <= bytesSize);
+        ASSERT(offsetInBytes <= bytes.size());
         switch (m_state) {
         case State::ModuleHeader: {
-            auto result = consume(bytes, bytesSize, offsetInBytes, moduleHeaderSize);
+            auto result = consume(bytes, offsetInBytes, moduleHeaderSize);
             if (!result)
                 return m_state;
             m_state = parseModuleHeader(WTFMove(*result));
@@ -315,7 +314,7 @@ auto StreamingParser::addBytes(const uint8_t* bytes, size_t bytesSize, IsEndOfSt
         }
 
         case State::SectionID: {
-            auto result = consume(bytes, bytesSize, offsetInBytes, sectionIDSize);
+            auto result = consume(bytes, offsetInBytes, sectionIDSize);
             if (!result)
                 return m_state;
             m_state = parseSectionID(WTFMove(*result));
@@ -323,7 +322,7 @@ auto StreamingParser::addBytes(const uint8_t* bytes, size_t bytesSize, IsEndOfSt
         }
 
         case State::SectionSize: {
-            auto result = consumeVarUInt32(bytes, bytesSize, offsetInBytes, isEndOfStream);
+            auto result = consumeVarUInt32(bytes, offsetInBytes, isEndOfStream);
             if (!result) {
                 if (result.error() == State::FatalError)
                     m_state = failOnState(m_state);
@@ -336,7 +335,7 @@ auto StreamingParser::addBytes(const uint8_t* bytes, size_t bytesSize, IsEndOfSt
         }
 
         case State::SectionPayload: {
-            auto result = consume(bytes, bytesSize, offsetInBytes, m_sectionLength);
+            auto result = consume(bytes, offsetInBytes, m_sectionLength);
             if (!result)
                 return m_state;
             m_state = parseSectionPayload(WTFMove(*result));
@@ -344,7 +343,7 @@ auto StreamingParser::addBytes(const uint8_t* bytes, size_t bytesSize, IsEndOfSt
         }
 
         case State::CodeSectionSize: {
-            auto result = consumeVarUInt32(bytes, bytesSize, offsetInBytes, isEndOfStream);
+            auto result = consumeVarUInt32(bytes, offsetInBytes, isEndOfStream);
             if (!result) {
                 if (result.error() == State::FatalError)
                     m_state = failOnState(m_state);
@@ -357,7 +356,7 @@ auto StreamingParser::addBytes(const uint8_t* bytes, size_t bytesSize, IsEndOfSt
         }
 
         case State::FunctionSize: {
-            auto result = consumeVarUInt32(bytes, bytesSize, offsetInBytes, isEndOfStream);
+            auto result = consumeVarUInt32(bytes, offsetInBytes, isEndOfStream);
             if (!result) {
                 if (result.error() == State::FatalError)
                     m_state = failOnState(m_state);
@@ -370,7 +369,7 @@ auto StreamingParser::addBytes(const uint8_t* bytes, size_t bytesSize, IsEndOfSt
         }
 
         case State::FunctionPayload: {
-            auto result = consume(bytes, bytesSize, offsetInBytes, m_functionSize);
+            auto result = consume(bytes, offsetInBytes, m_functionSize);
             if (!result)
                 return m_state;
             m_state = parseFunctionPayload(WTFMove(*result));
@@ -412,7 +411,7 @@ auto StreamingParser::failOnState(State) -> State
 
 auto StreamingParser::finalize() -> State
 {
-    addBytes(nullptr, 0, IsEndOfStream::Yes);
+    addBytes({ }, IsEndOfStream::Yes);
     switch (m_state) {
     case State::ModuleHeader:
     case State::SectionSize:

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.h
@@ -80,7 +80,7 @@ public:
 
     StreamingParser(ModuleInformation&, StreamingParserClient&);
 
-    State addBytes(const uint8_t* bytes, size_t length) { return addBytes(bytes, length, IsEndOfStream::No); }
+    State addBytes(std::span<const uint8_t> bytes) { return addBytes(bytes, IsEndOfStream::No); }
     State finalize();
 
     String errorMessage() const { return crossThreadCopy(m_errorMessage); }
@@ -91,7 +91,7 @@ private:
     static constexpr unsigned moduleHeaderSize = 8;
     static constexpr unsigned sectionIDSize = 1;
 
-    JS_EXPORT_PRIVATE State addBytes(const uint8_t* bytes, size_t length, IsEndOfStream);
+    JS_EXPORT_PRIVATE State addBytes(std::span<const uint8_t> bytes, IsEndOfStream);
 
     State parseModuleHeader(Vector<uint8_t>&&);
     State parseSectionID(Vector<uint8_t>&&);
@@ -102,8 +102,8 @@ private:
     State parseFunctionSize(uint32_t);
     State parseFunctionPayload(Vector<uint8_t>&&);
 
-    std::optional<Vector<uint8_t>> consume(const uint8_t* bytes, size_t, size_t&, size_t);
-    Expected<uint32_t, State> consumeVarUInt32(const uint8_t* bytes, size_t, size_t&, IsEndOfStream);
+    std::optional<Vector<uint8_t>> consume(std::span<const uint8_t> bytes, size_t&, size_t);
+    Expected<uint32_t, State> consumeVarUInt32(std::span<const uint8_t> bytes, size_t&, IsEndOfStream);
 
     void moveToStateIfNotFailed(State);
     template <typename ...Args> NEVER_INLINE State WARN_UNUSED_RETURN fail(Args...);

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -133,7 +133,7 @@ inline bool is8ByteAligned(void* p)
 }
 
 template<typename ToType, typename FromType>
-inline ToType bitwise_cast(FromType from)
+constexpr inline ToType bitwise_cast(FromType from)
 {
     static_assert(sizeof(FromType) == sizeof(ToType), "bitwise_cast size of FromType and ToType must be equal!");
 #if COMPILER_SUPPORTS(BUILTIN_IS_TRIVIALLY_COPYABLE)

--- a/Source/WTF/wtf/StreamBuffer.h
+++ b/Source/WTF/wtf/StreamBuffer.h
@@ -62,7 +62,7 @@ public:
             if (!m_buffer.size() || m_buffer.last()->size() == BlockSize)
                 m_buffer.append(makeUnique<Block>());
             size_t appendSize = std::min(BlockSize - m_buffer.last()->size(), data.size());
-            m_buffer.last()->append(data.subspan(0, appendSize));
+            m_buffer.last()->append(data.first(appendSize));
             data = data.subspan(appendSize);
         }
     }

--- a/Source/WTF/wtf/TrailingArray.h
+++ b/Source/WTF/wtf/TrailingArray.h
@@ -96,6 +96,8 @@ public:
 
     pointer data() { return bitwise_cast<T*>(bitwise_cast<uint8_t*>(static_cast<Derived*>(this)) + offsetOfData()); }
     const_pointer data() const { return bitwise_cast<const T*>(bitwise_cast<const uint8_t*>(static_cast<const Derived*>(this)) + offsetOfData()); }
+    std::span<T> span() { return { data(), size() }; }
+    std::span<const T> span() const { return { data(), size() }; }
 
     iterator begin() { return data(); }
     iterator end() { return data() + size(); }

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -442,7 +442,7 @@ static bool appendEncodedHostname(Vector<UChar, 512>& buffer, StringView string)
         string.upconvertedCharacters(), string.length(), hostnameBuffer, URLParser::hostnameBufferLength, &processingDetails, &error);
 
     if (U_SUCCESS(error) && !(processingDetails.errors & ~URLParser::allowedNameToASCIIErrors) && numCharactersConverted) {
-        buffer.append(hostnameBuffer, numCharactersConverted);
+        buffer.append(std::span(hostnameBuffer, numCharactersConverted));
         return true;
     }
     return false;

--- a/Source/WTF/wtf/URLParser.h
+++ b/Source/WTF/wtf/URLParser.h
@@ -124,8 +124,7 @@ private:
     bool hasForbiddenHostCodePoint(const LCharBuffer&);
     void percentEncodeByte(uint8_t);
     void appendToASCIIBuffer(char32_t);
-    void appendToASCIIBuffer(const char*, size_t);
-    void appendToASCIIBuffer(const LChar* characters, size_t size) { appendToASCIIBuffer(reinterpret_cast<const char*>(characters), size); }
+    void appendToASCIIBuffer(std::span<const LChar>);
     template<typename CharacterType> void encodeNonUTF8Query(const Vector<UChar>& source, const URLTextEncoding&, CodePointIterator<CharacterType>);
     void copyASCIIStringUntil(const String&, size_t length);
     bool copyBaseWindowsDriveLetter(const URL&);

--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -188,6 +188,7 @@ inline std::optional<float> makeVectorElement(const float*, CFNumberRef cfNumber
 
 using WTF::createCFArray;
 using WTF::makeVector;
+using WTF::toSpan;
 using WTF::toVector;
 
 #endif // USE(CF)

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -107,14 +107,12 @@ std::pair<String, PlatformFileHandle> openTemporaryFile(StringView prefix, Strin
     ASSERT(temporaryFilePath.last() == '/');
 
     // Append the file name.
-    CString prefixUTF8 = prefix.utf8();
-    temporaryFilePath.append(prefixUTF8.data(), prefixUTF8.length());
-    temporaryFilePath.append("XXXXXX", 6);
+    temporaryFilePath.append(prefix.utf8().bytes());
+    temporaryFilePath.append("XXXXXX"_span);
     
     // Append the file name suffix.
     CString suffixUTF8 = suffix.utf8();
-    temporaryFilePath.append(suffixUTF8.data(), suffixUTF8.length());
-    temporaryFilePath.append('\0');
+    temporaryFilePath.append(suffixUTF8.bytesInludingNullTerminator());
 
     platformFileHandle = mkstemps(temporaryFilePath.data(), suffixUTF8.length());
     if (platformFileHandle == invalidPlatformFileHandle)

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -145,6 +145,15 @@ constexpr ASCIILiteral operator"" _s(const char* characters, size_t n)
     return ASCIILiteral::fromLiteralUnsafe(characters);
 }
 
+constexpr std::span<const LChar> operator"" _span(const char* characters, size_t n)
+{
+#if ASSERT_ENABLED
+    for (size_t i = 0; i < n; ++i)
+        ASSERT_UNDER_CONSTEXPR_CONTEXT(isASCII(characters[i]));
+#endif
+    return std::span { bitwise_cast<const LChar*>(characters), n };
+}
+
 } // inline StringLiterals
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -68,6 +68,8 @@ public:
     bool is8Bit() const { return m_string.is8Bit(); }
     const LChar* characters8() const { return m_string.characters8(); }
     const UChar* characters16() const { return m_string.characters16(); }
+    std::span<const LChar> span8() const { return m_string.span8(); }
+    std::span<const UChar> span16() const { return m_string.span16(); }
     unsigned length() const { return m_string.length(); }
 
     UChar operator[](unsigned int i) const { return m_string[i]; }

--- a/Source/WTF/wtf/text/SuperFastHash.h
+++ b/Source/WTF/wtf/text/SuperFastHash.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <span>
 #include <wtf/text/StringHasher.h>
 
 namespace WTF {
@@ -119,6 +120,12 @@ public:
     }
 
     template<typename T, typename Converter = DefaultConverter>
+    void addCharacters(std::span<const T> data)
+    {
+        addCharacters(data.data(), data.size());
+    }
+
+    template<typename T, typename Converter = DefaultConverter>
     void addCharacters(const T* data)
     {
         if (m_hasPendingCharacter && *data) {
@@ -154,6 +161,12 @@ public:
     static constexpr unsigned computeHash(const T* data, unsigned length)
     {
         return StringHasher::finalize(computeHashImpl<T, Converter>(data, length));
+    }
+
+    template<typename T, typename Converter = DefaultConverter>
+    static constexpr unsigned computeHash(std::span<const T> data)
+    {
+        return StringHasher::finalize(computeHashImpl<T, Converter>(data.data(), data.size()));
     }
 
     template<typename T, typename Converter = DefaultConverter>

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -174,19 +174,16 @@ String String::foldCase() const
 Expected<Vector<UChar>, UTF8ConversionError> String::charactersWithoutNullTermination() const
 {
     Vector<UChar> result;
+    if (!m_impl)
+        return result;
 
-    if (m_impl) {
-        if (!result.tryReserveInitialCapacity(length() + 1))
-            return makeUnexpected(UTF8ConversionError::OutOfMemory);
+    if (!result.tryReserveInitialCapacity(length() + 1))
+        return makeUnexpected(UTF8ConversionError::OutOfMemory);
 
-        if (is8Bit()) {
-            const LChar* characters8 = m_impl->characters8();
-            result.append(characters8, m_impl->length());
-        } else {
-            const UChar* characters16 = m_impl->characters16();
-            result.append(characters16, m_impl->length());
-        }
-    }
+    if (is8Bit())
+        result.append(span8());
+    else
+        result.append(span16());
 
     return result;
 }

--- a/Source/WTF/wtf/text/win/StringWin.cpp
+++ b/Source/WTF/wtf/text/win/StringWin.cpp
@@ -31,22 +31,17 @@ namespace WTF {
 Vector<wchar_t> String::wideCharacters() const
 {
     Vector<wchar_t> result;
+    if (!m_impl)
+        return result;
 
-    if (m_impl) {
-        result.reserveInitialCapacity(length() + 1);
+    result.reserveInitialCapacity(length() + 1);
 
-        if (is8Bit()) {
-            const LChar* characters8 = m_impl->characters8();
-            for (size_t i = 0; i < length(); ++i)
-                result.append(characters8[i]);
-        } else {
-            const UChar* characters16 = m_impl->characters16();
-            result.append(characters16, m_impl->length());
-        }
+    if (is8Bit())
+        result.append(span8());
+    else
+        result.append(span16());
 
-        result.append(0);
-    }
-
+    result.append(0);
     return result;
 }
 

--- a/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
@@ -208,7 +208,7 @@ template <typename T> static bool readLittleEndian(const uint8_t*& ptr, const ui
 #else
 template <typename T> static void writeLittleEndian(Vector<uint8_t>& buffer, T value)
 {
-    buffer.append(reinterpret_cast<uint8_t*>(&value), sizeof(value));
+    buffer.append(std::span { reinterpret_cast<uint8_t*>(&value), sizeof(value) });
 }
 
 template <typename T> static bool readLittleEndian(const uint8_t*& ptr, const uint8_t* end, T& value)
@@ -263,7 +263,7 @@ static void encodeKey(Vector<uint8_t>& data, const IDBKeyData& key)
         auto* bufferData = buffer.data();
         ASSERT(bufferData || !size);
         if (bufferData)
-            data.append(bufferData->data(), bufferData->size());
+            data.append(bufferData->span());
 
         break;
     }
@@ -353,9 +353,7 @@ static WARN_UNUSED_RETURN bool decodeKey(const uint8_t*& data, const uint8_t* en
             return false;
 
         size_t size = static_cast<size_t>(size64);
-        Vector<uint8_t> dataVector;
-
-        dataVector.append(data, size);
+        Vector<uint8_t> dataVector(std::span { data, size });
         data += size;
 
         result.setBinaryValue(ThreadSafeDataBuffer::create(WTFMove(dataVector)));

--- a/Source/WebCore/Modules/mediastream/SFrameUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/SFrameUtils.cpp
@@ -174,7 +174,7 @@ void toRbsp(Vector<uint8_t>& frame, size_t offset)
 
     Vector<uint8_t> newFrame;
     newFrame.reserveInitialCapacity(frame.size() + count);
-    newFrame.append(frame.data(), offset);
+    newFrame.append(frame.subspan(0, offset));
 
     findEscapeRbspPatterns(frame, offset, [data = frame.data(), &newFrame](size_t position, bool shouldBeEscaped) {
         if (shouldBeEscaped)
@@ -199,7 +199,7 @@ size_t computeVP8PrefixOffset(const uint8_t* frame, size_t size)
 SFrameCompatibilityPrefixBuffer computeVP8PrefixBuffer(const uint8_t* frame, size_t size)
 {
     Vector<uint8_t> prefix;
-    prefix.append(frame, isVP8KeyFrame(frame, size) ? 10 : 3);
+    prefix.append(std::span(frame, isVP8KeyFrame(frame, size) ? 10 : 3));
     return { prefix.data(), prefix.size(), WTFMove(prefix) };
 }
 

--- a/Source/WebCore/Modules/mediastream/STUNMessageParsing.h
+++ b/Source/WebCore/Modules/mediastream/STUNMessageParsing.h
@@ -38,7 +38,7 @@ struct STUNMessageLengths {
     size_t messageLengthWithPadding { 0 };
 };
 
-WEBCORE_EXPORT std::optional<STUNMessageLengths> getSTUNOrTURNMessageLengths(const uint8_t*, size_t);
+WEBCORE_EXPORT std::optional<STUNMessageLengths> getSTUNOrTURNMessageLengths(std::span<const uint8_t>);
 
 enum class MessageType { STUN, Data };
 WEBCORE_EXPORT Vector<uint8_t> extractMessages(Vector<uint8_t>&&, MessageType, const Function<void(const uint8_t* data, size_t size)>&);

--- a/Source/WebCore/Modules/webauthn/cbor/CBORReader.cpp
+++ b/Source/WebCore/Modules/webauthn/cbor/CBORReader.cpp
@@ -239,7 +239,7 @@ std::optional<CBORValue> CBORReader::readBytes(uint64_t numBytes)
 
     Vector<uint8_t> cborByteString;
     ASSERT(numBytes <= std::numeric_limits<size_t>::max());
-    cborByteString.append(m_data.data() + std::distance(m_data.begin(), m_it), static_cast<size_t>(numBytes));
+    cborByteString.append(m_data.subspan(std::distance(m_data.begin(), m_it), static_cast<size_t>(numBytes)));
     m_it += numBytes;
 
     return CBORValue(WTFMove(cborByteString));

--- a/Source/WebCore/Modules/webauthn/cbor/CBORWriter.cpp
+++ b/Source/WebCore/Modules/webauthn/cbor/CBORWriter.cpp
@@ -88,7 +88,7 @@ bool CBORWriter::encodeCBOR(const CBORValue& node, int maxNestingLevel)
         auto utf8String = node.getString().utf8();
         startItem(CBORValue::Type::String, static_cast<uint64_t>(utf8String.length()));
         // Add the characters.
-        m_encodedCBOR->append(utf8String.data(), utf8String.length());
+        m_encodedCBOR->append(utf8String.bytes());
         return true;
     }
     // Represents an array.

--- a/Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp
@@ -96,7 +96,7 @@ Vector<uint8_t> FidoHidInitPacket::getSerializedData() const
     serialized.append(static_cast<uint8_t>(m_command) | 0x80);
     serialized.append((m_payloadLength >> 8) & 0xff);
     serialized.append(m_payloadLength & 0xff);
-    serialized.append(m_data.begin(), m_data.size());
+    serialized.appendVector(m_data);
     auto offset = serialized.size();
     serialized.grow(kHidPacketSize);
     memset(serialized.data() + offset, 0, kHidPacketSize - offset);
@@ -144,7 +144,7 @@ Vector<uint8_t> FidoHidContinuationPacket::getSerializedData() const
     serialized.append((m_channelId >> 8) & 0xff);
     serialized.append(m_channelId & 0xff);
     serialized.append(m_sequence);
-    serialized.append(m_data.begin(), m_data.size());
+    serialized.appendVector(m_data);
     auto offset = serialized.size();
     serialized.grow(kHidPacketSize);
     memset(serialized.data() + offset, 0, kHidPacketSize - offset);

--- a/Source/WebCore/Modules/webauthn/fido/FidoParsingUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/FidoParsingUtils.cpp
@@ -34,9 +34,7 @@ namespace fido {
 
 Vector<uint8_t> getInitPacketData(const Vector<uint8_t>& data)
 {
-    Vector<uint8_t> result;
-    result.append(data.data(), data.size() > kHidInitPacketDataSize ? kHidInitPacketDataSize : data.size());
-    return result;
+    return data.subvector(0, std::min(kHidInitPacketDataSize, data.size()));
 }
 
 Vector<uint8_t> getContinuationPacketData(const Vector<uint8_t>& data, size_t beginPosition)
@@ -44,9 +42,7 @@ Vector<uint8_t> getContinuationPacketData(const Vector<uint8_t>& data, size_t be
     if (beginPosition > data.size())
         return { };
 
-    Vector<uint8_t> result;
-    result.append(data.data() + beginPosition, data.size() > kHidContinuationPacketDataSize + beginPosition ? kHidContinuationPacketDataSize : data.size() - beginPosition);
-    return result;
+    return data.subspan(beginPosition, std::min(kHidContinuationPacketDataSize, data.size() - beginPosition));
 }
 
 } // namespace fido

--- a/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
@@ -71,7 +71,7 @@ static std::optional<Vector<uint8_t>> constructU2fSignCommand(const Vector<uint8
     data.appendVector(challengeParameter);
     data.appendVector(applicationParameter);
     data.append(static_cast<uint8_t>(keyHandle.length()));
-    data.append(keyHandle.data(), keyHandle.length());
+    data.append(keyHandle.bytes());
 
     apdu::ApduCommand command;
     command.setIns(static_cast<uint8_t>(U2fApduInstruction::kSign));

--- a/Source/WebCore/Modules/websockets/WebSocketFrame.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketFrame.cpp
@@ -162,7 +162,7 @@ void WebSocketFrame::makeFrameData(Vector<uint8_t>& frameData)
             remaining >>= 8;
         }
         ASSERT(!remaining);
-        frameData.append(extendedPayloadLength, 8);
+        frameData.append(std::span { extendedPayloadLength });
     }
 
     appendFramePayload(*this, frameData);

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -439,7 +439,7 @@ const uint8_t* WebSocketHandshake::readHTTPHeaders(const uint8_t* start, const u
     bool sawSecWebSocketProtocolHeaderField = false;
     auto p = start;
     for (; p < end; p++) {
-        size_t consumedLength = parseHTTPHeader(p, end - p, m_failureReason, name, value);
+        size_t consumedLength = parseHTTPHeader(std::span { p, static_cast<size_t>(end - p) }, m_failureReason, name, value);
         if (!consumedLength)
             return nullptr;
         p += consumedLength;

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -1118,7 +1118,7 @@ static void appendDecimal(char32_t c, Vector<uint8_t>& result)
 {
     uint8_t buffer[lengthOfIntegerAsString(std::numeric_limits<decltype(c)>::max())];
     writeIntegerToBuffer(c, buffer);
-    result.append(buffer, lengthOfIntegerAsString(c));
+    result.append(std::span { buffer, lengthOfIntegerAsString(c) });
 }
 
 static void urlEncodedEntityUnencodableHandler(char32_t c, Vector<uint8_t>& result)

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -313,7 +313,7 @@ Vector<uint8_t> TextCodecICU::encode(StringView string, UnencodableHandling hand
         char* targetLimit = target + ConversionBufferSize;
         error = U_ZERO_ERROR;
         ucnv_fromUnicode(m_converter.get(), &target, targetLimit, &source, sourceLimit, 0, true, &error);
-        result.append(reinterpret_cast<uint8_t*>(buffer), target - buffer);
+        result.append(std::span(reinterpret_cast<uint8_t*>(buffer), target - buffer));
     } while (needsToGrowToProduceBuffer(error));
     return result;
 }

--- a/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
@@ -215,7 +215,7 @@ static Vector<uint8_t> encodeComplexWindowsLatin1(StringView string, Unencodable
             // No way to encode this character with Windows Latin-1.
             UnencodableReplacementArray replacement;
             int replacementLength = TextCodec::getUnencodableReplacement(character, handling, replacement);
-            result.append(replacement.data(), replacementLength);
+            result.append(std::span(replacement.data(), replacementLength));
             continue;
         }
     gotByte:

--- a/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
@@ -68,7 +68,7 @@ static Vector<uint8_t> encodeComplexUserDefined(StringView string, UnencodableHa
             // No way to encode this character with x-user-defined.
             UnencodableReplacementArray replacement;
             int replacementLength = TextCodec::getUnencodableReplacement(character, handling, replacement);
-            result.append(replacement.data(), replacementLength);
+            result.append(std::span(replacement.data(), replacementLength));
         }
     }
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3009,7 +3009,7 @@ bool AccessibilityObject::supportsPressAction() const
         // Limit the amount of children we take. Some objects can have tens of thousands of children, so we don't want to unconditionally append `children()` to the candidate pool.
         const auto& children = candidate->children();
         if (size_t maxChildrenToTake = std::min(static_cast<size_t>(halfSearchLimit), candidatesLeftUntilLimit))
-            candidates.append(children.span().subspan(0, std::min(children.size(), maxChildrenToTake)));
+            candidates.append(children.subspan(0, std::min(children.size(), maxChildrenToTake)));
 
         // `candidates` should never be allowed to grow past `searchLimit`.
         ASSERT(searchLimit >= candidates.size());

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -558,7 +558,7 @@ static JSC::JSPromise* handleResponseOnStreamingAction(JSC::JSGlobalObject* glob
             }
 
             if (auto* chunk = result.returnValue())
-                compiler->addBytes(chunk->data(), chunk->size());
+                compiler->addBytes(*chunk);
             else
                 compiler->finalize(globalObject);
         });
@@ -569,7 +569,7 @@ static JSC::JSPromise* handleResponseOnStreamingAction(JSC::JSGlobalObject* glob
     WTF::switchOn(body, [&](Ref<FormData>&) {
         RELEASE_ASSERT_NOT_REACHED();
     }, [&](Ref<SharedBuffer>& buffer) {
-        compiler->addBytes(buffer->data(), buffer->size());
+        compiler->addBytes(buffer->bytes());
         compiler->finalize(globalObject);
     }, [&](std::nullptr_t&) {
         compiler->finalize(globalObject);

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -1129,8 +1129,7 @@ void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoK
             // FIXME: Converting to JS just to JSON-Stringify seems inefficient. We should find a way to go directly from the struct to JSON.
             auto jwk = toJS<IDLDictionary<JsonWebKey>>(*(promise->globalObject()), *(promise->globalObject()), WTFMove(std::get<JsonWebKey>(key)));
             String jwkString = JSONStringify(promise->globalObject(), jwk, 0);
-            CString jwkUTF8String = jwkString.utf8(StrictConversion);
-            bytes.append(jwkUTF8String.data(), jwkUTF8String.length());
+            bytes.append(jwkString.utf8(StrictConversion).bytes());
         }
         }
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
@@ -76,7 +76,7 @@ static ExceptionOr<Vector<uint8_t>> signECDSA(CryptoAlgorithmIdentifier hash, co
         offset += signature[offset] - keyLengthInBytes;
     offset++; // skip length
     ASSERT_WITH_SECURITY_IMPLICATION(signature.size() > offset + bytesToCopy);
-    newSignature.append(signature.data() + offset, bytesToCopy);
+    newSignature.append(signature.subspan(offset, bytesToCopy));
     offset += bytesToCopy + 1; // skip r, tag
 
     // If s < keyLengthInBytes, fill the head of s with 0s.
@@ -90,7 +90,7 @@ static ExceptionOr<Vector<uint8_t>> signECDSA(CryptoAlgorithmIdentifier hash, co
         offset += signature[offset] - keyLengthInBytes;
     ++offset; // skip length
     ASSERT_WITH_SECURITY_IMPLICATION(signature.size() >= offset + bytesToCopy);
-    newSignature.append(signature.data() + offset, bytesToCopy);
+    newSignature.append(signature.subspan(offset, bytesToCopy));
 
     return WTFMove(newSignature);
 }
@@ -139,12 +139,12 @@ static ExceptionOr<bool> verifyECDSA(CryptoAlgorithmIdentifier hash, const Platf
     addEncodedASN1Length(newSignature, keyLengthInBytes + rNeedsInitialOctet - rStart);
     if (rNeedsInitialOctet)
         newSignature.append(InitialOctet);
-    newSignature.append(signature.data() + rStart, keyLengthInBytes - rStart);
+    newSignature.append(signature.subspan(rStart, keyLengthInBytes - rStart));
     newSignature.append(IntegerMark);
     addEncodedASN1Length(newSignature, keyLengthInBytes * 2 + sNeedsInitialOctet - sStart);
     if (sNeedsInitialOctet)
         newSignature.append(InitialOctet);
-    newSignature.append(signature.data() + sStart, keyLengthInBytes * 2 - sStart);
+    newSignature.append(signature.subspan(sStart, keyLengthInBytes * 2 - sStart));
 
     uint32_t valid;
     CCCryptorStatus status = CCECCryptorVerifyHash(key, digestData.data(), digestData.size(), newSignature.data(), newSignature.size(), &valid);

--- a/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp
@@ -245,7 +245,7 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportSpki() const
     result.append(BitStringMark);
     addEncodedASN1Length(result, keySize + 1);
     result.append(InitialOctet);
-    result.append(platformKey().data(), platformKey().size());
+    result.append(platformKey().span());
 
     ASSERT(result.size() == totalSize);
 
@@ -360,7 +360,7 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyOKP::exportPkcs8() const
     addEncodedASN1Length(result, keySize + 2);
     result.append(OctetStringMark);
     addEncodedASN1Length(result, keySize);
-    result.append(platformKey().data(), platformKey().size());
+    result.append(platformKey().span());
 
     ASSERT(result.size() == totalSize);
 

--- a/Source/WebCore/crypto/cocoa/CryptoKeyRSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoKeyRSAMac.cpp
@@ -350,11 +350,11 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyRSA::exportSpki() const
     result.reserveInitialCapacity(totalSize + bytesNeededForEncodedLength(totalSize) + 1);
     result.append(SequenceMark);
     addEncodedASN1Length(result, totalSize);
-    result.append(RSAOIDHeader, sizeof(RSAOIDHeader));
+    result.append(std::span { RSAOIDHeader });
     result.append(BitStringMark);
     addEncodedASN1Length(result, keySize + 1);
     result.append(InitialOctet);
-    result.append(keyBytes.data(), keyBytes.size());
+    result.append(keyBytes.span());
 
     return WTFMove(result);
 }
@@ -409,11 +409,11 @@ ExceptionOr<Vector<uint8_t>> CryptoKeyRSA::exportPkcs8() const
     result.reserveInitialCapacity(totalSize + bytesNeededForEncodedLength(totalSize) + 1);
     result.append(SequenceMark);
     addEncodedASN1Length(result, totalSize);
-    result.append(Version, sizeof(Version));
-    result.append(RSAOIDHeader, sizeof(RSAOIDHeader));
+    result.append(std::span { Version });
+    result.append(std::span { RSAOIDHeader });
     result.append(OctetStringMark);
     addEncodedASN1Length(result, keySize);
-    result.append(keyBytes.data(), keyBytes.size());
+    result.append(keyBytes.span());
 
     return WTFMove(result);
 }

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
@@ -49,7 +49,7 @@ static bool extractECDSASignatureInteger(Vector<uint8_t>& signature, gcry_sexp_t
     size_t dataSize = integerData->size();
     if (dataSize >= keySizeInBytes) {
         // Append the last `keySizeInBytes` bytes of the data Vector, if available.
-        signature.append(&integerData->at(dataSize - keySizeInBytes), keySizeInBytes);
+        signature.append(integerData->subspan(dataSize - keySizeInBytes, keySizeInBytes));
     } else {
         // If not, prefix the binary data with zero bytes.
         for (size_t paddingSize = keySizeInBytes - dataSize; paddingSize > 0; --paddingSize)

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmEd25519GCrypt.cpp
@@ -39,7 +39,7 @@ static bool extractEDDSASignatureInteger(Vector<uint8_t>& signature, gcry_sexp_t
     size_t dataSize = integerData->size();
     if (dataSize >= keySizeInBytes) {
         // Append the last `keySizeInBytes` bytes of the data Vector, if available.
-        signature.append(&integerData->at(dataSize - keySizeInBytes), keySizeInBytes);
+        signature.append(integerData->subspan(dataSize - keySizeInBytes, keySizeInBytes));
     } else {
         // If not, prefix the binary data with zero bytes.
         for (size_t paddingSize = keySizeInBytes - dataSize; paddingSize > 0; --paddingSize)

--- a/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp
@@ -163,7 +163,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPublic(CryptoAlgorithmIdentifi
     // Construct the Vector that represents the EC point in uncompressed format.
     Vector<uint8_t> q;
     q.reserveInitialCapacity(curveUncompressedPointSize(curve));
-    q.append(CryptoConstants::s_ecUncompressedFormatLeadingByte.data(), CryptoConstants::s_ecUncompressedFormatLeadingByte.size());
+    q.append(std::span { CryptoConstants::s_ecUncompressedFormatLeadingByte });
     q.appendVector(x);
     q.appendVector(y);
 
@@ -187,7 +187,7 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::platformImportJWKPrivate(CryptoAlgorithmIdentif
     // Construct the Vector that represents the EC point in uncompressed format.
     Vector<uint8_t> q;
     q.reserveInitialCapacity(curveUncompressedPointSize(curve));
-    q.append(CryptoConstants::s_ecUncompressedFormatLeadingByte.data(), CryptoConstants::s_ecUncompressedFormatLeadingByte.size());
+    q.append(std::span { CryptoConstants::s_ecUncompressedFormatLeadingByte });
     q.appendVector(x);
     q.appendVector(y);
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h
@@ -42,7 +42,7 @@ public:
         if (!m_ivVector.isEmpty() || !iv.length())
             return m_ivVector;
 
-        m_ivVector.append(iv.data(), iv.length());
+        m_ivVector.append(iv.bytes());
         return m_ivVector;
     }
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h
@@ -43,7 +43,7 @@ public:
         if (!m_counterVector.isEmpty() || !counter.length())
             return m_counterVector;
 
-        m_counterVector.append(counter.data(), counter.length());
+        m_counterVector.append(counter.bytes());
         return m_counterVector;
     }
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h
@@ -45,7 +45,7 @@ public:
         if (!m_ivVector.isEmpty() || !iv.length())
             return m_ivVector;
 
-        m_ivVector.append(iv.data(), iv.length());
+        m_ivVector.append(iv.bytes());
         return m_ivVector;
     }
 
@@ -59,7 +59,7 @@ public:
         if (!additionalDataBuffer.length())
             return m_additionalDataVector;
 
-        m_additionalDataVector.append(additionalDataBuffer.data(), additionalDataBuffer.length());
+        m_additionalDataVector.append(additionalDataBuffer.bytes());
         return m_additionalDataVector;
     }
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h
@@ -46,7 +46,7 @@ public:
         if (!m_saltVector.isEmpty() || !salt.length())
             return m_saltVector;
 
-        m_saltVector.append(salt.data(), salt.length());
+        m_saltVector.append(salt.bytes());
         return m_saltVector;
     }
 
@@ -55,7 +55,7 @@ public:
         if (!m_infoVector.isEmpty() || !info.length())
             return m_infoVector;
 
-        m_infoVector.append(info.data(), info.length());
+        m_infoVector.append(info.bytes());
         return m_infoVector;
     }
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h
@@ -46,7 +46,7 @@ public:
         if (!m_saltVector.isEmpty() || !salt.length())
             return m_saltVector;
 
-        m_saltVector.append(salt.data(), salt.length());
+        m_saltVector.append(salt.bytes());
         return m_saltVector;
     }
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
@@ -43,7 +43,7 @@ public:
         if (!m_publicExponentVector.isEmpty() || !publicExponent->byteLength())
             return m_publicExponentVector;
 
-        m_publicExponentVector.append(publicExponent->data(), publicExponent->byteLength());
+        m_publicExponentVector.append(publicExponent->bytes());
         return m_publicExponentVector;
     }
 private:

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
@@ -48,7 +48,7 @@ public:
         if (!labelBuffer.length())
             return m_labelVector;
 
-        m_labelVector.append(labelBuffer.data(), labelBuffer.length());
+        m_labelVector.append(labelBuffer.bytes());
         return m_labelVector;
     }
 

--- a/Source/WebCore/dom/DatasetDOMStringMap.cpp
+++ b/Source/WebCore/dom/DatasetDOMStringMap.cpp
@@ -91,7 +91,7 @@ static inline AtomString convertPropertyNameToAttributeName(const StringImpl& na
     unsigned length = name.length();
     buffer.reserveInitialCapacity(std::size(dataPrefix) + length);
 
-    buffer.append(dataPrefix, std::size(dataPrefix));
+    buffer.append(std::span { dataPrefix });
 
     const CharacterType* characters = name.characters<CharacterType>();
     for (unsigned i = 0; i < length; ++i) {

--- a/Source/WebCore/fileapi/BlobBuilder.cpp
+++ b/Source/WebCore/fileapi/BlobBuilder.cpp
@@ -50,14 +50,14 @@ void BlobBuilder::append(RefPtr<ArrayBuffer>&& arrayBuffer)
 {
     if (!arrayBuffer)
         return;
-    m_appendableData.append(static_cast<const uint8_t*>(arrayBuffer->data()), arrayBuffer->byteLength());
+    m_appendableData.append(arrayBuffer->bytes());
 }
 
 void BlobBuilder::append(RefPtr<ArrayBufferView>&& arrayBufferView)
 {
     if (!arrayBufferView)
         return;
-    m_appendableData.append(static_cast<const uint8_t*>(arrayBufferView->baseAddress()), arrayBufferView->byteLength());
+    m_appendableData.append(arrayBufferView->bytes());
 }
 
 void BlobBuilder::append(RefPtr<Blob>&& blob)

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -453,8 +453,8 @@ int HistoryItem::showTreeWithIndent(unsigned indentLevel) const
 {
     Vector<char> prefix;
     for (unsigned i = 0; i < indentLevel; ++i)
-        prefix.append("  ", 2);
-    prefix.append("\0", 1);
+        prefix.append("  "_span);
+    prefix.append('\0');
 
     fprintf(stderr, "%s+-%s (%p)\n", prefix.data(), m_urlString.utf8().data(), this);
     

--- a/Source/WebCore/html/parser/HTMLToken.h
+++ b/Source/WebCore/html/parser/HTMLToken.h
@@ -421,7 +421,7 @@ inline void HTMLToken::appendToComment(char character)
 inline void HTMLToken::appendToComment(ASCIILiteral literal)
 {
     ASSERT(m_type == Type::Comment);
-    m_data.append(literal.characters8(), literal.length());
+    m_data.append(literal.span8());
 }
 
 inline void HTMLToken::appendToComment(UChar character)

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -631,7 +631,7 @@ String TextResourceDecoder::decode(std::span<const uint8_t> data)
         memcpy(m_buffer.data() + oldSize, data.data(), data.size());
     }
 
-    String result = m_codec->decode(m_buffer.span().subspan(lengthOfBOM), false, m_contentType == XML && !m_useLenientXMLDecoding, m_sawError);
+    String result = m_codec->decode(m_buffer.subspan(lengthOfBOM), false, m_contentType == XML && !m_useLenientXMLDecoding, m_sawError);
     m_buffer.clear();
     return result;
 }

--- a/Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp
@@ -210,7 +210,7 @@ RefPtr<ArchiveResource> MHTMLParser::parseNextPart(const MIMEHeader& mimeHeader,
         break;
     case MIMEHeader::SevenBit:
     case MIMEHeader::Binary:
-        data.append(contiguousContent->data(), contiguousContent->size());
+        data.append(contiguousContent->bytes());
         break;
     default:
         LOG_ERROR("Invalid encoding for MHTML part.");

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -376,7 +376,7 @@ void EventSource::parseEventStreamLine(unsigned position, std::optional<unsigned
     unsigned valueLength = lineLength - step;
 
     if (field == "data"_s) {
-        m_data.append(&m_receiveBuffer[position], valueLength);
+        m_data.append(m_receiveBuffer.subspan(position, valueLength));
         m_data.append('\n');
     } else if (field == "event"_s)
         m_eventName = { &m_receiveBuffer[position], valueLength };

--- a/Source/WebCore/page/PageConsoleClient.cpp
+++ b/Source/WebCore/page/PageConsoleClient.cpp
@@ -130,7 +130,7 @@ void PageConsoleClient::addMessage(std::unique_ptr<Inspector::ConsoleMessage>&& 
             messageArgumentsVector = consoleMessage->arguments()->getArgumentsAsStrings();
             if (!messageArgumentsVector.isEmpty()) {
                 message = messageArgumentsVector.first();
-                additionalArguments = messageArgumentsVector.span().subspan(1);
+                additionalArguments = messageArgumentsVector.subspan(1);
             }
         } else
             message = consoleMessage->message();
@@ -188,7 +188,7 @@ void PageConsoleClient::messageWithTypeAndLevel(MessageType type, MessageLevel l
     Vector<String> messageArgumentsVector = arguments->getArgumentsAsStrings();
     if (!messageArgumentsVector.isEmpty()) {
         messageText = messageArgumentsVector.first();
-        additionalArguments = messageArgumentsVector.span().subspan(1);
+        additionalArguments = messageArgumentsVector.subspan(1);
     }
 
     auto message = makeUnique<Inspector::ConsoleMessage>(MessageSource::ConsoleAPI, type, level, messageText, arguments.copyRef(), lexicalGlobalObject);

--- a/Source/WebCore/platform/SharedBufferChunkReader.cpp
+++ b/Source/WebCore/platform/SharedBufferChunkReader.cpp
@@ -60,7 +60,7 @@ void SharedBufferChunkReader::setSeparator(const Vector<char>& separator)
 void SharedBufferChunkReader::setSeparator(const char* separator)
 {
     m_separator.clear();
-    m_separator.append(separator, strlen(separator));
+    m_separator.append(std::span { separator, strlen(separator) });
 }
 
 bool SharedBufferChunkReader::nextChunk(Vector<uint8_t>& chunk, bool includeSeparator)
@@ -76,7 +76,7 @@ bool SharedBufferChunkReader::nextChunk(Vector<uint8_t>& chunk, bool includeSepa
             if (currentCharacter != m_separator[m_separatorIndex]) {
                 if (m_separatorIndex > 0) {
                     ASSERT_WITH_SECURITY_IMPLICATION(m_separatorIndex <= m_separator.size());
-                    chunk.append(m_separator.data(), m_separatorIndex);
+                    chunk.append(std::span { m_separator.data(), m_separatorIndex });
                     m_separatorIndex = 0;
                 }
                 chunk.append(currentCharacter);
@@ -96,7 +96,7 @@ bool SharedBufferChunkReader::nextChunk(Vector<uint8_t>& chunk, bool includeSepa
         if (++m_iteratorCurrent == m_iteratorEnd) {
             m_segment = nullptr;
             if (m_separatorIndex > 0)
-                chunk.append(reinterpret_cast<const uint8_t*>(m_separator.data()), m_separatorIndex);
+                chunk.append(std::span { reinterpret_cast<const uint8_t*>(m_separator.data()), m_separatorIndex });
             return !chunk.isEmpty();
         }
         m_segment = m_iteratorCurrent->segment->data();
@@ -122,7 +122,7 @@ size_t SharedBufferChunkReader::peek(Vector<uint8_t>& data, size_t requestedSize
         return 0;
 
     size_t availableInSegment = std::min(m_iteratorCurrent->segment->size() - m_segmentIndex, requestedSize);
-    data.append(m_segment + m_segmentIndex, availableInSegment);
+    data.append(std::span { m_segment + m_segmentIndex, availableInSegment });
 
     size_t readBytesCount = availableInSegment;
     requestedSize -= readBytesCount;
@@ -132,7 +132,7 @@ size_t SharedBufferChunkReader::peek(Vector<uint8_t>& data, size_t requestedSize
     while (requestedSize && ++currentSegment != m_iteratorEnd) {
         const uint8_t* segment = currentSegment->segment->data();
         size_t lengthInSegment = std::min(currentSegment->segment->size(), requestedSize);
-        data.append(segment, lengthInSegment);
+        data.append(std::span { segment, lengthInSegment });
         readBytesCount += lengthInSegment;
         requestedSize -= lengthInSegment;
     }

--- a/Source/WebCore/platform/SharedStringHash.h
+++ b/Source/WebCore/platform/SharedStringHash.h
@@ -45,7 +45,7 @@ using SharedStringHashMarkableTraits = IntegralMarkableTraits<SharedStringHash, 
 
 // Returns the hash of the string that will be used for visited link coloring.
 WEBCORE_EXPORT SharedStringHash computeSharedStringHash(const String& url);
-WEBCORE_EXPORT SharedStringHash computeSharedStringHash(const UChar* url, unsigned length);
+WEBCORE_EXPORT SharedStringHash computeSharedStringHash(std::span<const UChar> url);
 
 // Resolves the potentially relative URL "attributeURL" relative to the given
 // base URL, and returns the hash of the string that will be used for visited

--- a/Source/WebCore/platform/audio/MultiChannelResampler.cpp
+++ b/Source/WebCore/platform/audio/MultiChannelResampler.cpp
@@ -105,7 +105,7 @@ void MultiChannelResampler::provideInputForChannel(std::span<float> buffer, size
     }
 
     // Copy the channel data from what we received from m_multiChannelProvider.
-    memcpySpan(buffer.subspan(0, framesToProcess), m_multiChannelBus->channel(channelIndex)->span().subspan(0, framesToProcess));
+    memcpySpan(buffer.first(framesToProcess), m_multiChannelBus->channel(channelIndex)->span().first(framesToProcess));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/SincResampler.cpp
+++ b/Source/WebCore/platform/audio/SincResampler.cpp
@@ -209,7 +209,7 @@ void SincResampler::processBuffer(std::span<const float> source, std::span<float
         size_t framesToCopy = std::min(source.size(), framesToProcess);
 
         IGNORE_WARNINGS_BEGIN("restrict")
-        memcpySpan(buffer.subspan(0, framesToCopy), source.subspan(0, framesToCopy));
+        memcpySpan(buffer.first(framesToCopy), source.first(framesToCopy));
         IGNORE_WARNINGS_END
 
         // Zero-pad if necessary.
@@ -278,7 +278,7 @@ void SincResampler::process(std::span<float> destination, size_t framesToProcess
 
         // Step (3) Copy r3 to r1.
         // This wraps the last input frames back to the start of the buffer.
-        memcpySpan(m_r1.subspan(0, kernelSize), m_r3.subspan(0, kernelSize));
+        memcpySpan(m_r1.first(kernelSize), m_r3.first(kernelSize));
 
         // Step (4) -- Reinitialize regions if necessary.
         if (m_r0.data() == m_r2.data())

--- a/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
+++ b/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
@@ -68,13 +68,13 @@ static bool readUInt16(SharedBuffer& buffer, size_t& offset, uint16_t& value)
 static bool writeUInt32(Vector<uint8_t>& vector, uint32_t value)
 {
     uint32_t bigEndianValue = htonl(value);
-    return vector.tryAppend(reinterpret_cast_ptr<uint8_t*>(&bigEndianValue), sizeof(bigEndianValue));
+    return vector.tryAppend(std::span { reinterpret_cast_ptr<uint8_t*>(&bigEndianValue), sizeof(bigEndianValue) });
 }
 
 static bool writeUInt16(Vector<uint8_t>& vector, uint16_t value)
 {
     uint16_t bigEndianValue = htons(value);
-    return vector.tryAppend(reinterpret_cast_ptr<uint8_t*>(&bigEndianValue), sizeof(bigEndianValue));
+    return vector.tryAppend(std::span { reinterpret_cast_ptr<uint8_t*>(&bigEndianValue), sizeof(bigEndianValue) });
 }
 
 static const uint32_t woffSignature = 0x774f4646; /* 'wOFF' */
@@ -105,7 +105,7 @@ public:
     {
         if (!m_vector.tryReserveCapacity(m_vector.size() + n))
             return false;
-        m_vector.append(static_cast<const uint8_t*>(data), n);
+        m_vector.append(std::span { static_cast<const uint8_t*>(data), n });
         return true;
     }
 
@@ -265,7 +265,7 @@ bool convertWOFFToSfnt(SharedBuffer& woff, Vector<uint8_t>& sfnt)
 
         if (tableCompLength == tableOrigLength) {
             // The table is not compressed.
-            if (!sfnt.tryAppend(woff.data() + tableOffset, tableCompLength))
+            if (!sfnt.tryAppend(woff.bytes().subspan(tableOffset, tableCompLength)))
                 return false;
         } else {
             uLongf destLen = tableOrigLength;

--- a/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ImageBufferUtilitiesCairo.cpp
@@ -53,7 +53,7 @@ namespace WebCore {
 #if !PLATFORM(GTK)
 static cairo_status_t writeFunction(void* output, const unsigned char* data, unsigned length)
 {
-    if (!reinterpret_cast<Vector<uint8_t>*>(output)->tryAppend(data, length))
+    if (!reinterpret_cast<Vector<uint8_t>*>(output)->tryAppend(std::span { data, length }))
         return CAIRO_STATUS_WRITE_ERROR;
     return CAIRO_STATUS_SUCCESS;
 }

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -1218,7 +1218,7 @@ webm::Status WebMParser::AudioTrackData::consumeFrameData(webm::Reader& reader, 
         RefPtr<AudioInfo> formatDescription;
         auto& privateData = track().codec_private.value();
         if (codec() == CodecType::Vorbis)
-            formatDescription = createVorbisAudioInfo(privateData.size(), privateData.data());
+            formatDescription = createVorbisAudioInfo(privateData);
         else if (codec() == CodecType::Opus) {
             auto contiguousBuffer = contiguousCompleteBlockBuffer(0, kOpusMinimumFrameDataSize);
             if (!contiguousBuffer) {

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
@@ -39,7 +39,7 @@ class SharedBuffer;
 WEBCORE_EXPORT bool isVorbisDecoderAvailable();
 WEBCORE_EXPORT bool registerVorbisDecoderIfNeeded();
 static constexpr size_t kVorbisMinimumFrameDataSize = 1;
-RefPtr<AudioInfo> createVorbisAudioInfo(size_t, const uint8_t*);
+RefPtr<AudioInfo> createVorbisAudioInfo(std::span<const uint8_t>);
 
 struct OpusCookieContents {
     uint8_t version { 0 };

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -281,7 +281,7 @@ CDMInstanceSessionThunder::CDMInstanceSessionThunder(CDMInstanceThunder& instanc
     m_thunderSessionCallbacks.key_update_callback = [](OpenCDMSession*, void* userData, const uint8_t keyIDData[], const uint8_t keyIDLength) {
         GST_DEBUG("Got 'key updated' OCDM notification");
         KeyIDType keyID;
-        keyID.append(keyIDData, keyIDLength);
+        keyID.append(std::span { keyIDData, keyIDLength });
         callOnMainThread([session = WeakPtr { static_cast<CDMInstanceSessionThunder*>(userData) }, keyID = WTFMove(keyID)]() mutable {
             if (!session)
                 return;

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeUtilities.cpp
@@ -188,8 +188,8 @@ void EOTHeader::appendBigEndianString(const BigEndianUShort* string, unsigned sh
 
 void EOTHeader::appendPaddingShort()
 {
-    unsigned short padding = 0;
-    m_buffer.append(reinterpret_cast<uint8_t*>(&padding), sizeof(padding));
+    std::array<uint8_t, sizeof(unsigned short)> padding = { };
+    m_buffer.append(std::span { padding });
 }
 
 // adds fontName to the font table in fontData, and writes the new font table to rewrittenFontTable

--- a/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferUtilitiesSkia.cpp
@@ -52,7 +52,7 @@ public:
 
     bool write(const void* data, size_t length) override
     {
-        m_vector.append(static_cast<const uint8_t*>(data), length);
+        m_vector.append(std::span { static_cast<const uint8_t*>(data), length });
         return true;
     }
 

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -291,7 +291,7 @@ Vector<uint8_t> FormData::flatten() const
     Vector<uint8_t> data;
     for (auto& element : m_elements) {
         if (auto* vector = std::get_if<Vector<uint8_t>>(&element.data))
-            data.append(vector->data(), vector->size());
+            data.append(vector->span());
     }
     return data;
 }

--- a/Source/WebCore/platform/network/FormDataBuilder.cpp
+++ b/Source/WebCore/platform/network/FormDataBuilder.cpp
@@ -50,7 +50,7 @@ static inline void append(Vector<uint8_t>& buffer, std::span<const uint8_t> byte
 
 static inline void append(Vector<uint8_t>& buffer, const char* string)
 {
-    buffer.append(string, strlen(string));
+    buffer.append(std::span { string, strlen(string) });
 }
 
 static inline void append(Vector<uint8_t>& buffer, const CString& string)

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -703,10 +703,10 @@ static inline bool isValidHeaderNameCharacter(CharacterType character)
     }
 }
 
-size_t parseHTTPHeader(const uint8_t* start, size_t length, String& failureReason, StringView& nameStr, String& valueStr, bool strict)
+size_t parseHTTPHeader(std::span<const uint8_t> data, String& failureReason, StringView& nameStr, String& valueStr, bool strict)
 {
-    auto p = start;
-    auto end = start + length;
+    auto p = data.data();
+    auto end = data.data() + data.size();
 
     Vector<uint8_t> name;
     Vector<uint8_t> value;
@@ -723,7 +723,7 @@ size_t parseHTTPHeader(const uint8_t* start, size_t length, String& failureReaso
         case '\r':
             if (name.isEmpty()) {
                 if (p + 1 < end && *(p + 1) == '\n')
-                    return (p + 2) - start;
+                    return (p + 2) - data.data();
                 failureReason = makeString("CR doesn't follow LF in header name at ", trimInputSample(p, end - p));
                 return 0;
             }
@@ -787,15 +787,15 @@ size_t parseHTTPHeader(const uint8_t* start, size_t length, String& failureReaso
         failureReason = "Invalid UTF-8 sequence in header value"_s;
         return 0;
     }
-    return p - start;
+    return p - data.data();
 }
 
-size_t parseHTTPRequestBody(const uint8_t* data, size_t length, Vector<uint8_t>& body)
+size_t parseHTTPRequestBody(std::span<const uint8_t> data, Vector<uint8_t>& body)
 {
     body.clear();
-    body.append(data, length);
+    body.append(data);
 
-    return length;
+    return data.size();
 }
 
 std::optional<uint64_t> parseContentLength(StringView contentLengthValue)

--- a/Source/WebCore/platform/network/HTTPParsers.h
+++ b/Source/WebCore/platform/network/HTTPParsers.h
@@ -103,8 +103,8 @@ WEBCORE_EXPORT bool parseRange(StringView, RangeAllowWhitespace, long long& rang
 ContentTypeOptionsDisposition parseContentTypeOptionsHeader(StringView header);
 
 // Parsing Complete HTTP Messages.
-size_t parseHTTPHeader(const uint8_t* data, size_t length, String& failureReason, StringView& nameStr, String& valueStr, bool strict = true);
-size_t parseHTTPRequestBody(const uint8_t* data, size_t length, Vector<uint8_t>& body);
+size_t parseHTTPHeader(std::span<const uint8_t> data, String& failureReason, StringView& nameStr, String& valueStr, bool strict = true);
+size_t parseHTTPRequestBody(std::span<const uint8_t> data, Vector<uint8_t>& body);
 
 std::optional<uint64_t> parseContentLength(StringView);
 

--- a/Source/WebCore/platform/network/SynchronousLoaderClient.cpp
+++ b/Source/WebCore/platform/network/SynchronousLoaderClient.cpp
@@ -74,7 +74,7 @@ void SynchronousLoaderClient::didReceiveResponseAsync(ResourceHandle*, ResourceR
 
 void SynchronousLoaderClient::didReceiveData(ResourceHandle*, const SharedBuffer& buffer, int /*encodedDataLength*/)
 {
-    m_data.append(buffer.data(), buffer.size());
+    m_data.append(buffer.bytes());
 }
 
 void SynchronousLoaderClient::didFinishLoading(ResourceHandle* handle, const NetworkLoadMetrics&)

--- a/Source/WebCore/platform/network/curl/CertificateInfo.h
+++ b/Source/WebCore/platform/network/curl/CertificateInfo.h
@@ -55,7 +55,7 @@ public:
 
     bool isEmpty() const { return m_certificateChain.isEmpty(); }
 
-    static Certificate makeCertificate(const uint8_t*, size_t);
+    static Certificate makeCertificate(std::span<const uint8_t>);
 
     friend bool operator==(const CertificateInfo&, const CertificateInfo&) = default;
 

--- a/Source/WebCore/platform/network/curl/CertificateInfoCurl.cpp
+++ b/Source/WebCore/platform/network/curl/CertificateInfoCurl.cpp
@@ -50,10 +50,10 @@ String CertificateInfo::verificationErrorDescription() const
     return String::fromLatin1(X509_verify_cert_error_string(m_verificationError));
 }
 
-CertificateInfo::Certificate CertificateInfo::makeCertificate(const uint8_t* buffer, size_t size)
+CertificateInfo::Certificate CertificateInfo::makeCertificate(std::span<const uint8_t> buffer)
 {
     Certificate certificate;
-    certificate.append(buffer, size);
+    certificate.append(buffer);
     return certificate;
 }
 

--- a/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
+++ b/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
@@ -295,7 +295,7 @@ CurlMultipartHandle::ParseHeadersResult CurlMultipartHandle::parseHeadersIfPossi
     String value;
 
     for (auto p = contentStartPtr; p < end; ++p) {
-        size_t consumedLength = parseHTTPHeader(p, end - p, failureReason, name, value, false);
+        size_t consumedLength = parseHTTPHeader(std::span { p, static_cast<size_t>(end - p) }, failureReason, name, value, false);
         if (!consumedLength)
             break; // No more header to parse.
 

--- a/Source/WebCore/platform/text/QuotedPrintable.cpp
+++ b/Source/WebCore/platform/text/QuotedPrintable.cpp
@@ -33,12 +33,13 @@
 
 #include <wtf/ASCIICType.h>
 #include <wtf/Vector.h>
+#include <wtf/text/ASCIILiteral.h>
 
 namespace WebCore {
 
 static const size_t maximumLineLength = 76;
 
-static const char crlfLineEnding[] = "\r\n";
+static constexpr auto crlfLineEnding = "\r\n"_s;
 
 static size_t lengthOfLineEndingAtIndex(const uint8_t* input, size_t inputLength, size_t index)
 {
@@ -81,7 +82,7 @@ Vector<uint8_t> quotedPrintableEncode(const uint8_t* input, size_t inputLength)
         if (!isLastCharacter) {
             size_t lengthOfLineEnding = lengthOfLineEndingAtIndex(input, inputLength, i);
             if (lengthOfLineEnding) {
-                out.append(crlfLineEnding, strlen(crlfLineEnding));
+                out.append(crlfLineEnding.span8());
                 currentLineLength = 0;
                 i += (lengthOfLineEnding - 1); // -1 because we'll ++ in the for() above.
                 continue;
@@ -97,7 +98,7 @@ Vector<uint8_t> quotedPrintableEncode(const uint8_t* input, size_t inputLength)
         // Insert a soft line break if necessary.
         if (currentLineLength + lengthOfEncodedCharacter > maximumLineLength) {
             out.append('=');
-            out.append(crlfLineEnding, strlen(crlfLineEnding));
+            out.append(crlfLineEnding.span8());
             currentLineLength = 0;
         }
 

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -214,12 +214,12 @@ static String getFullCFHTML(IDataObject* data)
 
 static void append(Vector<char>& vector, const char* string)
 {
-    vector.append(string, strlen(string));
+    vector.append(std::span { string, strlen(string) });
 }
 
 static void append(Vector<char>& vector, const CString& string)
 {
-    vector.append(string.data(), string.length());
+    vector.append(string.bytes());
 }
 
 // Find the markup between "<!--StartFragment -->" and "<!--EndFragment -->", accounting for browser quirks.

--- a/Source/WebCore/rendering/svg/SVGTextChunk.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextChunk.cpp
@@ -73,7 +73,7 @@ SVGTextChunk::SVGTextChunk(const Vector<SVGInlineTextBox*>& lineLayoutBoxes, uns
         }
     }
 
-    m_boxes.append(&lineLayoutBoxes[first], limit - first);
+    m_boxes.append(lineLayoutBoxes.subspan(first, limit - first));
 }
 
 unsigned SVGTextChunk::totalCharacters() const

--- a/Source/WebCore/svg/SVGToOTFFontConversion.cpp
+++ b/Source/WebCore/svg/SVGToOTFFontConversion.cpp
@@ -515,7 +515,7 @@ void SVGToOTFFontConverter::appendOS2Table()
     append16(0); // No classification
 
     unsigned numPanoseBytes = 0;
-    const unsigned panoseSize = 10;
+    constexpr unsigned panoseSize = 10;
     char panoseBytes[panoseSize];
     if (m_fontFaceElement) {
         auto segments = StringView(m_fontFaceElement->attributeWithoutSynchronization(SVGNames::panose_1Attr)).split(' ');
@@ -530,7 +530,7 @@ void SVGToOTFFontConverter::appendOS2Table()
     }
     if (numPanoseBytes != panoseSize)
         memset(panoseBytes, 0, panoseSize);
-    m_result.append(panoseBytes, panoseSize);
+    m_result.append(std::span { panoseBytes });
 
     for (int i = 0; i < 4; ++i)
         append32(0); // "Bit assignments are pending. Set to 0"

--- a/Source/WebCore/testing/MockContentFilter.cpp
+++ b/Source/WebCore/testing/MockContentFilter.cpp
@@ -149,9 +149,7 @@ void MockContentFilter::maybeDetermineStatus(DecisionPoint decisionPoint)
     if (m_state != State::Blocked)
         return;
 
-    m_replacementData.clear();
-    const CString utf8BlockedString = settings().blockedString().utf8();
-    m_replacementData.append(utf8BlockedString.data(), utf8BlockedString.length());
+    m_replacementData = settings().blockedString().utf8().bytes();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -118,7 +118,7 @@ public:
         int numNamespaces, const xmlChar** namespaces,
         int numAttributes, int numDefaulted, const xmlChar** libxmlAttributes);
     void endElementNs();
-    void characters(const xmlChar*, int length);
+    void characters(std::span<const xmlChar>);
     void processingInstruction(const xmlChar* target, const xmlChar* data);
     void cdataBlock(const xmlChar*, int length);
     void comment(const xmlChar*);

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -122,7 +122,7 @@ static void sendReplyToSynchronousRequest(NetworkResourceLoader::SynchronousLoad
 
     Vector<uint8_t> responseBuffer;
     if (buffer && buffer->size())
-        responseBuffer.append(buffer->makeContiguous()->data(), buffer->size());
+        responseBuffer.append(buffer->makeContiguous()->bytes());
 
     data.response.setDeprecatedNetworkLoadMetrics(Box<NetworkLoadMetrics>::create(metrics));
 

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -269,7 +269,7 @@ bool WebSocketTask::appendReceivedBuffer(const WebCore::SharedBuffer& buffer)
     if (newBufferSize < m_receiveBuffer.size())
         return false;
 
-    m_receiveBuffer.append(buffer.data(), buffer.size());
+    m_receiveBuffer.append(buffer.bytes());
     return true;
 }
 
@@ -405,8 +405,7 @@ void WebSocketTask::sendClosingHandshakeIfNeeded(int32_t code, const String& rea
         unsigned char lowByte = static_cast<unsigned short>(code);
         buf.append(static_cast<char>(highByte));
         buf.append(static_cast<char>(lowByte));
-        auto reasonUTF8 = reason.utf8();
-        buf.append(reasonUTF8.data(), reasonUTF8.length());
+        buf.append(reason.utf8().bytes());
     }
 
     if (!sendFrame(WebCore::WebSocketFrame::OpCodeClose, buf.span()))

--- a/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp
@@ -66,9 +66,9 @@ LibWebRTCSocketClient::LibWebRTCSocketClient(WebCore::LibWebRTCSocketIdentifier 
     }
 }
 
-void LibWebRTCSocketClient::sendTo(const uint8_t* data, size_t size, const rtc::SocketAddress& socketAddress, const rtc::PacketOptions& options)
+void LibWebRTCSocketClient::sendTo(std::span<const uint8_t> data, const rtc::SocketAddress& socketAddress, const rtc::PacketOptions& options)
 {
-    m_socket->SendTo(data, size, socketAddress, options);
+    m_socket->SendTo(data.data(), data.size(), socketAddress, options);
     auto error = m_socket->GetError();
     RELEASE_LOG_ERROR_IF(error && m_sendError != error, Network, "LibWebRTCSocketClient::sendTo (ID=%" PRIu64 ") failed with error %d", m_identifier.toUInt64(), error);
     m_sendError = error;

--- a/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.h
+++ b/Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.h
@@ -54,7 +54,7 @@ private:
     void close() final;
 
     void setOption(int option, int value) final;
-    void sendTo(const uint8_t*, size_t, const rtc::SocketAddress&, const rtc::PacketOptions&) final;
+    void sendTo(std::span<const uint8_t>, const rtc::SocketAddress&, const rtc::PacketOptions&) final;
 
     void signalReadPacket(rtc::AsyncPacketSocket*, const char*, size_t, const rtc::SocketAddress&, const rtc::PacketTime&);
     void signalSentPacket(rtc::AsyncPacketSocket*, const rtc::SentPacket&);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -232,7 +232,7 @@ void NetworkRTCProvider::sendToSocket(LibWebRTCSocketIdentifier identifier, std:
     auto iterator = m_sockets.find(identifier);
     if (iterator == m_sockets.end())
         return;
-    iterator->second->sendTo(data.data(), data.size(), address.rtcAddress(), options.options);
+    iterator->second->sendTo(data, address.rtcAddress(), options.options);
 }
 
 void NetworkRTCProvider::closeSocket(LibWebRTCSocketIdentifier identifier)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -97,7 +97,7 @@ public:
 
         virtual void close() = 0;
         virtual void setOption(int option, int value) = 0;
-        virtual void sendTo(const uint8_t*, size_t, const rtc::SocketAddress&, const rtc::PacketOptions&) = 0;
+        virtual void sendTo(std::span<const uint8_t>, const rtc::SocketAddress&, const rtc::PacketOptions&) = 0;
     };
 
     std::unique_ptr<Socket> takeSocket(WebCore::LibWebRTCSocketIdentifier);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h
@@ -50,9 +50,9 @@ private:
     Type type() const final { return Type::ClientTCP; }
     void close() final;
     void setOption(int option, int value) final;
-    void sendTo(const uint8_t*, size_t, const rtc::SocketAddress&, const rtc::PacketOptions&) final;
+    void sendTo(std::span<const uint8_t>, const rtc::SocketAddress&, const rtc::PacketOptions&) final;
 
-    Vector<uint8_t> createMessageBuffer(const uint8_t*, size_t);
+    Vector<uint8_t> createMessageBuffer(std::span<const uint8_t>);
 
     WebCore::LibWebRTCSocketIdentifier m_identifier;
     NetworkRTCProvider& m_rtcProvider;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.h
@@ -73,7 +73,7 @@ private:
     Type type() const final { return Type::UDP; }
     void close() final;
     void setOption(int option, int value) final;
-    void sendTo(const uint8_t*, size_t, const rtc::SocketAddress&, const rtc::PacketOptions&) final;
+    void sendTo(std::span<const uint8_t>, const rtc::SocketAddress&, const rtc::PacketOptions&) final;
 
     NetworkRTCProvider& m_rtcProvider;
     WebCore::LibWebRTCSocketIdentifier m_identifier;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -52,7 +52,7 @@ public:
 
     void close();
     void setOption(int option, int value);
-    void sendTo(const uint8_t*, size_t, const rtc::SocketAddress&, const rtc::PacketOptions&);
+    void sendTo(std::span<const uint8_t>, const rtc::SocketAddress&, const rtc::PacketOptions&);
     void setListeningPort(int);
 
     class ConnectionStateTracker : public ThreadSafeRefCounted<ConnectionStateTracker> {
@@ -127,9 +127,9 @@ void NetworkRTCUDPSocketCocoa::setOption(int option, int value)
     m_connections->setOption(option, value);
 }
 
-void NetworkRTCUDPSocketCocoa::sendTo(const uint8_t* data, size_t size, const rtc::SocketAddress& address, const rtc::PacketOptions& options)
+void NetworkRTCUDPSocketCocoa::sendTo(std::span<const uint8_t> data, const rtc::SocketAddress& address, const rtc::PacketOptions& options)
 {
-    m_connections->sendTo(data, size, address, options);
+    m_connections->sendTo(data, address, options);
 }
 
 static rtc::SocketAddress socketAddressFromIncomingConnection(nw_connection_t connection)
@@ -371,7 +371,7 @@ void NetworkRTCUDPSocketCocoaConnections::setupNWConnection(nw_connection_t nwCo
     nw_connection_start(nwConnection);
 }
 
-void NetworkRTCUDPSocketCocoaConnections::sendTo(const uint8_t* data, size_t size, const rtc::SocketAddress& remoteAddress, const rtc::PacketOptions& options)
+void NetworkRTCUDPSocketCocoaConnections::sendTo(std::span<const uint8_t> data, const rtc::SocketAddress& remoteAddress, const rtc::PacketOptions& options)
 {
     bool isInCorrectValue = (remoteAddress == HashTraits<rtc::SocketAddress>::emptyValue()) || HashTraits<rtc::SocketAddress>::isDeletedValue(remoteAddress);
     ASSERT(!isInCorrectValue);
@@ -386,7 +386,7 @@ void NetworkRTCUDPSocketCocoaConnections::sendTo(const uint8_t* data, size_t siz
         }).iterator->value.first.get();
     }
 
-    auto value = adoptNS(dispatch_data_create(data, size, nullptr, DISPATCH_DATA_DESTRUCTOR_DEFAULT));
+    RetainPtr value = adoptNS(dispatch_data_create(data.data(), data.size(), nullptr, DISPATCH_DATA_DESTRUCTOR_DEFAULT));
     nw_connection_send(nwConnection, value.get(), NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, makeBlockPtr([identifier = m_identifier, connection = m_connection.copyRef(), options](_Nullable nw_error_t error) {
         RELEASE_LOG_ERROR_IF(error, WebRTC, "NetworkRTCUDPSocketCocoaConnections::sendTo failed with error %d", error ? nw_error_get_error_code(error) : 0);
         connection->send(Messages::LibWebRTCNetwork::SignalSentPacket { identifier, options.packet_id, rtc::TimeMillis() }, 0);

--- a/Source/WebKit/Shared/API/APIData.h
+++ b/Source/WebKit/Shared/API/APIData.h
@@ -86,9 +86,8 @@ public:
         m_freeDataFunction(const_cast<uint8_t*>(m_span.data()), m_context);
     }
 
-    const unsigned char* bytes() const { return m_span.data(); }
     size_t size() const { return m_span.size(); }
-    std::span<const uint8_t> dataReference() const { return m_span; }
+    std::span<const uint8_t> bytes() const { return m_span; }
 
 private:
     Data(std::span<const uint8_t> span, FreeDataFunction freeDataFunction, const void* context)

--- a/Source/WebKit/Shared/API/APIData.serialization.in
+++ b/Source/WebKit/Shared/API/APIData.serialization.in
@@ -21,5 +21,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [RefCounted, CustomHeader] class API::Data {
-    std::span<const uint8_t> dataReference()
+    std::span<const uint8_t> bytes()
 };

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -1146,7 +1146,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
     }
 
     *length = data->size();
-    return data->bytes();
+    return data->bytes().data();
 }
 
 - (BOOL)requiresSecureCoding

--- a/Source/WebKit/Shared/API/c/WKData.cpp
+++ b/Source/WebKit/Shared/API/c/WKData.cpp
@@ -41,7 +41,7 @@ WKDataRef WKDataCreate(const unsigned char* bytes, size_t size)
 
 const unsigned char* WKDataGetBytes(WKDataRef dataRef)
 {
-    return WebKit::toImpl(dataRef)->bytes();
+    return WebKit::toImpl(dataRef)->bytes().data();
 }
 
 size_t WKDataGetSize(WKDataRef dataRef)

--- a/Source/WebKit/Shared/APIWebArchive.mm
+++ b/Source/WebKit/Shared/APIWebArchive.mm
@@ -83,7 +83,7 @@ WebArchive::WebArchive(WebArchiveResource* mainResource, RefPtr<API::Array>&& su
 
 WebArchive::WebArchive(API::Data* data)
 {
-    m_legacyWebArchive = LegacyWebArchive::create(SharedBuffer::create(data->dataReference()).get());
+    m_legacyWebArchive = LegacyWebArchive::create(SharedBuffer::create(data->bytes()).get());
 }
 
 WebArchive::WebArchive(RefPtr<LegacyWebArchive>&& legacyWebArchive)

--- a/Source/WebKit/Shared/APIWebArchiveResource.mm
+++ b/Source/WebKit/Shared/APIWebArchiveResource.mm
@@ -47,7 +47,7 @@ Ref<WebArchiveResource> WebArchiveResource::create(RefPtr<ArchiveResource>&& arc
 }
 
 WebArchiveResource::WebArchiveResource(API::Data* data, const String& url, const String& MIMEType, const String& textEncoding)
-    : m_archiveResource(ArchiveResource::create(SharedBuffer::create(data->bytes(), data->size()), WTF::URL { url }, MIMEType, textEncoding, String()))
+    : m_archiveResource(ArchiveResource::create(SharedBuffer::create(data->bytes()), WTF::URL { url }, MIMEType, textEncoding, String()))
 {
 }
 

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -243,8 +243,7 @@ auto SandboxExtension::createHandleForTemporaryFile(StringView prefix, Type type
     ASSERT(path.last() == '/');
 
     // Append the file name.
-    auto prefixAsUTF8 = prefix.utf8();
-    path.append(prefixAsUTF8.data(), prefixAsUTF8.length());
+    path.append(prefix.utf8().bytes());
     path.append('\0');
 
     auto pathString = String::fromUTF8(path.data());

--- a/Source/WebKit/Shared/Cocoa/WKNSData.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSData.mm
@@ -51,7 +51,7 @@
 
 - (const void*)bytes
 {
-    return _data->bytes();
+    return _data->bytes().data();
 }
 
 #pragma mark NSCopying protocol implementation

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -199,7 +199,7 @@ static std::optional<Vector<char>> fileContents(const String& path, bool shouldL
     Vector<char> contents;
     contents.reserveInitialCapacity(chunkSize);
     while (size_t bytesRead = file.read(chunk, chunkSize))
-        contents.append(chunk, bytesRead);
+        contents.append(std::span { chunk, bytesRead });
     contents.shrinkToFit();
 
     return contents;
@@ -424,11 +424,11 @@ static SandboxProfilePtr compileAndCacheSandboxProfile(const SandboxInfo& info)
 
     Vector<char> cacheFile;
     cacheFile.reserveInitialCapacity(expectedFileSize);
-    cacheFile.append(bitwise_cast<uint8_t*>(&cachedHeader), sizeof(CachedSandboxHeader));
-    cacheFile.append(info.header.data(), info.header.length());
+    cacheFile.append(std::span { bitwise_cast<uint8_t*>(&cachedHeader), sizeof(CachedSandboxHeader) });
+    cacheFile.append(info.header.bytes());
     if (haveBuiltin)
-        cacheFile.append(sandboxProfile->builtin, cachedHeader.builtinSize);
-    cacheFile.append(sandboxProfile->data, cachedHeader.dataSize);
+        cacheFile.append(std::span { sandboxProfile->builtin, cachedHeader.builtinSize });
+    cacheFile.append(std::span { sandboxProfile->data, cachedHeader.dataSize });
 
     if (!writeSandboxDataToCacheFile(info, cacheFile))
         WTFLogAlways("%s: Unable to cache compiled sandbox\n", getprogname());

--- a/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
@@ -57,7 +57,7 @@ void WKNotificationManagerProviderDidClickNotification(WKNotificationManagerRef 
 
 void WKNotificationManagerProviderDidClickNotification_b(WKNotificationManagerRef managerRef, WKDataRef identifier)
 {
-    auto span = toImpl(identifier)->dataReference();
+    auto span = toImpl(identifier)->bytes();
     if (span.size() != 16)
         return;
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -243,13 +243,13 @@ void WKPageLoadFileWithUserData(WKPageRef pageRef, WKURLRef fileURL, WKURLRef re
 void WKPageLoadData(WKPageRef pageRef, WKDataRef dataRef, WKStringRef MIMETypeRef, WKStringRef encodingRef, WKURLRef baseURLRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->loadData(toImpl(dataRef)->dataReference(), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef));
+    toImpl(pageRef)->loadData(toImpl(dataRef)->bytes(), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef));
 }
 
 void WKPageLoadDataWithUserData(WKPageRef pageRef, WKDataRef dataRef, WKStringRef MIMETypeRef, WKStringRef encodingRef, WKURLRef baseURLRef, WKTypeRef userDataRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->loadData(toImpl(dataRef)->dataReference(), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef), toImpl(userDataRef));
+    toImpl(pageRef)->loadData(toImpl(dataRef)->bytes(), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef), toImpl(userDataRef));
 }
 
 static String encodingOf(const String& string)
@@ -582,7 +582,7 @@ static void restoreFromSessionState(WKPageRef pageRef, WKTypeRef sessionStateRef
 
     // FIXME: This is for backwards compatibility with Safari. Remove it once Safari no longer depends on it.
     if (toImpl(sessionStateRef)->type() == API::Object::Type::Data) {
-        if (!decodeLegacySessionState(toImpl(static_cast<WKDataRef>(sessionStateRef))->dataReference(), sessionState))
+        if (!decodeLegacySessionState(toImpl(static_cast<WKDataRef>(sessionStateRef))->bytes(), sessionState))
             return;
     } else {
         ASSERT(toImpl(sessionStateRef)->type() == API::Object::Type::SessionState);

--- a/Source/WebKit/UIProcess/API/C/WKSessionStateRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKSessionStateRef.cpp
@@ -40,7 +40,7 @@ WKTypeID WKSessionStateGetTypeID()
 WKSessionStateRef WKSessionStateCreateFromData(WKDataRef data)
 {
     WebKit::SessionState sessionState;
-    if (!WebKit::decodeLegacySessionState(WebKit::toImpl(data)->dataReference(), sessionState))
+    if (!WebKit::decodeLegacySessionState(WebKit::toImpl(data)->bytes(), sessionState))
         return nullptr;
 
     return WebKit::toAPI(&API::SessionState::create(WTFMove(sessionState)).leakRef());

--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.cpp
@@ -606,7 +606,7 @@ String IconDatabase::iconURLForPageURL(const String& pageURL)
     return m_pageURLToIconURLMap.get(pageURL);
 }
 
-void IconDatabase::setIconForPageURL(const String& iconURL, const uint8_t* iconData, size_t iconDataSize, const String& pageURL, AllowDatabaseWrite allowDatabaseWrite, CompletionHandler<void(bool)>&& completionHandler)
+void IconDatabase::setIconForPageURL(const String& iconURL, std::span<const uint8_t> iconData, const String& pageURL, AllowDatabaseWrite allowDatabaseWrite, CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(isMainRunLoop());
 
@@ -616,10 +616,10 @@ void IconDatabase::setIconForPageURL(const String& iconURL, const uint8_t* iconD
         {
             Locker locker { m_loadedIconsLock };
             auto addResult = m_loadedIcons.set(iconURL, std::make_pair<PlatformImagePtr, MonotonicTime>(nullptr, { }));
-            if (iconDataSize) {
+            if (iconData.size()) {
                 RefPtr<NativeImage> nativeImage;
-                auto image = BitmapImage::create();
-                if (image->setData(SharedBuffer::create(iconData, iconDataSize), true) >= EncodedDataStatus::SizeAvailable && (nativeImage = image->nativeImageForCurrentFrame()))
+                Ref image = BitmapImage::create();
+                if (image->setData(SharedBuffer::create(iconData), true) >= EncodedDataStatus::SizeAvailable && (nativeImage = image->nativeImageForCurrentFrame()))
                     addResult.iterator->value.first = nativeImage->platformImage();
                 else
                     result = false;
@@ -638,8 +638,7 @@ void IconDatabase::setIconForPageURL(const String& iconURL, const uint8_t* iconD
         return;
     }
 
-    Vector<uint8_t> data(std::span<const uint8_t> { iconData, static_cast<size_t>(iconDataSize) });
-    m_workQueue->dispatch([this, protectedThis = Ref { *this }, iconURL = iconURL.isolatedCopy(), iconData = WTFMove(data), pageURL = pageURL.isolatedCopy(), completionHandler = WTFMove(completionHandler)]() mutable {
+    m_workQueue->dispatch([this, protectedThis = Ref { *this }, iconURL = iconURL.isolatedCopy(), iconData = Vector(iconData), pageURL = pageURL.isolatedCopy(), completionHandler = WTFMove(completionHandler)]() mutable {
         bool result = false;
         if (m_db.isOpen()) {
             SQLiteTransaction transaction(m_db);

--- a/Source/WebKit/UIProcess/API/glib/IconDatabase.h
+++ b/Source/WebKit/UIProcess/API/glib/IconDatabase.h
@@ -46,7 +46,7 @@ public:
     void checkIconURLAndSetPageURLIfNeeded(const String& iconURL, const String& pageURL, AllowDatabaseWrite, CompletionHandler<void(bool, bool)>&&);
     void loadIconForPageURL(const String&, AllowDatabaseWrite, CompletionHandler<void(WebCore::PlatformImagePtr&&)>&&);
     String iconURLForPageURL(const String&);
-    void setIconForPageURL(const String& iconURL, const uint8_t*, size_t, const String& pageURL, AllowDatabaseWrite, CompletionHandler<void(bool)>&&);
+    void setIconForPageURL(const String& iconURL, std::span<const uint8_t>, const String& pageURL, AllowDatabaseWrite, CompletionHandler<void(bool)>&&);
     void clear(CompletionHandler<void()>&&);
 
 private:

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
@@ -149,7 +149,7 @@ void webkitFaviconDatabaseSetIconForPageURL(WebKitFaviconDatabase* database, con
     if (!webkitFaviconDatabaseIsOpen(database))
         return;
 
-    database->priv->iconDatabase->setIconForPageURL(icon.url.string(), iconData.bytes(), iconData.size(), pageURL,
+    database->priv->iconDatabase->setIconForPageURL(icon.url.string(), iconData.bytes(), pageURL,
         isEphemeral ? IconDatabase::AllowDatabaseWrite::No : IconDatabase::AllowDatabaseWrite::Yes,
         [database = GRefPtr<WebKitFaviconDatabase>(database), url = icon.url.string().isolatedCopy(), pageURL = pageURL.isolatedCopy()](bool success) {
             if (!webkitFaviconDatabaseIsOpen(database.get()) || !success)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
@@ -361,7 +361,7 @@ static void resourceDataCallback(API::Data* wkData, GTask* task)
 
     ResourceGetDataAsyncData* data = static_cast<ResourceGetDataAsyncData*>(g_task_get_task_data(task));
     data->webData = wkData;
-    if (!wkData->bytes())
+    if (!wkData->bytes().data())
         data->webData = API::Data::create(reinterpret_cast<const unsigned char*>(""), 1);
     g_task_return_boolean(task, TRUE);
 }
@@ -422,11 +422,11 @@ guchar* webkit_web_resource_get_data_finish(WebKitWebResource* resource, GAsyncR
     if (length)
         *length = data->webData->size();
 
-    auto* bytes = data->webData->bytes();
-    if (!bytes || !data->webData->size())
+    auto bytes = data->webData->bytes();
+    if (bytes.empty())
         return nullptr;
 
     auto* returnValue = g_malloc(data->webData->size());
-    memcpy(returnValue, bytes, data->webData->size());
+    memcpy(returnValue, bytes.data(), bytes.size());
     return static_cast<guchar*>(returnValue);
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -4684,7 +4684,7 @@ static void getContentsAsMHTMLDataCallback(API::Data* wkData, GTask* taskPtr)
     if (g_task_get_source_tag(task.get()) == webkit_web_view_save_to_file) {
         ASSERT(G_IS_FILE(data->file.get()));
         GCancellable* cancellable = g_task_get_cancellable(task.get());
-        g_file_replace_contents_async(data->file.get(), reinterpret_cast<const gchar*>(data->webData->bytes()), data->webData->size(),
+        g_file_replace_contents_async(data->file.get(), reinterpret_cast<const gchar*>(data->webData->bytes().data()), data->webData->size(),
             0, FALSE, G_FILE_CREATE_REPLACE_DESTINATION, cancellable, fileReplaceContentsCallback, task.leakRef());
         return;
     }
@@ -4750,9 +4750,9 @@ GInputStream* webkit_web_view_save_finish(WebKitWebView* webView, GAsyncResult* 
 
     GInputStream* dataStream = g_memory_input_stream_new();
     ViewSaveAsyncData* data = static_cast<ViewSaveAsyncData*>(g_task_get_task_data(task));
-    gsize length = data->webData->size();
-    if (length)
-        g_memory_input_stream_add_data(G_MEMORY_INPUT_STREAM(dataStream), fastMemDup(data->webData->bytes(), length), length, fastFree);
+    auto bytes = data->webData->bytes();
+    if (!bytes.empty())
+        g_memory_input_stream_add_data(G_MEMORY_INPUT_STREAM(dataStream), fastMemDup(bytes.data(), bytes.size()), bytes.size(), fastFree);
 
     return dataStream;
 }

--- a/Source/WebKit/UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
+++ b/Source/WebKit/UIProcess/Automation/cairo/WebAutomationSessionCairo.cpp
@@ -44,7 +44,7 @@ static std::optional<String> base64EncodedPNGData(cairo_surface_t* surface)
     Vector<unsigned char> pngData;
     cairo_surface_write_to_png_stream(surface, [](void* userData, const unsigned char* data, unsigned length) -> cairo_status_t {
         auto* pngData = static_cast<Vector<unsigned char>*>(userData);
-        pngData->append(data, length);
+        pngData->append(std::span { data, length });
         return CAIRO_STATUS_SUCCESS;
     }, &pngData);
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -253,7 +253,7 @@ void WebNotificationManagerProxy::providerDidCloseNotifications(API::Array* glob
             if (!dataValue)
                 continue;
 
-            auto span = dataValue->dataReference();
+            auto span = dataValue->bytes();
             if (span.size() != 16)
                 continue;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8828,7 +8828,7 @@ void WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon(const Vect
     send(Messages::WebPage::ExtendSandboxForFilesFromOpenPanel(WTFMove(sandboxExtensionHandles)));
 #endif
 
-    send(Messages::WebPage::DidChooseFilesForOpenPanelWithDisplayStringAndIcon(fileURLs, displayString, iconData ? iconData->dataReference() : std::span<const uint8_t>()));
+    send(Messages::WebPage::DidChooseFilesForOpenPanelWithDisplayStringAndIcon(fileURLs, displayString, iconData ? iconData->bytes() : std::span<const uint8_t>()));
 
     RefPtr openPanelResultListener = std::exchange(m_openPanelResultListener, nullptr);
     openPanelResultListener->invalidate();
@@ -11240,7 +11240,7 @@ std::optional<Vector<uint8_t>> WebPageProxy::getWebCryptoMasterKey()
     if (auto keyData = m_websiteDataStore->client().webCryptoMasterKey())
         return keyData;
     if (auto keyData = m_navigationClient->webCryptoMasterKey(*this))
-        return Vector(keyData->dataReference());
+        return Vector(keyData->bytes());
     return std::nullopt;
 }
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2476,7 +2476,7 @@ void WebsiteDataStore::resumeDownload(const DownloadProxy& downloadProxy, const 
             sandboxExtensionHandle = WTFMove(*handle);
     }
 
-    protectedNetworkProcess()->send(Messages::NetworkProcess::ResumeDownload(m_sessionID, downloadProxy.downloadID(), resumeData.dataReference(), path, WTFMove(sandboxExtensionHandle), callDownloadDidStart), 0);
+    protectedNetworkProcess()->send(Messages::NetworkProcess::ResumeDownload(m_sessionID, downloadProxy.downloadID(), resumeData.bytes(), path, WTFMove(sandboxExtensionHandle), callDownloadDidStart), 0);
 }
 
 bool WebsiteDataStore::hasActivePages()

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -631,7 +631,7 @@ public:
         const uint8_t* data = m_buffer;
         m_buffer += size;
 
-        value.append(data, size);
+        value.append(std::span { data, static_cast<size_t>(size) });
         return *this;
     }
 
@@ -648,7 +648,7 @@ public:
         const uint8_t* data = m_buffer;
         m_buffer += size;
 
-        value.append(data, size);
+        value.append(std::span { data, static_cast<size_t>(size) });
         return *this;
     }
 

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -292,7 +292,7 @@ static void pageDidDrawToImage(std::optional<WebCore::ShareableBitmap::Handle>&&
             ASSERT(view->_printedPagesData.isEmpty());
             ASSERT(!view->_printedPagesPDFDocument);
             if (data)
-                view->_printedPagesData.append(data->bytes(), data->size());
+                view->_printedPagesData.append(data->bytes());
             view->_expectedPrintCallback = { };
             view->_printingCallbackCondition.notifyOne();
         }

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp
@@ -156,7 +156,7 @@ void InjectedBundlePageEditorClient::getPasteboardDataForRange(WebPage& page, co
             pasteboardTypes.append(type->string());
 
         for (auto item : dataArray->elementsOfType<API::Data>()) {
-            auto buffer = SharedBuffer::create(item->bytes(), item->size());
+            auto buffer = SharedBuffer::create(item->bytes());
             pasteboardData.append(WTFMove(buffer));
         }
     }

--- a/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
@@ -88,7 +88,7 @@ static RetainPtr<NSKeyedUnarchiver> createUnarchiver(std::span<const uint8_t> da
 
 static RetainPtr<NSKeyedUnarchiver> createUnarchiver(const API::Data& data)
 {
-    return createUnarchiver(data.dataReference());
+    return createUnarchiver(data.bytes());
 }
 
 bool InjectedBundle::decodeBundleParameters(API::Data* bundleParameterDataPtr)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -64,7 +64,7 @@ public:
     NetscapePlugInStreamLoader* streamLoader() { return m_streamLoader; }
     void setStreamLoader(NetscapePlugInStreamLoader* loader) { m_streamLoader = loader; }
     void clearStreamLoader();
-    void addData(const uint8_t* data, size_t count) { m_accumulatedData.append(data, count); }
+    void addData(std::span<const uint8_t> data) { m_accumulatedData.append(data); }
 
     void completeWithBytes(const uint8_t*, size_t, PDFIncrementalLoader&);
     void completeWithAccumulatedData(PDFIncrementalLoader&);
@@ -224,7 +224,7 @@ void PDFPluginStreamLoaderClient::didReceiveData(NetscapePlugInStreamLoader* str
     if (!request)
         return;
 
-    request->addData(data.data(), data.size());
+    request->addData(data.bytes());
 }
 
 void PDFPluginStreamLoaderClient::didFail(NetscapePlugInStreamLoader* streamLoader, const ResourceError&)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8548,7 +8548,7 @@ void WebPage::completeTextManipulation(const Vector<WebCore::TextManipulationIte
     for (auto& item : items) {
         if (currentFrameID != item.frameID) {
             RELEASE_ASSERT(indexForCurrentItem >= itemCount);
-            completeManipulationForCurrentFrame(indexForCurrentItem - itemCount, items.span().subspan(indexForCurrentItem - itemCount, itemCount));
+            completeManipulationForCurrentFrame(indexForCurrentItem - itemCount, items.subspan(indexForCurrentItem - itemCount, itemCount));
             currentFrameID = item.frameID;
             itemCount = 0;
         }
@@ -8556,7 +8556,7 @@ void WebPage::completeTextManipulation(const Vector<WebCore::TextManipulationIte
         ++itemCount;
     }
     RELEASE_ASSERT(indexForCurrentItem >= itemCount);
-    completeManipulationForCurrentFrame(indexForCurrentItem - itemCount, items.span().subspan(indexForCurrentItem - itemCount, itemCount));
+    completeManipulationForCurrentFrame(indexForCurrentItem - itemCount, items.subspan(indexForCurrentItem - itemCount, itemCount));
 
     completionHandler(false, WTFMove(failuresForAllItems));
 }

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleClient.h
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleClient.h
@@ -43,7 +43,7 @@ public:
 
     virtual void didOpenSocketStream(SocketStreamHandle&) = 0;
     virtual void didCloseSocketStream(SocketStreamHandle&) = 0;
-    virtual void didReceiveSocketStreamData(SocketStreamHandle&, const uint8_t* data, size_t length) = 0;
+    virtual void didReceiveSocketStreamData(SocketStreamHandle&, std::span<const uint8_t> data) = 0;
     virtual void didFailToReceiveSocketStreamData(SocketStreamHandle&) = 0;
     virtual void didUpdateBufferedAmount(SocketStreamHandle&, size_t bufferedAmount) = 0;
     virtual void didFailSocketStream(SocketStreamHandle&, const SocketStreamError&) = 0;

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
@@ -569,7 +569,7 @@ void SocketStreamHandleImpl::readStreamCallback(CFStreamEventType type)
         if (length == -1)
             m_client.didFailToReceiveSocketStreamData(*this);
         else
-            m_client.didReceiveSocketStreamData(*this, ptr, length);
+            m_client.didReceiveSocketStreamData(*this, std::span { ptr, static_cast<size_t>(length) });
 
         return;
     }

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
@@ -88,7 +88,7 @@ public:
     // SocketStreamHandleClient functions.
     void didOpenSocketStream(SocketStreamHandle&) final;
     void didCloseSocketStream(SocketStreamHandle&) final;
-    void didReceiveSocketStreamData(SocketStreamHandle&, const uint8_t*, size_t) final;
+    void didReceiveSocketStreamData(SocketStreamHandle&, std::span<const uint8_t>) final;
     void didFailToReceiveSocketStreamData(SocketStreamHandle&) final;
     void didUpdateBufferedAmount(SocketStreamHandle&, size_t bufferedAmount) final;
     void didFailSocketStream(SocketStreamHandle&, const SocketStreamError&) final;
@@ -116,7 +116,7 @@ private:
     void refThreadableWebSocketChannel() override { ref(); }
     void derefThreadableWebSocketChannel() override { deref(); }
 
-    bool appendToBuffer(const uint8_t* data, size_t len);
+    bool appendToBuffer(std::span<const uint8_t>);
     void skipBuffer(size_t len);
     bool processBuffer();
     void resumeTimerFired();

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
@@ -85,14 +85,14 @@ void WebVisitedLinkStore::addVisitedLink(NSString *urlString)
     size_t length = urlString.length;
 
     if (auto characters = CFStringGetCharactersPtr((__bridge CFStringRef)urlString)) {
-        addVisitedLinkHash(computeSharedStringHash(reinterpret_cast<const UChar*>(characters), length));
+        addVisitedLinkHash(computeSharedStringHash(std::span { reinterpret_cast<const UChar*>(characters), length }));
         return;
     }
 
     Vector<UniChar, 512> buffer(length);
     [urlString getCharacters:buffer.data()];
 
-    addVisitedLinkHash(computeSharedStringHash(reinterpret_cast<const UChar*>(buffer.data()), length));
+    addVisitedLinkHash(computeSharedStringHash(std::span { reinterpret_cast<const UChar*>(buffer.data()), length }));
 }
 
 void WebVisitedLinkStore::removeVisitedLink(NSString *urlString)

--- a/Tools/DumpRenderTree/PixelDumpSupport.cpp
+++ b/Tools/DumpRenderTree/PixelDumpSupport.cpp
@@ -91,12 +91,12 @@ static void convertChecksumToPNGComment(const char* checksum, Vector<unsigned ch
     static const size_t prefixLength = sizeof(textCommentPrefix) - 1; // The -1 is for the null at the end of the char[].
     static const size_t checksumLength = 32;
 
-    bytesToAdd.append(textCommentPrefix, prefixLength);
-    bytesToAdd.append(checksum, checksumLength);
+    bytesToAdd.append(std::span { textCommentPrefix, prefixLength });
+    bytesToAdd.append(std::span { checksum, checksumLength });
 
     Vector<unsigned char> dataToCrc;
-    dataToCrc.append(textCommentPrefix + 4, prefixLength - 4); // Don't include the chunk length in the crc.
-    dataToCrc.append(checksum, checksumLength);
+    dataToCrc.append(std::span { textCommentPrefix + 4, prefixLength - 4 }); // Don't include the chunk length in the crc.
+    dataToCrc.append(std::span { checksum, checksumLength });
     unsigned crc32 = computeCrc(dataToCrc);
 
     appendIntToVector(crc32, bytesToAdd);

--- a/Tools/TestWebKitAPI/Tests/WebCore/ASN1Utilities.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ASN1Utilities.cpp
@@ -73,7 +73,7 @@ private:
         vector.append(0x6);
         auto oidBytes = bytes();
         vector.append(oidBytes.size());
-        vector.append(oidBytes.data(), oidBytes.size());
+        vector.append(std::span { oidBytes });
     }
     std::array<uint8_t, 9> bytes() const
     {

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
@@ -89,7 +89,7 @@ TEST(CtapPinTest, TestSetPinRequest)
 
     // Decode the CBOR binary to check if each field is encoded correctly.
     Vector<uint8_t> buffer;
-    buffer.append(result.data() + 1, result.size() - 1);
+    buffer.append(result.subspan(1));
     auto decodedResponse = cbor::CBORReader::read(buffer);
     EXPECT_TRUE(decodedResponse);
     EXPECT_TRUE(decodedResponse->isMap());
@@ -254,8 +254,8 @@ TEST(CtapPinTest, TestKeyAgreementResponse)
     Vector<uint8_t> expectedRawKey;
     expectedRawKey.reserveCapacity(65);
     expectedRawKey.append(0x04);
-    expectedRawKey.append(TestData::kCtapClientPinKeyAgreementResponse + 14, 32); // X
-    expectedRawKey.append(TestData::kCtapClientPinKeyAgreementResponse + 49, 32); // Y
+    expectedRawKey.append(std::span { TestData::kCtapClientPinKeyAgreementResponse + 14, 32 }); // X
+    expectedRawKey.append(std::span { TestData::kCtapClientPinKeyAgreementResponse + 49, 32 }); // Y
     EXPECT_TRUE(exportedRawKey.returnValue() == expectedRawKey);
 }
 
@@ -277,7 +277,7 @@ TEST(CtapPinTest, TestTokenRequest)
 
     // Decode the CBOR binary to check if each field is encoded correctly.
     Vector<uint8_t> buffer;
-    buffer.append(result.data() + 1, result.size() - 1);
+    buffer.append(result.subspan(1));
     auto decodedResponse = cbor::CBORReader::read(buffer);
     EXPECT_TRUE(decodedResponse);
     EXPECT_TRUE(decodedResponse->isMap());

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
@@ -65,7 +65,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParam)
     PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeMakeCredentialRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, extensions);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kCtapMakeCredentialRequest));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kCtapMakeCredentialRequest, serializedData.size()), 0);
@@ -89,7 +89,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamNoUVNoRK)
     PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeMakeCredentialRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, extensions);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kCtapMakeCredentialRequestShort));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kCtapMakeCredentialRequestShort, serializedData.size()), 0);
@@ -113,7 +113,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamUVRequiredButNotSup
     PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeMakeCredentialRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kNotSupported, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, extensions);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kCtapMakeCredentialRequestShort));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kCtapMakeCredentialRequestShort, serializedData.size()), 0);
@@ -136,12 +136,12 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamWithPin)
 
     PinParameters pin;
     pin.protocol = pin::kProtocolVersion;
-    pin.auth.append(TestData::kCtap2PinAuth, sizeof(TestData::kCtap2PinAuth));
+    pin.auth.append(std::span { TestData::kCtap2PinAuth });
 
     PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeMakeCredentialRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, extensions, pin);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kCtapMakeCredentialRequestWithPin));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kCtapMakeCredentialRequestWithPin, serializedData.size()), 0);
@@ -164,12 +164,12 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKPreferred)
 
     PinParameters pin;
     pin.protocol = pin::kProtocolVersion;
-    pin.auth.append(TestData::kCtap2PinAuth, sizeof(TestData::kCtap2PinAuth));
+    pin.auth.append(std::span { TestData::kCtap2PinAuth });
 
     PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeMakeCredentialRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, extensions, pin);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kCtapMakeCredentialRequestWithPin));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kCtapMakeCredentialRequestWithPin, serializedData.size()), 0);
@@ -193,7 +193,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKPreferredNotSupported)
     PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeMakeCredentialRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kNotSupported, AuthenticatorSupportedOptions::ResidentKeyAvailability::kNotSupported, extensions);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kCtapMakeCredentialRequestShort));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kCtapMakeCredentialRequestShort, serializedData.size()), 0);
@@ -217,7 +217,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKDiscouraged)
     PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeMakeCredentialRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kNotSupported, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, extensions);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kCtapMakeCredentialRequestShort));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kCtapMakeCredentialRequestShort, serializedData.size()), 0);
@@ -246,7 +246,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithLargeBlob)
     PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, extensionInputs };
     Vector<uint8_t> hash;
     Vector<String> extensions = { "largeBlob"_s };
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeMakeCredentialRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, extensions);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kCtapMakeCredentialRequestShortWithLargeBlob));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kCtapMakeCredentialRequestShortWithLargeBlob, serializedData.size()), 0);
@@ -275,7 +275,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithUnsupportedLargeBlob
     PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, extensionInputs };
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeMakeCredentialRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, extensions);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kCtapMakeCredentialRequestShort));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kCtapMakeCredentialRequestShort, serializedData.size()), 0);
@@ -313,7 +313,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequest)
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeGetAssertionRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, extensions);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kTestComplexCtapGetAssertionRequest));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kTestComplexCtapGetAssertionRequest, serializedData.size()), 0);
@@ -351,7 +351,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestNoUV)
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeGetAssertionRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, extensions);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kTestComplexCtapGetAssertionRequestShort));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kTestComplexCtapGetAssertionRequestShort, serializedData.size()), 0);
@@ -389,7 +389,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestUVRequiredButNotSupported)
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeGetAssertionRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kNotSupported, extensions);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kTestComplexCtapGetAssertionRequestShort));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kTestComplexCtapGetAssertionRequestShort, serializedData.size()), 0);
@@ -427,11 +427,11 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestWithPin)
 
     PinParameters pin;
     pin.protocol = pin::kProtocolVersion;
-    pin.auth.append(TestData::kCtap2PinAuth, sizeof(TestData::kCtap2PinAuth));
+    pin.auth.append(std::span { TestData::kCtap2PinAuth });
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeGetAssertionRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, extensions, pin);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kTestComplexCtapGetAssertionRequestWithPin));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kTestComplexCtapGetAssertionRequestWithPin, serializedData.size()), 0);
@@ -493,7 +493,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobRead)
 
     Vector<uint8_t> hash;
     Vector<String> extensions = { "largeBlob"_s };
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeGetAssertionRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, extensions);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kTestComplexCtapGetAssertionRequestWithLargeBlobRead));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kTestComplexCtapGetAssertionRequestWithLargeBlobRead, serializedData.size()), 0);
@@ -536,7 +536,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestUnsupportedLargeBlobRead)
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeGetAssertionRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, extensions);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kTestComplexCtapGetAssertionRequest));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kTestComplexCtapGetAssertionRequest, serializedData.size()), 0);
@@ -583,7 +583,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobWrite)
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
-    hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
+    hash.append(std::span { TestData::kClientDataHash });
     auto serializedData = encodeGetAssertionRequestAsCBOR(hash, options, AuthenticatorSupportedOptions::UserVerificationAvailability::kSupportedAndConfigured, extensions);
     EXPECT_EQ(serializedData.size(), sizeof(TestData::kTestComplexCtapGetAssertionRequest));
     EXPECT_EQ(memcmp(serializedData.data(), TestData::kTestComplexCtapGetAssertionRequest, serializedData.size()), 0);

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
@@ -295,7 +295,7 @@ Vector<uint8_t> getTestAttestedCredentialDataBytes()
 {
     // Combine kTestAttestedCredentialDataPrefix and kTestECPublicKeyCOSE.
     auto testAttestedData = convertBytesToVector(kTestAttestedCredentialDataPrefix, sizeof(kTestAttestedCredentialDataPrefix));
-    testAttestedData.append(TestData::kTestECPublicKeyCOSE, sizeof(TestData::kTestECPublicKeyCOSE));
+    testAttestedData.append(std::span { TestData::kTestECPublicKeyCOSE });
     return testAttestedData;
 }
 
@@ -311,9 +311,9 @@ Vector<uint8_t> getTestAuthenticatorDataBytes()
 Vector<uint8_t> getTestAttestationObjectBytes()
 {
     auto testAuthenticatorObject = convertBytesToVector(kFormatFidoU2fCBOR, sizeof(kFormatFidoU2fCBOR));
-    testAuthenticatorObject.append(kAttStmtCBOR, sizeof(kAttStmtCBOR));
-    testAuthenticatorObject.append(TestData::kU2fAttestationStatementCBOR, sizeof(TestData::kU2fAttestationStatementCBOR));
-    testAuthenticatorObject.append(kAuthDataCBOR, sizeof(kAuthDataCBOR));
+    testAuthenticatorObject.append(std::span { kAttStmtCBOR });
+    testAuthenticatorObject.append(std::span { TestData::kU2fAttestationStatementCBOR });
+    testAuthenticatorObject.append(std::span { kAuthDataCBOR });
     auto testAuthenticatorData = getTestAuthenticatorDataBytes();
     testAuthenticatorObject.appendVector(testAuthenticatorData);
     return testAuthenticatorObject;
@@ -330,7 +330,7 @@ Vector<uint8_t> getTestCorruptedSignResponse(size_t length)
     ASSERT(length < sizeof(TestData::kTestU2fSignResponse));
     Vector<uint8_t> testCorruptedSignResponse;
     testCorruptedSignResponse.reserveInitialCapacity(length);
-    testCorruptedSignResponse.append(TestData::kTestU2fSignResponse, length);
+    testCorruptedSignResponse.append(std::span { TestData::kTestU2fSignResponse, length });
     return testCorruptedSignResponse;
 }
 
@@ -345,8 +345,8 @@ Vector<uint8_t> getTestU2fRegisterResponse(size_t prefixSize, const uint8_t appe
 {
     Vector<uint8_t> result;
     result.reserveInitialCapacity(prefixSize + appendixSize);
-    result.append(TestData::kTestU2fRegisterResponse, prefixSize);
-    result.append(appendix, appendixSize);
+    result.append(std::span { TestData::kTestU2fRegisterResponse, prefixSize });
+    result.append(std::span { appendix, appendixSize });
     return result;
 }
 
@@ -523,21 +523,21 @@ TEST(CTAPResponseTest, TestParseIncorrectRegisterResponseData5)
     const auto suffix = sizeof(TestData::kTestU2fRegisterResponse) - signatureSize;
 
     Vector<uint8_t> testData1;
-    testData1.append(TestData::kTestU2fRegisterResponse, prefix);
+    testData1.append(std::span { TestData::kTestU2fRegisterResponse, prefix });
     testData1.append(0x30);
     testData1.append(0x01);
     testData1.append(0x00);
-    testData1.append(TestData::kTestU2fRegisterResponse + suffix, signatureSize);
+    testData1.append(std::span { TestData::kTestU2fRegisterResponse + suffix, signatureSize });
     auto response = readU2fRegisterResponse(TestData::kRelyingPartyId, testData1, AuthenticatorAttachment::CrossPlatform);
     EXPECT_TRUE(response);
 
     Vector<uint8_t> testData2;
-    testData2.append(TestData::kTestU2fRegisterResponse, prefix);
+    testData2.append(std::span { TestData::kTestU2fRegisterResponse, prefix });
     testData2.append(0x30);
     testData2.append(0x81);
     testData2.append(0x01);
     testData2.append(0x00);
-    testData2.append(TestData::kTestU2fRegisterResponse + suffix, signatureSize);
+    testData2.append(std::span { TestData::kTestU2fRegisterResponse + suffix, signatureSize });
     response = readU2fRegisterResponse(TestData::kRelyingPartyId, testData2, AuthenticatorAttachment::CrossPlatform);
     EXPECT_TRUE(response);
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
@@ -71,7 +71,7 @@ public:
 
     void didReceiveDataFromMultipart(std::span<const uint8_t> receivedData) final
     {
-        m_data.append(receivedData.data(), receivedData.size());
+        m_data.append(receivedData);
     }
 
     void didCompleteFromMultipart() final
@@ -769,18 +769,18 @@ TEST(CurlMultipartHandleTests, CompleteWhileHeaderProcessing)
 TEST(CurlMultipartHandleTests, MaxHeaderSize)
 {
     Vector<uint8_t> data;
-    data.append("--boundary\r\n", 12);
+    data.append("--boundary\r\n"_span);
 
     for (auto i = 0; i < 300 * 1024 - 4; i++)
-        data.append("a", 1);
+        data.append('a');
 
-    data.append("\r\n\r\n", 4);
-    data.append("\r\n--boundary\r\n", 14);
+    data.append("\r\n\r\n"_span);
+    data.append("\r\n--boundary\r\n"_span);
 
     for (auto i = 0; i < 300 * 1024 - 3; i++)
-        data.append("a", 1);
+        data.append('a');
 
-    data.append("\r\n\r\n", 4);
+    data.append("\r\n\r\n"_span);
 
     MultipartHandleClient client;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm
@@ -29,6 +29,7 @@
 #import "PlatformUtilities.h"
 #import "TestUIDelegate.h"
 #import "TestWKWebView.h"
+#import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/StringConcatenateNumbers.h>
 
 #import <pal/cocoa/AVFoundationSoftLink.h>
@@ -133,10 +134,7 @@ constexpr auto videoPlayTestHTML ="<script>"
 
 static Vector<uint8_t> testVideoBytes()
 {
-    NSData *data = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"mp4" subdirectory:@"TestWebKitAPI.resources"]];
-    Vector<uint8_t> vector;
-    vector.append(static_cast<const uint8_t*>(data.bytes), data.length);
-    return vector;
+    return toVector([NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"mp4" subdirectory:@"TestWebKitAPI.resources"]]);
 }
 
 static void runVideoTest(NSURLRequest *request, const char* expectedMessage)
@@ -205,10 +203,7 @@ TEST(MediaLoading, LockdownModeHLS)
     "<body onload='createVideoElement()'></body>"_s;
 
     auto testTransportStreamBytes = [&] () -> Vector<uint8_t> {
-        NSData *data = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"start-offset" withExtension:@"ts" subdirectory:@"TestWebKitAPI.resources"]];
-        Vector<uint8_t> vector;
-        vector.append(static_cast<const uint8_t*>(data.bytes), data.length);
-        return vector;
+        return toVector([NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"start-offset" withExtension:@"ts" subdirectory:@"TestWebKitAPI.resources"]]);
     };
 
     HTTPServer server({

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -711,7 +711,7 @@ static void respondToRangeRequests(const TestWebKitAPI::Connection& connection, 
         NSData *responseHeader = [responseHeaderString dataUsingEncoding:NSUTF8StringEncoding];
         NSData *responseBody = [data subdataWithRange:NSMakeRange(rangeBegin, rangeEnd - rangeBegin)];
         auto response = toVector(responseHeader);
-        response.append(static_cast<const uint8_t*>(responseBody.bytes), responseBody.length);
+        response.append(toSpan(responseBody));
         connection.send(WTFMove(response), [=] {
             respondToRangeRequests(connection, data);
         });

--- a/Tools/WebKitTestRunner/PixelDumpSupport.cpp
+++ b/Tools/WebKitTestRunner/PixelDumpSupport.cpp
@@ -49,12 +49,12 @@ static void convertChecksumToPNGComment(const char* checksum, Vector<unsigned ch
     static const size_t prefixLength = sizeof(textCommentPrefix) - 1; // The -1 is for the null at the end of the char[].
     static const size_t checksumLength = 32;
 
-    bytesToAdd.append(textCommentPrefix, prefixLength);
-    bytesToAdd.append(checksum, checksumLength);
+    bytesToAdd.append(std::span { textCommentPrefix, prefixLength });
+    bytesToAdd.append(std::span { checksum, checksumLength });
 
     Vector<unsigned char> dataToCrc;
-    dataToCrc.append(textCommentPrefix + 4, prefixLength - 4); // Don't include the chunk length in the crc.
-    dataToCrc.append(checksum, checksumLength);
+    dataToCrc.append(std::span { textCommentPrefix + 4, prefixLength - 4 }); // Don't include the chunk length in the crc.
+    dataToCrc.append(std::span { checksum, checksumLength });
     unsigned crc32 = computeCrc(dataToCrc);
 
     appendIntToVector(crc32, bytesToAdd);

--- a/Tools/WebKitTestRunner/cairo/TestInvocationCairo.cpp
+++ b/Tools/WebKitTestRunner/cairo/TestInvocationCairo.cpp
@@ -68,7 +68,7 @@ static void computeSHA1HashStringForCairoSurface(cairo_surface_t* surface, char 
 static cairo_status_t writeFunction(void* closure, const unsigned char* data, unsigned length)
 {
     Vector<unsigned char>* in = reinterpret_cast<Vector<unsigned char>*>(closure);
-    in->append(data, length);
+    in->append(std::span { data, length });
     return CAIRO_STATUS_SUCCESS;
 }
 

--- a/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
@@ -163,7 +163,7 @@ WKRetainPtr<WKStringRef> TestController::takeViewPortSnapshot()
     Vector<unsigned char> output;
 #if USE(CAIRO)
     cairo_surface_write_to_png_stream(mainWebView()->windowSnapshotImage(), [](void* output, const unsigned char* data, unsigned length) -> cairo_status_t {
-        reinterpret_cast<Vector<unsigned char>*>(output)->append(data, length);
+        reinterpret_cast<Vector<unsigned char>*>(output)->append(std::span { data, length });
         return CAIRO_STATUS_SUCCESS;
     }, &output);
 #elif USE(SKIA)

--- a/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
@@ -153,7 +153,7 @@ WKRetainPtr<WKStringRef> TestController::takeViewPortSnapshot()
     Vector<unsigned char> output;
 #if USE(CAIRO)
     cairo_surface_write_to_png_stream(mainWebView()->windowSnapshotImage(), [](void* output, const unsigned char* data, unsigned length) -> cairo_status_t {
-        reinterpret_cast<Vector<unsigned char>*>(output)->append(data, length);
+        reinterpret_cast<Vector<unsigned char>*>(output)->append(std::span { data, length });
         return CAIRO_STATUS_SUCCESS;
     }, &output);
 #elif USE(SKIA)


### PR DESCRIPTION
#### c904754b70e17186e32cafafc5d82dd7bb925741
<pre>
Drop Vector::append(T*, size_t) and use Vector::append(std::span&lt;const T&gt;) instead
<a href="https://bugs.webkit.org/show_bug.cgi?id=271118">https://bugs.webkit.org/show_bug.cgi?id=271118</a>

Reviewed by Darin Adler and Brent Fulgham.

Drop Vector::append(T*, size_t) and use Vector::append(std::span&lt;const T&gt;) instead.
This is part of an effort to use std::span more in the codebase, for better security.

* Source/JavaScriptCore/API/ObjcRuntimeExtras.h:
(forEachProtocolImplementingProtocol):
* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
(JSC::AbstractMacroAssembler::JumpList::append):
* Source/JavaScriptCore/bytecode/ObjectPropertyConditionSet.cpp:
(JSC::ObjectPropertyConditionSet::mergedWith const):
* Source/JavaScriptCore/jsc.cpp:
(runWithOptions):
* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;CharacterType&gt;::parseIdentifierSlowCase):
(JSC::Lexer&lt;T&gt;::parseTemplateLiteral):
* Source/JavaScriptCore/parser/Lexer.h:
(JSC::Lexer::append16):
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::LocaleIDBuilder::overrideLanguageScriptRegion):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization):
(JSC::addScriptlessLocaleIfNeeded):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::illFormedIndex):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
* Source/JavaScriptCore/wasm/WasmBBQPlan.h:
* Source/JavaScriptCore/wasm/WasmEntryPlan.cpp:
(JSC::Wasm::EntryPlan::parseAndValidateModule):
* Source/JavaScriptCore/wasm/WasmEntryPlan.h:
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::IPIntPlan):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::LLIntPlan):
* Source/JavaScriptCore/wasm/WasmStreamingCompiler.h:
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::StreamingParser::consume):
(JSC::Wasm::StreamingParser::consumeVarUInt32):
(JSC::Wasm::StreamingParser::addBytes):
(JSC::Wasm::StreamingParser::finalize):
* Source/JavaScriptCore/wasm/WasmStreamingParser.h:
(JSC::Wasm::StreamingParser::addBytes):
* Source/WTF/wtf/StreamBuffer.h:
(WTF::StreamBuffer::append):
* Source/WTF/wtf/TrailingArray.h:
(WTF::TrailingArray::span const):
* Source/WTF/wtf/URL.cpp:
(WTF::appendEncodedHostname):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::appendToASCIIBuffer):
(WTF::URLParser::utf8PercentEncode):
(WTF::URLParser::utf8QueryEncode):
(WTF::URLParser::copyASCIIStringUntil):
(WTF::URLParser::syntaxViolation):
(WTF::URLParser::parse):
(WTF::URLParser::appendNumberToASCIIBuffer):
(WTF::URLParser::serializeIPv6):
(WTF::URLParser::domainToASCII):
(WTF::URLParser::parseHostAndPort):
* Source/WTF/wtf/URLParser.h:
(WTF::URLParser::appendToASCIIBuffer): Deleted.
* Source/WTF/wtf/Vector.h:
(WTF::Vector::subspan const):
(WTF::Vector::tryAppend):
(WTF::Vector::append):
(WTF::Vector::appendList):
(WTF::Malloc&gt;::append):
(WTF::Malloc&gt;::appendVector):
* Source/WTF/wtf/cf/VectorCF.h:
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::openTemporaryFile):
* Source/WTF/wtf/text/AtomString.h:
* Source/WTF/wtf/text/SuperFastHash.h:
(WTF::SuperFastHash::addCharacters):
(WTF::SuperFastHash::computeHash):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::charactersWithoutNullTermination const):
* Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp:
(WebCore::writeLittleEndian):
(WebCore::encodeKey):
(WebCore::decodeKey):
* Source/WebCore/Modules/mediastream/SFrameUtils.cpp:
(WebCore::toRbsp):
(WebCore::computeVP8PrefixBuffer):
* Source/WebCore/Modules/mediastream/STUNMessageParsing.cpp:
(WebCore::WebRTC::getSTUNOrTURNMessageLengths):
(WebCore::WebRTC::extractSTUNOrTURNMessages):
* Source/WebCore/Modules/mediastream/STUNMessageParsing.h:
* Source/WebCore/Modules/webauthn/cbor/CBORReader.cpp:
(cbor::CBORReader::readBytes):
* Source/WebCore/Modules/webauthn/cbor/CBORWriter.cpp:
(cbor::CBORWriter::encodeCBOR):
* Source/WebCore/Modules/webauthn/fido/FidoHidPacket.cpp:
(fido::FidoHidInitPacket::getSerializedData const):
(fido::FidoHidContinuationPacket::getSerializedData const):
* Source/WebCore/Modules/webauthn/fido/FidoParsingUtils.cpp:
(fido::getInitPacketData):
(fido::getContinuationPacketData):
* Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp:
(fido::WebCore::constructU2fSignCommand):
* Source/WebCore/Modules/websockets/WebSocketFrame.cpp:
(WebCore::WebSocketFrame::makeFrameData):
* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::WebSocketHandshake::readHTTPHeaders):
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::appendDecimal):
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(PAL::TextCodecICU::encode const):
* Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp:
(PAL::encodeComplexWindowsLatin1):
* Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp:
(PAL::encodeComplexUserDefined):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::supportsPressAction const):
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::handleResponseOnStreamingAction):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::writeLittleEndian):
(WebCore::writeLittleEndian&lt;uint8_t&gt;):
(WebCore::CloneSerializer::serialize):
(WebCore::CloneSerializer::dumpImageBitmap):
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneSerializer::write):
(WebCore::CloneDeserializer::read):
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::SubtleCrypto::wrapKey):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp:
(WebCore::signECDSA):
(WebCore::verifyECDSA):
* Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp:
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformImportPkcs8):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):
* Source/WebCore/crypto/cocoa/CryptoKeyOKPCocoa.cpp:
(WebCore::CryptoKeyOKP::exportSpki const):
(WebCore::CryptoKeyOKP::exportPkcs8 const):
* Source/WebCore/crypto/cocoa/CryptoKeyRSAMac.cpp:
(WebCore::CryptoKeyRSA::exportSpki const):
(WebCore::CryptoKeyRSA::exportPkcs8 const):
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h:
(WebCore::CryptoAlgorithmRsaKeyGenParams::publicExponentVector const):
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h:
* Source/WebCore/dom/DatasetDOMStringMap.cpp:
(WebCore::convertPropertyNameToAttributeName):
* Source/WebCore/fileapi/BlobBuilder.cpp:
(WebCore::BlobBuilder::append):
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::showTreeWithIndent const):
* Source/WebCore/html/parser/HTMLToken.h:
(WebCore::HTMLToken::appendToComment):
* Source/WebCore/loader/TextResourceDecoder.cpp:
(WebCore::TextResourceDecoder::decode):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::parseEventStreamLine):
* Source/WebCore/page/PageConsoleClient.cpp:
(WebCore::PageConsoleClient::addMessage):
(WebCore::PageConsoleClient::messageWithTypeAndLevel):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::combineSegmentsData):
(WebCore::FragmentedSharedBuffer::getContiguousData const):
(WebCore::FragmentedSharedBuffer::read const):
* Source/WebCore/platform/SharedStringHash.cpp:
(WebCore::findSlashDotDotSlash):
(WebCore::findSlashSlash):
(WebCore::findSlashDotSlash):
(WebCore::containsColonSlashSlash):
(WebCore::cleanSlashDotDotSlashes):
(WebCore::mergeDoubleSlashes):
(WebCore::cleanSlashDotSlashes):
(WebCore::cleanPath):
(WebCore::needsTrailingSlash):
(WebCore::computeSharedStringHashInline):
(WebCore::computeSharedStringHash):
(WebCore::computeVisitedLinkHash):
* Source/WebCore/platform/SharedStringHash.h:
* Source/WebCore/platform/audio/MultiChannelResampler.cpp:
(WebCore::MultiChannelResampler::provideInputForChannel):
* Source/WebCore/platform/audio/SincResampler.cpp:
(WebCore::SincResampler::processBuffer):
(WebCore::SincResampler::process):
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp:
(WebCore::encode):
(WebCore::encodeToVector):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::AudioTrackData::consumeFrameData):
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::cookieFromVorbisCodecPrivate):
(WebCore::createVorbisAudioInfo):
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormData::flatten const):
* Source/WebCore/platform/network/FormDataBuilder.cpp:
(WebCore::FormDataBuilder::append):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::parseHTTPHeader):
(WebCore::parseHTTPRequestBody):
* Source/WebCore/platform/network/HTTPParsers.h:
* Source/WebCore/platform/network/SynchronousLoaderClient.cpp:
(WebCore::SynchronousLoaderClient::didReceiveData):
* Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp:
(WebCore::CurlMultipartHandle::parseHeadersIfPossible):
* Source/WebCore/platform/text/QuotedPrintable.cpp:
(WebCore::quotedPrintableEncode):
* Source/WebCore/rendering/svg/SVGTextChunk.cpp:
(WebCore::SVGTextChunk::SVGTextChunk):
* Source/WebCore/svg/SVGToOTFFontConversion.cpp:
(WebCore::SVGToOTFFontConverter::appendOS2Table):
* Source/WebCore/testing/MockContentFilter.cpp:
(WebCore::MockContentFilter::maybeDetermineStatus):
* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::PendingCallbacks::appendCharactersCallback):
(WebCore::XMLDocumentParser::characters):
(WebCore::charactersHandler):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::sendReplyToSynchronousRequest):
* Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.cpp:
(WebKit::LibWebRTCSocketClient::sendTo):
* Source/WebKit/NetworkProcess/webrtc/LibWebRTCSocketClient.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:
(WebKit::NetworkRTCProvider::sendToSocket):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
(WebKit::NetworkRTCTCPSocketCocoa::createMessageBuffer):
(WebKit::NetworkRTCTCPSocketCocoa::sendTo):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::NetworkRTCUDPSocketCocoa::sendTo):
(WebKit::NetworkRTCUDPSocketCocoaConnections::sendTo):
* Source/WebKit/Shared/API/APIData.h:
(API::Data::data const):
(API::Data::bytes const):
(API::Data::dataReference const): Deleted.
* Source/WebKit/Shared/API/APIData.serialization.in:
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(-[WKRemoteObjectDecoder decodeBytesForKey:returnedLength:]):
* Source/WebKit/Shared/API/c/WKData.cpp:
(WKDataGetBytes):
* Source/WebKit/Shared/APIWebArchive.mm:
(API::WebArchive::WebArchive):
* Source/WebKit/Shared/APIWebArchiveResource.mm:
(API::WebArchiveResource::WebArchiveResource):
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtension::createHandleForTemporaryFile):
* Source/WebKit/Shared/Cocoa/WKNSData.mm:
(-[WKNSData bytes]):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::fileContents):
(WebKit::compileAndCacheSandboxProfile):
* Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp:
(WKNotificationManagerProviderDidClickNotification_b):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageLoadData):
(WKPageLoadDataWithUserData):
(restoreFromSessionState):
* Source/WebKit/UIProcess/API/C/WKSessionStateRef.cpp:
(WKSessionStateCreateFromData):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::providerDidCloseNotifications):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon):
(WebKit::WebPageProxy::getWebCryptoMasterKey):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::resumeDownload):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::HistoryEntryDataDecoder::operator&gt;&gt;):
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView _preparePDFDataForPrintingOnSecondaryThread]):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp:
(WebKit::InjectedBundlePageEditorClient::getPasteboardDataForRange):
* Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm:
(WebKit::createUnarchiver):
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::ByteRangeRequest::addData):
(WebKit::PDFPluginStreamLoaderClient::didReceiveData):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::completeTextManipulation):
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleClient.h:
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.cpp:
(WebCore::removeTerminationCharacters):
(WebCore::cookieDataForHandshake):
(WebCore::SocketStreamHandleImpl::platformSendHandshake):
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp:
(WebCore::SocketStreamHandleImpl::readStreamCallback):
* Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm:
(WebCryptoClient::wrapCryptoKey const):
(WebCryptoClient::unwrapCryptoKey const):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::didReceiveSocketStreamData):
(WebCore::WebSocketChannel::appendToBuffer):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm:
(WebVisitedLinkStore::addVisitedLink):
* Tools/DumpRenderTree/PixelDumpSupport.cpp:
(convertChecksumToPNGComment):
* Tools/TestWebKitAPI/Tests/WebCore/ASN1Utilities.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp:
(TestWebKitAPI::getTestAttestedCredentialDataBytes):
(TestWebKitAPI::getTestAttestationObjectBytes):
(TestWebKitAPI::getTestCorruptedSignResponse):
(TestWebKitAPI::getTestU2fRegisterResponse):
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm:
(TestWebKitAPI::testVideoBytes):
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(respondToRangeRequests):
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::vectorFromData):
(TestWebKitAPI::appendUTF8ToVector):
(TestWebKitAPI::H2::Connection::receive const):
* Tools/WebKitTestRunner/PixelDumpSupport.cpp:
(convertChecksumToPNGComment):

Canonical link: <a href="https://commits.webkit.org/276319@main">https://commits.webkit.org/276319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a419535ef82363eddab5266cdfa4640953d2801

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46957 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40337 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20772 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38156 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39269 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2356 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48565 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19286 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15852 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/44357 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38427 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50946 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6091 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20273 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10315 "Passed tests") | 
<!--EWS-Status-Bubble-End-->