### PR TITLE
Remove SubgridEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6555,20 +6555,6 @@ StorageBlockingPolicy:
     WebCore:
       default: StorageBlockingPolicy::AllowAll
 
-SubgridEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "CSS subgrid support"
-  humanReadableDescription: "Enable CSS subgrid support"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 SuppressesIncrementalRendering:
   type: bool
   status: embedder

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -98,7 +98,6 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , cascadeLayersEnabled { document.settings().cssCascadeLayersEnabled() }
     , gradientPremultipliedAlphaInterpolationEnabled { document.settings().cssGradientPremultipliedAlphaInterpolationEnabled() }
     , gradientInterpolationColorSpacesEnabled { document.settings().cssGradientInterpolationColorSpacesEnabled() }
-    , subgridEnabled { document.settings().subgridEnabled() }
     , masonryEnabled { document.settings().masonryEnabled() }
     , cssNestingEnabled { document.settings().cssNestingEnabled() }
 #if ENABLE(CSS_PAINTING_API)
@@ -144,25 +143,24 @@ void add(Hasher& hasher, const CSSParserContext& context)
         | context.cascadeLayersEnabled                      << 13
         | context.gradientPremultipliedAlphaInterpolationEnabled << 14
         | context.gradientInterpolationColorSpacesEnabled   << 15
-        | context.subgridEnabled                            << 16
-        | context.masonryEnabled                            << 17
-        | context.cssNestingEnabled                         << 18
-        | context.cssPaintingAPIEnabled                     << 19
-        | context.cssScopeAtRuleEnabled                     << 20
-        | context.cssTextUnderlinePositionLeftRightEnabled  << 21
-        | context.cssWordBreakAutoPhraseEnabled             << 22
-        | context.popoverAttributeEnabled                   << 23
-        | context.sidewaysWritingModesEnabled               << 24
-        | context.cssTextWrapPrettyEnabled                  << 25
-        | context.highlightAPIEnabled                       << 26
-        | context.grammarAndSpellingPseudoElementsEnabled   << 27
-        | context.customStateSetEnabled                     << 28
-        | context.thumbAndTrackPseudoElementsEnabled        << 29
+        | context.masonryEnabled                            << 16
+        | context.cssNestingEnabled                         << 17
+        | context.cssPaintingAPIEnabled                     << 18
+        | context.cssScopeAtRuleEnabled                     << 19
+        | context.cssTextUnderlinePositionLeftRightEnabled  << 20
+        | context.cssWordBreakAutoPhraseEnabled             << 21
+        | context.popoverAttributeEnabled                   << 22
+        | context.sidewaysWritingModesEnabled               << 23
+        | context.cssTextWrapPrettyEnabled                  << 24
+        | context.highlightAPIEnabled                       << 25
+        | context.grammarAndSpellingPseudoElementsEnabled   << 26
+        | context.customStateSetEnabled                     << 27
+        | context.thumbAndTrackPseudoElementsEnabled        << 28
 #if ENABLE(SERVICE_CONTROLS)
-        | context.imageControlsEnabled                      << 30
+        | context.imageControlsEnabled                      << 29
 #endif
-        | context.lightDarkEnabled                          << 31
-        | (uint64_t)context.mode                            << 32; // This is multiple bits, so keep it last.
+        | context.lightDarkEnabled                          << 30
+        | (uint64_t)context.mode                            << 31; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -89,7 +89,6 @@ struct CSSParserContext {
     bool cascadeLayersEnabled : 1 { false };
     bool gradientPremultipliedAlphaInterpolationEnabled : 1 { false };
     bool gradientInterpolationColorSpacesEnabled : 1 { false };
-    bool subgridEnabled : 1 { false };
     bool masonryEnabled : 1 { false };
     bool cssNestingEnabled : 1 { false };
     bool cssPaintingAPIEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -8032,7 +8032,7 @@ RefPtr<CSSValue> consumeGridTrackList(CSSParserTokenRange& range, const CSSParse
     if (context.masonryEnabled && range.peek().id() == CSSValueMasonry)
         return consumeIdent(range);
     bool seenAutoRepeat = false;
-    if (trackListType == GridTemplate && context.subgridEnabled && range.peek().id() == CSSValueSubgrid) {
+    if (trackListType == GridTemplate && range.peek().id() == CSSValueSubgrid) {
         consumeIdent(range);
         CSSValueListBuilder values;
         while (!range.atEnd() && range.peek().type() != DelimiterToken) {


### PR DESCRIPTION
#### 7ca5949f8c61513b7c94fe7ad6d45545c633f2e7
<pre>
Remove SubgridEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=271143">https://bugs.webkit.org/show_bug.cgi?id=271143</a>

Reviewed by Tim Nguyen.

It&apos;s been stable for over a year.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeGridTrackList):

Canonical link: <a href="https://commits.webkit.org/276263@main">https://commits.webkit.org/276263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7ecdde7848a0486de0e036c4dd40e2aff907aed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46836 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40218 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36412 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17446 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39173 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2241 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/37513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48437 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/43749 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43287 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20532 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42012 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9820 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20756 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50831 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20158 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10285 "Passed tests") | 
<!--EWS-Status-Bubble-End-->