### PR TITLE
Update the PreviewWindowController to use PreviewItem

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -63,7 +63,6 @@
 #import "MRUIKitSPI.h"
 #if ENABLE(QUICKLOOK_FULLSCREEN)
 #import "WKSPreviewWindowController.h"
-#import <pal/ios/QuickLookSoftLink.h>
 #import "WebKitSwiftSoftLink.h"
 #endif // QUICKLOOK_FULLSCREEN
 #endif
@@ -1875,8 +1874,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         if (enter) {
             inWindowAlpha = 0;
             manager->prepareQuickLookImageURL([strongSelf = retainPtr(self), self] (URL&& url) mutable {
-                auto item = adoptNS([PAL::allocQLItemInstance() initWithURL:url]);
-                _previewWindowController = adoptNS([WebKit::allocWKSPreviewWindowControllerInstance() initWithItem:item.get()]);
+                _previewWindowController = adoptNS([WebKit::allocWKSPreviewWindowControllerInstance() initWithURL:url]);
                 [_previewWindowController setDelegate:self];
                 [_previewWindowController presentWindow];
             });

--- a/Source/WebKit/WebKitSwift/Preview/PreviewWindowController.swift
+++ b/Source/WebKit/WebKitSwift/Preview/PreviewWindowController.swift
@@ -23,29 +23,29 @@
 
 #if os(visionOS)
 
-#if canImport(QuickLook, _version: 953)
+#if canImport(QuickLook, _version: 956)
+import OSLog
 import WebKitSwift
 
 @_spi(PreviewApplication) import QuickLook
-import AssetViewer
 
 @objc(WKSPreviewWindowController)
 public final class PreviewWindowController: NSObject {
     private static let logger = Logger(subsystem: "com.apple.WebKit", category: "Fullscreen")
 
-    private var item: QLItem
+    private var item: PreviewItem
     private var previewSession: PreviewSession?
     private var isClosing = false
 
     @objc public weak var delegate: WKSPreviewWindowControllerDelegate?
 
-    @objc public init(item: QLItem) {
-        self.item = item
+    @objc(initWithURL:) public init(url: URL) {
+        self.item = PreviewItem(url: url, displayName: nil, editingMode: .disabled);
         super.init()
     }
 
     @objc public func presentWindow() {
-        previewSession = PreviewApplication.open(items: [self.item], selectedItemIndex: nil, editingMode: .disabled)
+        previewSession = PreviewApplication.open(items: [self.item], selectedItem: nil)
 
         Task.detached { [weak self] in
             guard let session = self?.previewSession else { return }

--- a/Source/WebKit/WebKitSwift/Preview/WKSPreviewWindowController.h
+++ b/Source/WebKit/WebKitSwift/Preview/WKSPreviewWindowController.h
@@ -29,7 +29,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class QLItem;
 @class WKSPreviewWindowController;
 
 @protocol WKSPreviewWindowControllerDelegate <NSObject>
@@ -39,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface WKSPreviewWindowController : NSObject
 @property (nonatomic, weak, nullable) id <WKSPreviewWindowControllerDelegate> delegate;
 
-- (instancetype)initWithItem:(QLItem *)item NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithURL:(NSURL *)url NS_DESIGNATED_INITIALIZER;
 - (void)presentWindow;
 - (void)dismissWindow;
 @end


### PR DESCRIPTION
#### ea1cc85f82ed82eae1be279bd597e9c49d995117
<pre>
Update the PreviewWindowController to use PreviewItem
<a href="https://bugs.webkit.org/show_bug.cgi?id=271291">https://bugs.webkit.org/show_bug.cgi?id=271291</a>
&lt;<a href="https://rdar.apple.com/125040242">rdar://125040242</a>&gt;

Reviewed by Aditya Keerthi.

Update the PreviewWindowController to use PreviewItem. Since this is a
Swift type, WKSPreviewWindowController now takes a URL directly on init
and instantiates the PreviewItem internally.

* Source/WebKit/WebKitSwift/Preview/WKSPreviewWindowController.h:
New designated initializer.
* Source/WebKit/WebKitSwift/Preview/PreviewWindowController.swift:
(PreviewWindowController.item):
(PreviewWindowController.presentWindow):
Update to the PreviewItem variant of the`open` method.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):
Use the new WKSPreviewWindowController initializer.

Canonical link: <a href="https://commits.webkit.org/276381@main">https://commits.webkit.org/276381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58c83ee25f6c70328d0372b277e2ef4813f289be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46975 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47177 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20994 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20655 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17681 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2574 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40718 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48798 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19489 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/16022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9902 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->