### PR TITLE
REGRESSION (275503@main): Autocorrection candidates fail to insert text when the selection is collapsed

### DIFF
--- a/LayoutTests/fast/events/ios/autocorrect-with-caret-selection-expected.txt
+++ b/LayoutTests/fast/events/ios/autocorrect-with-caret-selection-expected.txt
@@ -1,0 +1,10 @@
+To manually test, focus the editable element above, move the selection to the end, and select any text suggestion that appears in the keyboard. The text suggestion should be inserted.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS editable.textContent is "Hello world"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello world

--- a/LayoutTests/fast/events/ios/autocorrect-with-caret-selection.html
+++ b/LayoutTests/fast/events/ios/autocorrect-with-caret-selection.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="initial-scale=1.0, user-scalable=no">
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+#editable {
+    border: 1px solid tomato;
+    display: inline-block;
+    font-size: 32px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+addEventListener("load", async () => {
+    description("To manually test, focus the editable element above, move the selection to the end, and select any text suggestion that appears in the keyboard. The text suggestion should be inserted.");
+
+    editable = document.getElementById("editable");
+    await UIHelper.setHardwareKeyboardAttached(false);
+    await UIHelper.activateElementAndWaitForInputSession(editable);
+
+    getSelection().setPosition(editable, 1);
+    await UIHelper.applyAutocorrection("world", "");
+
+    shouldBeEqualToString("editable.textContent", "Hello world");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<div contenteditable id="editable">Hello&nbsp;</div>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2774,7 +2774,11 @@ bool WebPage::applyAutocorrectionInternal(const String& correction, const String
         // forward such that it matches the original selection as much as possible.
         if (foldQuoteMarks(textForRange) != originalTextWithFoldedQuoteMarks) {
             // Search for the original text near the selection caret.
-            if (auto searchRange = rangeExpandedAroundPositionByCharacters(position, numGraphemeClusters(originalText))) {
+            auto characterCount = numGraphemeClusters(originalText);
+            if (!characterCount) {
+                textForRange = emptyString();
+                range = makeSimpleRange(position);
+            } else if (auto searchRange = rangeExpandedAroundPositionByCharacters(position, characterCount)) {
                 if (auto foundRange = findPlainText(*searchRange, originalTextWithFoldedQuoteMarks, { DoNotSetSelection, DoNotRevealSelection }); !foundRange.collapsed()) {
                     textForRange = plainTextForContext(foundRange);
                     range = foundRange;


### PR DESCRIPTION
#### e9f9c8bd018f93284b62781df8a556300ab06676
<pre>
REGRESSION (275503@main): Autocorrection candidates fail to insert text when the selection is collapsed
<a href="https://bugs.webkit.org/show_bug.cgi?id=271288">https://bugs.webkit.org/show_bug.cgi?id=271288</a>
<a href="https://rdar.apple.com/125034366">rdar://125034366</a>

Reviewed by Richard Robinson.

The change in 275503@main refactored the text search logic in `WebPage::applyAutocorrectionInternal`
to use `rangeExpandedAroundPositionByCharacters` and `findPlainText`. However, this missed one
subtlety in the previous implementation, which is that it would set the `range` to the current
selection, in the case where both:

1. The current selection is collapsed, and
2. The `originalText` is also the empty string.

This scenario is exercised simply by inserting content by pressing one of the predictive text
candidates above the software keyboard on iOS, when the selection is after a space following a
previous word — for example:

```
Hello |(world)
```

...where `(world)` represents the predictive text candidate. The new codepath always fails here,
since `findPlainText` will be given an empty range (which it returns), and then we fail the
subsequent `!isCollapsed` check (which only makes sense in the case where the original text is non-
empty).

To fix this, we simply avoid falling down this `rangeExpandedAroundPositionByCharacters` codepath in
the first place when the selection is collapsed, and just insert the text candidate.

* LayoutTests/fast/events/ios/autocorrect-with-caret-selection.html: Added.
* LayoutTests/fast/events/ios/autocorrect-with-caret-selection-expected.txt: Added.

Add a layout test to exercise the change.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::applyAutocorrectionInternal):

Canonical link: <a href="https://commits.webkit.org/276385@main">https://commits.webkit.org/276385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6d6a1b95c0a5a7ddbe3159a03156ab5b4c1beef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47188 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40540 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21004 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20667 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38333 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17695 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39477 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2584 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40728 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48811 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16029 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42306 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9905 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->