### PR TITLE
Remove UnprefixedFullscreenAPIEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6783,20 +6783,6 @@ UnifiedPDFEnabled:
       "ENABLE(UNIFIED_PDF_BY_DEFAULT)": true
       default: false
 
-UnprefixedFullscreenAPIEnabled:
-  type: bool
-  status: stable
-  category: dom
-  humanReadableName: "Unprefixed Fullscreen API"
-  humanReadableDescription: "Enable Unprefixed Fullscreen API"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 UpgradeKnownHostsToHTTPSEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/dom/Document+Fullscreen.idl
+++ b/Source/WebCore/dom/Document+Fullscreen.idl
@@ -30,11 +30,11 @@
     DisabledByQuirk=shouldDisableElementFullscreen,
     ImplementedBy=DocumentFullscreen
 ] partial interface Document {
-    [LegacyLenientSetter, EnabledBySetting=UnprefixedFullscreenAPIEnabled, ImplementedAs=fullscreenEnabled] readonly attribute boolean fullscreenEnabled;
-    [LegacyLenientSetter, Unscopable, EnabledBySetting=UnprefixedFullscreenAPIEnabled, ImplementedAs=webkitIsFullScreen] readonly attribute boolean fullscreen; // historical
-    [EnabledBySetting=UnprefixedFullscreenAPIEnabled] Promise<undefined> exitFullscreen();
-    [EnabledBySetting=UnprefixedFullscreenAPIEnabled] attribute EventHandler onfullscreenchange;
-    [EnabledBySetting=UnprefixedFullscreenAPIEnabled] attribute EventHandler onfullscreenerror;
+    [LegacyLenientSetter] readonly attribute boolean fullscreenEnabled;
+    [LegacyLenientSetter, Unscopable, ImplementedAs=webkitIsFullScreen] readonly attribute boolean fullscreen; // historical
+    Promise<undefined> exitFullscreen();
+    attribute EventHandler onfullscreenchange;
+    attribute EventHandler onfullscreenerror;
 
     // Legacy WebKit-specific versions.
     readonly attribute boolean webkitFullscreenEnabled;

--- a/Source/WebCore/dom/DocumentOrShadowRoot+Fullscreen.idl
+++ b/Source/WebCore/dom/DocumentOrShadowRoot+Fullscreen.idl
@@ -26,7 +26,6 @@
 // https://fullscreen.spec.whatwg.org/#api
 [
     Conditional=FULLSCREEN_API,
-    EnabledBySetting=UnprefixedFullscreenAPIEnabled,
     DisabledByQuirk=shouldDisableElementFullscreen,
     ImplementedBy=DocumentOrShadowRootFullscreen
 ] partial interface mixin DocumentOrShadowRoot {

--- a/Source/WebCore/dom/Element+Fullscreen.idl
+++ b/Source/WebCore/dom/Element+Fullscreen.idl
@@ -29,9 +29,9 @@
     EnabledBySetting=FullScreenEnabled,
     DisabledByQuirk=shouldDisableElementFullscreen
 ] partial interface Element {
-    [EnabledBySetting=UnprefixedFullscreenAPIEnabled] Promise<undefined> requestFullscreen(optional FullscreenOptions options = {});
-    [EnabledBySetting=UnprefixedFullscreenAPIEnabled] attribute EventHandler onfullscreenchange;
-    [EnabledBySetting=UnprefixedFullscreenAPIEnabled] attribute EventHandler onfullscreenerror;
+    Promise<undefined> requestFullscreen(optional FullscreenOptions options = {});
+    attribute EventHandler onfullscreenchange;
+    attribute EventHandler onfullscreenerror;
 
     // Non-standard: WebKit prefixed variants.
     [ImplementedAs=webkitRequestFullscreen] undefined webkitRequestFullScreen(); // Prefixed Mozilla version.

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -671,19 +671,16 @@ void FullscreenManager::notifyAboutFullscreenChangeOrError()
 
 void FullscreenManager::dispatchEventForNode(Node& node, EventType eventType)
 {
-    bool supportsUnprefixedAPI = document().settings().unprefixedFullscreenAPIEnabled();
     switch (eventType) {
     case EventType::Change: {
-        if (supportsUnprefixedAPI)
-            node.dispatchEvent(Event::create(eventNames().fullscreenchangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));
+        node.dispatchEvent(Event::create(eventNames().fullscreenchangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));
         bool shouldEmitUnprefixed = !(node.hasEventListeners(eventNames().webkitfullscreenchangeEvent) && node.hasEventListeners(eventNames().fullscreenchangeEvent)) && !(node.document().hasEventListeners(eventNames().webkitfullscreenchangeEvent) && node.document().hasEventListeners(eventNames().fullscreenchangeEvent));
-        if (!supportsUnprefixedAPI || shouldEmitUnprefixed)
+        if (shouldEmitUnprefixed)
             node.dispatchEvent(Event::create(eventNames().webkitfullscreenchangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));
         break;
     }
     case EventType::Error:
-        if (supportsUnprefixedAPI)
-            node.dispatchEvent(Event::create(eventNames().fullscreenerrorEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));
+        node.dispatchEvent(Event::create(eventNames().fullscreenerrorEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));
         node.dispatchEvent(Event::create(eventNames().webkitfullscreenerrorEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));
         break;
     }


### PR DESCRIPTION
#### bf10e09dc8be4f7392f1c752f5a110196884c165
<pre>
Remove UnprefixedFullscreenAPIEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=271142">https://bugs.webkit.org/show_bug.cgi?id=271142</a>

Reviewed by Tim Nguyen.

It&apos;s been stable for over a year.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/Document+Fullscreen.idl:
* Source/WebCore/dom/DocumentOrShadowRoot+Fullscreen.idl:
* Source/WebCore/dom/Element+Fullscreen.idl:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::dispatchEventForNode):

Canonical link: <a href="https://commits.webkit.org/276301@main">https://commits.webkit.org/276301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e49ac2e2245fccf3b6bd7d07309a5f4956e05c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23310 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46890 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46547 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20707 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44819 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/20409 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17493 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39221 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2291 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37566 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48498 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43800 "Found 1 new JSC stress test failure: wasm.yaml/PerformanceTests/JetStream2/wasm-cli.js.wasm-slow-memory (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19221 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15794 "Found 1 new test failure: imported/w3c/web-platform-tests/streams/transform-streams/general.any.serviceworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43341 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20582 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42066 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9844 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20806 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50881 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20208 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10304 "Passed tests") | 
<!--EWS-Status-Bubble-End-->