### PR TITLE
ASAN_SEGV | Hard null deref |LayoutIntegration::BoxTree::layoutBoxForRenderer; LayoutIntegration::LineLayout::enclosingBorderBoxRectFor; WebCore::RenderInline::linesBoundingBox.

### DIFF
--- a/LayoutTests/fast/inline/sticky-inline-box-invalidation-repaint-crash-expected.txt
+++ b/LayoutTests/fast/inline/sticky-inline-box-invalidation-repaint-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/inline/sticky-inline-box-invalidation-repaint-crash.html
+++ b/LayoutTests/fast/inline/sticky-inline-box-invalidation-repaint-crash.html
@@ -1,0 +1,15 @@
+<style>
+*, image { path('M 0') -1px; border-top-left-radius: 1vmax }
+#htmlvar00006 { display: inline; separate; position: sticky; }
+#htmlvar00003, #htmlvar00003 { content: url(#svgvar00008); }
+#htmlvar00008 { path('M -1'); 0em; position: fixed; }
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+</script>
+<q list="htmlvar00002">PASS if no crash.</q>
+<p id="htmlvar00003" focus="true"></p>
+<form id="htmlvar00006" behavior="scroll">
+    <legend id="htmlvar00008" mayscript="false"></legend>
+</form>

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt
@@ -24,6 +24,7 @@ PASS Appending and removing children to mtext
 FAIL Appending and removing children to munder assert_approx_equals: block position (child 0) expected 0 +/- 1 but got 3
 FAIL Appending and removing children to munderover assert_approx_equals: block position (child 0) expected 0 +/- 1 but got 7
 FAIL Appending and removing children to semantics assert_approx_equals: block position (child 0) expected -33431774 +/- 1 but got -33431794
+|LayoutIntegration::BoxTree::layoutBoxForRenderer; LayoutIntegration::LineLayout::enclosingBorderBoxRectFor; WebCore::RenderInline::linesBoundingBox.)
 maction:
 mfrac:
 mmultiscripts:
@@ -36,4 +37,3 @@ msup:
 munder:
 munderover:
 semantics:
-

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -505,14 +505,20 @@ LayoutUnit RenderInline::innerPaddingBoxHeight() const
 
 IntRect RenderInline::linesBoundingBox() const
 {
+    IntRect result;
+
     if (auto* layout = LayoutIntegration::LineLayout::containing(*this)) {
         if (!layout->contains(*this))
-            return { };
+            return result;
+
+        if (!layoutBox()) {
+            // Repaint may be issued on subtrees during content mutation with newly inserted renderers.
+            ASSERT(needsLayout());
+            return result;
+        }
         return enclosingIntRect(layout->enclosingBorderBoxRectFor(*this));
     }
 
-    IntRect result;
-    
     // See <rdar://problem/5289721>, for an unknown reason the linked list here is sometimes inconsistent, first is non-zero and last is zero.  We have been
     // unable to reproduce this at all (and consequently unable to figure ot why this is happening).  The assert will hopefully catch the problem in debug
     // builds and help us someday figure out why.  We also put in a redundant check of lastLineBox() to avoid the crash for now.


### PR DESCRIPTION
#### 81b0d446a83d8bab20a4244d95b8885a53d81ad5
<pre>
ASAN_SEGV | Hard null deref |LayoutIntegration::BoxTree::layoutBoxForRenderer; LayoutIntegration::LineLayout::enclosingBorderBoxRectFor; WebCore::RenderInline::linesBoundingBox.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266567.">https://bugs.webkit.org/show_bug.cgi?id=266567.</a>
<a href="https://rdar.apple.com/114586645">rdar://114586645</a>.

Reviewed by Alan Baradlay.

similar to 107979394, apply handling for repainting a freshly inserted sticky inline box.

* LayoutTests/fast/inline/sticky-inline-box-invalidation-repaint-crash-expected.txt: Added.
* LayoutTests/fast/inline/sticky-inline-box-invalidation-repaint-crash.html: Added.
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002-expected.txt: re-baseline for <a href="https://rdar.apple.com/119187070">rdar://119187070</a>.
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::linesBoundingBox const):

Originally-landed-as: 272448.75@safari-7618-branch (2534e02e1983). <a href="https://rdar.apple.com/124556813">rdar://124556813</a>
Canonical link: <a href="https://commits.webkit.org/276404@main">https://commits.webkit.org/276404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c27adf54b84685b1968b651a67b1165dfe98191

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46962 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47205 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40521 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36636 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17708 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39453 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2562 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40757 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48802 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19478 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43547 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20823 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42293 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9915 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21151 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20472 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->