### PR TITLE
build-jsc/build-webgpu should build from Internal when it exists

### DIFF
--- a/Tools/Scripts/webkitperl/BuildSubproject.pm
+++ b/Tools/Scripts/webkitperl/BuildSubproject.pm
@@ -224,7 +224,11 @@ sub buildUpToProject
 {
     my ($projectDirectory, $projectName) = @_;
     my $result;
-    chdir $projectDirectory or die "Can't find $projectName directory to build from";
+    # Try to build from Internal if it exists since that will include WebKitAdditions.
+    chdirWebKit();
+    unless (chdir "../Internal") {
+        chdir $projectDirectory or die "Can't find $projectName directory to build from";
+    }
     if (isAppleCocoaWebKit()) {
         if (!configuredXcodeWorkspace()) {
             system("$FindBin::Bin/set-webkit-configuration", "--workspace=" . sourceDir() . "/WebKit.xcworkspace") == 0 or die;
@@ -256,7 +260,7 @@ sub buildUpToProject
 
         print "\n";
         print "building ", $projectName, "\n";
-        print "running build command '", $command, "' in ", $projectDirectory, "\n\n";
+        print "running build command '", $command, "' in ", Cwd::cwd(), "\n\n";
 
         $result = system $command;
     } else {


### PR DESCRIPTION
#### 343e1e3db286baf04b70cd332cf409fda2e0b013
<pre>
build-jsc/build-webgpu should build from Internal when it exists
<a href="https://bugs.webkit.org/show_bug.cgi?id=271173">https://bugs.webkit.org/show_bug.cgi?id=271173</a>
<a href="https://rdar.apple.com/124963672">rdar://124963672</a>

Reviewed by NOBODY (OOPS!).

Right now in order to get WebKitAdditions when using these scripts you have to already have started a build
from Internal. This is annoying for clean builds and when WebKitBuild has a stale WebKitAdditions. If we issue the build command
from the Internal directory when it exists we can avoid this problem.

* Tools/Scripts/webkitperl/BuildSubproject.pm:
(buildUpToProject):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/343e1e3db286baf04b70cd332cf409fda2e0b013

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46939 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40317 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20755 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36483 "Failure limit exceed. At least found 2 new test failures: fast/frames/lots-of-iframes.html, http/tests/cache/disk-cache/redirect-chain-limits.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17516 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39253 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2339 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40473 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39538 "Found 1 new test failure: imported/w3c/web-platform-tests/streams/piping/close-propagation-forward.any.worker.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48586 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43393 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20630 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42123 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/20959 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->