### PR TITLE
Remove CSSCascadeLayersEnabled, CSSColorMixEnabled, & CSSContainIntrinsicSizeEnabled preferences

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -875,20 +875,6 @@ CSS3DTransformBackfaceVisibilityInteroperabilityEnabled:
     WebCore:
       default: false
 
-CSSCascadeLayersEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "CSS Cascade Layers"
-  humanReadableDescription: "Enable CSS Cascade Layers"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
 CSSColorContrastEnabled:
   type: bool
   status: testable
@@ -902,34 +888,6 @@ CSSColorContrastEnabled:
       default: false
     WebCore:
       default: false
-
-CSSColorMixEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "CSS color-mix()"
-  humanReadableDescription: "Enable support for CSS color-mix() defined in CSS Color 5"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
-
-CSSContainIntrinsicSizeEnabled:
-  type: bool
-  status: stable
-  category: css
-  humanReadableName: "CSS Contain Intrinsic Size"
-  humanReadableDescription: "Enable contain-intrinsic-size CSS property"
-  defaultValue:
-    WebKitLegacy:
-      default: true
-    WebKit:
-      default: true
-    WebCore:
-      default: true
 
 CSSContentVisibilityEnabled:
   type: bool

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -6403,8 +6403,7 @@
                 "longhands": [
                     "contain-intrinsic-width",
                     "contain-intrinsic-height"
-                ],
-                "settings-flag": "cssContainIntrinsicSizeEnabled"
+                ]
             },
             "specification": {
                 "category": "css-sizing",
@@ -6414,7 +6413,6 @@
         "contain-intrinsic-height": {
             "codegen-properties": {
                 "custom": "All",
-                "settings-flag": "cssContainIntrinsicSizeEnabled",
                 "logical-property-group": {
                     "name": "contain-intrinsic-size",
                     "resolver": "vertical"
@@ -6432,7 +6430,6 @@
         "contain-intrinsic-width": {
             "codegen-properties": {
                 "custom": "All",
-                "settings-flag": "cssContainIntrinsicSizeEnabled",
                 "logical-property-group": {
                     "name": "contain-intrinsic-size",
                     "resolver": "horizontal"
@@ -6450,7 +6447,6 @@
         "contain-intrinsic-block-size": {
             "codegen-properties": {
                 "skip-builder": true,
-                "settings-flag": "cssContainIntrinsicSizeEnabled",
                 "logical-property-group": {
                     "name": "contain-intrinsic-size",
                     "resolver": "block"
@@ -6468,7 +6464,6 @@
         "contain-intrinsic-inline-size": {
             "codegen-properties": {
                 "skip-builder": true,
-                "settings-flag": "cssContainIntrinsicSizeEnabled",
                 "logical-property-group": {
                     "name": "contain-intrinsic-size",
                     "resolver": "inline"

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -55,7 +55,6 @@ CSSParserContext::CSSParserContext(CSSParserMode mode, const URL& baseURL)
 {
     // FIXME: We should turn all of the features on from their WebCore Settings defaults.
     if (isUASheetBehavior(mode)) {
-        colorMixEnabled = true;
         focusVisibleEnabled = true;
         lightDarkEnabled = true;
         popoverAttributeEnabled = true;
@@ -84,7 +83,6 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , hasDocumentSecurityOrigin { sheetBaseURL.isNull() || document.securityOrigin().canRequest(baseURL, OriginAccessPatternsForWebProcess::singleton()) }
     , useSystemAppearance { document.page() ? document.page()->useSystemAppearance() : false }
     , colorContrastEnabled { document.settings().cssColorContrastEnabled() }
-    , colorMixEnabled { document.settings().cssColorMixEnabled() }
     , constantPropertiesEnabled { document.settings().constantPropertiesEnabled() }
     , counterStyleAtRuleImageSymbolsEnabled { document.settings().cssCounterStyleAtRuleImageSymbolsEnabled() }
     , relativeColorSyntaxEnabled { document.settings().cssRelativeColorSyntaxEnabled() }
@@ -93,7 +91,6 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , transformStyleOptimized3DEnabled { document.settings().cssTransformStyleOptimized3DEnabled() }
 #endif
     , focusVisibleEnabled { document.settings().focusVisibleEnabled() }
-    , cascadeLayersEnabled { document.settings().cssCascadeLayersEnabled() }
     , gradientPremultipliedAlphaInterpolationEnabled { document.settings().cssGradientPremultipliedAlphaInterpolationEnabled() }
     , gradientInterpolationColorSpacesEnabled { document.settings().cssGradientInterpolationColorSpacesEnabled() }
     , masonryEnabled { document.settings().masonryEnabled() }
@@ -123,40 +120,38 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
 
 void add(Hasher& hasher, const CSSParserContext& context)
 {
-    uint64_t bits = context.isHTMLDocument                  << 0
+    uint32_t bits = context.isHTMLDocument                  << 0
         | context.hasDocumentSecurityOrigin                 << 1
         | context.isContentOpaque                           << 2
         | context.useSystemAppearance                       << 3
         | context.colorContrastEnabled                      << 4
-        | context.colorMixEnabled                           << 5
-        | context.constantPropertiesEnabled                 << 6
-        | context.relativeColorSyntaxEnabled                << 7
-        | context.springTimingFunctionEnabled               << 8
+        | context.constantPropertiesEnabled                 << 5
+        | context.relativeColorSyntaxEnabled                << 6
+        | context.springTimingFunctionEnabled               << 7
 #if ENABLE(CSS_TRANSFORM_STYLE_OPTIMIZED_3D)
-        | context.transformStyleOptimized3DEnabled          << 9
+        | context.transformStyleOptimized3DEnabled          << 8
 #endif
-        | context.focusVisibleEnabled                       << 10
-        | context.cascadeLayersEnabled                      << 11
-        | context.gradientPremultipliedAlphaInterpolationEnabled << 12
-        | context.gradientInterpolationColorSpacesEnabled   << 13
-        | context.masonryEnabled                            << 14
-        | context.cssNestingEnabled                         << 15
-        | context.cssPaintingAPIEnabled                     << 16
-        | context.cssScopeAtRuleEnabled                     << 17
-        | context.cssTextUnderlinePositionLeftRightEnabled  << 18
-        | context.cssWordBreakAutoPhraseEnabled             << 19
-        | context.popoverAttributeEnabled                   << 20
-        | context.sidewaysWritingModesEnabled               << 21
-        | context.cssTextWrapPrettyEnabled                  << 22
-        | context.highlightAPIEnabled                       << 23
-        | context.grammarAndSpellingPseudoElementsEnabled   << 24
-        | context.customStateSetEnabled                     << 25
-        | context.thumbAndTrackPseudoElementsEnabled        << 26
+        | context.focusVisibleEnabled                       << 9
+        | context.gradientPremultipliedAlphaInterpolationEnabled << 10
+        | context.gradientInterpolationColorSpacesEnabled   << 11
+        | context.masonryEnabled                            << 12
+        | context.cssNestingEnabled                         << 13
+        | context.cssPaintingAPIEnabled                     << 14
+        | context.cssScopeAtRuleEnabled                     << 15
+        | context.cssTextUnderlinePositionLeftRightEnabled  << 16
+        | context.cssWordBreakAutoPhraseEnabled             << 17
+        | context.popoverAttributeEnabled                   << 18
+        | context.sidewaysWritingModesEnabled               << 19
+        | context.cssTextWrapPrettyEnabled                  << 20
+        | context.highlightAPIEnabled                       << 21
+        | context.grammarAndSpellingPseudoElementsEnabled   << 22
+        | context.customStateSetEnabled                     << 23
+        | context.thumbAndTrackPseudoElementsEnabled        << 24
 #if ENABLE(SERVICE_CONTROLS)
-        | context.imageControlsEnabled                      << 27
+        | context.imageControlsEnabled                      << 25
 #endif
-        | context.lightDarkEnabled                          << 28
-        | (uint64_t)context.mode                            << 29; // This is multiple bits, so keep it last.
+        | context.lightDarkEnabled                          << 26
+        | (uint32_t)context.mode                            << 27; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -75,7 +75,6 @@ struct CSSParserContext {
 
     // Settings, excluding those affecting properties.
     bool colorContrastEnabled : 1 { false };
-    bool colorMixEnabled : 1 { false };
     bool constantPropertiesEnabled : 1 { false };
     bool counterStyleAtRuleImageSymbolsEnabled : 1 { false };
     bool relativeColorSyntaxEnabled : 1 { false };
@@ -84,7 +83,6 @@ struct CSSParserContext {
     bool transformStyleOptimized3DEnabled : 1 { false };
 #endif
     bool focusVisibleEnabled : 1 { false };
-    bool cascadeLayersEnabled : 1 { false };
     bool gradientPremultipliedAlphaInterpolationEnabled : 1 { false };
     bool gradientInterpolationColorSpacesEnabled : 1 { false };
     bool masonryEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -573,9 +573,6 @@ RefPtr<StyleRuleImport> CSSParserImpl::consumeImportRule(CSSParserTokenRange pre
     prelude.consumeWhitespace();
 
     auto consumeCascadeLayer = [&]() -> std::optional<CascadeLayerName> {
-        if (!m_context.cascadeLayersEnabled)
-            return { };
-
         auto& token = prelude.peek();
         if (token.type() == FunctionToken && equalLettersIgnoringASCIICase(token.value(), "layer"_s)) {
             auto savedPreludeForFailure = prelude;
@@ -1120,9 +1117,6 @@ RefPtr<StyleRuleStartingStyle> CSSParserImpl::consumeStartingStyleRule(CSSParser
 
 RefPtr<StyleRuleLayer> CSSParserImpl::consumeLayerRule(CSSParserTokenRange prelude, std::optional<CSSParserTokenRange> block)
 {
-    if (!m_context.cascadeLayersEnabled)
-        return nullptr;
-
     auto preludeCopy = prelude;
 
     if (!block) {

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -3020,9 +3020,6 @@ static Color parseColorMixFunctionParametersRaw(CSSParserTokenRange& range, cons
 
     ASSERT(range.peek().functionId() == CSSValueColorMix);
 
-    if (!context.colorMixEnabled)
-        return { };
-
     auto args = consumeFunction(range);
 
     if (args.peek().id() != CSSValueIn)
@@ -3066,9 +3063,6 @@ static std::optional<ColorOrUnresolvedColor> parseColorMixFunctionParameters(CSS
     // color-mix() = color-mix( <color-interpolation-method> , [ <color> && <percentage [0,100]>? ]#{2})
 
     ASSERT(range.peek().functionId() == CSSValueColorMix);
-
-    if (!context.colorMixEnabled)
-        return std::nullopt;
 
     auto args = consumeFunction(range);
 


### PR DESCRIPTION
#### 3d472e998b647fa0a30124147ae30f1da1e60010
<pre>
Remove CSSCascadeLayersEnabled, CSSColorMixEnabled, &amp; CSSContainIntrinsicSizeEnabled preferences
<a href="https://bugs.webkit.org/show_bug.cgi?id=271224">https://bugs.webkit.org/show_bug.cgi?id=271224</a>

Reviewed by Tim Nguyen.

They have all been stable for over a year.

While here, make CSSParserContext&apos;s Hasher slightly more efficient by
switching to uint32_t.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::CSSParserContext::CSSParserContext):
(WebCore::add):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeImportRule):
(WebCore::CSSParserImpl::consumeLayerRule):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::parseColorMixFunctionParametersRaw):
(WebCore::CSSPropertyParserHelpers::parseColorMixFunctionParameters):

Canonical link: <a href="https://commits.webkit.org/276352@main">https://commits.webkit.org/276352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94c58a044bd878322c87d98596203ad115bf71cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47050 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40425 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20865 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36533 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17578 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17968 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39345 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2448 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37641 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48664 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/43893 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Compiled JSC; Running jscore-test") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15911 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43441 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 102 flakes 109 failures 1 missing results; Uploaded test results; 5 flakes 99 failures 1 missing results; Running compile-webkit-without-change") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20736 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42173 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/replaced-objects (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9877 "Built successfully and passed tests") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51035 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20365 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10332 "Passed tests") | 
<!--EWS-Status-Bubble-End-->