### PR TITLE
[GTK][Skia] Initialize SkGraphics

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitInitialize.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitInitialize.cpp
@@ -35,6 +35,10 @@
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
 
+#if USE(SKIA)
+#include <skia/core/SkGraphics.h>
+#endif
+
 namespace WebKit {
 
 #if ENABLE(REMOTE_INSPECTOR)
@@ -101,6 +105,9 @@ void webkitInitialize()
 
     std::call_once(onceFlag, [] {
         InitializeWebKit2();
+#if USE(SKIA)
+        SkGraphics::Init();
+#endif
 #if ENABLE(REMOTE_INSPECTOR)
         initializeRemoteInspectorServer();
 #endif

--- a/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
+++ b/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
@@ -40,6 +40,10 @@
 #include <pal/crypto/gcrypt/Initialization.h>
 #endif
 
+#if USE(SKIA)
+#include <skia/core/SkGraphics.h>
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -49,6 +53,10 @@ public:
     {
 #if USE(GCRYPT)
         PAL::GCrypt::initialize();
+#endif
+
+#if USE(SKIA)
+        SkGraphics::Init();
 #endif
 
 #if ENABLE(DEVELOPER_MODE)


### PR DESCRIPTION
#### 4a8cfe4ed331acffe7d447cda6bdc7c8feff5bf4
<pre>
[GTK][Skia] Initialize SkGraphics
<a href="https://bugs.webkit.org/show_bug.cgi?id=271225">https://bugs.webkit.org/show_bug.cgi?id=271225</a>

Reviewed by Alejandro G. Castro.

It&apos;s done for WPE in the web process, we should do the same for GTK and
also initialize it in the UI process.

* Source/WebKit/UIProcess/API/glib/WebKitInitialize.cpp:
(WebKit::webkitInitialize):
* Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp:

Canonical link: <a href="https://commits.webkit.org/276338@main">https://commits.webkit.org/276338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13b4aeeed743cf39b9e366bdf8d3a371e7a13c4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47052 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40426 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20866 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44975 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/20514 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17579 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/17972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2449 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40582 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/39629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48667 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19379 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43443 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20737 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42175 "Passed tests") | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6102 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->