### PR TITLE
check-webkit-style should warn when using soft-linking

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3934,14 +3934,25 @@ def check_language(filename, clean_lines, line_number, file_extension, include_s
     matched = re.compile(r'^\s*SOFT_LINK_(PRIVATE_)?FRAMEWORK.*\((\S+)\)').search(line)
     if matched:
         framework_name = matched.group(2)
-        if file_extension == 'h' and not search(r'^\s*SOFT_LINK_(PRIVATE_)?FRAMEWORK_FOR_HEADER.*\(', line):
-            error(line_number, 'softlink/header', 5,
-                  'Never soft-link frameworks in headers. Put the soft-link macros in a source file, or create {framework}SoftLink.{{cpp,mm}} instead.'.format(framework=framework_name))
+        if file_extension == 'h':
+            if not search(r'^\s*SOFT_LINK_(PRIVATE_)?FRAMEWORK_FOR_HEADER.*\(', line):
+                error(line_number, 'softlink/header', 5,
+                      'Never soft-link frameworks in headers. Put the soft-link macros in a source file, or create {framework}SoftLink.{{cpp,mm}} instead.'.format(framework=framework_name))
+        else:
+            frameworks_with_soft_links = ['CoreMedia', 'CoreVideo', 'DataDetectorsCore', 'LocalAuthentication', 'MediaAccessibility', 'MediaRemote', 'PassKit', 'QuickLook', 'UIKit', 'VideoToolbox']
+            if framework_name in frameworks_with_soft_links and not re.compile(r'^\s*SOFT_LINK_(PRIVATE_)?FRAMEWORK_FOR_(HEADER|SOURCE)(_WITH_EXPORT)?\({}\)'.format(framework_name)).search(line):
+                error(line_number, 'softlink/framework', 5,
+                      'Use {framework}SoftLink.{{cpp,h,mm}} to soft-link to {framework}.framework.'.format(framework=framework_name))
+            else:
+                error(line_number, 'softlink/dynamic_linking', 4,
+                      'Please don\'t soft-link {framework}.framework; contact @ddkilzer or @thorton on Slack.'.format(framework=framework_name))
 
-        frameworks_with_soft_links = ['CoreMedia', 'CoreVideo', 'DataDetectorsCore', 'LocalAuthentication', 'MediaAccessibility', 'MediaRemote', 'PassKit', 'QuickLook', 'UIKit', 'VideoToolbox']
-        if framework_name in frameworks_with_soft_links and not re.compile(r'^\s*SOFT_LINK_(PRIVATE_)?FRAMEWORK_FOR_(HEADER|SOURCE)(_WITH_EXPORT)?\({}\)'.format(framework_name)).search(line):
-            error(line_number, 'softlink/framework', 5,
-                  'Use {framework}SoftLink.{{cpp,h,mm}} to soft-link to {framework}.framework.'.format(framework=framework_name))
+    matched = re.compile(r'^\s*SOFT_LINK_(SYSTEM_)?LIBRARY.*\((\S+)\)').search(line)
+    if matched:
+        library_name = matched.group(2)
+        error(line_number, 'softlink/dynamic_linking', 4,
+              'Please don\'t soft-link {library} library; contact @ddkilzer or @thorton on Slack.'.format(
+                  library=library_name))
 
     # Check for suspicious usage of "if" like
     # } if (a == b) {
@@ -4749,6 +4760,7 @@ class CppChecker(object):
         'security/missing_warn_unused_return',
         'security/printf',
         'security/temp_file',
+        'softlink/dynamic_linking',
         'softlink/framework',
         'softlink/header',
         'whitespace/blank_line',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -1947,33 +1947,53 @@ class CppStyleTest(CppStyleTestBase):
     def test_softlink_framework(self):
         self.assert_lint(
             '''SOFT_LINK_FRAMEWORK(Foundation)''',
-            '')
+            'Please don\'t soft-link Foundation.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
         self.assert_lint(
             '''SOFT_LINK_FRAMEWORK_OPTIONAL(Foundation)''',
-            '')
-        self.assert_lint(
-            '''SOFT_LINK_FRAMEWORK_OPTIONAL_PREFLIGHT(Foundation)''',
-            '')
-        self.assert_lint(
-            '''SOFT_LINK_FRAMEWORK_FOR_HEADER(Foundation)''',
-            '',
-             file_name='foo.h')
+            'Please don\'t soft-link Foundation.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
         self.assert_lint(
             '''SOFT_LINK_FRAMEWORK_FOR_SOURCE(Foundation)''',
-            '')
+            'Please don\'t soft-link Foundation.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
         self.assert_lint(
             '''SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(Foundation)''',
-            '')
+            'Please don\'t soft-link Foundation.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
         self.assert_lint(
-            '''SOFT_LINK_PRIVATE_FRAMEWORK_FOR_HEADER(Foundation)''',
-            '',
-             file_name='foo.h')
+            '''SOFT_LINK_FRAMEWORK_IN_UMBRELLA(MyFramework)''',
+            'Please don\'t soft-link MyFramework.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
+        self.assert_lint(
+            '''SOFT_LINK_FRAMEWORK_IN_UMBRELLA_OPTIONAL(MyFramework)''',
+            'Please don\'t soft-link MyFramework.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
+        self.assert_lint(
+            '''SOFT_LINK_FRAMEWORK_IN_UMBRELLA_FOR_SOURCE_WITH_EXPORT(MyFramework)''',
+            'Please don\'t soft-link MyFramework.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
+
+        self.assert_lint(
+            '''SOFT_LINK_PRIVATE_FRAMEWORK(Foundation)''',
+            'Please don\'t soft-link Foundation.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
+        self.assert_lint(
+            '''SOFT_LINK_PRIVATE_FRAMEWORK_OPTIONAL(Foundation)''',
+            'Please don\'t soft-link Foundation.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
         self.assert_lint(
             '''SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE(Foundation)''',
-            '')
+            'Please don\'t soft-link Foundation.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
         self.assert_lint(
             '''SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(Foundation)''',
-            '')
+            'Please don\'t soft-link Foundation.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
+        self.assert_lint(
+            '''SOFT_LINK_PRIVATE_FRAMEWORK_IN_UMBRELLA_OPTIONAL(MyFramework)''',
+            'Please don\'t soft-link MyFramework.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
 
         self.assert_lint(
             '''SOFT_LINK_FRAMEWORK(UIKit)''',
@@ -1993,10 +2013,12 @@ class CppStyleTest(CppStyleTestBase):
              file_name='foo.h')
         self.assert_lint(
             '''SOFT_LINK_FRAMEWORK_FOR_SOURCE(UIKit)''',
-            '')
+            'Please don\'t soft-link UIKit.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
         self.assert_lint(
             '''SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(UIKit)''',
-            '')
+            'Please don\'t soft-link UIKit.framework; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
 
     def test_softlink_header(self):
         self.assert_lint(
@@ -2025,6 +2047,10 @@ class CppStyleTest(CppStyleTestBase):
             '',
             file_name='foo.h')
         self.assert_lint(
+            '''SOFT_LINK_PRIVATE_FRAMEWORK_FOR_HEADER(MyFramework)''',
+            '',
+            file_name='foo.h')
+        self.assert_lint(
             '''SOFT_LINK_FRAMEWORK_FOR_SOURCE(MyFramework)''',
             'Never soft-link frameworks in headers. Put the soft-link macros in a source file, or create MyFrameworkSoftLink.{cpp,mm} instead.'
             '  [softlink/header] [5]',
@@ -2034,6 +2060,24 @@ class CppStyleTest(CppStyleTestBase):
             'Never soft-link frameworks in headers. Put the soft-link macros in a source file, or create MyFrameworkSoftLink.{cpp,mm} instead.'
             '  [softlink/header] [5]',
             file_name='foo.h')
+
+    def test_softlink_library(self):
+        self.assert_lint(
+            '''SOFT_LINK_LIBRARY(libLibrary)''',
+            'Please don\'t soft-link libLibrary library; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
+        self.assert_lint(
+            '''SOFT_LINK_SYSTEM_LIBRARY(libSystem)''',
+            'Please don\'t soft-link libSystem library; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
+        self.assert_lint(
+            '''SOFT_LINK_LIBRARY_OPTIONAL(libOptional)''',
+            'Please don\'t soft-link libOptional library; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
+        self.assert_lint(
+            '''SOFT_LINK_LIBRARY_FOR_SOURCE(libSource)''',
+            'Please don\'t soft-link libSource library; contact @ddkilzer or @thorton on Slack.'
+            '  [softlink/dynamic_linking] [4]')
 
     # Variable-length arrays are not permitted.
     def test_variable_length_array_detection(self):


### PR DESCRIPTION
#### 7a5a78dc4337dfc0962f37e32b26f6f02433e046
<pre>
check-webkit-style should warn when using soft-linking
<a href="https://bugs.webkit.org/show_bug.cgi?id=271270">https://bugs.webkit.org/show_bug.cgi?id=271270</a>
&lt;<a href="https://rdar.apple.com/125038029">rdar://125038029</a>&gt;

Reviewed by NOBODY (OOPS!).

The goal of this warning is to have a discussion on Slack about the
specific use case each time a new framework or library is soft-linked,
in case there is an alternative.  Adding more soft-linked frameworks or
libraries will become more work in the future, and may result in build
failures if not done correctly.

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_language):
- Separate check for SOFT_LINK macros in header files from source files.
- Always emit a warning when using SOFT_LINK macros for frameworks or
  libraries now.
(CppChecker):
- Add new &apos;softlink/dynamic_linking&apos; category.
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(CppStyleTest.test_softlink_framework):
- Remove test for SOFT_LINK_FRAMEWORK_OPTIONAL_PREFLIGHT() macro which
  doesn&apos;t exist anymore.
- Update test results for new warning.
- Add tests for SOFT_LINK framework macros that were missing.
(CppStyleTest.test_softlink_library): Add.
- Add tests for SOFT_LINK library macros.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a5a78dc4337dfc0962f37e32b26f6f02433e046

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41445 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37255 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18369 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/45303 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19073 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40293 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3483 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41771 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49851 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44331 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21730 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43157 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22089 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21417 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->