### PR TITLE
[LBSE] Fix performance of nested masks

### DIFF
--- a/LayoutTests/svg/custom/mask-nested-reference-expected.txt
+++ b/LayoutTests/svg/custom/mask-nested-reference-expected.txt
@@ -1,0 +1,3 @@
+Passes if it does not time out.
+
+

--- a/LayoutTests/svg/custom/mask-nested-reference.html
+++ b/LayoutTests/svg/custom/mask-nested-reference.html
@@ -1,0 +1,64 @@
+<body>
+    <p>Passes if it does not time out.</p>
+    <svg id="svg" width="600px" height="400px">
+        <ellipse cx="300" cy="200" rx="250" ry="150" mask="url(#z)" stroke="black" stroke-width="2" />
+    </svg>
+    <script>
+        function createMask(parent, id, fillURL, colors) {
+            var mask = document.createElementNS("http://www.w3.org/2000/svg", "mask");
+            parent.appendChild(mask);
+
+            mask.setAttribute("id", id);
+            mask.setAttribute("x", "10");
+            mask.setAttribute("y", "10");
+            mask.setAttribute("width", "100");
+            mask.setAttribute("height", "100");
+            mask.setAttribute("maskUnits", "userSpaceOnUse");
+
+            for (i in colors) {
+                var rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+                mask.appendChild(rect);
+
+                rect.setAttribute("x", i);
+                rect.setAttribute("y", i);
+                rect.setAttribute("width", "100");
+                rect.setAttribute("height", "100");
+                rect.setAttribute("mask", fillURL);
+                rect.setAttribute("stroke", colors[i]);
+            }
+        }
+
+        function setupMasks() {
+            var svg = document.getElementById("svg");
+
+            const colors = [
+                "green",
+                "brown",
+                "pink",
+                "grey",
+                "cyan",
+                "green",
+                "brown",
+                "pink",
+                "grey",
+                "cyan"
+            ];
+
+            createMask(svg, "z", "url(#i)", colors);
+            createMask(svg, "i", "url(#h)", colors);
+            createMask(svg, "h", "url(#g)", colors);
+            createMask(svg, "g", "url(#f)", colors);
+            createMask(svg, "f", "url(#e)", colors);
+            createMask(svg, "e", "url(#d)", colors);
+            createMask(svg, "d", "url(#c)", colors);
+            createMask(svg, "c", "url(#b)", colors);
+            createMask(svg, "b", "url(#a)", colors);
+            createMask(svg, "a", "none", colors);
+        }
+
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        setupMasks();
+    </script>
+</body>

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -54,6 +54,8 @@ public:
 
     void resourceChanged(SVGElement&) final;
 
+    const RenderElement& renderer() const final { return m_clientRenderer; }
+
 private:
     RenderElement& m_clientRenderer;
 };

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
@@ -34,6 +34,9 @@ public:
     void idChanged();
     void repaintAllClients() const;
 
+    virtual void addReferencingCSSClient(const RenderElement&) { }
+    virtual void removeReferencingCSSClient(const RenderElement&) { }
+
 protected:
     RenderSVGResourceContainer(Type, SVGElement&, RenderStyle&&);
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
@@ -45,10 +45,18 @@ public:
     inline SVGUnitTypes::SVGUnitType maskUnits() const;
     inline SVGUnitTypes::SVGUnitType maskContentUnits() const;
 
+    void invalidateMask()
+    {
+        m_masker.clear();
+    }
+
+    void removeReferencingCSSClient(const RenderElement&) final;
+
 private:
     void element() const = delete;
 
     ASCIILiteral renderName() const final { return "RenderSVGResourceMasker"_s; }
+    HashMap<SingleThreadWeakRef<const RenderLayerModelObject>, RefPtr<ImageBuffer>> m_masker;
 };
 
 }

--- a/Source/WebCore/svg/SVGCircleElement.cpp
+++ b/Source/WebCore/svg/SVGCircleElement.cpp
@@ -78,6 +78,7 @@ void SVGCircleElement::svgAttributeChanged(const QualifiedName& attrName)
     if (PropertyRegistry::isKnownAttribute(attrName)) {
         InstanceInvalidationGuard guard(*this);
         setPresentationalHintStyleIsDirty();
+        invalidateResourceImageBuffersIfNeeded();
         return;
     }
 

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -40,6 +40,7 @@
 #include "LegacyRenderSVGResourceContainer.h"
 #include "NodeName.h"
 #include "RenderAncestorIterator.h"
