### PR TITLE
REGRESSION(275801@main): In some cases, InteractionRegion layers accumulate in the layer tree

### DIFF
--- a/LayoutTests/interaction-region/content-hint-overlap-dedupe-expected.txt
+++ b/LayoutTests/interaction-region/content-hint-overlap-dedupe-expected.txt
@@ -1,0 +1,20 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction (0,0) width=400 height=300)
+        (content hint photo)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/content-hint-overlap-dedupe.html
+++ b/LayoutTests/interaction-region/content-hint-overlap-dedupe.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+
+    #interactive {
+        background: blue;
+    }
+    .rect {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 400px;
+        height: 300px;
+        opacity: 0.5;
+    }
+    span {
+        position: absolute;
+        top: 200px;
+        left: 100px;
+    }
+</style>
+<script src="../resources/ui-helper.js"></script>
+<body>
+<section id="test">
+    <a href="#">
+        <div id="interactive" class="rect"></div>
+        <img src="../fast/media/resources/apple_logo_big.jpg" alt="apple logo" class="rect" />
+        <span>link</span>
+    </a>
+    <div id="counter"></div>
+</section>
+
+<pre id="results"></pre>
+<script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.animationFrame();
+    await UIHelper.ensureStablePresentationUpdate();
+
+    // Re-render.
+    for (var i = 0; i <= 3; i++) {
+        document.getElementById("counter").textContent = i;
+        await UIHelper.animationFrame();
+        await UIHelper.ensureStablePresentationUpdate();
+    }
+
+    results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -298,10 +298,16 @@ void EventRegionContext::shrinkWrapInteractionRegions()
             region.cornerRadius = 0;
         }
 
-        for (auto& region : toAddAfterMerge) {
-            auto rectForTracking = enclosingIntRect(region.rectInLayerCoordinates);
-            region.contentHint = m_interactionRectsAndContentHints.get(rectForTracking);
-            m_interactionRegions.insert(++i, WTFMove(region));
+        auto finalRegionRectForTracking = enclosingIntRect(region.rectInLayerCoordinates);
+        for (auto& extraRegion : toAddAfterMerge) {
+            auto extraRectForTracking = enclosingIntRect(extraRegion.rectInLayerCoordinates);
+            // Do not insert a new region if it creates a duplicated Interaction Rect.
+            if (finalRegionRectForTracking == extraRectForTracking) {
+                region.contentHint = m_interactionRectsAndContentHints.get(extraRectForTracking);
+                continue;
+            }
+            extraRegion.contentHint = m_interactionRectsAndContentHints.get(extraRectForTracking);
+            m_interactionRegions.insert(++i, WTFMove(extraRegion));
         }
     }
 }


### PR DESCRIPTION
#### 3472dac0219c70ef58046eb7dac36209d7375aba
<pre>
REGRESSION(275801@main): In some cases, InteractionRegion layers accumulate in the layer tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=271195">https://bugs.webkit.org/show_bug.cgi?id=271195</a>
&lt;<a href="https://rdar.apple.com/124972680">rdar://124972680</a>&gt;

Reviewed by Mike Wyrzykowski.

The code managing InteractionRegion layers in the RemoteLayerTree has a
strict requirement for no &lt;IntRect, InteractionRegion::Type&gt; duplicate.
We use the `m_interactionRects` / `m_occlusionRects` / `m_elementGuardRects`
sets on the EventRegionContext to ensure this.

But 275801@main introduced a code-path where we insert extra Interaction
Regions for photos in `shrinkWrapInteractionRegions`. We need to maintain
the no-duplicate rule there too.

* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::shrinkWrapInteractionRegions):
Make sure the extra regions &quot;to add after merge&quot; do not create
&lt;IntRect, InteractionRegion::Type&gt; duplicates. Update the existing
region&apos;s content hint instead.

* LayoutTests/interaction-region/content-hint-overlap-dedupe-expected.txt: Added.
* LayoutTests/interaction-region/content-hint-overlap-dedupe.html: Added.
Add a test covering this and exercising the assertions in the
RemoteLayerTree code.

Canonical link: <a href="https://commits.webkit.org/276335@main">https://commits.webkit.org/276335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3348432c89e1dce32c21a205d355be35d80751ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/46984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40364 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20799 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36499 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17539 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39278 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2383 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40569 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48595 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19315 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15864 "Found 1 new test failure: imported/w3c/web-platform-tests/streams/transform-streams/reentrant-strategies.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43398 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42128 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9868 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20300 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->