### PR TITLE
Remove CSSCustomPropertiesAndValuesEnabled preference

### DIFF
--- a/LayoutTests/css-custom-properties-api/crash.html
+++ b/LayoutTests/css-custom-properties-api/crash.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSCustomPropertiesAndValuesEnabled=true ] -->
+<!DOCTYPE html>
 <!-- https://chromium.googlesource.com/chromium/src/+/01ce431409e3a019858677626a983c55168da6dc/third_party/WebKit/LayoutTests/custom-properties/register-property.html -->
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>

--- a/LayoutTests/css-custom-properties-api/cycles.html
+++ b/LayoutTests/css-custom-properties-api/cycles.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSCustomPropertiesAndValuesEnabled=true ] -->
+<!DOCTYPE html>
 <!-- https://chromium.googlesource.com/chromium/src/+/01ce431409e3a019858677626a983c55168da6dc/third_party/WebKit/LayoutTests/custom-properties/register-property.html -->
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>

--- a/LayoutTests/css-custom-properties-api/inherits.html
+++ b/LayoutTests/css-custom-properties-api/inherits.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSCustomPropertiesAndValuesEnabled=true ] -->
+<!DOCTYPE html>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
 

--- a/LayoutTests/css-custom-properties-api/initialValue.html
+++ b/LayoutTests/css-custom-properties-api/initialValue.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ CSSCustomPropertiesAndValuesEnabled=true ] -->
 <html>
 <head>
   <style>

--- a/LayoutTests/css-custom-properties-api/initialValueJS.html
+++ b/LayoutTests/css-custom-properties-api/initialValueJS.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSCustomPropertiesAndValuesEnabled=true ] -->
+<!DOCTYPE html>
 <!-- https://chromium.googlesource.com/chromium/src/+/01ce431409e3a019858677626a983c55168da6dc/third_party/WebKit/LayoutTests/custom-properties/register-property.html -->
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>

--- a/LayoutTests/css-custom-properties-api/inline.html
+++ b/LayoutTests/css-custom-properties-api/inline.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSCustomPropertiesAndValuesEnabled=true ] -->
+<!DOCTYPE html>
 <!-- https://chromium.googlesource.com/chromium/src/+/01ce431409e3a019858677626a983c55168da6dc/third_party/WebKit/LayoutTests/custom-properties/register-property.html -->
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>

--- a/LayoutTests/css-custom-properties-api/length.html
+++ b/LayoutTests/css-custom-properties-api/length.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSCustomPropertiesAndValuesEnabled=true ] -->
+<!DOCTYPE html>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
 

--- a/LayoutTests/css-custom-properties-api/length2.html
+++ b/LayoutTests/css-custom-properties-api/length2.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSCustomPropertiesAndValuesEnabled=true ] -->
+<!DOCTYPE html>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
 

--- a/LayoutTests/css-custom-properties-api/registerProperty.html
+++ b/LayoutTests/css-custom-properties-api/registerProperty.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSCustomPropertiesAndValuesEnabled=true ] -->
+<!DOCTYPE html>
 <!-- https://chromium.googlesource.com/chromium/src/+/01ce431409e3a019858677626a983c55168da6dc/third_party/WebKit/LayoutTests/custom-properties/register-property.html -->
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>

--- a/LayoutTests/fast/css-custom-paint/properties.html
+++ b/LayoutTests/fast/css-custom-paint/properties.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSCustomPropertiesAndValuesEnabled=true CSSTypedOMEnabled=true CSSPaintingAPIEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ CSSTypedOMEnabled=true CSSPaintingAPIEnabled=true ] -->
 <meta name="author" title="Justin Michaud" href="mailto:justin_michaud@webkit.org">
 <meta name="assert" content="Test paint worklet input properties and arguments">
 <link rel="help" content="https://drafts.css-houdini.org/css-paint-api-1/">

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -973,20 +973,6 @@ CSSCounterStyleAtRulesEnabled:
     WebCore:
       default: true
 
-CSSCustomPropertiesAndValuesEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "CSS Custom Properties and Values API"
-  humanReadableDescription: "Enable CSS Custom Properties and Values API"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 CSSFieldSizingEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9869,7 +9869,6 @@
         "@property": {
             "syntax": {
                 "codegen-properties": {
-                    "settings-flag": "cssCustomPropertiesAndValuesEnabled",
                     "parser-grammar": "<string>"
                 },
                 "specification": {
@@ -9879,7 +9878,6 @@
             },
             "inherits": {
                 "codegen-properties": {
-                    "settings-flag": "cssCustomPropertiesAndValuesEnabled",
                     "parser-grammar": "true | false"
                 },
                 "specification": {
@@ -9889,7 +9887,6 @@
             },
             "initial-value": {
                 "codegen-properties": {
-                    "settings-flag": "cssCustomPropertiesAndValuesEnabled",
                     "parser-grammar": "<declaration-value>"
                 },
                 "specification": {

--- a/Source/WebCore/css/DOMCSSCustomPropertyDescriptor.idl
+++ b/Source/WebCore/css/DOMCSSCustomPropertyDescriptor.idl
@@ -24,8 +24,7 @@
 */
 
 [
-    JSGenerateToJSObject,
-    EnabledBySetting=CSSCustomPropertiesAndValuesEnabled
+    JSGenerateToJSObject
 ] dictionary DOMCSSCustomPropertyDescriptor {
     required [AtomString] DOMString name;
              DOMString syntax       = "*";

--- a/Source/WebCore/css/DOMCSSNamespace+CSSPropertiesandValues.idl
+++ b/Source/WebCore/css/DOMCSSNamespace+CSSPropertiesandValues.idl
@@ -25,7 +25,6 @@
 
 // https://drafts.css-houdini.org/css-properties-values-api-1/#registering-custom-properties
 [
-    EnabledBySetting=CSSCustomPropertiesAndValuesEnabled,
     ImplementedBy=DOMCSSRegisterCustomProperty
 ] partial namespace DOMCSSNamespace {
     [CallWith=CurrentDocument] undefined registerProperty(DOMCSSCustomPropertyDescriptor descriptor);

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -1206,9 +1206,6 @@ RefPtr<StyleRuleContainer> CSSParserImpl::consumeContainerRule(CSSParserTokenRan
 
 RefPtr<StyleRuleProperty> CSSParserImpl::consumePropertyRule(CSSParserTokenRange prelude, CSSParserTokenRange block)
 {
-    if (!m_context.propertySettings.cssCustomPropertiesAndValuesEnabled)
-        return nullptr;
-
     auto nameToken = prelude.consumeIncludingWhitespace();
     if (nameToken.type() != IdentToken || !prelude.atEnd())
         return nullptr;

--- a/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
@@ -240,7 +240,6 @@
 #define WebKitWebAnimationsCompositeOperationsEnabledPreferenceKey @"WebKitWebAnimationsCompositeOperationsEnabled"
 #define WebKitWebAnimationsMutableTimelinesEnabledPreferenceKey @"WebKitWebAnimationsMutableTimelinesEnabled"
 #define WebKitMaskWebGLStringsEnabledPreferenceKey @"WebKitMaskWebGLStringsEnabled"
-#define WebKitCSSCustomPropertiesAndValuesEnabledPreferenceKey @"WebKitCSSCustomPropertiesAndValuesEnabled"
 #define WebKitPrivateClickMeasurementEnabledPreferenceKey @"WebKitPrivateClickMeasurementEnabled"
 #define WebKitGenericCueAPIEnabledKey @"WebKitGenericCueAPIEnabled"
 #define WebKitCoreMathMLEnabledPreferenceKey @"WebKitCoreMathMLEnabled"
@@ -254,6 +253,7 @@
 
 // The preference keys below this point are deprecated and have no effect. They should
 // be removed when it is considered safe to do so.
+#define WebKitCSSCustomPropertiesAndValuesEnabledPreferenceKey @"WebKitCSSCustomPropertiesAndValuesEnabled"
 #define WebKitAllowCrossOriginSubresourcesToAskForCredentialsKey @"WebKitAllowCrossOriginSubresourcesToAskForCredentials"
 #define WebKitAspectRatioOfImgFromWidthAndHeightEnabledPreferenceKey @"WebKitAspectRatioOfImgFromWidthAndHeightEnabled"
 #define WebKitResizeObserverEnabledPreferenceKey @"WebKitResizeObserverEnabled"

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -2905,16 +2905,6 @@ static RetainPtr<NSString>& classIBCreatorID()
     [self _setBoolValue:enabled forKey:WebKitMaskWebGLStringsEnabledPreferenceKey];
 }
 
-- (BOOL)CSSCustomPropertiesAndValuesEnabled
-{
-    return [self _boolValueForKey:WebKitCSSCustomPropertiesAndValuesEnabledPreferenceKey];
-}
-
-- (void)setCSSCustomPropertiesAndValuesEnabled:(BOOL)flag
-{
-    [self _setBoolValue:flag forKey:WebKitCSSCustomPropertiesAndValuesEnabledPreferenceKey];
-}
-
 - (BOOL)privateClickMeasurementEnabled
 {
     return [self _boolValueForKey:WebKitPrivateClickMeasurementEnabledPreferenceKey];
@@ -3021,6 +3011,15 @@ static RetainPtr<NSString>& classIBCreatorID()
 
 // The preferences in this category are deprecated and have no effect. They should
 // be removed when it is considered safe to do so.
+
+- (BOOL)CSSCustomPropertiesAndValuesEnabled
+{
+    return YES;
+}
+
+- (void)setCSSCustomPropertiesAndValuesEnabled:(BOOL)flag
+{
+}
 
 - (BOOL)syntheticEditingCommandsEnabled
 {

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
@@ -304,7 +304,6 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic) BOOL webAnimationsCompositeOperationsEnabled;
 @property (nonatomic) BOOL webAnimationsMutableTimelinesEnabled;
 @property (nonatomic) BOOL maskWebGLStringsEnabled;
-@property (nonatomic) BOOL CSSCustomPropertiesAndValuesEnabled;
 @property (nonatomic) BOOL privateClickMeasurementEnabled;
 @property (nonatomic) BOOL genericCueAPIEnabled;
 @property (nonatomic) BOOL coreMathMLEnabled;
@@ -323,6 +322,7 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 // The preferences in this category are deprecated and have no effect. They should
 // be removed when it is considered safe to do so.
 
+@property (nonatomic) BOOL CSSCustomPropertiesAndValuesEnabled;
 @property (nonatomic) BOOL syntheticEditingCommandsEnabled;
 @property (nonatomic) BOOL allowCrossOriginSubresourcesToAskForCredentials;
 @property (nonatomic) BOOL aspectRatioOfImgFromWidthAndHeightEnabled;


### PR DESCRIPTION
#### 014919f9c1daee75dec2ccb53771489899bb0c48
<pre>
Remove CSSCustomPropertiesAndValuesEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=271126">https://bugs.webkit.org/show_bug.cgi?id=271126</a>

Reviewed by Tim Nguyen.

It&apos;s been stable over a year.

* LayoutTests/css-custom-properties-api/crash.html:
* LayoutTests/css-custom-properties-api/cycles.html:
* LayoutTests/css-custom-properties-api/inherits.html:
* LayoutTests/css-custom-properties-api/initialValue.html:
* LayoutTests/css-custom-properties-api/initialValueJS.html:
* LayoutTests/css-custom-properties-api/inline.html:
* LayoutTests/css-custom-properties-api/length.html:
* LayoutTests/css-custom-properties-api/length2.html:
* LayoutTests/css-custom-properties-api/registerProperty.html:
* LayoutTests/fast/css-custom-paint/properties.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/DOMCSSCustomPropertyDescriptor.idl:
* Source/WebCore/css/DOMCSSNamespace+CSSPropertiesandValues.idl:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumePropertyRule):
* Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(-[WebPreferences CSSCustomPropertiesAndValuesEnabled]):
(-[WebPreferences setCSSCustomPropertiesAndValuesEnabled:]):
* Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h:

Canonical link: <a href="https://commits.webkit.org/276260@main">https://commits.webkit.org/276260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc1b014c5f6de1f7b666df62d704f1b24b3140d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46625 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46834 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40217 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20653 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36409 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17443 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39171 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2240 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/37512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48436 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/43748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19170 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43285 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42010 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9818 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20755 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50830 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20157 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10284 "Passed tests") | 
<!--EWS-Status-Bubble-End-->