### PR TITLE
UnifiedPDF: Clicks on the HUD buttons can pass through to the PDF and trigger form focus

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKPDFHUDView.h
+++ b/Source/WebKit/UIProcess/PDF/WKPDFHUDView.h
@@ -38,6 +38,9 @@ class WebPageProxy;
 - (instancetype)initWithFrame:(NSRect)frame pluginIdentifier:(WebKit::PDFPluginIdentifier)pluginIdentifier page:(WebKit::WebPageProxy&)page;
 - (void)setDeviceScaleFactor:(CGFloat)deviceScaleFactor;
 
+- (BOOL)handleMouseDown:(NSEvent *)event;
+- (BOOL)handleMouseUp:(NSEvent *)event;
+
 @end
 
 #endif // ENABLE(PDF_HUD)

--- a/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
@@ -177,29 +177,31 @@ static NSArray<NSString *> *controlArray()
         [self _setVisible:false];
 }
 
-- (void)mouseDown:(NSEvent *)event
+- (BOOL)handleMouseDown:(NSEvent *)event
 {
     _activeControl = [self _controlForEvent:event];
     if ([_activeControl isEqualToString:PDFHUDSeparatorControl])
         _activeControl = nil;
-    if (_activeControl) {
-        // Update rendering to highlight it..
-        _activeLayer = [self _layerForEvent:event];
-        
-        // Update layer image; do not animate
-        [CATransaction begin];
-        [CATransaction setDisableActions:YES];
-        
-        [_activeLayer setOpacity:controlLayerDownAlpha];
-        
-        [CATransaction commit];
-    }
+    if (!_activeControl)
+        return false;
+
+    // Update rendering to highlight it..
+    _activeLayer = [self _layerForEvent:event];
+
+    // Update layer image; do not animate
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+
+    [_activeLayer setOpacity:controlLayerDownAlpha];
+
+    [CATransaction commit];
+    return true;
 }
 
-- (void)mouseUp:(NSEvent *)event
+- (BOOL)handleMouseUp:(NSEvent *)event
 {
     if (!_activeControl)
-        return;
+        return false;
     
     NSString* mouseUpControl = [self _controlForEvent:event];
     if ([_activeControl isEqualToString:mouseUpControl])
@@ -212,6 +214,8 @@ static NSArray<NSString *> *controlArray()
 
     _activeLayer = nil;
     _activeControl = nil;
+
+    return true;
 }
 
 - (std::optional<NSUInteger>)_controlIndexForEvent:(NSEvent *)event

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5647,11 +5647,13 @@ void WebViewImpl::mouseDown(NSEvent *event)
     if (m_ignoresNonWheelEvents)
         return;
 
-    for (auto& hud : _pdfHUDViews.values())
-        [hud mouseDown:event];
-
     setLastMouseDownEvent(event);
     setIgnoresMouseDraggedEvents(false);
+
+    for (auto& hud : _pdfHUDViews.values()) {
+        if ([hud handleMouseDown:event])
+            return;
+    }
 
     mouseDownInternal(event);
 }
@@ -5661,10 +5663,13 @@ void WebViewImpl::mouseUp(NSEvent *event)
     if (m_ignoresNonWheelEvents)
         return;
 
-    for (auto& hud : _pdfHUDViews.values())
-        [hud mouseUp:event];
-
     setLastMouseDownEvent(nil);
+
+    for (auto& hud : _pdfHUDViews.values()) {
+        if ([hud handleMouseUp:event])
+            return;
+    }
+
     mouseUpInternal(event);
 }
 


### PR DESCRIPTION
#### 36a9e5373c6fb72786a7aa1f43f3a379063d4530
<pre>
UnifiedPDF: Clicks on the HUD buttons can pass through to the PDF and trigger form focus
<a href="https://bugs.webkit.org/show_bug.cgi?id=271171">https://bugs.webkit.org/show_bug.cgi?id=271171</a>
&lt;<a href="https://rdar.apple.com/problem/123668071">rdar://problem/123668071</a>&gt;

Reviewed by Abrar Rahman Protyasha.

Don&apos;t send mouse up/down events to the page if the PDF HUD handled them.

* Source/WebKit/UIProcess/PDF/WKPDFHUDView.h:
* Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm:
(-[WKPDFHUDView handleMouseDown:]):
(-[WKPDFHUDView handleMouseUp:]):
(-[WKPDFHUDView mouseDown:]): Deleted.
(-[WKPDFHUDView mouseUp:]): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::mouseDown):
(WebKit::WebViewImpl::mouseUp):

Canonical link: <a href="https://commits.webkit.org/276307@main">https://commits.webkit.org/276307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65a7da4f0f5d6075889fd34a65165d7dfd86bb6e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46944 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20760 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20407 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38147 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2344 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40479 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48553 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19274 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15826 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9841 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->