### PR TITLE
Remove FormAssociatedCustomElementsEnabled preference

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2726,20 +2726,6 @@ ForceWebGLUsesLowPower:
     WebCore:
       default: false
 
-FormAssociatedCustomElementsEnabled:
-  type: bool
-  status: stable
-  category: dom
-  humanReadableName: "Form-associated custom elements"
-  humanReadableDescription: "Support for form-associated custom elements"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 FullScreenEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp
@@ -168,32 +168,30 @@ JSValue JSCustomElementRegistry::define(JSGlobalObject& lexicalGlobalObject, Cal
             elementInterface->disableShadow();
     }
 
-    if (registry.document() && registry.document()->settings().formAssociatedCustomElementsEnabled()) {
-        auto formAssociatedValue = constructor->get(&lexicalGlobalObject, Identifier::fromString(vm, "formAssociated"_s));
+    auto formAssociatedValue = constructor->get(&lexicalGlobalObject, Identifier::fromString(vm, "formAssociated"_s));
+    RETURN_IF_EXCEPTION(scope, { });
+    if (formAssociatedValue.toBoolean(&lexicalGlobalObject)) {
+        elementInterface->setIsFormAssociated();
+
+        auto* formAssociatedCallback = getCustomElementCallback(lexicalGlobalObject, prototypeObject, Identifier::fromString(vm, "formAssociatedCallback"_s));
         RETURN_IF_EXCEPTION(scope, { });
-        if (formAssociatedValue.toBoolean(&lexicalGlobalObject)) {
-            elementInterface->setIsFormAssociated();
+        if (formAssociatedCallback)
+            elementInterface->setFormAssociatedCallback(formAssociatedCallback);
 
-            auto* formAssociatedCallback = getCustomElementCallback(lexicalGlobalObject, prototypeObject, Identifier::fromString(vm, "formAssociatedCallback"_s));
-            RETURN_IF_EXCEPTION(scope, { });
-            if (formAssociatedCallback)
-                elementInterface->setFormAssociatedCallback(formAssociatedCallback);
+        auto* formResetCallback = getCustomElementCallback(lexicalGlobalObject, prototypeObject, Identifier::fromString(vm, "formResetCallback"_s));
+        RETURN_IF_EXCEPTION(scope, { });
+        if (formResetCallback)
+            elementInterface->setFormResetCallback(formResetCallback);
 
-            auto* formResetCallback = getCustomElementCallback(lexicalGlobalObject, prototypeObject, Identifier::fromString(vm, "formResetCallback"_s));
-            RETURN_IF_EXCEPTION(scope, { });
-            if (formResetCallback)
-                elementInterface->setFormResetCallback(formResetCallback);
+        auto* formDisabledCallback = getCustomElementCallback(lexicalGlobalObject, prototypeObject, Identifier::fromString(vm, "formDisabledCallback"_s));
+        RETURN_IF_EXCEPTION(scope, { });
+        if (formDisabledCallback)
+            elementInterface->setFormDisabledCallback(formDisabledCallback);
 
-            auto* formDisabledCallback = getCustomElementCallback(lexicalGlobalObject, prototypeObject, Identifier::fromString(vm, "formDisabledCallback"_s));
-            RETURN_IF_EXCEPTION(scope, { });
-            if (formDisabledCallback)
-                elementInterface->setFormDisabledCallback(formDisabledCallback);
-
-            auto* formStateRestoreCallback = getCustomElementCallback(lexicalGlobalObject, prototypeObject, Identifier::fromString(vm, "formStateRestoreCallback"_s));
-            RETURN_IF_EXCEPTION(scope, { });
-            if (formStateRestoreCallback)
-                elementInterface->setFormStateRestoreCallback(formStateRestoreCallback);
-        }
+        auto* formStateRestoreCallback = getCustomElementCallback(lexicalGlobalObject, prototypeObject, Identifier::fromString(vm, "formStateRestoreCallback"_s));
+        RETURN_IF_EXCEPTION(scope, { });
+        if (formStateRestoreCallback)
+            elementInterface->setFormStateRestoreCallback(formStateRestoreCallback);
     }
 
     if (auto promise = registry.addElementDefinition(WTFMove(elementInterface)))

--- a/Source/WebCore/dom/ElementInternals.idl
+++ b/Source/WebCore/dom/ElementInternals.idl
@@ -26,8 +26,7 @@
 [
     GenerateIsReachable=ImplElementRoot,
     GenerateAddOpaqueRoot=element,
-    Exposed=Window,
-    EnabledBySetting=FormAssociatedCustomElementsEnabled,
+    Exposed=Window
 ] interface ElementInternals {
     readonly attribute ShadowRoot? shadowRoot;
 

--- a/Source/WebCore/html/HTMLElement.idl
+++ b/Source/WebCore/html/HTMLElement.idl
@@ -51,7 +51,7 @@
 
     [CEReactions=Needed] attribute [LegacyNullToEmptyString] DOMString innerText;
 
-    [EnabledBySetting=FormAssociatedCustomElementsEnabled] ElementInternals attachInternals();
+    ElementInternals attachInternals();
 
     [CEReactions=Needed, Reflect] attribute boolean inert;
 


### PR DESCRIPTION
#### d4ecd740a990f3594cf147b44a7e734924793aad
<pre>
Remove FormAssociatedCustomElementsEnabled preference
<a href="https://bugs.webkit.org/show_bug.cgi?id=271155">https://bugs.webkit.org/show_bug.cgi?id=271155</a>

Reviewed by Ryosuke Niwa.

It&apos;s been stable for over a year.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp:
(WebCore::JSCustomElementRegistry::define):
* Source/WebCore/dom/ElementInternals.idl:
* Source/WebCore/html/HTMLElement.idl:

Canonical link: <a href="https://commits.webkit.org/276287@main">https://commits.webkit.org/276287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44e0f09b4d2bc4aa5942afaf798c54aadd229481

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46892 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40243 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46522 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20679 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36451 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17491 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17845 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39201 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2266 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37541 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40440 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39488 "Found 1 new test failure: imported/w3c/web-platform-tests/streams/piping/close-propagation-forward.any.worker.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48469 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43774 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43321 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20557 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42045 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9834 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20781 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50856 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20183 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10297 "Passed tests") | 
<!--EWS-Status-Bubble-End-->