### PR TITLE
Unified PDF: HUD gets pinned to the left side of the viewport after dragging window from/to 1x display

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKPDFHUDView.h
+++ b/Source/WebKit/UIProcess/PDF/WKPDFHUDView.h
@@ -36,10 +36,6 @@ class WebPageProxy;
 @interface WKPDFHUDView : NSView
 
 - (instancetype)initWithFrame:(NSRect)frame pluginIdentifier:(WebKit::PDFPluginIdentifier)pluginIdentifier page:(WebKit::WebPageProxy&)page;
-- (void)setFrame:(NSRect)frame;
-- (void)mouseMoved:(NSEvent *)event;
-- (void)mouseDown:(NSEvent *)event;
-- (void)mouseUp:(NSEvent *)event;
 - (void)setDeviceScaleFactor:(CGFloat)deviceScaleFactor;
 
 @end

--- a/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
@@ -89,7 +89,6 @@ static NSArray<NSString *> *controlArray()
     CGFloat _deviceScaleFactor;
     RetainPtr<CALayer> _layer;
     RetainPtr<CALayer> _activeLayer;
-    CGSize _frameSize;
     RetainPtr<NSMutableDictionary<NSString *, NSImage *>> _cachedIcons;
     BOOL _visible;
     BOOL _mouseMovedToHUD;
@@ -123,15 +122,14 @@ static NSArray<NSString *> *controlArray()
     [super dealloc];
 }
 
-- (void)setFrame:(NSRect)rect
+- (void)layout
 {
-    [super setFrame:rect];
-    _frameSize = rect.size;
+    [super layout];
 
     [CATransaction begin];
     [CATransaction setDisableActions:YES];
     CGRect layerBounds = [_layer bounds];
-    [_layer setFrame:CGRectMake(rect.size.width / 2.0 - layerBounds.size.width / 2.0, layerVerticalOffset, layerBounds.size.width, layerBounds.size.height)];
+    [_layer setFrame:CGRectMake(self.frame.size.width / 2.0 - layerBounds.size.width / 2.0, layerVerticalOffset, layerBounds.size.width, layerBounds.size.height)];
     [CATransaction commit];
 }
 
@@ -272,9 +270,9 @@ static NSArray<NSString *> *controlArray()
     _layer = adoptNS([[CALayer alloc] init]);
     [_layer setCornerRadius:layerCornerRadius];
     [_layer setCornerCurve:kCACornerCurveCircular];
-
     [_layer setBackgroundColor:WebCore::cachedCGColor({ WebCore::SRGBA<float>(layerGrayComponent, layerGrayComponent, layerGrayComponent) }).get()];
     [self _setLayerOpacity:layerAlpha];
+    [self setNeedsLayout:YES];
     
     [self _loadIconImages];
     CGFloat minIconImageHeight = std::numeric_limits<CGFloat>::max();
@@ -324,7 +322,6 @@ static NSArray<NSString *> *controlArray()
     CALayer *parentLayer = [_layer superlayer];
     [_layer removeFromSuperlayer];
     [self _setupLayer:parentLayer];
-    [self setFrameSize:_frameSize];
 }
 
 - (NSImage *)_getImageForControlName:(NSString *)control


### PR DESCRIPTION
#### fee2d02ccb2159f478000d7b9264ac55c21889ef
<pre>
Unified PDF: HUD gets pinned to the left side of the viewport after dragging window from/to 1x display
<a href="https://bugs.webkit.org/show_bug.cgi?id=271170">https://bugs.webkit.org/show_bug.cgi?id=271170</a>

Reviewed by Simon Fraser and Abrar Rahman Protyasha.

Fix a longstanding bug in the HUD: if the device scale factor changes but the
HUD frame does not, we&apos;ll rebuild the layer, but not lay it out inside the view,
only set its size.

Fix this by removing our setFrame override and implementing -layout instead.

* Source/WebKit/UIProcess/PDF/WKPDFHUDView.h:
* Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm:
(-[WKPDFHUDView layout]):
(-[WKPDFHUDView _setupLayer:]):
(-[WKPDFHUDView _redrawLayer]):
(-[WKPDFHUDView setFrame:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/276289@main">https://commits.webkit.org/276289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/694b23839d458d121b7522092fb89f7ab827baac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46920 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20736 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44848 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20386 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38131 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2320 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40460 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/39527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48529 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/19250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9839 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20237 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->