### PR TITLE
Remove LazyIframeLoadingEnabled & LazyImageLoadingEnabled preferences

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3790,34 +3790,6 @@ LayoutViewportHeightExpansionFactor:
     WebCore:
       default: 0
 
-LazyIframeLoadingEnabled:
-  type: bool
-  status: stable
-  category: html
-  humanReadableName: "Lazy iframe loading"
-  humanReadableDescription: "Enable lazy iframe loading support"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
-LazyImageLoadingEnabled:
-  type: bool
-  status: stable
-  category: html
-  humanReadableName: "Lazy image loading"
-  humanReadableDescription: "Enable lazy image loading support"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: true
-    WebCore:
-      default: false
-
 LegacyEncryptedMediaAPIEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -180,12 +180,12 @@ const PermissionsPolicy& HTMLIFrameElement::permissionsPolicy() const
     return *m_permissionsPolicy;
 }
 
-const AtomString& HTMLIFrameElement::loadingForBindings() const
+const AtomString& HTMLIFrameElement::loading() const
 {
     return equalLettersIgnoringASCIICase(attributeWithoutSynchronization(HTMLNames::loadingAttr), "lazy"_s) ? lazyAtom() : eagerAtom();
 }
 
-void HTMLIFrameElement::setLoadingForBindings(const AtomString& value)
+void HTMLIFrameElement::setLoading(const AtomString& value)
 {
     setAttributeWithoutSynchronization(loadingAttr, value);
 }
