### PR TITLE
new exception handler adoption

### DIFF
--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -138,13 +138,13 @@ void initialize()
         if (Wasm::isSupported() || !Options::usePollingTraps()) {
             // JSLock::lock() can call registerThreadForMachExceptionHandling() which crashes if this has not been called first.
             int mask = 0;
-#if CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
             JSC::Wasm::MachExceptionSigningKey keygen;
             uint32_t signingKey = keygen.randomSigningKey;
             mask |= toMachMask(Signal::AccessFault);
 #else
             uint32_t signingKey = 0;
-#endif // CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#endif // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
             initializeSignalHandling(signingKey, mask);
 
             if (!Options::usePollingTraps())

--- a/Source/JavaScriptCore/runtime/MachineContext.h
+++ b/Source/JavaScriptCore/runtime/MachineContext.h
@@ -44,6 +44,7 @@ template<typename T = void*> T framePointer(const PlatformRegisters&);
 inline CodePtr<PlatformRegistersLRPtrTag> linkRegister(const PlatformRegisters&);
 inline std::optional<CodePtr<PlatformRegistersPCPtrTag>> instructionPointer(const PlatformRegisters&);
 inline void setInstructionPointer(PlatformRegisters&, CodePtr<CFunctionPtrTag>);
+inline void setInstructionPointer(PlatformRegisters&, void *);
 
 template<size_t N> void*& argumentPointer(PlatformRegisters&);
 template<size_t N> void* argumentPointer(const PlatformRegisters&);
@@ -457,10 +458,25 @@ inline void setInstructionPointer(PlatformRegisters& regs, CodePtr<CFunctionPtrT
 {
 #if USE(PLATFORM_REGISTERS_WITH_PROFILE)
     WTF_WRITE_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs, value.taggedPtr());
+#elif USE(DARWIN_REGISTER_MACROS) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+    __darwin_arm_thread_state64_set_presigned_pc_fptr(regs, value.taggedPtr());
 #elif USE(DARWIN_REGISTER_MACROS)
     __darwin_arm_thread_state64_set_pc_fptr(regs, value.taggedPtr());
 #else
     instructionPointerImpl(regs) = value.taggedPtr();
+#endif
+}
+
+inline void setInstructionPointer(PlatformRegisters& regs, void* value)
+{
+#if USE(PLATFORM_REGISTERS_WITH_PROFILE)
+    WTF_WRITE_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs, value);
+#elif USE(DARWIN_REGISTER_MACROS) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+    __darwin_arm_thread_state64_set_presigned_pc_fptr(regs, value);
+#elif USE(DARWIN_REGISTER_MACROS)
+    __darwin_arm_thread_state64_set_pc_fptr(regs, value);
+#else
+    instructionPointerImpl(regs) = value;
 #endif
 }
 #endif // OS(WINDOWS) || HAVE(MACHINE_CONTEXT)

