### PR TITLE
Update computeHashImpl() to use a span

### DIFF
--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -221,7 +221,7 @@ struct SubstringTranslator {
 struct SubstringTranslator8 : SubstringTranslator {
     static unsigned hash(const SubstringLocation& buffer)
     {
-        return StringHasher::computeHashAndMaskTop8Bits(buffer.baseString->characters8() + buffer.start, buffer.length);
+        return StringHasher::computeHashAndMaskTop8Bits(buffer.baseString->span8().subspan(buffer.start, buffer.length));
     }
 
     static bool equal(AtomStringTable::StringEntry const& string, const SubstringLocation& buffer)
@@ -233,7 +233,7 @@ struct SubstringTranslator8 : SubstringTranslator {
 struct SubstringTranslator16 : SubstringTranslator {
     static unsigned hash(const SubstringLocation& buffer)
     {
-        return StringHasher::computeHashAndMaskTop8Bits(buffer.baseString->characters16() + buffer.start, buffer.length);
+        return StringHasher::computeHashAndMaskTop8Bits(buffer.baseString->span16().subspan(buffer.start, buffer.length));
     }
 
     static bool equal(AtomStringTable::StringEntry const& string, const SubstringLocation& buffer)

--- a/Source/WTF/wtf/text/StringHash.h
+++ b/Source/WTF/wtf/text/StringHash.h
@@ -117,31 +117,22 @@ namespace WTF {
             }
         };
 
-        static unsigned hash(const UChar* data, unsigned length)
+        template<typename CharacterType>
+        static unsigned hash(std::span<const CharacterType> characters)
         {
-            return StringHasher::computeHashAndMaskTop8Bits<UChar, FoldCase>(data, length);
+            return StringHasher::computeHashAndMaskTop8Bits<CharacterType, FoldCase>(characters);
         }
 
         static unsigned hash(const StringImpl& string)
         {
             if (string.is8Bit())
-                return hash(string.characters8(), string.length());
-            return hash(string.characters16(), string.length());
+                return hash(string.span8());
+            return hash(string.span16());
         }
         static unsigned hash(const StringImpl* string)
         {
             ASSERT(string);
             return hash(*string);
-        }
-
-        static unsigned hash(const LChar* data, unsigned length)
-        {
-            return StringHasher::computeHashAndMaskTop8Bits<LChar, FoldCase>(data, length);
-        }
-
-        static inline unsigned hash(const char* data, unsigned length)
-        {
-            return hash(reinterpret_cast<const LChar*>(data), length);
         }
         
         static inline bool equal(const StringImpl& a, const StringImpl& b)
@@ -251,8 +242,8 @@ namespace WTF {
         static unsigned hash(StringView key)
         {
             if (key.is8Bit())
-                return ASCIICaseInsensitiveHash::hash(key.characters8(), key.length());
-            return ASCIICaseInsensitiveHash::hash(key.characters16(), key.length());
+                return ASCIICaseInsensitiveHash::hash(key.span8());
+            return ASCIICaseInsensitiveHash::hash(key.span16());
         }
 
         static bool equal(const String& a, StringView b)
@@ -264,7 +255,7 @@ namespace WTF {
     struct HashTranslatorASCIILiteral {
         static unsigned hash(ASCIILiteral literal)
         {
-            return StringHasher::computeHashAndMaskTop8Bits(literal.characters(), literal.length());
+            return StringHasher::computeHashAndMaskTop8Bits(literal.span8());
         }
 
         static bool equal(const String& a, ASCIILiteral b)
@@ -282,7 +273,7 @@ namespace WTF {
     struct HashTranslatorASCIILiteralCaseInsensitive {
         static unsigned hash(ASCIILiteral key)
         {
-            return ASCIICaseInsensitiveHash::hash(key.characters(), key.length());
+            return ASCIICaseInsensitiveHash::hash(key.span8());
         }
 
         static bool equal(const String& a, ASCIILiteral b)

--- a/Source/WTF/wtf/text/StringHasher.h
+++ b/Source/WTF/wtf/text/StringHasher.h
@@ -58,7 +58,7 @@ public:
     StringHasher() = default;
 
     template<typename T, typename Converter = DefaultConverter>
-    static unsigned computeHashAndMaskTop8Bits(const T* data, unsigned characterCount);
+    static unsigned computeHashAndMaskTop8Bits(std::span<const T> data);
 
     template<typename T, unsigned characterCount>
     static constexpr unsigned computeLiteralHashAndMaskTop8Bits(const T (&characters)[characterCount]);

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -1640,9 +1640,9 @@ CString StringImpl::utf8(ConversionMode mode) const
 NEVER_INLINE unsigned StringImpl::hashSlowCase() const
 {
     if (is8Bit())
-        setHash(StringHasher::computeHashAndMaskTop8Bits(m_data8, m_length));
+        setHash(StringHasher::computeHashAndMaskTop8Bits(span8()));
     else
-        setHash(StringHasher::computeHashAndMaskTop8Bits(m_data16, m_length));
+        setHash(StringHasher::computeHashAndMaskTop8Bits(span16()));
     return existingHash();
 }
 
@@ -1650,9 +1650,9 @@ unsigned StringImpl::concurrentHash() const
 {
     unsigned hash;
     if (is8Bit())
-        hash = StringHasher::computeHashAndMaskTop8Bits(m_data8, m_length);
+        hash = StringHasher::computeHashAndMaskTop8Bits(span8());
     else
-        hash = StringHasher::computeHashAndMaskTop8Bits(m_data16, m_length);
+        hash = StringHasher::computeHashAndMaskTop8Bits(span16());
     ASSERT(((hash << s_flagCount) >> s_flagCount) == hash);
     return hash;
 }

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -583,7 +583,7 @@ struct HashTranslatorCharBuffer {
     HashTranslatorCharBuffer(const CharacterType* characters, unsigned length)
         : characters(characters)
         , length(length)
-        , hash(StringHasher::computeHashAndMaskTop8Bits(characters, length))
+        , hash(StringHasher::computeHashAndMaskTop8Bits(std::span { characters, length }))
     {
     }
 
@@ -1122,7 +1122,7 @@ inline void StringImpl::setHash(unsigned hash) const
     ASSERT(!hasHash());
     ASSERT(!isStatic());
     // Multiple clients assume that StringHasher is the canonical string hash function.
-    ASSERT(hash == (is8Bit() ? StringHasher::computeHashAndMaskTop8Bits(m_data8, m_length) : StringHasher::computeHashAndMaskTop8Bits(m_data16, m_length)));
+    ASSERT(hash == (is8Bit() ? StringHasher::computeHashAndMaskTop8Bits(span8()) : StringHasher::computeHashAndMaskTop8Bits(span16())));
     ASSERT(!(hash & (s_flagMask << (8 * sizeof(hash) - s_flagCount)))); // Verify that enough high bits are empty.
 
     hash <<= s_flagCount;
@@ -1244,7 +1244,7 @@ inline StringImpl*& StringImpl::substringBuffer()
 
 inline void StringImpl::assertHashIsCorrect() const
 {
-    ASSERT(existingHash() == StringHasher::computeHashAndMaskTop8Bits(characters8(), length()));
+    ASSERT(existingHash() == StringHasher::computeHashAndMaskTop8Bits(span8()));
 }
 
 template<unsigned characterCount> constexpr StringImpl::StaticStringImpl::StaticStringImpl(const char (&characters)[characterCount], StringKind stringKind)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -494,8 +494,8 @@ inline const UChar* StringView::characters16() const
 inline unsigned StringView::hash() const
 {
     if (is8Bit())
-        return StringHasher::computeHashAndMaskTop8Bits(characters8(), length());
-    return StringHasher::computeHashAndMaskTop8Bits(characters16(), length());
+        return StringHasher::computeHashAndMaskTop8Bits(span8());
+    return StringHasher::computeHashAndMaskTop8Bits(span16());
 }
 
 template<> ALWAYS_INLINE const LChar* StringView::characters<LChar>() const

--- a/Source/WTF/wtf/text/SuperFastHash.h
+++ b/Source/WTF/wtf/text/SuperFastHash.h
@@ -146,9 +146,9 @@ public:
     }
 
     template<typename T, typename Converter = DefaultConverter>
-    ALWAYS_INLINE static constexpr unsigned computeHashAndMaskTop8Bits(const T* data, unsigned length)
+    ALWAYS_INLINE static constexpr unsigned computeHashAndMaskTop8Bits(std::span<const T> data)
     {
-        return StringHasher::finalizeAndMaskTop8Bits(computeHashImpl<T, Converter>(data, length));
+        return StringHasher::finalizeAndMaskTop8Bits(computeHashImpl<T, Converter>(data));
     }
 
     template<typename T, typename Converter = DefaultConverter>
@@ -158,15 +158,9 @@ public:
     }
 
     template<typename T, typename Converter = DefaultConverter>
-    static constexpr unsigned computeHash(const T* data, unsigned length)
-    {
-        return StringHasher::finalize(computeHashImpl<T, Converter>(data, length));
-    }
-
-    template<typename T, typename Converter = DefaultConverter>
     static constexpr unsigned computeHash(std::span<const T> data)
     {
-        return StringHasher::finalize(computeHashImpl<T, Converter>(data.data(), data.size()));
+        return StringHasher::finalize(computeHashImpl<T, Converter>(data));
     }
 
     template<typename T, typename Converter = DefaultConverter>
@@ -230,19 +224,13 @@ private:
     }
 
     template<typename T, typename Converter>
-    static constexpr unsigned computeHashImpl(const T* characters, unsigned length)
+    static constexpr unsigned computeHashImpl(std::span<const T> characters)
     {
         unsigned result = stringHashingStartValue;
-        bool remainder = length & 1;
-        length >>= 1;
-
-        while (length--) {
-            result = calculateWithTwoCharacters(result, Converter::convert(characters[0]), Converter::convert(characters[1]));
-            characters += 2;
-        }
-
-        if (remainder)
-            return calculateWithRemainingLastCharacter(result, Converter::convert(characters[0]));
+        for (size_t i = 0; i + 1 < characters.size(); i += 2)
+            result = calculateWithTwoCharacters(result, Converter::convert(characters[i]), Converter::convert(characters[i + 1]));
+        if (characters.size() % 2)
+            return calculateWithRemainingLastCharacter(result, Converter::convert(characters.back()));
         return result;
     }
 

--- a/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
@@ -64,7 +64,7 @@ public:
         if (!m_containsOnlyASCII) {
             m_containsOnlyASCII = charactersAreAllASCII(m_contiguousBuffer->data(), m_contiguousBuffer->size());
             if (*m_containsOnlyASCII)
-                m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(m_contiguousBuffer->data(), m_contiguousBuffer->size());
+                m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(m_contiguousBuffer->bytes());
         }
         if (*m_containsOnlyASCII)
             return { m_contiguousBuffer->data(), static_cast<unsigned>(m_contiguousBuffer->size()) };

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -87,8 +87,8 @@ static unsigned urlHostHash(const URL& url)
 {
     StringView host = url.host();
     if (host.is8Bit())
-        return AlreadyHashed::avoidDeletedValue(StringHasher::computeHashAndMaskTop8Bits(host.characters8(), host.length()));
-    return AlreadyHashed::avoidDeletedValue(StringHasher::computeHashAndMaskTop8Bits(host.characters16(), host.length()));
+        return AlreadyHashed::avoidDeletedValue(StringHasher::computeHashAndMaskTop8Bits(host.span8()));
+    return AlreadyHashed::avoidDeletedValue(StringHasher::computeHashAndMaskTop8Bits(host.span16()));
 }
 
 ApplicationCacheGroup* ApplicationCacheStorage::loadCacheGroup(const URL& manifestURL)

--- a/Source/WebCore/loader/cache/CachedScript.cpp
+++ b/Source/WebCore/loader/cache/CachedScript.cpp
@@ -78,7 +78,7 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
         setDecodedSize(0);
         stopDecodedDataDeletionTimer();
 
-        m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(contiguousData->data(), contiguousData->size());
+        m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(contiguousData->bytes());
     }
 
     if (m_decodingState == DataAndDecodedStringHaveSameBytes)

--- a/Source/WebCore/platform/graphics/WidthCache.h
+++ b/Source/WebCore/platform/graphics/WidthCache.h
@@ -62,7 +62,7 @@ private:
                 copySmallCharacters(m_characters.data(), string.characters8(), length);
             else
                 copySmallCharacters(m_characters.data(), string.characters16(), length);
-            m_hashAndLength = WYHash::computeHashAndMaskTop8Bits(m_characters.data(), s_capacity) | (length << 24);
+            m_hashAndLength = WYHash::computeHashAndMaskTop8Bits(std::span<const UChar> { m_characters }.first(s_capacity)) | (length << 24);
         }
 
         const UChar* characters() const { return m_characters.data(); }

--- a/Tools/TestWebKitAPI/Tests/WTF/StringHasher.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringHasher.cpp
@@ -53,10 +53,10 @@ TEST(WTF, StringHasher)
     StringHasher hash;
     unsigned max8Bit = std::numeric_limits<uint8_t>::max();
     for (size_t size = 0; size <= max8Bit; size++) {
-        std::unique_ptr<LChar[]> arr1 = generateLCharArray(size);
-        std::unique_ptr<UChar[]> arr2 = generateUCharArray(size);
-        unsigned left = StringHasher::computeHashAndMaskTop8Bits(arr1.get(), size);
-        unsigned right = StringHasher::computeHashAndMaskTop8Bits(arr2.get(), size);
+        std::unique_ptr<const LChar[]> arr1 = generateLCharArray(size);
+        std::unique_ptr<const UChar[]> arr2 = generateUCharArray(size);
+        unsigned left = StringHasher::computeHashAndMaskTop8Bits(std::span { arr1.get(), size });
+        unsigned right = StringHasher::computeHashAndMaskTop8Bits(std::span { arr2.get(), size });
         ASSERT_EQ(left, right);
 
         for (size_t i = 0; i < size; i++)
@@ -78,20 +78,20 @@ TEST(WTF, StringHasher_SuperFastHash_VS_WYHash)
         vector.resize(size);
         for (unsigned i = 0; i < size; ++i)
             vector[i] = i & 0x7f;
-        sum += SuperFastHash::computeHashAndMaskTop8Bits(vector.data(), size);
-        sum += WYHash::computeHashAndMaskTop8Bits(vector.data(), size);
-        sum += StringHasher::computeHashAndMaskTop8Bits(vector.data(), size);
+        sum += SuperFastHash::computeHashAndMaskTop8Bits(std::span<const UChar> { vector.data(), size });
+        sum += WYHash::computeHashAndMaskTop8Bits(std::span<const UChar> { vector.data(), size });
+        sum += StringHasher::computeHashAndMaskTop8Bits(std::span<const UChar> { vector.data(), size });
         auto start = MonotonicTime::now();
         for (unsigned i = 0; i < 1e5; ++i)
-            sum += SuperFastHash::computeHashAndMaskTop8Bits(vector.data(), size);
+            sum += SuperFastHash::computeHashAndMaskTop8Bits(std::span<const UChar> { vector.data(), size });
         dataLogLn("SFH ", size, " -> ", MonotonicTime::now() - start);
         start = MonotonicTime::now();
         for (unsigned i = 0; i < 1e5; ++i)
-            sum += WYHash::computeHashAndMaskTop8Bits(vector.data(), size);
+            sum += WYHash::computeHashAndMaskTop8Bits(std::span<const UChar> { vector.data(), size });
         dataLogLn("WYH ", size, " -> ", MonotonicTime::now() - start);
         start = MonotonicTime::now();
         for (unsigned i = 0; i < 1e5; ++i)
-            sum += StringHasher::computeHashAndMaskTop8Bits(vector.data(), size);
+            sum += StringHasher::computeHashAndMaskTop8Bits(std::span<const UChar> { vector.data(), size });
         dataLogLn("STH ", size, " -> ", MonotonicTime::now() - start);
     }
 
@@ -101,20 +101,20 @@ TEST(WTF, StringHasher_SuperFastHash_VS_WYHash)
         vector.resize(size);
         for (unsigned i = 0; i < size; ++i)
             vector[i] = i & 0x7f;
-        sum += SuperFastHash::computeHashAndMaskTop8Bits(vector.data(), size);
-        sum += WYHash::computeHashAndMaskTop8Bits(vector.data(), size);
-        sum += StringHasher::computeHashAndMaskTop8Bits(vector.data(), size);
+        sum += SuperFastHash::computeHashAndMaskTop8Bits(std::span<const LChar> { vector.data(), size });
+        sum += WYHash::computeHashAndMaskTop8Bits(std::span<const LChar> { vector.data(), size });
+        sum += StringHasher::computeHashAndMaskTop8Bits(std::span<const LChar> { vector.data(), size });
         auto start = MonotonicTime::now();
         for (unsigned i = 0; i < 1e5; ++i)
-            sum += SuperFastHash::computeHashAndMaskTop8Bits(vector.data(), size);
+            sum += SuperFastHash::computeHashAndMaskTop8Bits(std::span<const LChar> { vector.data(), size });
         dataLogLn("SFH ", size, " -> ", MonotonicTime::now() - start);
         start = MonotonicTime::now();
         for (unsigned i = 0; i < 1e5; ++i)
-            sum += WYHash::computeHashAndMaskTop8Bits(vector.data(), size);
+            sum += WYHash::computeHashAndMaskTop8Bits(std::span<const LChar> { vector.data(), size });
         dataLogLn("WYH ", size, " -> ", MonotonicTime::now() - start);
         start = MonotonicTime::now();
         for (unsigned i = 0; i < 1e5; ++i)
-            sum += StringHasher::computeHashAndMaskTop8Bits(vector.data(), size);
+            sum += StringHasher::computeHashAndMaskTop8Bits(std::span<const LChar> { vector.data(), size });
         dataLogLn("STH ", size, " -> ", MonotonicTime::now() - start);
     }
     dataLogLn(sum);

--- a/Tools/TestWebKitAPI/Tests/WTF/SuperFastHash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/SuperFastHash.cpp
@@ -433,32 +433,40 @@ TEST(WTF, SuperFastHash_addCharactersAssumingAligned)
 
 TEST(WTF, SuperFastHash_computeHash)
 {
-    ASSERT_EQ(emptyStringHash, SuperFastHash::computeHash(static_cast<LChar*>(0), 0));
-    ASSERT_EQ(emptyStringHash, SuperFastHash::computeHash(nullLChars, 0));
-    ASSERT_EQ(emptyStringHash, SuperFastHash::computeHash(static_cast<UChar*>(0), 0));
-    ASSERT_EQ(emptyStringHash, SuperFastHash::computeHash(nullUChars, 0));
+    // Use `zeroLength` instead of hardcoding `0` to work around around llvm bug:
+    // Ambiguous constructor call error when calling std::span<T>(T*, 0).
+    // https://bugs.llvm.org/show_bug.cgi?id=49295
+    static constexpr size_t zeroLength = 0;
+    ASSERT_EQ(emptyStringHash, SuperFastHash::computeHash(std::span { static_cast<const LChar*>(0), zeroLength }));
+    ASSERT_EQ(emptyStringHash, SuperFastHash::computeHash(std::span { nullLChars, zeroLength }));
+    ASSERT_EQ(emptyStringHash, SuperFastHash::computeHash(std::span { static_cast<const UChar*>(0), zeroLength }));
+    ASSERT_EQ(emptyStringHash, SuperFastHash::computeHash(std::span { nullUChars, zeroLength }));
 
-    ASSERT_EQ(singleNullCharacterHash, SuperFastHash::computeHash(nullLChars, 1));
-    ASSERT_EQ(singleNullCharacterHash, SuperFastHash::computeHash(nullUChars, 1));
+    ASSERT_EQ(singleNullCharacterHash, SuperFastHash::computeHash(std::span { nullLChars, 1 }));
+    ASSERT_EQ(singleNullCharacterHash, SuperFastHash::computeHash(std::span { nullUChars, 1 }));
 
-    ASSERT_EQ(testAHash5, SuperFastHash::computeHash(testALChars, 5));
-    ASSERT_EQ(testAHash5, SuperFastHash::computeHash(testAUChars, 5));
-    ASSERT_EQ(testBHash5, SuperFastHash::computeHash(testBUChars, 5));
+    ASSERT_EQ(testAHash5, SuperFastHash::computeHash(std::span { testALChars, 5 }));
+    ASSERT_EQ(testAHash5, SuperFastHash::computeHash(std::span { testAUChars, 5 }));
+    ASSERT_EQ(testBHash5, SuperFastHash::computeHash(std::span { testBUChars, 5 }));
 }
 
 TEST(WTF, SuperFastHash_computeHashAndMaskTop8Bits)
 {
-    ASSERT_EQ(emptyStringHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(static_cast<LChar*>(0), 0));
-    ASSERT_EQ(emptyStringHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(nullLChars, 0));
-    ASSERT_EQ(emptyStringHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(static_cast<UChar*>(0), 0));
-    ASSERT_EQ(emptyStringHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(nullUChars, 0));
+    // Use `zeroLength` instead of hardcoding `0` to work around around llvm bug:
+    // Ambiguous constructor call error when calling std::span<T>(T*, 0).
+    // https://bugs.llvm.org/show_bug.cgi?id=49295
+    static constexpr size_t zeroLength = 0;
+    ASSERT_EQ(emptyStringHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { static_cast<const LChar*>(0), zeroLength }));
+    ASSERT_EQ(emptyStringHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { nullLChars, zeroLength }));
+    ASSERT_EQ(emptyStringHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { static_cast<const UChar*>(0), zeroLength }));
+    ASSERT_EQ(emptyStringHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { nullUChars, zeroLength }));
 
