### PR TITLE
[WebCodecs] sampleRate and numberOfChannels are required and have to be non-zero in a valid AudioEncoderConfig

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing codec
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Empty codec
-FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing numberOfChannels assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing sampleRate
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing numberOfChannels
 FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Zero sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Zero channels assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Bit rate too big assert_unreached: Should have rejected: undefined Reached unreachable code
@@ -13,8 +13,8 @@ PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus fra
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Invalid Opus frameDuration
 PASS Test that AudioEncoder.configure() rejects invalid config: Missing codec
 PASS Test that AudioEncoder.configure() rejects invalid config: Empty codec
-FAIL Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate assert_unreached: unexpected error Reached unreachable code
-FAIL Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels assert_unreached: unexpected error Reached unreachable code
+PASS Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate
+PASS Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels
 FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_unreached: unexpected error Reached unreachable code
 FAIL Test that AudioEncoder.configure() rejects invalid config: Zero channels assert_unreached: unexpected error Reached unreachable code
 FAIL Test that AudioEncoder.configure() rejects invalid config: Bit rate too big assert_unreached: unexpected error Reached unreachable code

--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing codec
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Empty codec
-FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing numberOfChannels assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing sampleRate
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing numberOfChannels
 FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Zero sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Zero channels assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Bit rate too big assert_unreached: Should have rejected: undefined Reached unreachable code
@@ -13,8 +13,8 @@ PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus fra
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Invalid Opus frameDuration
 PASS Test that AudioEncoder.configure() rejects invalid config: Missing codec
 PASS Test that AudioEncoder.configure() rejects invalid config: Empty codec
-FAIL Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate assert_unreached: unexpected error Reached unreachable code
-FAIL Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels assert_unreached: unexpected error Reached unreachable code
+PASS Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate
+PASS Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels
 FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_unreached: unexpected error Reached unreachable code
 FAIL Test that AudioEncoder.configure() rejects invalid config: Zero channels assert_unreached: unexpected error Reached unreachable code
 FAIL Test that AudioEncoder.configure() rejects invalid config: Bit rate too big assert_unreached: unexpected error Reached unreachable code

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing codec
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Empty codec
-FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing numberOfChannels assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing sampleRate
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing numberOfChannels
 FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Zero sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Zero channels assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Bit rate too big assert_unreached: Should have rejected: undefined Reached unreachable code
@@ -13,12 +13,8 @@ PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus fra
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Invalid Opus frameDuration
 PASS Test that AudioEncoder.configure() rejects invalid config: Missing codec
 PASS Test that AudioEncoder.configure() rejects invalid config: Empty codec
-FAIL Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+PASS Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate
+PASS Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels
 FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
           codec.configure(entry.config);
         }" did not throw

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/audio-encoder-config.https.any.worker-expected.txt
@@ -1,8 +1,8 @@
 
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing codec
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Empty codec
-FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing numberOfChannels assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing sampleRate
+PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Missing numberOfChannels
 FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Zero sampleRate assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Zero channels assert_unreached: Should have rejected: undefined Reached unreachable code
 FAIL Test that AudioEncoder.isConfigSupported() rejects invalid config: Bit rate too big assert_unreached: Should have rejected: undefined Reached unreachable code
@@ -13,12 +13,8 @@ PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Opus fra
 PASS Test that AudioEncoder.isConfigSupported() rejects invalid config: Invalid Opus frameDuration
 PASS Test that AudioEncoder.configure() rejects invalid config: Missing codec
 PASS Test that AudioEncoder.configure() rejects invalid config: Empty codec
-FAIL Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
-FAIL Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels assert_throws_js: function "() => {
-          codec.configure(entry.config);
-        }" did not throw
+PASS Test that AudioEncoder.configure() rejects invalid config: Missing sampleRate
+PASS Test that AudioEncoder.configure() rejects invalid config: Missing numberOfChannels
 FAIL Test that AudioEncoder.configure() rejects invalid config: Zero sampleRate assert_throws_js: function "() => {
           codec.configure(entry.config);
         }" did not throw

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -119,9 +119,7 @@ static ExceptionOr<AudioEncoder::Config> createAudioEncoderConfig(const WebCodec
     if (config.flac)
         flacConfig = { config.flac->blockSize, config.flac->compressLevel };
 
-    std::optional<size_t> sampleRate = config.sampleRate;
-    std::optional<size_t> numberOfChannels = config.numberOfChannels;
-    return AudioEncoder::Config { WTFMove(sampleRate), WTFMove(numberOfChannels), config.bitrate.value_or(0), WTFMove(opusConfig), WTFMove(isAacADTS), WTFMove(flacConfig) };
+    return AudioEncoder::Config { config.sampleRate, config.numberOfChannels, config.bitrate.value_or(0), WTFMove(opusConfig), WTFMove(isAacADTS), WTFMove(flacConfig) };
 }
 
 ExceptionOr<void> WebCodecsAudioEncoder::configure(ScriptExecutionContext&, WebCodecsAudioEncoderConfig&& config)
