### PR TITLE
ScrollViews with snap points should not be candidates for Overlay Regions

### DIFF
--- a/LayoutTests/overlay-region/full-page-overflow-snapping-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-snapping-expected.txt
@@ -1,0 +1,189 @@
+
+(UIView tree root view [class: <class not in allowed list of classes>]
+  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+  (layer position [x: 400 y: 400])
+  (subviews
+    (view [class: WKScrollView]
+      (scrolling behavior 0)
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400])
+      (subviews
+        (view [class: WKContentView]
+          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+          (layer anchorPoint [x: 0 y: 0])
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer anchorPoint [x: 0 y: 0])
+              (subviews
+                (view [class: UIView]
+                  (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: WKCompositingView]
+                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                      (layer position [x: 400 y: 400])
+                      (subviews
+                        (view [class: WKCompositingView]
+                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                          (layer anchorPoint [x: 0 y: 0])
+                          (subviews
+                            (view [class: WKCompositingView]
+                              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                              (layer anchorPoint [x: 0 y: 0])
+                              (subviews
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                                (view [class: WKCompositingView]
+                                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                  (layer anchorPoint [x: 0 y: 0])
+                                  (subviews
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer position [x: 400 y: 400])
+                                      (subviews
+                                        (view [class: <class not in allowed list of classes>]
+                                          (scrolling behavior 0)
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                          (layer position [x: 400 y: 400])
+                                          (subviews
+                                            (view [class: WKCompositingView]
+                                              (layer bounds [x: 0 y: 0 width: 800 height: 7100])
+                                              (layer anchorPoint [x: 0 y: 0])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+                                            (view [class: <class not in allowed list of classes>]
+                                              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                              (layer position [x: 791 y: 791])
+                                              (layer zPosition 1000)
+                                              (subviews
+                                                (view [class: UIView]
+                                                  (layer bounds [x: 0 y: 0 width: 32 height: 116])
+                                                  (layer position [x: 6 y: 6]))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 12 height: 600])
+                                                  (layer position [x: 6 y: 6])
+                                                  (subviews
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                                                      (layer position [x: 6 y: 6])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                                                          (layer position [x: 6 y: 6]))
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 6 height: 28])
+                                                          (layer position [x: 6 y: 6]))))))))
+                                            (view [class: <class not in allowed list of classes>]
+                                              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+                                              (layer position [x: 400 y: 400])
+                                              (layer zPosition 1000)
+                                              (subviews
+                                                (view [class: UIView]
+                                                  (layer bounds [x: 0 y: 0 width: 116 height: 32])
+                                                  (layer position [x: 400 y: 400]))
+                                                (view [class: <class not in allowed list of classes>]
+                                                  (layer bounds [x: 0 y: 0 width: 800 height: 12])
+                                                  (layer position [x: 400 y: 400])
+                                                  (subviews
+                                                    (view [class: <class not in allowed list of classes>]
+                                                      (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                                                      (layer position [x: 400 y: 400])
+                                                      (subviews
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                                                          (layer position [x: 48 y: 48]))
+                                                        (view [class: <class not in allowed list of classes>]
+                                                          (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                                                          (layer position [x: 48 y: 48]))))))))))))
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer position [x: 400 y: 400])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                          (subviews
+                                            (view [class: WKTransformView]
+                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                              (layer position [x: 0 y: 0])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                                  (layer position [x: 400 y: 400]))))))))
+                                    (view [class: WKCompositingView]
+                                      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+                                      (layer position [x: 400 y: 400])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                          (subviews
+                                            (view [class: WKTransformView]
+                                              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                              (layer position [x: 0 y: 0])
+                                              (subviews
+                                                (view [class: WKCompositingView]
+                                                  (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                                  (layer position [x: 400 y: 400]))))))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))
+                                    (view [class: WKTransformView]
+                                      (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                                      (layer position [x: 0 y: 0])
+                                      (subviews
+                                        (view [class: WKCompositingView]
+                                          (layer bounds [x: 0 y: 0 width: 800 height: 50])
+                                          (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: _UILayerHostView]
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+        (view [class: UIView]
+          (layer bounds [x: 0 y: 0 width: 0 height: 0])
+          (layer anchorPoint [x: 0 y: 0]))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 12 height: 600])
+          (layer position [x: 791 y: 791])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 32 height: 116])
+              (layer position [x: 6 y: 6]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 12 height: 600])
+              (layer position [x: 6 y: 6])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 12 height: 96])
+                  (layer position [x: 6 y: 6])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 6 height: 90])
+                      (layer position [x: 6 y: 6]))))))))
+        (view [class: <class not in allowed list of classes>]
+          (layer bounds [x: 0 y: 0 width: 800 height: 12])
+          (layer position [x: 400 y: 400])
+          (layer zPosition 1000)
+          (subviews
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 116 height: 32])
+              (layer position [x: 400 y: 400]))
+            (view [class: <class not in allowed list of classes>]
+              (layer bounds [x: 0 y: 0 width: 800 height: 12])
+              (layer position [x: 400 y: 400])
+              (subviews
+                (view [class: <class not in allowed list of classes>]
+                  (layer bounds [x: 0 y: 0 width: 96 height: 12])
+                  (layer position [x: 400 y: 400])
+                  (subviews
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 5.999999999999995 height: 90])
+                      (layer position [x: 48 y: 48]))
+                    (view [class: <class not in allowed list of classes>]
+                      (layer bounds [x: 0 y: 0 width: 90 height: 6])
+                      (layer position [x: 48 y: 48]))))))))))))

