### PR TITLE
CSS3DTransformInteroperabilityEnabled preference removal follow-up

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -120,7 +120,6 @@ public:
     virtual bool shouldTemporarilyRetainTileCohorts(const GraphicsLayer*) const { return true; }
 
     virtual bool useGiantTiles() const { return false; }
-    virtual bool useCSS3DTransformInteroperability() const { return false; }
 
     virtual bool needsPixelAligment() const { return false; }
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1455,7 +1455,7 @@ FloatPoint GraphicsLayerCA::computePositionRelativeToBase(float& pageScale) cons
 
 void GraphicsLayerCA::flushCompositingState(const FloatRect& visibleRect)
 {
-    TransformState state(client().useCSS3DTransformInteroperability(), TransformState::UnapplyInverseTransformDirection, FloatQuad(visibleRect));
+    TransformState state(TransformState::UnapplyInverseTransformDirection, FloatQuad(visibleRect));
     state.setSecondaryQuad(FloatQuad { visibleRect });
 
     CommitState commitState;
@@ -1539,7 +1539,7 @@ bool GraphicsLayerCA::recursiveVisibleRectChangeRequiresFlush(const CommitState&
 
 bool GraphicsLayerCA::visibleRectChangeRequiresFlush(const FloatRect& clipRect) const
 {
-    TransformState state(client().useCSS3DTransformInteroperability(), TransformState::UnapplyInverseTransformDirection, FloatQuad(clipRect));
+    TransformState state(TransformState::UnapplyInverseTransformDirection, FloatQuad(clipRect));
     CommitState commitState;
     return recursiveVisibleRectChangeRequiresFlush(commitState, state);
 }
@@ -1972,11 +1972,6 @@ bool GraphicsLayerCA::platformCALayerShouldTemporarilyRetainTileCohorts(Platform
 bool GraphicsLayerCA::platformCALayerUseGiantTiles() const
 {
     return client().useGiantTiles();
-}
-
-bool GraphicsLayerCA::platformCALayerUseCSS3DTransformInteroperability() const
-{
-    return client().useCSS3DTransformInteroperability();
 }
 
 void GraphicsLayerCA::platformCALayerLogFilledVisibleFreshTile(unsigned blankPixelCount)

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -241,7 +241,6 @@ private:
     WEBCORE_EXPORT bool platformCALayerShouldAggressivelyRetainTiles(PlatformCALayer*) const override;
     WEBCORE_EXPORT bool platformCALayerShouldTemporarilyRetainTileCohorts(PlatformCALayer*) const override;
     WEBCORE_EXPORT bool platformCALayerUseGiantTiles() const override;
-    WEBCORE_EXPORT bool platformCALayerUseCSS3DTransformInteroperability() const override;
     WEBCORE_EXPORT void platformCALayerLogFilledVisibleFreshTile(unsigned) override;
     WEBCORE_EXPORT bool platformCALayerNeedsPlatformContext(const PlatformCALayer*) const override;
     bool platformCALayerContainsBitmapOnly(const PlatformCALayer*) const override { return client().layerContainsBitmapOnly(this); }

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
@@ -63,7 +63,6 @@ public:
     virtual bool platformCALayerShouldTemporarilyRetainTileCohorts(PlatformCALayer*) const { return true; }
 
     virtual bool platformCALayerUseGiantTiles() const { return false; }
-    virtual bool platformCALayerUseCSS3DTransformInteroperability() const { return false; }
 
     virtual bool isCommittingChanges() const { return false; }
 

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -310,7 +310,7 @@ void PlatformCALayerCocoa::commonInit()
         m_customSublayers = makeUnique<PlatformCALayerList>(tileController->containerLayers());
     }
 
-    if (m_owner && m_owner->platformCALayerUseCSS3DTransformInteroperability() && [m_layer respondsToSelector:@selector(setUsesWebKitBehavior:)]) {
+    if ([m_layer respondsToSelector:@selector(setUsesWebKitBehavior:)]) {
         [m_layer setUsesWebKitBehavior:YES];
         if (m_layerType == PlatformCALayer::LayerType::LayerTypeTransformLayer) {
             [m_layer setSortsSublayers:YES];

--- a/Source/WebCore/platform/graphics/transforms/TransformState.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformState.cpp
@@ -43,7 +43,6 @@ TransformState& TransformState::operator=(const TransformState& other)
         m_lastPlanarSecondaryQuad = other.m_lastPlanarSecondaryQuad;
     }
     m_accumulatingTransform = other.m_accumulatingTransform;
-    m_useCSS3DTransformInterop = other.m_useCSS3DTransformInterop;
     m_direction = other.m_direction;
     
     m_accumulatedTransform = nullptr;
@@ -123,16 +122,12 @@ void TransformState::applyAccumulatedOffset()
 
 bool TransformState::shouldFlattenBefore(TransformAccumulation accumulate)
 {
-    if (m_useCSS3DTransformInterop)
-        return accumulate == FlattenTransform && m_direction != ApplyTransformDirection;
-    return false;
+    return accumulate == FlattenTransform && m_direction != ApplyTransformDirection;
 }
 
 bool TransformState::shouldFlattenAfter(TransformAccumulation accumulate)
 {
-    if (m_useCSS3DTransformInterop)
-        return accumulate == FlattenTransform && m_direction == ApplyTransformDirection;
-    return accumulate == FlattenTransform;
+    return accumulate == FlattenTransform && m_direction == ApplyTransformDirection;
 }
 
 // FIXME: We transform AffineTransform to TransformationMatrix. This is rather inefficient.

--- a/Source/WebCore/platform/graphics/transforms/TransformState.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformState.h
@@ -44,30 +44,27 @@ public:
     enum TransformAccumulation { FlattenTransform, AccumulateTransform };
     enum TransformMatrixTracking { DoNotTrackTransformMatrix, TrackSVGCTMMatrix, TrackSVGScreenCTMMatrix };
 
-    TransformState(bool useCSS3DTransformInterop, TransformDirection mappingDirection, const FloatPoint& p, const FloatQuad& quad)
+    TransformState(TransformDirection mappingDirection, const FloatPoint& p, const FloatQuad& quad)
         : m_lastPlanarPoint(p)
         , m_lastPlanarQuad(quad)
         , m_mapPoint(true)
         , m_mapQuad(true)
-        , m_useCSS3DTransformInterop(useCSS3DTransformInterop)
         , m_direction(mappingDirection)
     {
     }
     
-    TransformState(bool useCSS3DTransformInterop, TransformDirection mappingDirection, const FloatPoint& p)
+    TransformState(TransformDirection mappingDirection, const FloatPoint& p)
         : m_lastPlanarPoint(p)
         , m_mapPoint(true)
         , m_mapQuad(false)
-        , m_useCSS3DTransformInterop(useCSS3DTransformInterop)
         , m_direction(mappingDirection)
     {
     }
     
-    TransformState(bool useCSS3DTransformInterop, TransformDirection mappingDirection, const FloatQuad& quad)
+    TransformState(TransformDirection mappingDirection, const FloatQuad& quad)
         : m_lastPlanarQuad(quad)
         , m_mapPoint(false)
         , m_mapQuad(true)
-        , m_useCSS3DTransformInterop(useCSS3DTransformInterop)
         , m_direction(mappingDirection)
     {
     }
@@ -144,7 +141,6 @@ private:
     bool m_accumulatingTransform { false };
     bool m_mapPoint;
     bool m_mapQuad;
-    bool m_useCSS3DTransformInterop;
     TransformMatrixTracking m_tracking { DoNotTrackTransformMatrix };
     TransformDirection m_direction;
 };

--- a/Source/WebCore/rendering/LayerOverlapMap.cpp
+++ b/Source/WebCore/rendering/LayerOverlapMap.cpp
@@ -279,7 +279,7 @@ String OverlapMapContainer::dump(unsigned indent) const
 }
 
 LayerOverlapMap::LayerOverlapMap(const RenderLayer& rootLayer)
-    : m_geometryMap(UseTransforms, true)
+    : m_geometryMap(UseTransforms)
     , m_rootLayer(rootLayer)
 {
     // Begin assuming the root layer will be composited so that there is

--- a/Source/WebCore/rendering/RenderGeometryMap.cpp
+++ b/Source/WebCore/rendering/RenderGeometryMap.cpp
@@ -36,9 +36,8 @@
 
 namespace WebCore {
 
-RenderGeometryMap::RenderGeometryMap(OptionSet<MapCoordinatesMode> flags, bool useCSS3DTransformInterop)
+RenderGeometryMap::RenderGeometryMap(OptionSet<MapCoordinatesMode> flags)
     : m_mapCoordinatesFlags(flags)
-    , m_useCSS3DTransformInterop(useCSS3DTransformInterop)
 {
 }
 
@@ -110,7 +109,7 @@ FloatPoint RenderGeometryMap::mapToContainer(const FloatPoint& p, const RenderLa
         result.move(m_accumulatedOffset);
         ASSERT(m_accumulatedOffsetMightBeSaturated || areEssentiallyEqual(rendererMappedResult, result));
     } else {
-        TransformState transformState(m_useCSS3DTransformInterop, TransformState::ApplyTransformDirection, p);
+        TransformState transformState(TransformState::ApplyTransformDirection, p);
         mapToContainer(transformState, container);
         result = transformState.lastPlanarPoint();
         ASSERT(m_accumulatedOffsetMightBeSaturated ||  areEssentiallyEqual(rendererMappedResult, result));
@@ -127,7 +126,7 @@ FloatQuad RenderGeometryMap::mapToContainer(const FloatRect& rect, const RenderL
         result = rect;
         result.move(m_accumulatedOffset);
     } else {
-        TransformState transformState(m_useCSS3DTransformInterop, TransformState::ApplyTransformDirection, rect.center(), rect);
+        TransformState transformState(TransformState::ApplyTransformDirection, rect.center(), rect);
         mapToContainer(transformState, container);
         result = transformState.lastPlanarQuad();
     }

--- a/Source/WebCore/rendering/RenderGeometryMap.h
+++ b/Source/WebCore/rendering/RenderGeometryMap.h
@@ -73,7 +73,7 @@ struct RenderGeometryMapStep {
 class RenderGeometryMap {
     WTF_MAKE_NONCOPYABLE(RenderGeometryMap);
 public:
-    explicit RenderGeometryMap(OptionSet<MapCoordinatesMode> = UseTransforms, bool useCSS3DTransformInterop = false);
+    explicit RenderGeometryMap(OptionSet<MapCoordinatesMode> = UseTransforms);
     ~RenderGeometryMap();
 
     OptionSet<MapCoordinatesMode> mapCoordinatesFlags() const { return m_mapCoordinatesFlags; }
@@ -130,7 +130,6 @@ private:
     RenderGeometryMapSteps m_mapping;
     LayoutSize m_accumulatedOffset;
     OptionSet<MapCoordinatesMode> m_mapCoordinatesFlags;
-    bool m_useCSS3DTransformInterop { false };
 #if ASSERT_ENABLED
     bool m_accumulatedOffsetMightBeSaturated { false };
 #endif

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2400,7 +2400,7 @@ bool RenderLayerBacking::updateTransformFlatteningLayer(const RenderLayer* compo
 {
     bool needsFlatteningLayer = false;
     // If our parent layer has preserve-3d or perspective, and it's not our DOM parent, then we need a flattening layer to block that from being applied in 3d.
-    if (useCSS3DTransformInteroperability() && ancestorLayerWillCombineTransform(compositingAncestor) && !ancestorLayerIsDOMParent(m_owningLayer, compositingAncestor))
+    if (ancestorLayerWillCombineTransform(compositingAncestor) && !ancestorLayerIsDOMParent(m_owningLayer, compositingAncestor))
         needsFlatteningLayer = true;
 
     bool layerChanged = false;

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -245,7 +245,6 @@ public:
     bool shouldAggressivelyRetainTiles(const GraphicsLayer*) const override;
     bool shouldTemporarilyRetainTileCohorts(const GraphicsLayer*) const override;
     bool useGiantTiles() const override;
-    bool useCSS3DTransformInteroperability() const override { return true; }
     void logFilledVisibleFreshTile(unsigned) override;
     bool needsPixelAligment() const override { return !m_isMainFrameRenderViewLayer; }
 

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1463,7 +1463,7 @@ void RenderObject::outputRenderSubTreeAndMark(TextStream& stream, const RenderOb
 
 FloatPoint RenderObject::localToAbsolute(const FloatPoint& localPoint, OptionSet<MapCoordinatesMode> mode, bool* wasFixed) const
 {
-    TransformState transformState(true, TransformState::ApplyTransformDirection, localPoint);
+    TransformState transformState(TransformState::ApplyTransformDirection, localPoint);
     mapLocalToContainer(nullptr, transformState, mode | ApplyContainerFlip, wasFixed);
     transformState.flatten();
     
@@ -1472,7 +1472,7 @@ FloatPoint RenderObject::localToAbsolute(const FloatPoint& localPoint, OptionSet
 
 FloatPoint RenderObject::absoluteToLocal(const FloatPoint& containerPoint, OptionSet<MapCoordinatesMode> mode) const
 {
-    TransformState transformState(true, TransformState::UnapplyInverseTransformDirection, containerPoint);
+    TransformState transformState(TransformState::UnapplyInverseTransformDirection, containerPoint);
     mapAbsoluteToLocalPoint(mode, transformState);
     transformState.flatten();
     
@@ -1481,7 +1481,7 @@ FloatPoint RenderObject::absoluteToLocal(const FloatPoint& containerPoint, Optio
 
 FloatQuad RenderObject::absoluteToLocalQuad(const FloatQuad& quad, OptionSet<MapCoordinatesMode> mode) const
 {
-    TransformState transformState(true, TransformState::UnapplyInverseTransformDirection, quad.boundingBox().center(), quad);
+    TransformState transformState(TransformState::UnapplyInverseTransformDirection, quad.boundingBox().center(), quad);
     mapAbsoluteToLocalPoint(mode, transformState);
     transformState.flatten();
     return transformState.lastPlanarQuad();
@@ -1619,7 +1619,7 @@ FloatQuad RenderObject::localToContainerQuad(const FloatQuad& localQuad, const R
 {
     // Track the point at the center of the quad's bounding box. As mapLocalToContainer() calls offsetFromContainer(),
     // it will use that point as the reference point to decide which column's transform to apply in multiple-column blocks.
-    TransformState transformState(true, TransformState::ApplyTransformDirection, localQuad.boundingBox().center(), localQuad);
+    TransformState transformState(TransformState::ApplyTransformDirection, localQuad.boundingBox().center(), localQuad);
     mapLocalToContainer(container, transformState, mode | ApplyContainerFlip, wasFixed);
     transformState.flatten();
     
@@ -1628,7 +1628,7 @@ FloatQuad RenderObject::localToContainerQuad(const FloatQuad& localQuad, const R
 
 FloatPoint RenderObject::localToContainerPoint(const FloatPoint& localPoint, const RenderLayerModelObject* container, OptionSet<MapCoordinatesMode> mode, bool* wasFixed) const
 {
-    TransformState transformState(true, TransformState::ApplyTransformDirection, localPoint);
+    TransformState transformState(TransformState::ApplyTransformDirection, localPoint);
     mapLocalToContainer(container, transformState, mode | ApplyContainerFlip, wasFixed);
     transformState.flatten();
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -549,7 +549,7 @@ void RenderSVGRoot::mapLocalToContainer(const RenderLayerModelObject* repaintCon
     // For getCTM/getScreenCTM computations the result must be independent of the page zoom factor.
     // To compute these matrices within a non-SVG context (e.g. SVG embedded in HTML -- inline SVG)
     // the scaling needs to be removed from the CSS transform state.
-    TransformState transformStateAboveSVGFragment(true, transformState.direction(), transformState.mappedPoint());
+    TransformState transformStateAboveSVGFragment(transformState.direction(), transformState.mappedPoint());
     transformStateAboveSVGFragment.setTransformMatrixTracking(transformState.transformMatrixTracking());
     container->mapLocalToContainer(repaintContainer, transformStateAboveSVGFragment, mode, wasFixed);
 

--- a/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
+++ b/Source/WebCore/rendering/svg/SVGLayerTransformComputation.h
@@ -70,7 +70,7 @@ public:
             ancestorContainer = ancestorsOfType<RenderLayerModelObject>(*stopAtRenderer).first();
         }
 
-        TransformState transformState(true, TransformState::ApplyTransformDirection, FloatPoint { });
+        TransformState transformState(TransformState::ApplyTransformDirection, FloatPoint { });
         transformState.setTransformMatrixTracking(trackingMode);
 
         renderer->mapLocalToContainer(ancestorContainer, transformState, { UseTransforms, ApplyContainerFlip });

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -526,7 +526,7 @@ void GraphicsLayerWC::flushCompositingState(const FloatRect& passedVisibleRect)
     // passedVisibleRect doesn't contain the scrollbar area. Inflate it.
     FloatRect visibleRect = passedVisibleRect;
     visibleRect.inflate(20.f);
-    TransformState state(client().useCSS3DTransformInteroperability(), TransformState::UnapplyInverseTransformDirection, FloatQuad(visibleRect));
+    TransformState state(TransformState::UnapplyInverseTransformDirection, FloatQuad(visibleRect));
     state.setSecondaryQuad(FloatQuad { visibleRect });
     recursiveCommitChanges(state);
 }


### PR DESCRIPTION
#### 787725bce0c09bdc6c67aaa9078850e9f5ee2683
<pre>
CSS3DTransformInteroperabilityEnabled preference removal follow-up
<a href="https://bugs.webkit.org/show_bug.cgi?id=271141">https://bugs.webkit.org/show_bug.cgi?id=271141</a>

Reviewed by Matt Woodrow.

This removes the remaining CSS 3D transform interoperability branches
where it is a little less apparent whether they are always true.

* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
(WebCore::GraphicsLayerClient::useGiantTiles const):
(WebCore::GraphicsLayerClient::useCSS3DTransformInteroperability const): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::flushCompositingState):
(WebCore::GraphicsLayerCA::visibleRectChangeRequiresFlush const):
(WebCore::GraphicsLayerCA::platformCALayerUseCSS3DTransformInteroperability const): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h:
(WebCore::PlatformCALayerClient::platformCALayerUseGiantTiles const):
(WebCore::PlatformCALayerClient::platformCALayerUseCSS3DTransformInteroperability const): Deleted.
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::commonInit):
* Source/WebCore/platform/graphics/transforms/TransformState.cpp:
(WebCore::TransformState::operator=):
(WebCore::TransformState::shouldFlattenBefore):
(WebCore::TransformState::shouldFlattenAfter):
* Source/WebCore/platform/graphics/transforms/TransformState.h:
(WebCore::TransformState::TransformState):
* Source/WebCore/rendering/LayerOverlapMap.cpp:
(WebCore::LayerOverlapMap::LayerOverlapMap):
* Source/WebCore/rendering/RenderGeometryMap.cpp:
(WebCore::RenderGeometryMap::RenderGeometryMap):
(WebCore::RenderGeometryMap::mapToContainer const):
* Source/WebCore/rendering/RenderGeometryMap.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateTransformFlatteningLayer):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::localToAbsolute const):
(WebCore::RenderObject::absoluteToLocal const):
(WebCore::RenderObject::absoluteToLocalQuad const):
(WebCore::RenderObject::localToContainerQuad const):
(WebCore::RenderObject::localToContainerPoint const):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::mapLocalToContainer const):
* Source/WebCore/rendering/svg/SVGLayerTransformComputation.h:
(WebCore::SVGLayerTransformComputation::computeAccumulatedTransform const):
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:
(WebKit::GraphicsLayerWC::flushCompositingState):

Canonical link: <a href="https://commits.webkit.org/276296@main">https://commits.webkit.org/276296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3343e953d4306bbb32266b3a5df34d2103640f4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46842 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40224 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36415 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20358 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17449 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17839 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39179 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2247 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40434 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48458 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15764 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43309 "Found 6 new test failures: animations/animation-css-rule-types.html, animations/change-keyframes.html, animations/keyframe-autoclose-brace.html, animations/keyframes-rule.html, animations/unprefixed-keyframes-rule.html, fast/dom/StyleSheet/gc-rule-children-wrappers.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20538 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42031 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9842 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20762 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->