### PR TITLE
Make host comparisons in Quirks case-sensitive, again

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -488,7 +488,7 @@ bool Quirks::shouldDispatchSimulatedMouseEvents(const EventTarget* target) const
             return ShouldDispatchSimulatedMouseEvents::Yes;
 
         auto& url = m_document->topDocument().url();
-        auto host = url.host().convertToASCIILowercase();
+        auto host = url.host();
 
         if (isDomain("wix.com"_s)) {
             // Disable simulated mouse dispatching for template selection.
@@ -1087,7 +1087,7 @@ bool Quirks::needsCanPlayAfterSeekedQuirk() const
     if (m_needsCanPlayAfterSeekedQuirk)
         return *m_needsCanPlayAfterSeekedQuirk;
 
-    auto domain = m_document->securityOrigin().domain().convertToASCIILowercase();
+    auto domain = m_document->securityOrigin().domain();
 
     m_needsCanPlayAfterSeekedQuirk = domain == "hulu.com"_s || domain.endsWith(".hulu.com"_s);
 
@@ -1695,7 +1695,7 @@ bool Quirks::shouldStarBePermissionsPolicyDefaultValue() const
         return false;
 
     if (!m_shouldStarBePermissionsPolicyDefaultValueQuirk) {
-        auto domain = m_document->securityOrigin().domain().convertToASCIILowercase();
+        auto domain = m_document->securityOrigin().domain();
         m_shouldStarBePermissionsPolicyDefaultValueQuirk = domain == "jsfiddle.net"_s;
     }
     return *m_shouldStarBePermissionsPolicyDefaultValueQuirk;
@@ -1754,81 +1754,83 @@ bool Quirks::shouldDisableNavigatorStandaloneQuirk() const
 // FIXME: find the reference radars and/or bugs.webkit.org issues on why these were added in the first place.
 // FIXME: There is no check currently on needsQuirks(), this needs to be fixed so it makes it easier
 // to deactivate them for testing.
-bool Quirks::needsIpadMiniUserAgent(StringView host)
+bool Quirks::needsIpadMiniUserAgent(const URL& url)
 {
+    auto host = url.host();
 
-    if (equalLettersIgnoringASCIICase(host, "tv.kakao.com"_s) || host.endsWithIgnoringASCIICase(".tv.kakao.com"_s))
+    if (host == "tv.kakao.com"_s || host.endsWith(".tv.kakao.com"_s))
         return true;
 
-    if (equalLettersIgnoringASCIICase(host, "tving.com"_s) || host.endsWithIgnoringASCIICase(".tving.com"_s))
+    if (host == "tving.com"_s || host.endsWith(".tving.com"_s))
         return true;
 
-    if (equalLettersIgnoringASCIICase(host, "live.iqiyi.com"_s) || host.endsWithIgnoringASCIICase(".live.iqiyi.com"_s))
+    if (host == "live.iqiyi.com"_s || host.endsWith(".live.iqiyi.com"_s))
         return true;
 
-    if (equalLettersIgnoringASCIICase(host, "jsfiddle.net"_s) || host.endsWithIgnoringASCIICase(".jsfiddle.net"_s))
+    if (host == "jsfiddle.net"_s || host.endsWith(".jsfiddle.net"_s))
         return true;
 
-    if (equalLettersIgnoringASCIICase(host, "video.sina.com.cn"_s) || host.endsWithIgnoringASCIICase(".video.sina.com.cn"_s))
+    if (host == "video.sina.com.cn"_s || host.endsWith(".video.sina.com.cn"_s))
         return true;
 
-    if (equalLettersIgnoringASCIICase(host, "huya.com"_s) || host.endsWithIgnoringASCIICase(".huya.com"_s))
+    if (host == "huya.com"_s || host.endsWith(".huya.com"_s))
         return true;
 
-    if (equalLettersIgnoringASCIICase(host, "video.tudou.com"_s) || host.endsWithIgnoringASCIICase(".video.tudou.com"_s))
+    if (host == "video.tudou.com"_s || host.endsWith(".video.tudou.com"_s))
         return true;
 
-    if (equalLettersIgnoringASCIICase(host, "cctv.com"_s) || host.endsWithIgnoringASCIICase(".cctv.com"_s))
+    if (host == "cctv.com"_s || host.endsWith(".cctv.com"_s))
         return true;
 
-    if (equalLettersIgnoringASCIICase(host, "v.china.com.cn"_s))
+    if (host == "v.china.com.cn"_s)
         return true;
 
-    if (equalLettersIgnoringASCIICase(host, "trello.com"_s) || host.endsWithIgnoringASCIICase(".trello.com"_s))
+    if (host == "trello.com"_s || host.endsWith(".trello.com"_s))
         return true;
 
-    if (equalLettersIgnoringASCIICase(host, "ted.com"_s) || host.endsWithIgnoringASCIICase(".ted.com"_s))
+    if (host == "ted.com"_s || host.endsWith(".ted.com"_s))
         return true;
 
-    if (host.containsIgnoringASCIICase("hsbc."_s)) {
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.au"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.au"_s))
+    if (host.contains("hsbc."_s)) {
+        if (host == "hsbc.com.au"_s || host.endsWith(".hsbc.com.au"_s))
             return true;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.eg"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.eg"_s))
+        if (host == "hsbc.com.eg"_s || host.endsWith(".hsbc.com.eg"_s))
             return true;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.lk"_s) || host.endsWithIgnoringASCIICase(".hsbc.lk"_s))
