### PR TITLE
Add a button to element fullscreen on visionOS that enters video fullscreen

### DIFF
--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -75,6 +75,7 @@ public:
     virtual void toggleFullscreen() = 0;
     virtual void togglePictureInPicture() = 0;
     virtual void toggleInWindowFullscreen() = 0;
+    virtual void enterFullscreen() = 0;
     virtual void toggleMuted() = 0;
     virtual void setMuted(bool) = 0;
     virtual void setVolume(double) = 0;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -75,6 +75,7 @@ public:
     WEBCORE_EXPORT void toggleFullscreen() final;
     WEBCORE_EXPORT void togglePictureInPicture() final;
     WEBCORE_EXPORT void toggleInWindowFullscreen() final;
+    WEBCORE_EXPORT void enterFullscreen() final;
     WEBCORE_EXPORT void toggleMuted() final;
     WEBCORE_EXPORT void setMuted(bool) final;
     WEBCORE_EXPORT void setVolume(double) final;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -386,6 +386,16 @@ void PlaybackSessionModelMediaElement::toggleInWindowFullscreen()
 #endif
 }
 
+void PlaybackSessionModelMediaElement::enterFullscreen()
+{
+    ASSERT(is<HTMLVideoElement>(*m_mediaElement));
+    if (!is<HTMLVideoElement>(*m_mediaElement))
+        return;
+
+    auto& element = downcast<HTMLVideoElement>(*m_mediaElement);
+    element.webkitEnterFullscreen();
+}
+
 void PlaybackSessionModelMediaElement::toggleMuted()
 {
     setMuted(!isMuted());

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -164,6 +164,7 @@ private:
     void toggleFullscreen() override { }
     void togglePictureInPicture() override { }
     void toggleInWindowFullscreen() override { }
+    void enterFullscreen() override { }
     void toggleMuted() override;
     void setMuted(bool) final;
     void setVolume(double) final;

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -102,6 +102,7 @@ private:
     void toggleFullscreen() final;
     void togglePictureInPicture() final;
     void toggleInWindowFullscreen() final;
+    void enterFullscreen() final;
     void toggleMuted() final;
     void setMuted(bool) final;
     void setVolume(double) final;
@@ -257,6 +258,7 @@ private:
     void selectLegibleMediaOption(PlaybackSessionContextIdentifier, uint64_t index);
     void toggleFullscreen(PlaybackSessionContextIdentifier);
     void togglePictureInPicture(PlaybackSessionContextIdentifier);
+    void enterFullscreen(PlaybackSessionContextIdentifier);
     void toggleInWindow(PlaybackSessionContextIdentifier);
     void toggleMuted(PlaybackSessionContextIdentifier);
     void setMuted(PlaybackSessionContextIdentifier, bool);

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -199,6 +199,13 @@ void PlaybackSessionModelContext::togglePictureInPicture()
         m_manager->togglePictureInPicture(m_contextId);
 }
 
+void PlaybackSessionModelContext::enterFullscreen()
+{
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
+    if (m_manager)
+        m_manager->enterFullscreen(m_contextId);
+}
+
 void PlaybackSessionModelContext::toggleInWindowFullscreen()
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
@@ -708,6 +715,11 @@ void PlaybackSessionManagerProxy::toggleFullscreen(PlaybackSessionContextIdentif
 void PlaybackSessionManagerProxy::togglePictureInPicture(PlaybackSessionContextIdentifier contextId)
 {
     m_page->send(Messages::PlaybackSessionManager::TogglePictureInPicture(contextId));
+}
+
+void PlaybackSessionManagerProxy::enterFullscreen(PlaybackSessionContextIdentifier contextId)
+{
+    m_page->send(Messages::PlaybackSessionManager::EnterFullscreen(contextId));
 }
 
 void PlaybackSessionManagerProxy::toggleInWindow(PlaybackSessionContextIdentifier contextId)

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -167,6 +167,7 @@ private:
     void handleControlledElementIDRequest(PlaybackSessionContextIdentifier);
     void toggleFullscreen(PlaybackSessionContextIdentifier);
     void togglePictureInPicture(PlaybackSessionContextIdentifier);
+    void enterFullscreen(PlaybackSessionContextIdentifier);
     void toggleInWindow(PlaybackSessionContextIdentifier);
     void toggleMuted(PlaybackSessionContextIdentifier);
     void setMuted(PlaybackSessionContextIdentifier, bool muted);

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in
@@ -40,6 +40,7 @@ messages -> PlaybackSessionManager {
     HandleControlledElementIDRequest(WebKit::PlaybackSessionContextIdentifier contextId)
     ToggleFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)
     TogglePictureInPicture(WebKit::PlaybackSessionContextIdentifier contextId)
+    EnterFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)
     ToggleInWindow(WebKit::PlaybackSessionContextIdentifier contextId)
     ToggleMuted(WebKit::PlaybackSessionContextIdentifier contextId)
     SetMuted(WebKit::PlaybackSessionContextIdentifier contextId, bool muted)

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -533,6 +533,12 @@ void PlaybackSessionManager::togglePictureInPicture(PlaybackSessionContextIdenti
     ensureModel(contextId).togglePictureInPicture();
 }
 
+void PlaybackSessionManager::enterFullscreen(PlaybackSessionContextIdentifier contextId)
+{
+    UserGestureIndicator indicator(IsProcessingUserGesture::Yes);
+    ensureModel(contextId).enterFullscreen();
+}
+
 void PlaybackSessionManager::toggleInWindow(PlaybackSessionContextIdentifier contextId)
 {
     ensureModel(contextId).toggleInWindowFullscreen();


### PR DESCRIPTION
#### 3eb35d50561bd162d00e619c6150ca85a3ab6750
<pre>
Add a button to element fullscreen on visionOS that enters video fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=271198">https://bugs.webkit.org/show_bug.cgi?id=271198</a>
<a href="https://rdar.apple.com/124975583">rdar://124975583</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::enterFullscreen):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::enterFullscreen):
(WebKit::PlaybackSessionManagerProxy::enterFullscreen):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController loadView]):
(-[WKFullScreenViewController _enterVideoFullscreenAction:]):
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::enterFullscreen):
</pre>