### PR TITLE
Move more ivars from WKWebViewConfiguration to API::PageConfiguration

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -255,6 +255,21 @@ public:
     bool undoManagerAPIEnabled() const { return m_data.undoManagerAPIEnabled; }
     void setUndoManagerAPIEnabled(bool enabled) { m_data.undoManagerAPIEnabled = enabled; }
 
+    bool mainContentUserGestureOverrideEnabled() const { return m_data.mainContentUserGestureOverrideEnabled; }
+    void setMainContentUserGestureOverrideEnabled(bool enabled) { m_data.mainContentUserGestureOverrideEnabled = enabled; }
+
+    bool invisibleAutoplayForbidden() const { return m_data.invisibleAutoplayForbidden; }
+    void setInvisibleAutoplayForbidden(bool forbidden) { m_data.invisibleAutoplayForbidden = forbidden; }
+
+    bool attachmentElementEnabled() const { return m_data.attachmentElementEnabled; }
+    void setAttachmentElementEnabled(bool enabled) { m_data.attachmentElementEnabled = enabled; }
+
+    bool attachmentWideLayoutEnabled() const { return m_data.attachmentWideLayoutEnabled; }
+    void setAttachmentWideLayoutEnabled(bool enabled) { m_data.attachmentWideLayoutEnabled = enabled; }
+
+    bool allowsInlinePredictions() const { return m_data.allowsInlinePredictions; }
+    void setAllowsInlinePredictions(bool allows) { m_data.allowsInlinePredictions = allows; }
+
     void setShouldRelaxThirdPartyCookieBlocking(WebCore::ShouldRelaxThirdPartyCookieBlocking value) { m_data.shouldRelaxThirdPartyCookieBlocking = value; }
     WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking() const { return m_data.shouldRelaxThirdPartyCookieBlocking; }
 
@@ -372,6 +387,11 @@ private:
         bool incompleteImageBorderEnabled { false };
         bool shouldDeferAsynchronousScriptsUntilAfterDocumentLoad { true };
         bool undoManagerAPIEnabled { false };
+        bool mainContentUserGestureOverrideEnabled { false };
+        bool invisibleAutoplayForbidden { false };
+        bool attachmentElementEnabled { false };
+        bool attachmentWideLayoutEnabled { false };
+        bool allowsInlinePredictions { false };
 
         WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
         WTF::String attributedBundleIdentifier { };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -146,14 +146,9 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     BOOL _shouldDecidePolicyBeforeLoadingQuickLookPreview;
 #endif
 
-    BOOL _invisibleAutoplayNotPermitted;
     BOOL _mediaDataLoadsAutomatically;
-    BOOL _attachmentElementEnabled;
-    BOOL _attachmentWideLayoutEnabled;
     Class _attachmentFileWrapperClass;
-    BOOL _mainContentUserGestureOverrideEnabled;
 
-    BOOL _waitsForPaintAfterViewDidMoveToWindow;
     BOOL _controlledByAutomation;
 
 #if ENABLE(APPLE_PAY)
@@ -164,7 +159,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
 #endif
     double _sampledPageTopColorMaxDifference;
     double _sampledPageTopColorMinHeight;
-    BOOL _allowsInlinePredictions;
 
     RetainPtr<NSString> _mediaContentTypesRequiringHardwareSupport;
     RetainPtr<NSArray<NSString *>> _additionalSupportedImageTypes;
@@ -200,12 +194,6 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     _mediaDataLoadsAutomatically = YES;
     _userInterfaceDirectionPolicy = WKUserInterfaceDirectionPolicyContent;
 #endif
-    _mainContentUserGestureOverrideEnabled = NO;
-    _invisibleAutoplayNotPermitted = NO;
-    _attachmentElementEnabled = NO;
-    _attachmentWideLayoutEnabled = NO;
-
-    _waitsForPaintAfterViewDidMoveToWindow = YES;
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     _allowsAirPlayForMediaPlayback = YES;
@@ -238,19 +226,17 @@ static bool defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
     _sampledPageTopColorMaxDifference = DEFAULT_VALUE_FOR_SampledPageTopColorMaxDifference;
     _sampledPageTopColorMinHeight = DEFAULT_VALUE_FOR_SampledPageTopColorMinHeight;
 
