### PR TITLE
Make NetworkStorageSession::nsCookieStorage() return RetainPtr

### DIFF
--- a/Source/WebCore/platform/network/NetworkStorageSession.h
+++ b/Source/WebCore/platform/network/NetworkStorageSession.h
@@ -121,7 +121,7 @@ public:
     CredentialStorage& credentialStorage() { return m_credentialStorage; }
 
 #ifdef __OBJC__
-    WEBCORE_EXPORT NSHTTPCookieStorage *nsCookieStorage() const;
+    WEBCORE_EXPORT RetainPtr<NSHTTPCookieStorage> nsCookieStorage() const;
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
+++ b/Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
@@ -62,12 +62,12 @@ void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionI
     if (!storageSession)
         return completionHandler();
 
-    auto* nsCookieStorage = storageSession->nsCookieStorage();
+    RetainPtr nsCookieStorage = storageSession->nsCookieStorage();
     if (!nsCookieStorage)
         return completionHandler();
 
     CFHTTPCookieStorageSetCookieAcceptPolicy([nsCookieStorage _cookieStorage], toCFHTTPCookieStorageAcceptPolicy(policy));
-    saveCookies(nsCookieStorage, WTFMove(completionHandler));
+    saveCookies(nsCookieStorage.get(), WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -206,10 +206,12 @@ void saveCookies(NSHTTPCookieStorage *cookieStorage, CompletionHandler<void()>&&
 void NetworkProcess::platformFlushCookies(PAL::SessionID sessionID, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
-    if (auto* networkStorageSession = storageSession(sessionID))
-        saveCookies(networkStorageSession->nsCookieStorage(), WTFMove(completionHandler));
-    else
-        completionHandler();
+    auto* networkStorageSession = storageSession(sessionID);
+    if (!networkStorageSession)
+        return completionHandler();
+
+    RetainPtr cookieStorage = networkStorageSession->nsCookieStorage();
+    saveCookies(cookieStorage.get(), WTFMove(completionHandler));
 }
 
 #if ENABLE(CFPREFS_DIRECT_MODE)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -219,7 +219,7 @@ void NetworkTaskCocoa::unblockCookies()
         return;
 
     if (auto* storageSession = m_networkSession->networkStorageSession()) {
-        [task() _setExplicitCookieStorage:storageSession->nsCookieStorage()._cookieStorage];
+        [task() _setExplicitCookieStorage:[storageSession->nsCookieStorage() _cookieStorage]];
         m_hasBeenSetToUseStatelessCookieStorage = false;
     }
 }


### PR DESCRIPTION
#### dd766a3312d0b3fc4f858951893ad75fc7b640f3
<pre>
Make NetworkStorageSession::nsCookieStorage() return RetainPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=271222">https://bugs.webkit.org/show_bug.cgi?id=271222</a>
<a href="https://rdar.apple.com/117317285">rdar://117317285</a>

Reviewed by Chris Dumez.

To avoid the returned NSHTTPCookieStorage being released while it&apos;s still in use.

* Source/WebCore/platform/network/NetworkStorageSession.h:
* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::NetworkStorageSession::getAllCookies):
(WebCore::NetworkStorageSession::hasCookies const):
(WebCore::NetworkStorageSession::setAllCookiesToSameSiteStrict):
(WebCore::NetworkStorageSession::nsCookieStorage const):
(WebCore::NetworkStorageSession::cookieStorageObserver const):
* Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm:
(WebKit::WebCookieManager::platformSetHTTPCookieAcceptPolicy):
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::platformFlushCookies):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::NetworkTaskCocoa::unblockCookies):

Canonical link: <a href="https://commits.webkit.org/276355@main">https://commits.webkit.org/276355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f44b5555f3f25a316d68605dc257e2390d4bcfee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47041 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40416 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20856 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36527 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 18 flakes 207 failures 1 missing results; Uploaded test results; Running layout-tests-repeat-failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39334 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2439 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48654 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43433 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20727 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42163 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9883 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21055 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->