### PR TITLE
[Skia] SkFontMgr should be created with the current FontConfig configuration

### DIFF
--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 
 void FontCache::platformInit()
 {
-    m_fontManager = SkFontMgr_New_FontConfig(nullptr);
+    m_fontManager = SkFontMgr_New_FontConfig(FcConfigReference(nullptr));
 }
 
 RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription& description, const Font&, IsForPlatformFont, PreferColoredFont, StringView stringView)


### PR DESCRIPTION
#### 1007bd9ff1d656d0b19c6076d2043995d7109de4
<pre>
[Skia] SkFontMgr should be created with the current FontConfig configuration
<a href="https://bugs.webkit.org/show_bug.cgi?id=271230">https://bugs.webkit.org/show_bug.cgi?id=271230</a>

Reviewed by Alejandro G. Castro.

This makes sure we use the configuration created by WTR when running layout tests.

* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
(WebCore::FontCache::platformInit):

Canonical link: <a href="https://commits.webkit.org/276390@main">https://commits.webkit.org/276390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c559c4cee16b7575af873006e038876b30a29e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44408 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23482 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46859 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47062 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40436 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27475 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20877 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36541 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44985 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20526 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Skipped layout-tests; Running layout-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/46859 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17587 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-api-tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/17982 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/46859 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2459 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40594 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/46859 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48677 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19389 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15922 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43452 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20747 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/46859 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42184 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6127 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20376 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request; Running compile-webkit") | | | 
<!--EWS-Status-Bubble-End-->