@@ -217,8 +215,8 @@ WebCodecsEncodedAudioChunkMetadata WebCodecsAudioEncoder::createEncodedChunkMeta
     if (m_hasNewActiveConfiguration) {
         m_hasNewActiveConfiguration = false;
         // FIXME: Provide more accurate decoder configuration...
-        auto baseConfigurationSampleRate = m_baseConfiguration.sampleRate.value_or(0);
-        auto baseConfigurationNumberOfChannels = m_baseConfiguration.numberOfChannels.value_or(0);
+        auto baseConfigurationSampleRate = m_baseConfiguration.sampleRate;
+        auto baseConfigurationNumberOfChannels = m_baseConfiguration.numberOfChannels;
         metadata.decoderConfig = WebCodecsAudioDecoderConfig {
             !m_activeConfiguration.codec.isEmpty() ? WTFMove(m_activeConfiguration.codec) : String { m_baseConfiguration.codec },
             { },

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoderConfig.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoderConfig.h
@@ -39,8 +39,8 @@ namespace WebCore {
 
 struct WebCodecsAudioEncoderConfig {
     String codec;
-    std::optional<size_t> sampleRate;
-    std::optional<size_t> numberOfChannels;
+    size_t sampleRate;
+    size_t numberOfChannels;
     std::optional<uint64_t> bitrate;
     BitrateMode bitrateMode { BitrateMode::Variable };
     std::optional<OpusEncoderConfig> opus;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoderConfig.idl
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoderConfig.idl
@@ -33,8 +33,8 @@ typedef [EnforceRange] unsigned long long WebCodecsAudioEncoderConfigBitrate;
     JSGenerateToJSObject,
 ] dictionary WebCodecsAudioEncoderConfig {
     required DOMString codec;
-    WebCodecsAudioEncoderConfigSize sampleRate;
-    WebCodecsAudioEncoderConfigSize numberOfChannels;
+    required WebCodecsAudioEncoderConfigSize sampleRate;
+    required WebCodecsAudioEncoderConfigSize numberOfChannels;
     WebCodecsAudioEncoderConfigBitrate bitrate;
     BitrateMode bitrateMode = "variable";
     OpusEncoderConfig opus;

--- a/Source/WebCore/platform/AudioEncoder.h
+++ b/Source/WebCore/platform/AudioEncoder.h
@@ -58,8 +58,8 @@ public:
     };
 
     struct Config {
-        std::optional<size_t> sampleRate;
-        std::optional<size_t> numberOfChannels;
+        size_t sampleRate;
+        size_t numberOfChannels;
         uint64_t bitRate { 0 };
         std::optional<OpusConfig> opusConfig;
         std::optional<bool> isAacADTS;

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -319,11 +319,8 @@ String GStreamerInternalAudioEncoder::initialize(const String& codecName, const 
                 gst_util_set_object_arg(G_OBJECT(m_encoder.get()), "frame-size", frameSize.ascii().data());
             }
         }
-        m_outputCaps = adoptGRef(gst_caps_new_empty_simple("audio/x-opus"));
-        if (config.numberOfChannels) {
-            int channelMappingFamily = *config.numberOfChannels <= 2 ? 0 : 1;
-            gst_caps_set_simple(m_outputCaps.get(), "channel-mapping-family", G_TYPE_INT, channelMappingFamily, nullptr);
-        }
+        int channelMappingFamily = config.numberOfChannels <= 2 ? 0 : 1;
+        m_outputCaps = adoptGRef(gst_caps_new_simple("audio/x-opus", "channel-mapping-family", G_TYPE_INT, channelMappingFamily, nullptr));
     } else if (codecName == "alaw"_s)
         m_outputCaps = adoptGRef(gst_caps_new_empty_simple("audio/x-alaw"));
     else if (codecName == "ulaw"_s)
@@ -365,13 +362,9 @@ String GStreamerInternalAudioEncoder::initialize(const String& codecName, const 
     // imported/w3c/web-platform-tests/webcodecs/audio-encoder.https.any.html make use of values
     // that would not be accepted by the Opus encoder. So we instead let caps negotiation figure out
     // the most suitable value.
-    m_inputCaps = adoptGRef(gst_caps_new_empty_simple("audio/x-raw"));
-
-    if (config.numberOfChannels)
-        gst_caps_set_simple(m_inputCaps.get(), "channels", G_TYPE_INT, *config.numberOfChannels, nullptr);
+    m_inputCaps = adoptGRef(gst_caps_new_simple("audio/x-raw", "channels", G_TYPE_INT, config.numberOfChannels, nullptr));
 
     g_object_set(m_inputCapsFilter.get(), "caps", m_inputCaps.get(), nullptr);
-
     g_object_set(m_outputCapsFilter.get(), "caps", m_outputCaps.get(), nullptr);
     return emptyString();
 }


### PR DESCRIPTION
#### a55f2304f88ff328ebbad4128ab76ae5a7e8a9ef
<pre>
[WebCodecs] sampleRate and numberOfChannels are required and have to be non-zero in a valid AudioEncoderConfig
<a href="https://bugs.webkit.org/show_bug.cgi?id=271238">https://bugs.webkit.org/show_bug.cgi?id=271238</a>

Reviewed by Youenn Fablet.

Mark the sampleRate and numberOfChannels fields as required. The isValidAudioDataInit() function
already checks they are non-zero.

* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::createAudioEncoderConfig):
(WebCore::WebCodecsAudioEncoder::createEncodedChunkMetadata):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoderConfig.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoderConfig.idl:
* Source/WebCore/platform/AudioEncoder.h:
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioEncoder::initialize):

Canonical link: <a href="https://commits.webkit.org/276413@main">https://commits.webkit.org/276413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3239488d2fb7a2afbab5f790e11f85d31e7ced7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47248 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40591 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46898 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21066 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20753 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38400 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17740 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39546 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2639 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40825 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39821 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Running apply-patch; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48880 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19550 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/16104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43634 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 50 flakes 89 failures 1 missing results; Uploaded test results (exception)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20881 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42380 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9925 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Checked out pull request; Reviewed by Youenn Fablet; Running compile-webkit") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21209 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6144 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->