### PR TITLE
Regression: Pages that update their title now get suspended when backgrounded

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -123,7 +123,6 @@ ProcessThrottler::ProcessThrottler(AuxiliaryProcessProxy& process, bool shouldTa
     , m_prepareToSuspendTimeoutTimer(RunLoop::main(), this, &ProcessThrottler::prepareToSuspendTimeoutTimerFired)
     , m_dropNearSuspendedAssertionTimer(RunLoop::main(), this, &ProcessThrottler::dropNearSuspendedAssertionTimerFired)
     , m_prepareToDropLastAssertionTimeoutTimer(RunLoop::main(), this, &ProcessThrottler::prepareToDropLastAssertionTimeoutTimerFired)
-    , m_pageAllowedToRunInTheBackgroundCounter([this](RefCounterEvent) { numberOfPagesAllowedToRunInTheBackgroundChanged(); })
     , m_shouldTakeUIBackgroundAssertion(shouldTakeUIBackgroundAssertion)
 {
 }
@@ -362,10 +361,7 @@ void ProcessThrottler::dropNearSuspendedAssertionTimerFired()
     PROCESSTHROTTLER_RELEASE_LOG("dropNearSuspendedAssertionTimerFired: Removing near-suspended process assertion");
     RELEASE_ASSERT(isHoldingNearSuspendedAssertion());
     ASSERT(m_shouldDropNearSuspendedAssertionAfterDelay);
-    if (m_pageAllowedToRunInTheBackgroundCounter.value())
-        PROCESSTHROTTLER_RELEASE_LOG("dropNearSuspendedAssertionTimerFired: Not releasing near-suspended assertion because a page is allowed to run in the background");
-    else
-        clearAssertion();
+    clearAssertion();
 }
 
 void ProcessThrottler::processReadyToSuspend()
@@ -520,25 +516,6 @@ void ProcessThrottler::clearAssertion()
 Ref<AuxiliaryProcessProxy> ProcessThrottler::protectedProcess() const
 {
     return m_process.get();
-}
-
-PageAllowedToRunInTheBackgroundCounter::Token ProcessThrottler::pageAllowedToRunInTheBackgroundToken()
-{
-    return m_pageAllowedToRunInTheBackgroundCounter.count();
-}
-
-void ProcessThrottler::numberOfPagesAllowedToRunInTheBackgroundChanged()
-{
-    if (m_pageAllowedToRunInTheBackgroundCounter.value())
-        return;
-
-    if (m_dropNearSuspendedAssertionTimer.isActive())
-        return;
-
-    if (isHoldingNearSuspendedAssertion()) {
-        PROCESSTHROTTLER_RELEASE_LOG("numberOfPagesAllowedToRunInTheBackgroundChanged: Releasing near-suspended assertion");
-        clearAssertion();
-    }
 }
 
 bool ProcessThrottler::isSuspended() const

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -50,9 +50,6 @@ enum ProcessSuppressionDisabledCounterType { };
 using ProcessSuppressionDisabledCounter = RefCounter<ProcessSuppressionDisabledCounterType>;
 using ProcessSuppressionDisabledToken = ProcessSuppressionDisabledCounter::Token;
 
-enum PageAllowedToRunInTheBackgroundCounterType { };
-using PageAllowedToRunInTheBackgroundCounter = RefCounter<PageAllowedToRunInTheBackgroundCounterType>;
-
 enum class IsSuspensionImminent : bool { No, Yes };
 enum class ProcessThrottleState : uint8_t { Suspended, Background, Foreground };
 enum class ProcessThrottlerActivityType : bool { Background, Foreground };
@@ -124,11 +121,6 @@ public:
     static bool isValidBackgroundActivity(const ActivityVariant&);
     static bool isValidForegroundActivity(const ActivityVariant&);
 
-    // If any page holds one of these tokens, we will never release the "suspended" assertion which
-    // means that the page will not be suspended when in the background, except if the application
-    // also gets backgrounded.
-    PageAllowedToRunInTheBackgroundCounter::Token pageAllowedToRunInTheBackgroundToken();
-
     using TimedActivity = ProcessThrottlerTimedActivity;
 
     void didConnectToProcess(AuxiliaryProcessProxy&);
@@ -168,7 +160,6 @@ private:
     void assertionWasInvalidated();
 
     void clearPendingRequestToSuspend();
