### PR TITLE
[UnifiedPDF] PDF flickers/flashes while zooming

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -108,6 +108,8 @@ public:
     virtual float pageScaleFactor() const { return 1; }
     virtual float zoomedOutPageScaleFactor() const { return 0; }
 
+    virtual std::optional<float> customContentsScale(const GraphicsLayer*) const { return { }; }
+
     virtual float contentsScaleMultiplierForNewTiles(const GraphicsLayer*) const { return 1; }
     virtual bool paintsOpaquelyAtNonIntegralScales(const GraphicsLayer*) const { return false; }
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -4117,6 +4117,9 @@ void GraphicsLayerCA::updateContentsScale(float pageScaleFactor)
         tiledBacking()->setZoomedOutContentsScale(zoomedOutScale);
     }
 
+    if (auto customScale = client().customContentsScale(this))
+        contentsScale = *customScale;
+
     if (contentsScale == m_layer->contentsScale())
         return;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -98,7 +98,9 @@ public:
 
     void setupWithLayer(WebCore::GraphicsLayer&);
     void teardown();
+
     bool paintTilesForPage(WebCore::GraphicsContext&, float documentScale, const WebCore::FloatRect& clipRect, const WebCore::FloatRect& pageBoundsInPaintingCoordinates, PDFDocumentLayout::PageIndex);
+    void paintPagePreview(WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect, const WebCore::FloatRect& pageBoundsInPaintingCoordinates, PDFDocumentLayout::PageIndex);
 
     // Throws away existing tiles. Can result in flashing.
     void invalidateTilesForPaintingRect(float pageScaleFactor, const WebCore::FloatRect& paintingRect);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -369,6 +369,8 @@ private:
     void paintContents(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect&, OptionSet<WebCore::GraphicsLayerPaintBehavior>) override;
     float pageScaleFactor() const override { return scaleFactor(); }
     bool layerNeedsPlatformContext(const WebCore::GraphicsLayer*) const override { return true; }
+    void tiledBackingUsageChanged(const WebCore::GraphicsLayer*, bool /*usingTiledBacking*/) override;
+    std::optional<float> customContentsScale(const WebCore::GraphicsLayer*) const override;
 
     // Package up the data needed to paint a set of pages for the given clip, for use by UnifiedPDFPlugin::paintPDFContent and async rendering.
     PDFPageCoverage pageCoverageForRect(const WebCore::FloatRect& clipRect) const;
@@ -471,14 +473,18 @@ private:
 
     bool shouldShowDebugIndicators() const;
 
+    void paintBackgroundLayerForPage(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect&, PDFDocumentLayout::PageIndex);
+    float scaleForPagePreviews() const;
+    void didGeneratePreviewForPage(PDFDocumentLayout::PageIndex);
+    WebCore::GraphicsLayer* backgroundLayerForPage(PDFDocumentLayout::PageIndex) const;
+    std::optional<PDFDocumentLayout::PageIndex> pageIndexForPageBackgroundLayer(const WebCore::GraphicsLayer*) const;
+
 #if PLATFORM(MAC)
     void createPasswordEntryForm();
 #endif
 
     Ref<AsyncPDFRenderer> asyncRenderer();
     RefPtr<AsyncPDFRenderer> asyncRendererIfExists() const;
-
-    void paintBackgroundLayerForPage(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect&);
 
     PDFDocumentLayout m_documentLayout;
     RefPtr<WebCore::GraphicsLayer> m_rootLayer;
@@ -491,6 +497,8 @@ private:
     RefPtr<WebCore::GraphicsLayer> m_layerForHorizontalScrollbar;
     RefPtr<WebCore::GraphicsLayer> m_layerForVerticalScrollbar;
     RefPtr<WebCore::GraphicsLayer> m_layerForScrollCorner;
