### PR TITLE
Plaintext Ping requests not blocked by mixed-content checks (262117)

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-beacon-in-iframe-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-beacon-in-iframe-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: [blocked] The page at https://127.0.0.1:8443/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-beacon.html requested insecure content from http://127.0.0.1:8000/xmlhttprequest/resources/access-control-basic-allow-star.cgi. This content was blocked and must be served over HTTPS.
+
+CONSOLE MESSAGE: Beacon API cannot load http://127.0.0.1:8000/xmlhttprequest/resources/access-control-basic-allow-star.cgi. Not allowed to request resource
+This test loads a secure iframe that triggers an insecure beacon load. We should trigger a mixed content block because the child frame has CSP directive block-all-mixed-content.
+
+

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-beacon-in-iframe.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-beacon-in-iframe.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+</head>
+<body>
+<p>This test loads a secure iframe that triggers an insecure beacon load.  We should trigger a
+mixed content block because the child frame has CSP directive block-all-mixed-content.</p>
+<iframe src="https://127.0.0.1:8443/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-beacon.html" width="100%" height="300"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-ping-in-iframe-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-ping-in-iframe-expected.txt
@@ -1,0 +1,3 @@
+This test loads a secure iframe that triggers an insecure ping load. We should trigger a mixed content block because the child frame has CSP directive block-all-mixed-content.
+
+

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-ping-in-iframe.https-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-ping-in-iframe.https-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: [blocked] The page at https://127.0.0.1:8443/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-ping.html# requested insecure content from http://127.0.0.1:8000/xmlhttprequest/resources/access-control-basic-allow-star.cgi. This content was blocked and must be served over HTTPS.
+
+This test loads a secure iframe that triggers an insecure ping load. We should trigger a mixed content block because the child frame has CSP directive block-all-mixed-content.
+
+

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-ping-in-iframe.https.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-ping-in-iframe.https.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+</head>
+<body>
+<p>This test loads a secure iframe that triggers an insecure ping load.  We should trigger a
+mixed content block because the child frame has CSP directive block-all-mixed-content.</p>
+<iframe id="pingFrame" src="https://127.0.0.1:8443/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-ping.html" width="100%" height="300"></iframe>
+<script>
+function clickOnLinkWithPing() {
+  const pingFrameDoc = pingFrame.contentDocument;
+  if (window.eventSender) {
+    const a = pingFrameDoc.getElementById("pingElement");
+    const x = pingFrame.offsetLeft + a.offsetLeft + 2;
+    const y = pingFrame.offsetTop + a.offsetTop + 2;
+    eventSender.mouseMoveTo(x, y);
+    eventSender.mouseDown();
+    eventSender.mouseUp();
+  }
+}
+
+function done()
+{
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+onload = () => {
+  window.setTimeout(done, 10000);
+  clickOnLinkWithPing();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-beacon.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-beacon.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<script>
+if (window.internals)
+    internals.clearMemoryCache();
+</script>
+<script src="dump-securitypolicyviolation-and-notify-done.js"></script>
+</head>
+<body>
+<script>
+function done()
+{
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+onload = () => {
+    navigator.sendBeacon("http://127.0.0.1:8000/xmlhttprequest/resources/access-control-basic-allow-star.cgi");
+    window.setTimeout(done, 10000);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-ping.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-ping.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="block-all-mixed-content">
+<script>
+if (window.internals)
+    internals.clearMemoryCache();
+</script>
+<script src="dump-securitypolicyviolation-and-notify-done.js?insecure-ping"></script>
+</head>
+<body>
+ <a id="pingElement" href="#" ping="http://127.0.0.1:8000/xmlhttprequest/resources/access-control-basic-allow-star.cgi">link</a>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2724,6 +2724,8 @@ fast/visual-viewport/client-rects-relative-to-layout-viewport-zoomed.html [ Skip
 fast/selectors/040.html
 
 webkit.org/b/165691 http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-iframe-in-main-frame.html [ Pass Failure ]
+# Test is using eventSender
+http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-ping-in-iframe.https.html [ Skip ]
 
 webkit.org/b/245610 http/tests/security/xss-DENIED-xsl-external-entity.xml [ Failure ]
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -959,6 +959,7 @@ imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/beacon.https.ht
 http/tests/security/contentSecurityPolicy/connect-src-beacon-allowed.html [ Skip ]
 http/tests/security/contentSecurityPolicy/connect-src-beacon-blocked.html [ Skip ]
 http/tests/security/contentSecurityPolicy/report-only-connect-src-beacon-redirect-blocked.py [ Skip ]
+http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-beacon-in-iframe.html [ Skip ]
 
 # testRunner.setStatisticsShouldDowngradeReferrer() is not supported on WK1
 http/tests/referrer-policy-script/ [ Skip ]
@@ -977,6 +978,9 @@ http/tests/referrer-policy-img/no-referrer-when-downgrade/ [ Skip ]
 http/tests/referrer-policy-img/unsafe-url/cross-origin-http-http.html [ Skip ]
 http/tests/referrer-policy-img/unsafe-url/cross-origin-http.https.html [ Skip ]
 http/tests/referrer-policy-img/unsafe-url/cross-origin-http-UpgradeMixedContent.https.html [ Skip ]
+
+# Cross origin HTTPS loads require certificate validation, which are not supported for WK1 ping loads.
+http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-ping-in-iframe.https.html [ Failure ]
 
 # Cross-Origin requests receive a didReceiveAuthenticationChallenge callback on the first iteration
 http/tests/referrer-policy-img/no-referrer/cross-origin-http-UpgradeMixedContent.https.html [ Pass Failure ]


### PR DESCRIPTION
#### dc48a9812a13182fc73335fd21b56d779818853e
<pre>
Plaintext Ping requests not blocked by mixed-content checks (262117)
<a href="https://rdar.apple.com/116054889">rdar://116054889</a>

Reviewed by Alex Christensen.

Enforce mixed content checks for beacons and poings, like we do for regular xhr/fetch.
This aligns the behavior with Chrome and Firefox.

We have to change some tests so that preloads kick in deterministically.
Preloads might not kick in if an early JS resource is already in the cache.
We therefore clear the memory cache to ensure dump-securitypolicyviolation-and-notify-done.js gets fetched again, which will trigger both preload and resource load.
Otherwise, we will get only one CONSOLE MESSAGE for the actual blocked load.

We also have to change some tests so that they use HTTPS and not HTTP.

* LayoutTests/http/tests/blink/sendbeacon/beacon-cross-origin.https-expected.txt:
* LayoutTests/http/tests/navigation/ping-attribute/anchor-cross-origin-from-https-expected.txt:
* LayoutTests/http/tests/navigation/ping-attribute/anchor-cross-origin-from-https.html:
* LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin-from-https-expected.txt:
* LayoutTests/http/tests/navigation/ping-attribute/area-cross-origin-from-https.html:
* LayoutTests/http/tests/navigation/ping-attribute/resources/secure-anchor-cross-origin.html:
* LayoutTests/http/tests/navigation/ping-attribute/secure-anchor-cross-origin-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-beacon-in-iframe-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-beacon-in-iframe.html: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-iframe-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-main-frame-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-ping-in-iframe-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-ping-in-iframe.https-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-ping-in-iframe.https.html: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-main-frame-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-beacon.html: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-css.html:
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-iframe.html:
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-image.html:
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-ping.html: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-plugin.html:
* LayoutTests/http/tests/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-script.html:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/beacon.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/beacon.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/beacon.https-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/beacon.https-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/opt-in/beacon.https-expected.txt: Removed.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/gen/top.meta/unset/beacon.https-expected.txt: Removed.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/wk2/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-iframe-expected.txt:
* LayoutTests/platform/wk2/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-image-in-main-frame-expected.txt:
* LayoutTests/platform/wk2/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-main-frame-expected.txt:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::checkInsecureContent const):

Originally-landed-as: 272448.10@safari-7618-branch (b856378e0a55). <a href="https://rdar.apple.com/124557284">rdar://124557284</a>
Canonical link: <a href="https://commits.webkit.org/276787@main">https://commits.webkit.org/276787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b58d2e4b3912fbca2729369c8d39df2aa320e03e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48362 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41728 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22215 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21894 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18566 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40506 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3737 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50112 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20682 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17193 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44526 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43373 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22347 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6361 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->