@@ -203,7 +203,7 @@ static bool isFrameLazyLoadable(const Document& document, const URL& url, const 
 
 bool HTMLIFrameElement::shouldLoadFrameLazily()
 {
-    if (!m_lazyLoadFrameObserver && document().settings().lazyIframeLoadingEnabled() && !document().quirks().shouldDisableLazyIframeLoadingQuirk()) {
+    if (!m_lazyLoadFrameObserver && !document().quirks().shouldDisableLazyIframeLoadingQuirk()) {
         URL completeURL = document().completeURL(frameURL());
         if (isFrameLazyLoadable(document(), completeURL, attributeWithoutSynchronization(HTMLNames::loadingAttr))) {
             auto currentReferrerPolicy = referrerPolicy();

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -45,8 +45,8 @@ public:
 
     const PermissionsPolicy& permissionsPolicy() const;
 
-    const AtomString& loadingForBindings() const;
-    void setLoadingForBindings(const AtomString&);
+    const AtomString& loading() const;
+    void setLoading(const AtomString&);
 
     LazyLoadFrameObserver& lazyLoadFrameObserver();
 

--- a/Source/WebCore/html/HTMLIFrameElement.idl
+++ b/Source/WebCore/html/HTMLIFrameElement.idl
@@ -33,7 +33,7 @@
     [Reflect, CEReactions=NotNeeded] attribute DOMString width;
     [Reflect, CEReactions=NotNeeded] attribute DOMString height;
     [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;
-    [CEReactions=NotNeeded, EnabledBySetting=LazyIframeLoadingEnabled, ImplementedAs=loadingForBindings] attribute [AtomString] DOMString loading;
+    [CEReactions=NotNeeded] attribute [AtomString] DOMString loading;
     [CheckSecurityForNode] readonly attribute Document? contentDocument;
     readonly attribute WindowProxy? contentWindow;
     [CheckSecurityForNode] Document? getSVGDocument();

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -1006,13 +1006,13 @@ void HTMLImageElement::setSrcsetForBindings(const AtomString& value)
     setAttributeWithoutSynchronization(srcsetAttr, value);
 }
 
-const AtomString& HTMLImageElement::loadingForBindings() const
+const AtomString& HTMLImageElement::loading() const
 {
     auto& attributeValue = attributeWithoutSynchronization(HTMLNames::loadingAttr);
     return hasLazyLoadableAttributeValue(attributeValue) ? lazyAtom() : eagerAtom();
 }
 
-void HTMLImageElement::setLoadingForBindings(const AtomString& value)
+void HTMLImageElement::setLoading(const AtomString& value)
 {
     setAttributeWithoutSynchronization(loadingAttr, value);
 }

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -153,8 +153,8 @@ public:
 
     bool usesSrcsetOrPicture() const;
 
-    const AtomString& loadingForBindings() const;
-    void setLoadingForBindings(const AtomString&);
+    const AtomString& loading() const;
+    void setLoading(const AtomString&);
 
     bool isLazyLoadable() const;
     static bool hasLazyLoadableAttributeValue(StringView);

--- a/Source/WebCore/html/HTMLImageElement.idl
+++ b/Source/WebCore/html/HTMLImageElement.idl
@@ -42,7 +42,7 @@
     readonly attribute USVString currentSrc;
     [CEReactions=NotNeeded, ImplementedAs=referrerPolicyForBindings] attribute [AtomString] DOMString referrerPolicy;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString decoding;
-    [CEReactions=NotNeeded, EnabledBySetting=LazyImageLoadingEnabled, ImplementedAs=loadingForBindings] attribute [AtomString] DOMString loading;
+    [CEReactions=NotNeeded] attribute [AtomString] DOMString loading;
 
     Promise<undefined> decode();
 

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -227,11 +227,9 @@ private:
                 m_referrerPolicy = parseReferrerPolicy(attributeValue, ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString);
                 break;
             }
-            if (document->settings().lazyImageLoadingEnabled()) {
-                if (match(attributeName, loadingAttr) && m_lazyloadAttribute.isNull()) {
-                    m_lazyloadAttribute = attributeValue.toString();
-                    break;
-                }
+            if (match(attributeName, loadingAttr) && m_lazyloadAttribute.isNull()) {
+                m_lazyloadAttribute = attributeValue.toString();
+                break;
             }
             processImageAndScriptAttribute(attributeName, attributeValue);
             break;

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -246,7 +246,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
             auto oldState = m_lazyImageLoadState;
 #endif
             if (m_lazyImageLoadState == LazyImageLoadState::None && imageElement) {
-                if (imageElement->isLazyLoadable() && document->settings().lazyImageLoadingEnabled() && !canReuseFromListOfAvailableImages(request, document)) {
+                if (imageElement->isLazyLoadable() && !canReuseFromListOfAvailableImages(request, document)) {
                     m_lazyImageLoadState = LazyImageLoadState::Deferred;
                     request.setIgnoreForRequestCount(true);
                 }

--- a/Tools/DumpRenderTree/TestOptions.cpp
+++ b/Tools/DumpRenderTree/TestOptions.cpp
@@ -123,8 +123,6 @@ const TestFeatures& TestOptions::defaults()
             { "DigitalCredentialsEnabled", false },
             { "GenericCueAPIEnabled", false },
             { "IsLoggedInAPIEnabled", false },
-            { "LazyIframeLoadingEnabled", false },
-            { "LazyImageLoadingEnabled", false },
             { "RequestIdleCallbackEnabled", false },
             { "WebAuthenticationEnabled", false },
 #elif PLATFORM(WIN)


### PR DESCRIPTION
#### 452e9eda0f16ebd79b9381be326e8ca5e7baeeb0
<pre>
Remove LazyIframeLoadingEnabled &amp; LazyImageLoadingEnabled preferences
<a href="https://bugs.webkit.org/show_bug.cgi?id=271150">https://bugs.webkit.org/show_bug.cgi?id=271150</a>

Reviewed by NOBODY (OOPS!).

They have been stable for over a year. As there are no notable code
differences, this also enables LazyImageLoadingEnabled on WebKitLegacy.
LazyIframeLoadingEnabled was already enabled there (except not in
DumpRenderTree for some reason).

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::loading const):
(WebCore::HTMLIFrameElement::setLoading):
(WebCore::HTMLIFrameElement::shouldLoadFrameLazily):
(WebCore::HTMLIFrameElement::loadingForBindings const): Deleted.
(WebCore::HTMLIFrameElement::setLoadingForBindings): Deleted.
* Source/WebCore/html/HTMLIFrameElement.h:
* Source/WebCore/html/HTMLIFrameElement.idl:
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::loading const):
(WebCore::HTMLImageElement::setLoading):
(WebCore::HTMLImageElement::loadingForBindings const): Deleted.
(WebCore::HTMLImageElement::setLoadingForBindings): Deleted.
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLImageElement.idl:
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):
* Tools/DumpRenderTree/TestOptions.cpp:
(WTR::TestOptions::defaults):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/452e9eda0f16ebd79b9381be326e8ca5e7baeeb0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40235 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20671 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36427 "Found 5 new test failures: http/tests/lazyload/attribute.html, http/tests/lazyload/js-image.html, http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled.html, http/tests/lazyload/lazy-image-load-in-iframes-scripting-enabled.html, http/tests/lazyload/lazy.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44786 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20348 "Found 5 new test failures: http/tests/lazyload/attribute.html, http/tests/lazyload/js-image.html, http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled.html, http/tests/lazyload/lazy-image-load-in-iframes-scripting-enabled.html, http/tests/lazyload/lazy.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17461 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17829 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39189 "Found 3 new test failures: imported/w3c/web-platform-tests/html/dom/idlharness.https.html?include=HTML.*, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html, imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2258 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37532 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40423 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39476 "Found 5 new test failures: http/tests/lazyload/attribute.html, http/tests/lazyload/js-image.html, http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled.html, http/tests/lazyload/lazy-image-load-in-iframes-scripting-enabled.html, http/tests/lazyload/lazy.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48456 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43766 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19188 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15762 "Found 5 new test failures: http/tests/lazyload/attribute.html, http/tests/lazyload/js-image.html, http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled.html, http/tests/lazyload/lazy-image-load-in-iframes-scripting-enabled.html, http/tests/lazyload/lazy.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43305 "Found 4 new test failures: http/tests/lazyload/attribute.html, http/tests/lazyload/lazy-image-load-in-iframes-scripting-disabled.html, http/tests/lazyload/lazy-image-load-in-iframes-scripting-enabled.html, http/tests/lazyload/lazy.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20549 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42029 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20773 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50848 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20175 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10293 "Passed tests") | 
<!--EWS-Status-Bubble-End-->