### PR TITLE
Images in image-set are not saved when saving web page resources

### DIFF
--- a/Source/WebCore/css/CSSImageSetOptionValue.cpp
+++ b/Source/WebCore/css/CSSImageSetOptionValue.cpp
@@ -98,4 +98,21 @@ void CSSImageSetOptionValue::setType(String type)
     m_mimeType = WTFMove(type);
 }
 
+bool CSSImageSetOptionValue::customTraverseSubresources(const Function<bool(const CachedResource&)>& handler) const
+{
+    return m_resolution->traverseSubresources(handler) || m_image->traverseSubresources(handler);
+}
+
+void CSSImageSetOptionValue::customSetReplacementURLForSubresources(const HashMap<String, String>& replacementURLStrings)
+{
+    m_image->setReplacementURLForSubresources(replacementURLStrings);
+    m_resolution->setReplacementURLForSubresources(replacementURLStrings);
+}
+
+void CSSImageSetOptionValue::customClearReplacementURLForSubresources()
+{
+    m_image->clearReplacementURLForSubresources();
+    m_resolution->clearReplacementURLForSubresources();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImageSetOptionValue.h
+++ b/Source/WebCore/css/CSSImageSetOptionValue.h
@@ -57,6 +57,9 @@ public:
             return IterationStatus::Done;
         return IterationStatus::Continue;
     }
+    bool customTraverseSubresources(const Function<bool(const CachedResource&)>&) const;
+    void customSetReplacementURLForSubresources(const HashMap<String, String>&);
+    void customClearReplacementURLForSubresources();
 
 private:
     CSSImageSetOptionValue(Ref<CSSValue>&&, Ref<CSSPrimitiveValue>&&);


### PR DESCRIPTION
#### 501aaeb2c61bc0727df5a1dc03b314f689718c9e
<pre>
Images in image-set are not saved when saving web page resources
<a href="https://bugs.webkit.org/show_bug.cgi?id=271299">https://bugs.webkit.org/show_bug.cgi?id=271299</a>
<a href="https://rdar.apple.com/problem/125064898">rdar://problem/125064898</a>

Reviewed by Ryosuke Niwa.

CSSImageSetOptionValue has two enclosed CSSValues (one of which is a CSSImageValue) that do not get visited by custom
functions. As a result, the subresource is not collected and URL is not replaced when web page is saved. To fix this,
add implementation for the custom functions in CSSImageSetOptionValue.

* Source/WebCore/css/CSSImageSetOptionValue.cpp:
(WebCore::CSSImageSetOptionValue::customTraverseSubresources const):
(WebCore::CSSImageSetOptionValue::customSetReplacementURLForSubresources):
(WebCore::CSSImageSetOptionValue::customClearReplacementURLForSubresources):
* Source/WebCore/css/CSSImageSetOptionValue.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CreateWebArchive.mm:

Canonical link: <a href="https://commits.webkit.org/276472@main">https://commits.webkit.org/276472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c23fedf4386a59c102264ec420ec805d1e854d77

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44557 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47240 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40557 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21024 "Built successfully") | [💥 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36678 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Exiting early after 500 failures. 500 tests run. 1 flakes 500 failures; Uploaded test results (exception)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38350 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17735 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39495 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2604 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40805 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39772 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48834 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16047 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43575 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20851 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42328 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9948 "") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21179 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6192 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->