### PR TITLE
Remove HasPseudoClassEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2981,20 +2981,6 @@ HTTPEquivEnabled:
     WebCore:
       default: true
 
-HasPseudoClassEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: ":has() pseudo-class"
-  humanReadableDescription: "Enable :has() pseudo-class"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 HiddenPageCSSAnimationSuspensionEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/contentextensions/ContentExtensionParser.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionParser.cpp
@@ -211,7 +211,6 @@ bool isValidCSSSelector(const String& selector)
     // we want to use quirks mode in parsing, but automatic mode when actually applying the content blocker styles.
     // FIXME: rdar://105733691 (Parse/apply content blocker style sheets in both standards and quirks mode lazily).
     WebCore::CSSParserContext context(HTMLQuirksMode);
-    context.hasPseudoClassEnabled = true;
     CSSParser parser(context);
     return !!parser.parseSelectorList(selector);
 }
@@ -219,7 +218,6 @@ bool isValidCSSSelector(const String& selector)
 WebCore::CSSParserContext contentExtensionCSSParserContext()
 {
     WebCore::CSSParserContext context(HTMLStandardMode);
-    context.hasPseudoClassEnabled = true;
     return context;
 }
 

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -130,8 +130,7 @@
             "conditional": "ENABLE(VIDEO)"
         },
         "has": {
-            "argument": "required",
-            "settings-flag": "hasPseudoClassEnabled"
+            "argument": "required"
         },
         "horizontal": {
             "comment": "For scrollbar styling.",

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -94,7 +94,6 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
 #endif
     , useLegacyBackgroundSizeShorthandBehavior { document.settings().useLegacyBackgroundSizeShorthandBehavior() }
     , focusVisibleEnabled { document.settings().focusVisibleEnabled() }
-    , hasPseudoClassEnabled { document.settings().hasPseudoClassEnabled() }
     , cascadeLayersEnabled { document.settings().cssCascadeLayersEnabled() }
     , gradientPremultipliedAlphaInterpolationEnabled { document.settings().cssGradientPremultipliedAlphaInterpolationEnabled() }
     , gradientInterpolationColorSpacesEnabled { document.settings().cssGradientInterpolationColorSpacesEnabled() }
@@ -139,28 +138,27 @@ void add(Hasher& hasher, const CSSParserContext& context)
 #endif
         | context.useLegacyBackgroundSizeShorthandBehavior  << 10
         | context.focusVisibleEnabled                       << 11
-        | context.hasPseudoClassEnabled                     << 12
-        | context.cascadeLayersEnabled                      << 13
-        | context.gradientPremultipliedAlphaInterpolationEnabled << 14
-        | context.gradientInterpolationColorSpacesEnabled   << 15
-        | context.masonryEnabled                            << 16
-        | context.cssNestingEnabled                         << 17
-        | context.cssPaintingAPIEnabled                     << 18
-        | context.cssScopeAtRuleEnabled                     << 19
-        | context.cssTextUnderlinePositionLeftRightEnabled  << 20
-        | context.cssWordBreakAutoPhraseEnabled             << 21
-        | context.popoverAttributeEnabled                   << 22
-        | context.sidewaysWritingModesEnabled               << 23
-        | context.cssTextWrapPrettyEnabled                  << 24
-        | context.highlightAPIEnabled                       << 25
-        | context.grammarAndSpellingPseudoElementsEnabled   << 26
-        | context.customStateSetEnabled                     << 27
-        | context.thumbAndTrackPseudoElementsEnabled        << 28
+        | context.cascadeLayersEnabled                      << 12
+        | context.gradientPremultipliedAlphaInterpolationEnabled << 13
+        | context.gradientInterpolationColorSpacesEnabled   << 14
+        | context.masonryEnabled                            << 15
+        | context.cssNestingEnabled                         << 16
+        | context.cssPaintingAPIEnabled                     << 17
+        | context.cssScopeAtRuleEnabled                     << 18
+        | context.cssTextUnderlinePositionLeftRightEnabled  << 19
+        | context.cssWordBreakAutoPhraseEnabled             << 20
+        | context.popoverAttributeEnabled                   << 21
+        | context.sidewaysWritingModesEnabled               << 22
+        | context.cssTextWrapPrettyEnabled                  << 23
+        | context.highlightAPIEnabled                       << 24
+        | context.grammarAndSpellingPseudoElementsEnabled   << 25
+        | context.customStateSetEnabled                     << 26
+        | context.thumbAndTrackPseudoElementsEnabled        << 27
 #if ENABLE(SERVICE_CONTROLS)
-        | context.imageControlsEnabled                      << 29
+        | context.imageControlsEnabled                      << 28
 #endif
-        | context.lightDarkEnabled                          << 30
-        | (uint64_t)context.mode                            << 31; // This is multiple bits, so keep it last.
+        | context.lightDarkEnabled                          << 29
+        | (uint64_t)context.mode                            << 30; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -85,7 +85,6 @@ struct CSSParserContext {
 #endif
     bool useLegacyBackgroundSizeShorthandBehavior : 1 { false };
     bool focusVisibleEnabled : 1 { false };
-    bool hasPseudoClassEnabled : 1 { false };
     bool cascadeLayersEnabled : 1 { false };
     bool gradientPremultipliedAlphaInterpolationEnabled : 1 { false };
     bool gradientInterpolationColorSpacesEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.cpp
@@ -38,7 +38,6 @@ CSSSelectorParserContext::CSSSelectorParserContext(const CSSParserContext& conte
     , customStateSetEnabled(context.customStateSetEnabled)
     , focusVisibleEnabled(context.focusVisibleEnabled)
     , grammarAndSpellingPseudoElementsEnabled(context.grammarAndSpellingPseudoElementsEnabled)
-    , hasPseudoClassEnabled(context.hasPseudoClassEnabled)
     , highlightAPIEnabled(context.highlightAPIEnabled)
 #if ENABLE(SERVICE_CONTROLS)
     , imageControlsEnabled(context.imageControlsEnabled)
@@ -55,7 +54,6 @@ CSSSelectorParserContext::CSSSelectorParserContext(const Document& document)
     , customStateSetEnabled(document.settings().customStateSetEnabled())
     , focusVisibleEnabled(document.settings().focusVisibleEnabled())
     , grammarAndSpellingPseudoElementsEnabled(document.settings().grammarAndSpellingPseudoElementsEnabled())
-    , hasPseudoClassEnabled(document.settings().hasPseudoClassEnabled())
     , highlightAPIEnabled(document.settings().highlightAPIEnabled())
 #if ENABLE(SERVICE_CONTROLS)
     , imageControlsEnabled(document.settings().imageControlsEnabled())
@@ -74,7 +72,6 @@ void add(Hasher& hasher, const CSSSelectorParserContext& context)
         context.customStateSetEnabled,
         context.focusVisibleEnabled,
         context.grammarAndSpellingPseudoElementsEnabled,
-        context.hasPseudoClassEnabled,
         context.highlightAPIEnabled,
 #if ENABLE(SERVICE_CONTROLS)
         context.imageControlsEnabled,

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -40,7 +40,6 @@ struct CSSSelectorParserContext {
     bool customStateSetEnabled { false };
     bool focusVisibleEnabled { false };
     bool grammarAndSpellingPseudoElementsEnabled { false };
-    bool hasPseudoClassEnabled { false };
     bool highlightAPIEnabled { false };
 #if ENABLE(SERVICE_CONTROLS)
     bool imageControlsEnabled { false };


### PR DESCRIPTION
#### e13808ae29cfebdb2bc36b9721a7b718dce6c0f6
<pre>
Remove HasPseudoClassEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=271151">https://bugs.webkit.org/show_bug.cgi?id=271151</a>

Reviewed by Antti Koivisto.

It&apos;s been stable for over a year.

Potentially some more code could be cleaned up in
ContentExtensionParser given how this was added in 259068@main, but
changes have been made there meanwhile and this might well be needed
for other CSS-related preferences in the future.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/contentextensions/ContentExtensionParser.cpp:
(WebCore::ContentExtensions::isValidCSSSelector):
(WebCore::ContentExtensions::contentExtensionCSSParserContext):
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSSelectorParserContext.cpp:
(WebCore::CSSSelectorParserContext::CSSSelectorParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSSelectorParserContext.h:

Canonical link: <a href="https://commits.webkit.org/276272@main">https://commits.webkit.org/276272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe2a3b1d0b3045b9c291815ec58055164f16df5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23279 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46857 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40237 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46516 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20673 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36429 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39193 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2260 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/37534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48466 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43768 "Found 1 new JSC stress test failure: stress/wasm-error-message-get-local.js.ftl-eager-no-cjit (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15763 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20551 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9826 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20775 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50850 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20177 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10294 "Passed tests") | 
<!--EWS-Status-Bubble-End-->