### PR TITLE
[WebGPU] only last getMappedRange() is copied back to buffer in GPUMapMode.WRITE

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.h
@@ -78,8 +78,11 @@ private:
     void internalUnmap(ScriptExecutionContext&);
 
     Ref<WebGPU::Buffer> m_backing;
-    WebGPU::Buffer::MappedRange m_mappedRange;
-    RefPtr<JSC::ArrayBuffer> m_arrayBuffer;
+    struct ArrayBufferWithOffset {
+        RefPtr<JSC::ArrayBuffer> buffer;
+        uint8_t* source;
+    };
+    Vector<ArrayBufferWithOffset> m_arrayBuffers;
     size_t m_bufferSize { 0 };
     size_t m_mappedRangeOffset { 0 };
     size_t m_mappedRangeSize { 0 };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
@@ -51,7 +51,7 @@ public:
 
     virtual void mapAsync(MapModeFlags, Size64 offset, std::optional<Size64>, CompletionHandler<void(bool)>&&) = 0;
     struct MappedRange {
-        void* source { nullptr };
+        uint8_t* source { nullptr };
         size_t byteLength { 0 };
     };
     virtual MappedRange getMappedRange(Size64 offset, std::optional<Size64>) = 0;


### PR DESCRIPTION
#### 71b962443b70953cb2b4840b22e76a99f5574759
<pre>
[WebGPU] only last getMappedRange() is copied back to buffer in GPUMapMode.WRITE
<a href="https://bugs.webkit.org/show_bug.cgi?id=271261">https://bugs.webkit.org/show_bug.cgi?id=271261</a>
&lt;radar://125003533&gt;

Reviewed by Dan Glastonbury.

We were only copying data from the most recent getMappedRange, which
is wrong, we need to copy from all the ranges.

* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::GPUBuffer::~GPUBuffer):
(WebCore::makeArrayBuffer):
(WebCore::GPUBuffer::getMappedRange):
(WebCore::GPUBuffer::internalUnmap):
* Source/WebCore/Modules/WebGPU/GPUBuffer.h:

* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h:
Change from void* to uint8_t* as this represents a byte vector.

Canonical link: <a href="https://commits.webkit.org/276382@main">https://commits.webkit.org/276382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ebcc26df4dc4e507a5aaa92d4f82af5657093eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47121 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40484 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46773 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36591 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17631 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39409 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2517 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40702 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48740 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15973 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43497 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20790 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42234 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9903 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21118 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->