### PR TITLE
[Legacy line layout removal] Remove annotations and text combine

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h
@@ -71,11 +71,10 @@ public:
 
     TextBoxSelectableRange selectableRange() const { return inlineTextBox()->selectableRange(); }
 
-    TextRun textRun(TextRunMode mode = TextRunMode::Painting) const
+    TextRun textRun(TextRunMode = TextRunMode::Painting) const
     {
-        bool ignoreCombinedText = mode == TextRunMode::Editing;
         if (isText())
-            return inlineTextBox()->createTextRun(ignoreCombinedText);
+            return inlineTextBox()->createTextRun();
         ASSERT_NOT_REACHED();
         return TextRun { emptyString() };
     }

--- a/Source/WebCore/rendering/LegacyInlineTextBox.h
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.h
@@ -30,8 +30,6 @@
 
 namespace WebCore {
 
-class RenderCombineText;
-
 namespace InlineIterator {
 class BoxLegacyPath;
 }
@@ -56,12 +54,6 @@ public:
 
     bool hasTextContent() const;
 
-    // These functions do not account for combined text. For combined text this box will always have len() == 1
-    // regardless of whether the resulting composition is the empty string. Use hasTextContent() if you want to
-    // know whether this box has text content.
-    //
-    // FIXME: These accessors should ASSERT(!isDirty()). See https://bugs.webkit.org/show_bug.cgi?id=97264
-    // Note len() == 1 for combined text regardless of whether the composition is empty. Use hasTextContent() to
     unsigned start() const { return m_start; }
     unsigned end() const { return m_start + m_len; }
     unsigned len() const { return m_len; }
@@ -136,11 +128,10 @@ public:
 private:
     friend class InlineIterator::BoxLegacyPath;
 
-    const RenderCombineText* combinedText() const;
     const FontCascade& lineFont() const;
 
-    String text(bool ignoreCombinedText = false) const; // The effective text for the run.
-    TextRun createTextRun(bool ignoreCombinedText = false) const;
+    String text() const; // The effective text for the run.
+    TextRun createTextRun() const;
 
     LegacyInlineTextBox* m_prevTextBox { nullptr }; // The previous box that also uses our RenderObject
     LegacyInlineTextBox* m_nextTextBox { nullptr }; // The next box that also uses our RenderObject

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -196,7 +196,6 @@ LegacyInlineFlowBox* LegacyLineLayout::createLineBoxes(RenderObject* obj, const 
     unsigned lineDepth = 1;
     LegacyInlineFlowBox* parentBox = nullptr;
     LegacyInlineFlowBox* result = nullptr;
-    bool hasDefaultLineBoxContain = style().lineBoxContain() == RenderStyle::initialLineBoxContain();
     do {
         RenderInline* inlineFlow = obj != &m_flow ? &checkedDowncast<RenderInline>(*obj) : nullptr;
 
@@ -217,8 +216,6 @@ LegacyInlineFlowBox* LegacyLineLayout::createLineBoxes(RenderObject* obj, const 
             parentBox = downcast<LegacyInlineFlowBox>(newBox);
             parentBox->setIsFirstLine(lineInfo.isFirstLine());
             parentBox->setIsHorizontal(m_flow.isHorizontalWritingMode());
-            if (!hasDefaultLineBoxContain)
-                parentBox->clearDescendantsHaveSameLineHeightAndBaseline();
             constructedNewBox = true;
         }
 
@@ -864,21 +861,11 @@ void LegacyLineLayout::layoutLineBoxes(bool relayoutChildren, LayoutUnit& repain
         layoutRunsAndFloats(layoutState, hasInlineChild);
     }
 
-    // Expand the last line to accommodate Ruby and emphasis marks.
-    int lastLineAnnotationsAdjustment = 0;
-    if (lastRootBox()) {
-        LayoutUnit lowestAllowedPosition = std::max(lastRootBox()->lineBottom(), m_flow.logicalHeight() + m_flow.paddingAfter());
-        if (!style().isFlippedLinesWritingMode())
-            lastLineAnnotationsAdjustment = lastRootBox()->computeUnderAnnotationAdjustment(lowestAllowedPosition);
-        else
-            lastLineAnnotationsAdjustment = lastRootBox()->computeOverAnnotationAdjustment(lowestAllowedPosition);
-    }
-    
     // Now do the handling of the bottom of the block, adding in our bottom border/padding and
     // determining the correct collapsed bottom margin information. This collapse is only necessary
     // if our last child was an anonymous inline block that might need to propagate margin information out to
     // us.
-    LayoutUnit afterEdge = m_flow.borderAndPaddingAfter() + m_flow.scrollbarLogicalHeight() + lastLineAnnotationsAdjustment;
+    LayoutUnit afterEdge = m_flow.borderAndPaddingAfter() + m_flow.scrollbarLogicalHeight();
     m_flow.setLogicalHeight(m_flow.logicalHeight() + afterEdge);
 
     if (!firstRootBox() && m_flow.hasLineIfEmpty())

--- a/Source/WebCore/rendering/LegacyRootInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.cpp
@@ -139,9 +139,6 @@ const LegacyInlineBox* LegacyRootInlineBox::lastSelectedBox() const
 LayoutUnit LegacyRootInlineBox::selectionTop() const
 {
     LayoutUnit selectionTop = m_lineTop;
-    
-    if (m_hasAnnotationsBefore)
-        selectionTop -= !renderer().style().isFlippedLinesWritingMode() ? computeOverAnnotationAdjustment(m_lineTop) : computeUnderAnnotationAdjustment(m_lineTop);
 
     if (renderer().style().isFlippedLinesWritingMode())
         return selectionTop;
@@ -151,18 +148,6 @@ LayoutUnit LegacyRootInlineBox::selectionTop() const
         prevBottom = previousBox->selectionBottom();
     else
         prevBottom = selectionTop;
-
-    if (prevBottom < selectionTop && blockFlow().containsFloats()) {
-        // This line has actually been moved further down, probably from a large line-height, but possibly because the
-        // line was forced to clear floats. If so, let's check the offsets, and only be willing to use the previous
-        // line's bottom if the offsets are greater on both sides.
-        LayoutUnit prevLeft = blockFlow().logicalLeftOffsetForLine(prevBottom, DoNotIndentText);
-        LayoutUnit prevRight = blockFlow().logicalRightOffsetForLine(prevBottom, DoNotIndentText);
-        LayoutUnit newLeft = blockFlow().logicalLeftOffsetForLine(selectionTop, DoNotIndentText);
-        LayoutUnit newRight = blockFlow().logicalRightOffsetForLine(selectionTop, DoNotIndentText);
-        if (prevLeft > newLeft || prevRight < newRight)
-            return selectionTop;
-    }
 
     return prevBottom;
 }
@@ -176,26 +161,10 @@ LayoutUnit LegacyRootInlineBox::selectionBottom() const
 {
     LayoutUnit selectionBottom = m_lineBottom;
 
-    if (m_hasAnnotationsAfter)
-        selectionBottom += !renderer().style().isFlippedLinesWritingMode() ? computeUnderAnnotationAdjustment(m_lineBottom) : computeOverAnnotationAdjustment(m_lineBottom);
-    
     if (!renderer().style().isFlippedLinesWritingMode() || !nextRootBox())
         return selectionBottom;
 
-    LayoutUnit nextTop = nextRootBox()->selectionTop();
-    if (nextTop > selectionBottom && blockFlow().containsFloats()) {
-        // The next line has actually been moved further over, probably from a large line-height, but possibly because the
-        // line was forced to clear floats. If so, let's check the offsets, and only be willing to use the next
-        // line's top if the offsets are greater on both sides.
-        LayoutUnit nextLeft = blockFlow().logicalLeftOffsetForLine(nextTop, DoNotIndentText);
-        LayoutUnit nextRight = blockFlow().logicalRightOffsetForLine(nextTop, DoNotIndentText);
-        LayoutUnit newLeft = blockFlow().logicalLeftOffsetForLine(selectionBottom, DoNotIndentText);
-        LayoutUnit newRight = blockFlow().logicalRightOffsetForLine(selectionBottom, DoNotIndentText);
-        if (nextLeft > newLeft || nextRight < newRight)
-            return selectionBottom;
-    }
-
-    return nextTop;
+    return nextRootBox()->selectionTop();
 }
 
 RenderBlockFlow& LegacyRootInlineBox::blockFlow() const

--- a/Source/WebCore/rendering/line/LineBreaker.cpp
+++ b/Source/WebCore/rendering/line/LineBreaker.cpp
@@ -26,7 +26,6 @@
 #include "LineBreaker.h"
 
 #include "BreakingContext.h"
-#include "RenderCombineText.h"
 
 namespace WebCore {
 
@@ -38,17 +37,9 @@ void LineBreaker::skipTrailingWhitespace(LegacyInlineIterator& iterator, const L
 
 void LineBreaker::skipLeadingWhitespace(InlineBidiResolver& resolver, LineInfo& lineInfo)
 {
-    while (!resolver.position().atEnd() && !requiresLineBox(resolver.position(), lineInfo, LeadingWhitespace)) {
-        RenderObject& object = *resolver.position().renderer();
-        if (object.style().hasTextCombine()) {
-            if (CheckedPtr combineText = dynamicDowncast<RenderCombineText>(object)) {
-                combineText->combineTextIfNeeded();
-                if (combineText->isCombined())
-                    continue;
-            }
-        }
+    while (!resolver.position().atEnd() && !requiresLineBox(resolver.position(), lineInfo, LeadingWhitespace))
         resolver.increment();
-    }
+
     resolver.commitExplicitEmbedding();
 }
 


### PR DESCRIPTION
#### 6b47b20aed64d66a0820b522bd050640d7ba2fce
<pre>
[Legacy line layout removal] Remove annotations and text combine
<a href="https://bugs.webkit.org/show_bug.cgi?id=271226">https://bugs.webkit.org/show_bug.cgi?id=271226</a>
<a href="https://rdar.apple.com/124999850">rdar://124999850</a>

Reviewed by Alan Baradlay.

They are not not used anymore.

* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::LegacyInlineFlowBox::addToLine):
(WebCore::LegacyInlineFlowBox::adjustPosition):
(WebCore::LegacyInlineFlowBox::computeOverAnnotationAdjustment const): Deleted.
(WebCore::LegacyInlineFlowBox::computeUnderAnnotationAdjustment const): Deleted.
* Source/WebCore/rendering/LegacyInlineFlowBox.h:
(WebCore::LegacyInlineFlowBox::LegacyInlineFlowBox):
(WebCore::LegacyInlineFlowBox::hasTextDescendants const):
(WebCore::LegacyInlineFlowBox::logicalFrameRectIncludingLineHeight const):
(WebCore::LegacyInlineFlowBox::hasHardLinebreak const): Deleted.
(WebCore::LegacyInlineFlowBox::descendantsHaveSameLineHeightAndBaseline const): Deleted.
(WebCore::LegacyInlineFlowBox::clearDescendantsHaveSameLineHeightAndBaseline): Deleted.

Also remove descendantsHaveSameLineHeightAndBaseline bit which no one is using.

* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::createLineBoxes):
(WebCore::LegacyLineLayout::layoutLineBoxes):
* Source/WebCore/rendering/LegacyRootInlineBox.cpp:
(WebCore::LegacyRootInlineBox::selectionTop const):
(WebCore::LegacyRootInlineBox::selectionBottom const):
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::textWidth):
(WebCore::BreakingContext::handleText):
(WebCore::iteratorIsBeyondEndOfRenderCombineText): Deleted.
* Source/WebCore/rendering/line/LineBreaker.cpp:
(WebCore::LineBreaker::skipLeadingWhitespace):

Canonical link: <a href="https://commits.webkit.org/276347@main">https://commits.webkit.org/276347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70bfad8babcdba41e755ecfb8ea1298f00c0f18d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40428 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46706 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27463 "Failed to checkout and rebase branch from PR 26111") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20868 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44977 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/27463 "Failed to checkout and rebase branch from PR 26111") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38224 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17580 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/27463 "Failed to checkout and rebase branch from PR 26111") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39347 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2451 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/27463 "Failed to checkout and rebase branch from PR 26111") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48669 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19381 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15915 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 6 flakes 4 failures; Uploaded test results; Running re-run-layout-tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43447 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 19 flakes 150 failures 1 missing results; Uploaded test results; Running layout-tests-repeat-failures") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20739 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42179 "Passed tests") | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->