### PR TITLE
REGRESSION (276307@main?): [ macOS ] TestWebKitAPI.WebKit.PDFLinkReferrer is flaky timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFLinkReferrer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFLinkReferrer.mm
@@ -105,6 +105,10 @@ TEST(WebKit, PDFLinkReferrer)
         EXPECT_NULL([action.request valueForHTTPHeaderField:@"Referer"]);
         decisionHandler(WKNavigationActionPolicyAllow);
     };
+
+    // We need to make sure the WKWebView's layout is up to date
+    // or the clicks might get eaten by the PDF's HUD.
+    [webView layoutSubtreeIfNeeded];
     
     [webView sendClicksAtPoint:NSMakePoint(75, 75) numberOfClicks:1];
     [navigationDelegate waitForDidFinishNavigation];


### PR DESCRIPTION
#### 0ebe5abb16ffdb2434f1b573b9c8e261b9c806c5
<pre>
REGRESSION (276307@main?): [ macOS ] TestWebKitAPI.WebKit.PDFLinkReferrer is flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=271259">https://bugs.webkit.org/show_bug.cgi?id=271259</a>
<a href="https://rdar.apple.com/125027483">rdar://125027483</a>

Reviewed by Abrar Rahman Protyasha.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/PDFLinkReferrer.mm:
(TEST):
Make sure layout is up to date before tapping on the PDF, or the HUD might
be in the wrong place and eat the touch.

Canonical link: <a href="https://commits.webkit.org/276369@main">https://commits.webkit.org/276369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d336f54592b9294c74ec6e6f14794baaf461daf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47137 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20951 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20605 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17644 "Found 2 new API test failures: /WPE/TestWebKitWebView:/webkit/WebKitWebView/save, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/languages (failure)") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18053 "Build is in progress. Recent messages:") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2534 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37692 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48756 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/19450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/15984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42246 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9894 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->