### PR TITLE
GlyphBuffer caching including partial runs

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2644,6 +2644,7 @@ rendering/BorderEdge.cpp
 rendering/BorderPainter.cpp
 rendering/BreakLines.cpp
 rendering/CSSFilter.cpp
+rendering/GlyphBufferCache.cpp
 rendering/CaretRectComputation.cpp
 rendering/ClipRect.cpp
 rendering/ContentfulPaintChecker.cpp

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -228,10 +228,12 @@ public:
 
     unsigned generation() const { return m_generation; }
 
-private:
     enum class ForTextEmphasisOrNot : bool { NotForTextEmphasis, ForTextEmphasis };
 
     GlyphBuffer layoutText(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
+    GlyphBuffer layoutTextFromCache(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
+
+private:
     GlyphBuffer layoutSimpleText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
     void drawGlyphBuffer(GraphicsContext&, const GlyphBuffer&, FloatPoint&, CustomFontNotReadyAction) const;
     void drawEmphasisMarks(GraphicsContext&, const GlyphBuffer&, const AtomString&, const FloatPoint&) const;

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -37,6 +37,7 @@
 #include <limits>
 #include <wtf/CheckedRef.h>
 #include <wtf/FastMalloc.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -45,7 +46,9 @@ static const constexpr GlyphBufferGlyph deletedGlyph = 0xFFFF;
 
 class Font;
 
-class GlyphBuffer {
+class GlyphBuffer : public CanMakeCheckedPtr<GlyphBuffer> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GlyphBuffer);
 public:
     bool isEmpty() const { return m_fonts.isEmpty(); }
     unsigned size() const { return m_fonts.size(); }

--- a/Source/WebCore/rendering/GlyphBufferCache.cpp
+++ b/Source/WebCore/rendering/GlyphBufferCache.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "GlyphBufferCache.h"
+
+#include "platform/graphics/FontCascade.h"
+#include <wtf/StdLibExtras.h>
+
+namespace WebCore {
+
+GlyphBufferCache& GlyphBufferCache::singleton()
+{
+    static NeverDestroyed<GlyphBufferCache> cache;
+    return cache;
+}
+
+void GlyphBufferCache::clear()
+{
+    m_entries.clear();
+}
+
+unsigned GlyphBufferCache::size() const
+{
+    return m_entries.size();
+}
+
+GlyphBuffer GlyphBufferCache::glyphBuffer(const FontCascade& font, FontCascade::CodePath codePath, FontCascade::ForTextEmphasisOrNot forTextEmphasisOrNot, const TextRun& textRun, unsigned from, unsigned to)
+{
+    if (MemoryPressureHandler::singleton().isUnderMemoryPressure()) {
+        if (!m_entries.isEmpty()) {
+            LOG(MemoryPressure, "GlyphBufferCache::%s - Under memory pressure - size: %d", __FUNCTION__, size());
+            clear();
+        }
+        return font.layoutText(codePath, textRun, from, to, forTextEmphasisOrNot);
+    }
+
+    // if (from || to != textRun.length())
+    //     return font.layoutText(codePath, textRun, from, to);
+
+    if (font.isLoadingCustomFonts() || !font.fonts())
+        return font.layoutText(codePath, textRun, from, to, forTextEmphasisOrNot);
+
+    GlyphBufferCacheKey key { textRun, font, codePath, forTextEmphasisOrNot, from, to };
+    if (auto entry = m_entries.find(key); entry != m_entries.end())
+        return *entry->value;
+
+    auto glyphBuffer = font.layoutText(codePath, textRun, from, to, forTextEmphasisOrNot);
+    return *m_entries.add(key, WTF::makeUniqueRef<GlyphBuffer>(WTFMove((glyphBuffer)))).iterator->value;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/GlyphBufferCache.h
+++ b/Source/WebCore/rendering/GlyphBufferCache.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FloatSizeHash.h"
+#include "FontCascade.h"
+#include "GlyphBuffer.h"
+#include "Logging.h"
+#include "TextRun.h"
+#include "TextRunHash.h"
+#include <memory>
+#include <wtf/GetPtr.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashTraits.h>
+#include <wtf/MemoryPressureHandler.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/UniqueRef.h>
+
+namespace WebCore {
+
+class GlyphBufferCacheKey {
+    WTF_MAKE_FAST_ALLOCATED;
+    friend struct GlyphBufferCacheEntryHashTraits;
+    friend void add(Hasher&, const GlyphBufferCacheKey&);
+public:
+    bool operator==(const GlyphBufferCacheKey& other) const
+    {
+        return m_textRun == other.m_textRun
+            && m_fontCascadeGeneration == other.m_fontCascadeGeneration
+            && m_codePath == other.m_codePath
+            && m_forTextEmphasisOrNot == other.m_forTextEmphasisOrNot
+            && from == other.from
+            && to == other.to;
+    }
+
+    GlyphBufferCacheKey(WTF::HashTableEmptyValueType)
+        : m_textRun(WTF::HashTableEmptyValue)
+    { }
+
+    GlyphBufferCacheKey(WTF::HashTableDeletedValueType)
+        : m_textRun(WTF::HashTableDeletedValue)
+    { }
+
+    GlyphBufferCacheKey(const TextRun& textRun, const FontCascade& font, FontCascade::CodePath& codePath, FontCascade::ForTextEmphasisOrNot forTextEmphasisOrNot, unsigned from, unsigned to)
+        : m_textRun(textRun)
+        , m_fontCascadeGeneration(font.generation())
+        , m_codePath(codePath)
+        , m_forTextEmphasisOrNot(forTextEmphasisOrNot)
+        , from(from)
+        , to(to)
+    {
+    }
+
+private:
+    TextRun m_textRun;
+    unsigned m_fontCascadeGeneration;
+    FontCascade::CodePath m_codePath;
+    FontCascade::ForTextEmphasisOrNot m_forTextEmphasisOrNot;
+    unsigned from;
+    unsigned to;
+};
+
+inline void add(Hasher& hasher, const GlyphBufferCacheKey& key)
+{
+    add(hasher, key.m_textRun, key.m_fontCascadeGeneration, key.m_codePath, key.m_forTextEmphasisOrNot, key.from, key.to);
+}
+
+struct GlyphBufferCacheEntryHash {
+    static unsigned hash(const GlyphBufferCacheKey& key) { return computeHash(key); }
+    static bool equal (const GlyphBufferCacheKey& a, const GlyphBufferCacheKey& b) { return a == b; }
+    static constexpr bool safeToCompareToEmptyOrDeleted = false;
+};
+
+struct GlyphBufferCacheEntryHashTraits : WTF::GenericHashTraits<GlyphBufferCacheKey> {
+    static const bool emptyValueIsZero = false;
+    static const bool hasIsEmptyValueFunction = true;
+    static GlyphBufferCacheKey emptyValue() { return GlyphBufferCacheKey(WTF::HashTableEmptyValue); }
+    static void constructDeletedValue(GlyphBufferCacheKey& slot) { new (NotNull, &slot) GlyphBufferCacheKey(WTF::HashTableDeletedValue); }
+    static const bool hasIsDeletedValueFunction = true;
+    static bool isDeletedValue(const GlyphBufferCacheKey& key) { return key.m_textRun.isHashTableDeletedValue(); }
+    static bool isEmptyValue(const GlyphBufferCacheKey& key) { return key.m_textRun.isHashTableEmptyValue(); }
+};
+
+class GlyphBufferCache {
+    WTF_MAKE_FAST_ALLOCATED;
+    friend class GlyphBufferCacheKey;
+public:
+    GlyphBufferCache() = default;
+
+    static GlyphBufferCache& singleton();
+
+    // DisplayList::DisplayList* getDisplayList(const FontCascade&, GraphicsContext&, const TextRun&);
+    GlyphBuffer glyphBuffer(const FontCascade&, FontCascade::CodePath, FontCascade::ForTextEmphasisOrNot, const TextRun&, unsigned, unsigned);
+
+    void clear();
+    unsigned size() const;
+
+private:
+    // static bool canShareDisplayList(const DisplayList::DisplayList&);
+    HashMap<GlyphBufferCacheKey, WTF::UniqueRef<GlyphBuffer>, GlyphBufferCacheEntryHash, GlyphBufferCacheEntryHashTraits> m_entries;
+    // HashMap<GlyphBufferCacheKey,std::unique_ptr<GlyphBuffer>, GlyphBufferCacheEntryHash, GlyphBufferCacheEntryHashTraits> m_entries;
+};
+
+} // namespace WebCore
+
+namespace WTF {
+
+template<> struct DefaultHash<WebCore::GlyphBufferCacheKey> : WebCore::GlyphBufferCacheEntryHash { };
+
+} // namespace WTF


### PR DESCRIPTION
#### d5abe2bff89375861597d5561e8186966b69198e
<pre>
GlyphBuffer caching including partial runs
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::layoutTextFromCache const):
(WebCore::FontCascade::drawText const):
(WebCore::FontCascade::drawEmphasisMarks const):
(WebCore::FontCascade::displayListForTextRun const):
(WebCore::FontCascade::dashesForIntersectionsWithRect const):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/GlyphBuffer.h:
* Source/WebCore/rendering/GlyphBufferCache.cpp: Added.
(WebCore::GlyphBufferCache::singleton):
(WebCore::GlyphBufferCache::clear):
(WebCore::GlyphBufferCache::size const):
(WebCore::GlyphBufferCache::glyphBuffer):
* Source/WebCore/rendering/GlyphBufferCache.h: Added.
(WebCore::GlyphBufferCacheKey::operator== const):
(WebCore::GlyphBufferCacheKey::GlyphBufferCacheKey):
(WebCore::add):
(WebCore::GlyphBufferCacheEntryHash::hash):
(WebCore::GlyphBufferCacheEntryHash::equal):
(WebCore::GlyphBufferCacheEntryHashTraits::emptyValue):
(WebCore::GlyphBufferCacheEntryHashTraits::constructDeletedValue):
(WebCore::GlyphBufferCacheEntryHashTraits::isDeletedValue):
(WebCore::GlyphBufferCacheEntryHashTraits::isEmptyValue):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5abe2bff89375861597d5561e8186966b69198e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10178 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/61783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48394 "Passed tests") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7124 "Too many flaky failures: editing/selection/extend-selection-enclosing-block-win.html, fast/canvas/canvas-css-crazy.html, fast/canvas/webgl/debug-messages-to-console.html, fast/css/parsing-css-escapes.html, fast/dom/Document/createdDocument-readyState.html, fast/dom/regress-131530.html, fast/events/message-port-context-destroyed.html, fast/workers/worker-terminate-forever.html, http/tests/IndexedDB/storage-limit.https.html, http/tests/navigation/timerredirect-goback.html, imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-htb-htb.html, imported/w3c/web-platform-tests/css/selectors/invalidation/lang-pseudo-class-in-has.html, imported/w3c/web-platform-tests/service-workers/idlharness.https.any.worker.html, jquery/css.html, jquery/offset.html, js/console.html, js/dfg-cfg-simplify-eliminate-set-local-type-check-then-typeof.html, js/dfg-inline-arguments-osr-exit-and-capture.html, js/dom/document-all-is-callable-builtins.html, js/kde/evil-n.html, js/pic/cached-named-property-getter.html, performance-api/performance-timeline-api.html, webgl/2.0.0/conformance/textures/image/tex-2d-rgb-rgb-unsigned_short_5_6_5.html, webgl/2.0.0/conformance/textures/image_bitmap_from_image_data/tex-2d-rgb-rgb-unsigned_byte.html, webgl/2.0.0/conformance/textures/misc/default-texture.html, webgl/2.0.0/conformance/textures/webgl_canvas/tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-2d-rgb8-rgb-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-2d-rgba4-rgba-unsigned_byte.html, webgl/2.0.0/conformance2/textures/image_bitmap_from_canvas/tex-3d-r11f_g11f_b10f-rgb-half_float.html, webgl/2.0.0/conformance2/textures/image_data/tex-3d-rgba4-rgba-unsigned_byte.html, webgl/2.0.0/conformance2/textures/misc/gl-get-tex-parameter.html, webgl/2.0.y/conformance/glsl/functions/glsl-function-dot.html, webgl/2.0.y/conformance/glsl/implicit/add_int_mat2.vert.html, webgl/2.0.y/conformance/glsl/implicit/assign_int_to_float.vert.html, webgl/2.0.y/conformance/glsl/implicit/divide_int_vec4.vert.html, webgl/2.0.y/conformance/glsl/implicit/ternary_ivec3_vec3.vert.html, webgl/2.0.y/conformance/glsl/samplers/glsl-function-texture2dlod.html, webgl/2.0.y/conformance/more/functions/texImage2D.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29232 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8890 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9101 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55053 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65301 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3582 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9060 "Found 1 new test failure: http/tests/media/media-stream/get-user-media-in-embed-element.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55737 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3593 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55868 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2974 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34813 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35896 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36982 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->