### PR TITLE
[GStreamer][WebRTC] webrtc/connection-state.html started failing after update to 1.24.0

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1935,8 +1935,6 @@ fast/mediastream/microphone-interruption-and-audio-session.html [ Skip ]
 webkit.org/b/261329 webrtc/video-clone-track.html [ Failure ]
 webrtc/clone-audio-track.html [ Pass Failure ]
 
-webkit.org/b/271243 webrtc/connection-state.html [ Failure ]
-
 webkit.org/b/256758 fast/mediastream/captureStream/canvas3d.html [ Failure ]
 
 webkit.org/b/194611 http/wpt/webrtc/getUserMedia-processSwapping.html [ Failure ]


### PR DESCRIPTION
#### da50e63df7f3e6b3090496e1dd8b4221752cdeff
<pre>
[GStreamer][WebRTC] webrtc/connection-state.html started failing after update to 1.24.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=271243">https://bugs.webkit.org/show_bug.cgi?id=271243</a>
&lt;<a href="https://rdar.apple.com/problem/125014192">rdar://problem/125014192</a>&gt;

Reviewed by Xabier Rodriguez-Calvar.

The `doneGatheringCandidates()` method is called by the PeerConnectionBackend when it&apos;s notified
from gst-webrtc that the ICE gathering is finished, so we don&apos;t need to call it ourselves. The
end-of-candidates SDP attribute shouldn&apos;t appear in the offer/answer the end-point reports either.
This is covered by the webrtc/libwebrtc/descriptionGetters.html test.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::fetchDescription):
(WebCore::GStreamerMediaEndpoint::doSetLocalDescription):
(WebCore::GStreamerMediaEndpoint::doSetRemoteDescription):
(WebCore::GStreamerMediaEndpoint::onIceCandidate):

Canonical link: <a href="https://commits.webkit.org/276412@main">https://commits.webkit.org/276412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c7fa85f4c3a13829a92c60ad6b7276f4686ab7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47235 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40579 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21052 "Built successfully") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36685 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 43 flakes 186 failures 1 missing results; Uploaded test results (exception)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17730 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18182 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 4 pre-existing failure based on results-db; Uploaded test results (exception)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39520 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2627 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40788 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48864 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43598 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20869 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42354 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21197 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6143 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->