### PR TITLE
m_propertyVector should be a private member of MutableStyleProperties

### DIFF
--- a/Source/WebCore/css/MutableStyleProperties.h
+++ b/Source/WebCore/css/MutableStyleProperties.h
@@ -85,8 +85,6 @@ public:
     int findPropertyIndex(CSSPropertyID) const;
     int findCustomPropertyIndex(StringView propertyName) const;
 
-    Vector<CSSProperty, 4> m_propertyVector;
-
     // Methods for querying and altering CSS custom properties.
     bool setCustomProperty(const String& propertyName, const String& value, bool important, CSSParserContext);
     bool removeCustomProperty(const String& propertyName, String* returnText = nullptr);
@@ -105,6 +103,8 @@ private:
     bool canUpdateInPlace(const CSSProperty&, CSSProperty* toReplace) const;
 
     friend class StyleProperties;
+
+    Vector<CSSProperty, 4> m_propertyVector;
 };
 
 inline void MutableStyleProperties::deref() const

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1506,13 +1506,11 @@ template<typename T>
 void EditingStyle::removeEquivalentProperties(T& style)
 {
     Vector<CSSPropertyID> propertiesToRemove;
-    for (auto& property : m_mutableStyle->m_propertyVector) {
-        if (style.propertyMatches(property.id(), property.protectedValue().get()))
+    for (auto property : *m_mutableStyle) {
+        if (style.propertyMatches(property.id(), property.value()))
             propertiesToRemove.append(property.id());
     }
-    // FIXME: This should use mass removal.
-    for (auto& property : propertiesToRemove)
-        m_mutableStyle->removeProperty(property);
+    m_mutableStyle->removeProperties(propertiesToRemove.span());
 }
 
 void EditingStyle::forceInline()


### PR DESCRIPTION
#### 4ff86d0b875388092bd08578042ae7c8da246ee9
<pre>
m_propertyVector should be a private member of MutableStyleProperties
<a href="https://bugs.webkit.org/show_bug.cgi?id=271293">https://bugs.webkit.org/show_bug.cgi?id=271293</a>

Reviewed by Simon Fraser.

Made m_propertyVector private to MutableStyleProperties.

* Source/WebCore/css/MutableStyleProperties.h:
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::removeEquivalentProperties):

Canonical link: <a href="https://commits.webkit.org/276386@main">https://commits.webkit.org/276386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82f18ac7ea83bee88403b57d9f1f29c257c06c84

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47182 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40534 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/20998 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17687 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39466 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2578 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48803 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19491 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43548 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42295 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6125 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->