### PR TITLE
Move WinPortTest to be testing WinCairo

### DIFF
--- a/Tools/Scripts/webkitpy/port/win_unittest.py
+++ b/Tools/Scripts/webkitpy/port/win_unittest.py
@@ -35,7 +35,7 @@ from webkitpy.common.system.executive_mock import MockExecutive
 from webkitpy.common.system.systemhost_mock import MockSystemHost
 from webkitpy.common.version_name_map import PUBLIC_TABLE, VersionNameMap
 from webkitpy.port import port_testcase
-from webkitpy.port.win import WinPort
+from webkitpy.port.win import WinCairoPort
 from webkitpy.tool.mocktool import MockOptions
 
 
@@ -43,25 +43,26 @@ class WinPortTest(port_testcase.PortTestCase):
     os_name = 'win'
     os_version = Version.from_name('XP')
     port_name = 'win-xp'
-    port_maker = WinPort
+    port_maker = WinCairoPort
 
     def _assert_search_path(self, expected_search_paths, version, use_webkit2=False):
         port = self.make_port(port_name='win', os_version=version, options=MockOptions(webkit_test_runner=use_webkit2))
-        absolute_search_paths = list(map(port._webkit_baseline_path, expected_search_paths))
-        self.assertEqual(port.baseline_search_path(), absolute_search_paths)
+        platform_dir = port.host.filesystem.dirname(port._webkit_baseline_path("xxx"))
+        relative_search_paths = [port.host.filesystem.relpath(p, platform_dir) for p in port.baseline_search_path()]
+        self.assertEqual(relative_search_paths, expected_search_paths)
 
     def test_baseline_search_path(self):
-        self._assert_search_path(['win-xp', 'win-vista', 'win-7sp0', 'win-8', 'win-8.1', 'win-win10', 'win', 'mac'], Version.from_name('XP'))
-        self._assert_search_path(['win-vista', 'win-7sp0', 'win-8', 'win-8.1', 'win-win10', 'win', 'mac'], Version.from_name('Vista'))
-        self._assert_search_path(['win-7sp0', 'win-8', 'win-8.1', 'win-win10', 'win', 'mac'], Version.from_name('7sp0'))
+        self._assert_search_path(['wincairo-xp-wk1', 'wincairo-xp', 'wincairo-vista-wk1', 'wincairo-vista', 'wincairo-7sp0-wk1', 'wincairo-7sp0', 'wincairo-8-wk1', 'wincairo-8', 'wincairo-8.1-wk1', 'wincairo-8.1', 'wincairo-win10-wk1', 'wincairo-win10', 'wincairo-wk1', 'wincairo'], Version.from_name('XP'))
+        self._assert_search_path(['wincairo-vista-wk1', 'wincairo-vista', 'wincairo-7sp0-wk1', 'wincairo-7sp0', 'wincairo-8-wk1', 'wincairo-8', 'wincairo-8.1-wk1', 'wincairo-8.1', 'wincairo-win10-wk1', 'wincairo-win10', 'wincairo-wk1', 'wincairo'], Version.from_name('Vista'))
+        self._assert_search_path(['wincairo-7sp0-wk1', 'wincairo-7sp0', 'wincairo-8-wk1', 'wincairo-8', 'wincairo-8.1-wk1', 'wincairo-8.1', 'wincairo-win10-wk1', 'wincairo-win10', 'wincairo-wk1', 'wincairo'], Version.from_name('7sp0'))
 
-        self._assert_search_path(['win-wk2', 'win-xp', 'win-vista', 'win-7sp0', 'win-8', 'win-8.1', 'win-win10', 'win', 'mac-wk2', 'mac'], Version.from_name('XP'), use_webkit2=True)
-        self._assert_search_path(['win-wk2', 'win-vista', 'win-7sp0', 'win-8', 'win-8.1', 'win-win10', 'win', 'mac-wk2', 'mac'], Version.from_name('Vista'), use_webkit2=True)
-        self._assert_search_path(['win-wk2', 'win-7sp0', 'win-8', 'win-8.1', 'win-win10', 'win', 'mac-wk2', 'mac'], Version.from_name('7sp0'), use_webkit2=True)
+        self._assert_search_path(['wincairo-wk2', 'wincairo', 'wk2'], Version.from_name('XP'), use_webkit2=True)
+        self._assert_search_path(['wincairo-wk2', 'wincairo', 'wk2'], Version.from_name('Vista'), use_webkit2=True)
+        self._assert_search_path(['wincairo-wk2', 'wincairo', 'wk2'], Version.from_name('7sp0'), use_webkit2=True)
 
     def _assert_version(self, port_name, expected_version):
         host = MockSystemHost(os_name='win', os_version=expected_version)
