### PR TITLE
[webkitpy] Refactor Port.expectations_files definitions

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py
@@ -193,5 +193,5 @@ class SummarizedResultsTest(unittest.TestCase):
             )
             self.assertEqual(
                 summary['baseline_search_path'],
-                ['platform/test-mac-leopard', 'platform/test-mac-snowleopard'],
+                ['platform/test-mac-leopard', 'platform/test-mac-snowleopard', 'platform/test'],
             )

--- a/Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py
@@ -118,8 +118,8 @@ class  Testprinter(unittest.TestCase):
         printer, err = self.get_printer()
         printer.print_baseline_search_path()
 
-        self.assertIn('Verbose baseline search path: platform/test-mac-leopard -> platform/test-mac-snowleopard -> generic', err.getvalue())
-        self.assertIn('Baseline search path: platform/test-mac-leopard -> generic', err.getvalue())
+        self.assertIn('Verbose baseline search path: platform/test-mac-leopard -> platform/test-mac-snowleopard -> platform/test -> generic', err.getvalue())
+        self.assertIn('Baseline search path: platform/test-mac-leopard -> platform/test -> generic', err.getvalue())
 
         self.reset(err)
         printer._options.quiet = True

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -1095,23 +1095,11 @@ class Port(object):
                 _log.warning("additional_expectations path '%s' does not exist" % path)
         return expectations
 
-    def _port_specific_expectations_files(self, **kwargs):
-        # Unlike baseline_search_path, we only want to search [WK2-PORT, PORT-VERSION, PORT] and any directories
-        # included via --additional-platform-directory, not the full casade.
-        search_paths = [self.port_name]
-
-        non_wk2_name = self.name().replace('-wk2', '')
-        if non_wk2_name != self.port_name:
-            search_paths.append(non_wk2_name)
-
-        if self.get_option('webkit_test_runner'):
-            # Because nearly all of the skipped tests for WebKit 2 are due to cross-platform
-            # issues, all wk2 ports share a skipped list under platform/wk2.
-            search_paths.extend(["wk2", self._wk2_port_name()])
-
-        search_paths.extend(self.get_option("additional_platform_directory", []))
-
-        return [self._filesystem.join(self._webkit_baseline_path(d), 'TestExpectations') for d in search_paths]
+    def _port_specific_expectations_files(self, device_type=None):
+        return [
+            self._filesystem.join(self._webkit_baseline_path(p), "TestExpectations")
+            for p in reversed(self.baseline_search_path(device_type=device_type))
+        ]
 
     def expectations_files(self, device_type=None):
         return [self.path_to_generic_test_expectations_file()] + self._port_specific_expectations_files(device_type=device_type)

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -58,9 +58,6 @@ class DarwinPort(ApplePort):
             return 350 * 1000
         return super(DarwinPort, self).default_timeout_ms()
 
-    def _port_specific_expectations_files(self, device_type=None):
-        return list(reversed([self._filesystem.join(self._webkit_baseline_path(p), 'TestExpectations') for p in self.baseline_search_path(device_type=device_type)]))
-
     def check_for_leaks(self, process_name, process_id):
         if not self.get_option('leaks'):
             return

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -131,9 +131,6 @@ class GtkPort(GLibPort):
     def default_baseline_search_path(self, **kwargs):
         return list(map(self._webkit_baseline_path, self._search_paths()))
 
-    def _port_specific_expectations_files(self, **kwargs):
-        return [self._filesystem.join(self._webkit_baseline_path(p), 'TestExpectations') for p in reversed(self._search_paths())]
-
     def print_leaks_summary(self):
         if not self.get_option('leaks'):
             return

--- a/Tools/Scripts/webkitpy/port/port_testcase.py
+++ b/Tools/Scripts/webkitpy/port/port_testcase.py
@@ -544,7 +544,7 @@ class PortTestCase(unittest.TestCase):
         self.assertEqual(platform_dirs(port), ['LayoutTests', 'testwebkitport', 'testwebkitport-version'])
 
         port = TestWebKitPort(port_name="testwebkitport-version-wk2")
-        self.assertEqual(platform_dirs(port), ['LayoutTests', 'testwebkitport', 'testwebkitport-version', 'wk2', 'testwebkitport-wk2'])
+        self.assertEqual(platform_dirs(port), ['LayoutTests', 'testwebkitport', 'testwebkitport-version-wk2', 'testwebkitport-wk2'])
 
         port = TestWebKitPort(port_name="testwebkitport-version",
                               options=MockOptions(additional_platform_directory=["internal-testwebkitport"]))