-    ASSERT_EQ(singleNullCharacterHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(nullLChars, 1));
-    ASSERT_EQ(singleNullCharacterHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(nullUChars, 1));
+    ASSERT_EQ(singleNullCharacterHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { nullLChars, 1 }));
+    ASSERT_EQ(singleNullCharacterHash & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { nullUChars, 1 }));
 
-    ASSERT_EQ(testAHash5 & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(testALChars, 5));
-    ASSERT_EQ(testAHash5 & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(testAUChars, 5));
-    ASSERT_EQ(testBHash5 & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(testBUChars, 5));
+    ASSERT_EQ(testAHash5 & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { testALChars, 5 }));
+    ASSERT_EQ(testAHash5 & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { testAUChars, 5 }));
+    ASSERT_EQ(testBHash5 & 0xFFFFFF, SuperFastHash::computeHashAndMaskTop8Bits(std::span { testBUChars, 5 }));
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/WYHash.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WYHash.cpp
@@ -69,10 +69,10 @@ TEST(WTF, WYHasher)
 
     unsigned max8Bit = std::numeric_limits<uint8_t>::max();
     for (size_t size = 0; size <= max8Bit; size++) {
-        std::unique_ptr<LChar[]> arr1 = generateLCharArray(size);
-        std::unique_ptr<UChar[]> arr2 = generateUCharArray(size);
-        unsigned left = WYHash::computeHashAndMaskTop8Bits(arr1.get(), size);
-        unsigned right = WYHash::computeHashAndMaskTop8Bits(arr2.get(), size);
+        std::unique_ptr<const LChar[]> arr1 = generateLCharArray(size);
+        std::unique_ptr<const UChar[]> arr2 = generateUCharArray(size);
+        unsigned left = WYHash::computeHashAndMaskTop8Bits(std::span { arr1.get(), size });
+        unsigned right = WYHash::computeHashAndMaskTop8Bits(std::span { arr2.get(), size });
         ASSERT_EQ(left, right);
         ASSERT_EQ(left, expected[size]);
     }