--- a/Source/JavaScriptCore/runtime/MachineContext.h
+++ b/Source/JavaScriptCore/runtime/MachineContext.h
@@ -458,8 +458,6 @@ inline void setInstructionPointer(PlatformRegisters& regs, CodePtr<CFunctionPtrT
 {
 #if USE(PLATFORM_REGISTERS_WITH_PROFILE)
     WTF_WRITE_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs, value.taggedPtr());
-#elif USE(DARWIN_REGISTER_MACROS) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
-    __darwin_arm_thread_state64_set_presigned_pc_fptr(regs, value.taggedPtr());
 #elif USE(DARWIN_REGISTER_MACROS)
     __darwin_arm_thread_state64_set_pc_fptr(regs, value.taggedPtr());
 #else
@@ -471,7 +469,7 @@ inline void setInstructionPointer(PlatformRegisters& regs, void* value)
 {
 #if USE(PLATFORM_REGISTERS_WITH_PROFILE)
     WTF_WRITE_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs, value);
-#elif USE(DARWIN_REGISTER_MACROS) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#elif USE(DARWIN_REGISTER_MACROS) && HAVE(HARDENED_MACH_EXCEPTIONS) && CPU(ARM64E)
     __darwin_arm_thread_state64_set_presigned_pc_fptr(regs, value);
 #elif USE(DARWIN_REGISTER_MACROS)
     __darwin_arm_thread_state64_set_pc_fptr(regs, value);

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -201,6 +201,7 @@ public:
         , m_vm(vm)
     {
         activateSignalHandlersFor(Signal::AccessFault);
+        finalizeSignalHandlers();
     }
 
     static void initializeSignals()

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -38,11 +38,29 @@
 #include "WasmExceptionType.h"
 #include "WasmMemory.h"
 #include "WasmThunks.h"
+#include <wtf/CodePtr.h>
+#include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/threads/Signals.h>
 
 namespace JSC { namespace Wasm {
+
+using WTF::CodePtr;
+
+#if CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+void* presignedTrampoline = { };
+
+MachExceptionSigningKey::MachExceptionSigningKey()
+{
+    // Sign the trampoline pointer using a random diversifier and stash it away before webcontent has started so that
+    // even a PAC signing gadget cannot fake this random diversifier
+    randomSigningKey = WTF::cryptographicallyRandomNumber<uint32_t>() & __DARWIN_ARM_THREAD_STATE64_USER_DIVERSIFIER_MASK;
+    uint64_t diversifier = ptrauth_blend_discriminator((void *)(unsigned long)randomSigningKey, ptrauth_string_discriminator("pc"));
+    presignedTrampoline = JSC::LLInt::getCodePtr<CFunctionPtrTag>(wasm_throw_from_fault_handler_trampoline_reg_instance).untaggedPtr();
+    presignedTrampoline = ptrauth_sign_unauthenticated(presignedTrampoline, ptrauth_key_function_pointer, diversifier);
+}
+#endif // CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
 
 namespace {
 namespace WasmFaultSignalHandlerInternal {
@@ -96,7 +114,11 @@ static SignalAction trapHandler(Signal signal, SigInfo& sigInfo, PlatformRegiste
             };
 
             if (didFaultInWasm(faultingInstruction)) {
+#if CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+                MachineContext::setInstructionPointer(context, presignedTrampoline);
+#else
                 MachineContext::setInstructionPointer(context, LLInt::getCodePtr<CFunctionPtrTag>(wasm_throw_from_fault_handler_trampoline_reg_instance));
+#endif
                 return SignalAction::Handled;
             }
         }
@@ -115,6 +137,7 @@ void activateSignalingMemory()
             return;
 
         activateSignalHandlersFor(Signal::AccessFault);
+        WTF::finalizeSignalHandlers();
     });
 }
 

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
@@ -28,7 +28,6 @@
 namespace JSC {
 
 namespace Wasm {
-
 #if ENABLE(WEBASSEMBLY)
 void activateSignalingMemory();
 void prepareSignalingMemory();
@@ -36,5 +35,13 @@ void prepareSignalingMemory();
 inline void activateSignalingMemory() { }
 inline void prepareSignalingMemory() { }
 #endif // ENABLE(WEBASSEMBLY)
+
+#if CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+class MachExceptionSigningKey {
+public:
+    uint32_t randomSigningKey = { };
+    MachExceptionSigningKey();
+};
+#endif // CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
 
 } } // namespace JSC::Wasm

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -4060,6 +4060,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B7014689C4700E78B76 /* DebugRelease.xcconfig */;
 			buildSettings = {
+				OTHER_MIGFLAGS = "-DMACH_EXC_SERVER_TASKIDTOKEN_STATE";
 			};
 			name = Debug;
 		};
@@ -4067,6 +4068,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B7014689C4700E78B76 /* DebugRelease.xcconfig */;
 			buildSettings = {
+				OTHER_MIGFLAGS = "-DMACH_EXC_SERVER_TASKIDTOKEN_STATE";
 			};
 			name = Release;
 		};
@@ -4088,6 +4090,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B6E14689C4700E78B76 /* Base.xcconfig */;
 			buildSettings = {
+				OTHER_MIGFLAGS = "-DMACH_EXC_SERVER_TASKIDTOKEN_STATE";
 			};
 			name = Production;
 		};

--- a/Source/WTF/wtf/PlatformJSCOnly.cmake
+++ b/Source/WTF/wtf/PlatformJSCOnly.cmake
@@ -84,7 +84,7 @@ elseif (APPLE)
             ${WTF_DERIVED_SOURCES_DIR}/mach_excUser.c
         MAIN_DEPENDENCY mac/MachExceptions.defs
         WORKING_DIRECTORY ${WTF_DERIVED_SOURCES_DIR}