+
+    HashMap<RefPtr<WebCore::GraphicsLayer>, PDFDocumentLayout::PageIndex> m_pageBackgroundLayers;
 
     WebCore::ScrollingNodeID m_scrollingNodeID;
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -56,7 +56,7 @@ Ref<PlatformCALayerRemote> PlatformCALayerRemote::create(PlatformCALayer::LayerT
 {
     RefPtr<PlatformCALayerRemote> layer;
 
-    if (layerType == WebCore::PlatformCALayer::LayerType::LayerTypeTiledBackingLayer ||  layerType == WebCore::PlatformCALayer::LayerType::LayerTypePageTiledBackingLayer)
+    if (layerType == WebCore::PlatformCALayer::LayerType::LayerTypeTiledBackingLayer || layerType == WebCore::PlatformCALayer::LayerType::LayerTypePageTiledBackingLayer)
         layer = adoptRef(new PlatformCALayerRemoteTiledBacking(layerType, owner, context));
     else
         layer = adoptRef(new PlatformCALayerRemote(layerType, owner, context));


### PR DESCRIPTION
#### c71e10996782481c1c4e50483cade26d81e001f6
<pre>
[UnifiedPDF] PDF flickers/flashes while zooming
<a href="https://bugs.webkit.org/show_bug.cgi?id=271292">https://bugs.webkit.org/show_bug.cgi?id=271292</a>
<a href="https://rdar.apple.com/122884598">rdar://122884598</a>

Reviewed by Tim Horton.

Change the way we paint the low-resolution page backgrounds so that they reliably appear behind
the PDF tiles when zooming.

Previously, the page previews were only painted in `AsyncPDFRenderer::paintTilesForPage()` if
we&apos;d painted no cached tiles. However, there was no guarantee that the entire rect was covered
in cached tile paints, and &quot;leakage&quot; of repaint rects between tiles (because of GraphicsLayerCA-level
integral rounding) often resulting in painting some strips of tiles around the edges, but not
filling the entire area; this area would remain white (from the white fill painted earlier), hence
flashing.

Conceptually the page preview needs to appear behind cached tiles, and it&apos;s hard to answer the
question &quot;have I filled the given rect with tiles&quot; given floating point drawing coordinates.
We also want to avoid always painting the page previews behind the tiles, for performance.

So instead, display the page previews in the &quot;page background&quot; layers which we already have
and currently just provide a white fill. We need draw the page previews only once; we can just
scale the page background layers as necessary. To avoid repaints on page scale changes, we need
to implement a new GraphicsLayerClient callback that allows us to keep the layer contentsScale
fixed.

The page background layers, and their associated cache buffers are always sized using `layoutBoundsForPageAtIndex()`,
and the buffer scale, and the layer contents scale are determined via `scaleForPagePreviews()`.

The white fill behind the full-resolution PDF content is now painted into the cached buffers.

* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
(WebCore::GraphicsLayerClient::customContentsScale const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::updateContentsScale):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::paintPagePreviewOnWorkQueue):
(WebKit::AsyncPDFRenderer::coverageRectDidChange):
(WebKit::AsyncPDFRenderer::paintPDFIntoBuffer):
(WebKit::AsyncPDFRenderer::paintTilesForPage):
(WebKit::AsyncPDFRenderer::paintPagePreview):
(WebKit::AsyncPDFRenderer::updateTilesForPaintingRect):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updatePageBackgroundLayers):
(WebKit::UnifiedPDFPlugin::paintBackgroundLayerForPage):
(WebKit::UnifiedPDFPlugin::scaleForPagePreviews const):
(WebKit::UnifiedPDFPlugin::didGeneratePreviewForPage):
(WebKit::UnifiedPDFPlugin::backgroundLayerForPage const):
(WebKit::UnifiedPDFPlugin::pageIndexForPageBackgroundLayer const):
(WebKit::UnifiedPDFPlugin::customContentsScale const):
(WebKit::UnifiedPDFPlugin::tiledBackingUsageChanged):
(WebKit::UnifiedPDFPlugin::didChangeIsInWindow):
(WebKit::UnifiedPDFPlugin::paint):
(WebKit::UnifiedPDFPlugin::paintContents):
(WebKit::UnifiedPDFPlugin::paintPDFContent):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::create):

,

Canonical link: <a href="https://commits.webkit.org/276433@main">https://commits.webkit.org/276433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce1f353d2a647b1fda06f1b899f6599afa4d8142

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47181 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40533 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36621 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17685 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18178 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 4 pre-existing failure based on results-db; Uploaded test results (exception)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39470 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2577 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39746 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48801 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43549 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20834 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42296 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9944 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21162 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20488 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->