### PR TITLE
Web Inspector: console's code completion should be case-insensitive

### DIFF
--- a/LayoutTests/inspector/console/js-completions-expected.txt
+++ b/LayoutTests/inspector/console/js-completions-expected.txt
@@ -13,3 +13,145 @@ PASS: Completions should still contain myVariable before cache is cleared.
 PASS: Completions should change after cache is cleared.
 PASS: Completions should not contain myVariable after it's deleted by code run in console.
 
+-- Running test case: console.jsCompletions.completionOrdering
+Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":""} and experimentalShowCaseSensitiveAutocomplete=false:
+[
+  "aa",
+  "Aa",
+  "ab",
+  "Ab",
+  "__aa__",
+  "__ab__"
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"a"} and experimentalShowCaseSensitiveAutocomplete=false:
+[
+  "aa",
+  "ab",
+  "Aa",
+  "Ab"
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"A"} and experimentalShowCaseSensitiveAutocomplete=false:
+[
+  "Aa",
+  "Ab",
+  "aa",
+  "ab"
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"_"} and experimentalShowCaseSensitiveAutocomplete=false:
+[
+  "__aa__",
+  "__ab__"
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":""} and experimentalShowCaseSensitiveAutocomplete=false:
+[
+  "1",
+  "2",
+  "10",
+  "20",
+  "\"__aa__\"",
+  "\"__ab__\"",
+  "\"aa\"",
+  "\"Aa\"",
+  "\"ab\"",
+  "\"Ab\""
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"1"} and experimentalShowCaseSensitiveAutocomplete=false:
+[
+  "1",
+  "10"
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"a"} and experimentalShowCaseSensitiveAutocomplete=false:
+[
+  "\"aa\"",
+  "\"ab\"",
+  "\"Aa\"",
+  "\"Ab\""
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"A"} and experimentalShowCaseSensitiveAutocomplete=false:
+[
+  "\"Aa\"",
+  "\"Ab\"",
+  "\"aa\"",
+  "\"ab\""
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"_"} and experimentalShowCaseSensitiveAutocomplete=false:
+[
+  "\"__aa__\"",
+  "\"__ab__\""
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":""} and experimentalShowCaseSensitiveAutocomplete=true:
+[
+  "aa",
+  "Aa",
+  "ab",
+  "Ab",
+  "__aa__",
+  "__ab__"
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"a"} and experimentalShowCaseSensitiveAutocomplete=true:
+[
+  "aa",
+  "ab"
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"A"} and experimentalShowCaseSensitiveAutocomplete=true:
+[
+  "Aa",
+  "Ab"
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"_"} and experimentalShowCaseSensitiveAutocomplete=true:
+[
+  "__aa__",
+  "__ab__"
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":""} and experimentalShowCaseSensitiveAutocomplete=true:
+[
+  "1",
+  "2",
+  "10",
+  "20",
+  "\"__aa__\"",
+  "\"__ab__\"",
+  "\"aa\"",
+  "\"Aa\"",
+  "\"ab\"",
+  "\"Ab\""
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"1"} and experimentalShowCaseSensitiveAutocomplete=true:
+[
+  "1",
+  "10"
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"a"} and experimentalShowCaseSensitiveAutocomplete=true:
+[
+  "\"aa\"",
+  "\"ab\""
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"A"} and experimentalShowCaseSensitiveAutocomplete=true:
+[
+  "\"Aa\"",
+  "\"Ab\""
+]
+
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"_"} and experimentalShowCaseSensitiveAutocomplete=true:
+[
+  "\"__aa__\"",
+  "\"__ab__\""
+]
+
+

--- a/LayoutTests/inspector/console/js-completions.html
+++ b/LayoutTests/inspector/console/js-completions.html
@@ -3,30 +3,43 @@
 <head>
 <script src="../../http/tests/inspector/resources/inspector-test.js"></script>
 <script>
+let objectWithMixedPropertyKinds = Object.assign(Object.create(null), {
+    1: 42,
+    2: 42,
+    10: 42,
+    20: 42,
+    aa: 42,
+    ab: 42,
+    Aa: 42,
+    Ab: 42,
+    __aa__: 42,
+    __ab__: 42
+});
+
 function test()
 {
+    const generateJSCompletions = (options = {}) => new Promise((resolve, reject) => {
+        let mockCompletionController = {
+            mode: null,
+            updateCompletions: (completions) => {
+                resolve(completions);
+            },
+        };
+
+        let defaultCompletions = options.defaultCompletions || [];
+        let baseString = options.baseString || "";
+        let prefix = options.prefix || "";
+        let suffix = options.suffix || "";
+        const forced = true;
+        WI.javaScriptRuntimeCompletionProvider.completionControllerCompletionsNeeded(mockCompletionController, defaultCompletions, baseString, prefix, suffix, forced);
+    });
+
     let suite = InspectorTest.createAsyncSuite("console.jsCompletions");
 
     suite.addTestCase({
         name: "console.jsCompletions.variableCompletions",
         description: "Test that the JavaScript completions for variables and its cache work as expected.",
         async test() {
-            const generateJSCompletions = () => new Promise((resolve, reject) => {
-                let mockCompletionController = {
-                    mode: null,
-                    updateCompletions: (completions) => {
-                        resolve(completions);
-                    },
-                };
-
-                const defaultCompletions = [];
-                const baseString = "";
-                const prefix = "";
-                const suffix = "";
-                const forced = true;
-                WI.javaScriptRuntimeCompletionProvider.completionControllerCompletionsNeeded(mockCompletionController, defaultCompletions, baseString, prefix, suffix, forced);
-            });
-
             let completionsBeforeEvaluating = await generateJSCompletions();
             InspectorTest.expectFalse(completionsBeforeEvaluating.includes("myVariable"), "Completions should not contain myVariable by default.");
 
@@ -49,6 +62,44 @@ function test()
             let completionsAfterDeletingAndClearing = await generateJSCompletions();
             InspectorTest.expectNotShallowEqual(completionsAfterDeletingAndClearing, completionsAfterDeletingBeforeClearing, "Completions should change after cache is cleared.");
             InspectorTest.expectFalse(completionsAfterDeletingAndClearing.includes("myVariable"), "Completions should not contain myVariable after it's deleted by code run in console.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "console.jsCompletions.completionOrdering",
+        description: "Test that the JavaScript completions are ordered correctly.",
+        async test() {
+            const outputCompletions = async (options) => {
+                InspectorTest.log(`Completions with options=${JSON.stringify(options)} and experimentalShowCaseSensitiveAutocomplete=${WI.settings.experimentalShowCaseSensitiveAutocomplete.value}:`);
+                InspectorTest.json(await generateJSCompletions(options));
+                InspectorTest.log("");
+            };
+
+            WI.settings.experimentalShowCaseSensitiveAutocomplete.value = false;
+            WI.javaScriptRuntimeCompletionProvider.clearCachedPropertyNames();
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: ""}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: "a"}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: "A"}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: "_"}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: ""}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "1"}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "\"a"}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "\"A"}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "\"_"}));
+
+            WI.settings.experimentalShowCaseSensitiveAutocomplete.value = true;
+            WI.javaScriptRuntimeCompletionProvider.clearCachedPropertyNames();
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: ""}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: "a"}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: "A"}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: "_"}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: ""}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "1"}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "\"a"}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "\"A"}));
+            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "\"_"}));
+
+            WI.settings.experimentalShowCaseSensitiveAutocomplete.reset();
         }
     });
 

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1853,6 +1853,7 @@ localizedStrings["Update Font"] = "Update Font";
 localizedStrings["Update Image"] = "Update Image";
 localizedStrings["Update Local Override"] = "Update Local Override";
 localizedStrings["Usage: %s"] = "Usage: %s";