+#include "RenderSVGResourceContainer.h"
 #include "ResolvedStyle.h"
 #include "SVGDocumentExtensions.h"
 #include "SVGElementRareData.h"
@@ -286,6 +287,8 @@ Vector<WeakPtr<SVGResourceElementClient>> SVGElement::referencingCSSClients() co
 
 void SVGElement::addReferencingCSSClient(SVGResourceElementClient& client)
 {
+    if (CheckedPtr container = dynamicDowncast<RenderSVGResourceContainer>(this->renderer()))
+        container->addReferencingCSSClient(client.renderer());
     ensureSVGRareData().addReferencingCSSClient(client);
 }
 
@@ -293,6 +296,8 @@ void SVGElement::removeReferencingCSSClient(SVGResourceElementClient& client)
 {
     if (!m_svgRareData)
         return;
+    if (CheckedPtr container = dynamicDowncast<RenderSVGResourceContainer>(this->renderer()))
+        container->removeReferencingCSSClient(client.renderer());
     ensureSVGRareData().removeReferencingCSSClient(client);
 }
 

--- a/Source/WebCore/svg/SVGEllipseElement.cpp
+++ b/Source/WebCore/svg/SVGEllipseElement.cpp
@@ -81,6 +81,7 @@ void SVGEllipseElement::svgAttributeChanged(const QualifiedName& attrName)
     if (PropertyRegistry::isKnownAttribute(attrName)) {
         InstanceInvalidationGuard guard(*this);
         setPresentationalHintStyleIsDirty();
+        invalidateResourceImageBuffersIfNeeded();
         return;
     }
 

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -27,8 +27,10 @@
 #include "RenderAncestorIterator.h"
 #include "RenderElementInlines.h"
 #include "RenderLayer.h"
+#include "RenderLayerInlines.h"
 #include "RenderSVGHiddenContainer.h"
 #include "RenderSVGPath.h"
+#include "RenderSVGResourceMasker.h"
 #include "SVGMatrix.h"
 #include "SVGNames.h"
 #include "SVGPathData.h"
@@ -211,6 +213,18 @@ Path SVGGraphicsElement::toClipPath()
     // FIXME: How do we know the element has done a layout?
     path.transform(animatedLocalTransform());
     return path;
+}
+
+void SVGGraphicsElement::invalidateResourceImageBuffersIfNeeded()
+{
+    if (!document().settings().layerBasedSVGEngineEnabled())
+        return;
+    if (CheckedPtr svgRenderer = dynamicDowncast<RenderLayerModelObject>(renderer())) {
+        if (auto* container = svgRenderer->enclosingLayer()->enclosingSVGHiddenOrResourceContainer()) {
+            if (auto* patternRenderer = dynamicDowncast<RenderSVGResourceMasker>(container))
+                patternRenderer->invalidateMask();
+        }
+    }
 }
 
 }

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -78,6 +78,8 @@ protected:
     void svgAttributeChanged(const QualifiedName&) override;
     void didAttachRenderers() override;
 
+    void invalidateResourceImageBuffersIfNeeded();
+
 private:
     bool isSVGGraphicsElement() const override { return true; }
 

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -140,11 +140,13 @@ void SVGImageElement::svgAttributeChanged(const QualifiedName& attrName)
             ASSERT(attrName == SVGNames::preserveAspectRatioAttr);
             updateSVGRendererForElementChange();
         }
+        invalidateResourceImageBuffersIfNeeded();
         return;
     }
 
     if (SVGURIReference::isKnownAttribute(attrName)) {
         m_imageLoader.updateFromElementIgnoringPreviousError();
+        invalidateResourceImageBuffersIfNeeded();
         return;
     }
 

