### PR TITLE
[run-webkit-tests] Manager shouldn't treat all IOErrors invalid --test-list paths

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
@@ -131,19 +131,13 @@ class LayoutTestFinder(object):
         fs = self._filesystem
         tests = []
         for filename in filenames:
-            try:
-                if test_path_separator != fs.sep:
-                    filename = filename.replace(test_path_separator, fs.sep)
-                file_contents = fs.read_text_file(filename).split('\n')
-                for line in file_contents:
-                    line = self._strip_comments(line)
-                    if line:
-                        tests.append(line)
-            except IOError as e:
-                if e.errno == errno.ENOENT:
-                    _log.critical('')
-                    _log.critical('--test-list file "{}" not found'.format(filenames))
-                raise
+            if test_path_separator != fs.sep:
+                filename = filename.replace(test_path_separator, fs.sep)
+            file_contents = fs.read_text_file(filename).split('\n')
+            for line in file_contents:
+                line = self._strip_comments(line)
+                if line:
+                    tests.append(line)
         return tests
 
     @staticmethod

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -319,12 +319,15 @@ class Manager(object):
     def run(self, args):
         num_failed_uploads = 0
 
+        if self._options.test_list:
+            for list_path in self._options.test_list:
+                if not self._port.host.filesystem.isfile(list_path):
+                    _log.critical('')
+                    _log.critical('--test-list file "{}" not found'.format(list_path))
+                    return test_run_results.RunDetails(exit_code=-1)
+
         device_type_list = self._port.supported_device_types()
-        try:
-            tests_to_run_by_device, aggregate_tests_to_skip = self._collect_tests(args, device_type_list)
-        except IOError:
-            # This is raised if --test-list doesn't exist
-            return test_run_results.RunDetails(exit_code=-1)
+        tests_to_run_by_device, aggregate_tests_to_skip = self._collect_tests(args, device_type_list)
 
         aggregate_tests_to_run = set()  # type: Set[Test]
         for v in tests_to_run_by_device.values():
@@ -748,11 +751,14 @@ class Manager(object):
     def print_expectations(self, args):
         device_type_list = self._port.supported_device_types()
 
-        try:
-            tests_to_run_by_device, aggregate_tests_to_skip = self._collect_tests(args, device_type_list)
-        except IOError:
-            # This is raised if --test-list doesn't exist
-            return -1
+        if self._options.test_list:
+            for list_path in self._options.test_list:
+                if not self._port.host.filesystem.isfile(list_path):
+                    _log.critical('')
+                    _log.critical('--test-list file "{}" not found'.format(list_path))
+                    return -1
+
+        tests_to_run_by_device, aggregate_tests_to_skip = self._collect_tests(args, device_type_list)
 
         aggregate_tests_to_run = set()
         for v in tests_to_run_by_device.values():
@@ -773,11 +779,14 @@ class Manager(object):
         device_type_list = self._port.supported_device_types()
         test_stats = {}
 
-        try:
-            self._collect_tests(args, device_type_list)
-        except IOError:
-            # This is raised if --test-list doesn't exist
-            return test_run_results.RunDetails(exit_code=-1)
+        if self._options.test_list:
+            for list_path in self._options.test_list:
+                if not self._port.host.filesystem.isfile(list_path):
+                    _log.critical('')
+                    _log.critical('--test-list file "{}" not found'.format(list_path))
+                    return test_run_results.RunDetails(exit_code=-1)
+
+        self._collect_tests(args, device_type_list)
 
         for device_type, expectations in self._expectations.items():
             test_stats[device_type] = {'__root__': {'count': 0, 'skip': 0, 'pass': 0, 'flaky': 0, 'fail': 0, 'has_tests': False}}


### PR DESCRIPTION
#### f342b3fa9121a066f4662153f043e664e02408c9
<pre>
[run-webkit-tests] Manager shouldn&apos;t treat all IOErrors invalid --test-list paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=271180">https://bugs.webkit.org/show_bug.cgi?id=271180</a>

Reviewed by Jonathan Bedard and Darin Adler.

Currently this means all IOErrors are swallowed by Manager, which is
awkward when we have an actual bug (<a href="https://rdar.apple.com/124918090">rdar://124918090</a>) here, which should
show up as an uncaught exception rather than silently failing.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py:
(LayoutTestFinder._read_test_names_from_file):
* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager.run):
(Manager.print_expectations):
(Manager.print_summary):

Canonical link: <a href="https://commits.webkit.org/276304@main">https://commits.webkit.org/276304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7fd039522691afc6bfa63b8302d8be776b958003

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23377 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/46745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/46959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20774 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/46959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44886 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/20421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/46745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/46959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/44185 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/46745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/2358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/46745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/48567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/19288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/48567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/46745 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/48567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6084 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->