### PR TITLE
Remove AriaReflectionForElementReferencesEnabled preference

### DIFF
--- a/LayoutTests/fast/custom-elements/reactions-for-aria-element-attributes.html
+++ b/LayoutTests/fast/custom-elements/reactions-for-aria-element-attributes.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ AriaReflectionForElementReferencesEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
 <title>Custom Elements: CEReactions on Element interface</title>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -561,20 +561,6 @@ ApplePayEnabled:
       "ENABLE(APPLE_PAY_REMOTE_UI)": true
       default: false
 
-AriaReflectionForElementReferencesEnabled:
-  type: bool
-  status: stable
-  category: dom
-  humanReadableName: "ARIA Reflection for Element References"
-  humanReadableDescription: "Enable ARIA reflection for attributes that refer to elements"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 # FIXME: This is on by default in WebKit2 PLATFORM(COCOA). Perhaps we should consider turning it on for WebKitLegacy as well.
 AsyncClipboardAPIEnabled:
   type: bool

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5057,19 +5057,16 @@ bool AXObjectCache::addRelation(Element& origin, const QualifiedName& attribute)
 
     bool addedRelation = false;
     auto relationType = attributeToRelationType(attribute);
-    if (m_document->settings().ariaReflectionForElementReferencesEnabled()) {
-        Ref settings = m_document->settings();
-        if (Element::isElementReflectionAttribute(settings, attribute)) {
-            if (auto reflectedElement = origin.getElementAttribute(attribute))
-                return addRelation(&origin, reflectedElement.get(), relationType);
-        } else if (Element::isElementsArrayReflectionAttribute(settings, attribute)) {
-            if (auto reflectedElements = origin.getElementsArrayAttribute(attribute)) {
-                for (auto reflectedElement : reflectedElements.value()) {
-                    if (addRelation(&origin, reflectedElement.get(), relationType))
-                        addedRelation = true;
-                }
-                return addedRelation;
+    if (Element::isElementReflectionAttribute(Ref { m_document->settings() }, attribute)) {
+        if (auto reflectedElement = origin.getElementAttribute(attribute))
+            return addRelation(&origin, reflectedElement.get(), relationType);
+    } else if (Element::isElementsArrayReflectionAttribute(attribute)) {
+        if (auto reflectedElements = origin.getElementsArrayAttribute(attribute)) {
+            for (auto reflectedElement : reflectedElements.value()) {
+                if (addRelation(&origin, reflectedElement.get(), relationType))
+                    addedRelation = true;
             }
+            return addedRelation;
         }
     }
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -4120,19 +4120,17 @@ Vector<Ref<Element>> AccessibilityObject::elementsFromAttribute(const QualifiedN
     if (!element)
         return { };
 
-    if (document()->settings().ariaReflectionForElementReferencesEnabled()) {
-        if (Element::isElementReflectionAttribute(document()->settings(), attribute)) {
-            if (RefPtr reflectedElement = element->getElementAttribute(attribute)) {
-                Vector<Ref<Element>> elements;
-                elements.append(reflectedElement.releaseNonNull());
-                return elements;
-            }
-        } else if (Element::isElementsArrayReflectionAttribute(document()->settings(), attribute)) {
-            if (auto reflectedElements = element->getElementsArrayAttribute(attribute)) {
-                return WTF::map(reflectedElements.value(), [](RefPtr<Element> element) -> Ref<Element> {
-                    return *element;
-                });
-            }
+    if (Element::isElementReflectionAttribute(document()->settings(), attribute)) {
+        if (RefPtr reflectedElement = element->getElementAttribute(attribute)) {
+            Vector<Ref<Element>> elements;
+            elements.append(reflectedElement.releaseNonNull());
+            return elements;
+        }
+    } else if (Element::isElementsArrayReflectionAttribute(attribute)) {
+        if (auto reflectedElements = element->getElementsArrayAttribute(attribute)) {
+            return WTF::map(reflectedElements.value(), [](RefPtr<Element> element) -> Ref<Element> {
+                return *element;
+            });
         }
     }
 

--- a/Source/WebCore/accessibility/AriaAttributes.idl
+++ b/Source/WebCore/accessibility/AriaAttributes.idl
@@ -25,7 +25,7 @@
 
 // https://w3c.github.io/aria/#idl-interface
 interface mixin AriaAttributes {
-    [CEReactions=Needed, Reflect=aria_activedescendant, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute Element? ariaActiveDescendantElement;
+    [CEReactions=Needed, Reflect=aria_activedescendant] attribute Element? ariaActiveDescendantElement;
     [CEReactions=Needed, Reflect=aria_atomic]                 attribute DOMString? ariaAtomic;
     [CEReactions=Needed, Reflect=aria_autocomplete]           attribute DOMString? ariaAutoComplete;
     [CEReactions=Needed, Reflect=aria_braillelabel]           attribute DOMString? ariaBrailleLabel;
@@ -35,28 +35,28 @@ interface mixin AriaAttributes {
     [CEReactions=Needed, Reflect=aria_colcount]               attribute DOMString? ariaColCount;
     [CEReactions=Needed, Reflect=aria_colindex]               attribute DOMString? ariaColIndex;
     [CEReactions=Needed, Reflect=aria_colspan]                attribute DOMString? ariaColSpan;
-    [CEReactions=Needed, CustomGetter, Reflect=aria_controls, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaControlsElements;
+    [CEReactions=Needed, CustomGetter, Reflect=aria_controls] attribute FrozenArray<Element>? ariaControlsElements;
     [CEReactions=Needed, Reflect=aria_current]          attribute DOMString? ariaCurrent;
-    [CEReactions=Needed, CustomGetter, Reflect=aria_describedby, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaDescribedByElements;
+    [CEReactions=Needed, CustomGetter, Reflect=aria_describedby] attribute FrozenArray<Element>? ariaDescribedByElements;
     [CEReactions=Needed, Reflect=aria_description]      attribute DOMString? ariaDescription;
-    [CEReactions=Needed, CustomGetter, Reflect=aria_details, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaDetailsElements;
+    [CEReactions=Needed, CustomGetter, Reflect=aria_details] attribute FrozenArray<Element>? ariaDetailsElements;
     [CEReactions=Needed, Reflect=aria_disabled]         attribute DOMString? ariaDisabled;
-    [CEReactions=Needed, CustomGetter, Reflect=aria_errormessage, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaErrorMessageElements;
+    [CEReactions=Needed, CustomGetter, Reflect=aria_errormessage] attribute FrozenArray<Element>? ariaErrorMessageElements;
     [CEReactions=Needed, Reflect=aria_expanded]         attribute DOMString? ariaExpanded;
-    [CEReactions=Needed, CustomGetter, Reflect=aria_flowto, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaFlowToElements;
+    [CEReactions=Needed, CustomGetter, Reflect=aria_flowto] attribute FrozenArray<Element>? ariaFlowToElements;
     [CEReactions=Needed, Reflect=aria_haspopup]         attribute DOMString? ariaHasPopup;
     [CEReactions=Needed, Reflect=aria_hidden]           attribute DOMString? ariaHidden;
     [CEReactions=Needed, Reflect=aria_invalid]          attribute DOMString? ariaInvalid;
     [CEReactions=Needed, Reflect=aria_keyshortcuts]     attribute DOMString? ariaKeyShortcuts;
     [CEReactions=Needed, Reflect=aria_label]            attribute DOMString? ariaLabel;
-    [CEReactions=Needed, CustomGetter, Reflect=aria_labelledby, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaLabelledByElements;
+    [CEReactions=Needed, CustomGetter, Reflect=aria_labelledby] attribute FrozenArray<Element>? ariaLabelledByElements;
     [CEReactions=Needed, Reflect=aria_level]            attribute DOMString? ariaLevel;
     [CEReactions=Needed, Reflect=aria_live]             attribute DOMString? ariaLive;
     [CEReactions=Needed, Reflect=aria_modal]            attribute DOMString? ariaModal;
     [CEReactions=Needed, Reflect=aria_multiline]        attribute DOMString? ariaMultiLine;
     [CEReactions=Needed, Reflect=aria_multiselectable]  attribute DOMString? ariaMultiSelectable;
     [CEReactions=Needed, Reflect=aria_orientation]      attribute DOMString? ariaOrientation;
-    [CEReactions=Needed, CustomGetter, Reflect=aria_owns, EnabledBySetting=AriaReflectionForElementReferencesEnabled] attribute FrozenArray<Element>? ariaOwnsElements;
+    [CEReactions=Needed, CustomGetter, Reflect=aria_owns] attribute FrozenArray<Element>? ariaOwnsElements;
     [CEReactions=Needed, Reflect=aria_placeholder]      attribute DOMString? ariaPlaceholder;
     [CEReactions=Needed, Reflect=aria_posinset]         attribute DOMString? ariaPosInSet;
     [CEReactions=Needed, Reflect=aria_pressed]          attribute DOMString? ariaPressed;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2055,16 +2055,13 @@ static inline AtomString makeIdForStyleResolution(const AtomString& value, bool 
 
 bool Element::isElementReflectionAttribute(const Settings& settings, const QualifiedName& name)
 {
-    return (settings.ariaReflectionForElementReferencesEnabled() && name == HTMLNames::aria_activedescendantAttr)
+    return name == HTMLNames::aria_activedescendantAttr
         || (settings.popoverAttributeEnabled() && name == HTMLNames::popovertargetAttr)
         || (settings.invokerAttributesEnabled() && name == HTMLNames::invoketargetAttr);
 }
 
-bool Element::isElementsArrayReflectionAttribute(const Settings& settings, const QualifiedName& name)
+bool Element::isElementsArrayReflectionAttribute(const QualifiedName& name)
 {
-    if (!settings.ariaReflectionForElementReferencesEnabled())
-        return false;
-
     switch (name.nodeName()) {
     case AttributeNames::aria_controlsAttr:
     case AttributeNames::aria_describedbyAttr:
@@ -2166,7 +2163,7 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
     }
     default: {
         Ref document = this->document();
-        if (isElementReflectionAttribute(document->settings(), name) || isElementsArrayReflectionAttribute(document->settings(), name)) {
+        if (isElementReflectionAttribute(document->settings(), name) || isElementsArrayReflectionAttribute(name)) {
             if (auto* map = explicitlySetAttrElementsMapIfExists())
                 map->remove(name);
         }
@@ -2245,7 +2242,7 @@ void Element::setElementAttribute(const QualifiedName& attributeName, Element* e
 
 std::optional<Vector<RefPtr<Element>>> Element::getElementsArrayAttribute(const QualifiedName& attributeName) const
 {
-    ASSERT(isElementsArrayReflectionAttribute(document().settings(), attributeName));
+    ASSERT(isElementsArrayReflectionAttribute(attributeName));
 
     if (auto* map = explicitlySetAttrElementsMapIfExists()) {
         if (auto it = map->find(attributeName); it != map->end()) {
@@ -2275,7 +2272,7 @@ std::optional<Vector<RefPtr<Element>>> Element::getElementsArrayAttribute(const 
 
 void Element::setElementsArrayAttribute(const QualifiedName& attributeName, std::optional<Vector<RefPtr<Element>>>&& elements)
 {
-    ASSERT(isElementsArrayReflectionAttribute(document().settings(), attributeName));
+    ASSERT(isElementsArrayReflectionAttribute(attributeName));
 
     if (!elements) {
         if (auto* map = explicitlySetAttrElementsMapIfExists())

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -157,7 +157,7 @@ public:
     WEBCORE_EXPORT std::optional<Vector<RefPtr<Element>>> getElementsArrayAttribute(const QualifiedName& attributeName) const;
     WEBCORE_EXPORT void setElementsArrayAttribute(const QualifiedName& attributeName, std::optional<Vector<RefPtr<Element>>>&& value);
     static bool isElementReflectionAttribute(const Settings&, const QualifiedName&);
-    static bool isElementsArrayReflectionAttribute(const Settings&, const QualifiedName&);
+    static bool isElementsArrayReflectionAttribute(const QualifiedName&);
 
     // Call this to get the value of an attribute that is known not to be the style
     // attribute or one of the SVG animatable attributes.


### PR DESCRIPTION
#### 9e27679dcfcb40158f9237e335ef83052f34e370
<pre>
Remove AriaReflectionForElementReferencesEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=271121">https://bugs.webkit.org/show_bug.cgi?id=271121</a>

Reviewed by Tim Nguyen.

It&apos;s been stable for at least a year.

* LayoutTests/fast/custom-elements/reactions-for-aria-element-attributes.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::addRelation):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::elementsFromAttribute const):
* Source/WebCore/accessibility/AriaAttributes.idl:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isElementReflectionAttribute):
(WebCore::Element::isElementsArrayReflectionAttribute):
(WebCore::Element::attributeChanged):
(WebCore::Element::getElementsArrayAttribute const):
(WebCore::Element::setElementsArrayAttribute):
* Source/WebCore/dom/Element.h:

Canonical link: <a href="https://commits.webkit.org/276259@main">https://commits.webkit.org/276259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba07e47c7d69e80e9a844682a189769fcec399c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46832 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40215 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20651 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36410 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17444 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17785 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/39172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2238 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/37510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39460 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48434 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/43746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15742 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38339 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9817 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20753 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50828 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20155 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10282 "Passed tests") | 
<!--EWS-Status-Bubble-End-->