-        port = WinPort(host, port_name=port_name)
+        port = WinCairoPort(host, port_name=port_name)
         self.assertEqual(port.version_name(), VersionNameMap.map().to_name(expected_version, platform='win', table=PUBLIC_TABLE))
 
     def test_versions(self):
@@ -85,8 +86,50 @@ class WinPortTest(port_testcase.PortTestCase):
         self.assertEqual('win', self.make_port().operating_system())
 
     def test_expectations_files(self):
-        self.assertEqual(len(self.make_port().expectations_files()), 3)
-        self.assertEqual(len(self.make_port(options=MockOptions(webkit_test_runner=True, configuration='Release')).expectations_files()), 5)
+        self.assertEqual(
+            self.make_port().expectations_files(),
+            [
+                "/mock-checkout/LayoutTests/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-wk1/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-win10/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-win10-wk1/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-8.1/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-8.1-wk1/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-8/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-8-wk1/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-7sp0/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-7sp0-wk1/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-vista/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-vista-wk1/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-xp/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-xp-wk1/TestExpectations",
+            ],
+        )
+
+        self.assertEqual(
+            self.make_port(
+                options=MockOptions(webkit_test_runner=True, configuration="Release")
+            ).expectations_files(),
+            [
+                "/mock-checkout/LayoutTests/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wk2/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-wk2/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-win10/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-win10-wk2/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-8.1/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-8.1-wk2/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-8/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-8-wk2/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-7sp0/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-7sp0-wk2/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-vista/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-vista-wk2/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-xp/TestExpectations",
+                "/mock-checkout/LayoutTests/platform/wincairo-xp-wk2/TestExpectations",
+            ],
+        )
 
     def test_get_crash_log(self):
         # Win crash logs are tested elsewhere, so here we just make sure we don't crash.
@@ -98,7 +141,16 @@ class WinPortTest(port_testcase.PortTestCase):
             time_fn=fake_time_cb(), sleep_fn=lambda delay: None)
 
     def test_layout_test_searchpath_with_apple_additions(self):
+        search_path = self.make_port().default_baseline_search_path()
         with port_testcase.bind_mock_apple_additions():
-            search_path = self.make_port().default_baseline_search_path()
-        self.assertEqual(search_path[0], '/additional_testing_path/win')
-        self.assertEqual(search_path[1], '/mock-checkout/LayoutTests/platform/win-xp')
+            additions_search_path = self.make_port().default_baseline_search_path()
+        self.assertEqual(search_path, additions_search_path)
+
+    def test_default_upload_configuration(self):
+        port = self.make_port()
+        configuration = port.configuration_for_upload()
+        self.assertEqual(configuration['architecture'], port.architecture())
+        self.assertEqual(configuration['is_simulator'], False)
+        self.assertEqual(configuration['platform'], 'wincairo')
+        self.assertEqual(configuration['style'], 'release')
+        self.assertEqual(configuration['version_name'], 'XP')


### PR DESCRIPTION
#### ac94152bc1b0141eba9ffd43c75ccf02009f309c
<pre>
Move WinPortTest to be testing WinCairo
<a href="https://bugs.webkit.org/show_bug.cgi?id=271253">https://bugs.webkit.org/show_bug.cgi?id=271253</a>

Reviewed by Fujii Hironori and Jonathan Bedard.

With AppleWin gone, WinCairoPort is the only subclass we actually
initialize, thus it makes sense to test its behavior.

* Tools/Scripts/webkitpy/port/win_unittest.py:
(WinPortTest):
(WinPortTest._assert_search_path):
(WinPortTest.test_baseline_search_path):
(WinPortTest._assert_version):
(WinPortTest.test_expectations_files):
(WinPortTest.test_layout_test_searchpath_with_apple_additions):
(WinPortTest.test_default_upload_configuration):

Canonical link: <a href="https://commits.webkit.org/276470@main">https://commits.webkit.org/276470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b2bc23704959c9a159526143291ce47a6a90e2a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-skia ](https://ews-build.webkit.org/#/builders/WPE-Skia-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6190 "Built successfully and passed tests") | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->