### PR TITLE
[IFC][Ruby] Ruby base content may wrap even when style says no

### DIFF
--- a/LayoutTests/fast/ruby/ruby-base-content-should-not-wrap-expected.html
+++ b/LayoutTests/fast/ruby/ruby-base-content-should-not-wrap-expected.html
@@ -1,0 +1,11 @@
+<meta charset="UTF-8">
+<style>
+div {
+  font-family: Ahem;
+  font-size: 20px;
+  width: 40px;
+  border: 1px solid green;
+  overflow: hidden;
+}
+</style>
+<div>X <ruby>稲稲</ruby></div>

--- a/LayoutTests/fast/ruby/ruby-base-content-should-not-wrap.html
+++ b/LayoutTests/fast/ruby/ruby-base-content-should-not-wrap.html
@@ -1,0 +1,12 @@
+<meta charset="UTF-8">
+<style>
+div {
+  font-family: Ahem;
+  font-size: 20px;
+  width: 40px;
+  border: 1px solid green;
+  overflow: hidden;
+}
+</style>
+<!-- while there's a natural breaking position between 稲 and 稲, nowrap should prevent wrapping -->
+<div>X <ruby>稲稲</ruby>,X</div>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp
@@ -440,6 +440,11 @@ bool InlineFormattingUtils::isAtSoftWrapOpportunity(const InlineItem& previous, 
             return true;
         }
         // Both previous and next items are non-whitespace text.
+        // [text][text] : is a continuous content.
+        // [text-][text] : after [hyphen] position is a soft wrap opportunity.
+        auto previousAndNextHaveSameParent = &previousInlineTextItem.layoutBox().parent() == &nextInlineTextItem.layoutBox().parent();
+        if (previousAndNextHaveSameParent && !TextUtil::isWrappingAllowed(previousInlineTextItem.style()))
+            return false;
         // For soft wrap opportunities defined by the boundary between two characters, the white-space property on the nearest common ancestor of the two characters controls breaking.
         if (!endsWithSoftWrapOpportunity(previousInlineTextItem, nextInlineTextItem))
             return false;


### PR DESCRIPTION
#### 34b398f9df154d66b8f8567cc27fe3ad1d856182
<pre>
[IFC][Ruby] Ruby base content may wrap even when style says no
<a href="https://bugs.webkit.org/show_bug.cgi?id=269235">https://bugs.webkit.org/show_bug.cgi?id=269235</a>
&lt;<a href="https://rdar.apple.com/122811940">rdar://122811940</a>&gt;

Reviewed by Antti Koivisto.

There&apos;s no soft wrap opportunity between 2 adjacent non-whitespace characters when style says nowrap.

* LayoutTests/fast/ruby/ruby-base-content-should-not-wrap-expected.html: Added.
* LayoutTests/fast/ruby/ruby-base-content-should-not-wrap.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.cpp:
(WebCore::Layout::isAtSoftWrapOpportunity):

Originally-landed-as: 2c41110b8852. <a href="https://rdar.apple.com/124558811">rdar://124558811</a>
Canonical link: <a href="https://commits.webkit.org/276350@main">https://commits.webkit.org/276350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b47aab43fb82a9be38a0a6f798f44d4d1d6187e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40295 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36478 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17511 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17861 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39240 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2318 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40459 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48579 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19248 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15812 "Found 1 new test failure: imported/w3c/web-platform-tests/streams/transform-streams/reentrant-strategies.any.worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43389 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20609 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38401 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42117 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9878 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20235 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->