### PR TITLE
Increase platform coverage of check-for-duplicated-platform-test-results

### DIFF
--- a/Tools/Scripts/check-for-duplicated-platform-test-results
+++ b/Tools/Scripts/check-for-duplicated-platform-test-results
@@ -95,7 +95,11 @@ def platform_list(platform):
     if apple_additions():
         platform_dirs.append(apple_additions().layout_tests_path())
     if platform == 'all':
-        return list(itertools.chain(*(os.listdir(path) for path in platform_dirs)))
+        existing_dirs = list(itertools.chain(*(os.listdir(path) for path in platform_dirs)))
+        for port_name in host.port_factory.all_port_names():
+            if port_name not in existing_dirs:
+                existing_dirs.append(port_name)
+        return sorted(existing_dirs)
     return [platform]
 
 def find_duplicates_in_path(baseline_search_path):
@@ -120,18 +124,21 @@ def find_duplicates_in_path(baseline_search_path):
     return duplicates
 
 
-def check_platform(options, baseline_search_paths_checked):
+def check_platform(options, baseline_search_paths_checked, webkit_test_runner):
     total = 0
 
     for platform in platform_list(options.platform):
         try:
             _log.debug('Trying to create port for platform {0}'.format(platform))
-            port = host.port_factory.get(platform, options)
+            # Ports sometimes change options, so create a new object.
+            port_options = optparse.Values(defaults={"webkit_test_runner": webkit_test_runner})
+            port = host.port_factory.get(platform, port_options)
         except:
-            _log.debug('Failed to create port object for {0}'.format(platform))
+            _log.warning('Failed to create port object for {0}'.format(platform))
             continue
 
         if not port.supports_layout_tests():
+            _log.warning('Platform {0} does not support layout tests'.format(platform))
             continue
 
         try:
@@ -140,12 +147,12 @@ def check_platform(options, baseline_search_paths_checked):
             _log.warning('Error computing baseline search paths from {0}, {1}'.format(platform, e))
             continue
 
-        _log.info('Checking search paths [{0}]'.format(', '.join(remove_layout_test_path_prefix(p) for p in baseline_search_path[:-1])))
-
         if baseline_search_path in baseline_search_paths_checked:
             continue
 
         baseline_search_paths_checked.add(baseline_search_path)
+
+        _log.info('Checking search paths [{0}]'.format(', '.join(remove_layout_test_path_prefix(p) for p in baseline_search_path[:-1])))
 
         duplicates = find_duplicates_in_path(baseline_search_path)
         if not duplicates:
@@ -160,7 +167,7 @@ def check_platform(options, baseline_search_paths_checked):
         duplicates_len = len(duplicates)
         total += duplicates_len
         _log.info('{0} found in {1} -> generic\n'.format(duplicates_len, ' -> '.join([os.path.basename(p) for p in baseline_search_path[:-1]])))
-    
+
     return total
 
 def main():
@@ -182,11 +189,8 @@ def main():
     total = 0
     baseline_search_paths_checked = set()
 
-    options.webkit_test_runner = False
-    total += check_platform(options, baseline_search_paths_checked)
-
-    options.webkit_test_runner = True
-    total += check_platform(options, baseline_search_paths_checked)
+    total += check_platform(options, baseline_search_paths_checked, webkit_test_runner=False)
+    total += check_platform(options, baseline_search_paths_checked, webkit_test_runner=True)
 
     if total:
         if options.no_delete:

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -161,13 +161,17 @@ class PortFactory(object):
         platform = platform or '*'
         all_port_names = [
             'gtk',
-            'ios-simulator-16',
-            'ios-simulator-16-wk2',
+            'ios-simulator-17',
+            'ios-simulator-17-wk2',
+            'ipad-simulator-17',
+            'ipad-simulator-17-wk2',
             'mac-monterey-wk1',
             'mac-monterey-wk2',
+            'mac-sonoma-wk1',
+            'mac-sonoma-wk2',
             'mac-ventura-wk1',
             'mac-ventura-wk2',
             'wincairo-win10',
-            'wpe'
+            'wpe',
         ]
         return fnmatch.filter(all_port_names, platform)

--- a/Tools/Scripts/webkitpy/port/ios.py
+++ b/Tools/Scripts/webkitpy/port/ios.py
@@ -50,6 +50,9 @@ class IOSPort(DevicePort):
         return VersionNameMap.map(self.host.platform).to_name(self._os_version, platform=IOSPort.port_name)
 
     def default_baseline_search_path(self, device_type=None):
+        if device_type is None:
+            device_type = self.DEVICE_TYPE
+
         wk_string = 'wk1'
         if self.get_option('webkit_test_runner'):
             wk_string = 'wk2'

--- a/Tools/Scripts/webkitpy/port/win.py
+++ b/Tools/Scripts/webkitpy/port/win.py
@@ -98,8 +98,11 @@ class WinPort(ApplePort):
         ApplePort.__init__(self, host, port_name, **kwargs)
         if len(port_name.split('-')) > 1:
             self._os_version = VersionNameMap.map(host.platform).from_name(port_name.split('-')[1])[1]
-        else:
+        elif self.host.platform.is_win():
             self._os_version = self.host.platform.os_version
+
+        if not self._os_version:
+            self._os_version = WinPort.VERSION_MAX
 
     def do_text_results_differ(self, expected_text, actual_text):
         # Sanity was restored in WebKitTestRunner, so we don't need this hack there.
@@ -500,7 +503,10 @@ class WinCairoPort(WinPort):
         wk_version = 'wk2' if self.get_option('webkit_test_runner') else 'wk1'
 
         for version in versions:
-            name = self.port_name + '-' + normalize(to_name(version))
+            version_name = to_name(version)
+            if not version_name:
+                continue
+            name = self.port_name + '-' + normalize(version_name)
             paths.append(name + '-' + wk_version)
             paths.append(name)
 


### PR DESCRIPTION
#### b8532bcbdb398f3c962fb793b5b2eafe254fee9f
<pre>
Increase platform coverage of check-for-duplicated-platform-test-results
<a href="https://bugs.webkit.org/show_bug.cgi?id=271276">https://bugs.webkit.org/show_bug.cgi?id=271276</a>

Reviewed by Jonathan Bedard.

This is really a smörgåsbord of small fixes; see below:

* Tools/Scripts/check-for-duplicated-platform-test-results:
(platform_list): Also use PortFactory.all_port_names() when &apos;all&apos; is passed.
(check_platform): Some logging changes, plus creating a new optparse.Values object for each Port.
(main): Move webkit_test_runner to be an argument.
* Tools/Scripts/webkitpy/port/factory.py:
(PortFactory.all_port_names): Update our list of known ports.
* Tools/Scripts/webkitpy/port/ios.py:
(IOSPort.default_baseline_search_path): Use the generic device_type if one isn&apos;t passed.
* Tools/Scripts/webkitpy/port/win.py:
(WinPort.__init__): Only use the platform version if we&apos;re on Windows, to match MacPort.
(WinCairoPort._search_paths): Gracefully handle not knowing the name of a version.

Canonical link: <a href="https://commits.webkit.org/277843@main">https://commits.webkit.org/277843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8704849e8f9572c6bdda98f93f8be0d9b9c9b230

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47154 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40510 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46807 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36601 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17661 "Passed tests") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39442 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2551 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39720 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48796 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/15999 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43544 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20813 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42301 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21141 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6954 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20461 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->