### PR TITLE
Remove CSSTypedOMEnabled preference

### DIFF
--- a/LayoutTests/css-typedom/attributeStyleMap.html
+++ b/LayoutTests/css-typedom/attributeStyleMap.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSTypedOMEnabled=true ] -->
+<!DOCTYPE html>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
 <meta name="author" title="Justin Michaud" href="mailto:justin_michaud@webkit.org">

--- a/LayoutTests/css-typedom/css-style-value-parse.html
+++ b/LayoutTests/css-typedom/css-style-value-parse.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSTypedOMEnabled=true ] -->
+<!DOCTYPE html>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>
 <meta name="author" title="Johnson Zhou" href="mailto:qiaosong_zhou@apple.com">

--- a/LayoutTests/css-typedom/sameobject.html
+++ b/LayoutTests/css-typedom/sameobject.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSTypedOMEnabled=true ] -->
+<!DOCTYPE html>
 <meta name="author" title="Justin Michaud" href="mailto:justin_michaud@webkit.org">
 <meta name="assert" content="Test that the [SameObject] idl attribute is respected">
 <script src="../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/css-custom-paint/properties.html
+++ b/LayoutTests/fast/css-custom-paint/properties.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ CSSTypedOMEnabled=true CSSPaintingAPIEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ CSSPaintingAPIEnabled=true ] -->
 <meta name="author" title="Justin Michaud" href="mailto:justin_michaud@webkit.org">
 <meta name="assert" content="Test paint worklet input properties and arguments">
 <link rel="help" content="https://drafts.css-houdini.org/css-paint-api-1/">

--- a/LayoutTests/fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html
+++ b/LayoutTests/fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ CSSTypedOMEnabled=true ] -->
+<!DOCTYPE html>
 <html>
 <body>
 <script src="../../../resources/js-test.js"></script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1411,20 +1411,6 @@ CSSTypedOMColorEnabled:
     WebCore:
       default: false
 
-CSSTypedOMEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "CSS Typed OM"
-  humanReadableDescription: "Enable the CSS Typed OM"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 CSSUnprefixedBackdropFilterEnabled:
   type: bool
   status: Backdropfilter_feature_status

