### PR TITLE
[UnifiedPDF] Refactor selectionBoundsAcrossDocument() to accept a target coordinate space

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
@@ -260,10 +260,12 @@ void PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects(Should
         return;
 
     Vector<IntRect> dirtyRectsInContentSpace;
+
     if (activeHighlight)
-        dirtyRectsInContentSpace.appendVector(plugin->selectionBoundsAcrossDocumentInContentSpace(activeDataDetectorItem->selection().get()));
+        dirtyRectsInContentSpace.appendVector(plugin->boundsForSelection(activeDataDetectorItem->selection().get(), UnifiedPDFPlugin::CoordinateSpace::Contents));
+
     if (previousActiveHighlight)
-        dirtyRectsInContentSpace.appendVector(plugin->selectionBoundsAcrossDocumentInContentSpace(previousDataDetectorItem->selection().get()));
+        dirtyRectsInContentSpace.appendVector(plugin->boundsForSelection(previousDataDetectorItem->selection().get(), UnifiedPDFPlugin::CoordinateSpace::Contents));
 
     RefPtr overlay = protectedOverlay();
     if (!overlay)


### PR DESCRIPTION
#### 241cc4bba9ccc2218fc30b9ee65a24dd7636daef
<pre>
[UnifiedPDF] Refactor selectionBoundsAcrossDocument() to accept a target coordinate space
<a href="https://bugs.webkit.org/show_bug.cgi?id=271181">https://bugs.webkit.org/show_bug.cgi?id=271181</a>
<a href="https://rdar.apple.com/124969883">rdar://124969883</a>

Reviewed by Sammy Gill.

This patch is a small refactor of the selectionBoundsAcrossDocument()
family of methods to some review feedback from 276239@main. This method
now accepts a target coordinate space to represent its results in. I&apos;ve
also taken the liberty to rename it to `boundsForSelection`, since the
target coordinate space needn&apos;t be implicit in the name anymore.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm:
(WebKit::PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::boundsForSelection const):
(WebKit::UnifiedPDFPlugin::repaintOnSelectionActiveStateChangeIfNeeded):
(WebKit::UnifiedPDFPlugin::setCurrentSelection):
(WebKit::UnifiedPDFPlugin::selectionBoundsAcrossDocument const): Deleted.
(WebKit::UnifiedPDFPlugin::selectionBoundsAcrossDocumentInContentSpace const): Deleted.

Canonical link: <a href="https://commits.webkit.org/276321@main">https://commits.webkit.org/276321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0a4ed3972d813de70538855b46523a21f4c934f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46965 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20780 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38161 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17532 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17907 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2364 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48573 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19294 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42115 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9858 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/20984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->