--- a/Source/WebCore/svg/SVGLineElement.cpp
+++ b/Source/WebCore/svg/SVGLineElement.cpp
@@ -90,6 +90,7 @@ void SVGLineElement::svgAttributeChanged(const QualifiedName& attrName)
             shape->setNeedsShapeUpdate();
 
         updateSVGRendererForElementChange();
+        invalidateResourceImageBuffersIfNeeded();
         return;
     }
 

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -115,9 +115,11 @@ void SVGMaskElement::svgAttributeChanged(const QualifiedName& attrName)
 
     if (PropertyRegistry::isKnownAttribute(attrName)) {
         if (document().settings().layerBasedSVGEngineEnabled()) {
-            if (CheckedPtr renderer = this->renderer())
-                renderer->repaintClientsOfReferencedSVGResources();
-            return;
+            if (CheckedPtr maskRenderer = dynamicDowncast<RenderSVGResourceMasker>(renderer())) {
+                maskRenderer->invalidateMask();
+                maskRenderer->repaintClientsOfReferencedSVGResources();
+                return;
+            }
         }
 
         updateSVGRendererForElementChange();
@@ -135,9 +137,10 @@ void SVGMaskElement::childrenChanged(const ChildChange& change)
         return;
 
     if (document().settings().layerBasedSVGEngineEnabled()) {
-        if (CheckedPtr renderer = this->renderer())
-            renderer->repaintClientsOfReferencedSVGResources();
-        return;
+        if (CheckedPtr maskRenderer = dynamicDowncast<RenderSVGResourceMasker>(renderer())) {
+            maskRenderer->invalidateMask();
+            maskRenderer->repaintClientsOfReferencedSVGResources();
+        }
     }
 
     updateSVGRendererForElementChange();

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -143,6 +143,7 @@ void SVGPathElement::svgAttributeChanged(const QualifiedName& attrName)
             path->setNeedsShapeUpdate();
 
         updateSVGRendererForElementChange();
+        invalidateResourceImageBuffersIfNeeded();
         return;
     }
 

--- a/Source/WebCore/svg/SVGPolyElement.cpp
+++ b/Source/WebCore/svg/SVGPolyElement.cpp
@@ -66,6 +66,7 @@ void SVGPolyElement::svgAttributeChanged(const QualifiedName& attrName)
             path->setNeedsShapeUpdate();
 
         updateSVGRendererForElementChange();
+        invalidateResourceImageBuffersIfNeeded();
         return;
     }
 

--- a/Source/WebCore/svg/SVGRectElement.cpp
+++ b/Source/WebCore/svg/SVGRectElement.cpp
@@ -90,6 +90,7 @@ void SVGRectElement::svgAttributeChanged(const QualifiedName& attrName)
     if (PropertyRegistry::isKnownAttribute(attrName)) {
         InstanceInvalidationGuard guard(*this);
         setPresentationalHintStyleIsDirty();
+        invalidateResourceImageBuffersIfNeeded();
         return;
     }
 

--- a/Source/WebCore/svg/SVGResourceElementClient.h
+++ b/Source/WebCore/svg/SVGResourceElementClient.h
@@ -37,6 +37,7 @@ public:
 
     virtual void resourceChanged(SVGElement&) = 0;
 
+    virtual const RenderElement& renderer() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -187,6 +187,7 @@ void SVGTextContentElement::svgAttributeChanged(const QualifiedName& attrName)
 
         InstanceInvalidationGuard guard(*this);
         updateSVGRendererForElementChange();
+        invalidateResourceImageBuffersIfNeeded();
         return;
     }
 

--- a/Source/WebCore/svg/SVGTextElement.cpp
+++ b/Source/WebCore/svg/SVGTextElement.cpp
@@ -62,4 +62,14 @@ bool SVGTextElement::childShouldCreateRenderer(const Node& child) const
     return false;
 }
 
+void SVGTextElement::childrenChanged(const ChildChange& change)
+{
+    SVGTextPositioningElement::childrenChanged(change);
+
+    if (change.source == ChildChange::Source::Parser)
+        return;
+
+    invalidateResourceImageBuffersIfNeeded();
+}
+
 }

