### PR TITLE
Remove ImperativeSlotAPIEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3150,20 +3150,6 @@ ImageControlsEnabled:
     WebCore:
       default: false
 
-ImperativeSlotAPIEnabled:
-  type: bool
-  status: stable
-  category: dom
-  humanReadableName: "Imperative Slot API"
-  humanReadableDescription: "Imperative Shadow DOM Distribution API"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 InWindowFullscreenEnabled:
   type: bool
   status: internal

--- a/Source/WebCore/dom/ShadowRoot.idl
+++ b/Source/WebCore/dom/ShadowRoot.idl
@@ -32,7 +32,7 @@
 ] interface ShadowRoot : DocumentFragment {
     readonly attribute ShadowRootMode mode;
     readonly attribute boolean delegatesFocus;
-    [ImplementedAs=slotAssignmentMode, EnabledBySetting=ImperativeSlotAPIEnabled] readonly attribute SlotAssignmentMode slotAssignment;
+    [ImplementedAs=slotAssignmentMode] readonly attribute SlotAssignmentMode slotAssignment;
     [ImplementedAs=isClonable, EnabledBySetting=DeclarativeShadowRootsEnabled] readonly attribute boolean clonable;
     readonly attribute Element host;
     attribute EventHandler onslotchange;

--- a/Source/WebCore/dom/ShadowRootInit.idl
+++ b/Source/WebCore/dom/ShadowRootInit.idl
@@ -29,5 +29,5 @@ dictionary ShadowRootInit {
     required ShadowRootMode mode;
     boolean delegatesFocus = false;
     [EnabledBySetting=DeclarativeShadowRootsEnabled] boolean clonable = false;
-    [EnabledBySetting=ImperativeSlotAPIEnabled] SlotAssignmentMode slotAssignment = "named";
+    SlotAssignmentMode slotAssignment = "named";
 };

--- a/Source/WebCore/html/HTMLSlotElement.idl
+++ b/Source/WebCore/html/HTMLSlotElement.idl
@@ -30,7 +30,7 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
     sequence<Node> assignedNodes(optional AssignedNodesOptions options);
     sequence<Element> assignedElements(optional AssignedNodesOptions options);
-    [EnabledBySetting=ImperativeSlotAPIEnabled] undefined assign((Element or Text)... nodes);
+    undefined assign((Element or Text)... nodes);
 };
 
 dictionary AssignedNodesOptions {


### PR DESCRIPTION
#### 34d57dde0c8f223d0698f9e280f4b76736221775
<pre>
Remove ImperativeSlotAPIEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=271148">https://bugs.webkit.org/show_bug.cgi?id=271148</a>

Reviewed by Ryosuke Niwa.

It&apos;s been stable for over a year.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/ShadowRoot.idl:
* Source/WebCore/dom/ShadowRootInit.idl:
* Source/WebCore/html/HTMLSlotElement.idl:

Canonical link: <a href="https://commits.webkit.org/276284@main">https://commits.webkit.org/276284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e41665ed52d902463c836f73ae1dc1171bf76b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23273 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46849 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40231 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46510 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36426 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38081 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17460 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39186 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2254 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37528 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40394 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48450 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43762 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19184 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43308 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20545 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42033 "Found 2 new API test failures: /TestWTF:WTF_ParkingLot.UnparkOneOneFast, /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9836 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20769 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50844 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20171 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10291 "Passed tests") | 
<!--EWS-Status-Bubble-End-->