### PR TITLE
Update TextCodec::decode() to take in a std::span

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp
@@ -61,7 +61,7 @@ RefPtr<Uint8Array> CDMSessionClearKey::generateKeyRequest(const String& mimeType
     m_initData = initData;
 
     bool sawError = false;
-    String keyID = PAL::UTF8Encoding().decode(static_cast<char*>(m_initData->baseAddress()), m_initData->byteLength(), true, sawError);
+    String keyID = PAL::UTF8Encoding().decode(m_initData->bytes(), true, sawError);
     if (sawError) {
         errorCode = WebKitMediaKeyError::MEDIA_KEYERR_CLIENT;
         return nullptr;

--- a/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
+++ b/Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h
@@ -96,13 +96,13 @@ struct URLEscapeSequence {
         return runEnd;
     }
 
-    static Vector<char, 512> decodeRun(StringView run)
+    static Vector<uint8_t, 512> decodeRun(StringView run)
     {
         // For URL escape sequences, we know that findEndOfRun() has given us a run where every %-sign introduces
         // a valid escape sequence, but there may be characters between the sequences.
-        Vector<char, 512> buffer;
+        Vector<uint8_t, 512> buffer;
         buffer.grow(run.length()); // Unescaping hex sequences only makes the length smaller.
-        char* p = buffer.data();
+        uint8_t* p = buffer.data();
         while (!run.isEmpty()) {
             if (run[0] == '%') {
                 *p++ = (toASCIIHexValue(run[1]) << 4) | toASCIIHexValue(run[2]);
@@ -121,8 +121,8 @@ struct URLEscapeSequence {
     {
         auto buffer = decodeRun(run);
         if (!encoding.isValid())
-            return PAL::UTF8Encoding().decode(buffer.data(), buffer.size());
-        return encoding.decode(buffer.data(), buffer.size());
+            return PAL::UTF8Encoding().decode(buffer.span());
+        return encoding.decode(buffer.span());
     }
 };
 

--- a/Source/WebCore/PAL/pal/text/TextCodec.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodec.cpp
@@ -35,11 +35,6 @@
 
 namespace PAL {
 
-String TextCodec::decode(std::span<const uint8_t> data, bool flush, bool stopOnError, bool& sawError)
-{
-    return decode(reinterpret_cast<const char*>(data.data()), data.size(), flush, stopOnError, sawError);
-}
-
 int TextCodec::getUnencodableReplacement(char32_t codePoint, UnencodableHandling handling, UnencodableReplacementArray& replacement)
 {
     ASSERT(!(codePoint > UCHAR_MAX_VALUE));

--- a/Source/WebCore/PAL/pal/text/TextCodec.h
+++ b/Source/WebCore/PAL/pal/text/TextCodec.h
@@ -47,8 +47,7 @@ public:
     virtual ~TextCodec() = default;
 
     virtual void stripByteOrderMark() { }
-    virtual String decode(const char*, size_t length, bool flush, bool stopOnError, bool& sawError) = 0; // FIXME: We should drop once all call sites start passing a span.
-    String decode(std::span<const uint8_t> data, bool flush, bool stopOnError, bool& sawError);
+    virtual String decode(std::span<const uint8_t> data, bool flush, bool stopOnError, bool& sawError) = 0;
 
     virtual Vector<uint8_t> encode(StringView, UnencodableHandling) const = 0;
 

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.h
@@ -39,19 +39,19 @@ public:
     explicit TextCodecCJK(Encoding);
 
 private:
-    String decode(const char*, size_t length, bool flush, bool stopOnError, bool& sawError) final;
+    String decode(std::span<const uint8_t>, bool flush, bool stopOnError, bool& sawError) final;
     Vector<uint8_t> encode(StringView, UnencodableHandling) const final;
 
     enum class SawError : bool { No, Yes };
-    String decodeCommon(const uint8_t*, size_t, bool, bool, bool&, const Function<SawError(uint8_t, StringBuilder&)>&);
+    String decodeCommon(std::span<const uint8_t>, bool, bool, bool&, const Function<SawError(uint8_t, StringBuilder&)>&);
 
-    String eucJPDecode(const uint8_t*, size_t, bool, bool, bool&);
-    String iso2022JPDecode(const uint8_t*, size_t, bool, bool, bool&);
-    String shiftJISDecode(const uint8_t*, size_t, bool, bool, bool&);
-    String eucKRDecode(const uint8_t*, size_t, bool, bool, bool&);
-    String big5Decode(const uint8_t*, size_t, bool, bool, bool&);
-    String gbkDecode(const uint8_t*, size_t, bool, bool, bool&);
-    String gb18030Decode(const uint8_t*, size_t, bool, bool, bool&);
+    String eucJPDecode(std::span<const uint8_t>, bool, bool, bool&);
+    String iso2022JPDecode(std::span<const uint8_t>, bool, bool, bool&);
+    String shiftJISDecode(std::span<const uint8_t>, bool, bool, bool&);
+    String eucKRDecode(std::span<const uint8_t>, bool, bool, bool&);
+    String big5Decode(std::span<const uint8_t>, bool, bool, bool&);
+    String gbkDecode(std::span<const uint8_t>, bool, bool, bool&);
+    String gb18030Decode(std::span<const uint8_t>, bool, bool, bool&);
 
     const Encoding m_encoding;
 

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -211,7 +211,7 @@ private:
     UConverterToUCallback m_savedAction { nullptr };
 };
 
-String TextCodecICU::decode(const char* bytes, size_t length, bool flush, bool stopOnError, bool& sawError)
+String TextCodecICU::decode(std::span<const uint8_t> bytes, bool flush, bool stopOnError, bool& sawError)
 {
     // Get a converter for the passed-in encoding.
     if (!m_converter) {
@@ -229,8 +229,8 @@ String TextCodecICU::decode(const char* bytes, size_t length, bool flush, bool s
 
     UChar buffer[ConversionBufferSize];
     UChar* bufferLimit = buffer + ConversionBufferSize;
-    const char* source = reinterpret_cast<const char*>(bytes);
-    const char* sourceLimit = source + length;
+    const char* source = reinterpret_cast<const char*>(bytes.data());
+    const char* sourceLimit = source + bytes.size();
     int32_t* offsets = nullptr;
     UErrorCode err = U_ZERO_ERROR;
 

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.h
@@ -44,7 +44,7 @@ public:
     virtual ~TextCodecICU();
 
 private:
-    String decode(const char*, size_t length, bool flush, bool stopOnError, bool& sawError) final;
+    String decode(std::span<const uint8_t>, bool flush, bool stopOnError, bool& sawError) final;
     Vector<uint8_t> encode(StringView, UnencodableHandling) const final;
 
     void createICUConverter() const;

--- a/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp
@@ -97,15 +97,15 @@ void TextCodecLatin1::registerCodecs(TextCodecRegistrar registrar)
     });
 }
 
-String TextCodecLatin1::decode(const char* bytes, size_t length, bool, bool, bool&)
+String TextCodecLatin1::decode(std::span<const uint8_t> bytes, bool, bool, bool&)
 {
     LChar* characters;
-    if (!length)
+    if (bytes.empty())
         return emptyString();
-    String result = String::createUninitialized(length, characters);
+    String result = String::createUninitialized(bytes.size(), characters);
 
-    const uint8_t* source = reinterpret_cast<const uint8_t*>(bytes);
-    const uint8_t* end = reinterpret_cast<const uint8_t*>(bytes + length);
+    const uint8_t* source = bytes.data();
+    const uint8_t* end = bytes.data() + bytes.size();
     const uint8_t* alignedEnd = WTF::alignToMachineWord(end);
     LChar* destination = characters;
 
@@ -148,7 +148,7 @@ useLookupTable:
     
 upConvertTo16Bit:
     UChar* characters16;
-    String result16 = String::createUninitialized(length, characters16);
+    String result16 = String::createUninitialized(bytes.size(), characters16);
 
     UChar* destination16 = characters16;
 

--- a/Source/WebCore/PAL/pal/text/TextCodecLatin1.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecLatin1.h
@@ -35,7 +35,7 @@ public:
     static void registerCodecs(TextCodecRegistrar);
 
 private:
-    String decode(const char*, size_t length, bool flush, bool stopOnError, bool& sawError) final;
+    String decode(std::span<const uint8_t>, bool flush, bool stopOnError, bool& sawError) final;
     Vector<uint8_t> encode(StringView, UnencodableHandling) const final;
 };
 

--- a/Source/WebCore/PAL/pal/text/TextCodecReplacement.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecReplacement.cpp
@@ -50,7 +50,7 @@ void TextCodecReplacement::registerCodecs(TextCodecRegistrar registrar)
     });
 }
 
-String TextCodecReplacement::decode(const char*, size_t, bool, bool, bool& sawError)
+String TextCodecReplacement::decode(std::span<const uint8_t>, bool, bool, bool& sawError)
 {
     sawError = true;
     if (m_sentEOF)

--- a/Source/WebCore/PAL/pal/text/TextCodecReplacement.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecReplacement.h
@@ -35,7 +35,7 @@ public:
     static void registerCodecs(TextCodecRegistrar);
 
 private:
-    String decode(const char*, size_t length, bool flush, bool stopOnError, bool& sawError) final;
+    String decode(std::span<const uint8_t>, bool flush, bool stopOnError, bool& sawError) final;
     Vector<uint8_t> encode(StringView, UnencodableHandling) const final;
 
     bool m_sentEOF { false };

--- a/Source/WebCore/PAL/pal/text/TextCodecSingleByte.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecSingleByte.h
@@ -38,7 +38,7 @@ public:
     explicit TextCodecSingleByte(Encoding);
 
 private:
-    String decode(const char*, size_t length, bool flush, bool stopOnError, bool& sawError) final;
+    String decode(std::span<const uint8_t>, bool flush, bool stopOnError, bool& sawError) final;
     Vector<uint8_t> encode(StringView, UnencodableHandling) const final;
 
     const Encoding m_encoding;

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp
@@ -64,14 +64,14 @@ void TextCodecUTF16::registerCodecs(TextCodecRegistrar registrar)
 }
 
 // https://encoding.spec.whatwg.org/#shared-utf-16-decoder
-String TextCodecUTF16::decode(const char* bytes, size_t length, bool flush, bool, bool& sawError)
+String TextCodecUTF16::decode(std::span<const uint8_t> bytes, bool flush, bool, bool& sawError)
 {
-    const auto* p = reinterpret_cast<const uint8_t*>(bytes);
-    const auto* const end = p + length;
+    const auto* p = bytes.data();
+    const auto* const end = p + bytes.size();
     const auto* const endMinusOneOrNull = end ? end - 1 : nullptr;
 
     StringBuilder result;
-    result.reserveCapacity(length / 2);
+    result.reserveCapacity(bytes.size() / 2);
 
     auto processCodeUnit = [&] (UChar codeUnit) {
         if (std::exchange(m_shouldStripByteOrderMark, false) && codeUnit == byteOrderMark)

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF16.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF16.h
@@ -39,7 +39,7 @@ public:
 
 private:
     void stripByteOrderMark() final { m_shouldStripByteOrderMark = true; }
-    String decode(const char*, size_t length, bool flush, bool stopOnError, bool& sawError) final;
+    String decode(std::span<const uint8_t>, bool flush, bool stopOnError, bool& sawError) final;
     Vector<uint8_t> encode(StringView, UnencodableHandling) const final;
 
     bool m_littleEndian;

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -296,15 +296,15 @@ void TextCodecUTF8::handlePartialSequence(UChar*& destination, const uint8_t*& s
     } while (m_partialSequenceSize);
 }
 
-String TextCodecUTF8::decode(const char* bytes, size_t length, bool flush, bool stopOnError, bool& sawError)
+String TextCodecUTF8::decode(std::span<const uint8_t> bytes, bool flush, bool stopOnError, bool& sawError)
 {
     // Each input byte might turn into a character.
     // That includes all bytes in the partial-sequence buffer because
     // each byte in an invalid sequence will turn into a replacement character.
-    StringBuffer<LChar> buffer(m_partialSequenceSize + length);
+    StringBuffer<LChar> buffer(m_partialSequenceSize + bytes.size());
 
-    const uint8_t* source = reinterpret_cast<const uint8_t*>(bytes);
-    const uint8_t* end = source + length;
+    const uint8_t* source = bytes.data();
+    const uint8_t* end = source + bytes.size();
     const uint8_t* alignedEnd = WTF::alignToMachineWord(end);
     LChar* destination = buffer.characters();
 
@@ -383,7 +383,7 @@ String TextCodecUTF8::decode(const char* bytes, size_t length, bool flush, bool 
     return String::adopt(WTFMove(buffer));
 
 upConvertTo16Bit:
-    StringBuffer<UChar> buffer16(m_partialSequenceSize + length);
+    StringBuffer<UChar> buffer16(m_partialSequenceSize + bytes.size());
 
     UChar* destination16 = buffer16.characters();
 

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
@@ -41,7 +41,7 @@ public:
 
 private:
     void stripByteOrderMark() final { m_shouldStripByteOrderMark = true; }
-    String decode(const char*, size_t length, bool flush, bool stopOnError, bool& sawError) final;
+    String decode(std::span<const uint8_t>, bool flush, bool stopOnError, bool& sawError) final;
     Vector<uint8_t> encode(StringView, UnencodableHandling) const final;
 
     bool handlePartialSequence(LChar*& destination, const uint8_t*& source, const uint8_t* end, bool flush);

--- a/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp
@@ -45,14 +45,12 @@ void TextCodecUserDefined::registerCodecs(TextCodecRegistrar registrar)
     });
 }
 
-String TextCodecUserDefined::decode(const char* bytes, size_t length, bool, bool, bool&)
+String TextCodecUserDefined::decode(std::span<const uint8_t> bytes, bool, bool, bool&)
 {
     StringBuilder result;
-    result.reserveCapacity(length);
-    for (size_t i = 0; i < length; ++i) {
-        signed char c = bytes[i];
-        result.append(static_cast<UChar>(c & 0xF7FF));
-    }
+    result.reserveCapacity(bytes.size());
+    for (char byte : bytes)
+        result.append(static_cast<UChar>(byte & 0xF7FF));
     return result.toString();
 }
 

--- a/Source/WebCore/PAL/pal/text/TextCodecUserDefined.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecUserDefined.h
@@ -35,7 +35,7 @@ public:
     static void registerCodecs(TextCodecRegistrar);
 
 private:
-    String decode(const char*, size_t length, bool flush, bool stopOnError, bool& sawError) final;
+    String decode(std::span<const uint8_t>, bool flush, bool stopOnError, bool& sawError) final;
     Vector<uint8_t> encode(StringView, UnencodableHandling) const final;
 };
 

--- a/Source/WebCore/PAL/pal/text/TextEncoding.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncoding.cpp
@@ -60,12 +60,12 @@ TextEncoding::TextEncoding(const String& name)
 {
 }
 
-String TextEncoding::decode(const char* data, size_t length, bool stopOnError, bool& sawError) const
+String TextEncoding::decode(std::span<const uint8_t> data, bool stopOnError, bool& sawError) const
 {
     if (m_name.isNull())
         return String();
 
-    return newTextCodec(*this)->decode(data, length, true, stopOnError, sawError);
+    return newTextCodec(*this)->decode(data, true, stopOnError, sawError);
 }
 
 Vector<uint8_t> TextEncoding::encode(StringView string, PAL::UnencodableHandling handling, NFCNormalize normalize) const

--- a/Source/WebCore/PAL/pal/text/TextEncoding.h
+++ b/Source/WebCore/PAL/pal/text/TextEncoding.h
@@ -49,9 +49,8 @@ public:
     const TextEncoding& closestByteBasedEquivalent() const;
     const TextEncoding& encodingForFormSubmissionOrURLParsing() const;
 
-    PAL_EXPORT String decode(const char*, size_t length, bool stopOnError, bool& sawError) const;
-    String decode(const char*, size_t length) const;
-    String decode(const uint8_t* data, size_t length) const { return decode(reinterpret_cast<const char*>(data), length); }
+    PAL_EXPORT String decode(std::span<const uint8_t>, bool stopOnError, bool& sawError) const;
+    String decode(std::span<const uint8_t>) const;
     PAL_EXPORT Vector<uint8_t> encode(StringView, PAL::UnencodableHandling, NFCNormalize = NFCNormalize::Yes) const;
     Vector<uint8_t> encodeForURLParsing(StringView string) const final { return encode(string, PAL::UnencodableHandling::URLEncodedEntities, NFCNormalize::No); }
 
@@ -80,10 +79,10 @@ PAL_EXPORT const TextEncoding& WindowsLatin1Encoding();
 // the resulting string will have embedded null characters!
 PAL_EXPORT String decodeURLEscapeSequences(StringView, const TextEncoding& = UTF8Encoding());
 
-inline String TextEncoding::decode(const char* characters, size_t length) const
+inline String TextEncoding::decode(std::span<const uint8_t> characters) const
 {
     bool ignored;
-    return decode(characters, length, false, ignored);
+    return decode(characters, false, ignored);
 }
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/text/win/TextCodecWin.cpp
+++ b/Source/WebCore/PAL/pal/text/win/TextCodecWin.cpp
@@ -231,18 +231,17 @@ static void decodeInternal(Vector<UChar, 8192>& result, UINT codePage, const cha
     }
 }
 
-String TextCodecWin::decode(const char* bytes, size_t length, bool flush, bool stopOnError, bool& sawError)
+String TextCodecWin::decode(std::span<const uint8_t> bytes, bool flush, bool stopOnError, bool& sawError)
 {
     if (!m_decodeBuffer.isEmpty()) {
-        m_decodeBuffer.append(bytes, length);
-        bytes = m_decodeBuffer.data();
-        length = m_decodeBuffer.size();
+        m_decodeBuffer.append(bytes);
+        bytes = std::span { reinterpret_cast<const uint8_t*>(m_decodeBuffer.data()), m_decodeBuffer.size() };
     }
 
     size_t left;
     Vector<UChar, 8192> result;
     for (;;) {
-        decodeInternal(result, m_codePage, bytes, length, &left);
+        decodeInternal(result, m_codePage, bytes, &left);
         if (!left)
             break;
 
@@ -257,14 +256,13 @@ String TextCodecWin::decode(const char* bytes, size_t length, bool flush, bool s
         if (left == 1)
             break;
 
-        bytes += length - left + 1;
-        length = left - 1;
+        bytes = std::span { bytes.data() + bytes.size() - left + 1, left - 1 };
     }
     if (left && !flush) {
         if (m_decodeBuffer.isEmpty())
-            m_decodeBuffer.append(bytes + length - left, left);
+            m_decodeBuffer.append(bytes.subspan(length - left, left));
         else {
-            memmove(m_decodeBuffer.data(), bytes + length - left, left);
+            memmove(m_decodeBuffer.data(), bytes.data() + bytes.size() - left, left);
             m_decodeBuffer.resize(left);
         }
     } else

--- a/Source/WebCore/PAL/pal/text/win/TextCodecWin.h
+++ b/Source/WebCore/PAL/pal/text/win/TextCodecWin.h
@@ -44,7 +44,7 @@ public:
     TextCodecWin(UINT codePage);
     virtual ~TextCodecWin();
 
-    virtual String decode(const char*, size_t length, bool flush, bool stopOnError, bool& sawError);
+    virtual String decode(std::span<const uint8_t>, bool flush, bool stopOnError, bool& sawError);
     virtual CString encode(const UChar*, size_t length, UnencodableHandling);
 
     struct EncodingInfo {

--- a/Source/WebCore/dom/TextDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoder.cpp
@@ -53,12 +53,10 @@ ExceptionOr<Ref<TextDecoder>> TextDecoder::create(const String& label, Options o
 ExceptionOr<String> TextDecoder::decode(std::optional<BufferSource::VariantType> input, DecodeOptions options)
 {
     std::optional<BufferSource> inputBuffer;
-    const uint8_t* data = nullptr;
-    size_t length = 0;
+    std::span<const uint8_t> data;
     if (input) {
         inputBuffer = BufferSource(WTFMove(input.value()));
-        data = inputBuffer->data();
-        length = inputBuffer->length();
+        data = inputBuffer->bytes();
     }
 
     if (!m_codec) {
@@ -68,7 +66,7 @@ ExceptionOr<String> TextDecoder::decode(std::optional<BufferSource::VariantType>
     }
 
     bool sawError = false;
-    String result = m_codec->decode(reinterpret_cast<const char*>(data), length, !options.stream, m_options.fatal, sawError);
+    String result = m_codec->decode(data, !options.stream, m_options.fatal, sawError);
 
     if (!options.stream && !m_options.ignoreBOM)
         m_codec->stripByteOrderMark();

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.h
@@ -156,7 +156,7 @@ private:
     double timestamp();
 
     static bool mainResourceContent(LocalFrame*, bool withBase64Encode, String* result);
-    static bool dataContent(const uint8_t* data, unsigned size, const String& textEncodingName, bool withBase64Encode, String* result);
+    static bool dataContent(std::span<const uint8_t> data, const String& textEncodingName, bool withBase64Encode, String* result);
 
     void overridePrefersReducedMotion(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);
     void overridePrefersContrast(std::optional<Inspector::Protocol::Page::UserPreferenceValue>&&);

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -298,8 +298,7 @@ Vector<uint8_t> FormData::flatten() const
 
 String FormData::flattenToString() const
 {
-    auto bytes = flatten();
-    return PAL::Latin1Encoding().decode(bytes.data(), bytes.size());
+    return PAL::Latin1Encoding().decode(flatten().span());
 }
 
 static void appendBlobResolved(BlobRegistryImpl* blobRegistry, FormData& formData, const URL& url)

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -202,9 +202,8 @@ static String getFullCFHTML(IDataObject* data)
     STGMEDIUM store;
     if (SUCCEEDED(data->GetData(htmlFormat(), &store))) {
         // MS HTML Format parsing
-        char* data = static_cast<char*>(GlobalLock(store.hGlobal));
-        SIZE_T dataSize = ::GlobalSize(store.hGlobal);
-        String cfhtml(PAL::UTF8Encoding().decode(data, dataSize));
+        std::span bytes { static_cast<uint8_t*>(GlobalLock(store.hGlobal)), ::GlobalSize(store.hGlobal) };
+        String cfhtml(PAL::UTF8Encoding().decode(bytes));
         GlobalUnlock(store.hGlobal);
         ReleaseStgMedium(&store);
         return cfhtml;
@@ -700,7 +699,8 @@ void getUTF8Data(IDataObject* data, FORMATETC* format, Vector<String>& dataStrin
     STGMEDIUM store;
     if (FAILED(data->GetData(format, &store)))
         return;
-    dataStrings.append(String(PAL::UTF8Encoding().decode(static_cast<char*>(GlobalLock(store.hGlobal)), GlobalSize(store.hGlobal))));
+    std::span bytes { static_cast<uint8_t*>(GlobalLock(store.hGlobal)), GlobalSize(store.hGlobal) };
+    dataStrings.append(String(PAL::UTF8Encoding().decode(bytes)));
     GlobalUnlock(store.hGlobal);
     ReleaseStgMedium(&store);
 }

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -858,8 +858,8 @@ RefPtr<DocumentFragment> Pasteboard::documentFragment(LocalFrame& frame, const S
         // get data off of clipboard
         HANDLE cbData = ::GetClipboardData(HTMLClipboardFormat);
         if (cbData) {
-            SIZE_T dataSize = ::GlobalSize(cbData);
-            String cfhtml(PAL::UTF8Encoding().decode(static_cast<char*>(GlobalLock(cbData)), dataSize));
+            std::span data { static_cast<uint8_t*>(GlobalLock(cbData)), ::GlobalSize(cbData) };
+            String cfhtml(PAL::UTF8Encoding().decode(data));
             GlobalUnlock(cbData);
             ::CloseClipboard();
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -590,7 +590,7 @@ String WebFrame::source() const
     RefPtr<FragmentedSharedBuffer> mainResourceData = documentLoader->mainResourceData();
     if (!mainResourceData)
         return String();
-    return decoder->encoding().decode(mainResourceData->makeContiguous()->data(), mainResourceData->size());
+    return decoder->encoding().decode(mainResourceData->makeContiguous()->bytes());
 }
 
 String WebFrame::contentsAsString() const 

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1772,7 +1772,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     PAL::TextEncoding encoding(textEncodingName);
     if (!encoding.isValid())
         encoding = PAL::WindowsLatin1Encoding();
-    return encoding.decode(reinterpret_cast<const char*>([data bytes]), [data length]);
+    return encoding.decode(toSpan(data));
 }
 
 - (NSRect)caretRectAtNode:(DOMNode *)node offset:(int)offset affinity:(NSSelectionAffinity)affinity

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
@@ -240,7 +240,7 @@ using JSC::Yarr::RegularExpression;
     NSData *data = [_private->dataSource data];
     if (!data)
         return nil;
-    return decoder->encoding().decode(reinterpret_cast<const char*>([data bytes]), [data length]);
+    return decoder->encoding().decode(toSpan(data));
 }
 
 - (NSString *)title

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -368,8 +368,10 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
     if (!encoding.isValid())
         encoding = PAL::WindowsLatin1Encoding();
     
-    FragmentedSharedBuffer* coreData = _private->coreResource ? &_private->coreResource->data() : nullptr;
-    return encoding.decode(reinterpret_cast<const char*>(coreData ? coreData->makeContiguous()->data() : nullptr), coreData ? coreData->size() : 0);
+    RefPtr coreData = _private->coreResource ? &_private->coreResource->data() : nullptr;
+    if (!coreData)
+        return @"";
+    return encoding.decode(coreData->makeContiguous()->bytes());
 }
 
 @end

--- a/Tools/TestWebKitAPI/Tests/WebCore/TextCodec.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TextCodec.cpp
@@ -34,9 +34,9 @@ namespace TestWebKitAPI {
 
 // Expects hex bytes with optional spaces between them.
 // Returns an empty vector if it encounters non-hex-digit characters.
-static Vector<char> decodeHexTestBytes(const char* input)
+static Vector<uint8_t> decodeHexTestBytes(const char* input)
 {
-    Vector<char> result;
+    Vector<uint8_t> result;
     for (size_t i = 0; input[i]; ) {
         if (!isASCIIHexDigit(input[i]))
             return { };
@@ -94,7 +94,7 @@ static const char* testDecode(const char* encodingName, std::initializer_list<co
         auto vector = decodeHexTestBytes(inputs.begin()[i]);
         bool last = i == size - 1;
         bool sawError = false;
-        resultBuilder.append(escapeNonASCIIPrintableCharacters(codec->decode(vector.data(), vector.size(), last, false, sawError)));
+        resultBuilder.append(escapeNonASCIIPrintableCharacters(codec->decode(vector.span(), last, false, sawError)));
         if (sawError)
             resultBuilder.append(" ERROR");
     }


### PR DESCRIPTION
#### c6ba4e769fb09334ad7f67d6464f37b0beb7055d
<pre>
Update TextCodec::decode() to take in a std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=271284">https://bugs.webkit.org/show_bug.cgi?id=271284</a>

Reviewed by Darin Adler.

Update TextCodec::decode() to take in a std::span instead of a raw pointer &amp; size.

* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp:
(WebCore::CDMSessionClearKey::generateKeyRequest):
* Source/WebCore/PAL/pal/text/DecodeEscapeSequences.h:
(PAL::URLEscapeSequence::decodeRun):
* Source/WebCore/PAL/pal/text/TextCodec.cpp:
(PAL::TextCodec::decode): Deleted.
* Source/WebCore/PAL/pal/text/TextCodec.h:
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::TextCodecCJK::decodeCommon):
(PAL::TextCodecCJK::eucJPDecode):
(PAL::TextCodecCJK::iso2022JPDecode):
(PAL::TextCodecCJK::shiftJISDecode):
(PAL::TextCodecCJK::eucKRDecode):
(PAL::TextCodecCJK::gb18030Decode):
(PAL::TextCodecCJK::gbkDecode):
(PAL::TextCodecCJK::big5Decode):
(PAL::TextCodecCJK::decode):
* Source/WebCore/PAL/pal/text/TextCodecCJK.h:
* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(PAL::TextCodecICU::decode):
* Source/WebCore/PAL/pal/text/TextCodecICU.h:
* Source/WebCore/PAL/pal/text/TextCodecLatin1.cpp:
(PAL::TextCodecLatin1::decode):
* Source/WebCore/PAL/pal/text/TextCodecLatin1.h:
* Source/WebCore/PAL/pal/text/TextCodecReplacement.cpp:
(PAL::TextCodecReplacement::decode):
* Source/WebCore/PAL/pal/text/TextCodecReplacement.h:
* Source/WebCore/PAL/pal/text/TextCodecSingleByte.cpp:
(PAL::decode):
(PAL::TextCodecSingleByte::decode):
* Source/WebCore/PAL/pal/text/TextCodecSingleByte.h:
* Source/WebCore/PAL/pal/text/TextCodecUTF16.cpp:
(PAL::TextCodecUTF16::decode):
* Source/WebCore/PAL/pal/text/TextCodecUTF16.h:
* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::TextCodecUTF8::decode):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.h:
* Source/WebCore/PAL/pal/text/TextCodecUserDefined.cpp:
(PAL::TextCodecUserDefined::decode):
* Source/WebCore/PAL/pal/text/TextCodecUserDefined.h:
* Source/WebCore/PAL/pal/text/TextEncoding.cpp:
(PAL::TextEncoding::decode const):
* Source/WebCore/PAL/pal/text/TextEncoding.h:
(PAL::TextEncoding::decode const):
* Source/WebCore/PAL/pal/text/win/TextCodecWin.cpp:
(PAL::TextCodecWin::decode):
* Source/WebCore/PAL/pal/text/win/TextCodecWin.h:
* Source/WebCore/dom/TextDecoder.cpp:
(WebCore::TextDecoder::decode):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::decodeBuffer):
(WebCore::InspectorPageAgent::mainResourceContent):
(WebCore::InspectorPageAgent::sharedBufferContent):
(WebCore::InspectorPageAgent::dataContent):
* Source/WebCore/inspector/agents/InspectorPageAgent.h:
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormData::flattenToString const):

Canonical link: <a href="https://commits.webkit.org/276422@main">https://commits.webkit.org/276422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b1b8441d68bc033242d5a43e5145718a0f4fcd5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44597 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23674 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47048 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47253 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [💥 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40603 "An unexpected error occured. Recent messages:Failed to print configuration") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46902 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27714 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21071 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/47253 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45173 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/27714 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/47048 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/47253 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/27714 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/47048 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2650 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/27714 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/47048 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48887 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19552 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/51/builds/21071 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/48887 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20883 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/47048 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/48887 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/9936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21215 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6157 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20550 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | 
<!--EWS-Status-Bubble-End-->