### PR TITLE
[visionOS] Enable Linear Media Player by default

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3739,7 +3739,7 @@ LegacyOverflowScrollingTouchEnabled:
 
 LinearMediaPlayerEnabled:
   type: bool
-  status: unstable
+  status: internal
   category: media
   humanReadableName: "Linear Media Player"
   humanReadableDescription: "Enable LinearMediaPlayer for fullscreen video"
@@ -3748,7 +3748,7 @@ LinearMediaPlayerEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: false
+      default: true
     WebCore:
       default: false
 


### PR DESCRIPTION
#### c330ea99229f6bb478dde74497ee652e44a3d7d5
<pre>
[visionOS] Enable Linear Media Player by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=271172">https://bugs.webkit.org/show_bug.cgi?id=271172</a>
<a href="https://rdar.apple.com/123402134">rdar://123402134</a>

Reviewed by Jer Noble.

Changed LinearMediaPlayerEnabled&apos;s category to internal and set its default value to true in WebKit.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/276373@main">https://commits.webkit.org/276373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be68f4f8e38965cdbea3adbc5644b542481917b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46935 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40313 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36482 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17515 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39252 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2335 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48544 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/43855 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Found 134 jsc stress test failures: wasm.yaml/wasm/gc/bug254412.js.wasm-omg, wasm.yaml/wasm/gc/bug254413.js.wasm-omg, wasm.yaml/wasm/gc/bug258128.js.wasm-omg, wasm.yaml/wasm/gc/simd.js.wasm-omg, wasm.yaml/wasm/simd-spec-tests/simd_address.wast.js.wasm-omg ...; Compiled JSC; jscore-tests (cancelled)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43383 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20626 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42111 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9896 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20958 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/50925 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20252 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10310 "Passed tests") | 
<!--EWS-Status-Bubble-End-->