### PR TITLE
REGRESSION (276177@main): LinearMediaPlayer controls briefly appear when entering element fullscreen

### DIFF
--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -281,7 +281,7 @@ bool VideoPresentationManager::supportsVideoFullscreen(WebCore::HTMLMediaElement
 
 bool VideoPresentationManager::supportsVideoFullscreenStandby() const
 {
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY) && !PLATFORM(VISION)
     return true;
 #else
     return false;


### PR DESCRIPTION
#### e021db348aed9d2cc916ea427bb6b3113558de12
<pre>
REGRESSION (276177@main): LinearMediaPlayer controls briefly appear when entering element fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=271251">https://bugs.webkit.org/show_bug.cgi?id=271251</a>
<a href="https://rdar.apple.com/125019855">rdar://125019855</a>

Reviewed by Jer Noble.

On platforms that support fullscreen standby, VideoPresentationInterface::setupFullscreen() is
called (with `standby` set to true) when element fullscreen is activated for an element containing
a &lt;video&gt; descendant. This prewarms the presentation interface so that&apos;s it&apos;s ready to enter
picture-in-picture if requested.

After 276177@main, this prewarming inserts a LMKPlayableViewController in the WKWebView&apos;s hierarchy.
Even though the VC&apos;s root view&apos;s `hidden` property is set to YES, due to a bug in LinearMediaKit
parts of the media controls remain visible for a brief period. To work around this bug, since
visionOS does not support automatic picture-in-picture we can just disable support for fullscreen
standby. This avoids calls to VideoPresentationInterface::setupFullscreen() when entering element
fullscreen.

* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::supportsVideoFullscreenStandby const):

Canonical link: <a href="https://commits.webkit.org/276364@main">https://commits.webkit.org/276364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/264aac55503ec70b251349d9f004f8cfef0673f9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47094 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40464 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20908 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36562 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38249 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17609 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18015 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2490 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40626 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48712 "Built successfully") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43474 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20772 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42209 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9888 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21099 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->