-    void numberOfPagesAllowedToRunInTheBackgroundChanged();
     void clearAssertion();
 
     class ProcessAssertionCache;
@@ -186,7 +177,6 @@ private:
     WeakHashSet<Activity> m_backgroundActivities;
     std::optional<uint64_t> m_pendingRequestToSuspendID;
     ProcessThrottleState m_state { ProcessThrottleState::Suspended };
-    PageAllowedToRunInTheBackgroundCounter m_pageAllowedToRunInTheBackgroundCounter;
     bool m_shouldDropNearSuspendedAssertionAfterDelay { false };
     const bool m_shouldTakeUIBackgroundAssertion { false };
     bool m_shouldTakeNearSuspendedAssertion { true };

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -216,7 +216,7 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     WebCore::IntRect visibleScrollerThumbRect;
     WebCore::PageIdentifier webPageID;
     WindowKind windowKind { WindowKind::Unparented };
-    PageAllowedToRunInTheBackgroundCounter::Token pageAllowedToRunInTheBackgroundToken;
+    std::unique_ptr<ProcessThrottlerActivity> pageAllowedToRunInTheBackgroundActivityDueToTitleChanges;
     std::unique_ptr<ProcessThrottlerActivity> pageAllowedToRunInTheBackgroundActivityDueToNotifications;
 
     WebPageProxyMessageReceiverRegistration messageReceiverRegistration;

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1455,15 +1455,6 @@ void WebProcessProxy::didDestroyUserGestureToken(PageIdentifier pageID, uint64_t
 
 bool WebProcessProxy::canBeAddedToWebProcessCache() const
 {
-#if PLATFORM(IOS_FAMILY)
-    // Don't add the Web process to the cache if there are still assertions being held, preventing it from suspending.
-    // This is a fix for a regression in page load speed we see on http://www.youtube.com when adding it to the cache.
-    if (throttler().shouldBeRunnable()) {
-        WEBPROCESSPROXY_RELEASE_LOG(Process, "canBeAddedToWebProcessCache: Not adding to process cache because the process is runnable");
-        return false;
-    }
-#endif
-
     if (isRunningServiceWorkers()) {
         WEBPROCESSPROXY_RELEASE_LOG(Process, "canBeAddedToWebProcessCache: Not adding to process cache because the process is running workers");
         return false;


### PR DESCRIPTION
#### 7cd42ac1d51cd7b8c245caf7e61f58173017d7f1
<pre>
Regression: Pages that update their title now get suspended when backgrounded
<a href="https://bugs.webkit.org/show_bug.cgi?id=270813">https://bugs.webkit.org/show_bug.cgi?id=270813</a>
<a href="https://rdar.apple.com/124222280">rdar://124222280</a>

Reviewed by Ben Nham.

Pages that update their title now get suspended when backgrounded since we&apos;ve
stopped taking near-suspended assertions on both iOS and macOS. We used to
monitor pages in the background for 8 minutes to see if they update their title
while in the background, if they did, we would let them keep running in the
background.

Since we no longer take near-suspended assertions, we can no longer observe
pages in the background (since they&apos;d get suspended as soon as backgrounded).
To address the issue, we now monitor title changes while in the foreground. If
the page updates its title, we now take a background assertion to let it keep
running after backgrounding.

This is not perfect but this addresses the regression for now. We should
revisit though because this is too permissive. Maybe we only want to consider
title changes without recent user interaction for e.g.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::ProcessThrottler):
(WebKit::ProcessThrottler::dropNearSuspendedAssertionTimerFired):
(WebKit::m_shouldTakeUIBackgroundAssertion): Deleted.
(WebKit::ProcessThrottler::pageAllowedToRunInTheBackgroundToken): Deleted.
(WebKit::ProcessThrottler::numberOfPagesAllowedToRunInTheBackgroundChanged): Deleted.
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didFailLoadForFrame):
(WebKit::WebPageProxy::hasAllowedToRunInTheBackgroundActivity const):
(WebKit::WebPageProxy::didReceiveTitleForFrame):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::canBeAddedToWebProcessCache const):

Canonical link: <a href="https://commits.webkit.org/276418@main">https://commits.webkit.org/276418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e4d293bb0a35c0d2cfdcdab50d9c466016a2917

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47191 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40543 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36630 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17698 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18190 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 4 pre-existing failure based on results-db; Uploaded test results (exception)") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2587 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48843 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43583 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20842 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42336 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21170 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6153 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->