### PR TITLE
ImageData (rect) size and destination offset overflow causes IPC decoder to fail during 2D context rendering.

### DIFF
--- a/LayoutTests/fast/canvas/canvas-imagedata-dimension-no-overflow-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-imagedata-dimension-no-overflow-expected.txt
@@ -1,0 +1,22 @@
+CONSOLE MESSAGE: Drawing canvas with MaxSize and getting ImageData from image
+CONSOLE MESSAGE: 0,255,0,255
+CONSOLE MESSAGE: Getting ImageData which overflows and outside of image
+CONSOLE MESSAGE: 0,0,0,0
+CONSOLE MESSAGE: Putting ImageData which overflows and outside of image
+CONSOLE MESSAGE: 0,0,0,0
+PASS data[0] is 0
+PASS data[1] is 255
+PASS data[2] is 0
+PASS data[3] is 255
+PASS data[0] is 0
+PASS data[1] is 0
+PASS data[2] is 0
+PASS data[3] is 0
+PASS data[0] is 0
+PASS data[1] is 0
+PASS data[2] is 0
+PASS data[3] is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/canvas-imagedata-dimension-no-overflow.html
+++ b/LayoutTests/fast/canvas/canvas-imagedata-dimension-no-overflow.html
@@ -1,0 +1,40 @@
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+var canvas = document.createElement('canvas');
+var ctx = canvas.getContext('2d');
+canvas.width = 8192;
+canvas.height = 8190;
+ctx.fillStyle ='rgba(0, 255, 0, 1)';
+ctx.fillRect(0, 0, canvas.width, canvas.height);
+var result = ctx.getImageData(0, 0, 1, 1);
+var data = result.data;
+console.log('Drawing canvas with MaxSize and getting ImageData from image');
+console.log(data);
+shouldBe("data[0]", "0");
+shouldBe("data[1]", "255");
+shouldBe("data[2]", "0");
+shouldBe("data[3]", "255");
+console.log('Getting ImageData which overflows and outside of image');
+var result = ctx.getImageData(1, 2147483647, 1, 1);
+var data = result.data;
+console.log(data);
+shouldBe("data[0]", "0");
+shouldBe("data[1]", "0");
+shouldBe("data[2]", "0");
+shouldBe("data[3]", "0");
+// should not timeout either:
+console.log('Putting ImageData which overflows and outside of image');
+ctx.putImageData(result, 1, 2147483647);
+result = ctx.getImageData(2147483646, 1, 1, 1);
+data = result.data;
+console.log(data);
+shouldBe("data[0]", "0");
+shouldBe("data[1]", "0");
+shouldBe("data[2]", "0");
+shouldBe("data[3]", "0");
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -62,9 +62,10 @@ private:
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     // Messages
-    void getPixelBuffer(WebCore::PixelBufferFormat, WebCore::IntRect srcRect, CompletionHandler<void()>&&);
-    void getPixelBufferWithNewMemory(WebCore::SharedMemory::Handle&&, WebCore::PixelBufferFormat, WebCore::IntRect, CompletionHandler<void()>&&);
-    void putPixelBuffer(Ref<WebCore::PixelBuffer>, WebCore::IntRect srcRect, WebCore::IntPoint destPoint, WebCore::AlphaPremultiplication destFormat);
+    // This is using location and size as opposed to rect because invalid rect object gets restricted by IPC rect object decoder and triggers timeout in WebContent process.
+    void getPixelBuffer(WebCore::PixelBufferFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, CompletionHandler<void()>&&);
+    void getPixelBufferWithNewMemory(WebCore::SharedMemory::Handle&&, WebCore::PixelBufferFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, CompletionHandler<void()>&&);
+    void putPixelBuffer(Ref<WebCore::PixelBuffer>, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, WebCore::IntPoint destPoint, WebCore::AlphaPremultiplication destFormat);
     void getShareableBitmap(WebCore::PreserveResolution, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
     void filteredNativeImage(Ref<WebCore::Filter>, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
     void convertToLuminanceMask();

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in
@@ -24,9 +24,9 @@
 
 // FIXME: Will be renamed to RemoteImageBufferBackend.
 messages -> RemoteImageBuffer NotRefCounted Stream {
-    GetPixelBuffer(struct WebCore::PixelBufferFormat outputFormat, WebCore::IntRect srcRect) -> () Synchronous
-    GetPixelBufferWithNewMemory(WebCore::SharedMemory::Handle handle, struct WebCore::PixelBufferFormat outputFormat, WebCore::IntRect srcRect) -> () Synchronous NotStreamEncodable
-    PutPixelBuffer(Ref<WebCore::PixelBuffer> pixelBuffer,  WebCore::IntRect srcRect, WebCore::IntPoint destPoint, enum:uint8_t WebCore::AlphaPremultiplication destFormat)
+    GetPixelBuffer(struct WebCore::PixelBufferFormat outputFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize) -> () Synchronous
+    GetPixelBufferWithNewMemory(WebCore::SharedMemory::Handle handle, struct WebCore::PixelBufferFormat outputFormat, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize) -> () Synchronous NotStreamEncodable
+    PutPixelBuffer(Ref<WebCore::PixelBuffer> pixelBuffer, WebCore::IntPoint srcPoint, WebCore::IntSize srcSize, WebCore::IntPoint destPoint, enum:uint8_t WebCore::AlphaPremultiplication destFormat)
     GetShareableBitmap(enum:bool WebCore::PreserveResolution preserveResolution) -> (std::optional<WebCore::ShareableBitmapHandle> handle) Synchronous NotStreamEncodableReply
     FilteredNativeImage(Ref<WebCore::Filter> filter) -> (std::optional<WebCore::ShareableBitmapHandle> handle) Synchronous NotStreamEncodableReply
     ConvertToLuminanceMask()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -245,13 +245,13 @@ void RemoteRenderingBackendProxy::moveToImageBuffer(WebCore::RenderingResourceId
 bool RemoteRenderingBackendProxy::getPixelBufferForImageBuffer(RenderingResourceIdentifier imageBuffer, const PixelBufferFormat& destinationFormat, const IntRect& srcRect, std::span<uint8_t> result)
 {
     if (auto handle = updateSharedMemoryForGetPixelBuffer(result.size())) {
-        auto sendResult = sendSync(Messages::RemoteImageBuffer::GetPixelBufferWithNewMemory(WTFMove(*handle), destinationFormat, srcRect), imageBuffer);
+        auto sendResult = sendSync(Messages::RemoteImageBuffer::GetPixelBufferWithNewMemory(WTFMove(*handle), destinationFormat, srcRect.location(), srcRect.size()), imageBuffer);
         if (!sendResult.succeeded())
             return false;
     } else {
         if (!m_getPixelBufferSharedMemory)
             return false;
-        auto sendResult = sendSync(Messages::RemoteImageBuffer::GetPixelBuffer(destinationFormat, srcRect), imageBuffer);
+        auto sendResult = sendSync(Messages::RemoteImageBuffer::GetPixelBuffer(destinationFormat, srcRect.location(), srcRect.size()), imageBuffer);
         if (!sendResult.succeeded())
             return false;
     }
@@ -261,7 +261,7 @@ bool RemoteRenderingBackendProxy::getPixelBufferForImageBuffer(RenderingResource
 
 void RemoteRenderingBackendProxy::putPixelBufferForImageBuffer(RenderingResourceIdentifier imageBuffer, const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
-    send(Messages::RemoteImageBuffer::PutPixelBuffer(Ref { const_cast<PixelBuffer&>(pixelBuffer) }, srcRect, destPoint, destFormat), imageBuffer);
+    send(Messages::RemoteImageBuffer::PutPixelBuffer(Ref { const_cast<PixelBuffer&>(pixelBuffer) }, srcRect.location(), srcRect.size(), destPoint, destFormat), imageBuffer);
 }
 
 std::optional<SharedMemory::Handle> RemoteRenderingBackendProxy::updateSharedMemoryForGetPixelBuffer(size_t dataSize)


### PR DESCRIPTION
#### 80efddf753c773046959715f02cb7421cf8245ce
<pre>
ImageData (rect) size and destination offset overflow causes IPC decoder to fail during 2D context rendering.
<a href="https://bugs.webkit.org/show_bug.cgi?id=271080">https://bugs.webkit.org/show_bug.cgi?id=271080</a>
<a href="https://rdar.apple.com/121959787">rdar://121959787</a>

Reviewed by Kimmo Kinnunen.

ImageData (rect) size and destination offset overflow causes IPC (rect) object
decoder to fail in WebContentProcess, during 2D context rendering which causes timeout.
Using location and size params in the getPixelBuffer and putPixelBuffer APIs instead
of rect in order to avoid this issue.

* LayoutTests/fast/canvas/canvas-imagedata-dimension-no-overflow-expected.txt: Added.
* LayoutTests/fast/canvas/canvas-imagedata-dimension-no-overflow.html: Added.
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::getPixelBuffer):
(WebKit::RemoteImageBuffer::getPixelBufferWithNewMemory):
(WebKit::RemoteImageBuffer::putPixelBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::getPixelBufferForImageBuffer):
(WebKit::RemoteRenderingBackendProxy::putPixelBufferForImageBuffer):

Canonical link: <a href="https://commits.webkit.org/276563@main">https://commits.webkit.org/276563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bf2effe5ae7f9e50a7c54e0e60d70f8a549ab30

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47420 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40771 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36792 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17858 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39691 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2813 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49081 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43772 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21051 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42519 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10013 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21390 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->