### PR TITLE
[webkitpy] Move the majority of tests to using pyfakefs

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/__init__.py
@@ -1,4 +1,12 @@
 # Copyright (C) 2020 Apple Inc. All rights reserved.
 
+import os
+import glob
+
 from webkitscmpy.mocks import local
 from webkitscmpy.mocks import remote
+
+
+def add_datafiles_to_pyfakefs(fs):
+    for path in glob.iglob(os.path.join(os.path.dirname(__file__), "*.json")):
+        fs.add_real_file(path)

--- a/Tools/Scripts/webkitpy/common/checkout/checkout_mock.py
+++ b/Tools/Scripts/webkitpy/common/checkout/checkout_mock.py
@@ -31,7 +31,6 @@ from webkitpy.common.checkout.commitinfo import CommitInfo
 # FIXME: These imports are wrong, we should use a shared MockCommittersList.
 from webkitpy.common.config.committers import CommitterList
 from webkitpy.common.net.bugzilla.bugzilla_mock import _mock_reviewers
-from webkitpy.common.system.filesystem_mock import MockFileSystem
 
 
 class MockCommitMessage(object):
@@ -98,10 +97,10 @@ mock_revisions = {
 
 
 class MockCheckout(object):
-    def __init__(self):
+    def __init__(self, filesystem):
         # FIXME: It's unclear if a MockCheckout is very useful.  A normal Checkout
         # with a MockSCM/MockFileSystem/MockExecutive is probably better.
-        self._filesystem = MockFileSystem()
+        self._filesystem = filesystem
 
     def commit_info_for_revision(self, svn_revision):
         if isinstance(svn_revision, str) and svn_revision.startswith('r'):

--- a/Tools/Scripts/webkitpy/common/checkout/scm/detection_unittest.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/detection_unittest.py
@@ -29,18 +29,22 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
+
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.checkout.scm.detection import SCMDetector
-from webkitpy.common.system.filesystem_mock import MockFileSystem
 from webkitpy.common.system.executive_mock import MockExecutive
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 
 from webkitcorepy import OutputCapture
 
 
-class SCMDetectorTest(unittest.TestCase):
+class SCMDetectorTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_detect_scm_system(self):
-        filesystem = MockFileSystem()
+        filesystem = MockCompatibleFileSystem()
         executive = MockExecutive(should_log=True)
         detector = SCMDetector(filesystem, executive)
 

--- a/Tools/Scripts/webkitpy/common/checkout/scm/scm_mock.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/scm_mock.py
@@ -28,16 +28,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from webkitpy.common.checkout.scm import CommitMessage
-from webkitpy.common.system.filesystem_mock import MockFileSystem
-from webkitpy.common.system.executive_mock import MockExecutive
 
 
 class MockSCM(object):
-    def __init__(self, filesystem=None, executive=None):
+    def __init__(self, filesystem, executive):
         self.checkout_root = "/mock-checkout"
         self.added_paths = set()
-        self._filesystem = filesystem or MockFileSystem()
-        self._executive = executive or MockExecutive()
+        self._filesystem = filesystem
+        self._executive = executive
         self._mockChangedFiles = ["MockFile1"]
 
     def add(self, destination_path):

--- a/Tools/Scripts/webkitpy/common/checkout/scm/stub_repository_unittest.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/stub_repository_unittest.py
@@ -20,9 +20,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.common.system.executive_mock import MockExecutive
 from webkitpy.common.host_mock import MockHost
 from webkitpy.common.checkout.scm.stub_repository import StubRepository
@@ -36,12 +36,15 @@ FAKE_FILES = {
 }
 
 
-class StubRepositoryTest(unittest.TestCase):
+class StubRepositoryTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
 
     @staticmethod
     def mock_host_for_stub_repository():
         host = MockHost(create_stub_repository_files=True)
-        host.filesystem = MockFileSystem(files=FAKE_FILES)
+        host.filesystem = MockCompatibleFileSystem(files=FAKE_FILES)
         host.executive = MockExecutive()
         return host
 

--- a/Tools/Scripts/webkitpy/common/host_mock.py
+++ b/Tools/Scripts/webkitpy/common/host_mock.py
@@ -47,7 +47,7 @@ class MockHost(MockSystemHost):
             add_checkout_information_json_to_mock_filesystem(self.filesystem)
         self.web = web or MockWeb()
 
-        self._checkout = MockCheckout()
+        self._checkout = MockCheckout(self.filesystem)
         self._scm = None
         # FIXME: we should never initialize the SCM by default, since the real
         # object doesn't either. This has caused at least one bug (see bug 89498).

--- a/Tools/Scripts/webkitpy/common/message_pool.py
+++ b/Tools/Scripts/webkitpy/common/message_pool.py
@@ -69,6 +69,17 @@ def get(caller, worker_factory, num_workers, worker_startup_delay_secs=0.0, host
 
 class _MessagePool(object):
     def __init__(self, caller, worker_factory, num_workers, worker_startup_delay_secs=0.0, host=None, timeout=30):
+        if (
+            num_workers > 1
+            and sys.platform == "darwin"
+            and (
+                sys.version_info < (3, 4)
+                or multiprocessing.get_start_method() != "spawn"
+            )
+        ):
+            msg = "macOS only supports a single worker when the fork start method is being used"
+            raise ValueError(msg)
+
         self._caller = caller
         self._worker_factory = worker_factory
         self._num_workers = num_workers

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater_unittest.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater_unittest.py
@@ -27,13 +27,14 @@
 
 import io
 import json
-import unittest
 import zipfile
+
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.common.net.bugzilla.test_expectation_updater import TestExpectationUpdater
 from webkitpy.common.system.executive_mock import MockExecutive2
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.thirdparty import mock
 
 
@@ -572,7 +573,10 @@ class MockRequestsGet:
         return json.loads(self.content)
 
 
-class TestExpectationUpdaterTest(unittest.TestCase):
+class TestExpectationUpdaterTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def _exists(self, host, filename):
         return host.filesystem.exists("/mock-checkout/LayoutTests/" + filename)
 
@@ -583,7 +587,7 @@ class TestExpectationUpdaterTest(unittest.TestCase):
         host = MockHost()
         port = host.port_factory.get()
         host.executive = MockExecutive2(exception=OSError())
-        host.filesystem = MockFileSystem(files={
+        host.filesystem = MockCompatibleFileSystem(files={
             '/mock-checkout/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fetch/api/redirect/redirect-location-expected.txt': 'e-wk1',
             '/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/dom/events/EventTarget-dispatchEvent-expected.txt': "g",
             '/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/open-features-tokenization-001-expected.txt': "h",

--- a/Tools/Scripts/webkitpy/common/system/filesystem_mockcompatible.py
+++ b/Tools/Scripts/webkitpy/common/system/filesystem_mockcompatible.py
@@ -1,0 +1,175 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
+
+from pyfakefs.fake_filesystem_unittest import Patcher
+
+from webkitcorepy import string_utils
+
+from . import filesystem
+
+
+class MockCompatibleFileSystem(filesystem.FileSystem):
+    def __init__(self, files=None, dirs=None, cwd="/", reset=False):
+        try:
+            assert Patcher.PATCHER is not None
+        except AttributeError:
+            pass
+
+        super(MockCompatibleFileSystem, self).__init__()
+        self.current_tmpno = 0
+        self.last_tmpdir = None
+        self._written_files = set()
+
+        if reset:
+            self.reset()
+
+        self.maybe_make_directory(cwd)
+        self.chdir(cwd)
+
+        if dirs is not None:
+            for d in dirs:
+                self.maybe_make_directory(d)
+
+        if files is not None:
+            for name, contents in files.items():
+                d = self.dirname(name)
+                if d:
+                    self.maybe_make_directory(d)
+                if contents is None:
+                    continue
+                self.write_binary_file(name, string_utils.encode(contents))
+
+    def reset(self):
+        for path in self.listdir("/"):
+            path = self.join("/", path)
+            if self.isdir(path):
+                self.rmtree(path)
+                # We pass ignore_errors=True to rmtree, so check we didn't error.
+                if self.isdir(path):
+                    raise Exception("Failed to rmtree")
+            else:
+                self.remove(path)
+
+    def write_binary_file(self, path, contents):
+        self._written_files.add(path)
+        d = self.dirname(path)
+        if d:
+            self.maybe_make_directory(d)
+        super(MockCompatibleFileSystem, self).write_binary_file(path, contents)
+
+    def write_text_file(self, path, contents):
+        self._written_files.add(path)
+        d = self.dirname(path)
+        if d:
+            self.maybe_make_directory(d)
+        super(MockCompatibleFileSystem, self).write_text_file(path, contents)
+
+    def move(self, source, destination):
+        d = self.dirname(destination)
+        if d:
+            self.maybe_make_directory(d)
+        super(MockCompatibleFileSystem, self).move(source, destination)
+
+    def expanduser(self, path):
+        if path[0] != "~":
+            return path
+        parts = path.split(self.sep, 1)
+        home_directory = self.sep + "Users" + self.sep + "mock"
+        if len(parts) == 1:
+            return home_directory
+        return home_directory + self.sep + parts[1]
+
+    def path_to_module(self, module_name):
+        return "/mock-checkout/Tools/Scripts/" + module_name.replace(".", "/") + ".py"
+
+    def mkdtemp(self, **kwargs):
+        def _mktemp(suffix="", prefix="tmp", dir=None, **kwargs):
+            if dir is None:
+                dir = self.sep + "__im_tmp"
+            curno = self.current_tmpno
+            self.current_tmpno += 1
+            self.last_tmpdir = self.join(dir, "%s_%u_%s" % (prefix, curno, suffix))
+            self.maybe_make_directory(self.last_tmpdir)
+            return self.last_tmpdir
+
+        old = filesystem.tempfile.mkdtemp
+        filesystem.tempfile.mkdtemp = _mktemp
+        try:
+            return super(MockCompatibleFileSystem, self).mkdtemp(**kwargs)
+        finally:
+            filesystem.tempfile.mkdtemp = old
+
+    def open_text_file_for_writing(self, path, *args, **kwargs):
+        self._written_files.add(path)
+        return super(MockCompatibleFileSystem, self).open_text_file_for_writing(
+            path, *args, **kwargs
+        )
+
+    def clear_written_files(self):
+        self._written_files = set()
+
+    @property
+    def files(self):
+        return FilesMapping(self)
+
+    @property
+    def written_files(self):
+        files = self.files
+        return {k: files.get(k) for k in self._written_files}
+
+    @property
+    def _slow_but_correct_join(self):
+        return self.join
+
+    @property
+    def _slow_but_correct_normpath(self):
+        return self.normpath
+
+
+class FilesMapping(MutableMapping):
+    def __init__(self, fs):
+        self.fs = fs
+
+    def __getitem__(self, name):
+        if not self.fs.isfile(name):
+            return None
+        return self.fs.read_binary_file(name)
+
+    def __setitem__(self, name, value):
+        d = self.fs.dirname(name)
+        if d:
+            self.fs.maybe_make_directory(d)
+        self.fs.write_binary_file(name, string_utils.encode(value))
+
+    def __delitem__(self, name):
+        self.fs.remove(name)
+
+    def __iter__(self):
+        return iter(self.fs.files_under("/"))
+
+    def __len__(self):
+        return len(self.fs.files_under("/"))

--- a/Tools/Scripts/webkitpy/common/system/filesystem_mockcompatible_unittest.py
+++ b/Tools/Scripts/webkitpy/common/system/filesystem_mockcompatible_unittest.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2011 Google Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#    * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#    * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from pyfakefs import fake_filesystem_unittest
+
+from webkitpy.common.system import filesystem_unittest
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
+
+
+class MockCompatibleFileSystemTest(unittest.TestCase, filesystem_unittest.GenericFileSystemTests):
+    def setUp(self):
+
+        self.patcher = fake_filesystem_unittest.Patcher()
+        self.patcher.setUp()
+        self.addCleanup(self.patcher.tearDown)
+
+        self.fs = MockCompatibleFileSystem()
+        self.setup_generic_test_dir()
+
+    def tearDown(self):
+        self.teardown_generic_test_dir()
+        self.fs = None
+
+    def quick_check(self, test_fn, good_fn, *tests):
+        for test in tests:
+            if hasattr(test, '__iter__'):
+                expected = good_fn(*test)
+                actual = test_fn(*test)
+            else:
+                expected = good_fn(test)
+                actual = test_fn(test)
+            self.assertEqual(expected, actual, 'given %s, expected %s, got %s' % (repr(test), repr(expected), repr(actual)))
+
+    def test_join(self):
+        self.quick_check(self.fs.join,
+                         self.fs._slow_but_correct_join,
+                         ('',),
+                         ('', 'bar'),
+                         ('foo',),
+                         ('foo/',),
+                         ('foo', ''),
+                         ('foo/', ''),
+                         ('foo', 'bar'),
+                         ('foo', '/bar'),
+                         )
+
+    def test_normpath(self):
+        self.quick_check(self.fs.normpath,
+                         self.fs._slow_but_correct_normpath,
+                         ('',),
+                         ('/',),
+                         ('.',),
+                         ('/.',),
+                         ('foo',),
+                         ('foo/',),
+                         ('foo/.',),
+                         ('foo/bar',),
+                         ('/foo',),
+                         ('foo/../bar',),
+                         ('foo/../bar/baz',),
+                         ('../foo',))
+
+    def test_dirs_under(self):
+        FAKE_FILES = {
+            '/tests/test1.txt': '',
+            '/tests/test3/test2/test.txt': 'test',
+            '/tests/test2/test.txt': 'test'}
+        fs = MockCompatibleFileSystem(files=FAKE_FILES)
+
+        self.assertEqual(sorted(fs.dirs_under('/tests')), ['/tests', '/tests/test2', '/tests/test3', '/tests/test3/test2'])
+        self.assertEqual(sorted(fs.dirs_under('/tests/')), ['/tests/', '/tests/test2', '/tests/test3', '/tests/test3/test2'])
+
+        def filter_dir(fs, dirpath):
+            return fs.basename(dirpath) != 'test2'
+
+        self.assertEqual(sorted(fs.dirs_under('/tests', filter_dir)), ['/tests', '/tests/test3'])

--- a/Tools/Scripts/webkitpy/common/system/filesystem_unittest.py
+++ b/Tools/Scripts/webkitpy/common/system/filesystem_unittest.py
@@ -329,7 +329,9 @@ class RealFileSystemTest(unittest.TestCase, GenericFileSystemTests):
         fs = FileSystem()
         parentDir = fs.normpath(fs.join(self._this_dir, ".."))
 
-        self.assertTrue(self._this_dir in fs.dirs_under(parentDir))
+        self.assertIn(self._this_dir, fs.dirs_under(parentDir))
+
+        self.assertNotIn(parentDir, fs.dirs_under(fs.join(parentDir, "")))
 
         def filter_no_dir(fs, dirpath):
             return False

--- a/Tools/Scripts/webkitpy/common/system/profiler_unittest.py
+++ b/Tools/Scripts/webkitpy/common/system/profiler_unittest.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.system.platforminfo_mock import MockPlatformInfo
 from webkitpy.common.system.systemhost_mock import MockSystemHost
@@ -34,7 +34,10 @@ from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.common.system.profiler import ProfilerFactory, GooglePProf
 
 
-class ProfilerFactoryTest(unittest.TestCase):
+class ProfilerFactoryTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def _assert_default_profiler_name(self, os_name, expected_profiler_name):
         profiler_name = ProfilerFactory.default_profiler_name(MockPlatformInfo(os_name))
         self.assertEqual(profiler_name, expected_profiler_name)
@@ -60,7 +63,10 @@ class ProfilerFactoryTest(unittest.TestCase):
         self.assertEqual(profiler._output_path, "/tmp/output/test.data")
 
 
-class GooglePProfTest(unittest.TestCase):
+class GooglePProfTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_pprof_output_regexp(self):
         pprof_output = """
 sometimes

--- a/Tools/Scripts/webkitpy/common/system/systemhost_mock.py
+++ b/Tools/Scripts/webkitpy/common/system/systemhost_mock.py
@@ -29,7 +29,7 @@
 
 from webkitpy.common.system.environment import Environment
 from webkitpy.common.system.executive_mock import MockExecutive
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.common.system.platforminfo_mock import MockPlatformInfo
 from webkitpy.common.system.user_mock import MockUser
 from webkitpy.common.system.workspace_mock import MockWorkspace
@@ -40,7 +40,7 @@ from webkitcorepy import mocks
 class MockSystemHost(object):
     def __init__(self, log_executive=False, executive_throws_when_run=None, os_name=None, os_version=None, executive=None, filesystem=None):
         self.executive = executive or MockExecutive(should_log=log_executive, should_throw_when_run=executive_throws_when_run)
-        self.filesystem = filesystem or MockFileSystem()
+        self.filesystem = filesystem or MockCompatibleFileSystem()
         self.user = MockUser()
         self.platform = MockPlatformInfo()
         if os_name:

--- a/Tools/Scripts/webkitpy/common/system/workspace_unittest.py
+++ b/Tools/Scripts/webkitpy/common/system/workspace_unittest.py
@@ -26,16 +26,19 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.common.system.workspace import Workspace
 
 
-class WorkspaceTest(unittest.TestCase):
+class WorkspaceTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
 
     def test_find_unused_filename(self):
-        filesystem = MockFileSystem({
+        filesystem = MockCompatibleFileSystem({
             "dir/foo.jpg": "",
             "dir/foo-1.jpg": "",
             "dir/foo-2.jpg": "",

--- a/Tools/Scripts/webkitpy/common/test_expectations_unittest.py
+++ b/Tools/Scripts/webkitpy/common/test_expectations_unittest.py
@@ -20,7 +20,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.common.test_expectations import TestExpectations
@@ -41,7 +41,10 @@ class MockTestExpectations(TestExpectations):
         return subtest in self.skipped_subtests(test)
 
 
-class ExpectationsTest(unittest.TestCase):
+class ExpectationsTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
 
     BASIC = """
 {

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py
@@ -26,13 +26,11 @@
 import errno
 import json
 import sys
-import unittest
 
-from pyfakefs.fake_filesystem_unittest import TestCaseMixin
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.common.system.filesystem import FileSystem
-from webkitpy.common.system.filesystem_mock import MockFileSystem
 from webkitpy.layout_tests.controllers.layout_test_finder_legacy import (
     LayoutTestFinder,
     _is_reference_html_file,
@@ -44,7 +42,7 @@ from webkitpy.port.test import (
 )
 
 
-class LayoutTestFinderTests(unittest.TestCase, TestCaseMixin):
+class LayoutTestFinderTests(fake_filesystem_unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(LayoutTestFinderTests, self).__init__(*args, **kwargs)
         self.port = None
@@ -62,7 +60,7 @@ class LayoutTestFinderTests(unittest.TestCase, TestCaseMixin):
         self.finder = None
 
     def test_is_reference_html_file(self):
-        filesystem = MockFileSystem()
+        filesystem = self.port.host.filesystem
         self.assertTrue(_is_reference_html_file(filesystem, '', 'foo-expected.html'))
         self.assertTrue(_is_reference_html_file(filesystem, '', 'foo-expected-mismatch.xml'))
         self.assertTrue(_is_reference_html_file(filesystem, '', 'foo-ref.xhtml'))

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py
@@ -28,7 +28,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import pickle
-import unittest
+
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.common.system.systemhost_mock import MockSystemHost
@@ -75,7 +76,10 @@ class FakePrinter(object):
         pass
 
 
-class LayoutTestRunnerTests(unittest.TestCase):
+class LayoutTestRunnerTests(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def _runner(self, port=None):
         # FIXME: we shouldn't have to use run_webkit_tests.py to get the options we need.
         options = run_webkit_tests.parse_args(['--platform', 'test-mac-snowleopard'])[0]
@@ -270,7 +274,10 @@ class LayoutTestRunnerTests(unittest.TestCase):
         self.assertEqual(self.web_platform_test_server_stopped, False)
 
 
-class SharderTests(unittest.TestCase):
+class SharderTests(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
 
     test_list = [
         "http/tests/websocket/tests/unicode.htm",
@@ -328,7 +335,10 @@ class SharderTests(unittest.TestCase):
              ('.', ['dom/html/level2/html/HTMLAnchorElement06.html'])])
 
 
-class ShardTests(unittest.TestCase):
+class ShardTests(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_pickle(self):
         tests = [
             Test(

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 
 # Copyright (C) 2010 Google Inc. All rights reserved.
 # Copyright (C) 2010 Gabor Rapcsanyi (rgabor@inf.u-szeged.hu), University of Szeged

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager_unittest.py
@@ -30,19 +30,21 @@
 """Unit tests for manager.py."""
 
 import time
-import unittest
+
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.layout_tests.controllers.manager import Manager
 from webkitpy.layout_tests.models import test_expectations
 from webkitpy.layout_tests.models.test_run_results import TestRunResults
-from webkitpy.port.test import TestPort
 from webkitpy.thirdparty.mock import Mock
 from webkitpy.tool.mocktool import MockOptions
-from webkitpy.xcode.device_type import DeviceType
 
 
-class ManagerTest(unittest.TestCase):
+class ManagerTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_look_for_new_crash_logs(self):
         def get_manager():
             host = MockHost()

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner_unittest.py
@@ -21,7 +21,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
-import unittest
+
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.layout_tests.controllers.single_test_runner import SingleTestRunner
@@ -44,7 +45,10 @@ class TestDriver:
         """do nothing"""
 
 
-class SingleTestRunnerTest(unittest.TestCase):
+class SingleTestRunnerTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
 
     def _add_file(self, port, file_path, contents):
         filesystem = port.host.filesystem

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py
@@ -23,7 +23,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.layout_tests.controllers import test_result_writer
@@ -33,7 +33,10 @@ from webkitpy.port.test import TestPort
 from webkitpy.port.image_diff import ImageDiffResult
 
 
-class TestResultWriterTest(unittest.TestCase):
+class TestResultWriterTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
 
     def test_reftest_diff_image(self):
         """A write_test_result should call port.diff_image with tolerance=0 in case of FailureReftestMismatch."""

--- a/Tools/Scripts/webkitpy/layout_tests/lint_test_expectations_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/lint_test_expectations_unittest.py
@@ -27,8 +27,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import optparse
-import unittest
 
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import StringIO
 
 from webkitpy.common.host_mock import MockHost
@@ -78,7 +78,10 @@ class FakeFactory(object):
         return sorted(self.ports.keys())
 
 
-class LintTest(unittest.TestCase):
+class LintTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_all_configurations(self):
         host = MockHost()
         host.ports_parsed = []
@@ -127,7 +130,10 @@ class LintTest(unittest.TestCase):
         self.assertIn('bar:1', logging_stream.getvalue())
 
 
-class MainTest(unittest.TestCase):
+class MainTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_success(self):
         orig_lint_fn = lint_test_expectations.lint
 
@@ -145,7 +151,7 @@ class MainTest(unittest.TestCase):
         stderr = StringIO()
         try:
             lint_test_expectations.lint = interrupting_lint
-            res = lint_test_expectations.main([], stdout, stderr)
+            res = lint_test_expectations.main(['--platform', 'test'], stdout, stderr)
             self.assertEqual(res, lint_test_expectations.INTERRUPTED_EXIT_STATUS)
 
             lint_test_expectations.lint = successful_lint
@@ -153,7 +159,7 @@ class MainTest(unittest.TestCase):
             self.assertEqual(res, 0)
 
             lint_test_expectations.lint = exception_raising_lint
-            res = lint_test_expectations.main([], stdout, stderr)
+            res = lint_test_expectations.main(['--platform', 'test'], stdout, stderr)
             self.assertEqual(res, lint_test_expectations.EXCEPTIONAL_EXIT_STATUS)
         finally:
             lint_test_expectations.lint = orig_lint_fn

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_expectations_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_expectations_unittest.py
@@ -27,12 +27,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from collections import OrderedDict
 
+from pyfakefs import fake_filesystem_unittest
+from webkitcorepy import OutputCapture
 from collections import OrderedDict
 
 from webkitpy.common.host_mock import MockHost
-
 from webkitpy.layout_tests.models.test_configuration import *
 from webkitpy.layout_tests.models.test_expectations import *
 from webkitpy.layout_tests.models.test_configuration import *
@@ -40,15 +41,15 @@ from webkitpy.layout_tests.models.test_configuration import *
 from webkitcorepy import OutputCapture
 
 
-class Base(unittest.TestCase):
+class Base(fake_filesystem_unittest.TestCase):
     # Note that all of these tests are written assuming the configuration
     # being tested is Windows XP, Release build.
 
-    def __init__(self, testFunc):
+    def setUp(self):
+        self.setUpPyfakefs()
         host = MockHost()
         self._port = host.port_factory.get('test-win-xp', None)
         self._exp = None
-        unittest.TestCase.__init__(self, testFunc)
 
     def get_basic_tests(self):
         return ['failures/expected/text.html',
@@ -590,12 +591,12 @@ class RebaseliningTest(Base):
         self.assertEqual(len(self._exp.get_rebaselining_failures()), 0)
 
 
-class TestExpectationSerializationTests(unittest.TestCase):
-    def __init__(self, testFunc):
+class TestExpectationSerializationTests(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
         host = MockHost()
         test_port = host.port_factory.get('test-win-xp', None)
         self._converter = TestConfigurationConverter(test_port.all_test_configurations(), test_port.configuration_specifier_macros())
-        unittest.TestCase.__init__(self, testFunc)
 
     def _tokenize(self, line):
         return TestExpectationParser._tokenize_line('path', line, 0)

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.layout_tests.models import test_expectations
@@ -119,8 +119,9 @@ def summarized_results(port, expected, passing, flaky, include_passes=False):
         enabled_pixel_tests_in_retry=False, include_passes=include_passes)
 
 
-class InterpretTestFailuresTest(unittest.TestCase):
+class InterpretTestFailuresTest(fake_filesystem_unittest.TestCase):
     def setUp(self):
+        self.setUpPyfakefs()
         host = MockHost()
         self.port = host.port_factory.get(port_name='test')
 
@@ -149,8 +150,9 @@ class InterpretTestFailuresTest(unittest.TestCase):
         self.assertIn('is_missing_image', test_dict)
 
 
-class SummarizedResultsTest(unittest.TestCase):
+class SummarizedResultsTest(fake_filesystem_unittest.TestCase):
     def setUp(self):
+        self.setUpPyfakefs()
         host = MockHost(initialize_scm_by_default=False, create_stub_repository_files=True)
         self.port = host.port_factory.get(port_name='test', options=MockOptions(http=True, pixel_tests=False, world_leaks=False))
 
@@ -159,30 +161,50 @@ class SummarizedResultsTest(unittest.TestCase):
         self.assertNotIn('revision', summary)
 
     def test_git_revision_identifier(self):
+        self.fs.pause()
+        mocks.add_datafiles_to_pyfakefs(self.fs)
+        self.fs.resume()
+
         with mocks.local.Git(path='/'), OutputCapture():
             self.port._options.builder_name = 'dummy builder'
             summary = summarized_results(self.port, expected=False, passing=False, flaky=False)
             self.assertEqual(summary['revision'], '5@main')
 
     def test_summarized_results_wontfix(self):
+        self.fs.pause()
+        mocks.add_datafiles_to_pyfakefs(self.fs)
+        self.fs.resume()
+
         with mocks.local.Git(path='/'), OutputCapture():
             self.port._options.builder_name = 'dummy builder'
             summary = summarized_results(self.port, expected=False, passing=False, flaky=False)
             self.assertTrue(summary['tests']['failures']['expected']['hang.html']['wontfix'])
 
     def test_summarized_results_include_passes(self):
+        self.fs.pause()
+        mocks.add_datafiles_to_pyfakefs(self.fs)
+        self.fs.resume()
+
         with mocks.local.Git(path='/'), OutputCapture():
             self.port._options.builder_name = 'dummy builder'
             summary = summarized_results(self.port, expected=False, passing=True, flaky=False, include_passes=True)
             self.assertEqual(summary['tests']['passes']['text.html']['expected'], 'PASS')
 
     def test_summarized_results_world_leaks_disabled(self):
+        self.fs.pause()
+        mocks.add_datafiles_to_pyfakefs(self.fs)
+        self.fs.resume()
+
         with mocks.local.Git(path='/'), OutputCapture():
             self.port._options.builder_name = 'dummy builder'
             summary = summarized_results(self.port, expected=False, passing=True, flaky=False, include_passes=True)
             self.assertEqual(summary['tests']['failures']['expected']['leak.html']['expected'], 'PASS')
 
     def test_summarized_run_metadata(self):
+        self.fs.pause()
+        mocks.add_datafiles_to_pyfakefs(self.fs)
+        self.fs.resume()
+
         with mocks.local.Git(path='/'), OutputCapture():
             self.port._options.builder_name = 'dummy builder'
             summary = summarized_results(self.port, expected=False, passing=True, flaky=False, include_passes=True)

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
@@ -830,7 +830,9 @@ class RunTest(fake_filesystem_unittest.TestCase, StreamTestingMixin):
         # We run a configuration that should fail, to generate output, then
         # look for what the output results url was.
         host = MockHost()
-        host.filesystem.remove('/tmp')  # Remove the /tmp symlink.
+        if host.filesystem.exists('/tmp'):
+            # Remove any /tmp symlink.
+            host.filesystem.remove('/tmp')
         host.filesystem.maybe_make_directory('/tmp/cwd')
         host.filesystem.chdir('/tmp/cwd')
         _, _, user = logging_run(['--results-directory=foo'], tests_included=True, host=host)

--- a/Tools/Scripts/webkitpy/layout_tests/servers/apache_http_server_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/apache_http_server_unittest.py
@@ -28,7 +28,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import sys
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.system.executive_mock import MockExecutive
 from webkitpy.common.host_mock import MockHost
@@ -38,7 +38,10 @@ from webkitpy.layout_tests.servers.apache_http_server import LayoutTestApacheHtt
 from webkitcorepy import OutputCapture
 
 
-class TestLayoutTestApacheHttpd(unittest.TestCase):
+class TestLayoutTestApacheHttpd(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_start_cmd(self):
         # Fails on win - see https://bugs.webkit.org/show_bug.cgi?id=84726
         if sys.platform.startswith('win') or sys.platform == 'cygwin':

--- a/Tools/Scripts/webkitpy/layout_tests/servers/http_server_base_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/http_server_base_unittest.py
@@ -26,14 +26,17 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.port import test
 from webkitpy.layout_tests.servers.http_server_base import HttpServerBase
 
 
-class TestHttpServerBase(unittest.TestCase):
+class TestHttpServerBase(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_corrupt_pid_file(self):
         # This tests that if the pid file is corrupt or invalid,
         # both start() and stop() deal with it correctly and delete the file.

--- a/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server_unittest.py
@@ -22,20 +22,19 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import optparse
-import sys
-import time
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
-from webkitpy.common.system.filesystem import FileSystem
 from webkitpy.port import Port
-from webkitpy.tool.mocktool import MockOptions
 
 from webkitpy.layout_tests.servers.http_server_base import ServerError
 from webkitpy.layout_tests.servers.web_platform_test_server import WebPlatformTestServer
 
 
-class TestWebPlatformTestServer(unittest.TestCase):
+class TestWebPlatformTestServer(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_previously_spawned_instance(self):
         host = MockHost()
         options = optparse.Values()

--- a/Tools/Scripts/webkitpy/layout_tests/servers/websocket_server_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/websocket_server_unittest.py
@@ -26,17 +26,20 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import re
 import sys
-import unittest
+
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
-from webkitpy.port import test
-from webkitpy.layout_tests.servers.websocket_server import PyWebSocket
 from webkitpy.layout_tests.servers.http_server_base import ServerError
+from webkitpy.layout_tests.servers.websocket_server import PyWebSocket
+from webkitpy.port import test
 
 
-class TestWebsocketServer(unittest.TestCase):
+class TestWebsocketServer(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_start_cmd(self):
         # Fails on win - see https://bugs.webkit.org/show_bug.cgi?id=84726
         if sys.platform.startswith('win') or sys.platform == 'cygwin':

--- a/Tools/Scripts/webkitpy/layout_tests/views/buildbot_results_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/views/buildbot_results_unittest.py
@@ -26,8 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
-
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import StringIO
 
 from webkitpy.common.host_mock import MockHost
@@ -37,7 +36,10 @@ from webkitpy.layout_tests.models import test_run_results_unittest
 from webkitpy.layout_tests.views import buildbot_results
 
 
-class BuildBotPrinterTests(unittest.TestCase):
+class BuildBotPrinterTests(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def assertEmpty(self, stream):
         self.assertFalse(stream.getvalue())
 

--- a/Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py
@@ -30,8 +30,8 @@
 
 import optparse
 import sys
-import unittest
 
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import StringIO
 
 from webkitpy.common.host_mock import MockHost
@@ -47,13 +47,19 @@ def get_options(args):
     return option_parser.parse_args(args)
 
 
-class TestUtilityFunctions(unittest.TestCase):
+class TestUtilityFunctions(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_print_options(self):
         options, args = get_options([])
         self.assertIsNotNone(options)
 
 
-class  Testprinter(unittest.TestCase):
+class Testprinter(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def assertEmpty(self, stream):
         self.assertFalse(stream.getvalue())
 

--- a/Tools/Scripts/webkitpy/performance_tests/perftest_unittest.py
+++ b/Tools/Scripts/webkitpy/performance_tests/perftest_unittest.py
@@ -28,7 +28,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
+
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.port.driver import DriverOutput
@@ -46,7 +47,10 @@ class MockPort(TestPort):
         super(MockPort, self).__init__(host=MockHost(), custom_run_test=custom_run_test)
 
 
-class TestPerfTestMetric(unittest.TestCase):
+class TestPerfTestMetric(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_init_set_missing_unit(self):
         self.assertEqual(PerfTestMetric(['some', 'test'], 'some/test.html', 'Time', iterations=[1, 2, 3, 4, 5]).unit(), 'ms')
         self.assertEqual(PerfTestMetric(['some', 'test'], 'some/test.html', 'Malloc', iterations=[1, 2, 3, 4, 5]).unit(), 'bytes')
@@ -87,7 +91,10 @@ class TestPerfTestMetric(unittest.TestCase):
         self.assertEqual(metric.flattened_iteration_values(), [1, 2, 4, 5])
 
 
-class TestPerfTest(unittest.TestCase):
+class TestPerfTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def _assert_results_are_correct(self, test, output):
         test.run_single = lambda driver, path, time_out_ms: output
         self.assertTrue(test.run(10))
@@ -284,7 +291,10 @@ median= 2324.0 ms, stdev= 12.1326007105 ms, min= 2312.0 ms, max= 2345.0 ms
 """)
 
 
-class TestSingleProcessPerfTest(unittest.TestCase):
+class TestSingleProcessPerfTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_use_only_one_process(self):
         called = [0]
 
@@ -301,7 +311,10 @@ Description: this is a test description.
         self.assertEqual(called[0], 1)
 
 
-class TestPerfTestFactory(unittest.TestCase):
+class TestPerfTestFactory(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_regular_test(self):
         test = PerfTestFactory.create_perf_test(MockPort(), 'some-dir/some-test', '/path/some-dir/some-test')
         self.assertEqual(test.__class__, PerfTest)

--- a/Tools/Scripts/webkitpy/performance_tests/perftestsrunner_integrationtest.py
+++ b/Tools/Scripts/webkitpy/performance_tests/perftestsrunner_integrationtest.py
@@ -33,7 +33,7 @@ import datetime
 import json
 import logging
 import re
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.port.driver import DriverOutput
@@ -159,7 +159,10 @@ class TestDriver:
         """do nothing"""
 
 
-class MainTest(unittest.TestCase):
+class MainTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def _normalize_output(self, log):
         return re.sub(r'(stdev=\s+\d+\.\d{5})\d+', r'\1', re.sub(r'Finished: [0-9\.]+ s', 'Finished: 0.1 s', log))
 

--- a/Tools/Scripts/webkitpy/performance_tests/perftestsrunner_unittest.py
+++ b/Tools/Scripts/webkitpy/performance_tests/perftestsrunner_unittest.py
@@ -31,8 +31,8 @@
 
 import json
 import logging
-import unittest
 
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import BytesIO
 
 from webkitpy.common.host_mock import MockHost
@@ -42,7 +42,10 @@ from webkitpy.performance_tests.perftestsrunner import PerfTestsRunner
 from webkitcorepy import OutputCapture
 
 
-class MainTest(unittest.TestCase):
+class MainTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def create_runner(self, args=[]):
         options, parsed_args = PerfTestsRunner._parse_args(args)
         test_port = TestPort(host=MockHost(), options=options)
@@ -52,7 +55,7 @@ class MainTest(unittest.TestCase):
         runner._host.filesystem.maybe_make_directory(runner._base_path, 'Parser')
         return runner, test_port
 
-    def _add_file(self, runner, dirname, filename, content=True):
+    def _add_file(self, runner, dirname, filename, content=""):
         dirname = runner._host.filesystem.join(runner._base_path, dirname) if dirname else runner._base_path
         runner._host.filesystem.maybe_make_directory(dirname)
         runner._host.filesystem.files[runner._host.filesystem.join(dirname, filename)] = content

--- a/Tools/Scripts/webkitpy/port/darwin_testcase.py
+++ b/Tools/Scripts/webkitpy/port/darwin_testcase.py
@@ -26,7 +26,7 @@ import time
 
 from webkitpy.port import port_testcase
 from webkitpy.tool.mocktool import MockOptions
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.common.system.executive_mock import MockExecutive, MockExecutive2, MockProcess, ScriptError
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.common.version_name_map import VersionNameMap
@@ -95,7 +95,7 @@ class DarwinTest(port_testcase.PortTestCase):
         port = self.make_port()
         self.assertEqual(port.path_to_crash_logs(), '/Users/mock/Library/Logs/CrashReporter')
 
-        host = MockSystemHost(filesystem=MockFileSystem(files={'/Users/mock/Library/Logs/DiagnosticReports/crashlog.crash': None}))
+        host = MockSystemHost(filesystem=MockCompatibleFileSystem(files={'/Users/mock/Library/Logs/DiagnosticReports/crashlog.crash': None}))
         port = self.make_port(host)
         self.assertEqual(port.path_to_crash_logs(), '/Users/mock/Library/Logs/DiagnosticReports')
 
@@ -116,7 +116,7 @@ class DarwinTest(port_testcase.PortTestCase):
 ['/usr/sbin/spindump', '-i', '/__im_tmp/tmp_0_/test-42-tailspin-temp.txt', '-file', '/__im_tmp/tmp_0_/test-42-tailspin.txt', '-noBulkSymbolication']
 """,
         )
-        self.assertEqual(port.host.filesystem.files['/mock-build/layout-test-results/test-42-tailspin.txt'], 'Symbolocated tailspin file')
+        self.assertEqual(port.host.filesystem.files['/mock-build/layout-test-results/test-42-tailspin.txt'], b'Symbolocated tailspin file')
         self.assertIsNone(port.host.filesystem.files['/__im_tmp/tmp_0_/test-42-tailspin-temp.txt'])
         self.assertIsNone(port.host.filesystem.files['/__im_tmp/tmp_0_/test-42-tailspin.txt'])
 
@@ -129,7 +129,7 @@ class DarwinTest(port_testcase.PortTestCase):
             return 0
 
         port = self.make_port()
-        port.host.filesystem.files['/__im_tmp/tmp_0_/test-42-sample.txt'] = 'Sample file'
+        port.host.filesystem.files['/__im_tmp/tmp_0_/test-42-sample.txt'] = b'Sample file'
         port.host.executive = MockExecutive2(run_command_fn=logging_run_command)
         with OutputCapture() as captured:
             port.sample_process('test', 42)
@@ -137,7 +137,7 @@ class DarwinTest(port_testcase.PortTestCase):
             captured.stdout.getvalue(),
             "['/usr/bin/sample', 42, 10, 10, '-file', '/__im_tmp/tmp_0_/test-42-sample.txt']\n",
         )
-        self.assertEqual(port.host.filesystem.files['/mock-build/layout-test-results/test-42-sample.txt'], 'Sample file')
+        self.assertEqual(port.host.filesystem.files['/mock-build/layout-test-results/test-42-sample.txt'], b'Sample file')
         self.assertIsNone(port.host.filesystem.files['/__im_tmp/tmp_0_/test-42-sample.txt'])
 
     def test_sample_process_exception(self):

--- a/Tools/Scripts/webkitpy/port/driver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/driver_unittest.py
@@ -26,8 +26,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
 import optparse
+
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 
@@ -44,7 +45,10 @@ import os
 import sys
 
 
-class DriverOutputTest(unittest.TestCase):
+class DriverOutputTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_strip_metrics(self):
         patterns = [
             ('RenderView at (0,0) size 800x600', 'RenderView '),
@@ -85,7 +89,10 @@ class DriverOutputTest(unittest.TestCase):
             self.assertEqual(driver_output.text, pattern[1])
 
 
-class DriverTest(unittest.TestCase):
+class DriverTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def make_port(self, host=None, options=None):
         port = Port(host or MockSystemHost(), 'test', options or MockOptions(configuration='Release'))
         port._config.build_directory = lambda configuration: '/mock-build'

--- a/Tools/Scripts/webkitpy/port/factory_unittest.py
+++ b/Tools/Scripts/webkitpy/port/factory_unittest.py
@@ -27,7 +27,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitcorepy import Version
 
@@ -40,12 +40,13 @@ from webkitpy.port import mac
 from webkitpy.port import win
 
 
-class FactoryTest(unittest.TestCase):
+class FactoryTest(fake_filesystem_unittest.TestCase):
     """Test that the factory creates the proper port object for given combination of port_name, host.platform, and options."""
     # FIXME: The ports themselves should expose what options they require,
     # instead of passing generic "options".
 
     def setUp(self):
+        self.setUpPyfakefs()
         self.webkit_options = MockOptions(pixel_tests=False)
 
     def assert_port(self, port_name=None, os_name=None, os_version=None, options=None, cls=None):

--- a/Tools/Scripts/webkitpy/port/gtk_unittest.py
+++ b/Tools/Scripts/webkitpy/port/gtk_unittest.py
@@ -28,15 +28,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import os
-import sys
-import unittest
 
 from webkitpy.common.system.executive_mock import MockExecutive
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.port.gtk import GtkPort
 from webkitpy.port import port_testcase
-from webkitpy.thirdparty.mock import Mock
 from webkitpy.tool.mocktool import MockOptions
 
 from webkitcorepy import OutputCapture
@@ -64,7 +60,7 @@ class GtkPortTest(port_testcase.PortTestCase):
     def test_show_results_html_file(self):
         port = self.make_port()
         port._executive = MockExecutive(should_log=True)
-        port._filesystem = MockFileSystem({
+        port._filesystem = MockCompatibleFileSystem({
             "/mock-build/bin/MiniBrowser": ""
         })
         with OutputCapture(level=logging.INFO) as captured:
@@ -99,7 +95,7 @@ class GtkPortTest(port_testcase.PortTestCase):
 
     def test_gtk4_expectations_binary_only(self):
         port = self.make_port()
-        port._filesystem = MockFileSystem({
+        port._filesystem = MockCompatibleFileSystem({
             "/mock-build/lib/libwebkitgtk-6.0.so": ""
         })
         with OutputCapture() as _:
@@ -112,7 +108,7 @@ class GtkPortTest(port_testcase.PortTestCase):
 
     def test_gtk3_expectations_binary_only(self):
         port = self.make_port()
-        port._filesystem = MockFileSystem({
+        port._filesystem = MockCompatibleFileSystem({
             "/mock-build/lib/libwebkit2gtk-4.0.so": ""
         })
 
@@ -125,7 +121,7 @@ class GtkPortTest(port_testcase.PortTestCase):
 
     def test_gtk_expectations_both_binaries(self):
         port = self.make_port()
-        port._filesystem = MockFileSystem({
+        port._filesystem = MockCompatibleFileSystem({
             "/mock-build/lib/libwebkit2gtk-4.0.so": "",
             "/mock-build/lib/libwebkitgtk-6.0.so": ""
         })

--- a/Tools/Scripts/webkitpy/port/headlessdriver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/headlessdriver_unittest.py
@@ -27,7 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.port import Port
@@ -39,7 +39,10 @@ from webkitpy.tool.mocktool import MockOptions
 _log = logging.getLogger(__name__)
 
 
-class HeadlessDriverTest(unittest.TestCase):
+class HeadlessDriverTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def make_driver(self, worker_number=0, xorg_running=False, executive=None):
         port = Port(MockSystemHost(log_executive=True, executive=executive), 'headlessdrivertestport', options=MockOptions(configuration='Release'))
         port._config.build_directory = lambda configuration: '/mock-build'

--- a/Tools/Scripts/webkitpy/port/ios_device_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_device_unittest.py
@@ -65,7 +65,7 @@ class IOSDeviceTest(ios_testcase.IOSTest):
 """,
         )
 
-        self.assertEqual(port.host.filesystem.files['/mock-build/layout-test-results/test-42-tailspin.txt'], 'Symbolocated tailspin file')
+        self.assertEqual(port.host.filesystem.files['/mock-build/layout-test-results/test-42-tailspin.txt'], b'Symbolocated tailspin file')
         self.assertIsNone(port.host.filesystem.files['/__im_tmp/tmp_0_/test-42-tailspin-temp.txt'])
         self.assertIsNone(port.host.filesystem.files['/__im_tmp/tmp_0_/test-42-tailspin.txt'])
 
@@ -77,7 +77,7 @@ class IOSDeviceTest(ios_testcase.IOSTest):
             return 0
 
         port = self.make_port()
-        port.host.filesystem.files['/__im_tmp/tmp_0_/test-42-sample.txt'] = 'Sample file'
+        port.host.filesystem.files['/__im_tmp/tmp_0_/test-42-sample.txt'] = b'Sample file'
         port.host.executive = MockExecutive2(run_command_fn=logging_run_command)
 
         with OutputCapture() as captured:
@@ -87,7 +87,7 @@ class IOSDeviceTest(ios_testcase.IOSTest):
             "['/usr/bin/sample', 42, 10, 10, '-file', '/__im_tmp/tmp_0_/test-42-sample.txt']\n",
         )
 
-        self.assertEqual(port.host.filesystem.files['/mock-build/layout-test-results/test-42-sample.txt'], 'Sample file')
+        self.assertEqual(port.host.filesystem.files['/mock-build/layout-test-results/test-42-sample.txt'], b'Sample file')
         self.assertIsNone(port.host.filesystem.files['/__im_tmp/tmp_0_/test-42-sample.txt'])
 
     def test_sample_process_exception(self):

--- a/Tools/Scripts/webkitpy/port/leakdetector_unittest.py
+++ b/Tools/Scripts/webkitpy/port/leakdetector_unittest.py
@@ -27,20 +27,23 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.port.leakdetector import LeakDetector
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.common.system.executive_mock import MockExecutive
 
 from webkitcorepy import OutputCapture
 
 
-class LeakDetectorTest(unittest.TestCase):
+class LeakDetectorTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def _mock_port(self):
         class MockPort(object):
             def __init__(self):
-                self._filesystem = MockFileSystem()
+                self._filesystem = MockCompatibleFileSystem()
                 self._executive = MockExecutive()
 
             def results_directory(self):
@@ -121,7 +124,7 @@ Binary Images:
     def test_leaks_files_in_directory(self):
         detector = self._make_detector()
         self.assertEqual(detector.leaks_files_in_directory('/bogus-directory'), [])
-        detector._filesystem = MockFileSystem({
+        detector._filesystem = MockCompatibleFileSystem({
             '/mock-results/DumpRenderTree-1234-leaks.txt': '',
             '/mock-results/DumpRenderTree-23423-leaks.txt': '',
             '/mock-results/DumpRenderTree-823-leaks.txt': '',
@@ -151,7 +154,7 @@ total: 5,888 bytes (0 bytes excluded)."""
 
     def test_count_total_leaks(self):
         detector = self._make_detector()
-        detector._filesystem = MockFileSystem({
+        detector._filesystem = MockCompatibleFileSystem({
             # The \xff is some non-utf8 characters to make sure we don't blow up trying to parse the file.
             '/mock-results/DumpRenderTree-1234-leaks.txt': '\xff\nProcess 1234: 12 leaks for 40 total leaked bytes.\n\xff\n',
             '/mock-results/DumpRenderTree-23423-leaks.txt': 'Process 1235: 12341 leaks for 27934 total leaked bytes.\n',

--- a/Tools/Scripts/webkitpy/port/leakdetector_valgrind_unittest.py
+++ b/Tools/Scripts/webkitpy/port/leakdetector_valgrind_unittest.py
@@ -24,12 +24,12 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
 
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import string_utils, OutputCapture
 
 from webkitpy.common.system.executive_mock import MockExecutive2
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.port.leakdetector_valgrind import LeakDetectorValgrind
 
 
@@ -812,7 +812,10 @@ def mock_run_cppfilt_command(args):
     return ""
 
 
-class LeakDetectorValgrindTest(unittest.TestCase):
+class LeakDetectorValgrindTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
 
     def test_parse_and_print_leaks_detail_pass(self):
         mock_valgrind_output1 = make_mock_valgrind_output('DumpRenderTree', 28529, 'db92e4843be411e3bae1d43d7e01ba08')
@@ -821,7 +824,7 @@ class LeakDetectorValgrindTest(unittest.TestCase):
         files['/tmp/layout-test-results/drt-28529-db92e4843be411e3bae1d43d7e01ba08-leaks.xml'] = mock_valgrind_output1
         files['/tmp/layout-test-results/drt-28530-dd7213423be411e3aa7fd43d7e01ba08-leaks.xml'] = mock_valgrind_output2
 
-        leakdetector_valgrind = LeakDetectorValgrind(MockExecutive2(run_command_fn=mock_run_cppfilt_command), MockFileSystem(files), '/tmp/layout-test-results/')
+        leakdetector_valgrind = LeakDetectorValgrind(MockExecutive2(run_command_fn=mock_run_cppfilt_command), MockCompatibleFileSystem(files), '/tmp/layout-test-results/')
 
         with OutputCapture(level=logging.INFO) as captured:
             leakdetector_valgrind.parse_and_print_leaks_detail(files)
@@ -831,7 +834,7 @@ class LeakDetectorValgrindTest(unittest.TestCase):
         mock_incomplete_valgrind_output = make_mock_incomplete_valgrind_output('DumpRenderTree', 28531, 'e8c7d7b83be411e390c9d43d7e01ba08')
         files = {}
         files['/tmp/layout-test-results/drt-28531-e8c7d7b83be411e390c9d43d7e01ba08-leaks.xml'] = mock_incomplete_valgrind_output
-        leakdetector_valgrind = LeakDetectorValgrind(MockExecutive2(), MockFileSystem(files), '/tmp/layout-test-results/')
+        leakdetector_valgrind = LeakDetectorValgrind(MockExecutive2(), MockCompatibleFileSystem(files), '/tmp/layout-test-results/')
 
         with OutputCapture(level=logging.INFO) as captured:
             leakdetector_valgrind.parse_and_print_leaks_detail(files)
@@ -840,7 +843,7 @@ class LeakDetectorValgrindTest(unittest.TestCase):
     def test_parse_and_print_leaks_detail_empty(self):
         files = {}
         files['/tmp/Logs/layout-test-results/drt-28532-ebc9a6c63be411e399d4d43d7e01ba08-leaks.xml'] = ""
-        leakdetector_valgrind = LeakDetectorValgrind(MockExecutive2(), MockFileSystem(files), '/tmp/layout-test-results/')
+        leakdetector_valgrind = LeakDetectorValgrind(MockExecutive2(), MockCompatibleFileSystem(files), '/tmp/layout-test-results/')
 
         with OutputCapture(level=logging.INFO) as captured:
             leakdetector_valgrind.parse_and_print_leaks_detail(files)
@@ -851,7 +854,7 @@ class LeakDetectorValgrindTest(unittest.TestCase):
         misformatted_mock_valgrind_output = 'Junk that should not appear in a valgrind xml file' + make_mock_valgrind_output('DumpRenderTree', 28533, 'fa6d0cd63be411e39c72d43d7e01ba08')[:20]
         files = {}
         files['/tmp/layout-test-results/drt-28533-fa6d0cd63be411e39c72d43d7e01ba08-leaks.xml'] = misformatted_mock_valgrind_output
-        leakdetector_valgrind = LeakDetectorValgrind(MockExecutive2(), MockFileSystem(files), '/tmp/layout-test-results/')
+        leakdetector_valgrind = LeakDetectorValgrind(MockExecutive2(), MockCompatibleFileSystem(files), '/tmp/layout-test-results/')
 
         with OutputCapture(level=logging.INFO) as captured:
             leakdetector_valgrind.parse_and_print_leaks_detail(files)

--- a/Tools/Scripts/webkitpy/port/linux_get_crash_log_unittest.py
+++ b/Tools/Scripts/webkitpy/port/linux_get_crash_log_unittest.py
@@ -29,15 +29,19 @@
 
 import os
 import sys
-import unittest
+
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.system.executive_mock import MockExecutive
 from webkitpy.common.system.executive_mock import MockProcess
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.port.linux_get_crash_log import GDBCrashLogGenerator
 
 
-class GDBCrashLogGeneratorTest(unittest.TestCase):
+class GDBCrashLogGeneratorTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
 
     def test_generate_crash_log(self):
         if sys.platform.startswith('win'):
@@ -46,7 +50,7 @@ class GDBCrashLogGeneratorTest(unittest.TestCase):
         executive = MockExecutive()
         executive._proc = MockProcess()
         executive._proc.stdout = 'STDERR: <empty>'
-        generator = GDBCrashLogGenerator(executive, 'DumpRenderTree', 28529, newer_than=None, filesystem=MockFileSystem({'/path/to/coredumps': ''}), path_to_driver=None, port_name="gtk", configuration="Debug")
+        generator = GDBCrashLogGenerator(executive, 'DumpRenderTree', 28529, newer_than=None, filesystem=MockCompatibleFileSystem({'/path/to/coredumps': ''}), path_to_driver=None, port_name="gtk", configuration="Debug")
 
         core_directory = os.environ.get('WEBKIT_CORE_DUMPS_DIRECTORY', '/path/to/coredumps')
         core_pattern = generator._filesystem.join(core_directory, "core-pid_%p.dump")

--- a/Tools/Scripts/webkitpy/port/server_process_unittest.py
+++ b/Tools/Scripts/webkitpy/port/server_process_unittest.py
@@ -30,6 +30,7 @@
 import sys
 import time
 import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.port.factory import PortFactory
 from webkitpy.port import server_process
@@ -203,6 +204,11 @@ class TestServerProcess(unittest.TestCase):
         self.assertEqual(True, proc.has_crashed())
 
         proc.stop(0)
+
+
+class TestFakeServerProcess(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
 
     def test_cleanup(self):
         port_obj = TrivialMockPort()

--- a/Tools/Scripts/webkitpy/port/waylanddriver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/waylanddriver_unittest.py
@@ -27,7 +27,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
+
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.port import Port
@@ -39,7 +40,10 @@ from webkitpy.tool.mocktool import MockOptions
 _log = logging.getLogger(__name__)
 
 
-class WaylandDriverTest(unittest.TestCase):
+class WaylandDriverTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def make_driver(self, worker_number=0, xorg_running=False, executive=None):
         port = Port(MockSystemHost(log_executive=True, executive=executive), 'waylanddrivertestport', options=MockOptions(configuration='Release'))
         port._config.build_directory = lambda configuration: '/mock-build'

--- a/Tools/Scripts/webkitpy/port/westondriver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/westondriver_unittest.py
@@ -29,9 +29,8 @@
 
 import logging
 import re
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
-from webkitpy.common.system.filesystem_mock import MockFileSystem
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.port import Port
 from webkitpy.port.server_process_mock import MockServerProcess
@@ -54,7 +53,10 @@ class WestonXvfbDriverDisplayTest():
         return True
 
 
-class WestonDriverTest(unittest.TestCase):
+class WestonDriverTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def make_driver(self):
         port = Port(MockSystemHost(log_executive=True), 'westondrivertestport', options=MockOptions(configuration='Release'))
         port._config.build_directory = lambda configuration: "/mock_build"

--- a/Tools/Scripts/webkitpy/port/wpe_unittest.py
+++ b/Tools/Scripts/webkitpy/port/wpe_unittest.py
@@ -27,15 +27,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import os
-import sys
-import unittest
 
 from webkitpy.common.system.executive_mock import MockExecutive
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.port.wpe import WPEPort
 from webkitpy.port import port_testcase
-from webkitpy.thirdparty.mock import Mock, patch
+from webkitpy.thirdparty.mock import patch
 from webkitpy.tool.mocktool import MockOptions
 from webkitcorepy import OutputCapture
 import logging
@@ -45,7 +42,7 @@ class WPEPortTest(port_testcase.PortTestCase):
     port_maker = WPEPort
 
     def _mock_port_cog_is_built(self, port):
-        port._filesystem = MockFileSystem({
+        port._filesystem = MockCompatibleFileSystem({
             '/mock-build/Tools/cog-prefix/src/cog-build/launcher/cog': '',
         })
 

--- a/Tools/Scripts/webkitpy/port/xorgdriver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/xorgdriver_unittest.py
@@ -27,7 +27,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
+
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.port import Port
@@ -39,7 +40,10 @@ from webkitpy.tool.mocktool import MockOptions
 _log = logging.getLogger(__name__)
 
 
-class XorgDriverTest(unittest.TestCase):
+class XorgDriverTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def make_driver(self, worker_number=0, xorg_running=False, executive=None):
         port = Port(MockSystemHost(log_executive=True, executive=executive), 'xorgdrivertestport', options=MockOptions(configuration='Release'))
         port._config.build_directory = lambda configuration: '/mock-build'

--- a/Tools/Scripts/webkitpy/port/xvfbdriver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/xvfbdriver_unittest.py
@@ -28,9 +28,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
 
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from pyfakefs import fake_filesystem_unittest
+
 from webkitpy.common.system.executive_mock import MockProcess
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.port import Port
@@ -43,7 +43,10 @@ from webkitcorepy import OutputCapture
 _log = logging.getLogger(__name__)
 
 
-class XvfbDriverTest(unittest.TestCase):
+class XvfbDriverTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def assertRaisesRegex(self, *args, **kwargs):
         try:
             return super(XvfbDriverTest, self).assertRaisesRegex(*args, **kwargs)

--- a/Tools/Scripts/webkitpy/style/checkers/png_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/png_unittest.py
@@ -23,10 +23,10 @@
 
 """Unit test for png.py."""
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.style.checkers.png import PNGChecker
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 
 
@@ -43,7 +43,10 @@ class MockSCMDetector(object):
         return self._prop
 
 
-class PNGCheckerTest(unittest.TestCase):
+class PNGCheckerTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     """Tests PNGChecker class."""
 
     def test_init(self):
@@ -63,7 +66,7 @@ class PNGCheckerTest(unittest.TestCase):
             error = (line_number, category, confidence, message)
             errors.append(error)
 
-        fs = MockFileSystem()
+        fs = MockCompatibleFileSystem()
         file_path = "foo-expected.png"
         fs.write_binary_file(file_path, "Dummy binary data")
         scm = MockSCMDetector('git')

--- a/Tools/Scripts/webkitpy/style/checkers/test_expectations_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/test_expectations_unittest.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.style.checkers.test_expectations import TestExpectationsChecker
@@ -54,10 +54,11 @@ class ErrorCollector(object):
         self.turned_off_filtering = False
 
 
-class TestExpectationsTestCase(unittest.TestCase):
+class TestExpectationsTestCase(fake_filesystem_unittest.TestCase):
     """TestCase for test_expectations.py"""
 
     def setUp(self):
+        self.setUpPyfakefs()
         self._error_collector = ErrorCollector()
         self._test_file = 'passes/text.html'
 

--- a/Tools/Scripts/webkitpy/style/main_unittest.py
+++ b/Tools/Scripts/webkitpy/style/main_unittest.py
@@ -24,11 +24,13 @@
 import logging
 import optparse
 import unittest
+from pyfakefs import fake_filesystem_unittest
 
 import webkitpy.style.checker as checker
 
 from webkitpy.common.host import Host
 from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.common.system.logtesting import LogTesting
 from webkitpy.style.checker import StyleProcessor
 from webkitpy.style.filereader import TextFileReader
@@ -37,13 +39,15 @@ from webkitpy.style.main import change_directory
 from webkitcorepy import OutputCapture
 
 
-class ChangeDirectoryTest(unittest.TestCase):
+class ChangeDirectoryTest(fake_filesystem_unittest.TestCase):
     _original_directory = "/original"
     _checkout_root = "/WebKit"
 
     def setUp(self):
+        self.setUpPyfakefs()
+
         self._log = LogTesting.setUp(self)
-        self.filesystem = MockFileSystem(dirs=[self._original_directory, self._checkout_root], cwd=self._original_directory)
+        self.filesystem = MockCompatibleFileSystem(dirs=[self._original_directory, self._checkout_root], cwd=self._original_directory)
 
     def tearDown(self):
         self._log.tearDown()

--- a/Tools/Scripts/webkitpy/style/patchreader_unittest.py
+++ b/Tools/Scripts/webkitpy/style/patchreader_unittest.py
@@ -29,14 +29,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.style.patchreader import PatchReader
 
 
-class PatchReaderTest(unittest.TestCase):
-
+class PatchReaderTest(fake_filesystem_unittest.TestCase):
     """Test the PatchReader class."""
 
     class MockTextFileReader(object):
@@ -57,6 +56,8 @@ class PatchReaderTest(unittest.TestCase):
             pass
 
     def setUp(self):
+        self.setUpPyfakefs()
+
         file_reader = self.MockTextFileReader()
         self._file_reader = file_reader
         self._patch_checker = PatchReader(file_reader)
@@ -94,7 +95,7 @@ index ef65bee..e3db70e 100644
         self._assert_checked([], 1)
 
     def test_check_patch_with_png_deletion(self):
-        fs = MockFileSystem()
+        fs = MockCompatibleFileSystem()
         diff_text = """Index: LayoutTests/platform/mac/foo-expected.png
 ===================================================================
 Cannot display: file marked as a binary type.

--- a/Tools/Scripts/webkitpy/test/main.py
+++ b/Tools/Scripts/webkitpy/test/main.py
@@ -379,13 +379,22 @@ class Tester(object):
         upload_group.add_options(upload_options())
         parser.add_option_group(upload_group)
 
+        if (
+            sys.platform.startswith('win')
+            or sys.platform == 'darwin'
+            and sys.version_info < (3,)
+        ):
+            default_child_processes = 1
+        else:
+            default_child_processes = multiprocessing.cpu_count()
+
         parser.add_option('-a', '--all', action='store_true', default=False,
                           help='run all the tests')
         parser.add_option('-c', '--coverage', action='store_true', default=False,
                           help='generate code coverage info (requires http://pypi.python.org/pypi/coverage)')
         parser.add_option('-i', '--integration-tests', action='store_true', default=False,
                           help='run integration tests as well as unit tests'),
-        parser.add_option('-j', '--child-processes', action='store', type='int', default=(1 if sys.platform.startswith('win') else multiprocessing.cpu_count()),
+        parser.add_option('-j', '--child-processes', action='store', type='int', default=default_child_processes,
                           help='number of tests to run in parallel (default=%default)')
         parser.add_option('-p', '--pass-through', action='store_true', default=False,
                           help='be debugger friendly by passing captured output through to the system')

--- a/Tools/Scripts/webkitpy/test/main.py
+++ b/Tools/Scripts/webkitpy/test/main.py
@@ -180,6 +180,7 @@ def main():
         "webkitpy.common.system.environment_unittest",
         "webkitpy.common.system.executive_unittest",
         "webkitpy.common.system.filesystem_mock_unittest",
+        "webkitpy.common.system.filesystem_mockcompatible_unittest",
         "webkitpy.common.system.filesystem_unittest",
         "webkitpy.common.system.logutils_unittest",
         "webkitpy.common.system.outputtee_unittest",

--- a/Tools/Scripts/webkitpy/tool/commands/commandtest.py
+++ b/Tools/Scripts/webkitpy/tool/commands/commandtest.py
@@ -28,15 +28,24 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
 
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import OutputCapture
 
 from webkitpy.tool.mocktool import MockOptions, MockTool
 
 
-class CommandsTest(unittest.TestCase):
-    def assert_execute_outputs(self, command, args=[], expected_stdout="", expected_stderr="", expected_exception=None, expected_logs=None, options=MockOptions(), tool=MockTool()):
+class CommandsTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
+    def assert_execute_outputs(self, command, args=[], expected_stdout="", expected_stderr="", expected_exception=None, expected_logs=None, options=None, tool=None):
+        if options is None:
+            options = MockOptions()
+
+        if tool is None:
+            tool = MockTool()
+
         options.blocks = None
         if getattr(options, "cc", None) == None:
             options.cc = 'MOCK cc'

--- a/Tools/Scripts/webkitpy/tool/commands/download_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/commands/download_unittest.py
@@ -27,18 +27,21 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
-
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import OutputCapture, mocks
 
 from webkitpy.common.checkout.checkout_mock import MockCheckout
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.thirdparty.mock import Mock
 from webkitpy.tool.commands.commandtest import CommandsTest
 from webkitpy.tool.commands.download import *
 from webkitpy.tool.mocktool import MockOptions, MockTool
 
 
-class AbstractRevertPrepCommandTest(unittest.TestCase):
+class AbstractRevertPrepCommandTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_commit_info(self):
         command = AbstractRevertPrepCommand()
         tool = MockTool()
@@ -59,7 +62,8 @@ class AbstractRevertPrepCommandTest(unittest.TestCase):
 
     def test_prepare_state(self):
         command = AbstractRevertPrepCommand()
-        mock_commit_info = MockCheckout().commit_info_for_revision(123)
+        filesystem = MockCompatibleFileSystem()
+        mock_commit_info = MockCheckout(filesystem).commit_info_for_revision(123)
         command._commit_info = lambda revision: mock_commit_info
 
         state = command._prepare_state(None, ["124 123 125", "Reason"], None)

--- a/Tools/Scripts/webkitpy/tool/commands/suggestnominations_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/commands/suggestnominations_unittest.py
@@ -27,12 +27,29 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from webkitpy.common.system.filesystem import FileSystem
+from webkitpy.common.webkit_finder import WebKitFinder
 from webkitpy.tool.commands.commandtest import CommandsTest
 from webkitpy.tool.commands.suggestnominations import SuggestNominations
 from webkitpy.tool.mocktool import MockOptions, MockTool
 
 
 class SuggestNominationsTest(CommandsTest):
+    def setUp(self):
+        super(SuggestNominationsTest, self).setUp()
+
+        self.pause()
+
+        # Find the path to the (real) contributors.json file
+        webkit_finder = WebKitFinder(FileSystem())
+        contributors_path = webkit_finder.path_from_webkit_base(
+            "metadata", "contributors.json"
+        )
+
+        # Map the (real) contributors.json file into the fake filesystem
+        self.fs.add_real_file(contributors_path)
+
+        self.resume()
 
     mock_git_output = """commit a7df8145fd61987ec39092defb94dbab072fa541
 Author: fpizlo@apple.com <fpizlo@apple.com@268f45cc-cd09-0410-ab3c-d52691b4dbfc>

--- a/Tools/Scripts/webkitpy/tool/servers/rebaselineserver_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/servers/rebaselineserver_unittest.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.common.net import resultsjsonparser_unittest
@@ -36,7 +36,10 @@ from webkitpy.tool.commands.rebaselineserver import RebaselineServer, TestConfig
 from webkitpy.tool.servers import rebaselineserver
 
 
-class RebaselineTestTest(unittest.TestCase):
+class RebaselineTestTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_text_rebaseline_update(self):
         self._assertRebaseline(
             test_files=(
@@ -225,7 +228,10 @@ class RebaselineTestTest(unittest.TestCase):
         self.assertEqual(expected_success, success)
 
 
-class GetActualResultFilesTest(unittest.TestCase):
+class GetActualResultFilesTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test(self):
         test_config = get_test_config(result_files=(
             'fast/text-actual.txt',
@@ -239,7 +245,10 @@ class GetActualResultFilesTest(unittest.TestCase):
                 'fast/text.html', test_config))
 
 
-class GetBaselinesTest(unittest.TestCase):
+class GetBaselinesTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_no_baselines(self):
         self._assertBaselines(
             test_files=(),

--- a/Tools/Scripts/webkitpy/tool/steps/applywatchlist_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/steps/applywatchlist_unittest.py
@@ -28,15 +28,18 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
 
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import OutputCapture
 
 from webkitpy.tool.mocktool import MockOptions, MockTool
 from webkitpy.tool.steps.applywatchlist import ApplyWatchList
 
 
-class ApplyWatchListTest(unittest.TestCase):
+class ApplyWatchListTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_apply_watch_list_local(self):
         step = ApplyWatchList(MockTool(log_executive=True), MockOptions())
         state = {

--- a/Tools/Scripts/webkitpy/tool/steps/cleanworkingdirectory_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/steps/cleanworkingdirectory_unittest.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.system.executive import ScriptError
 from webkitpy.thirdparty.mock import Mock
@@ -34,7 +34,10 @@ from webkitpy.tool.mocktool import MockOptions, MockTool
 from webkitpy.tool.steps.cleanworkingdirectory import CleanWorkingDirectory
 
 
-class CleanWorkingDirectoryTest(unittest.TestCase):
+class CleanWorkingDirectoryTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_run_working_directory_changes_no_force(self):
         tool = MockTool()
         tool._scm = Mock()

--- a/Tools/Scripts/webkitpy/tool/steps/closebugforlanddiff_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/steps/closebugforlanddiff_unittest.py
@@ -28,15 +28,18 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
 
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import OutputCapture, mocks
 
 from webkitpy.tool.mocktool import MockOptions, MockTool
 from webkitpy.tool.steps.closebugforlanddiff import CloseBugForLandDiff
 
 
-class CloseBugForLandDiffTest(unittest.TestCase):
+class CloseBugForLandDiffTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_empty_state(self):
         with mocks.Requests('commits.webkit.org', **{
             'r49824/json': mocks.Response.fromJson(dict(

--- a/Tools/Scripts/webkitpy/tool/steps/commit_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/steps/commit_unittest.py
@@ -28,8 +28,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
 
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import OutputCapture
 
 from webkitpy.common.system.executive import ScriptError
@@ -38,7 +38,10 @@ from webkitpy.tool.mocktool import MockOptions, MockTool
 from webkitpy.tool.steps.commit import Commit
 
 
-class CommitTest(unittest.TestCase):
+class CommitTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def _test_check_test_expectations(self, filename):
         options = MockOptions()
         options.git_commit = ""

--- a/Tools/Scripts/webkitpy/tool/steps/discardlocalchanges_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/steps/discardlocalchanges_unittest.py
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.system.executive import ScriptError
 from webkitpy.thirdparty.mock import Mock
@@ -34,7 +34,10 @@ from webkitpy.tool.mocktool import MockOptions, MockTool
 from webkitpy.tool.steps.discardlocalchanges import DiscardLocalChanges
 
 
-class DiscardLocalChangesTest(unittest.TestCase):
+class DiscardLocalChangesTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_skip_on_clean(self):
         tool = MockTool()
         tool._scm = Mock()

--- a/Tools/Scripts/webkitpy/tool/steps/preparechangelog_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/steps/preparechangelog_unittest.py
@@ -32,7 +32,7 @@
 from webkitcorepy import OutputCapture
 
 from webkitpy.common.checkout import changelog_unittest
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.tool.mocktool import MockOptions, MockTool
 from webkitpy.tool.steps.preparechangelog import PrepareChangeLog
 
@@ -109,7 +109,7 @@ class PrepareChangeLogTest(changelog_unittest.ChangeLogTest):
             end_file = final_entry + self._rolled_over_footer
 
             path = "ChangeLog"
-            step._tool.filesystem = MockFileSystem()
+            step._tool.filesystem = MockCompatibleFileSystem()
             step._tool.filesystem.write_text_file(path, start_file)
             step._resolve_existing_entry(path)
             actual_output = step._tool.filesystem.read_text_file(path)
@@ -124,7 +124,7 @@ class PrepareChangeLogTest(changelog_unittest.ChangeLogTest):
             "bug_id": 1234,
             "changelogs": [changelog_path],
         }
-        step._tool.filesystem = MockFileSystem()
+        step._tool.filesystem = MockCompatibleFileSystem()
         step._tool.filesystem.write_text_file(changelog_path, changelog_contents)
 
         with OutputCapture():

--- a/Tools/Scripts/webkitpy/tool/steps/steps_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/steps/steps_unittest.py
@@ -28,8 +28,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
 
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import OutputCapture
 
 from webkitpy.common.config.ports import DeprecatedPort
@@ -37,9 +37,10 @@ from webkitpy.tool import steps
 from webkitpy.tool.mocktool import MockOptions, MockTool
 
 
-class StepsTest(unittest.TestCase):
-
+class StepsTest(fake_filesystem_unittest.TestCase):
     def setUp(self):
+        self.setUpPyfakefs()
+
         # Port._build_path() calls Tools/Scripts/webkit-build-directory and caches the result. When capturing output,
         # this can cause the first invocation of Port._build_path() to have more output than subsequent invocations.
         # This may cause test flakiness when test order changes. By explicitly calling Port._build_path() before running

--- a/Tools/Scripts/webkitpy/tool/steps/suggestreviewers_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/steps/suggestreviewers_unittest.py
@@ -28,15 +28,18 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
 
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import OutputCapture
 
 from webkitpy.tool.mocktool import MockOptions, MockTool
 from webkitpy.tool.steps.suggestreviewers import SuggestReviewers
 
 
-class SuggestReviewersTest(unittest.TestCase):
+class SuggestReviewersTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_disabled(self):
         step = SuggestReviewers(MockTool(), MockOptions(suggest_reviewers=False))
         with OutputCapture(level=logging.INFO) as captured:

--- a/Tools/Scripts/webkitpy/tool/steps/update_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/steps/update_unittest.py
@@ -26,14 +26,17 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.config.ports import MacPort, MacWK2Port
 from webkitpy.tool.mocktool import MockOptions, MockTool
 from webkitpy.tool.steps.update import Update
 
 
-class UpdateTest(unittest.TestCase):
+class UpdateTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
 
     def test_update_command_non_interactive(self):
         tool = MockTool()

--- a/Tools/Scripts/webkitpy/tool/steps/updatechangelogswithreview_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/steps/updatechangelogswithreview_unittest.py
@@ -28,8 +28,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
 
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import OutputCapture
 
 from webkitpy.tool.mocktool import MockOptions, MockTool
@@ -38,7 +38,10 @@ from webkitpy.tool.steps.updatechangelogswithreviewer import (
 )
 
 
-class UpdateChangeLogsWithReviewerTest(unittest.TestCase):
+class UpdateChangeLogsWithReviewerTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def test_guess_reviewer_from_bug(self):
         step = UpdateChangeLogsWithReviewer(MockTool(), MockOptions())
         with OutputCapture(level=logging.INFO) as captured:

--- a/Tools/Scripts/webkitpy/tool/steps/validatechangelogs_unittest.py
+++ b/Tools/Scripts/webkitpy/tool/steps/validatechangelogs_unittest.py
@@ -28,8 +28,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
-import unittest
 
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import OutputCapture
 
 from webkitpy.thirdparty.mock import Mock
@@ -37,7 +37,10 @@ from webkitpy.tool.mocktool import MockOptions, MockTool
 from webkitpy.tool.steps.validatechangelogs import ValidateChangeLogs
 
 
-class ValidateChangeLogsTest(unittest.TestCase):
+class ValidateChangeLogsTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
 
     def _assert_start_line_produces_output(self, start_line, should_fail=False, non_interactive=False):
         tool = MockTool()

--- a/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
@@ -20,17 +20,21 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
-from webkitpy.common.system.filesystem_mock import MockFileSystem
 from webkitpy.common.system.executive_mock import MockExecutive2
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.w3c.test_exporter import WebPlatformTestExporter, parse_args
 from webkitpy.w3c.wpt_github_mock import MockWPTGitHub
 
 mock_linter = None
 
-class TestExporterTest(unittest.TestCase):
+
+class TestExporterTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     maxDiff = None
 
     class MockBugzilla(object):
@@ -100,7 +104,7 @@ class TestExporterTest(unittest.TestCase):
         def __init__(self):
             MockHost.__init__(self)
             self.executive = MockExecutive2(exception=OSError())
-            self.filesystem = MockFileSystem()
+            self.filesystem = MockCompatibleFileSystem()
             self._mockSCM = TestExporterTest.MockGit(None, None, None, None)
 
         def scm(self):

--- a/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
@@ -28,10 +28,10 @@
 
 import json
 import os
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.host_mock import MockHost
-from webkitpy.common.system.filesystem_mock import MockFileSystem
+from webkitpy.common.system.filesystem_mockcompatible import MockCompatibleFileSystem
 from webkitpy.common.system.executive_mock import MockExecutive2, ScriptError
 from webkitpy.port.test import TestPort
 from webkitpy.w3c.test_downloader import TestDownloader
@@ -66,7 +66,10 @@ MINIMAL_TESTHARNESS = '''
 '''
 
 
-class TestImporterTest(unittest.TestCase):
+class TestImporterTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
     def _parse_options(self, args):
         options, args = parse_args(args)
         return options
@@ -413,7 +416,7 @@ class TestImporterTest(unittest.TestCase):
 
         host = MockHost()
         host.executive = MockExecutive2()
-        host.filesystem = MockFileSystem(files=FAKE_FILES)
+        host.filesystem = MockCompatibleFileSystem(files=FAKE_FILES)
 
         fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
 
@@ -434,7 +437,7 @@ class TestImporterTest(unittest.TestCase):
 
         host = MockHost()
         host.executive = MockExecutive2()
-        host.filesystem = MockFileSystem(files=FAKE_FILES)
+        host.filesystem = MockCompatibleFileSystem(files=FAKE_FILES)
 
         fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
 
@@ -452,7 +455,7 @@ class TestImporterTest(unittest.TestCase):
 
         host = MockHost()
         host.executive = MockExecutive2()
-        host.filesystem = MockFileSystem(files=FAKE_FILES)
+        host.filesystem = MockCompatibleFileSystem(files=FAKE_FILES)
 
         fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '-d', 'w3c'], FAKE_FILES)
         self.assertFalse(fs.exists('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/new-manual.html'))

--- a/Tools/Scripts/webkitpy/w3c/wpt_github_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_github_unittest.py
@@ -27,17 +27,17 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import base64
-import unittest
 
+from pyfakefs import fake_filesystem_unittest
 from webkitcorepy import string_utils
 
 from webkitpy.common.host_mock import MockHost
 from webkitpy.w3c.wpt_github import WPTGitHub
 
 
-class WPTGitHubTest(unittest.TestCase):
-
+class WPTGitHubTest(fake_filesystem_unittest.TestCase):
     def setUp(self):
+        self.setUpPyfakefs()
         self.wpt_github = WPTGitHub(MockHost(), user='rutabaga', token='decafbad')
 
     def test_init(self):

--- a/Tools/Scripts/webkitpy/w3c/wpt_runner_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/wpt_runner_unittest.py
@@ -20,14 +20,17 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import unittest
+from pyfakefs import fake_filesystem_unittest
 
 from webkitpy.common.config.ports_mock import MockPort
 from webkitpy.common.host_mock import MockHost
 from webkitpy.w3c.wpt_runner import WPTRunner, parse_args
 
 
-class WPTRunnerTest(unittest.TestCase):
+class WPTRunnerTest(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
 
     class MockTestDownloader(object):
         @staticmethod


### PR DESCRIPTION
#### a58c71a08504
<pre>
[webkitpy] Move the majority of tests to using pyfakefs
<a href="https://bugs.webkit.org/show_bug.cgi?id=271200">https://bugs.webkit.org/show_bug.cgi?id=271200</a>

Reviewed by NOBODY (OOPS!).

Along with moving the majority of TestCase subclasses to use pyfakefs,
which more accurately models a fake filesystem than we are likely to,
this patch:

 * Introduces a MockCompatibleFileSystem class, which mimics the
   behavior of MockFileSystem in a few ways, but otherwise talks to the
   real (or otherwise faked) filesystem.

 * Stops run_webkit_tests.py creating Host() objects to find the root of
   the WebKit tree, avoiding accidentally calling out to the real system
   and real filesystem during tests.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/__init__.py:
(add_datafiles_to_pyfakefs):
* Tools/Scripts/webkitpy/common/checkout/changelog_unittest.py:
(ChangeLogTest):
(ChangeLogTest.setUp):
(test_set_reviewer):
(test_set_short_description_and_bug_url):
(test_delete_entries):
(test_prepend_text):
* Tools/Scripts/webkitpy/common/checkout/checkout_mock.py:
(MockCheckout.__init__):
* Tools/Scripts/webkitpy/common/checkout/checkout_unittest.py:
(CommitMessageForThisCommitTest.mock_checkout_for_test):
(CheckoutTest):
(CheckoutTest.setUp):
(CheckoutTest._make_checkout):
* Tools/Scripts/webkitpy/common/checkout/scm/detection_unittest.py:
(SCMDetectorTest):
(SCMDetectorTest.setUp):
(SCMDetectorTest.test_detect_scm_system):
* Tools/Scripts/webkitpy/common/checkout/scm/scm_mock.py:
(MockSCM.__init__):
* Tools/Scripts/webkitpy/common/checkout/scm/stub_repository_unittest.py:
(StubRepositoryTest):
(StubRepositoryTest.setUp):
(StubRepositoryTest.mock_host_for_stub_repository):
* Tools/Scripts/webkitpy/common/find_files_unittest.py:
(TestWinNormalize):
(TestWinNormalize.setUp):
(TestFindFiles):
(TestFindFiles.setUp):
(TestFindFiles.test_directory_sort_key):
(TestFindFiles.test_directory_sort_key_with_paths):
* Tools/Scripts/webkitpy/common/host_mock.py:
(MockHost.__init__):
* Tools/Scripts/webkitpy/common/net/bugzilla/test_expectation_updater_unittest.py:
(TestExpectationUpdaterTest):
(TestExpectationUpdaterTest.setUp):
(TestExpectationUpdaterTest.test_update_test_expectations):
* Tools/Scripts/webkitpy/common/system/crashlogs_unittest.py:
* Tools/Scripts/webkitpy/common/system/executive_unittest.py:
(ScriptErrorTest):
(ScriptErrorTest.setUp):
(FakefsExecutiveTest):
(FakefsExecutiveTest.setUp):
(FakefsExecutiveTest.assert_interpreter_for_content):
(FakefsExecutiveTest.test_interpreter_for_script):
(FakefsExecutiveTest._assert_windows_image_name):
(FakefsExecutiveTest.test_windows_image_name):
(ExecutiveTest):
(ExecutiveTest.serial_test_kill_all):
(ExecutiveTest.assert_interpreter_for_content): Deleted.
(ExecutiveTest.test_interpreter_for_script): Deleted.
(ExecutiveTest._assert_windows_image_name): Deleted.
(ExecutiveTest.test_windows_image_name): Deleted.
* Tools/Scripts/webkitpy/common/system/filesystem_mockcompatible.py: Added.
(MockCompatibleFileSystem):
(MockCompatibleFileSystem.__init__):
(MockCompatibleFileSystem.reset):
(MockCompatibleFileSystem.write_binary_file):
(MockCompatibleFileSystem.write_text_file):
(MockCompatibleFileSystem.move):
(MockCompatibleFileSystem.expanduser):
(MockCompatibleFileSystem.path_to_module):
(MockCompatibleFileSystem.mkdtemp):
(MockCompatibleFileSystem.mkdtemp._mktemp):
(MockCompatibleFileSystem.open_text_file_for_writing):
(MockCompatibleFileSystem.clear_written_files):
(MockCompatibleFileSystem.files):
(MockCompatibleFileSystem.written_files):
(MockCompatibleFileSystem._slow_but_correct_join):
(MockCompatibleFileSystem._slow_but_correct_normpath):
(FilesMapping):
(FilesMapping.__init__):
(FilesMapping.__getitem__):
(FilesMapping.__setitem__):
(FilesMapping.__delitem__):
(FilesMapping.__iter__):
(FilesMapping.__len__):
* Tools/Scripts/webkitpy/common/system/filesystem_mockcompatible_unittest.py: Added.
(MockCompatibleFileSystemTest):
(MockCompatibleFileSystemTest.setUp):
(MockCompatibleFileSystemTest.tearDown):
(MockCompatibleFileSystemTest.quick_check):
(MockCompatibleFileSystemTest.test_join):
(MockCompatibleFileSystemTest.test_normpath):
(MockCompatibleFileSystemTest.test_dirs_under):
(MockCompatibleFileSystemTest.test_dirs_under.filter_dir):
* Tools/Scripts/webkitpy/common/system/filesystem_unittest.py:
(RealFileSystemTest.test_dirs_under):
* Tools/Scripts/webkitpy/common/system/profiler_unittest.py:
(ProfilerFactoryTest):
(ProfilerFactoryTest.setUp):
(GooglePProfTest):
(GooglePProfTest.setUp):
* Tools/Scripts/webkitpy/common/system/systemhost_mock.py:
(MockSystemHost.__init__):
* Tools/Scripts/webkitpy/common/system/workspace_unittest.py:
(WorkspaceTest):
(WorkspaceTest.setUp):
(WorkspaceTest.test_find_unused_filename):
* Tools/Scripts/webkitpy/common/test_expectations_unittest.py:
(ExpectationsTest):
(ExpectationsTest.setUp):
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy_unittest.py:
(LayoutTestFinderTests):
(LayoutTestFinderTests.test_is_reference_html_file):
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py:
(LayoutTestRunnerTests):
(LayoutTestRunnerTests.setUp):
(SharderTests):
(SharderTests.setUp):
(ShardTests):
(ShardTests.setUp):
* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
* Tools/Scripts/webkitpy/layout_tests/controllers/manager_unittest.py:
(ManagerTest):
(ManagerTest.setUp):
* Tools/Scripts/webkitpy/layout_tests/controllers/single_test_runner_unittest.py:
(SingleTestRunnerTest):
(SingleTestRunnerTest.setUp):
* Tools/Scripts/webkitpy/layout_tests/controllers/test_result_writer_unittest.py:
(TestResultWriterTest):
(TestResultWriterTest.setUp):
* Tools/Scripts/webkitpy/layout_tests/lint_test_expectations_unittest.py:
(LintTest):
(LintTest.setUp):
(MainTest):
(MainTest.setUp):
(MainTest.test_success):
* Tools/Scripts/webkitpy/layout_tests/models/test_expectations_unittest.py:
(Base):
(Base.setUp):
(Base.__init__): Deleted.
* Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py:
(InterpretTestFailuresTest):
(InterpretTestFailuresTest.setUp):
(SummarizedResultsTest):
(SummarizedResultsTest.setUp):
(SummarizedResultsTest.test_git_revision_identifier):
(SummarizedResultsTest.test_summarized_results_wontfix):
(SummarizedResultsTest.test_summarized_results_include_passes):
(SummarizedResultsTest.test_summarized_results_world_leaks_disabled):
(SummarizedResultsTest.test_summarized_run_metadata):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args):
(_set_up_derived_options):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(RunTest):
(RunTest.setUp):
(RunTest.serial_test_basic):
(RunTest.test_child_processes_2):
(RunTest.test_child_processes_min):
(RunTest.test_exception_raised):
(RunTest.test_keyboard_interrupt):
(RunTest.serial_test_results_directory_relative):
(RunTest.test_unsupported_platform):
(RunTest.test_verbose_in_child_processes):
(RebaselineTest):
(RebaselineTest.setUp):
(RebaselineTest.test_missing_results):
(MainTest):
(MainTest.setUp):
(MainTest.test_exception_handling):
* Tools/Scripts/webkitpy/layout_tests/servers/apache_http_server_unittest.py:
(TestLayoutTestApacheHttpd):
(TestLayoutTestApacheHttpd.setUp):
* Tools/Scripts/webkitpy/layout_tests/servers/http_server_base_unittest.py:
(TestHttpServerBase):
(TestHttpServerBase.setUp):
* Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server_unittest.py:
(TestWebPlatformTestServer):
(TestWebPlatformTestServer.setUp):
* Tools/Scripts/webkitpy/layout_tests/servers/websocket_server_unittest.py:
(TestWebsocketServer):
(TestWebsocketServer.setUp):
* Tools/Scripts/webkitpy/layout_tests/views/buildbot_results_unittest.py:
(BuildBotPrinterTests):
(BuildBotPrinterTests.setUp):
* Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py:
(TestUtilityFunctions):
(TestUtilityFunctions.setUp):
(Testprinter):
(Testprinter.setUp):
* Tools/Scripts/webkitpy/performance_tests/perftest_unittest.py:
(TestPerfTestMetric):
(TestPerfTestMetric.setUp):
(TestPerfTest):
(TestPerfTest.setUp):
* Tools/Scripts/webkitpy/performance_tests/perftestsrunner_integrationtest.py:
(MainTest):
(MainTest.setUp):
* Tools/Scripts/webkitpy/performance_tests/perftestsrunner_unittest.py:
(MainTest):
(MainTest.setUp):
(MainTest._add_file):
* Tools/Scripts/webkitpy/port/base_unittest.py:
(PortTest):
(PortTest.setUp):
(PortTest.test_uses_test_expectations_file):
(PortTest.test_commits_for_upload):
(PortTest.test_commits_for_upload_git_svn):
(NaturalCompareTest):
(NaturalCompareTest.setUp):
(KeyCompareTest):
(KeyCompareTest.setUp):
* Tools/Scripts/webkitpy/port/config_unittest.py:
(ConfigTest):
(ConfigTest.setUp):
(ConfigTest.make_config):
(ConfigTest.test_default_configuration__standalone):
(ConfigTest.test_asan):
(ConfigTest.test_asan_default):
* Tools/Scripts/webkitpy/port/darwin_testcase.py:
(DarwinTest.test_crashlog_path):
* Tools/Scripts/webkitpy/port/driver_unittest.py:
(DriverOutputTest):
(DriverOutputTest.setUp):
* Tools/Scripts/webkitpy/port/factory_unittest.py:
(FactoryTest):
(FactoryTest.setUp):
* Tools/Scripts/webkitpy/port/gtk_unittest.py:
(GtkPortTest.test_show_results_html_file):
(GtkPortTest.test_gtk4_expectations_binary_only):
(GtkPortTest.test_gtk3_expectations_binary_only):
(GtkPortTest.test_gtk_expectations_both_binaries):
* Tools/Scripts/webkitpy/port/headlessdriver_unittest.py:
(HeadlessDriverTest):
(HeadlessDriverTest.setUp):
* Tools/Scripts/webkitpy/port/ios_device_unittest.py:
* Tools/Scripts/webkitpy/port/leakdetector_unittest.py:
(LeakDetectorTest):
(LeakDetectorTest.setUp):
(LeakDetectorTest._mock_port.MockPort.__init__):
(test_leaks_files_in_directory):
(test_count_total_leaks):
* Tools/Scripts/webkitpy/port/leakdetector_valgrind_unittest.py:
(LeakDetectorValgrindTest):
(LeakDetectorValgrindTest.setUp):
(LeakDetectorValgrindTest.test_parse_and_print_leaks_detail_pass):
(LeakDetectorValgrindTest.test_parse_and_print_leaks_detail_incomplete):
(LeakDetectorValgrindTest.test_parse_and_print_leaks_detail_empty):
(LeakDetectorValgrindTest.test_parse_and_print_leaks_detail_misformatted):
* Tools/Scripts/webkitpy/port/linux_get_crash_log_unittest.py:
(GDBCrashLogGeneratorTest):
(GDBCrashLogGeneratorTest.setUp):
(GDBCrashLogGeneratorTest.test_generate_crash_log):
* Tools/Scripts/webkitpy/port/port_testcase.py:
(PortTestCase):
(PortTestCase.setUp):
(PortTestCase.make_port):
* Tools/Scripts/webkitpy/port/server_process_unittest.py:
(TestServerProcess.serial_test_process_crashing_no_data):
(TestFakeServerProcess):
(TestFakeServerProcess.setUp):
(TestServerProcess.test_cleanup): Deleted.
(TestServerProcess.test_broken_pipe): Deleted.
* Tools/Scripts/webkitpy/port/waylanddriver_unittest.py:
(WaylandDriverTest):
(WaylandDriverTest.setUp):
* Tools/Scripts/webkitpy/port/westondriver_unittest.py:
(WestonDriverTest):
(WestonDriverTest.setUp):
* Tools/Scripts/webkitpy/port/wpe_unittest.py:
(WPEPortTest._mock_port_cog_is_built):
* Tools/Scripts/webkitpy/port/xorgdriver_unittest.py:
(XorgDriverTest):
(XorgDriverTest.setUp):
* Tools/Scripts/webkitpy/port/xvfbdriver_unittest.py:
(XvfbDriverTest):
(XvfbDriverTest.setUp):
* Tools/Scripts/webkitpy/style/checkers/png_unittest.py:
(PNGCheckerTest):
(PNGCheckerTest.setUp):
(PNGCheckerTest.test_check):
* Tools/Scripts/webkitpy/style/checkers/test_expectations_unittest.py:
(TestExpectationsTestCase):
(TestExpectationsTestCase.setUp):
* Tools/Scripts/webkitpy/style/main_unittest.py:
(ChangeDirectoryTest):
(ChangeDirectoryTest.setUp):
* Tools/Scripts/webkitpy/style/patchreader_unittest.py:
(PatchReaderTest):
(PatchReaderTest.setUp):
* Tools/Scripts/webkitpy/test/finder_unittest.py:
(FinderTest):
(FinderTest.setUp):
(FinderTest.test_clean):
(FinderTest.test_paths):
(FinderTest.test_non_package):
* Tools/Scripts/webkitpy/test/main.py:
(main):
* Tools/Scripts/webkitpy/tool/commands/commandtest.py:
(CommandsTest):
(CommandsTest.setUp):
(CommandsTest.assert_execute_outputs):
* Tools/Scripts/webkitpy/tool/commands/download_unittest.py:
(AbstractRevertPrepCommandTest):
(AbstractRevertPrepCommandTest.setUp):
(AbstractRevertPrepCommandTest.test_prepare_state):
* Tools/Scripts/webkitpy/tool/commands/suggestnominations_unittest.py:
(SuggestNominationsTest.setUp):
* Tools/Scripts/webkitpy/tool/servers/rebaselineserver_unittest.py:
(RebaselineTestTest):
(RebaselineTestTest.setUp):
(GetActualResultFilesTest):
(GetActualResultFilesTest.setUp):
(GetBaselinesTest):
(GetBaselinesTest.setUp):
* Tools/Scripts/webkitpy/tool/steps/applywatchlist_unittest.py:
(ApplyWatchListTest):
(ApplyWatchListTest.setUp):
* Tools/Scripts/webkitpy/tool/steps/cleanworkingdirectory_unittest.py:
(CleanWorkingDirectoryTest):
(CleanWorkingDirectoryTest.setUp):
* Tools/Scripts/webkitpy/tool/steps/closebugforlanddiff_unittest.py:
(CloseBugForLandDiffTest):
(CloseBugForLandDiffTest.setUp):
* Tools/Scripts/webkitpy/tool/steps/commit_unittest.py:
(CommitTest):
(CommitTest.setUp):
* Tools/Scripts/webkitpy/tool/steps/discardlocalchanges_unittest.py:
(DiscardLocalChangesTest):
(DiscardLocalChangesTest.setUp):
* Tools/Scripts/webkitpy/tool/steps/preparechangelog_unittest.py:
* Tools/Scripts/webkitpy/tool/steps/preparechangelogforrevert_unittest.py:
(UpdateChangeLogsForRevertTest):
(UpdateChangeLogsForRevertTest.setUp):
(_assert_message_for_revert_output):
* Tools/Scripts/webkitpy/tool/steps/steps_unittest.py:
(StepsTest):
(StepsTest.setUp):
* Tools/Scripts/webkitpy/tool/steps/suggestreviewers_unittest.py:
(SuggestReviewersTest):
(SuggestReviewersTest.setUp):
* Tools/Scripts/webkitpy/tool/steps/update_unittest.py:
(UpdateTest):
(UpdateTest.setUp):
* Tools/Scripts/webkitpy/tool/steps/updatechangelogswithreview_unittest.py:
(UpdateChangeLogsWithReviewerTest):
(UpdateChangeLogsWithReviewerTest.setUp):
* Tools/Scripts/webkitpy/tool/steps/validatechangelogs_unittest.py:
(ValidateChangeLogsTest):
(ValidateChangeLogsTest.setUp):
* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest):
(TestExporterTest.setUp):
(TestExporterTest.MyMockHost.__init__):
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:
* Tools/Scripts/webkitpy/w3c/wpt_github_unittest.py:
(WPTGitHubTest):
(WPTGitHubTest.setUp):
* Tools/Scripts/webkitpy/w3c/wpt_runner_unittest.py:
(WPTRunnerTest):
(WPTRunnerTest.setUp):
* Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py:
(SimulatedDeviceTest):
(SimulatedDeviceTest.setUp):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b15a01d62be9bb0649f06f52835e7f1b6b284ae8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45313 "Failed to checkout and rebase branch from PR 26089") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24435 "Failed to checkout and rebase branch from PR 26089") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47840 "Failed to checkout and rebase branch from PR 26089") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47977 "Failed to checkout and rebase branch from PR 26089") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41321 "Failed to checkout and rebase branch from PR 26089") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47620 "Failed to checkout and rebase branch from PR 26089") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28640 "Failed to checkout and rebase branch from PR 26089") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21830 "Failed to checkout and rebase branch from PR 26089") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/47977 "Failed to checkout and rebase branch from PR 26089") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45891 "Failed to checkout and rebase branch from PR 26089") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/28640 "Failed to checkout and rebase branch from PR 26089") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/47840 "Failed to checkout and rebase branch from PR 26089") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/47977 "Failed to checkout and rebase branch from PR 26089") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/48147 "Failed to checkout and rebase branch from PR 26089") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/28640 "Failed to checkout and rebase branch from PR 26089") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/47840 "Failed to checkout and rebase branch from PR 26089") | [❌ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3360 "Failed to checkout and rebase branch from PR 26089") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/28640 "Failed to checkout and rebase branch from PR 26089") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/47840 "Failed to checkout and rebase branch from PR 26089") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49686 "Failed to checkout and rebase branch from PR 26089") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20296 "Failed to checkout and rebase branch from PR 26089") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/21830 "Failed to checkout and rebase branch from PR 26089") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/49686 "Failed to checkout and rebase branch from PR 26089") | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/45354 "Failed to checkout and rebase branch from PR 26089") | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21603 "Failed to checkout and rebase branch from PR 26089") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/47840 "Failed to checkout and rebase branch from PR 26089") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/49686 "Failed to checkout and rebase branch from PR 26089") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21963 "Failed to checkout and rebase branch from PR 26089") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21291 "Failed to checkout and rebase branch from PR 26089") | | | 
<!--EWS-Status-Bubble-End-->