--- a/LayoutTests/overlay-region/full-page-overflow-snapping.html
+++ b/LayoutTests/overlay-region/full-page-overflow-snapping.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system; }
+        h1, h2 { margin: 0; padding: 0; line-height: 50px; }
+        h2 { font-size: 1.1em; }
+
+        #test {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            overflow: scroll;
+            scroll-snap-type: y mandatory;
+        }
+        .fixed {
+            position: fixed;
+            left: 0;
+            right: 0;
+            height: 50px;
+            background: #F67280;
+            z-index: 100;
+        }
+
+        #header {
+            top: 0;
+        }
+        #footer {
+            top: unset;
+            bottom: 0;
+        }
+
+        .sticky {
+            position: sticky;
+            top: 50px;
+            height: 50px;
+            background: #6C5B7B;
+            z-index: 10;
+            scroll-snap-align: start;
+        }
+
+        .long {
+            position: relative;
+            height: 1000px;
+            background: #355C7D;
+            scroll-snap-align: start;
+        }
+        .long::before {
+            content: "↓";
+            color: white;
+            font-size: 20em;
+            text-align: center;
+            position: absolute;
+            top: 400px;
+            left: 0;
+            right: 0;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<section id="test">
+    <div id="header" class="fixed">
+        <h1>This is a fixed header</h1>
+    </div>
+    <h2 class="sticky">This is a sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <h2 class="sticky">This is another sticky header</h2>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div class="long">
+    </div>
+    <div id="footer" class="fixed">
+        <h1>This is a fixed footer</h1>
+    </div>
+</section>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+    results.textContent = await UIHelper.getUIViewTree();
+    document.getElementById('test').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>
+

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -114,9 +114,12 @@ Vector<WKBaseScrollView*> RemoteScrollingCoordinatorProxyIOS::overlayRegionScrol
 {
     Vector<WKBaseScrollView*> candidates;
     for (auto scrollingNodeID : m_scrollingNodesByLayerID.values()) {
-        auto* scrollView = scrollViewForScrollingNodeID(scrollingNodeID);
-        if (scrollView)
-            candidates.append((WKBaseScrollView *)scrollView);
+        auto* treeNode = scrollingTree()->nodeForID(scrollingNodeID);
+        if (auto* scrollingNode = dynamicDowncast<ScrollingTreeScrollingNode>(treeNode)) {
+            auto* scrollView = scrollViewForScrollingNodeID(scrollingNodeID);
+            if (scrollView && scrollingNode->snapOffsetsInfo().isEmpty())
+                candidates.append((WKBaseScrollView *)scrollView);
+        }
     }
     return candidates;
 }


### PR DESCRIPTION
#### cba69a9ffcad82de44923be9027d70948edf8ebc
<pre>
ScrollViews with snap points should not be candidates for Overlay Regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=271255">https://bugs.webkit.org/show_bug.cgi?id=271255</a>
&lt;<a href="https://rdar.apple.com/124334848">rdar://124334848</a>&gt;

Reviewed by Mike Wyrzykowski.

Check for snap offsets info when generating the candidates list for Overlay
Regions.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit:: const):
Add the check.

* LayoutTests/overlay-region/full-page-overflow-snapping-expected.txt: Added.
* LayoutTests/overlay-region/full-page-overflow-snapping.html: Added.
Add a test with scroll snapping.

Canonical link: <a href="https://commits.webkit.org/276377@main">https://commits.webkit.org/276377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d950e9d5bf95d8a2536bdd53a884af55240e739

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40471 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36569 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17618 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39393 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2499 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40673 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48721 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43483 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42229 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9897 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21106 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20412 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->