### PR TITLE
[Navigation] Implement more of NavigationTransition and NavigationDestination

### DIFF
--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -27,6 +27,7 @@
 
 #include "EventTarget.h"
 #include "JSDOMPromise.h"
+#include "JSDOMPromiseDeferred.h"
 #include "LocalDOMWindowProperty.h"
 #include "NavigationHistoryEntry.h"
 #include "NavigationTransition.h"

--- a/Source/WebCore/page/NavigationDestination.cpp
+++ b/Source/WebCore/page/NavigationDestination.cpp
@@ -32,4 +32,11 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(NavigationDestination);
 
+NavigationDestination::NavigationDestination(const URL& url, RefPtr<NavigationHistoryEntry>&& entry, bool isSameDocument)
+    : m_entry(WTFMove(entry))
+    , m_url(url)
+    , m_isSameDocument(isSameDocument)
+{
 }
+
+} // namespace WebCore

--- a/Source/WebCore/page/NavigationDestination.h
+++ b/Source/WebCore/page/NavigationDestination.h
@@ -27,6 +27,7 @@
 
 #include "EventHandler.h"
 #include "LocalDOMWindowProperty.h"
+#include "NavigationHistoryEntry.h"
 #include "ScriptWrappable.h"
 
 namespace JSC {
@@ -38,20 +39,22 @@ namespace WebCore {
 class NavigationDestination final : public RefCounted<NavigationDestination>, public ScriptWrappable {
     WTF_MAKE_ISO_ALLOCATED(NavigationDestination);
 public:
-    const String& url() const { return m_url; };
-    const String& key() const { return m_key; };
-    const String& id() const { return m_id; };
-    uint64_t index() const { return m_index; };
-    bool sameDocument() const { return m_sameDocument; };
+    static Ref<NavigationDestination> create(const URL& url, RefPtr<NavigationHistoryEntry>&& entry, bool isSameDocument) { return adoptRef(*new NavigationDestination(url, WTFMove(entry), isSameDocument)); };
+
+    const URL& url() const { return m_url; };
+    String key() const { return m_entry ? m_entry->key() : String(); };
+    String id() const { return m_entry ? m_entry->id() : String(); };
+    int64_t index() const { return m_entry ? m_entry->index() : -1; };
+    bool sameDocument() const { return m_isSameDocument; };
     const JSC::JSValue& getState() const { return m_state; };
 
 private:
-    String m_url;
-    String m_key;
-    String m_id;
-    uint64_t m_index;
+    explicit NavigationDestination(const URL&, RefPtr<NavigationHistoryEntry>&&, bool isSameDocument);
+
+    RefPtr<NavigationHistoryEntry> m_entry;
+    URL m_url;
+    bool m_isSameDocument;
     JSC::JSValue m_state;
-    bool m_sameDocument;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationTransition.cpp
+++ b/Source/WebCore/page/NavigationTransition.cpp
@@ -32,4 +32,10 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(NavigationTransition);
 
+NavigationTransition::NavigationTransition(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry)
+    : m_navigationType(type)
+    , m_from(WTFMove(fromEntry))
+{
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/NavigationTransition.h
+++ b/Source/WebCore/page/NavigationTransition.h
@@ -25,27 +25,29 @@
 
 #pragma once
 
-#include "DOMPromiseProxy.h"
 #include "NavigationHistoryEntry.h"
 #include "NavigationNavigationType.h"
 #include "ScriptWrappable.h"
 
 namespace WebCore {
 
+class DOMPromise;
+
 class NavigationTransition final : public RefCounted<NavigationTransition>, public ScriptWrappable {
     WTF_MAKE_ISO_ALLOCATED(NavigationTransition);
 public:
-
-    using FinishedPromise = DOMPromiseProxy<IDLUndefined>;
+    static Ref<NavigationTransition> create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& fromEntry) { return adoptRef(*new NavigationTransition(type, WTFMove(fromEntry))); };
 
     NavigationNavigationType navigationType() { return m_navigationType; };
     NavigationHistoryEntry& from() { return m_from; };
-    FinishedPromise& finished() { return *m_finished; };
+    DOMPromise* finished() { return m_finished.get(); };
 
 private:
+    explicit NavigationTransition(NavigationNavigationType, Ref<NavigationHistoryEntry>&& fromEntry);
+
     NavigationNavigationType m_navigationType;
     Ref<NavigationHistoryEntry> m_from;
-    UniqueRef<FinishedPromise> m_finished;
+    RefPtr<DOMPromise> m_finished;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### e6f92e4eab14dc9dbeaa2d70d0238dc7ee99df83
<pre>
[Navigation] Implement more of NavigationTransition and NavigationDestination
<a href="https://bugs.webkit.org/show_bug.cgi?id=271166">https://bugs.webkit.org/show_bug.cgi?id=271166</a>

Reviewed by Chris Dumez.

This implements their constructors and a few properties in preparation for
using with NavigateEvent.

* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/NavigationDestination.cpp:
(WebCore::NavigationDestination::NavigationDestination):
(WebCore::NavigationDestination::create):
* Source/WebCore/page/NavigationDestination.h:
* Source/WebCore/page/NavigationTransition.cpp:
(WebCore::NavigationTransition::NavigationTransition):
* Source/WebCore/page/NavigationTransition.h:

Canonical link: <a href="https://commits.webkit.org/276502@main">https://commits.webkit.org/276502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c93858e41d8ad68054b96f3c7cdd3279578e920

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47422 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40773 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36793 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20937 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17859 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39709 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2815 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49083 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43773 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21053 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42520 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21392 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6213 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->