### PR TITLE
Word completion suggestion interferes with website's suggestion results

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4784,7 +4784,7 @@ bool Element::isWritingSuggestionsEnabled() const
     // not in the `default` state and the nearest such ancestor's `writingsuggestions` content attribute
     // is in the `false` state, then return `false`.
 
-    for (auto* ancestor = this; ancestor; ancestor = ancestor->parentElementInComposedTree()) {
+    for (RefPtr ancestor = this; ancestor; ancestor = ancestor->parentElementInComposedTree()) {
         auto& value = ancestor->attributeWithoutSynchronization(HTMLNames::writingsuggestionsAttr);
 
         if (value.isNull())
@@ -4794,6 +4794,12 @@ bool Element::isWritingSuggestionsEnabled() const
         if (equalLettersIgnoringASCIICase(value, "false"_s))
             return false;
     }
+
+    // This is not yet part of the spec, but it improves web-compatibility; if autocomplete
+    // is intentionally off, the site author probably wants writingsuggestions off too.
+    auto autocompleteValue = attributeWithoutSynchronization(HTMLNames::autocompleteAttr);
+    if (equalLettersIgnoringASCIICase(autocompleteValue, "off"_s))
+        return false;
 
     if (protectedDocument()->quirks().shouldDisableWritingSuggestionsByDefaultQuirk())
         return false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingSuggestions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingSuggestions.mm
@@ -117,4 +117,12 @@ TEST(WritingSuggestionsWebAPI, ExplicitlyDisabledOnParent)
     EXPECT_EQ(UITextInlinePredictionTypeNo, [webView effectiveTextInputTraits].inlinePredictionType);
 }
 
+TEST(WritingSuggestionsWebAPI, DefaultStateWithDisabledAutocomplete)
+{
+    auto webView = adoptNS([[WritingSuggestionsWebAPIWKWebView alloc] initWithHTMLString:@"<body><input id='input' type='text' autocomplete='off'></input></body>"]);
+    [webView focusElementAndEnsureEditorStateUpdate:@"document.getElementById('input')"];
+
+    EXPECT_EQ(UITextInlinePredictionTypeNo, [webView effectiveTextInputTraits].inlinePredictionType);
+}
+
 #endif


### PR DESCRIPTION
#### ab8b39b36339bb473f6c3f5943732a78d1d87d34
<pre>
Word completion suggestion interferes with website&apos;s suggestion results
<a href="https://bugs.webkit.org/show_bug.cgi?id=271197">https://bugs.webkit.org/show_bug.cgi?id=271197</a>
<a href="https://rdar.apple.com/124727588">rdar://124727588</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

If the value of `writingsuggestions` isn&apos;t explicitly specified, have the default value for it be
`false` instead of `true` if the element has disabled `autocomplete`.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isWritingSuggestionsEnabled const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingSuggestions.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/276344@main">https://commits.webkit.org/276344@main</a>
</pre>