### PR DESCRIPTION
#### ec9483a7d0e3850cee94dd22f1635397c6a1c764
<pre>
Update computeHashImpl() to use a span
<a href="https://bugs.webkit.org/show_bug.cgi?id=271215">https://bugs.webkit.org/show_bug.cgi?id=271215</a>

Reviewed by Darin Adler and Sam Weinig.

* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::SubstringTranslator8::hash):
(WTF::SubstringTranslator16::hash):
* Source/WTF/wtf/text/StringHash.h:
(WTF::ASCIICaseInsensitiveHash::hash):
(WTF::HashTranslatorASCIILiteral::hash):
* Source/WTF/wtf/text/StringHasher.h:
* Source/WTF/wtf/text/StringHasherInlines.h:
(WTF::StringHasher::computeHashAndMaskTop8Bits):
(WTF::StringHasher::computeLiteralHashAndMaskTop8Bits):
(WTF::StringHasher::hashWithTop8BitsMasked):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::hashSlowCase const):
(WTF::StringImpl::concurrentHash const):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::HashTranslatorCharBuffer::HashTranslatorCharBuffer):
(WTF::StringImpl::setHash const):
(WTF::StringImpl::assertHashIsCorrect const):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::hash const):
* Source/WTF/wtf/text/SuperFastHash.h:
(WTF::SuperFastHash::computeHashAndMaskTop8Bits):
(WTF::SuperFastHash::computeHash):
(WTF::SuperFastHash::computeHashImpl):
* Source/WTF/wtf/text/WYHash.h:
(WTF::WYHash::computeHashAndMaskTop8Bits):
(WTF::WYHash::hash):
(WTF::WYHash::computeHashImpl):
* Source/WebCore/bindings/js/ScriptBufferSourceProvider.h:
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::urlHostHash):
* Source/WebCore/loader/cache/CachedScript.cpp:
(WebCore::CachedScript::script):
* Source/WebCore/platform/graphics/WidthCache.h:
(WebCore::WidthCache::SmallStringKey::SmallStringKey):

Canonical link: <a href="https://commits.webkit.org/276406@main">https://commits.webkit.org/276406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54268cd5461dafa78824eb302263c3ef2352ed18

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46982 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/47251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21001 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36651 "Exiting early after 500 failures. 1145 tests run. 500 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17725 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18141 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39475 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2581 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37726 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48808 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43984 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16027 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43555 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20836 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42303 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21164 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51166 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6133 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20492 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10374 "Passed tests") | 
<!--EWS-Status-Bubble-End-->