### PR TITLE
[Skia][GTK] Implement printing support

### DIFF
--- a/Source/ThirdParty/skia/CMakeLists.txt
+++ b/Source/ThirdParty/skia/CMakeLists.txt
@@ -140,12 +140,22 @@ add_library(Skia STATIC
     src/base/SkUtils.cpp
 
     src/codec/SkCodec.cpp
+    src/codec/SkCodecImageGenerator.cpp
     src/codec/SkColorPalette.cpp
     src/codec/SkEncodedInfo.cpp
+    src/codec/SkExif.cpp
+    src/codec/SkImageGenerator_FromEncoded.cpp
+    src/codec/SkJpegCodec.cpp
+    src/codec/SkJpegDecoderMgr.cpp
+    src/codec/SkJpegSegmentScan.cpp
+    src/codec/SkJpegSourceMgr.cpp
+    src/codec/SkJpegUtility.cpp
+    src/codec/SkParseEncodedOrigin.cpp
     src/codec/SkPixmapUtils.cpp
     src/codec/SkPngCodec.cpp
     src/codec/SkSampler.cpp
     src/codec/SkSwizzler.cpp
+    src/codec/SkTiffUtility.cpp
 
     src/core/SkAAClip.cpp
     src/core/SkATrace.cpp
@@ -673,6 +683,28 @@ add_library(Skia STATIC
     src/pathops/SkPathWriter.cpp
     src/pathops/SkReduceOrder.cpp
 
+    src/pdf/SkClusterator.cpp
+    src/pdf/SkDeflate.cpp
+    src/pdf/SkKeyedImage.cpp
+    src/pdf/SkPDFBitmap.cpp
+    src/pdf/SkPDFDevice.cpp
+    src/pdf/SkPDFDocument.cpp
+    src/pdf/SkPDFFont.cpp
+    src/pdf/SkPDFFormXObject.cpp
+    src/pdf/SkPDFGradientShader.cpp
+    src/pdf/SkPDFGraphicStackState.cpp
+    src/pdf/SkPDFGraphicState.cpp
+    src/pdf/SkPDFMakeCIDGlyphWidthsArray.cpp
+    src/pdf/SkPDFMakeToUnicodeCmap.cpp
+    src/pdf/SkPDFMetadata.cpp
+    src/pdf/SkPDFResourceDict.cpp
+    src/pdf/SkPDFShader.cpp
+    src/pdf/SkPDFSubsetFont.cpp
+    src/pdf/SkPDFTag.cpp
+    src/pdf/SkPDFType1Font.cpp
+    src/pdf/SkPDFTypes.cpp
+    src/pdf/SkPDFUtils.cpp
+
     src/shaders/SkBitmapProcShader.cpp
     src/shaders/SkBlendShader.cpp
     src/shaders/SkColorFilterShader.cpp
@@ -817,9 +849,11 @@ add_library(Skia STATIC
     src/sksl/transform/SkSLReplaceConstVarsWithLiterals.cpp
     src/sksl/transform/SkSLRewriteIndexedSwizzle.cpp
 
+    src/utils/SkClipStackUtils.cpp
     src/utils/SkCharToGlyphCache.cpp
     src/utils/SkCustomTypeface.cpp
     src/utils/SkDashPath.cpp
+    src/utils/SkFloatToDecimal.cpp
     src/utils/SkMatrix22.cpp
     src/utils/SkNWayCanvas.cpp
     src/utils/SkPatchUtils.cpp

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -189,7 +189,7 @@ public:
 #endif
 
 #if USE(SKIA)
-    WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create(SkData*);
+    WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create(sk_sp<SkData>&&);
 #endif
     WEBCORE_EXPORT Vector<uint8_t> copyData() const;
     WEBCORE_EXPORT Vector<uint8_t> read(size_t offset, size_t length) const;
@@ -259,7 +259,7 @@ protected:
     WEBCORE_EXPORT explicit FragmentedSharedBuffer(GstMappedOwnedBuffer&);
 #endif
 #if USE(SKIA)
-    WEBCORE_EXPORT explicit FragmentedSharedBuffer(SkData*);
+    WEBCORE_EXPORT explicit FragmentedSharedBuffer(sk_sp<SkData>&&);
 #endif
     size_t m_size { 0 };
 

--- a/Source/WebCore/platform/skia/SharedBufferSkia.cpp
+++ b/Source/WebCore/platform/skia/SharedBufferSkia.cpp
@@ -28,16 +28,16 @@
 
 namespace WebCore {
 
-FragmentedSharedBuffer::FragmentedSharedBuffer(SkData* data)
+FragmentedSharedBuffer::FragmentedSharedBuffer(sk_sp<SkData>&& data)
 {
     ASSERT(data);
     m_size = data->size();
-    m_segments.append({ 0, DataSegment::create(sk_ref_sp(data)) });
+    m_segments.append({ 0, DataSegment::create(WTFMove(data)) });
 }
 
-Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(SkData* data)
+Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(sk_sp<SkData>&& data)
 {
-    return adoptRef(*new FragmentedSharedBuffer(data));
+    return adoptRef(*new FragmentedSharedBuffer(WTFMove(data)));
 }
 
 sk_sp<SkData> SharedBuffer::createSkData() const

--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp
@@ -261,12 +261,12 @@ static WebKitPrintOperationResponse webkitPrintOperationRunDialog(WebKitPrintOpe
 {
     GtkPrintUnixDialog* printDialog = GTK_PRINT_UNIX_DIALOG(gtk_print_unix_dialog_new(0, parent));
     gtk_print_unix_dialog_set_manual_capabilities(printDialog, static_cast<GtkPrintCapabilities>(GTK_PRINT_CAPABILITY_NUMBER_UP
-                                                                                                 | GTK_PRINT_CAPABILITY_NUMBER_UP_LAYOUT
-                                                                                                 | GTK_PRINT_CAPABILITY_PAGE_SET
-                                                                                                 | GTK_PRINT_CAPABILITY_REVERSE
-                                                                                                 | GTK_PRINT_CAPABILITY_COPIES
-                                                                                                 | GTK_PRINT_CAPABILITY_COLLATE
-                                                                                                 | GTK_PRINT_CAPABILITY_SCALE));
+        | GTK_PRINT_CAPABILITY_NUMBER_UP_LAYOUT | GTK_PRINT_CAPABILITY_PAGE_SET | GTK_PRINT_CAPABILITY_REVERSE
+        | GTK_PRINT_CAPABILITY_COPIES | GTK_PRINT_CAPABILITY_COLLATE | GTK_PRINT_CAPABILITY_SCALE
+#if USE(SKIA)
+        | GTK_PRINT_CAPABILITY_GENERATE_PDF
+#endif
+        ));
 
     WebKitPrintOperationPrivate* priv = printOperation->priv;
     // Make sure the initial settings of the GtkPrintUnixDialog is a valid

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
@@ -42,7 +42,6 @@
 #include <gtk/gtk.h>
 #include <memory>
 #include <wtf/URL.h>
-#include <wtf/Vector.h>
 #include <wtf/glib/GUniquePtr.h>
 
 #if USE(CAIRO)
@@ -50,6 +49,9 @@
 #include <cairo-pdf.h>
 #include <cairo-ps.h>
 #include <cairo-svg.h>
+#elif USE(SKIA)
+#include <WebCore/GraphicsContextSkia.h>
+#include <skia/docs/SkPDFDocument.h>
 #endif
 
 namespace WebKit {
@@ -201,8 +203,11 @@ WebPrintOperationGtk::~WebPrintOperationGtk()
 void WebPrintOperationGtk::startPrint(WebCore::PrintContext* printContext, CompletionHandler<void(RefPtr<WebCore::FragmentedSharedBuffer>&&, WebCore::ResourceError&&)>&& completionHandler)
 {
     m_printContext = printContext;
-#if USE(CAIRO)
     m_completionHandler = WTFMove(completionHandler);
+
+    const char* outputFormat = gtk_print_settings_get(m_printSettings.get(), GTK_PRINT_SETTINGS_OUTPUT_FILE_FORMAT);
+
+#if USE(CAIRO)
     m_buffer.reset();
 
     auto writeCairoStream = [](void* userData, const unsigned char* data, unsigned length) -> cairo_status_t {
@@ -214,7 +219,6 @@ void WebPrintOperationGtk::startPrint(WebCore::PrintContext* printContext, Compl
     auto* paperSize = gtk_page_setup_get_paper_size(m_pageSetup.get());
     double width = gtk_paper_size_get_width(paperSize, GTK_UNIT_POINTS);
     double height = gtk_paper_size_get_height(paperSize, GTK_UNIT_POINTS);
-    const char* outputFormat = gtk_print_settings_get(m_printSettings.get(), GTK_PRINT_SETTINGS_OUTPUT_FILE_FORMAT);
     RefPtr<cairo_surface_t> surface;
     if (!g_strcmp0(outputFormat, "pdf"))
         surface = adoptRef(cairo_pdf_surface_create_for_stream(writeCairoStream, this, width, height));
@@ -232,6 +236,9 @@ void WebPrintOperationGtk::startPrint(WebCore::PrintContext* printContext, Compl
 
     auto lpi = gtk_print_settings_get_printer_lpi(m_printSettings.get());
     cairo_surface_set_fallback_resolution(surface.get(), 2.0 * lpi, 2.0 * lpi);
+#elif USE(SKIA)
+    RELEASE_ASSERT(!g_strcmp0(outputFormat, "pdf"));
+#endif
 
     int rangesCount;
     m_pageRanges = gtk_print_settings_get_page_ranges(m_printSettings.get(), &rangesCount);
@@ -248,10 +255,10 @@ void WebPrintOperationGtk::startPrint(WebCore::PrintContext* printContext, Compl
     m_collateCopies = gtk_print_settings_get_collate(m_printSettings.get());
     m_scale = gtk_print_settings_get_scale(m_printSettings.get());
 
+#if USE(CAIRO)
     print(surface.get(), 72, 72);
 #elif USE(SKIA)
-    completionHandler(nullptr, WebCore::internalError(frameURL()));
-    UNUSED_PARAM(printContext);
+    print(72, 72);
 #endif
 }
 
@@ -306,6 +313,62 @@ void WebPrintOperationGtk::endPrint(cairo_t* cr)
     cairo_surface_finish(cairo_get_target(cr));
     printDone(m_buffer.take(), { });
 }
+#elif USE(SKIA)
+void WebPrintOperationGtk::startPage(SkPictureRecorder& recorder)
+{
+    if (!currentPageIsFirstPageOfSheet()) {
+        ASSERT(m_pageCanvas);
+        return;
+    }
+
+    ASSERT(!m_pageCanvas);
+
+    GtkPaperSize* paperSize = gtk_page_setup_get_paper_size(m_pageSetup.get());
+    double width = gtk_paper_size_get_width(paperSize, GTK_UNIT_POINTS);
+    double height = gtk_paper_size_get_height(paperSize, GTK_UNIT_POINTS);
+
+    switch (gtk_page_setup_get_orientation(m_pageSetup.get())) {
+    case GTK_PAGE_ORIENTATION_PORTRAIT:
+    case GTK_PAGE_ORIENTATION_REVERSE_PORTRAIT:
+        m_pageCanvas = recorder.beginRecording(width, height);
+        break;
+    case GTK_PAGE_ORIENTATION_LANDSCAPE:
+    case GTK_PAGE_ORIENTATION_REVERSE_LANDSCAPE:
+        m_pageCanvas = recorder.beginRecording(height, width);
+        break;
+    }
+
+    ASSERT(m_pageCanvas);
+}
+
+void WebPrintOperationGtk::endPage(SkPictureRecorder& recorder)
+{
+    ASSERT(m_pageCanvas);
+
+    if (currentPageIsLastPageOfSheet()) {
+        m_pages.append(recorder.finishRecordingAsPicture());
+        m_pageCanvas = nullptr;
+    }
+}
+
+void WebPrintOperationGtk::endPrint()
+{
+    SkDynamicMemoryWStream memoryBuffer;
+
+    auto document = SkPDF::MakeDocument(&memoryBuffer);
+    ASSERT(document);
+    for (auto page : m_pages) {
+        const auto& rect = page->cullRect();
+        auto canvas = document->beginPage(rect.width(), rect.height());
+        canvas->drawPicture(page);
+        document->endPage();
+    }
+    document->close();
+
+    printDone(WebCore::FragmentedSharedBuffer::create(memoryBuffer.detachAsData()), { });
+
+    m_pages.clear();
+}
 #endif
 
 int WebPrintOperationGtk::pageCount() const
@@ -337,11 +400,11 @@ void WebPrintOperationGtk::rotatePageIfNeeded()
     if (!m_needsRotation)
         return;
 
-#if USE(CAIRO)
     GtkPaperSize* paperSize = gtk_page_setup_get_paper_size(m_pageSetup.get());
     double width = gtk_paper_size_get_width(paperSize, GTK_UNIT_INCH) * m_xDPI;
     double height = gtk_paper_size_get_height(paperSize, GTK_UNIT_INCH) * m_yDPI;
 
+#if USE(CAIRO)
     cairo_matrix_t matrix;
     switch (gtk_page_setup_get_orientation(m_pageSetup.get())) {
     case GTK_PAGE_ORIENTATION_LANDSCAPE:
@@ -364,7 +427,24 @@ void WebPrintOperationGtk::rotatePageIfNeeded()
         break;
     }
 #elif USE(SKIA)
-    notImplemented();
+    switch (gtk_page_setup_get_orientation(m_pageSetup.get())) {
+    case GTK_PAGE_ORIENTATION_LANDSCAPE:
+        m_pageCanvas->translate(0, height);
+        m_pageCanvas->rotate(90);
+        break;
+    case GTK_PAGE_ORIENTATION_REVERSE_PORTRAIT:
+        m_pageCanvas->translate(width, height);
+        m_pageCanvas->scale(-1, -1);
+        break;
+    case GTK_PAGE_ORIENTATION_REVERSE_LANDSCAPE:
+        m_pageCanvas->translate(width, 0);
+        m_pageCanvas->rotate(90);
+        m_pageCanvas->scale(-1, 1);
+        break;
+    case GTK_PAGE_ORIENTATION_PORTRAIT:
+    default:
+        break;
+    }
 #endif
 }
 
@@ -438,15 +518,20 @@ void WebPrintOperationGtk::getPositionOfPageInSheet(size_t rows, size_t columns,
 
 void WebPrintOperationGtk::prepareContextToDraw()
 {
-#if USE(CAIRO)
     if (m_numberUp < 2) {
         double left = gtk_page_setup_get_left_margin(m_pageSetup.get(), GTK_UNIT_INCH);
         double top = gtk_page_setup_get_top_margin(m_pageSetup.get(), GTK_UNIT_INCH);
+#if USE(CAIRO)
         if (m_scale != 1.0)
             cairo_scale(m_cairoContext.get(), m_scale, m_scale);
         rotatePageIfNeeded();
         cairo_translate(m_cairoContext.get(), left * m_xDPI, top * m_yDPI);
-
+#elif USE(SKIA)
+        if (m_scale != 1.0)
+            m_pageCanvas->scale(m_scale, m_scale);
+        rotatePageIfNeeded();
+        m_pageCanvas->translate(left * m_xDPI, top * m_yDPI);
+#endif
         return;
     }
 
@@ -471,13 +556,21 @@ void WebPrintOperationGtk::prepareContextToDraw()
     case GTK_PAGE_ORIENTATION_REVERSE_PORTRAIT:
         pageWidth = paperWidth - (marginLeft + marginRight);
         pageHeight = paperHeight - (marginTop + marginBottom);
+#if USE(CAIRO)
         cairo_translate(m_cairoContext.get(), marginLeft, marginTop);
+#elif USE(SKIA)
+        m_pageCanvas->translate(marginLeft, marginTop);
+#endif
         break;
     case GTK_PAGE_ORIENTATION_LANDSCAPE:
     case GTK_PAGE_ORIENTATION_REVERSE_LANDSCAPE:
         pageWidth = paperWidth - (marginTop + marginBottom);
         pageHeight = paperHeight - (marginLeft + marginRight);
+#if USE(CAIRO)
         cairo_translate(m_cairoContext.get(), marginTop, marginLeft);
+#elif USE(SKIA)
+        m_pageCanvas->translate(marginTop, marginLeft);
+#endif
 
         size_t tmp = columns;
         columns = rows;
@@ -511,10 +604,17 @@ void WebPrintOperationGtk::prepareContextToDraw()
             offsetY = (stepY - height) / 2.0;
         }
 
+#if USE(CAIRO)
         cairo_scale(m_cairoContext.get(), scale, scale);
         cairo_translate(m_cairoContext.get(), x * stepX + offsetX, y * stepY + offsetY);
         if (m_scale != 1.0)
             cairo_scale(m_cairoContext.get(), m_scale, m_scale);
+#elif USE(SKIA)
+        m_pageCanvas->scale(scale, scale);
+        m_pageCanvas->translate(x * stepX + offsetX, y * stepY + offsetY);
+        if (m_scale != 1.0)
+            m_pageCanvas->scale(m_scale, m_scale);
+#endif
         break;
     }
     case 2:
@@ -529,19 +629,24 @@ void WebPrintOperationGtk::prepareContextToDraw()
         double offsetX = ((stepX - paperWidth) / 2.0 * columns) - marginRight;
         double offsetY = ((stepY - paperHeight) / 2.0 * rows) + marginTop;
 
+#if USE(CAIRO)
         cairo_scale(m_cairoContext.get(), scale, scale);
         cairo_translate(m_cairoContext.get(), y * paperHeight + offsetY, (columns - x) * paperWidth + offsetX);
         if (m_scale != 1.0)
             cairo_scale(m_cairoContext.get(), m_scale, m_scale);
         cairo_rotate(m_cairoContext.get(), -G_PI / 2);
+#elif USE(SKIA)
+        m_pageCanvas->scale(scale, scale);
+        m_pageCanvas->translate(y * paperHeight + offsetY, (columns - x) * paperWidth + offsetX);
+        if (m_scale != 1.0)
+            m_pageCanvas->scale(m_scale, m_scale);
+        m_pageCanvas->rotate(-90);
+#endif
         break;
     }
     default:
         break;
     }
-#elif USE(SKIA)
-    notImplemented();
-#endif
 }
 
 void WebPrintOperationGtk::renderPage(int pageNumber)
@@ -549,17 +654,28 @@ void WebPrintOperationGtk::renderPage(int pageNumber)
 #if USE(CAIRO)
     startPage(m_cairoContext.get());
     cairo_save(m_cairoContext.get());
+#elif USE(SKIA)
+    SkPictureRecorder recorder;
+    startPage(recorder);
+    m_pageCanvas->save();
+#endif
 
     prepareContextToDraw();
 
     double pageWidth = gtk_page_setup_get_page_width(m_pageSetup.get(), GTK_UNIT_INCH) * m_xDPI;
+#if USE(CAIRO)
     WebCore::GraphicsContextCairo graphicsContext(m_cairoContext.get());
+#elif USE(SKIA)
+    WebCore::GraphicsContextSkia graphicsContext(*m_pageCanvas, WebCore::RenderingMode::Unaccelerated, WebCore::RenderingPurpose::Unspecified);
+#endif
     m_printContext->spoolPage(graphicsContext, pageNumber, pageWidth / m_scale);
 
+#if USE(CAIRO)
     cairo_restore(m_cairoContext.get());
     endPage(m_cairoContext.get());
 #elif USE(SKIA)
-    notImplemented();
+    m_pageCanvas->restore();
+    endPage(recorder);
 #endif
 }
 
@@ -590,7 +706,7 @@ void WebPrintOperationGtk::printPagesDone()
     endPrint(m_cairoContext.get());
     m_cairoContext = nullptr;
 #elif USE(SKIA)
-    notImplemented();
+    endPrint();
 #endif
 }
 
@@ -607,19 +723,26 @@ void WebPrintOperationGtk::printDone(RefPtr<WebCore::FragmentedSharedBuffer>&& b
 
 #if USE(CAIRO)
 void WebPrintOperationGtk::print(cairo_surface_t* surface, double xDPI, double yDPI)
+#elif USE(SKIA)
+void WebPrintOperationGtk::print(double xDPI, double yDPI)
+#endif
 {
     ASSERT(m_printContext);
 
     auto data = makeUnique<PrintPagesData>(this);
     if (!data->isValid) {
+#if USE(CAIRO)
         cairo_surface_finish(surface);
+#endif
         printDone(nullptr, invalidPageRangeToPrint(frameURL()));
         return;
     }
 
     m_xDPI = xDPI;
     m_yDPI = yDPI;
+#if USE(CAIRO)
     m_cairoContext = adoptRef(cairo_create(surface));
+#endif
 
     // Make sure the print pages idle has more priority than IPC messages comming from
     // the IO thread, so that the EndPrinting message is always handled once the print
@@ -632,6 +755,5 @@ void WebPrintOperationGtk::print(cairo_surface_t* surface, double xDPI, double y
         g_main_loop_run(mainLoop);
     }
 }
-#endif
 
 } // namespace WebKit


### PR DESCRIPTION
#### 9046ee541dbffdf24a9e923afc0920cc4c910cbb
<pre>
[Skia][GTK] Implement printing support
<a href="https://bugs.webkit.org/show_bug.cgi?id=271153">https://bugs.webkit.org/show_bug.cgi?id=271153</a>

Reviewed by Carlos Garcia Campos.

Enable SkPDF in the build by adding the corresponding files, and their
dependencies, to the sources list in CMake.

Implement Skia code paths for WebPrintOperationGtk. Most of it is a
pretty direct conversion of cairo_t to SkCanvas APIs. The most notable
difference is that one SkPicture is created for each page sheet using
SkPictureRecorder, whereas Cairo operates on a single context for all
pages. When ending the print, take all SkPictures and add them in the
final document.

Limit WebKitPrintOperation to PDF files when printing using Skia, as
it&apos;s the only supported method for now. Modern printers support it, and
CUPS is able to implicitly convert between PDF and PostScript if that&apos;s
needed.

At last, change the Skia constructor of FragmentedSharedBuffer to receive
sk_sp&lt;SkData&gt;&amp;&amp; instead of a bare pointer (SkData*). This allows writing
the Skia variant of WebPrintOperationGtk::endPrint() in a more concise
way:

```
WebCore::FragmentedSharedBuffer::create(memoryBuffer.detachAsData())
```

instead of

```
sk_sp&lt;SkData&gt; data = memoryBuffer.detachAsData();
WebCore::FragmentedSharedBuffer::create(data.release());
```

* Source/ThirdParty/skia/CMakeLists.txt:
* Source/WebCore/platform/SharedBuffer.h:
* Source/WebCore/platform/skia/SharedBufferSkia.cpp:
(WebCore::FragmentedSharedBuffer::FragmentedSharedBuffer):
(WebCore::FragmentedSharedBuffer::create):
* Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp:
(webkitPrintOperationRunDialog):
* Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp:
(WebKit::WebPrintOperationGtk::startPrint):
(WebKit::WebPrintOperationGtk::startPage):
(WebKit::WebPrintOperationGtk::endPage):
(WebKit::WebPrintOperationGtk::endPrint):
(WebKit::WebPrintOperationGtk::rotatePageIfNeeded):
(WebKit::WebPrintOperationGtk::prepareContextToDraw):
(WebKit::WebPrintOperationGtk::renderPage):
(WebKit::WebPrintOperationGtk::printPagesDone):
(WebKit::WebPrintOperationGtk::print):
* Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.h:

Canonical link: <a href="https://commits.webkit.org/276477@main">https://commits.webkit.org/276477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b0ac21e74640a7c2581e880c69337b561f37a15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23856 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/47266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47416 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40767 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21249 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20932 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/47266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18357 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/47266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2809 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41006 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/47266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49077 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16298 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/47266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42525 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6196 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->