### PR TITLE
UnifiedPDF: Home and End keys don't work

### DIFF
--- a/Source/WebCore/platform/KeyboardScrollingAnimator.h
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.h
@@ -29,6 +29,7 @@
 #include "KeyboardScroll.h" // FIXME: This is a layering violation.
 #include "RectEdges.h"
 #include "ScrollableArea.h"
+#include <wtf/CheckedPtr.h>
 
 namespace WebCore {
 
@@ -50,13 +51,13 @@ const std::optional<KeyboardScrollingKey> keyboardScrollingKeyForKeyboardEvent(c
 const std::optional<ScrollDirection> scrollDirectionForKeyboardEvent(const KeyboardEvent&);
 const std::optional<ScrollGranularity> scrollGranularityForKeyboardEvent(const KeyboardEvent&);
 
-class KeyboardScrollingAnimator : public CanMakeWeakPtr<KeyboardScrollingAnimator> {
+class KeyboardScrollingAnimator : public CanMakeWeakPtr<KeyboardScrollingAnimator>, public CanMakeCheckedPtr {
     WTF_MAKE_NONCOPYABLE(KeyboardScrollingAnimator);
     WTF_MAKE_FAST_ALLOCATED;
 public:
     KeyboardScrollingAnimator(ScrollableArea&);
 
-    bool beginKeyboardScrollGesture(ScrollDirection, ScrollGranularity, bool isKeyRepeat);
+    WEBCORE_EXPORT bool beginKeyboardScrollGesture(ScrollDirection, ScrollGranularity, bool isKeyRepeat);
     void handleKeyUpEvent();
     WEBCORE_EXPORT void stopScrollingImmediately();
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -47,6 +47,7 @@
 #include "WebEventModifier.h"
 #include "WebEventType.h"
 #include "WebHitTestResultData.h"
+#include "WebKeyboardEvent.h"
 #include "WebMouseEvent.h"
 #include "WebPageProxyMessages.h"
 #include <CoreGraphics/CoreGraphics.h>
@@ -80,6 +81,7 @@
 #include <WebCore/RenderLayerBacking.h>
 #include <WebCore/RenderLayerCompositor.h>
 #include <WebCore/ScreenProperties.h>
+#include <WebCore/ScrollAnimator.h>
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/ScrollbarTheme.h>
 #include <WebCore/ScrollbarsController.h>
@@ -2009,8 +2011,21 @@ bool UnifiedPDFPlugin::handleContextMenuEvent(const WebMouseEvent& event)
 #endif // ENABLE(CONTEXT_MENUS)
 }
 
-bool UnifiedPDFPlugin::handleKeyboardEvent(const WebKeyboardEvent&)
+bool UnifiedPDFPlugin::handleKeyboardEvent(const WebKeyboardEvent& event)
 {
+#if PLATFORM(MAC)
+    auto& commands = event.commands();
+    if (commands.size() != 1)
+        return false;
+    auto commandName = commands[0].commandName;
+
+    CheckedPtr keyboardAnimator = scrollAnimator().keyboardScrollingAnimator();
+    if (commandName == "scrollToBeginningOfDocument:"_s)
+        return keyboardAnimator->beginKeyboardScrollGesture(ScrollDirection::ScrollUp, ScrollGranularity::Document, false);
+    if (commandName == "scrollToEndOfDocument:"_s)
+        return keyboardAnimator->beginKeyboardScrollGesture(ScrollDirection::ScrollDown, ScrollGranularity::Document, false);
+#endif
+
     return false;
 }
 


### PR DESCRIPTION
#### 07b0249cdf4af4e82778d4a7f381de4f468b7a8f
<pre>
UnifiedPDF: Home and End keys don&apos;t work
<a href="https://bugs.webkit.org/show_bug.cgi?id=271165">https://bugs.webkit.org/show_bug.cgi?id=271165</a>
&lt;<a href="https://rdar.apple.com/problem/124785475">rdar://problem/124785475</a>&gt;

Reviewed by Abrar Rahman Protyasha.

* Source/WebCore/platform/KeyboardScrollingAnimator.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::handleKeyboardEvent):
Take care of Home and End key commands that make it to us.

Canonical link: <a href="https://commits.webkit.org/276288@main">https://commits.webkit.org/276288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdc06debac1d3789b029b21797bffac67d18539d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46909 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20725 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38125 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39234 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2309 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40454 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48517 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19239 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15806 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9838 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20226 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->