-    _allowsInlinePredictions = NO;
-
     return self;
 }
 
 - (void)setAllowsInlinePredictions:(BOOL)enabled
 {
-    _allowsInlinePredictions = enabled;
+    _pageConfiguration->setAllowsInlinePredictions(enabled);
 }
 
 - (BOOL)allowsInlinePredictions
 {
-    return _allowsInlinePredictions;
+    return _pageConfiguration->allowsInlinePredictions();
 }
 
 - (NSString *)description
@@ -365,14 +351,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     configuration->_suppressesIncrementalRendering = self->_suppressesIncrementalRendering;
     configuration->_applicationNameForUserAgent = self->_applicationNameForUserAgent;
 
-    configuration->_invisibleAutoplayNotPermitted = self->_invisibleAutoplayNotPermitted;
     configuration->_mediaDataLoadsAutomatically = self->_mediaDataLoadsAutomatically;
-    configuration->_attachmentElementEnabled = self->_attachmentElementEnabled;
-    configuration->_attachmentWideLayoutEnabled = self->_attachmentWideLayoutEnabled;
     configuration->_attachmentFileWrapperClass = self->_attachmentFileWrapperClass;
     configuration->_mediaTypesRequiringUserActionForPlayback = self->_mediaTypesRequiringUserActionForPlayback;
-    configuration->_mainContentUserGestureOverrideEnabled = self->_mainContentUserGestureOverrideEnabled;
-    configuration->_waitsForPaintAfterViewDidMoveToWindow = self->_waitsForPaintAfterViewDidMoveToWindow;
     configuration->_controlledByAutomation = self->_controlledByAutomation;
 
 #if PLATFORM(IOS_FAMILY)
@@ -409,8 +390,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     configuration->_sampledPageTopColorMaxDifference = self->_sampledPageTopColorMaxDifference;
     configuration->_sampledPageTopColorMinHeight = self->_sampledPageTopColorMinHeight;
-
-    configuration->_allowsInlinePredictions = self->_allowsInlinePredictions;
 
     return configuration;
 }
@@ -911,12 +890,12 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (BOOL)_invisibleAutoplayNotPermitted
 {
-    return _invisibleAutoplayNotPermitted;
+    return _pageConfiguration->invisibleAutoplayForbidden();
 }
 
 - (void)_setInvisibleAutoplayNotPermitted:(BOOL)notPermitted
 {
-    _invisibleAutoplayNotPermitted = notPermitted;
+    _pageConfiguration->setInvisibleAutoplayForbidden(notPermitted);
 }
 
 - (BOOL)_mediaDataLoadsAutomatically
@@ -931,22 +910,22 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (BOOL)_attachmentElementEnabled
 {
-    return _attachmentElementEnabled;
+    return _pageConfiguration->attachmentElementEnabled();
 }
 
 - (void)_setAttachmentElementEnabled:(BOOL)attachmentElementEnabled
 {
-    _attachmentElementEnabled = attachmentElementEnabled;
+    _pageConfiguration->setAttachmentElementEnabled(attachmentElementEnabled);
 }
 
 - (BOOL)_attachmentWideLayoutEnabled
 {
-    return _attachmentWideLayoutEnabled;
+    return _pageConfiguration->attachmentWideLayoutEnabled();
 }
 
 - (void)_setAttachmentWideLayoutEnabled:(BOOL)attachmentWideLayoutEnabled
 {
-    _attachmentWideLayoutEnabled = attachmentWideLayoutEnabled;
+    _pageConfiguration->setAttachmentWideLayoutEnabled(attachmentWideLayoutEnabled);
 }
 
 - (Class)_attachmentFileWrapperClass
@@ -1123,12 +1102,12 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (BOOL)_mainContentUserGestureOverrideEnabled
 {
-    return _mainContentUserGestureOverrideEnabled;
+    return _pageConfiguration->mainContentUserGestureOverrideEnabled();
 }
 
 - (void)_setMainContentUserGestureOverrideEnabled:(BOOL)mainContentUserGestureOverrideEnabled
 {
-    _mainContentUserGestureOverrideEnabled = mainContentUserGestureOverrideEnabled;
+    _pageConfiguration->setMainContentUserGestureOverrideEnabled(mainContentUserGestureOverrideEnabled);
 }
 
 - (BOOL)_initialCapitalizationEnabled
