### PR TITLE
Add more smart pointers to MarkupAccumulator.cpp

### DIFF
--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -321,7 +321,7 @@ std::pair<String, MarkupAccumulator::IsCreatedByURLReplacement> MarkupAccumulato
     }
 
     if (!m_replacementURLStrings.isEmpty()) {
-        if (auto frame = frameForAttributeReplacement(element)) {
+        if (RefPtr frame = frameForAttributeReplacement(element)) {
             auto replacementURLString = m_replacementURLStrings.get(frame->frameID().toString());
             if (!replacementURLString.isEmpty())
                 return { replacementURLString, IsCreatedByURLReplacement::Yes };
@@ -348,7 +348,7 @@ RefPtr<Element> MarkupAccumulator::replacementElement(const Node& node)
     if (shadowRoot->mode() == ShadowRootMode::UserAgent)
         return nullptr;
 
-    auto element = HTMLTemplateElement::create(HTMLNames::templateTag, node.document());
+    auto element = HTMLTemplateElement::create(HTMLNames::templateTag, node.protectedDocument());
     if (shadowRoot->mode() == ShadowRootMode::Open)
         element->setShadowRootMode(AtomString { "open"_s });
     else if (shadowRoot->mode() == ShadowRootMode::Closed)
@@ -664,7 +664,7 @@ LocalFrame* MarkupAccumulator::frameForAttributeReplacement(const Element& eleme
 Attribute MarkupAccumulator::replaceAttributeIfNecessary(const Element& element, const Attribute& attribute)
 {
     if (element.isHTMLContentAttribute(attribute)) {
-        auto frame = frameForAttributeReplacement(element);
+        RefPtr frame = frameForAttributeReplacement(element);
         if (!frame || !frame->loader().documentLoader()->response().url().isAboutSrcDoc())
             return attribute;
 
@@ -680,7 +680,7 @@ Attribute MarkupAccumulator::replaceAttributeIfNecessary(const Element& element,
 
 bool MarkupAccumulator::appendURLAttributeForReplacementIfNecessary(StringBuilder& result, const Element& element, Namespaces* namespaces)
 {
-    auto frame = frameForAttributeReplacement(element);
+    RefPtr frame = frameForAttributeReplacement(element);
     if (!frame)
         return false;
 


### PR DESCRIPTION
#### 119a9a97ca3f1c0b1487723b9222f905a97446ce
<pre>
Add more smart pointers to MarkupAccumulator.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=271278">https://bugs.webkit.org/show_bug.cgi?id=271278</a>
<a href="https://rdar.apple.com/125044266">rdar://125044266</a>

Reviewed by Ryosuke Niwa and David Kilzer.

* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::replacementElement):
(WebCore::MarkupAccumulator::replaceAttributeIfNecessary):
(WebCore::MarkupAccumulator::appendURLAttributeForReplacementIfNecessary):

Canonical link: <a href="https://commits.webkit.org/276443@main">https://commits.webkit.org/276443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/822f2ffadf50e08ec3125092b5bd05d1edeb472f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47198 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40549 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21014 "Built successfully") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36680 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 101 flakes 185 failures 1 missing results; Uploaded test results (exception)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17704 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39491 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2594 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40796 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48823 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43580 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20846 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42320 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9955 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21174 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->