### PR TITLE
[IFC] Do not treat out-of-flow line break as text content

### DIFF
--- a/LayoutTests/fast/text/out-of-flow-line-break-crash-expected.txt
+++ b/LayoutTests/fast/text/out-of-flow-line-break-crash-expected.txt
@@ -1,0 +1,4 @@
+PASS if no crash or assert.
+
+
+text

--- a/LayoutTests/fast/text/out-of-flow-line-break-crash.html
+++ b/LayoutTests/fast/text/out-of-flow-line-break-crash.html
@@ -1,0 +1,24 @@
+<style>
+br, span, pre, a {
+  position: absolute;
+}
+</style>
+PASS if no crash or assert.
+<div id=container>
+  <meter id=meter>
+  <textarea id=textarea>foobar</textarea>
+</div>
+<meter id=mm></meter>
+<pre contenteditable="true">
+  <embed id=embed><span></span>
+</pre>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+  embed.appendChild(meter);
+  textarea.setSelectionRange(1,0,"text");
+  container.appendChild(meter);
+  document.execCommand("selectAll", false);
+  document.execCommand("createLink", false, "#link");
+  document.execCommand("insertText", false, "text");
+</script>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -135,7 +135,7 @@ void InlineItemsBuilder::build(InlineItemPosition startPosition)
 
 static inline bool isTextOrLineBreak(const Box& layoutBox)
 {
-    return layoutBox.isInlineTextBox() || (layoutBox.isLineBreakBox() && !layoutBox.isWordBreakOpportunity());
+    return layoutBox.isInFlow() && (layoutBox.isInlineTextBox() || (layoutBox.isLineBreakBox() && !layoutBox.isWordBreakOpportunity()));
 }
 
 static bool requiresVisualReordering(const Box& layoutBox)

--- a/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp
@@ -229,7 +229,6 @@ InlineItemPosition TextOnlySimpleLineBuilder::placeNonWrappingInlineTextContent(
 
     while (!isEndOfLine) {
         auto& inlineItem = m_inlineItemList[nextItemIndex];
-        ASSERT(inlineItem.isText() || inlineItem.isLineBreak());
         if (auto* inlineTextItem = dynamicDowncast<InlineTextItem>(inlineItem)) {
             auto contentWidth = [&] {
                 if (auto logicalWidth = inlineTextItem->width())
@@ -239,6 +238,10 @@ InlineItemPosition TextOnlySimpleLineBuilder::placeNonWrappingInlineTextContent(
             candidateContent.append(contentWidth());
         } else if (inlineItem.isLineBreak())
             trailingLineBreakIndex = nextItemIndex;
+        else {
+            ASSERT_NOT_REACHED();
+            return layoutRange.end;
+        }
         ++nextItemIndex;
         isEndOfLine = nextItemIndex >= layoutRange.endIndex() || trailingLineBreakIndex.has_value();
     }


### PR DESCRIPTION
#### 2932db01f807bec257d8022434f43a6c02ad4221
<pre>
[IFC] Do not treat out-of-flow line break as text content
<a href="https://bugs.webkit.org/show_bug.cgi?id=267268">https://bugs.webkit.org/show_bug.cgi?id=267268</a>
<a href="https://rdar.apple.com/120662940">rdar://120662940</a>

Reviewed by Antti Koivisto.

Out-of-flow line break is not eligible for simplified (text-only) line building.

* LayoutTests/fast/text/out-of-flow-line-break-crash-expected.txt: Added.
* LayoutTests/fast/text/out-of-flow-line-break-crash.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::isTextOrLineBreak):
* Source/WebCore/layout/formattingContexts/inline/TextOnlySimpleLineBuilder.cpp:
(WebCore::Layout::TextOnlySimpleLineBuilder::placeNonWrappingInlineTextContent):

Originally-landed-as: 272448.28@safari-7618-branch (2658caa71663). <a href="https://rdar.apple.com/124557079">rdar://124557079</a>
Canonical link: <a href="https://commits.webkit.org/276700@main">https://commits.webkit.org/276700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bdd83f27c7cf033475b66c7976592f06f5904d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48028 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41372 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28710 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37201 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39137 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18303 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18961 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40220 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3411 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41649 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49747 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16873 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44251 "Found 38 new test failures: fast/dom/Window/window-lookup-precedence.html, fast/dom/dom-constructors.html, fast/events/event-handler-detached-document.html, http/tests/xmlhttprequest/post-content-type-document.html, http/tests/xmlhttprequest/xhr-and-parse-large-document.html, imported/w3c/web-platform-tests/custom-elements/parser/parser-uses-registry-of-owner-document.html, imported/w3c/web-platform-tests/fetch/private-network-access/nested-worker.https.window.html, imported/w3c/web-platform-tests/fetch/private-network-access/nested-worker.window.html, imported/w3c/web-platform-tests/html/dom/idlharness.worker.html, imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/nested-worker-success.https.html ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43064 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10099 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21342 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->