--- a/Source/WebCore/css/CSSStyleRule.idl
+++ b/Source/WebCore/css/CSSStyleRule.idl
@@ -29,7 +29,7 @@ typedef USVString CSSOMString;
     [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 
     // https://drafts.css-houdini.org/css-typed-om/#declared-stylepropertymap-objects
-    [SameObject, EnabledBySetting=CSSTypedOMEnabled] readonly attribute StylePropertyMap styleMap;
+    [SameObject] readonly attribute StylePropertyMap styleMap;
 
     [EnabledBySetting=CSSNestingEnabled, SameObject] readonly attribute CSSRuleList cssRules;
     [EnabledBySetting=CSSNestingEnabled] unsigned long insertRule(CSSOMString rule, optional unsigned long index = 0);

--- a/Source/WebCore/css/DOMCSSNamespace+CSSNumericFactory.idl
+++ b/Source/WebCore/css/DOMCSSNamespace+CSSNumericFactory.idl
@@ -25,7 +25,6 @@
 
 // https://www.w3.org/TR/css-typed-om-1/#numeric-factory
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     ImplementedBy=CSSNumericFactory
 ] partial namespace DOMCSSNamespace {
 

--- a/Source/WebCore/css/ElementCSSInlineStyle.idl
+++ b/Source/WebCore/css/ElementCSSInlineStyle.idl
@@ -27,5 +27,5 @@
 // https://drafts.csswg.org/cssom/#the-elementcssinlinestyle-interface
 interface mixin ElementCSSInlineStyle {
     [ImplementedAs=cssomStyle, SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
-    [ImplementedAs=ensureAttributeStyleMap, SameObject, CachedAttribute, EnabledBySetting=CSSTypedOMEnabled] readonly attribute StylePropertyMap attributeStyleMap;
+    [ImplementedAs=ensureAttributeStyleMap, SameObject, CachedAttribute] readonly attribute StylePropertyMap attributeStyleMap;
 };

--- a/Source/WebCore/css/typedom/CSSKeywordValue.idl
+++ b/Source/WebCore/css/typedom/CSSKeywordValue.idl
@@ -25,7 +25,6 @@
 
 // https://drafts.css-houdini.org/css-typed-om/#csskeywordvalue
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet),
     JSGenerateToJSObject,
     JSGenerateToNativeObject,

--- a/Source/WebCore/css/typedom/CSSNumericValue.idl
+++ b/Source/WebCore/css/typedom/CSSNumericValue.idl
@@ -28,7 +28,6 @@ typedef (double or CSSNumericValue) CSSNumberish;
 // https://drafts.css-houdini.org/css-typed-om/#cssnumericvalue
 [
     InterfaceName=CSSNumericValue,
-    EnabledBySetting=CSSTypedOMEnabled,
     JSGenerateToNativeObject,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSNumericValue : CSSStyleValue {

--- a/Source/WebCore/css/typedom/CSSOMVariableReferenceValue.idl
+++ b/Source/WebCore/css/typedom/CSSOMVariableReferenceValue.idl
@@ -26,7 +26,6 @@
 // https://drafts.css-houdini.org/css-typed-om/#cssvariablereferencevalue
 [
     InterfaceName=CSSVariableReferenceValue,
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet),
 ] interface CSSOMVariableReferenceValue {
     constructor(USVString variable, optional CSSUnparsedValue? fallback = null);

--- a/Source/WebCore/css/typedom/CSSStyleImageValue.idl
+++ b/Source/WebCore/css/typedom/CSSStyleImageValue.idl
@@ -26,7 +26,6 @@
 // https://drafts.css-houdini.org/css-typed-om/#cssstyleimagevalue
 [
     InterfaceName=CSSImageValue,
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet),
     JSGenerateToNativeObject,
 ] interface CSSStyleImageValue : CSSStyleValue {

--- a/Source/WebCore/css/typedom/CSSStyleValue.idl
+++ b/Source/WebCore/css/typedom/CSSStyleValue.idl
@@ -27,7 +27,6 @@
 [
     InterfaceName=CSSStyleValue,
     CustomToJSObject,
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet),
     SkipVTableValidation
 ] interface CSSStyleValue {

--- a/Source/WebCore/css/typedom/CSSUnitValue.idl
+++ b/Source/WebCore/css/typedom/CSSUnitValue.idl
@@ -26,7 +26,6 @@
 // https://drafts.css-houdini.org/css-typed-om/#cssunitvalue
 [
     InterfaceName=CSSUnitValue,
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet),
 ] interface CSSUnitValue : CSSNumericValue {
     constructor(double value, USVString unit);

--- a/Source/WebCore/css/typedom/CSSUnparsedValue.idl
+++ b/Source/WebCore/css/typedom/CSSUnparsedValue.idl
@@ -28,7 +28,6 @@ typedef (USVString or CSSOMVariableReferenceValue) CSSUnparsedSegment;
 // https://drafts.css-houdini.org/css-typed-om/#cssunparsedvalue
 [
     InterfaceName=CSSUnparsedValue,
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet),
     JSGenerateToNativeObject
 ] interface CSSUnparsedValue : CSSStyleValue {

--- a/Source/WebCore/css/typedom/StylePropertyMap.idl
+++ b/Source/WebCore/css/typedom/StylePropertyMap.idl
@@ -25,7 +25,6 @@
 
 // https://drafts.css-houdini.org/css-typed-om/#cssstylepropertymap
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=Window,
     SkipVTableValidation,
     JSGenerateToJSObject

--- a/Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl
+++ b/Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl
@@ -25,7 +25,6 @@
 
 // https://drafts.css-houdini.org/css-typed-om/#cssstylepropertymapreadonly
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet),
     SkipVTableValidation,
     JSGenerateToJSObject,

--- a/Source/WebCore/css/typedom/color/CSSColor.idl
+++ b/Source/WebCore/css/typedom/color/CSSColor.idl
@@ -29,7 +29,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#csscolor
 [
-    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
+    EnabledBySetting=CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSColor : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSColorValue.idl
+++ b/Source/WebCore/css/typedom/color/CSSColorValue.idl
@@ -27,7 +27,7 @@ typedef (DOMString or CSSKeywordValue) CSSKeywordish;
 
 // https://drafts.css-houdini.org/css-typed-om/#csscolorvalue
 [
-    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
+    EnabledBySetting=CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSColorValue : CSSStyleValue {

--- a/Source/WebCore/css/typedom/color/CSSHSL.idl
+++ b/Source/WebCore/css/typedom/color/CSSHSL.idl
@@ -30,7 +30,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#csshsl
 [
-    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
+    EnabledBySetting=CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSHSL : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSHWB.idl
+++ b/Source/WebCore/css/typedom/color/CSSHWB.idl
@@ -27,7 +27,7 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
 // https://drafts.css-houdini.org/css-typed-om/#csshwb
 [
-    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
+    EnabledBySetting=CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSHWB : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSLCH.idl
+++ b/Source/WebCore/css/typedom/color/CSSLCH.idl
@@ -30,7 +30,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#csslch
 [
-    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
+    EnabledBySetting=CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSLCH : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSLab.idl
+++ b/Source/WebCore/css/typedom/color/CSSLab.idl
@@ -30,7 +30,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#csslab
 [
-    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
+    EnabledBySetting=CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSLab : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSOKLCH.idl
+++ b/Source/WebCore/css/typedom/color/CSSOKLCH.idl
@@ -30,7 +30,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssoklch
 [
-    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
+    EnabledBySetting=CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSOKLCH : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSOKLab.idl
+++ b/Source/WebCore/css/typedom/color/CSSOKLab.idl
@@ -30,7 +30,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssoklab
 [
-    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
+    EnabledBySetting=CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSOKLab : CSSColorValue {

--- a/Source/WebCore/css/typedom/color/CSSRGB.idl
+++ b/Source/WebCore/css/typedom/color/CSSRGB.idl
@@ -30,7 +30,7 @@ typedef (CSSNumberish or CSSKeywordish) CSSColorPercent;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssrgb
 [
-    EnabledBySetting=CSSTypedOMEnabled&CSSTypedOMColorEnabled,
+    EnabledBySetting=CSSTypedOMColorEnabled,
     Exposed=(Window,Worker,PaintWorklet/*,LayoutWorklet*/),
     JSGenerateToNativeObject,
 ] interface CSSRGB : CSSColorValue {

--- a/Source/WebCore/css/typedom/numeric/CSSMathClamp.idl
+++ b/Source/WebCore/css/typedom/numeric/CSSMathClamp.idl
@@ -27,7 +27,6 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssmathclamp
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSMathClamp : CSSMathValue {
     constructor(CSSNumberish lower, CSSNumberish value, CSSNumberish upper);

--- a/Source/WebCore/css/typedom/numeric/CSSMathInvert.idl
+++ b/Source/WebCore/css/typedom/numeric/CSSMathInvert.idl
@@ -27,7 +27,6 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssmathinvert
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSMathInvert : CSSMathValue {
     constructor(CSSNumberish arg);

--- a/Source/WebCore/css/typedom/numeric/CSSMathMax.idl
+++ b/Source/WebCore/css/typedom/numeric/CSSMathMax.idl
@@ -27,7 +27,6 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssmathmax
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSMathMax : CSSMathValue {
     constructor(CSSNumberish... args);

--- a/Source/WebCore/css/typedom/numeric/CSSMathMin.idl
+++ b/Source/WebCore/css/typedom/numeric/CSSMathMin.idl
@@ -27,7 +27,6 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssmathmin
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSMathMin : CSSMathValue {
     constructor(CSSNumberish... args);

--- a/Source/WebCore/css/typedom/numeric/CSSMathNegate.idl
+++ b/Source/WebCore/css/typedom/numeric/CSSMathNegate.idl
@@ -27,7 +27,6 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssmathnegate
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSMathNegate : CSSMathValue {
     constructor(CSSNumberish arg);

--- a/Source/WebCore/css/typedom/numeric/CSSMathProduct.idl
+++ b/Source/WebCore/css/typedom/numeric/CSSMathProduct.idl
@@ -27,7 +27,6 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssmathproduct
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSMathProduct : CSSMathValue {
     constructor(CSSNumberish... args);

--- a/Source/WebCore/css/typedom/numeric/CSSMathSum.idl
+++ b/Source/WebCore/css/typedom/numeric/CSSMathSum.idl
@@ -27,7 +27,6 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssmathsum
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSMathSum : CSSMathValue {
     constructor(CSSNumberish... args);

--- a/Source/WebCore/css/typedom/numeric/CSSMathValue.idl
+++ b/Source/WebCore/css/typedom/numeric/CSSMathValue.idl
@@ -27,7 +27,6 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssmathvalue
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSMathValue : CSSNumericValue {
     [ImplementedAs=getOperator] readonly attribute CSSMathOperator operator;

--- a/Source/WebCore/css/typedom/numeric/CSSNumericArray.idl
+++ b/Source/WebCore/css/typedom/numeric/CSSNumericArray.idl
@@ -25,7 +25,6 @@
 
 // https://drafts.css-houdini.org/css-typed-om/#cssnumericarray
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSNumericArray {
     iterable<CSSNumericValue>;

--- a/Source/WebCore/css/typedom/numeric/CSSNumericBaseType.idl
+++ b/Source/WebCore/css/typedom/numeric/CSSNumericBaseType.idl
@@ -24,9 +24,7 @@
 */
 
 // https://drafts.css-houdini.org/css-typed-om/#enumdef-cssnumericbasetype
-[
-    EnabledBySetting=CSSTypedOMEnabled,
-] enum CSSNumericBaseType {
+enum CSSNumericBaseType {
     "length",
     "angle",
     "time",

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.idl
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.idl
@@ -25,7 +25,6 @@
 
 // https://drafts.css-houdini.org/css-typed-om/#cssmatrixcomponent
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet),
 ] interface CSSMatrixComponent : CSSTransformComponent {
     constructor(DOMMatrixReadOnly matrix, optional CSSMatrixComponentOptions options = {});

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.idl
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.idl
@@ -28,7 +28,6 @@ typedef (CSSNumericValue or CSSKeywordish) CSSPerspectiveValue;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssperspective
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSPerspective : CSSTransformComponent {
     constructor(CSSPerspectiveValue length);

--- a/Source/WebCore/css/typedom/transform/CSSRotate.idl
+++ b/Source/WebCore/css/typedom/transform/CSSRotate.idl
@@ -27,7 +27,6 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssrotate
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSRotate : CSSTransformComponent {
     constructor(CSSNumericValue angle);

--- a/Source/WebCore/css/typedom/transform/CSSScale.idl
+++ b/Source/WebCore/css/typedom/transform/CSSScale.idl
@@ -27,7 +27,6 @@ typedef (double or CSSNumericValue) CSSNumberish;
 
 // https://drafts.css-houdini.org/css-typed-om/#cssscale
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSScale : CSSTransformComponent {
     constructor(CSSNumberish x, CSSNumberish y, optional CSSNumberish z);

--- a/Source/WebCore/css/typedom/transform/CSSSkew.idl
+++ b/Source/WebCore/css/typedom/transform/CSSSkew.idl
@@ -25,7 +25,6 @@
 
 // https://drafts.css-houdini.org/css-typed-om/#cssskew
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSSkew : CSSTransformComponent {
     constructor(CSSNumericValue ax, CSSNumericValue ay);

--- a/Source/WebCore/css/typedom/transform/CSSSkewX.idl
+++ b/Source/WebCore/css/typedom/transform/CSSSkewX.idl
@@ -25,7 +25,6 @@
 
 // https://drafts.css-houdini.org/css-typed-om/#cssskewx
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSSkewX : CSSTransformComponent {
     constructor(CSSNumericValue ax);

--- a/Source/WebCore/css/typedom/transform/CSSSkewY.idl
+++ b/Source/WebCore/css/typedom/transform/CSSSkewY.idl
@@ -25,7 +25,6 @@
 
 // https://drafts.css-houdini.org/css-typed-om/#cssskewy
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSSkewY : CSSTransformComponent {
     constructor(CSSNumericValue ay);

--- a/Source/WebCore/css/typedom/transform/CSSTransformComponent.idl
+++ b/Source/WebCore/css/typedom/transform/CSSTransformComponent.idl
@@ -25,7 +25,6 @@
 
 // https://drafts.css-houdini.org/css-typed-om/#csstransformcomponent
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet),
     CustomToJSObject,
 ] interface CSSTransformComponent {

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.idl
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.idl
@@ -25,7 +25,6 @@
 
 // https://drafts.css-houdini.org/css-typed-om/#csstransformvalue
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet),
 ] interface CSSTransformValue : CSSStyleValue {
     constructor(sequence<CSSTransformComponent> transforms);

--- a/Source/WebCore/css/typedom/transform/CSSTranslate.idl
+++ b/Source/WebCore/css/typedom/transform/CSSTranslate.idl
@@ -25,7 +25,6 @@
 
 // https://drafts.css-houdini.org/css-typed-om/#csstranslate
 [
-    EnabledBySetting=CSSTypedOMEnabled,
     Exposed=(Window,Worker,PaintWorklet)
 ] interface CSSTranslate : CSSTransformComponent {
     constructor(CSSNumericValue x, CSSNumericValue y, optional CSSNumericValue z);

--- a/Source/WebCore/dom/Element+ComputedStyleMap.idl
+++ b/Source/WebCore/dom/Element+ComputedStyleMap.idl
@@ -24,8 +24,6 @@
  */
 
 // https://drafts.css-houdini.org/css-typed-om-1/#computed-stylepropertymapreadonly-objects
-[
-    EnabledBySetting=CSSTypedOMEnabled,
-] partial interface Element {
+partial interface Element {
     StylePropertyMapReadOnly computedStyleMap();
 };

--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
@@ -60,7 +60,6 @@ RemoteWebInspectorUI::RemoteWebInspectorUI(WebPage& page)
     : m_page(page)
     , m_frontendAPIDispatcher(InspectorFrontendAPIDispatcher::create(*page.corePage()))
 {
-    WebInspectorUI::enableFrontendFeatures(page);
 }
 
 RemoteWebInspectorUI::~RemoteWebInspectorUI() = default;

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -54,17 +54,11 @@ Ref<WebInspectorUI> WebInspectorUI::create(WebPage& page)
     return adoptRef(*new WebInspectorUI(page));
 }
 
-void WebInspectorUI::enableFrontendFeatures(WebPage& page)
-{
-    page.corePage()->settings().setCSSTypedOMEnabled(true);
-}
-
 WebInspectorUI::WebInspectorUI(WebPage& page)
     : m_page(page)
     , m_frontendAPIDispatcher(InspectorFrontendAPIDispatcher::create(*page.corePage()))
     , m_debuggableInfo(DebuggableInfoData::empty())
 {
-    WebInspectorUI::enableFrontendFeatures(page);
 }
 
 WebInspectorUI::~WebInspectorUI() = default;

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
@@ -60,8 +60,6 @@ public:
     static Ref<WebInspectorUI> create(WebPage&);
     virtual ~WebInspectorUI();
 
-    static void enableFrontendFeatures(WebPage&);
-
     // Implemented in generated WebInspectorUIMessageReceiver.cpp
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 


### PR DESCRIPTION
#### e225c278f4c06f451ea92cc68b12986dd2a99979
<pre>
Remove CSSTypedOMEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=271128">https://bugs.webkit.org/show_bug.cgi?id=271128</a>

Reviewed by Tim Nguyen.

It&apos;s been stable for over a year.

* LayoutTests/css-typedom/attributeStyleMap.html:
* LayoutTests/css-typedom/css-style-value-parse.html:
* LayoutTests/css-typedom/sameobject.html:
* LayoutTests/fast/css-custom-paint/properties.html:
* LayoutTests/fast/css/css-typed-om/style-property-map-set-CSSMathSum-value.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSStyleRule.idl:
* Source/WebCore/css/DOMCSSNamespace+CSSNumericFactory.idl:
* Source/WebCore/css/ElementCSSInlineStyle.idl:
* Source/WebCore/css/typedom/CSSKeywordValue.idl:
* Source/WebCore/css/typedom/CSSNumericValue.idl:
* Source/WebCore/css/typedom/CSSOMVariableReferenceValue.idl:
* Source/WebCore/css/typedom/CSSStyleImageValue.idl:
* Source/WebCore/css/typedom/CSSStyleValue.idl:
* Source/WebCore/css/typedom/CSSUnitValue.idl:
* Source/WebCore/css/typedom/CSSUnparsedValue.idl:
* Source/WebCore/css/typedom/StylePropertyMap.idl:
* Source/WebCore/css/typedom/StylePropertyMapReadOnly.idl:
* Source/WebCore/css/typedom/color/CSSColor.idl:
* Source/WebCore/css/typedom/color/CSSColorValue.idl:
* Source/WebCore/css/typedom/color/CSSHSL.idl:
* Source/WebCore/css/typedom/color/CSSHWB.idl:
* Source/WebCore/css/typedom/color/CSSLCH.idl:
* Source/WebCore/css/typedom/color/CSSLab.idl:
* Source/WebCore/css/typedom/color/CSSOKLCH.idl:
* Source/WebCore/css/typedom/color/CSSOKLab.idl:
* Source/WebCore/css/typedom/color/CSSRGB.idl:
* Source/WebCore/css/typedom/numeric/CSSMathClamp.idl:
* Source/WebCore/css/typedom/numeric/CSSMathInvert.idl:
* Source/WebCore/css/typedom/numeric/CSSMathMax.idl:
* Source/WebCore/css/typedom/numeric/CSSMathMin.idl:
* Source/WebCore/css/typedom/numeric/CSSMathNegate.idl:
* Source/WebCore/css/typedom/numeric/CSSMathProduct.idl:
* Source/WebCore/css/typedom/numeric/CSSMathSum.idl:
* Source/WebCore/css/typedom/numeric/CSSMathValue.idl:
* Source/WebCore/css/typedom/numeric/CSSNumericArray.idl:
* Source/WebCore/css/typedom/numeric/CSSNumericBaseType.idl:
* Source/WebCore/css/typedom/transform/CSSMatrixComponent.idl:
* Source/WebCore/css/typedom/transform/CSSPerspective.idl:
* Source/WebCore/css/typedom/transform/CSSRotate.idl:
* Source/WebCore/css/typedom/transform/CSSScale.idl:
* Source/WebCore/css/typedom/transform/CSSSkew.idl:
* Source/WebCore/css/typedom/transform/CSSSkewX.idl:
* Source/WebCore/css/typedom/transform/CSSSkewY.idl:
* Source/WebCore/css/typedom/transform/CSSTransformComponent.idl:
* Source/WebCore/css/typedom/transform/CSSTransformValue.idl:
* Source/WebCore/css/typedom/transform/CSSTranslate.idl:
* Source/WebCore/dom/Element+ComputedStyleMap.idl:
* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp:
(WebKit::RemoteWebInspectorUI::RemoteWebInspectorUI):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::WebInspectorUI):
(WebKit::WebInspectorUI::enableFrontendFeatures): Deleted.
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.h:

Canonical link: <a href="https://commits.webkit.org/276266@main">https://commits.webkit.org/276266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e0c8f7f6513030fbcbef161d8a00e9a6d7a47de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46843 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40225 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46504 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20661 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38076 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17450 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39181 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2248 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/37521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40390 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48452 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/43756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15752 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38347 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9821 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20763 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50838 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20165 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10289 "Passed tests") | 
<!--EWS-Status-Bubble-End-->