### PR TITLE
[webkitbugspy/webkitscmpy/webkitpy] Replace deprecated datetime methods utcfromtimestamp() and utcnow().

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
@@ -20,6 +20,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import pytz
+
 from .tracker import Tracker
 from .user import User
 from datetime import datetime
@@ -47,7 +49,7 @@ class Issue(object):
         def __repr__(self):
             return '({} @ {}) {}'.format(
                 self.user,
-                datetime.utcfromtimestamp(self.timestamp) if self.timestamp else '-',
+                datetime.fromtimestamp(self.timestamp, pytz.UTC).replace(tzinfo=None) if self.timestamp else '-',
                 self.content,
             )
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -39,8 +39,9 @@ class Bugzilla(Base, mocks.Requests):
 
     @classmethod
     def time_string(cls, timestamp):
+        import pytz
         from datetime import datetime, timedelta
-        return datetime.utcfromtimestamp(timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%SZ')
+        return datetime.fromtimestamp(timestamp - timedelta(hours=7).seconds, pytz.UTC).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     @classmethod
     def transform_user(cls, user):

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/github.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/github.py
@@ -54,8 +54,9 @@ class GitHub(Base, mocks.Requests):
 
     @classmethod
     def time_string(cls, timestamp):
+        import pytz
         from datetime import datetime, timedelta
-        return datetime.utcfromtimestamp(timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%SZ')
+        return datetime.fromtimestamp(timestamp - timedelta(hours=7).seconds, pytz.UTC).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     def __init__(self, hostname='github.example.com/WebKit/WebKit', users=None, issues=None, environment=None, projects=None, labels=None):
         hostname, repo = hostname.split('/', 1)

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -96,7 +96,7 @@ class TestRadar(unittest.TestCase):
 
     def test_modified(self):
         with mocks.Radar(issues=mocks.ISSUES):
-            self.assertEqual(radar.Tracker().issue(1).modified, 1710859207)
+            self.assertEqual(radar.Tracker().issue(1).modified, 1710844807)
 
     def test_creator(self):
         with mocks.Radar(issues=mocks.ISSUES):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py
@@ -21,6 +21,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import pytz
 import re
 
 from datetime import datetime
@@ -265,7 +266,7 @@ class Commit(object):
         if self.author:
             result += '    by {}'.format(self.author)
             if self.timestamp:
-                result += ' @ {}'.format(datetime.utcfromtimestamp(self.timestamp))
+                result += ' @ {}'.format(datetime.fromtimestamp(self.timestamp, pytz.UTC).replace(tzinfo=None))
             result += '\n'
 
         if self.message and message:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -23,6 +23,7 @@
 import hashlib
 import json
 import os
+import pytz
 import re
 import time
 
@@ -374,7 +375,7 @@ nothing to commit, working tree clean
                             hash=commit.hash,
                             author=commit.author.name,
                             email=commit.author.email,
-                            date=commit.timestamp if '--date=unix' in args else datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000'),
+                            date=commit.timestamp if '--date=unix' in args else datetime.fromtimestamp(commit.timestamp + time.timezone, pytz.UTC).strftime('%a %b %d %H:%M:%S %Y +0000'),
                             log='\n'.join(
                                 [
                                     ('    ' + line) if line else '' for line in commit.message.splitlines()
@@ -658,7 +659,7 @@ nothing to commit, working tree clean
                             hash=self.find(args[2]).hash,
                             author=self.find(args[2]).author.name,
                             email=self.find(args[2]).author.email,
-                            date=self.find(args[2]).timestamp if '--date=unix' in args else datetime.utcfromtimestamp(self.find(args[2]).timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000'),
+                            date=self.find(args[2]).timestamp if '--date=unix' in args else datetime.fromtimestamp(self.find(args[2]).timestamp + time.timezone, pytz.UTC).strftime('%a %b %d %H:%M:%S %Y +0000'),
                             log='\n'.join(
                                 [
                                     ('    ' + line) if line else '' for line in self.find(args[2]).message.splitlines()

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py
@@ -22,6 +22,7 @@
 
 import json
 import os
+import pytz
 import re
 
 from datetime import datetime
@@ -41,7 +42,7 @@ class Svn(mocks.Subprocess):
         return 'r{revision} | {email} | {date}'.format(
             revision=commit.revision,
             email=email,
-            date=datetime.utcfromtimestamp(commit.timestamp).strftime('%Y-%m-%d %H:%M:%S {} (%a, %d %b %Y)'.format(self.utc_offset)),
+            date=datetime.fromtimestamp(commit.timestamp, pytz.UTC).strftime('%Y-%m-%d %H:%M:%S {} (%a, %d %b %Y)'.format(self.utc_offset)),
         )
 
     def __init__(self, path='/.invalid-svn', datafile=None, remote=None, utc_offset=None):
@@ -209,7 +210,7 @@ class Svn(mocks.Subprocess):
                 branch=self.branch,
                 revision=commit.revision,
                 author=commit.author.email,
-                date=datetime.utcfromtimestamp(commit.timestamp).strftime('%Y-%m-%d %H:%M:%S {} (%a, %d %b %Y)'.format(self.utc_offset)),
+                date=datetime.fromtimestamp(commit.timestamp, pytz.UTC).strftime('%Y-%m-%d %H:%M:%S {} (%a, %d %b %Y)'.format(self.utc_offset)),
             ),
         )
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
@@ -21,8 +21,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import pytz
 import re
 import time
+
+from datetime import datetime, timedelta
 
 import json as jsonlib
 from webkitbugspy import mocks as bmocks, Issue
@@ -152,8 +155,6 @@ class GitHub(bmocks.GitHub):
         ], url=url)
 
     def _commits_response(self, url, ref):
-        from datetime import datetime, timedelta
-
         base = self.commit(ref)
         if not base:
             return mocks.Response.fromJson(
@@ -178,11 +179,11 @@ class GitHub(bmocks.GitHub):
                         'author': {
                             'name': commit.author.name,
                             'email': commit.author.email,
-                            'date': datetime.utcfromtimestamp(commit.timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                            'date': datetime.fromtimestamp(commit.timestamp - timedelta(hours=7).seconds, pytz.UTC).strftime('%Y-%m-%dT%H:%M:%SZ'),
                         }, 'committer': {
                             'name': commit.author.name,
                             'email': commit.author.email,
-                            'date': datetime.utcfromtimestamp(commit.timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                            'date': datetime.fromtimestamp(commit.timestamp - timedelta(hours=7).seconds, pytz.UTC).strftime('%Y-%m-%dT%H:%M:%SZ'),
                         }, 'message': commit.message + ('\ngit-svn-id: https://svn.example.org/repository/webkit/{}@{} 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'.format(
                             'trunk' if commit.branch == self.default_branch else commit.branch, commit.revision,
                         ) if commit.revision else ''),
@@ -198,8 +199,6 @@ class GitHub(bmocks.GitHub):
         return mocks.Response.fromJson(response, url=url)
 
     def _commit_response(self, url, ref):
-        from datetime import datetime, timedelta
-
         path = None
         split = ref.split('/', 1)
         if len(split) > 1:
@@ -229,11 +228,11 @@ class GitHub(bmocks.GitHub):
                 'author': {
                     'name': commit.author.name,
                     'email': commit.author.email,
-                    'date': datetime.utcfromtimestamp(commit.timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                    'date': datetime.fromtimestamp(commit.timestamp - timedelta(hours=7).seconds, pytz.UTC).strftime('%Y-%m-%dT%H:%M:%SZ'),
                 }, 'committer': {
                     'name': commit.author.name,
                     'email': commit.author.email,
-                    'date': datetime.utcfromtimestamp(commit.timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                    'date': datetime.fromtimestamp(commit.timestamp - timedelta(hours=7).seconds, pytz.UTC).strftime('%Y-%m-%dT%H:%M:%SZ'),
                 }, 'message': commit.message + ('\ngit-svn-id: https://svn.example.org/repository/webkit/{}@{} 268f45cc-cd09-0410-ab3c-d52691b4dbfc\n'.format(
                     'trunk' if commit.branch == self.default_branch else commit.branch, commit.revision,
                 ) if commit.revision else ''),

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/svn.py
@@ -118,6 +118,7 @@ class Svn(mocks.Requests):
                 yield candidate
 
     def request(self, method, url, data=None, **kwargs):
+        import pytz
         import xmltodict
         from datetime import datetime, timedelta
 
@@ -246,7 +247,7 @@ class Svn(mocks.Requests):
                     '</D:multistatus>\n'.format(
                         stripped_url,
                         commit.revision,
-                        datetime.utcfromtimestamp(commit.timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%S.103754Z'),
+                        datetime.fromtimestamp(commit.timestamp - timedelta(hours=7).seconds, pytz.UTC).strftime('%Y-%m-%dT%H:%M:%S.103754Z'),
                         commit.author.email,
                 ),
             )
@@ -278,7 +279,7 @@ class Svn(mocks.Requests):
                         '<S:date>{}</S:date>\n'
                         '{}{}</S:log-item>\n'.format(
                             commit.revision,
-                            datetime.utcfromtimestamp(commit.timestamp - timedelta(hours=7).seconds).strftime('%Y-%m-%dT%H:%M:%S.103754Z'),
+                            datetime.fromtimestamp(commit.timestamp - timedelta(hours=7).seconds, pytz.UTC).strftime('%Y-%m-%dT%H:%M:%S.103754Z'),
                             '' if data['S:log-report'].get('S:revpro') else '<D:comment>{}</D:comment>\n'
                             '<D:creator-displayname>{}</D:creator-displayname>\n'.format(
                                 commit.message,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
@@ -21,6 +21,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import pytz
 import re
 
 from .commit import Commit
@@ -57,7 +58,7 @@ class PullRequest(object):
         def __repr__(self):
             return '({} @ {}) {}'.format(
                 self.author,
-                datetime.utcfromtimestamp(self.timestamp) if self.timestamp else '-',
+                datetime.fromtimestamp(self.timestamp, pytz.UTC).replace(tzinfo=None) if self.timestamp else '-',
                 self.content,
             )
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
@@ -21,6 +21,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import logging
+import pytz
 import re
 import sys
 import time
@@ -48,7 +49,7 @@ class ScmBase(object):
             return int(time.localtime().tm_gmtoff * 100 / (60 * 60))
 
         ts = time.time()
-        return int((datetime.fromtimestamp(ts) - datetime.utcfromtimestamp(ts)).total_seconds() * 100 / (60 * 60))
+        return int((datetime.fromtimestamp(0) - datetime.fromtimestamp(0, pytz.UTC).replace(tzinfo=None)).total_seconds() * 100 / (60 * 60))
 
     def __init__(self, dev_branches=None, prod_branches=None, contributors=None, id=None, classifier=None):
         self.dev_branches = dev_branches or self.DEV_BRANCHES

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py
@@ -23,6 +23,7 @@
 import json
 import logging
 import os
+import pytz
 import unittest
 
 from mock import patch
@@ -125,7 +126,7 @@ class TestCommit(unittest.TestCase):
     SVN revision: r123 on trunk
     identifier: 123 on trunk
     by Jonathan Bedard <jbedard@apple.com> @ {}
-'''.format(datetime.utcfromtimestamp(1000)),
+'''.format(datetime.fromtimestamp(1000, pytz.UTC).replace(tzinfo=None)),
         )
 
         self.assertEqual(
@@ -140,7 +141,7 @@ class TestCommit(unittest.TestCase):
     SVN revision: r124 on branch-a
     identifier: 1 on branch-a branched from 123
     by Jonathan Bedard <jbedard@apple.com> @ {}
-'''.format(datetime.utcfromtimestamp(1000)),
+'''.format(datetime.fromtimestamp(1000, pytz.UTC).replace(tzinfo=None)),
         )
 
         self.assertEqual(
@@ -157,7 +158,7 @@ class TestCommit(unittest.TestCase):
     by Jonathan Bedard <jbedard@apple.com> @ {}
 
 PRINTED
-'''.format(datetime.utcfromtimestamp(1000)),
+'''.format(datetime.fromtimestamp(1000, pytz.UTC).replace(tzinfo=None)),
         )
 
     def test_repr(self):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/log_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/log_unittest.py
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import pytz
 import time
 import sys
 
@@ -78,7 +79,7 @@ Date:   {}
 
     1st commit
 '''.format(*reversed([
-                datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000')
+                datetime.fromtimestamp(commit.timestamp + time.timezone, pytz.UTC).strftime('%a %b %d %H:%M:%S %Y +0000')
                 for commit in mocks.local.Git(self.path).commits['main']
             ])),
         )
@@ -127,7 +128,7 @@ Date:   {}
     1st commit
     git-svn-id: https://svn.example.org/repository/repository/trunk@1 268f45cc-cd09-0410-ab3c-d52691b4dbfc
 '''.format(*reversed([
-                    datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000')
+                    datetime.fromtimestamp(commit.timestamp + time.timezone, pytz.UTC).strftime('%a %b %d %H:%M:%S %Y +0000')
                     for commit in mocks.local.Git(self.path).commits['main']
                 ])),
             )
@@ -176,7 +177,7 @@ Date:   {}
     1st commit
     git-svn-id: https://svn.example.org/repository/repository/trunk@1 268f45cc-cd09-0410-ab3c-d52691b4dbfc
 '''.format(*reversed([
-                    datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000')
+                    datetime.fromtimestamp(commit.timestamp + time.timezone, pytz.UTC).strftime('%a %b %d %H:%M:%S %Y +0000')
                     for commit in mocks.local.Git(self.path).commits['main']
                 ])),
             )

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/show_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/show_unittest.py
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import pytz
 import time
 import sys
 
@@ -66,7 +67,7 @@ index 2deba859a126..7b85f5cecd66 100644
 +        return;
     auto offset = layer.convertToLayerCoords(&clippingRoot, {{ }}, RenderLayer::AdjustForColumns);
     clipRect.moveBy(-offset);
-'''.format(datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000')),
+'''.format(datetime.fromtimestamp(commit.timestamp + time.timezone, pytz.UTC).strftime('%a %b %d %H:%M:%S %Y +0000')),
         )
 
     def test_git_svn(self):
@@ -99,7 +100,7 @@ index 2deba859a126..7b85f5cecd66 100644
 +        return;
     auto offset = layer.convertToLayerCoords(&clippingRoot, {{ }}, RenderLayer::AdjustForColumns);
     clipRect.moveBy(-offset);
-'''.format(datetime.utcfromtimestamp(commit.timestamp + time.timezone).strftime('%a %b %d %H:%M:%S %Y +0000')),
+'''.format(datetime.fromtimestamp(commit.timestamp + time.timezone, pytz.UTC).strftime('%a %b %d %H:%M:%S %Y +0000')),
         )
 
     def test_svn(self):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/svn_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/svn_unittest.py
@@ -21,6 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import pytz
 
 from datetime import datetime, timedelta
 from webkitcorepy import OutputCapture, LoggerCapture, testing
@@ -95,7 +96,7 @@ class TestLocalSvn(testing.PathTestCase):
                     u'Schedule': u'normal',
                     u'Last Changed Author': u'jbedard@apple.com',
                     u'Last Changed Rev': u'6',
-                    u'Last Changed Date': datetime.utcfromtimestamp(1601665100).strftime('%Y-%m-%d %H:%M:%S 0000 (%a, %d %b %Y)'),
+                    u'Last Changed Date': datetime.fromtimestamp(1601665100, pytz.UTC).strftime('%Y-%m-%d %H:%M:%S 0000 (%a, %d %b %Y)'),
                 }, local.Svn(self.path).info(),
             )
 
@@ -295,7 +296,7 @@ class TestRemoteSvn(testing.TestCase):
         with mocks.remote.Svn():
             self.assertDictEqual({
                 'Last Changed Author': 'jbedard@apple.com',
-                'Last Changed Date': datetime.utcfromtimestamp(1601665100 - timedelta(hours=7).seconds).strftime('%Y-%m-%d %H:%M:%S'),
+                'Last Changed Date': datetime.fromtimestamp(1601665100 - timedelta(hours=7).seconds, pytz.UTC).strftime('%Y-%m-%d %H:%M:%S'),
                 'Last Changed Rev': '6',
                 'Revision': 10,
             }, remote.Svn(self.remote).info())

--- a/Tools/Scripts/webkitpy/common/checkout/scm/git.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/git.py
@@ -314,8 +314,9 @@ class Git(SCM, SVNRepository):
         return time_without_timezone.strftime('%Y-%m-%dT%H:%M:%SZ')
 
     def timestamp_of_native_revision(self, path, sha):
+        import pytz
         unix_timestamp = self._run_git(['-C', self.find_checkout_root(path), 'log', '-1', sha, '--pretty=format:%ct']).rstrip()
-        commit_timestamp = datetime.datetime.utcfromtimestamp(float(unix_timestamp))
+        commit_timestamp = datetime.datetime.fromtimestamp(float(unix_timestamp), pytz.UTC)
         return commit_timestamp.strftime('%Y-%m-%dT%H:%M:%SZ')
 
     def create_patch(self, git_commit=None, changed_files=None, git_index=False, commit_message=True, find_branch=False):

--- a/Tools/Scripts/webkitpy/performance_tests/perftestsrunner.py
+++ b/Tools/Scripts/webkitpy/performance_tests/perftestsrunner.py
@@ -32,6 +32,7 @@ import os
 import json
 import logging
 import optparse
+import pytz
 import sys
 import time
 import datetime
@@ -79,7 +80,7 @@ class PerfTestsRunner(object):
         self._webkit_base_dir_len = len(self._port.webkit_base())
         self._base_path = self._port.perf_tests_dir()
         self._timestamp = time.time()
-        self._utc_timestamp = datetime.datetime.utcnow()
+        self._utc_timestamp = datetime.datetime.now(pytz.UTC)
 
     @staticmethod
     def _parse_args(args=None):


### PR DESCRIPTION
#### 30b764b0cead09337e77eb03e14afb3fc14798bf
<pre>
[webkitbugspy/webkitscmpy/webkitpy] Replace deprecated datetime methods utcfromtimestamp() and utcnow().
<a href="https://rdar.apple.com/125050750">rdar://125050750</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=271286">https://bugs.webkit.org/show_bug.cgi?id=271286</a>

Reviewed by NOBODY (OOPS!).

The methods datetime.utcfromtimestamp() and datetime.utcnow() are deprecated in python 3.12.
We should remove these calls from the WebKit repo where possible to prevent future issues.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/issue.py
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/github.py
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/radar.py
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/commit.py
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/svn.py
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/git_hub.py
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/remote/svn.py
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/pull_request.py
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/scm_base.py
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/commit_unittest.py
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/log_unittest.py
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/show_unittest.py
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/svn_unittest.py
* Tools/Scripts/webkitpy/common/checkout/scm/git.py
* Tools/Scripts/webkitpy/performance_tests/perftestsrunner.py
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30b764b0cead09337e77eb03e14afb3fc14798bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44682 "check-webkit-style (failure)") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47164 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47335 "") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40687 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46984 "bindings-tests (failure)") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21321 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/47335 "") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45259 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20832 "Found unexpected failure with change (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39283 "Build is in progress. Recent messages:") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/47335 "") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/44548 "webkitpy-tests (failure)") | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39632 "Found unexpected failure with change (failure)") | [❌ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2729 "") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41258 "re-run-api-tests (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39918 "Found unexpected failure with change (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48975 "") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19640 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16350 "Found unexpected failure with change (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/48975 "") | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/44723 "Failed resultsdbpy unit tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20967 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/48975 "") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->