### PR TITLE
[JSC] We should fix the backwards propagation for DFG node use flags after the fixup phase

### DIFF
--- a/JSTests/stress/propogate-PureInt-double-use.js
+++ b/JSTests/stress/propogate-PureInt-double-use.js
@@ -1,0 +1,29 @@
+function test(opt) {
+    let expected = opt();
+    for (let i = 0; i < 1e3; i++) {
+        let actual = opt();
+        if (actual != expected)
+            throw new Error("bad actual " + actual + " expected " + expected);
+    }
+}
+
+{
+    function opt1(f) {
+        var x = -19278.05 >>> NaN;
+        var y = -19278.05 + x;
+        var z = y >> 0;
+        return z;
+    }
+    noInline(opt1);
+
+    function opt2(v) {
+        let x = -1 >>> v;
+        let y = x + -0.2;
+        let z = y | 0;
+        return z;
+    }
+    noInline(opt2);
+
+    test(opt1);
+    test(opt2);
+}

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.h
@@ -32,10 +32,18 @@ namespace JSC { namespace DFG {
 
 class Graph;
 
-// Infer basic information about how nodes are used by doing a block-local
+// Infer basic information about how nodes are likely to be used by doing a block-local
 // backwards flow analysis.
 
-void performBackwardsPropagation(Graph&);
+
+// Infer information after fixup has run. This should only pessimize the existing information.
+// By this point, we ensure that any new uses inserted by fixup are accounted for.
+//
+// For example, consider:
+//     b = a + 0.1
+// If {b} is PureInt, then we would propagate that to {a}. But we don't actually know
+// until after fixup if {a} may be used as a double.
+bool performBackwardsPropagation(Graph&);
 
 } } // namespace JSC::DFG
 

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -444,9 +444,7 @@ private:
             
         case UInt32ToNumber: {
             fixIntConvertingEdge(node->child1());
-            if (bytecodeCanTruncateInteger(node->arithNodeFlags()))
-                node->convertToIdentity();
-            else if (node->canSpeculateInt32(FixupPass))
+            if (bytecodeCanTruncateInteger(node->arithNodeFlags()) || node->canSpeculateInt32(FixupPass))
                 node->setArithMode(Arith::CheckOverflow);
             else {
                 node->setArithMode(Arith::DoOverflow);

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -1153,6 +1153,8 @@ public:
 
     const BoyerMooreHorspoolTable<uint8_t>* tryAddStringSearchTable8(const String&);
 
+    bool afterFixup() { return m_planStage >= PlanStage::AfterFixup; }
+
     StackCheck m_stackChecker;
     VM& m_vm;
     Plan& m_plan;

--- a/Source/JavaScriptCore/dfg/DFGPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPhase.cpp
@@ -56,7 +56,7 @@ void Phase::beginPhase()
 
 void Phase::endPhase()
 {
-    if (!Options::validateGraphAtEachPhase())
+    if (!Options::validateGraphAtEachPhase() || !m_validateGraph)
         return;
     validate();
 }

--- a/Source/JavaScriptCore/dfg/DFGPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGPhase.h
@@ -35,9 +35,10 @@ namespace JSC { namespace DFG {
 
 class Phase {
 public:
-    Phase(Graph& graph, const char* name)
+    Phase(Graph& graph, const char* name, const bool validateGraph = true)
         : m_graph(graph)
         , m_name(name)
+        , m_validateGraph(validateGraph)
     {
         beginPhase();
     }
@@ -72,7 +73,8 @@ private:
     // Call these hooks when starting and finishing.
     void beginPhase();
     void endPhase();
-    
+
+    bool m_validateGraph { true };
     CString m_graphDumpBeforePhase;
 };
 

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(DFG_JIT)
 
 #include "DFGArgumentsEliminationPhase.h"
+#include "DFGBackwardsPropagationPhase.h"
 #include "DFGByteCodeParser.h"
 #include "DFGCFAPhase.h"
 #include "DFGCFGSimplificationPhase.h"
@@ -274,6 +275,7 @@ Plan::CompilationPath Plan::compileInThreadImpl()
     if (validationEnabled())
         validate(dfg);
         
+    RUN_PHASE(performBackwardsPropagation);
     RUN_PHASE(performStrengthReduction);
     RUN_PHASE(performCPSRethreading);
     RUN_PHASE(performCFA);

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -114,6 +114,11 @@ private:
                 m_changed = true;
                 break;
             }
+            if (bytecodeCanTruncateInteger(m_node->arithNodeFlags())) {
+                m_node->convertToIdentity();
+                m_changed = true;
+                break;
+            }
             break;
             
         case ArithAdd:


### PR DESCRIPTION
#### f5b95a221c2e77a79052e1cd0cf6f2e38b50aadd
<pre>
[JSC] We should fix the backwards propagation for DFG node use flags after the fixup phase
<a href="https://bugs.webkit.org/show_bug.cgi?id=257949">https://bugs.webkit.org/show_bug.cgi?id=257949</a>
<a href="https://rdar.apple.com/110661900">rdar://110661900</a>

Reviewed by Yusuke Suzuki.

Given JS code:

    let x = -1 &gt;&gt;&gt; v;  // &lt;-- [1]
    let y = x + -0.2;  // &lt;-- [2]
    let z = y | 0;     // &lt;-- [3]

In the BackwardsPropagationPhase, Node {y} is a PureInt (The node
is never used as a number) since it&apos;s only used in [3] which will
be truncated to int32, see spec [4]. Then, the PureInt info will be
propagated to node {x} since the right operand (-0.2) at [2] is within
two to the 32th power range. Later then, the UInt32ToNumber emitted at
[1] will be optimized out in the FixupPhase due to the PureInt {x}.
However, this is not expected since {x} should be treated as a number
when being added with -0.2.

This brings us the concern that PureInt is not sufficiently proven in
the BackwardsPropagationPhase until the FixupPhase which is used to fixes
edge uses. In this case, since the {x} node has a number result because of
the emitted UInt32ToNumber, [2] wouldn&apos;t be treated as an integer add. As a
result, a DoubleRep(x) is introduced for the double arithmetic add at [2].
Here, the DoubleRep is basically a double representation which can be leveraged
by floating point arithmetic operations. With that we can confirm that the wrapped
node is definitely going to be used as a double and we should rely on that to
prove the number use of a DFG node.

So to fix this issue, we should run BackwardsPropagationPhase again after the
FixupPhase with those inserted double representation nodes as proofs in order
to fix the node uses. And move the corresponding UInt32ToNumber optimization
to the later StrengthReductionPhase.

[4] <a href="https://tc39.es/ecma262/#sec-numeric-types-number-bitwiseOR">https://tc39.es/ecma262/#sec-numeric-types-number-bitwiseOR</a>

* JSTests/stress/propogate-PureInt-double-use.js: Added.
(test):
(throw.new.Error.opt1):
(throw.new.Error.opt2):
(throw.new.Error):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::BackwardsPropagationPhase):
(JSC::DFG::BackwardsPropagationPhase::propagate):
(JSC::DFG::performBackwardsPropagation):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.h:
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGPhase.cpp:
(JSC::DFG::Phase::endPhase):
* Source/JavaScriptCore/dfg/DFGPhase.h:
(JSC::DFG::Phase::Phase):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):

Canonical link: <a href="https://commits.webkit.org/276654@main">https://commits.webkit.org/276654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e7c312fc1d1cd5b21721788e74738708fc16620

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47466 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40817 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36812 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18422 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39728 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2859 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38007 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49130 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44268 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43796 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21097 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42550 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10064 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21437 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51440 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20773 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10440 "Passed tests") | 
<!--EWS-Status-Bubble-End-->