### PR TITLE
Remove non-standard `width()` and `height()` functions of HTMLDocument

### DIFF
--- a/Source/WebCore/html/HTMLDocument.cpp
+++ b/Source/WebCore/html/HTMLDocument.cpp
@@ -103,20 +103,6 @@ HTMLDocument::HTMLDocument(LocalFrame* frame, const Settings& settings, const UR
 
 HTMLDocument::~HTMLDocument() = default;
 
-int HTMLDocument::width()
-{
-    updateLayoutIgnorePendingStylesheets();
-    RefPtr frameView = view();
-    return frameView ? frameView->contentsWidth() : 0;
-}
-
-int HTMLDocument::height()
-{
-    updateLayoutIgnorePendingStylesheets();
-    RefPtr frameView = view();
-    return frameView ? frameView->contentsHeight() : 0;
-}
-
 Ref<DocumentParser> HTMLDocument::createParser()
 {
     return HTMLDocumentParser::create(*this, parserContentPolicy());

--- a/Source/WebCore/html/HTMLDocument.h
+++ b/Source/WebCore/html/HTMLDocument.h
@@ -33,9 +33,6 @@ public:
     static Ref<HTMLDocument> create(LocalFrame*, const Settings&, const URL&, ScriptExecutionContextIdentifier = { });
     static Ref<HTMLDocument> createSynthesizedDocument(LocalFrame&, const URL&);
     virtual ~HTMLDocument();
-
-    WEBCORE_EXPORT int width();
-    WEBCORE_EXPORT int height();
     
     std::optional<std::variant<RefPtr<WindowProxy>, RefPtr<Element>, RefPtr<HTMLCollection>>> namedItem(const AtomString&);
     Vector<AtomString> supportedPropertyNames() const;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLDocument.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLDocument.cpp
@@ -297,20 +297,12 @@ void webkit_dom_html_document_release_events(WebKitDOMHTMLDocument* self)
 
 glong webkit_dom_html_document_get_width(WebKitDOMHTMLDocument* self)
 {
-    WebCore::JSMainThreadNullState state;
-    g_return_val_if_fail(WEBKIT_DOM_IS_HTML_DOCUMENT(self), 0);
-    WebCore::HTMLDocument* item = WebKit::core(self);
-    glong result = item->width();
-    return result;
+    return 0;
 }
 
 glong webkit_dom_html_document_get_height(WebKitDOMHTMLDocument* self)
 {
-    WebCore::JSMainThreadNullState state;
-    g_return_val_if_fail(WEBKIT_DOM_IS_HTML_DOCUMENT(self), 0);
-    WebCore::HTMLDocument* item = WebKit::core(self);
-    glong result = item->height();
-    return result;
+    return 0;
 }
 
 gchar* webkit_dom_html_document_get_dir(WebKitDOMHTMLDocument* self)

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLDocument.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLDocument.mm
@@ -60,14 +60,12 @@
 
 - (int)width
 {
-    WebCore::JSMainThreadNullState state;
-    return IMPL->width();
+    return 0;
 }
 
 - (int)height
 {
-    WebCore::JSMainThreadNullState state;
-    return IMPL->height();
+    return 0;
 }
 
 - (NSString *)dir


### PR DESCRIPTION
#### 9e4d6906a76b73fae8fa281245ec884929dbd6a5
<pre>
Remove non-standard `width()` and `height()` functions of HTMLDocument

<a href="https://bugs.webkit.org/show_bug.cgi?id=271190">https://bugs.webkit.org/show_bug.cgi?id=271190</a>

Reviewed by Ryosuke Niwa and Michael Catanzaro.

This patch is to remove remaining code for dropped `HTMLDocument.width / height`
attributes, which were dropped in 171244@main (via IDL changes) and later
removed in 179619@main (both in 2016 - via removal from IDL).

* Source/WebCore/html/HTMLDocument.cpp:
(HTMLDocument::width): Deleted
(HTMLDocument::height): Deleted
* Source/WebCore/html/HTMLDocument.h:
* Source/WebKitLegacy/mac/DOM/DOMHTMLDocument.mm:
(width):
(height):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMHTMLDocument.cpp:
(webkit_dom_html_document_get_width):
(webkit_dom_html_document_get_height):

Canonical link: <a href="https://commits.webkit.org/276488@main">https://commits.webkit.org/276488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/450f296ada47a5cebb9487ea00af30ca71afc857

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47303 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40655 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36721 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17779 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39574 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2697 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48939 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43664 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20934 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42413 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/9979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20603 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->