### PR TITLE
[WebAuthn] Unable to submit new requests after cancelling conditional mediation via abortSignal

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -185,10 +185,9 @@ void AuthenticatorCoordinator::create(const Document& document, CredentialCreati
             weakThis->m_client->cancel([weakThis = WTFMove(weakThis)] () mutable {
                 if (!weakThis)
                     return;
-                if (auto queuedRequest = WTFMove(weakThis->m_queuedRequest)) {
-                    weakThis->m_isCancelling = false;
+                weakThis->m_isCancelling = false;
+                if (auto queuedRequest = WTFMove(weakThis->m_queuedRequest))
                     queuedRequest();
-                }
             });
         });
     }
@@ -289,10 +288,9 @@ void AuthenticatorCoordinator::discoverFromExternalSource(const Document& docume
             weakThis->m_client->cancel([weakThis = WTFMove(weakThis)] () mutable {
                 if (!weakThis)
                     return;
-                if (auto queuedRequest = WTFMove(weakThis->m_queuedRequest)) {
-                    weakThis->m_isCancelling = false;
+                weakThis->m_isCancelling = false;
+                if (auto queuedRequest = WTFMove(weakThis->m_queuedRequest))
                     queuedRequest();
-                }
             });
         });
     }


### PR DESCRIPTION
#### 80b0cc5927c72554468e135fcdd28fb6a7316f51
<pre>
[WebAuthn] Unable to submit new requests after cancelling conditional mediation via abortSignal
<a href="https://rdar.apple.com/124727713">rdar://124727713</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=271257">https://bugs.webkit.org/show_bug.cgi?id=271257</a>

Reviewed by Charlie Wolfe.

In <a href="https://bugs.webkit.org/show_bug.cgi?id=257176">https://bugs.webkit.org/show_bug.cgi?id=257176</a>, functionality was introduced to wait for a
previous request&apos;s cancel to complete before submitting a subsequent one. However, there&apos;s currently
a bug that does not set the cancel flag to false if there&apos;s no subsequent request.

This patch fixes that bug by setting m_isCancelling to false once the cancel completes regardless of
if there&apos;s a subsequent request.

* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::create):
(WebCore::AuthenticatorCoordinator::discoverFromExternalSource):

Canonical link: <a href="https://commits.webkit.org/276368@main">https://commits.webkit.org/276368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/363f54875b37dbac670a221ca6109b98eaeed619

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47129 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46782 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27558 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20943 "") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20598 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17640 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39411 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2526 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48748 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/19445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/20943 "") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42241 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9892 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20436 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->