### PR TITLE
[iOS] Entering fullscreen from iframe without explicit viewport results in badly cropped video

### DIFF
--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -319,6 +319,8 @@ void WebFullScreenManager::willEnterFullScreen(WebCore::HTMLMediaElementEnums::V
 
     ALWAYS_LOG(LOGIDENTIFIER, "<", m_element->tagName(), " id=\"", m_element->getIdAttribute(), "\">");
 
+    m_page->isInFullscreenChanged(WebPage::IsInFullscreenMode::Yes);
+
     if (!m_element->document().fullscreenManager().willEnterFullscreen(*m_element, mode)) {
         close();
         return;
@@ -328,8 +330,6 @@ void WebFullScreenManager::willEnterFullScreen(WebCore::HTMLMediaElementEnums::V
         close();
         return;
     }
-
-    m_page->isInFullscreenChanged(WebPage::IsInFullscreenMode::Yes);
 
 #if !PLATFORM(IOS_FAMILY)
     m_page->hidePageBanners();


### PR DESCRIPTION
#### db57a9aa346bded84559a78247d35ad528795990
<pre>
[iOS] Entering fullscreen from iframe without explicit viewport results in badly cropped video
<a href="https://bugs.webkit.org/show_bug.cgi?id=270909">https://bugs.webkit.org/show_bug.cgi?id=270909</a>
<a href="https://rdar.apple.com/123725878">rdar://123725878</a>

Reviewed by Eric Carlson.

Follow-up fix to 276138@main: resetViewportDefaultConfiguration() will not trigger viewportDidChange(),
and therefore calling those methods in that order can leave the calculated viewport in an inconsistent state.
Instead, ensure resetViewportDefaultConfiguration() is called before viewportDidChange() by calling
isInFullscreenChanged() before willEnterFullscreen().

* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::willEnterFullScreen):

Canonical link: <a href="https://commits.webkit.org/276427@main">https://commits.webkit.org/276427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3aceb55792ced153df892ddff5c703a6a941f3c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/46989 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47192 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40544 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36631 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17699 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18114 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2588 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40736 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48816 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43564 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20843 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42323 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9939 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21171 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->