### PR TITLE
Build scripts should default to the Internal workspace using the internal SDK

### DIFF
--- a/Tools/Scripts/webkitperl/BuildSubproject.pm
+++ b/Tools/Scripts/webkitperl/BuildSubproject.pm
@@ -224,11 +224,11 @@ sub buildUpToProject
 {
     my ($projectDirectory, $projectName) = @_;
     my $result;
+
     chdir $projectDirectory or die "Can't find $projectName directory to build from";
     if (isAppleCocoaWebKit()) {
-        if (!configuredXcodeWorkspace()) {
-            system("$FindBin::Bin/set-webkit-configuration", "--workspace=" . sourceDir() . "/WebKit.xcworkspace") == 0 or die;
-        }
+        configuredXcodeWorkspace() or die "Can't determine configured Xcode workspace";
+
         # By convention, projects that support this build workflow
         # (JavaScriptCore, WebGPU) have a scheme which builds that project
         # and its implicit dependencies.
@@ -256,7 +256,7 @@ sub buildUpToProject
 
         print "\n";
         print "building ", $projectName, "\n";
-        print "running build command '", $command, "' in ", $projectDirectory, "\n\n";
+        print "running build command '", $command, "' in ", Cwd::cwd(), "\n\n";
 
         $result = system $command;
     } else {


### PR DESCRIPTION
#### 29536a50b549dd94eaa0f0f6c6a60e364a62dee5
<pre>
Build scripts should default to the Internal workspace using the internal SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=271245">https://bugs.webkit.org/show_bug.cgi?id=271245</a>
<a href="https://rdar.apple.com/125015308">rdar://125015308</a>

Reviewed by Elliott Williams.

Right now in order to get WebKitAdditions when using these scripts you have to already have started a build
from Internal. This is annoying for clean builds or when WebKitBuild has a stale WebKitAdditions. This patch
changes the build scripts to default to the Internal workspace when building for a .internal SDK and the
regular workspace when building for a public SDK. If there&apos;s already a configured workspace then we just
use that.

* Tools/Scripts/webkitdirs.pm:
(determineConfiguredXcodeWorkspaceOrDefault):
(configuredXcodeWorkspace):
(XcodeOptions):
(determineConfiguredXcodeWorkspace): Deleted.
* Tools/Scripts/webkitperl/BuildSubproject.pm:
(buildUpToProject):

Canonical link: <a href="https://commits.webkit.org/276366@main">https://commits.webkit.org/276366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c7399b44fdd60d3c4ae156475e4b7b6128d7420

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47078 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40449 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36554 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/44999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20547 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17599 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39369 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2473 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/37661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48695 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/43913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43465 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20760 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42200 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9891 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21088 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51059 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20389 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10343 "Passed tests") | 
<!--EWS-Status-Bubble-End-->