### PR TITLE
[CSS] Any @scope limit makes the element out of scope

### DIFF
--- a/LayoutTests/fast/css/scope-at-rule-expected.html
+++ b/LayoutTests/fast/css/scope-at-rule-expected.html
@@ -88,3 +88,9 @@
 <div>
   <span class="green italic">should be green and italic</span>
 </div>
+<div>
+  <span style="text-decoration: underline">should be underlined</span>
+</div>
+<div>
+  <span>should not be underlined</span>
+</div>

--- a/LayoutTests/fast/css/scope-at-rule.html
+++ b/LayoutTests/fast/css/scope-at-rule.html
@@ -93,6 +93,10 @@ div {
 @scope (#green-18) {
   * { color: red; font-style: italic; }
 }
+
+@scope (#green-21) to (#limit1, #limit2) {
+ * { text-decoration: underline; }
+}
 </style>
 
 <div class="a">
@@ -242,4 +246,11 @@ div {
     }
   </style>
 <span>should be green and italic</span>
+</div>
+
+<div id="green-21">
+  <span>should be underlined</span>
+  <div id=limit2>
+    <span>should not be underlined</span>
+  </div>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt
@@ -21,4 +21,5 @@ PASS :scope indirect adjacent sibling
 PASS Relative selector inside @scope
 PASS :scope in two different compounds
 PASS Scope root with :has()
+PASS Any scope limit makes the element out of scope
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation.html
@@ -512,7 +512,6 @@ test_scope(document.currentScript, () => {
 }, ':scope in two different compounds');
 </script>
 
-
 <template>
   <style>
     @scope (.a:has(.c)) {
@@ -544,4 +543,25 @@ test_scope(document.currentScript, () => {
   assert_not_green('.second .b');
   assert_not_green('.second .d');
 }, 'Scope root with :has()');
+</script>
+
+<template>
+  <style>
+    @scope (.a) to (.b, .c) {
+      * { background-color:green; }
+    }
+  </style>
+  <div class=a>
+    <span id="in"></span>
+    <div class=b>
+      <span id="out"</span>
+      <div class=c></div>
+    </div>
+  </div>
+</template>
+<script>
+test_scope(document.currentScript, () => {
+  assert_green('#in');
+  assert_not_green('#out');
+}, 'Any scope limit makes the element out of scope');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt
@@ -3,7 +3,7 @@ PASS Element becoming scope root
 PASS Element becoming scope root (selector list)
 FAIL Element becoming scope root, with inner :scope rule assert_equals: expected "rgb(0, 128, 0)" but got "rgb(0, 0, 0)"
 PASS Parent element becoming scope limit
-FAIL Parent element becoming scope limit (selector list) assert_equals: expected "rgb(0, 0, 0)" but got "rgb(0, 128, 0)"
+PASS Parent element becoming scope limit (selector list)
 PASS Subject element becoming scope limit
 PASS Parent element affecting scope limit
 PASS Sibling element affecting scope limit


### PR DESCRIPTION
#### 432386fb902b696fb2fbcb272588e21f0519b1bd
<pre>
[CSS] Any @scope limit makes the element out of scope
<a href="https://bugs.webkit.org/show_bug.cgi?id=270806">https://bugs.webkit.org/show_bug.cgi?id=270806</a>
<a href="https://rdar.apple.com/124956673">rdar://124956673</a>

Reviewed by Antti Koivisto.

&lt;scope-end&gt; is a relative selector list, any valid complex selector
inside it represents a scope limit : for an element to be in scope,
it needs to not have any of those selectors matching one of its ancestors.

 * LayoutTests/fast/css/scope-at-rule-expected.html:
 * LayoutTests/fast/css/scope-at-rule.html:
 * LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation-expected.txt:
 * LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-evaluation.html:
 * LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-invalidation-expected.txt:
 * Source/WebCore/style/ElementRuleCollector.cpp:
 (WebCore::Style::ElementRuleCollector::scopeRulesMatch):

Canonical link: <a href="https://commits.webkit.org/276359@main">https://commits.webkit.org/276359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd002431418fc4275d1339d1d2e7218c06f58e22

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47085 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40456 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20898 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36555 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17601 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18008 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39374 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2480 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48702 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15937 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43467 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42202 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9882 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21093 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->