### PR TITLE
Add more smart pointers to accessibility

### DIFF
--- a/Source/WebCore/accessibility/AXGeometryManager.cpp
+++ b/Source/WebCore/accessibility/AXGeometryManager.cpp
@@ -125,7 +125,7 @@ void AXGeometryManager::scheduleRenderingUpdate()
     if (!m_cache)
         return;
 
-    if (auto* page = m_cache->document().page())
+    if (RefPtr page = m_cache->document().page())
         page->scheduleRenderingUpdate(RenderingUpdateStep::AccessibilityRegionUpdate);
 }
 

--- a/Source/WebCore/accessibility/AccessibilityList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityList.cpp
@@ -100,7 +100,7 @@ bool AccessibilityList::childHasPseudoVisibleListItemMarkers(Node* node)
 {
     // Check if the list item has a pseudo-element that should be accessible (e.g. an image or text)
     auto* element = dynamicDowncast<Element>(node);
-    auto* beforePseudo = element ? element->beforePseudoElement() : nullptr;
+    RefPtr beforePseudo = element ? element->beforePseudoElement() : nullptr;
     if (!beforePseudo)
         return false;
 
@@ -157,6 +157,7 @@ AccessibilityRole AccessibilityList::determineAccessibilityRole()
         return AccessibilityRole::DescriptionList;
 
     for (const auto& child : children) {
+        RefPtr node = child->node();
         auto* axChild = dynamicDowncast<AccessibilityObject>(child.get());
         if (axChild && axChild->ariaRoleAttribute() == AccessibilityRole::ListItem)
             listItemCount++;
@@ -166,12 +167,12 @@ AccessibilityRole AccessibilityList::determineAccessibilityRole()
                 if (!hasVisibleMarkers && (childRenderer->style().listStyleType().type != ListStyleType::Type::None || childRenderer->style().listStyleImage() || childHasPseudoVisibleListItemMarkers(childRenderer->node())))
                     hasVisibleMarkers = true;
                 listItemCount++;
-            } else if (child->node() && child->node()->hasTagName(liTag)) {
+            } else if (node && node->hasTagName(liTag)) {
                 // Inline elements that are in a list with an explicit role should also count.
                 if (m_ariaRole == AccessibilityRole::List)
                     listItemCount++;
 
-                if (childHasPseudoVisibleListItemMarkers(child->node())) {
+                if (childHasPseudoVisibleListItemMarkers(node.get())) {
                     hasVisibleMarkers = true;
                     listItemCount++;
                 }

--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
@@ -58,13 +58,13 @@ String AccessibilityProgressIndicator::valueDescription() const
     if (!description.isEmpty())
         return description;
 
-    auto* meter = meterElement();
+    RefPtr meter = meterElement();
     if (!meter)
         return description;
 
     // The HTML spec encourages authors to include a textual representation of the meter's state in
     // the element's contents. We'll fall back on that if there is not a more accessible alternative.
-    if (auto* nodeObject = dynamicDowncast<AccessibilityNodeObject>(axObjectCache()->getOrCreate(meter)))
+    if (auto* nodeObject = dynamicDowncast<AccessibilityNodeObject>(axObjectCache()->getOrCreate(meter.get())))
         description = nodeObject->accessibilityDescriptionForChildren();
 
     if (description.isEmpty())


### PR DESCRIPTION
#### 993b0f2b6cd6519ab36bd5a2212029303baa0802
<pre>
Add more smart pointers to accessibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=271297">https://bugs.webkit.org/show_bug.cgi?id=271297</a>
<a href="https://rdar.apple.com/125063164">rdar://125063164</a>

Reviewed by Tim Nguyen.

* Source/WebCore/accessibility/AXGeometryManager.cpp:
(WebCore::AXGeometryManager::scheduleRenderingUpdate):
* Source/WebCore/accessibility/AccessibilityList.cpp:
(WebCore::AccessibilityList::childHasPseudoVisibleListItemMarkers):
(WebCore::AccessibilityList::determineAccessibilityRole):
* Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp:
(WebCore::AccessibilityProgressIndicator::valueDescription const):

Canonical link: <a href="https://commits.webkit.org/276442@main">https://commits.webkit.org/276442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba0be07eea1cc5d9aa1380e53b3b982603a6a567

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47084 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47284 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40636 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36706 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18218 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39555 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2678 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40847 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48920 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43648 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20915 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42395 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9954 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21251 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20583 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->