+localizedStrings["Use case sensitive autocomplete"] = "Use case sensitive autocomplete";
 localizedStrings["Use default media styles"] = "Use default media styles";
 localizedStrings["Use fuzzy matching for CSS code completion"] = "Use fuzzy matching for CSS code completion";
 localizedStrings["Use mock capture devices"] = "Use mock capture devices";

--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -240,6 +240,7 @@ WI.settings = {
     experimentalCSSSortPropertyNameAutocompletionByUsage: new WI.Setting("experimental-css-sort-property-name-autocompletion-by-usage", true),
     experimentalEnableNetworkEmulatedCondition: new WI.Setting("experimental-enable-network-emulated-condition", false),
     experimentalGroupSourceMapErrors: new WI.Setting("experimental-group-source-map-errors", true),
+    experimentalShowCaseSensitiveAutocomplete: new WI.Setting("experimental-show-case-sensitive-auto-complete", false),
     experimentalLimitSourceCodeHighlighting: new WI.Setting("engineering-limit-source-code-highlighting", false),
     experimentalUseFuzzyMatchingForCSSCodeCompletion: new WI.Setting("experimental-use-fuzzy-matching-for-css-code-completion", true),
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorCompletionController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorCompletionController.js
@@ -648,6 +648,8 @@ WI.CodeMirrorCompletionController = class CodeMirrorCompletionController extends
         var matchingWords = [];
 
         var prefix = this._prefix;
+        let prefixLowerCase = prefix.toLowerCase();
+        let caseSensitiveMatching = WI.settings.experimentalShowCaseSensitiveAutocomplete.value;
 
         var localState = mainToken.state.localState ? mainToken.state.localState : mainToken.state;
 
@@ -688,8 +690,11 @@ WI.CodeMirrorCompletionController = class CodeMirrorCompletionController extends
                     continue;
                 if (declaringVariable && !allowedKeywordsWhenDeclaringVariable.has(keyword))
                     continue;
-                if (!keyword.startsWith(prefix))
+
+                let startsWithPrefix = caseSensitiveMatching ? keyword.startsWith(prefix) : keyword.toLowerCase().startsWith(prefixLowerCase);
+                if (!startsWithPrefix)
                     continue;
+
                 matchingWords.push(keyword);
             }
         }