--- a/Source/WebCore/svg/SVGTextElement.h
+++ b/Source/WebCore/svg/SVGTextElement.h
@@ -34,6 +34,8 @@ private:
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     bool childShouldCreateRenderer(const Node&) const override;
+
+    void childrenChanged(const ChildChange&) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGTextPositioningElement.cpp
+++ b/Source/WebCore/svg/SVGTextPositioningElement.cpp
@@ -104,6 +104,7 @@ void SVGTextPositioningElement::svgAttributeChanged(const QualifiedName& attrNam
                 textAncestor->setNeedsPositioningValuesUpdate();
         }
         updateSVGRendererForElementChange();
+        invalidateResourceImageBuffersIfNeeded();
         return;
     }
 

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -182,12 +182,14 @@ void SVGUseElement::svgAttributeChanged(const QualifiedName& attrName)
                 transferSizeAttributesToTargetClone(*targetClone);
         }
         updateSVGRendererForElementChange();
+        invalidateResourceImageBuffersIfNeeded();
         return;
     }
 
     if (SVGURIReference::isKnownAttribute(attrName)) {
         updateExternalDocument();
         invalidateShadowTree();
+        invalidateResourceImageBuffersIfNeeded();
         return;
     }
 


### PR DESCRIPTION
#### 466a4e163671edd79710f625f32e3ee740b3a522
<pre>
[LBSE] Fix performance of nested masks
<a href="https://bugs.webkit.org/show_bug.cgi?id=271146">https://bugs.webkit.org/show_bug.cgi?id=271146</a>

Reviewed by Nikolas Zimmermann.

Masks with a high amount of nesting can take a lot of resources, both in computation and memory.
One example of this is mask-nested-reference.html (based on pattern-nested-reference.html).

To fix this, implement two optimizations:
- cache masks as image bitmaps (like legacy did)
- restrict the nesting level when calculating the mask bounding box
- take care of correctly invalidating in case mask contents change or a referencing client is added or removed

* LayoutTests/svg/custom/mask-nested-reference-expected.txt: Added.
* LayoutTests/svg/custom/mask-nested-reference.html: Added.
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.h:
(WebCore::RenderSVGResourceContainer::addReferencingCSSClient):
(WebCore::RenderSVGResourceContainer::removeReferencingCSSClient):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::applyMask):
(WebCore::RenderSVGResourceMasker::removeReferencingCSSClient):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.h:
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::adjustBoxForClippingAndEffects const):
* Source/WebCore/svg/SVGCircleElement.cpp:
(WebCore::SVGCircleElement::svgAttributeChanged):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::addReferencingCSSClient):
(WebCore::SVGElement::removeReferencingCSSClient):
* Source/WebCore/svg/SVGEllipseElement.cpp:
(WebCore::SVGEllipseElement::svgAttributeChanged):
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::invalidateResourceImageBuffersIfNeeded):
* Source/WebCore/svg/SVGGraphicsElement.h:
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::svgAttributeChanged):
* Source/WebCore/svg/SVGLineElement.cpp:
(WebCore::SVGLineElement::svgAttributeChanged):
* Source/WebCore/svg/SVGMaskElement.cpp:
(WebCore::SVGMaskElement::svgAttributeChanged):
(WebCore::SVGMaskElement::childrenChanged):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::svgAttributeChanged):
* Source/WebCore/svg/SVGPolyElement.cpp:
(WebCore::SVGPolyElement::svgAttributeChanged):
* Source/WebCore/svg/SVGRectElement.cpp:
(WebCore::SVGRectElement::svgAttributeChanged):
* Source/WebCore/svg/SVGResourceElementClient.h:
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::svgAttributeChanged):
* Source/WebCore/svg/SVGTextElement.cpp:
(WebCore::SVGTextElement::childrenChanged):
* Source/WebCore/svg/SVGTextElement.h:
* Source/WebCore/svg/SVGTextPositioningElement.cpp:
(WebCore::SVGTextPositioningElement::svgAttributeChanged):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::svgAttributeChanged):

Canonical link: <a href="https://commits.webkit.org/277292@main">https://commits.webkit.org/277292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a35b81f162dd73d221480dfed3ae80bd0cadf1d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49794 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43160 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38376 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19683 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41751 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5155 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43495 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51670 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18511 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45671 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44676 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10415 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23129 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->