### PR TITLE
[JSC] Use DeferGCForAWhile instead of DeferGC in computeErrorInfo

### DIFF
--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -257,7 +257,9 @@ void ErrorInstance::finalizeUnconditionally(VM& vm, CollectionScope)
 void ErrorInstance::computeErrorInfo(VM& vm)
 {
     ASSERT(!m_errorInfoMaterialized);
-    DeferGC deferGC(vm);
+    // Here we use DeferGCForAWhile instead of DeferGC since GC's Heap::runEndPhase can trigger this function. In
+    // that case, DeferGC's destructor might trigger another GC cycle which is unexpected.
+    DeferGCForAWhile deferGC(vm);
 
     if (m_stackTrace && !m_stackTrace->isEmpty()) {
         getLineColumnAndSource(vm, m_stackTrace.get(), m_lineColumn, m_sourceURL);


### PR DESCRIPTION
#### c1017d3d1fc53f46679a5e2df2d6d71b66253fd8
<pre>
[JSC] Use DeferGCForAWhile instead of DeferGC in computeErrorInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=268489">https://bugs.webkit.org/show_bug.cgi?id=268489</a>
<a href="https://rdar.apple.com/121906810">rdar://121906810</a>

Reviewed by Mark Lam, Yusuke Suzuki and Justin Michaud.

ErrorInstance::computeErrorInfo can be called from GC&apos;s Heap::runEndPhase.
In the case, we should use DeferGCForAWhile instead of DeferGC since it
can trigger another GC in its destruction.

* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::ErrorInstance::computeErrorInfo):

Originally-landed-as: 272448.442@safari-7618-branch (58204e87a044). <a href="https://rdar.apple.com/124554094">rdar://124554094</a>
Canonical link: <a href="https://commits.webkit.org/276346@main">https://commits.webkit.org/276346@main</a>
</pre>
