### PR TITLE
Remove ConstructableStylesheetsEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1680,20 +1680,6 @@ ConstantPropertiesEnabled:
     WebCore:
       default: false
 
-ConstructableStylesheetsEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "Constructable Stylesheets"
-  humanReadableDescription: "Enable Constructable Stylesheets"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 ContactPickerAPIEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/css/CSSStyleSheet.idl
+++ b/Source/WebCore/css/CSSStyleSheet.idl
@@ -22,7 +22,7 @@
     Exposed=Window,
     JSGenerateToNativeObject
 ] interface CSSStyleSheet : StyleSheet {
-    [EnabledBySetting=ConstructableStylesheetsEnabled, CallWith=CurrentDocument] constructor(optional CSSStyleSheetInit options = {});
+    [CallWith=CurrentDocument] constructor(optional CSSStyleSheetInit options = {});
 
     readonly attribute CSSRule ownerRule;
     [ImplementedAs=cssRulesForBindings] readonly attribute CSSRuleList cssRules;
@@ -33,8 +33,8 @@
     long addRule(optional DOMString selector = "undefined", optional DOMString style = "undefined", optional unsigned long index);
     undefined removeRule(optional unsigned long index = 0);
 
-    [EnabledBySetting=ConstructableStylesheetsEnabled] Promise<CSSStyleSheet> replace(USVString text);
-    [EnabledBySetting=ConstructableStylesheetsEnabled] undefined replaceSync(USVString text);
+    Promise<CSSStyleSheet> replace(USVString text);
+    undefined replaceSync(USVString text);
 };
 
 dictionary CSSStyleSheetInit {

--- a/Source/WebCore/css/DocumentOrShadowRoot+CSSOM.idl
+++ b/Source/WebCore/css/DocumentOrShadowRoot+CSSOM.idl
@@ -29,6 +29,6 @@ partial interface mixin DocumentOrShadowRoot {
 
     // FIXME: This should use an ObservableArray<CSSStyleSheet> but we don't support this yet.
     // https://bugs.webkit.org/show_bug.cgi?id=238281
-    [EnabledBySetting=ConstructableStylesheetsEnabled, CallWith=CurrentGlobalObject, ImplementedAs=adoptedStyleSheetWrapper, CachedAttribute, CustomSetter] attribute any adoptedStyleSheets;
+    [CallWith=CurrentGlobalObject, ImplementedAs=adoptedStyleSheetWrapper, CachedAttribute, CustomSetter] attribute any adoptedStyleSheets;
 };
 


### PR DESCRIPTION
#### e5f8e964dc554b7bcdb89a1d417fbedf0f6e5002
<pre>
Remove ConstructableStylesheetsEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=271152">https://bugs.webkit.org/show_bug.cgi?id=271152</a>

Reviewed by Ryosuke Niwa.

It&apos;s been stable for over a year.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSStyleSheet.idl:
* Source/WebCore/css/DocumentOrShadowRoot+CSSOM.idl:

Canonical link: <a href="https://commits.webkit.org/276285@main">https://commits.webkit.org/276285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5d810ff3bae50d7734367793dc71f979e29f7fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46891 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20708 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17492 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17844 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39222 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2292 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/37567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40439 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48499 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/43801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15796 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42077 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9837 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50882 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20209 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10305 "Passed tests") | 
<!--EWS-Status-Bubble-End-->