### PR TITLE
Unreviewed, build fix with newer SDK

### DIFF
--- a/Source/WebKit/WebKitSwift/GroupActivities/GroupSession.swift
+++ b/Source/WebKit/WebKitSwift/GroupActivities/GroupSession.swift
@@ -28,7 +28,7 @@ import Combine
 @_spi(Safari) import GroupActivities
 import Foundation
 
-@available(macOS 12.0, iOS 15.0, *)
+@available(macOS 15.0, iOS 18.0, *)
 @objc(WKGroupSessionState)
 public enum GroupSessionState : Int {
     case waiting = 0
@@ -36,7 +36,7 @@ public enum GroupSessionState : Int {
     case invalidated = 2
 }
 
-@available(macOS 12.0, iOS 15.0, *)
+@available(macOS 15.0, iOS 18.0, *)
 @objc(WKURLActivity)
 public final class URLActivityWrapper : NSObject {
     private var urlActivity: URLActivity
@@ -50,7 +50,7 @@ public final class URLActivityWrapper : NSObject {
     }
 }
 
-@available(macOS 12.0, iOS 15.0, *)
+@available(macOS 15.0, iOS 18.0, *)
 @objc(WKGroupSession)
 public final class GroupSessionWrapper : NSObject {
     private var groupSession: GroupSession<URLActivity>
@@ -128,7 +128,7 @@ public final class GroupSessionWrapper : NSObject {
     }
 }
 
-@available(macOS 12.0, iOS 15.0, *)
+@available(macOS 15.0, iOS 18.0, *)
 @objc(WKGroupSessionObserver)
 public class GroupSessionObserver : NSObject {
     @objc public var newSessionCallback: ((GroupSessionWrapper) -> Void)?


### PR DESCRIPTION
#### 56adf027a1d840309275e10a51ac990808f8775c
<pre>
Unreviewed, build fix with newer SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=271267">https://bugs.webkit.org/show_bug.cgi?id=271267</a>
<a href="https://rdar.apple.com/125035625">rdar://125035625</a>

* Source/WebKit/WebKitSwift/GroupActivities/GroupSession.swift:

Canonical link: <a href="https://commits.webkit.org/276365@main">https://commits.webkit.org/276365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81cccae5779e7fc6c7f553121b58d9487cc1e9b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23556 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/46926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/47131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40492 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20945 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/47131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45055 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/20596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/46926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/47131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/46926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2528 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/46926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/48750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/19447 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/48750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/46926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/48750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6115 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/20438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->