### PR TITLE
REGRESSION (271805@main): [iOS] Updating options in a visible <select> menu can result in hangs

### DIFF
--- a/LayoutTests/fast/forms/ios/select-option-update-1000-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-option-update-1000-expected.txt
@@ -1,0 +1,11 @@
+This test verifies that updating a <select> element's menu while it is visible does not result in a hang.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS items.length is 1
+PASS items.length is 1001
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/select-option-update-1000.html
+++ b/LayoutTests/fast/forms/ios/select-option-update-1000.html
@@ -7,32 +7,33 @@
     </head>
 <body>
 <select id="select">
-    <option>Option 1</option>
-    <option>Option 2</option>
-    <option>Option 3</option>
+    <option>1</option>
 </select>
 </body>
 <script>
 jsTestIsAsync = true;
 
 addEventListener("load", async () => {
-    description("This test verifies that a &lt;select&gt; element's menu is updated if options are removed while it is visible.");
+    description("This test verifies that updating a &lt;select&gt; element's menu while it is visible does not result in a hang.");
 
-    shouldBeEqualToString("select.value", "Option 1");
     await UIHelper.activateElement(select);
 
     items = await UIHelper.selectMenuItems();
-    shouldBeTrue("areArraysEqual(items, " + '["Option 1", "Option 2", "Option 3"]' + ")");
+    shouldBeEqualToNumber("items.length", 1);
 
-    select.remove(0);
+    for (let i = 1; i <= 1000; i++) {
+        let option = document.createElement("option");
+        option.text = i + 1;
+        select.appendChild(option);
+    }
+
     await UIHelper.delayFor(200);
 
     items = await UIHelper.selectMenuItems();
-    shouldBeTrue("areArraysEqual(items, " + '["Option 2", "Option 3"]' + ")");
+    shouldBeEqualToNumber("items.length", 1001);
 
     await UIHelper.selectFormAccessoryPickerRow(1);
     await UIHelper.waitForContextMenuToHide();
-    shouldBeEqualToString("select.value", "Option 3");
 
     finishJSTest();
 });

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -84,6 +84,7 @@
 #include <WebCore/SubstituteData.h>
 #include <WebCore/TextManipulationController.h>
 #include <WebCore/TextManipulationItem.h>
+#include <WebCore/Timer.h>
 #include <WebCore/UserActivity.h>
 #include <WebCore/UserMediaRequestIdentifier.h>
 #include <WebCore/UserScriptTypes.h>
@@ -892,6 +893,7 @@ public:
 
     void blurFocusedElement();
     void requestFocusedElementInformation(CompletionHandler<void(const std::optional<FocusedElementInformation>&)>&&);
+    void updateFocusedElementInformation();
     void selectWithGesture(const WebCore::IntPoint&, GestureType, GestureRecognizerState, bool isInteractingWithFocusedElement, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&&);
     void updateSelectionWithTouches(const WebCore::IntPoint&, SelectionTouch, bool baseIsStart, CompletionHandler<void(const WebCore::IntPoint&, SelectionTouch, OptionSet<SelectionFlags>)>&&);
     void selectWithTwoTouches(const WebCore::IntPoint& from, const WebCore::IntPoint& to, GestureType, GestureRecognizerState, CompletionHandler<void(const WebCore::IntPoint&, GestureType, GestureRecognizerState, OptionSet<SelectionFlags>)>&&);
@@ -2572,6 +2574,8 @@ private:
     std::optional<DynamicViewportSizeUpdateID> m_pendingDynamicViewportSizeUpdateID;
     double m_lastTransactionPageScaleFactor { 0 };
     TransactionID m_lastTransactionIDWithScaleChange;
+
+    WebCore::DeferrableOneShotTimer m_updateFocusedElementInformationTimer;
 
     CompletionHandler<void(InteractionInformationAtPosition&&)> m_pendingSynchronousPositionInformationReply;
     std::optional<std::pair<TransactionID, double>> m_lastLayerTreeTransactionIdAndPageScaleBeforeScalingPage;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1015,6 +1015,20 @@ void WebPage::requestFocusedElementInformation(CompletionHandler<void(const std:
     completionHandler(information);
 }
 
+void WebPage::updateFocusedElementInformation()
+{
+    m_updateFocusedElementInformationTimer.stop();
+
+    if (!m_focusedElement)
+        return;
+
+    auto information = focusedElementInformation();
+    if (!information)
+        return;
+
+    send(Messages::WebPageProxy::UpdateFocusedElementInformation(*information));
+}
+
 #if ENABLE(DRAG_SUPPORT)
 void WebPage::requestDragStart(const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
 {


### PR DESCRIPTION
#### cfd86982fcdf69b0a1585024e43a477ffe8e7288
<pre>
REGRESSION (271805@main): [iOS] Updating options in a visible &lt;select&gt; menu can result in hangs
<a href="https://bugs.webkit.org/show_bug.cgi?id=271138">https://bugs.webkit.org/show_bug.cgi?id=271138</a>
<a href="https://rdar.apple.com/124576235">rdar://124576235</a>

Reviewed by Abrar Rahman Protyasha.

271805@main introduced logic that would update a visible &lt;select&gt; menu&apos;s options
as they are changed. Currently, the logic sends an update every time an option is
added or removed. This is problematic when options are added in a loop, as (n - 1)
unnecessary IPC messages are sent, and O(n^2) menu items are constructed in the UI
process. Additionally, there is further overhead from auto layout. Consequently,
adding options in a loop can result in a hang when there is a visible &lt;select&gt; menu.

Fix by adding a debouncing mechanism, so that changes to options can be coalesced
into a single update.

* LayoutTests/fast/forms/ios/select-option-removed-update.html:
* LayoutTests/fast/forms/ios/select-option-update-1000-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-option-update-1000.html: Added.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::close):
(WebKit::WebPage::elementDidFocus):
(WebKit::WebPage::focusedSelectElementDidChangeOptions):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Use a `DeferrableOneShotTimer` to ensure that any changes that happen within 100ms
are coalesced into a single update.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateFocusedElementInformation):

Canonical link: <a href="https://commits.webkit.org/276349@main">https://commits.webkit.org/276349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c6de801213baae9d7f0a3eaa33f6a81a6d1651f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47034 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40410 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20849 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36525 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Passed layout tests; Exiting early after 500 failures. 6955 tests run. 500 failures; Uploaded test results; 201 flakes 1 failures; Running compile-webkit-without-change") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17567 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39329 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2433 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40560 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48647 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43430 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20721 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42160 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21049 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6108 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20350 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->