-        COMMAND mig -sheader MachExceptionsServer.h MachExceptions.defs
+        COMMAND mig -DMACH_EXC_SERVER_TASKIDTOKEN_STATE -sheader MachExceptionsServer.h MachExceptions.defs
         VERBATIM)
     list(APPEND WTF_SOURCES
         cocoa/MemoryFootprintCocoa.cpp

--- a/Source/WTF/wtf/PlatformMac.cmake
+++ b/Source/WTF/wtf/PlatformMac.cmake
@@ -117,7 +117,7 @@ add_custom_command(
         ${WTF_DERIVED_SOURCES_DIR}/mach_excUser.c
     MAIN_DEPENDENCY mac/MachExceptions.defs
     WORKING_DIRECTORY ${WTF_DERIVED_SOURCES_DIR}
-    COMMAND mig -sheader MachExceptionsServer.h MachExceptions.defs
+    COMMAND mig -DMACH_EXC_SERVER_TASKIDTOKEN_STATE -sheader MachExceptionsServer.h MachExceptions.defs
     VERBATIM)
 list(APPEND WTF_SOURCES
     ${WTF_DERIVED_SOURCES_DIR}/mach_excServer.c

--- a/Source/WTF/wtf/PlatformRegisters.cpp
+++ b/Source/WTF/wtf/PlatformRegisters.cpp
@@ -53,6 +53,14 @@ void* threadStateLRInternal(PlatformRegisters& regs)
 
 void* threadStatePCInternal(PlatformRegisters& regs)
 {
+#if CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+    // If userspace has modified the PC and set it to the presignedTrampoline,
+    // we want to avoid authing the value as it is using a custom ptrauth signing scheme.
+    _STRUCT_ARM_THREAD_STATE64* ts = &(regs);
+    if (!(ts->__opaque_flags & __DARWIN_ARM_THREAD_STATE64_FLAGS_KERNEL_SIGNED_PC))
+        return nullptr;
+#endif // defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+
     void* candidatePC = arm_thread_state64_get_pc_fptr(regs);
 
 #if USE(UNTAGGED_THREAD_STATE_PTR)

--- a/Source/WTF/wtf/PlatformRegisters.cpp
+++ b/Source/WTF/wtf/PlatformRegisters.cpp
@@ -53,13 +53,13 @@ void* threadStateLRInternal(PlatformRegisters& regs)
 
 void* threadStatePCInternal(PlatformRegisters& regs)
 {
-#if CPU(ARM64E) && defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
     // If userspace has modified the PC and set it to the presignedTrampoline,
     // we want to avoid authing the value as it is using a custom ptrauth signing scheme.
     _STRUCT_ARM_THREAD_STATE64* ts = &(regs);
     if (!(ts->__opaque_flags & __DARWIN_ARM_THREAD_STATE64_FLAGS_KERNEL_SIGNED_PC))
         return nullptr;
-#endif // defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#endif // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
 
     void* candidatePC = arm_thread_state64_get_pc_fptr(regs);
 

--- a/Source/WTF/wtf/PlatformRegisters.h
+++ b/Source/WTF/wtf/PlatformRegisters.h
@@ -30,6 +30,7 @@
 #include <wtf/StdLibExtras.h>
 
 #if OS(DARWIN)
+#include <mach/exception_types.h>
 #include <mach/thread_act.h>
 #include <signal.h>
 #elif OS(WINDOWS)
@@ -130,8 +131,13 @@ using WTF::threadStatePCInternal;
 #define WTF_READ_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs) \
     threadStatePCInternal(const_cast<PlatformRegisters&>(regs))
 
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#define WTF_WRITE_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs, newPointer) \
+    arm_thread_state64_set_pc_presigned_fptr(regs, newPointer)
+#else // defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
 #define WTF_WRITE_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs, newPointer) \
     arm_thread_state64_set_pc_fptr(regs, newPointer)
+#endif // defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
 
 #define WTF_READ_MACHINE_CONTEXT_SP_WITH_PROFILE(machineContext) \
     WTF_READ_PLATFORM_REGISTERS_SP_WITH_PROFILE(machineContext->__ss)

--- a/Source/WTF/wtf/PlatformRegisters.h
+++ b/Source/WTF/wtf/PlatformRegisters.h
@@ -131,13 +131,13 @@ using WTF::threadStatePCInternal;
 #define WTF_READ_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs) \
     threadStatePCInternal(const_cast<PlatformRegisters&>(regs))
 
-#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
 #define WTF_WRITE_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs, newPointer) \
     arm_thread_state64_set_pc_presigned_fptr(regs, newPointer)
-#else // defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#else // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
 #define WTF_WRITE_PLATFORM_REGISTERS_PC_WITH_PROFILE(regs, newPointer) \
     arm_thread_state64_set_pc_fptr(regs, newPointer)
-#endif // defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#endif // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
 
 #define WTF_READ_MACHINE_CONTEXT_SP_WITH_PROFILE(machineContext) \
     WTF_READ_PLATFORM_REGISTERS_SP_WITH_PROFILE(machineContext->__ss)

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -41,27 +41,29 @@ extern "C" {
 #if HAVE(MACH_EXCEPTIONS)
 #include <dispatch/dispatch.h>
 #include <mach/mach.h>
+#include <mach/port.h>
+#include <mach/task.h>
 #include <mach/thread_act.h>
+#include <mach/thread_status.h>
 #endif
 
 #if OS(DARWIN)
 #include <mach/vm_param.h>
 #endif
 
+#include <unistd.h>
 #include <wtf/Atomics.h>
 #include <wtf/DataLog.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/PlatformRegisters.h>
+#include <wtf/Scope.h>
 #include <wtf/ThreadGroup.h>
 #include <wtf/Threading.h>
+#include <wtf/TranslatedProcess.h>
 #include <wtf/WTFConfig.h>
 
 namespace WTF {
-
-#if HAVE(MACH_EXCEPTIONS)
-static exception_mask_t toMachMask(Signal);
-#endif
 
 void SignalHandlers::add(Signal signal, SignalHandler&& handler)
 {
@@ -110,8 +112,9 @@ inline void SignalHandlers::forEachHandler(Signal signal, const Func& func) cons
 // http://www.cs.cmu.edu/afs/cs/project/mach/public/doc/unpublished/mig.ps
 
 static constexpr size_t maxMessageSize = 1 * KB;
+uint32_t randomSigningKey = 0;
 
-void initMachExceptionHandlerThread(bool enable)
+void initMachExceptionHandlerThread(bool enable, uint32_t signingKey, exception_mask_t mask)
 {
     static std::once_flag once;
     std::call_once(once, [=] {
@@ -124,18 +127,37 @@ void initMachExceptionHandlerThread(bool enable)
         Config::AssertNotFrozenScope assertScope;
         SignalHandlers& handlers = g_wtfConfig.signalHandlers;
 
-        uint16_t flags = 0;
+        uint16_t flags = MPO_INSERT_SEND_RIGHT;
+
+// This provisional flag can be removed once macos sonoma is no longer supported
 #ifdef MPO_PROVISIONAL_ID_PROT_OPTOUT
         flags |= MPO_PROVISIONAL_ID_PROT_OPTOUT;
+#endif
+
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+        flags |= MPO_EXCEPTION_PORT;
 #endif
         mach_port_options_t opts = {
             .flags = flags
         };
 
+
         kern_return_t kr = mach_port_construct(mach_task_self(), &opts, 0, &handlers.exceptionPort);
         RELEASE_ASSERT(kr == KERN_SUCCESS);
-        kr = mach_port_insert_right(mach_task_self(), handlers.exceptionPort, handlers.exceptionPort, MACH_MSG_TYPE_MAKE_SEND);
+
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+        uint64_t exceptionsAllowed = mask;
+        uint64_t behaviorsAllowed = EXCEPTION_STATE_IDENTITY_PROTECTED | MACH_EXCEPTION_CODES;
+        uint64_t flavorsAllowed = MACHINE_THREAD_STATE;
+
+        kr = task_register_hardened_exception_handler(current_task(),
+            signingKey, exceptionsAllowed,
+            behaviorsAllowed, flavorsAllowed, handlers.exceptionPort);
         RELEASE_ASSERT(kr == KERN_SUCCESS);
+#else
+        UNUSED_PARAM(signingKey);
+        UNUSED_PARAM(mask);
+#endif
 
         dispatch_source_t source = dispatch_source_create(
             DISPATCH_SOURCE_TYPE_MACH_RECV, handlers.exceptionPort, 0, DISPATCH_TARGET_QUEUE_DEFAULT);
@@ -165,18 +187,6 @@ static Signal fromMachException(exception_type_t type)
     default: break;
     }
     return Signal::Unknown;
-}
-
-static exception_mask_t toMachMask(Signal signal)
-{
-    switch (signal) {
-    case Signal::AccessFault: return EXC_MASK_BAD_ACCESS;
-    case Signal::IllegalInstruction: return EXC_MASK_BAD_INSTRUCTION;
-    case Signal::FloatingPoint: return EXC_MASK_ARITHMETIC;
-    case Signal::Breakpoint: return EXC_MASK_BREAKPOINT;
-    default: break;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
 }
 
 #if CPU(ARM64E) && OS(DARWIN)
@@ -222,6 +232,53 @@ kern_return_t catch_mach_exception_raise_state_identity(mach_port_t, mach_port_t
     return KERN_FAILURE;
 }
 
+static kern_return_t runSignalHandlers(Signal &signal, PlatformRegisters& registers, bool &didHandle, mach_msg_type_number_t dataCount, mach_exception_data_t exceptionData)
+{
+    SigInfo info;
+    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    if (signal == Signal::AccessFault) {
+        ASSERT_UNUSED(dataCount, dataCount == 2);
+        info.faultingAddress = reinterpret_cast<void*>(exceptionData[1]);
+#if CPU(ADDRESS64)
+        // If the faulting address is out of the range of any valid memory, we would
+        // not have any reason to handle it. Just let the default handler take care of it.
+        static constexpr unsigned validAddressBits = OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH);
+        static constexpr uintptr_t invalidAddressMask = ~((1ull << validAddressBits) - 1);
+        if (bitwise_cast<uintptr_t>(info.faultingAddress) & invalidAddressMask)
+            return KERN_FAILURE;
+#endif
+    }
+
+    handlers.forEachHandler(signal, [&] (const SignalHandler& handler) {
+        SignalAction handlerResult = handler(signal, info, registers);
+        didHandle |= handlerResult == SignalAction::Handled;
+    });
+    return KERN_SUCCESS;
+}
+
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+
+kern_return_t catch_mach_exception_raise_state_identity_protected(
+    mach_port_t exceptionPort,
+    uint64_t threadID,
+    mach_port_t taskIDToken,
+    exception_type_t exceptionType,
+    mach_exception_data_t exceptionData,
+    mach_msg_type_number_t dataCount,
+    int* stateFlavor,
+    const thread_state_t inState,
+    mach_msg_type_number_t inStateCount,
+    thread_state_t outState,
+    mach_msg_type_number_t* outStateCount)
+{
+    UNUSED_PARAM(threadID);
+    UNUSED_PARAM(taskIDToken);
+    return catch_mach_exception_raise_state(exceptionPort, exceptionType, exceptionData,
+        dataCount, stateFlavor, inState, inStateCount, outState, outStateCount);
+}
+
+#endif // defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
+
 kern_return_t catch_mach_exception_raise_state(
     mach_port_t port,
     exception_type_t exceptionType,
@@ -263,25 +320,10 @@ kern_return_t catch_mach_exception_raise_state(
     PlatformRegisters& registers = reinterpret_cast<arm_unified_thread_state*>(outState)->ts_32;
 #endif
 
-    SigInfo info;
-    if (signal == Signal::AccessFault) {
-        ASSERT_UNUSED(dataCount, dataCount == 2);
-        info.faultingAddress = reinterpret_cast<void*>(exceptionData[1]);
-#if CPU(ADDRESS64)
-        // If the faulting address is out of the range of any valid memory, we would
-        // not have any reason to handle it. Just let the default handler take care of it.
-        static constexpr unsigned validAddressBits = OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH);
-        static constexpr uintptr_t invalidAddressMask = ~((1ull << validAddressBits) - 1);
-        if (bitwise_cast<uintptr_t>(info.faultingAddress) & invalidAddressMask)
-            return KERN_FAILURE;
-#endif
-    }
-
     bool didHandle = false;
-    handlers.forEachHandler(signal, [&] (const SignalHandler& handler) {
-        SignalAction handlerResult = handler(signal, info, registers);
-        didHandle |= handlerResult == SignalAction::Handled;
-    });
+    kern_return_t kr = runSignalHandlers(signal, registers, didHandle, dataCount, exceptionData);
+    if (kr != KERN_SUCCESS)
+        return kr;
 
     if (didHandle) {
 #if CPU(ARM64E) && OS(DARWIN)
@@ -307,7 +349,27 @@ inline void setExceptionPorts(const AbstractLocker& threadGroupLocker, Thread& t
 {
     UNUSED_PARAM(threadGroupLocker);
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    kern_return_t result = thread_set_exception_ports(thread.machThread(), handlers.addedExceptions & activeExceptions, handlers.exceptionPort, EXCEPTION_STATE | MACH_EXCEPTION_CODES, MACHINE_THREAD_STATE);
+
+#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+    exception_behavior_t newBehavior = MACH_EXCEPTION_CODES;
+    if (WTF::isX86BinaryRunningOnARM()) {
+        // If we are a translated process in rosetta, use the old exception style
+        newBehavior |= EXCEPTION_STATE;
+    } else {
+        // Otherwise use the new style
+        newBehavior |= EXCEPTION_STATE_IDENTITY_PROTECTED;
+        kern_return_t result = thread_adopt_exception_handler(thread.machThread(), handlers.exceptionPort, handlers.addedExceptions &activeExceptions, newBehavior, MACHINE_THREAD_STATE);
+        if (result != KERN_SUCCESS) {
+            dataLogLn("thread adopt exception handler failed due to ", mach_error_string(result));
+            CRASH();
+        }
+        return;
+    }
+#else // defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+    exception_behavior_t newBehavior = EXCEPTION_STATE | MACH_EXCEPTION_CODES;
+#endif // defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+
+    kern_return_t result = thread_set_exception_ports(thread.machThread(), handlers.addedExceptions &activeExceptions, handlers.exceptionPort, newBehavior, MACHINE_THREAD_STATE);
     if (result != KERN_SUCCESS) {
         dataLogLn("thread set port failed due to ", mach_error_string(result));
         CRASH();
@@ -418,10 +480,20 @@ void activateSignalHandlersFor(Signal signal)
     ASSERT(signal < Signal::Unknown);
     ASSERT(!handlers.useMach || signal != Signal::Usr);
 
+    if (handlers.useMach)
+        activeExceptions |= toMachMask(signal);
+#endif
+}
+
+
+void finalizeSignalHandlers()
+{
+#if HAVE(MACH_EXCEPTIONS)
+    const SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    RELEASE_ASSERT(handlers.initState >= SignalHandlers::InitState::InitializedHandlerThread);
+
     Locker locker { activeThreads().getLock() };
     if (handlers.useMach) {
-        activeExceptions |= toMachMask(signal);
-
         for (auto& thread : activeThreads().threads(locker))
             setExceptionPorts(locker, thread.get());
     }

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -134,7 +134,7 @@ void initMachExceptionHandlerThread(bool enable, uint32_t signingKey, exception_
         flags |= MPO_PROVISIONAL_ID_PROT_OPTOUT;
 #endif
 
-#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
         flags |= MPO_EXCEPTION_PORT;
 #endif
         mach_port_options_t opts = {
@@ -145,7 +145,7 @@ void initMachExceptionHandlerThread(bool enable, uint32_t signingKey, exception_
         kern_return_t kr = mach_port_construct(mach_task_self(), &opts, 0, &handlers.exceptionPort);
         RELEASE_ASSERT(kr == KERN_SUCCESS);
 
-#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
         uint64_t exceptionsAllowed = mask;
         uint64_t behaviorsAllowed = EXCEPTION_STATE_IDENTITY_PROTECTED | MACH_EXCEPTION_CODES;
         uint64_t flavorsAllowed = MACHINE_THREAD_STATE;
@@ -350,7 +350,7 @@ inline void setExceptionPorts(const AbstractLocker& threadGroupLocker, Thread& t
     UNUSED_PARAM(threadGroupLocker);
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
 
-#if defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
     exception_behavior_t newBehavior = MACH_EXCEPTION_CODES;
     if (WTF::isX86BinaryRunningOnARM()) {
         // If we are a translated process in rosetta, use the old exception style
@@ -365,9 +365,9 @@ inline void setExceptionPorts(const AbstractLocker& threadGroupLocker, Thread& t
         }
         return;
     }
-#else // defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#else // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
     exception_behavior_t newBehavior = EXCEPTION_STATE | MACH_EXCEPTION_CODES;
-#endif // defined(EXCEPTION_STATE_IDENTITY_PROTECTED) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#endif // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
 
     kern_return_t result = thread_set_exception_ports(thread.machThread(), handlers.addedExceptions &activeExceptions, handlers.exceptionPort, newBehavior, MACHINE_THREAD_STATE);
     if (result != KERN_SUCCESS) {

--- a/Source/WTF/wtf/threads/Signals.h
+++ b/Source/WTF/wtf/threads/Signals.h
@@ -124,18 +124,36 @@ struct SignalHandlers {
 // and once commited they can't be turned off.
 WTF_EXPORT_PRIVATE void addSignalHandler(Signal, SignalHandler&&);
 WTF_EXPORT_PRIVATE void activateSignalHandlersFor(Signal);
+WTF_EXPORT_PRIVATE void finalizeSignalHandlers();
 
+#if OS(UNIX) && HAVE(MACH_EXCEPTIONS)
+inline exception_mask_t toMachMask(Signal signal)
+{
+    switch (signal) {
+    case Signal::AccessFault: return EXC_MASK_BAD_ACCESS;
+    case Signal::IllegalInstruction: return EXC_MASK_BAD_INSTRUCTION;
+    case Signal::FloatingPoint: return EXC_MASK_ARITHMETIC;
+    case Signal::Breakpoint: return EXC_MASK_BREAKPOINT;
+    default: break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+#endif // OS(UNIX) && HAVE(MACH_EXCEPTIONS)
 
 #if HAVE(MACH_EXCEPTIONS)
 class Thread;
 void registerThreadForMachExceptionHandling(Thread&);
-WTF_EXPORT_PRIVATE void initMachExceptionHandlerThread(bool);
-inline void initializeSignalHandling() { initMachExceptionHandlerThread(true); }
-inline void disableSignalHandling() { initMachExceptionHandlerThread(false); }
+WTF_EXPORT_PRIVATE void initMachExceptionHandlerThread(bool, uint32_t, exception_mask_t);
+inline void initializeSignalHandling(uint32_t signingKey, exception_mask_t mask) { initMachExceptionHandlerThread(true, signingKey, mask); }
+inline void disableSignalHandling() { initMachExceptionHandlerThread(false, 0, 0); }
 
 void handleSignalsWithMach();
 #else
-inline void initializeSignalHandling() { }
+inline void initializeSignalHandling(uint32_t signingKey, int mask)
+{
+    UNUSED_PARAM(signingKey);
+    UNUSED_PARAM(mask);
+}
 inline void disableSignalHandling() { }
 #endif // HAVE(MACH_EXCEPTIONS)
 
@@ -152,5 +170,6 @@ using WTF::SignalAction;
 using WTF::SignalHandler;
 using WTF::addSignalHandler;
 using WTF::activateSignalHandlersFor;
+using WTF::finalizeSignalHandlers;
 using WTF::initializeSignalHandling;
 using WTF::disableSignalHandling;

--- a/Source/WTF/wtf/win/SignalsWin.cpp
+++ b/Source/WTF/wtf/win/SignalsWin.cpp
@@ -149,6 +149,11 @@ void SignalHandlers::initialize()
     // noop
 }
 
+void finalizeSignalHandlers()
+{
+    // noop
+}
+
 } // namespace WTF
 
 #endif // OS(WINDOWS)

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1466,13 +1466,28 @@
 #endif
 #endif
 
+#if HAVE(HARDENED_MACH_EXCEPTIONS)
+        (with-filter (require-not (lockdown-mode))
+            (allow mach-message-send (kernel-mig-routine thread_adopt_exception_handler))
 #if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
-        (with-filter (require-not (webcontent-process-launched))
-            (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
+            (with-filter (require-not (webcontent-process-launched))
+                (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler)))
+#else
+            (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler))
+#endif ;; ENABLE(BLOCK_SET_EXCEPTION_PORTS)
+        )
 #else
         (with-filter (require-not (lockdown-mode))
-            (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
-#endif
+#if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
+            (with-filter (require-not (webcontent-process-launched))
+                (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
+#else
+            (allow mach-message-send (kernel-mig-routine thread_set_exception_ports))
+#endif ;; ENABLE(BLOCK_SET_EXCEPTION_PORTS)
+        )
+#endif ;; HAVE(HARDENED_MACH_EXCEPTIONS)
+
+
 
         (with-filter (lockdown-mode)
             (deny mach-message-send (with telemetry) (with message "Lockdown mode")

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1822,6 +1822,18 @@
 #endif
 ))
 
+(define (allow-thread-adopt-exception-handler)
+    (when (defined? 'thread_adopt_exception_handler)
+        (allow mach-message-send (kernel-mig-routine thread_adopt_exception_handler))))
+
+(define (allow-mach-exceptions)
+#if HAVE(HARDENED_MACH_EXCEPTIONS)
+    (when (defined? 'task_register_hardened_exception_handler)
+        (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler))))
+#else
+    (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
+#endif
+
 (if (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'mach-kernel-endpoint))
     (allow mach-kernel-endpoint
         (apply-message-filter
@@ -1829,17 +1841,21 @@
 #if ENABLE(LOCKDOWN_MODE_TELEMETRY)
             (with-filter (require-not (lockdown-mode))
                 (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode))
-                (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry)))
+                (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry))
+                (allow-thread-adopt-exception-handler))
             (with-filter (lockdown-mode)
                 (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode))
                 (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry)))
 #else
             (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode))
             (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry))
+            (allow-thread-adopt-exception-handler)
 #endif
 #if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
             (with-filter (require-not (webcontent-process-launched))
-                (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
+                (allow-mach-exceptions))
+#else
+            (allow-mach-exceptions)
 #endif
 
             (allow mach-message-send (kernel-mig-routines-in-use))

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1824,14 +1824,25 @@
 
 (define (allow-thread-adopt-exception-handler)
     (when (defined? 'thread_adopt_exception_handler)
-        (allow mach-message-send (kernel-mig-routine thread_adopt_exception_handler))))
+        (allow mach-message-send (kernel-mig-routine thread_adopt_exception_handler))
+    )
+)
 
 (define (allow-mach-exceptions)
 #if HAVE(HARDENED_MACH_EXCEPTIONS)
+(if (equal? (param "CPU") "arm64")
     (when (defined? 'task_register_hardened_exception_handler)
-        (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler))))
+        (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler))
+    )
+    ; else (
+        (when (defined? 'task_register_hardened_exception_handler)
+            (allow mach-message-send (kernel-mig-routine thread_set_exception_ports))
+        )
+    )
+))
 #else
-    (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
+    (allow mach-message-send (kernel-mig-routine thread_set_exception_ports))
+)
 #endif
 
 (if (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'mach-kernel-endpoint))


### PR DESCRIPTION
<pre>
https://bugs.webkit.org/show_bug.cgi?id=269728
rdar://119256062

Reviewed by NOBODY (OOPS!).

This adopts the new hardened mach exception mechanism which was introduced in darwin recently. See the radar for more details.

* Source/JavaScriptCore/jsc.cpp: (main):
(CommandLine::parseArguments):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp: (JSC::initialize):
* Source/JavaScriptCore/runtime/MachineContext.h: (JSC::MachineContext::setInstructionPointer):
* Source/JavaScriptCore/runtime/VMTraps.cpp:
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp: (JSC::Wasm::MachExceptionSigningKey::MachExceptionSigningKey): (JSC::Wasm::trapHandler):
(JSC::Wasm::activateSignalingMemory):
(): Deleted.
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h:
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/PlatformJSCOnly.cmake:
* Source/WTF/wtf/PlatformMac.cmake:
* Source/WTF/wtf/PlatformRegisters.cpp: (WTF::threadStatePCInternal):
* Source/WTF/wtf/PlatformRegisters.h:
* Source/WTF/wtf/threads/Signals.cpp: (WTF::initMachExceptionHandlerThread):
(WTF::setExceptionPorts):
(WTF::activateSignalHandlersFor):
(WTF::finalizeSignalHandlers):
(WTF::toMachMask): Deleted.
* Source/WTF/wtf/threads/Signals.h: (WTF::toMachMask):
(WTF::initializeSignalHandling):
(WTF::disableSignalHandling):
* Source/WTF/wtf/win/SignalsWin.cpp: (WTF::finalizeSignalHandlers):
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:
* Tools/TestWebKitAPI/Tests/WTF/Signals.cpp: (TEST):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06b62aa872f0c1df9f6ff0669e82e38ab4c0331d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44393 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23465 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47046 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40421 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36549 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17594 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17965 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39344 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2444 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37637 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40574 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48660 "Built successfully") | 
| [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43889 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Found 135 jsc stress test failures: wasm.yaml/PerformanceTests/JetStream2/wasm-cli.js.wasm-slow-memory, wasm.yaml/wasm/gc/bug254412.js.wasm-omg, wasm.yaml/wasm/gc/bug254413.js.wasm-omg, wasm.yaml/wasm/gc/bug258128.js.wasm-omg, wasm.yaml/wasm/gc/simd.js.wasm-omg ...; Compiled JSC (warnings); Running jscore-test-without-change") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43438 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20732 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42169 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21060 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Running compile-webkit") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51031 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20361 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10331 "Passed tests") | 
<!--EWS-Status-Bubble-End-->