--- a/Tools/Scripts/webkitpy/port/test.py
+++ b/Tools/Scripts/webkitpy/port/test.py
@@ -425,7 +425,7 @@ class TestPort(Port):
         # the mock_drt Driver. We return something, but make sure it's useless.
         return 'MOCK _path_to_driver'
 
-    def baseline_search_path(self, device_type=None):
+    def default_baseline_search_path(self, device_type=None):
         search_paths = {
             'test-mac-snowleopard': ['test-mac-snowleopard'],
             'test-mac-leopard': ['test-mac-leopard', 'test-mac-snowleopard'],
@@ -434,7 +434,10 @@ class TestPort(Port):
             'test-win-xp': ['test-win-xp', 'test-win-vista', 'test-win-7sp0'],
             'test-linux-x86_64': ['test-linux'],
         }
-        return [self._webkit_baseline_path(d) for d in search_paths[self.name()]]
+        applicable_search_paths = search_paths[self.name()]
+        if self.port_name not in applicable_search_paths:
+            applicable_search_paths = applicable_search_paths + [self.port_name]
+        return [self._webkit_baseline_path(d) for d in applicable_search_paths]
 
     def default_child_processes(self, **kwargs):
         return 1

--- a/Tools/Scripts/webkitpy/port/win_unittest.py
+++ b/Tools/Scripts/webkitpy/port/win_unittest.py
@@ -85,8 +85,8 @@ class WinPortTest(port_testcase.PortTestCase):
         self.assertEqual('win', self.make_port().operating_system())
 
     def test_expectations_files(self):
-        self.assertEqual(len(self.make_port().expectations_files()), 3)
-        self.assertEqual(len(self.make_port(options=MockOptions(webkit_test_runner=True, configuration='Release')).expectations_files()), 5)
+        self.assertEqual(len(self.make_port().expectations_files()), 9)
+        self.assertEqual(len(self.make_port(options=MockOptions(webkit_test_runner=True, configuration='Release')).expectations_files()), 11)
 
     def test_get_crash_log(self):
         # Win crash logs are tested elsewhere, so here we just make sure we don't crash.

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -96,9 +96,6 @@ class WPEPort(GLibPort):
     def default_baseline_search_path(self, **kwargs):
         return list(map(self._webkit_baseline_path, self._search_paths()))
 
-    def _port_specific_expectations_files(self, **kwargs):
-        return list(map(lambda x: self._filesystem.join(self._webkit_baseline_path(x), 'TestExpectations'), reversed(self._search_paths())))
-
     def configuration_for_upload(self, host=None):
         configuration = super(WPEPort, self).configuration_for_upload(host=host)
         configuration['platform'] = 'WPE'


### PR DESCRIPTION
#### a6d6bf975f50
<pre>
[webkitpy] Refactor Port.expectations_files definitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=271262">https://bugs.webkit.org/show_bug.cgi?id=271262</a>

Reviewed by NOBODY (OOPS!).

Currently we override Port._port_specific_expectations_files and
define it based on the baseline search path in every port except
JscOnlyPort, TestPort, and TestWebKitPort.

We shouldn&apos;t have different behavior in TestPort and TestWebKitPort to
the rest of the world, so we should just define
Port._port_specific_expectations_files in terms of
Port.baseline_search_path.

In the case of JscOnlyPort, I believe this doesn&apos;t change behavior
given its current definitions of the two methods.

As part of this, we need to change the behavior of TestPort to add
`platform/test` to its baseline search path, as it currently relies on
reading the TestExpectations file there.

* Tools/Scripts/webkitpy/layout_tests/models/test_run_results_unittest.py:
(SummarizedResultsTest.test_summarized_run_metadata):
* Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py:
(Testprinter.test_print_baseline_search_path):
* Tools/Scripts/webkitpy/port/base.py:
(Port._port_specific_expectations_files):
* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort._port_specific_expectations_files): Deleted.
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort._port_specific_expectations_files): Deleted.
* Tools/Scripts/webkitpy/port/port_testcase.py:
(PortTestCase.test_expectations_files):
* Tools/Scripts/webkitpy/port/test.py:
* Tools/Scripts/webkitpy/port/win_unittest.py:
(WinPortTest.test_expectations_files):
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort._port_specific_expectations_files): Deleted.
</pre>