+        if (host == "hsbc.lk"_s || host.endsWith(".hsbc.lk"_s))
             return true;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.co.uk"_s) || host.endsWithIgnoringASCIICase(".hsbc.co.uk"_s))
+        if (host == "hsbc.co.uk"_s || host.endsWith(".hsbc.co.uk"_s))
             return true;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.hk"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.hk"_s))
+        if (host == "hsbc.com.hk"_s || host.endsWith(".hsbc.com.hk"_s))
             return true;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.mx"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.mx"_s))
+        if (host == "hsbc.com.mx"_s || host.endsWith(".hsbc.com.mx"_s))
             return true;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.ca"_s) || host.endsWithIgnoringASCIICase(".hsbc.ca"_s))
+        if (host == "hsbc.ca"_s || host.endsWith(".hsbc.ca"_s))
             return true;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.ar"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.ar"_s))
+        if (host == "hsbc.com.ar"_s || host.endsWith(".hsbc.com.ar"_s))
             return true;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.ph"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.ph"_s))
+        if (host == "hsbc.com.ph"_s || host.endsWith(".hsbc.com.ph"_s))
             return true;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com"_s) || host.endsWithIgnoringASCIICase(".hsbc.com"_s))
+        if (host == "hsbc.com"_s || host.endsWith(".hsbc.com"_s))
             return true;
-        if (equalLettersIgnoringASCIICase(host, "hsbc.com.cn"_s) || host.endsWithIgnoringASCIICase(".hsbc.com.cn"_s))
+        if (host == "hsbc.com.cn"_s || host.endsWith(".hsbc.com.cn"_s))
             return true;
     }
 
-    if (equalLettersIgnoringASCIICase(host, "nhl.com"_s) || host.endsWithIgnoringASCIICase(".nhl.com"_s))
+    if (host == "nhl.com"_s || host.endsWith(".nhl.com"_s))
         return true;
 
     // FIXME: Remove this quirk when <rdar://problem/59480381> is complete.
-    if (equalLettersIgnoringASCIICase(host, "fidelity.com"_s) || host.endsWithIgnoringASCIICase(".fidelity.com"_s))
+    if (host == "fidelity.com"_s || host.endsWith(".fidelity.com"_s))
         return true;
 
     // FIXME: Remove this quirk when <rdar://problem/61733101> is complete.
-    if (equalLettersIgnoringASCIICase(host, "roblox.com"_s) || host.endsWithIgnoringASCIICase(".roblox.com"_s))
+    if (host == "roblox.com"_s || host.endsWith(".roblox.com"_s))
         return true;
 
     // FIXME: Remove this quirk when <rdar://122481999> is complete
-    if (equalLettersIgnoringASCIICase(host, "spotify.com"_s) || host.endsWithIgnoringASCIICase(".spotify.com"_s) || host.endsWithIgnoringASCIICase(".spotifycdn.com"_s))
+    if (host == "spotify.com"_s || host.endsWith(".spotify.com"_s) || host.endsWith(".spotifycdn.com"_s))
         return true;
+
     return false;
 }
 

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -103,7 +103,7 @@ public:
 
     WEBCORE_EXPORT static void updateStorageAccessUserAgentStringQuirks(HashMap<RegistrableDomain, String>&&);
     WEBCORE_EXPORT String storageAccessUserAgentStringQuirkForDomain(const URL&);
-    WEBCORE_EXPORT static bool needsIpadMiniUserAgent(StringView host);
+    WEBCORE_EXPORT static bool needsIpadMiniUserAgent(const URL&);
 
     bool needsGMailOverflowScrollQuirk() const;
     bool needsYouTubeOverflowScrollQuirk() const;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1354,8 +1354,7 @@ static RecommendDesktopClassBrowsingForRequest desktopClassBrowsingRecommendedFo
     // FIXME: This should be additionally gated on site-specific quirks being enabled.
     // See also: <rdar://problem/50035167>.
     // The list of domain names is currently available in Source/WebCore/page/Quirks.cpp
-    auto host = request.url().host();
-    if (Quirks::needsIpadMiniUserAgent(host))
+    if (Quirks::needsIpadMiniUserAgent(request.url()))
         return RecommendDesktopClassBrowsingForRequest::No;
 
     return RecommendDesktopClassBrowsingForRequest::Auto;


### PR DESCRIPTION
#### 82fe811f87857c4c494ad1532dcbcde028dce103
<pre>
Make host comparisons in Quirks case-sensitive, again
<a href="https://bugs.webkit.org/show_bug.cgi?id=271250">https://bugs.webkit.org/show_bug.cgi?id=271250</a>

Reviewed by Sihui Liu.

Follow-up to 273228@main as new case-insensitive checks appeared. The
URL parser canonicalizes hosts. SecurityOrigin is derived from a URL.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldDispatchSimulatedMouseEvents const):
(WebCore::Quirks::needsCanPlayAfterSeekedQuirk const):
(WebCore::Quirks::shouldStarBePermissionsPolicyDefaultValue const):
(WebCore::Quirks::needsIpadMiniUserAgent):
* Source/WebCore/page/Quirks.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::desktopClassBrowsingRecommendedForRequest):

Canonical link: <a href="https://commits.webkit.org/276447@main">https://commits.webkit.org/276447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fe4f6e585229f64bda1c5cb6f7d48e2a9f15b48

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47220 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40566 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21036 "Built successfully") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36681 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 46 flakes 186 failures 1 missing results; Uploaded test results (exception)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38361 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17717 "Found 1 new API test failure: /WPE/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39506 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2614 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40830 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48848 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43587 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20856 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42343 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9959 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21184 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->