### PR TITLE
Web Inspector: FolderizedTreeElement doesn't need to remember expansion states anymore since FolderTreeElement already does the job

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/FolderizedTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FolderizedTreeElement.js
@@ -31,7 +31,6 @@ WI.FolderizedTreeElement = class FolderizedTreeElement extends WI.GeneralTreeEle
 
         this.shouldRefreshChildren = true;
 
-        this._folderExpandedSettingMap = new Map;
         this._folderSettingsKey = "";
         this._folderTypeMap = new Map;
         this._folderizeSettingsMap = new Map;
@@ -75,7 +74,6 @@ WI.FolderizedTreeElement = class FolderizedTreeElement extends WI.GeneralTreeEle
 
         this._clearNewChildQueue();
 
-        this._folderExpandedSettingMap.clear();
         this._folderTypeMap.clear();
 
         this._groupedIntoFolders = false;
@@ -275,21 +273,7 @@ WI.FolderizedTreeElement = class FolderizedTreeElement extends WI.GeneralTreeEle
 
         console.assert(this._folderSettingsKey !== "");
 
-        function createFolderTreeElement(settings)
-        {
-            let folderTreeElement = new WI.FolderTreeElement(settings.displayName, settings.representedObject);
-            let folderExpandedSetting = new WI.Setting(settings.type + "-folder-expanded-" + this._folderSettingsKey, false);
-            this._folderExpandedSettingMap.set(folderTreeElement, folderExpandedSetting);
-
-            if (folderExpandedSetting.value)
-                folderTreeElement.expand();
-
-            folderTreeElement.onexpand = this._folderTreeElementExpandedStateChange.bind(this);
-            folderTreeElement.oncollapse = this._folderTreeElementExpandedStateChange.bind(this);
-            return folderTreeElement;
-        }
-
-        var settings = this._settingsForRepresentedObject(representedObject);
+        let settings = this._settingsForRepresentedObject(representedObject);
         if (!settings) {
             console.error("Unknown representedObject", representedObject);
             return this;
@@ -298,23 +282,15 @@ WI.FolderizedTreeElement = class FolderizedTreeElement extends WI.GeneralTreeEle
         if (settings.topLevel)
             return this;
 
-        var folder = this._folderTypeMap.get(settings.type);
+        let folder = this._folderTypeMap.get(settings.type);
         if (folder)
             return folder;
 
-        folder = createFolderTreeElement.call(this, settings);
+        folder = new WI.FolderTreeElement(settings.displayName, settings.representedObject, {
+            id: `${settings.type}-${settings._folderSettingsKey}`,
+        });
         this._folderTypeMap.set(settings.type, folder);
         return folder;
-    }
-
-    _folderTreeElementExpandedStateChange(folderTreeElement)
-    {
-        let expandedSetting = this._folderExpandedSettingMap.get(folderTreeElement);
-        console.assert(expandedSetting, "No expanded setting for folderTreeElement", folderTreeElement);
-        if (!expandedSetting)
-            return;
-
-        expandedSetting.value = folderTreeElement.expanded;
     }
 
     _settingsForRepresentedObject(representedObject)


### PR DESCRIPTION
#### 3cc63f452ee1f7b27315942d53543c6dd041dfb9
<pre>
Web Inspector: FolderizedTreeElement doesn&apos;t need to remember expansion states anymore since FolderTreeElement already does the job
<a href="https://rdar.apple.com/124158713">rdar://124158713</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=270595">https://bugs.webkit.org/show_bug.cgi?id=270595</a>

Reviewed by Devin Rousso.

Remove the creating and handling of expansion states from
FolderizedTreeElement.

* Source/WebInspectorUI/UserInterface/Views/FolderizedTreeElement.js:
(WI.FolderizedTreeElement):
(WI.FolderizedTreeElement.prototype.removeChildren):
- No need anymore for remembering the WI.Setting items for each created
  child FolderTreeElement.

(WI.FolderizedTreeElement.prototype._parentTreeElementForRepresentedObject):
- Passing the folderId into the created child FolderTreeElement will
  make it do the state-remembering job.

(WI.FolderizedTreeElement.prototype._folderTreeElementExpandedStateChange): Deleted.
- The child FolderTreeElement already does this job.

Canonical link: <a href="https://commits.webkit.org/276357@main">https://commits.webkit.org/276357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35d11618e8a1279961d59e68815cf6b80def3ee2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47096 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20910 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20561 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17610 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/39388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2492 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40627 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/39665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/48729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19417 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15949 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43476 "layout-tests (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9884 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20405 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->