### PR TITLE
Simplify Navigation::scriptExecutionContext()

### DIFF
--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -695,7 +695,7 @@ History& LocalDOMWindow::history()
 Navigation& LocalDOMWindow::navigation()
 {
     if (!m_navigation)
-        m_navigation = Navigation::create(protectedScriptExecutionContext().get(), *this);
+        m_navigation = Navigation::create(*this);
     return *m_navigation;
 }
 

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -68,12 +68,12 @@ private:
     uint64_t id;
 };
 
-class Navigation final : public RefCounted<Navigation>, public EventTarget, public ContextDestructionObserver, public LocalDOMWindowProperty {
+class Navigation final : public RefCounted<Navigation>, public EventTarget, public LocalDOMWindowProperty {
     WTF_MAKE_ISO_ALLOCATED(Navigation);
 public:
     ~Navigation();
 
-    static Ref<Navigation> create(ScriptExecutionContext* context, LocalDOMWindow& window) { return adoptRef(*new Navigation(context, window)); }
+    static Ref<Navigation> create(LocalDOMWindow& window) { return adoptRef(*new Navigation(window)); }
 
     using RefCounted<Navigation>::ref;
     using RefCounted<Navigation>::deref;
@@ -115,7 +115,7 @@ public:
 
     void initializeEntries(const Ref<HistoryItem>& currentItem, Vector<Ref<HistoryItem>> &items);
 
-    Result navigate(ScriptExecutionContext&, const String& url, NavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
+    Result navigate(const String& url, NavigateOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
     Result reload(ReloadOptions&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
@@ -123,14 +123,15 @@ public:
     Result back(Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
     Result forward(Options&&, Ref<DeferredPromise>&&, Ref<DeferredPromise>&&);
 
-    ExceptionOr<void> updateCurrentEntry(JSDOMGlobalObject&, UpdateCurrentEntryOptions&&);
+    ExceptionOr<void> updateCurrentEntry(UpdateCurrentEntryOptions&&);
 
     void updateForNavigation(Ref<HistoryItem>&&, FrameLoadType);
 
 private:
-    Navigation(ScriptExecutionContext*, LocalDOMWindow&);
+    explicit Navigation(LocalDOMWindow&);
 
     enum EventTargetInterfaceType eventTargetInterface() const final;
+    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
     ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/page/Navigation.idl
+++ b/Source/WebCore/page/Navigation.idl
@@ -5,13 +5,13 @@
 ] interface Navigation : EventTarget {
   sequence<NavigationHistoryEntry> entries();
   readonly attribute NavigationHistoryEntry? currentEntry;
-  [CallWith=CurrentGlobalObject] undefined updateCurrentEntry(NavigationUpdateCurrentEntryOptions options);
+  undefined updateCurrentEntry(NavigationUpdateCurrentEntryOptions options);
   readonly attribute NavigationTransition? transition;
 
   readonly attribute boolean canGoBack;
   readonly attribute boolean canGoForward;
 
-  [ReturnsPromisePair,CallWith=CurrentScriptExecutionContext] NavigationResult navigate(USVString url, optional NavigationNavigateOptions options = {});
+  [ReturnsPromisePair] NavigationResult navigate(USVString url, optional NavigationNavigateOptions options = {});
   [ReturnsPromisePair] NavigationResult reload(optional NavigationReloadOptions options = {});
 
   [ReturnsPromisePair] NavigationResult traverseTo(DOMString key, optional NavigationOptions options = {});


### PR DESCRIPTION
#### 30c07bfcf389ac842ae25fd40d99c9b1913d78af
<pre>
Simplify Navigation::scriptExecutionContext()
<a href="https://bugs.webkit.org/show_bug.cgi?id=271161">https://bugs.webkit.org/show_bug.cgi?id=271161</a>

Reviewed by Chris Dumez.

As Navigation is a LocalDOMWindowProperty it always has
access to its own ScriptExecutionContext.

* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::navigation):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::Navigation):
(WebCore::Navigation::initializeEntries):
(WebCore::Navigation::scriptExecutionContext const):
(WebCore::Navigation::serializeState):
(WebCore::Navigation::navigate):
(WebCore::Navigation::updateCurrentEntry):
(WebCore::Navigation::updateForNavigation):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/Navigation.idl:

Canonical link: <a href="https://commits.webkit.org/276478@main">https://commits.webkit.org/276478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b35672d9ffa5cf5ebae1bb63cb5e01b02c39949

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47399 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40750 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21231 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36782 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45323 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/20952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38553 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17847 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39687 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2792 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/41026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49060 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16278 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43759 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21030 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42506 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21367 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6197 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->