@@ -703,9 +708,14 @@ WI.CodeMirrorCompletionController = class CodeMirrorCompletionController extends
                     // Otherwise the currently typed text will always match and that isn't useful.
                     if (declaringVariable && variable.name === prefix)
                         continue;
+                    if (matchingWords.includes(variable.name))
+                        continue;
 
-                    if (variable.name.startsWith(prefix) && !matchingWords.includes(variable.name))
-                        matchingWords.push(variable.name);
+                    let startsWithPrefix = caseSensitiveMatching ? variable.name.startsWith(prefix) : variable.name.toLowerCase().startsWith(prefixLowerCase);
+                    if (!startsWithPrefix)
+                        continue;
+
+                    matchingWords.push(variable.name);
                 }
             }
 

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -409,6 +409,7 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         
         let consoleGroup = experimentalSettingsView.addGroup(WI.UIString("Console:"));
         consoleGroup.addSetting(WI.settings.experimentalGroupSourceMapErrors, WI.UIString("Group source map network errors"));
+        consoleGroup.addSetting(WI.settings.experimentalShowCaseSensitiveAutocomplete, WI.UIString("Use case sensitive autocomplete"));
         
         experimentalSettingsView.addSeparator();
 


### PR DESCRIPTION
#### 14ea1c16323321db0dd237aad3aa22a9e48f9a54
<pre>
Web Inspector: console&apos;s code completion should be case-insensitive
<a href="https://rdar.apple.com/124544458">rdar://124544458</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=270925">https://bugs.webkit.org/show_bug.cgi?id=270925</a>

Reviewed by Devin Rousso.

Convert both strings into lowercase when trying to match prefixes for
function, variable, or property names.

Also add an experimental setting item for this feature enhancement.

* Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorCompletionController.js:
(WI.CodeMirrorCompletionController.prototype._applyCompletionHint.update):
(WI.CodeMirrorCompletionController.prototype._applyCompletionHint):
   - Since case-insensitive matching may be used, only show the
     watermark text on the prompt if the typed text exactly,
     case-sensitively matches the prefix.

* Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorCompletionController.js:
(WI.CodeMirrorCompletionController.prototype._generateJavaScriptCompletions.):
(WI.CodeMirrorCompletionController.prototype._generateJavaScriptCompletions):
* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js:
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded.receivedPropertyNames):
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded):
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded.receivedPropertyNames.compare): Deleted.
   - Optionally perform case-insensitive prefix matching when filtering
     the code completion suggestions.

* Source/WebInspectorUI/UserInterface/Base/Setting.js:
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
   - Add the experimental setting item for this change in the Settings
     tab&apos;s Experimental sub-tab.

* LayoutTests/inspector/console/js-completions-expected.txt:
* LayoutTests/inspector/console/js-completions.html:
   - Add a test case for the code completions&apos; ordering since now it
     gets slightly more involved with case-insensitive matching.

Canonical link: <a href="https://commits.webkit.org/279195@main">https://commits.webkit.org/279195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bc910057bc9a885adc431fdf347f4b7401e9230

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/52614 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/31949 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/5044 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/55889 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/3337 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/38531 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/3038 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/55889 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/3337 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/54712 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/38531 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/5044 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/55889 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/38531 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/5044 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/1496 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/38531 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/5044 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/57484 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/27750 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/3038 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/57484 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/28975 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/5044 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/57484 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11527 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/29889 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/28725 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->