### PR TITLE
VP8 WebCoreDecompressionSession should attribute its IOSurfaces to the media player resource owner

### DIFF
--- a/Source/WebCore/platform/VideoDecoder.h
+++ b/Source/WebCore/platform/VideoDecoder.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ProcessIdentity.h"
 #include <span>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Expected.h>
@@ -47,6 +48,7 @@ public:
         uint64_t height { 0 };
         HardwareAcceleration decoding { HardwareAcceleration::No };
         HardwareBuffer pixelBuffer { HardwareBuffer::No };
+        ProcessIdentity resourceOwner { };
     };
 
     struct EncodedFrame {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -294,6 +294,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::load(const URL&, const ContentType&, 
     ALWAYS_LOG(LOGIDENTIFIER);
 
     m_mediaSourcePrivate = MediaSourcePrivateAVFObjC::create(*this, client);
+    m_mediaSourcePrivate->setResourceOwner(m_resourceOwner);
     m_mediaSourcePrivate->setVideoRenderer(sampleBufferVideoRenderer());
     m_mediaSourcePrivate->setDecompressionSession(m_decompressionSession.get());
 
@@ -1070,6 +1071,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::ensureDecompressionSession()
 
     m_decompressionSession = WebCoreDecompressionSession::createOpenGL();
     m_decompressionSession->setTimebase([m_synchronizer timebase]);
+    m_decompressionSession->setResourceOwner(m_resourceOwner);
 
     if (m_mediaSourcePrivate)
         m_mediaSourcePrivate->setDecompressionSession(m_decompressionSession.get());

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(MEDIA_SOURCE) && USE(AVFOUNDATION)
 
+#include "ProcessIdentity.h"
 #include "MediaSourcePrivate.h"
 #include "MediaSourcePrivateClient.h"
 #include <wtf/Deque.h>
@@ -109,6 +110,8 @@ public:
     void failedToCreateRenderer(RendererType);
     bool needsVideoLayer() const;
 
+    void setResourceOwner(const ProcessIdentity& resourceOwner) { m_resourceOwner = resourceOwner; }
+
 private:
     MediaSourcePrivateAVFObjC(MediaPlayerPrivateMediaSourceAVFObjC&, MediaSourcePrivateClient&);
     MediaPlayerPrivateMediaSourceAVFObjC* platformPlayer() const { return m_player.get(); }
@@ -134,6 +137,8 @@ private:
     const void* m_logIdentifier;
     uint64_t m_nextSourceBufferID { 0 };
 #endif
+
+    ProcessIdentity m_resourceOwner;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
@@ -94,6 +94,7 @@ MediaSourcePrivate::AddStatus MediaSourcePrivateAVFObjC::addSourceBuffer(const C
 #if ENABLE(ENCRYPTED_MEDIA)
     newSourceBuffer->setCDMInstance(m_cdmInstance.get());
 #endif
+    newSourceBuffer->setResourceOwner(m_resourceOwner);
     outPrivate = newSourceBuffer.copyRef();
     newSourceBuffer->setMediaSourceDuration(duration());
     m_sourceBuffers.append(WTFMove(newSourceBuffer));

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(MEDIA_SOURCE) && USE(AVFOUNDATION)
 
+#include "ProcessIdentity.h"
 #include "SourceBufferParser.h"
 #include "SourceBufferPrivate.h"
 #include "WebAVSampleBufferListener.h"
@@ -142,6 +143,8 @@ public:
     const Logger& sourceBufferLogger() const final { return m_logger.get(); }
     const void* sourceBufferLogIdentifier() final { return logIdentifier(); }
 #endif
+
+    void setResourceOwner(const ProcessIdentity& resourceOwner) { m_resourceOwner = resourceOwner; }
 
 private:
     explicit SourceBufferPrivateAVFObjC(MediaSourcePrivateAVFObjC&, Ref<SourceBufferParser>&&);
@@ -263,6 +266,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     Ref<const Logger> m_logger;
     const void* m_logIdentifier;
 #endif
+
+    ProcessIdentity m_resourceOwner;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -1285,6 +1285,7 @@ void SourceBufferPrivateAVFObjC::setVideoRenderer(WebSampleBufferVideoRendering 
 
     if (renderer) {
         m_videoRenderer = VideoMediaSampleRenderer::create(renderer);
+        m_videoRenderer->setResourceOwner(m_resourceOwner);
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
         if (m_cdmInstance && shouldAddContentKeyRecipients())
             [m_cdmInstance->contentKeySession() addContentKeyRecipient:m_videoRenderer->displayLayer()];

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1426,6 +1426,7 @@ void MediaPlayerPrivateWebM::ensureLayer()
     }
 
     m_videoRenderer = VideoMediaSampleRenderer::create(displayLayer.get());
+    m_videoRenderer->setResourceOwner(m_resourceOwner);
     m_videoRenderer->requestMediaDataWhenReady([weakThis = WeakPtr { *this }, this] {
         if (weakThis && m_enabledVideoTrackID)
             didBecomeReadyForMoreSamples(*m_enabledVideoTrackID);
@@ -1450,7 +1451,8 @@ void MediaPlayerPrivateWebM::ensureDecompressionSession()
 
     m_decompressionSession = WebCoreDecompressionSession::createOpenGL();
     m_decompressionSession->setTimebase([m_synchronizer timebase]);
-    
+    m_decompressionSession->setResourceOwner(m_resourceOwner);
+
     m_decompressionSession->requestMediaDataWhenReady([weakThis = WeakPtr { *this }, this] {
         if (weakThis && m_enabledVideoTrackID)
             didBecomeReadyForMoreSamples(*m_enabledVideoTrackID);

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ProcessIdentity.h"
 #include "SampleMap.h"
 #include <wtf/Function.h>
 #include <wtf/Ref.h>
@@ -60,6 +61,9 @@ public:
     RetainPtr<CVPixelBufferRef> copyDisplayedPixelBuffer() const;
     CGRect bounds() const;
 #endif
+
+    void setResourceOwner(const ProcessIdentity& resourceOwner) { m_resourceOwner = resourceOwner; }
+
 private:
     VideoMediaSampleRenderer(WebSampleBufferVideoRendering *);
     void resetReadyForMoreSample();
@@ -75,6 +79,8 @@ private:
     bool m_requestMediaDataWhenReadySet { false };
     std::optional<uint32_t> m_currentCodec;
     std::optional<MediaTime> m_minimumUpcomingPresentationTime;
+
+    ProcessIdentity m_resourceOwner;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -115,6 +115,7 @@ void VideoMediaSampleRenderer::initializeDecompressionSession()
         m_decompressionSession->invalidate();
     m_decompressionSession = WebCoreDecompressionSession::createOpenGL();
     m_decompressionSession->setTimebase([m_renderer timebase]);
+    m_decompressionSession->setResourceOwner(m_resourceOwner);
     m_decompressionSession->decodedFrameWhenAvailable([weakThis = ThreadSafeWeakPtr { *this }](RetainPtr<CMSampleBufferRef>&& sample) {
         if (RefPtr protectedThis = weakThis.get())
             [protectedThis->m_renderer enqueueSampleBuffer:sample.get()];

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -27,6 +27,7 @@
 
 #include "MediaPromiseTypes.h"
 
+#include "ProcessIdentity.h"
 #include <CoreMedia/CMTime.h>
 #include <atomic>
 #include <wtf/Deque.h>
@@ -90,6 +91,8 @@ public:
 
     bool hardwareDecoderEnabled() const { return m_hardwareDecoderEnabled; }
     void setHardwareDecoderEnabled(bool enabled) { m_hardwareDecoderEnabled = enabled; }
+
+    void setResourceOwner(const ProcessIdentity& resourceOwner) { m_resourceOwner = resourceOwner; }
 
 private:
     enum Mode {
@@ -173,6 +176,8 @@ private:
     std::atomic<unsigned> m_corruptedVideoFrames { 0 };
     std::atomic<bool> m_deliverDecodedFrames { false };
     MediaTime m_totalFrameDelay;
+
+    ProcessIdentity m_resourceOwner;
 };
 
 }

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 #import "WebCoreDecompressionSession.h"
 
+#import "IOSurface.h"
 #import "Logging.h"
 #import "PixelBufferConformerCV.h"
 #import "VideoDecoder.h"
@@ -826,7 +827,7 @@ void WebCoreDecompressionSession::updateQosWithDecodeTimeStatistics(double ratio
 
 Ref<MediaPromise> WebCoreDecompressionSession::initializeVideoDecoder(FourCharCode codec)
 {
-    VideoDecoder::Config config { { }, 0, 0, VideoDecoder::HardwareAcceleration::Yes, VideoDecoder::HardwareBuffer::Yes };
+    VideoDecoder::Config config { { }, 0, 0, VideoDecoder::HardwareAcceleration::Yes, VideoDecoder::HardwareBuffer::Yes, m_resourceOwner };
     MediaPromise::Producer producer;
     auto promise = producer.promise();
     VideoDecoder::create(VideoDecoder::fourCCToCodecString(codec), config, [protectedThis = Ref { *this }, this, producer = WTFMove(producer)](VideoDecoder::CreateResult&& result) {


### PR DESCRIPTION
#### fa9c6d7fd22bb76f2a4b349e899025e72dfdfb3a
<pre>
VP8 WebCoreDecompressionSession should attribute its IOSurfaces to the media player resource owner
<a href="https://bugs.webkit.org/show_bug.cgi?id=271144">https://bugs.webkit.org/show_bug.cgi?id=271144</a>
<a href="https://rdar.apple.com/123795173">rdar://123795173</a>

Reviewed by Jean-Yves Avenard.

When WebCoreDecompressionSession uses a VideoDecoder to do its decoding, it uses an IOSurface pixel buffer pool.
We then need to attribute these buffers to the corresponding resource owner.
To do so, we are setting a resourceOwner in WebCoreDecompressionSession from VideoMediaSampleRenderer, which gets it from MediaPlayerPrivateWebM.
The WebCoreDecompressionSession is creating a VideoDecoder that is given the resourceOwner so that,
everytime we have a pixel buffer coming from the buffer pool, we then do the attribution.

We also do this for MediaPlayerPrivateMediaSourceAVFObjC&apos;s session.
This means piping the resource owner to MediaSourcePrivate -&gt; SourceBufferPrivate.

* Source/WebCore/platform/VideoDecoder.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::load):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::ensureDecompressionSession):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::addSourceBuffer):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::setVideoRenderer):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::ensureLayer):
(WebCore::MediaPlayerPrivateWebM::ensureDecompressionSession):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
(WebCore::VideoMediaSampleRenderer::setResourceOwner):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::initializeDecompressionSession):
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::initializeVideoDecoder):
* Source/WebCore/platform/libwebrtc/LibWebRTCVPXVideoDecoder.cpp:
(WebCore::LibWebRTCVPXInternalVideoDecoder::LibWebRTCVPXInternalVideoDecoder):
(WebCore::LibWebRTCVPXInternalVideoDecoder::Decoded):

Canonical link: <a href="https://commits.webkit.org/276270@main">https://commits.webkit.org/276270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/098431042a9e54e34fcbc86bf92ae34534576f58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44212 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46858 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40238 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20674 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38088 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17467 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17809 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39194 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2261 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48460 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19191 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15765 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43310 "Found 1 new test failure: printing/print-with-media-query-destory.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20552 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9825 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20776 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20178 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->