@@ -1143,12 +1122,12 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (BOOL)_waitsForPaintAfterViewDidMoveToWindow
 {
-    return _waitsForPaintAfterViewDidMoveToWindow;
+    return _pageConfiguration->waitsForPaintAfterViewDidMoveToWindow();
 }
 
 - (void)_setWaitsForPaintAfterViewDidMoveToWindow:(BOOL)shouldSynchronize
 {
-    _waitsForPaintAfterViewDidMoveToWindow = shouldSynchronize;
+    _pageConfiguration->setWaitsForPaintAfterViewDidMoveToWindow(shouldSynchronize);
 }
 
 - (BOOL)_isControlledByAutomation
@@ -1454,12 +1433,12 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 // FIXME: Remove this SPI once rdar://110277838 is resolved and all clients adopt the API.
 - (void)_setMarkedTextInputEnabled:(BOOL)enabled
 {
-    _allowsInlinePredictions = enabled;
+    _pageConfiguration->setAllowsInlinePredictions(enabled);
 }
 
 - (BOOL)_markedTextInputEnabled
 {
-    return _allowsInlinePredictions;
+    return _pageConfiguration->allowsInlinePredictions();
 }
 
 @end


### PR DESCRIPTION
#### ac7e2c914e1046e159a945949f54fe122b0ec8cd
<pre>
Move more ivars from WKWebViewConfiguration to API::PageConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=271282">https://bugs.webkit.org/show_bug.cgi?id=271282</a>
<a href="https://rdar.apple.com/125046091">rdar://125046091</a>

Reviewed by Charlie Wolfe.

* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::mainContentUserGestureOverrideEnabled const):
(API::PageConfiguration::setMainContentUserGestureOverrideEnabled):
(API::PageConfiguration::invisibleAutoplayNotPermitted const):
(API::PageConfiguration::setInvisibleAutoplayForbidden):
(API::PageConfiguration::attachmentElementEnabled const):
(API::PageConfiguration::setAttachmentElementEnabled):
(API::PageConfiguration::attachmentWideLayoutEnabled const):
(API::PageConfiguration::setAttachmentWideLayoutEnabled):
(API::PageConfiguration::allowsInlinePredictions const):
(API::PageConfiguration::setAllowsInlinePredictions):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration init]):
(-[WKWebViewConfiguration setAllowsInlinePredictions:]):
(-[WKWebViewConfiguration allowsInlinePredictions]):
(-[WKWebViewConfiguration copyWithZone:]):
(-[WKWebViewConfiguration _invisibleAutoplayNotPermitted]):
(-[WKWebViewConfiguration _setInvisibleAutoplayNotPermitted:]):
(-[WKWebViewConfiguration _attachmentElementEnabled]):
(-[WKWebViewConfiguration _setAttachmentElementEnabled:]):
(-[WKWebViewConfiguration _attachmentWideLayoutEnabled]):
(-[WKWebViewConfiguration _setAttachmentWideLayoutEnabled:]):
(-[WKWebViewConfiguration _mainContentUserGestureOverrideEnabled]):
(-[WKWebViewConfiguration _setMainContentUserGestureOverrideEnabled:]):
(-[WKWebViewConfiguration _waitsForPaintAfterViewDidMoveToWindow]):
(-[WKWebViewConfiguration _setWaitsForPaintAfterViewDidMoveToWindow:]):
(-[WKWebViewConfiguration _setMarkedTextInputEnabled:]):
(-[WKWebViewConfiguration _markedTextInputEnabled]):

Canonical link: <a href="https://commits.webkit.org/276383@main">https://commits.webkit.org/276383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f0a50e1b7c5a46f97e9db9db387449cae900c82

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47157 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40513 "Built successfully") 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27593 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20972 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17663 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2554 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48777 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16003 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20816 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42271 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21144 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6121 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->