### PR TITLE
[view-transitions] Fix white flash on certain demos

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6922,7 +6922,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/new-content-scaling.htm
 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-with-object-view-box.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/object-view-box-new-image.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/object-view-box-old-image.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/old-content-captures-different-size.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/old-content-intrinsic-aspect-ratio.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/old-content-with-overflow-zoomed.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/root-captured-as-different-tag.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+<body style="background-color: #000;"></body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+<body style="background-color: #000;"></body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <title>View Transitions: No white flash should be visible during the duration of the update callback</title>
+    <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/#ref-for-captured-in-a-view-transition">
+    <link rel="match" href="no-white-flash-before-activation-ref.html">
+    <style>
+        body {
+            margin: 0;
+        }
+        div {
+            width: 100vw;
+            height: 100vh;
+            background-color: #000;
+        }
+    </style>
+</head>
+<body>
+    <div></div>
+    <script>
+        window.addEventListener("load", () => {
+            document.startViewTransition(() => {
+                requestAnimationFrame(() => document.documentElement.classList.remove("reftest-wait"));
+                return new Promise(() => {});
+            });
+        });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -773,6 +773,9 @@ public:
     bool hasCustomState(const AtomString& state) const;
     CustomStateSet& ensureCustomStateSet();
 
+    bool capturedInViewTransition() const { return hasEventTargetFlag(EventTargetFlag::CapturedInViewTransition); }
+    void setCapturedInViewTransition(bool captured) { setEventTargetFlag(EventTargetFlag::CapturedInViewTransition, captured); }
+
 protected:
     Element(const QualifiedName&, Document&, OptionSet<TypeFlag>);
 

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -202,9 +202,9 @@ protected:
         HasFormAssociatedCustomElementInterface = 1 << 11,
         HasShadowRootContainingSlots = 1 << 12,
         IsInTopLayer = 1 << 13,
+        CapturedInViewTransition = 1 << 14,
         // SVGElement bits
-        HasPendingResources = 1 << 14,
-        // 1 Free bits
+        HasPendingResources = 1 << 15,
     };
 
     EventTargetData& ensureEventTargetData()

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2068,7 +2068,7 @@ bool RenderElement::capturedInViewTransition() const
     if (!hasViewTransitionName())
         return false;
 
-    return !!document().activeViewTransition();
+    return element() && element()->capturedInViewTransition();
 }
 
 bool RenderElement::hasViewTransitionName() const


### PR DESCRIPTION
#### 1a69a06fefcb4f147bce55072b5346aedc75d170
<pre>
[view-transitions] Fix white flash on certain demos
<a href="https://bugs.webkit.org/show_bug.cgi?id=270146">https://bugs.webkit.org/show_bug.cgi?id=270146</a>
<a href="https://rdar.apple.com/123668861">rdar://123668861</a>

Reviewed by Matt Woodrow.

The white flash was caused by the definition of `RenderElement::capturedInViewTransition` leading to the original element layers being hidden too early before the pseudo-elements are even shown.

To fix this, update the definition of capturedInViewTransition to match exactly what the spec specifies:

<a href="https://drafts.csswg.org/css-view-transitions-1/#ref-for-captured-in-a-view-transition">https://drafts.csswg.org/css-view-transitions-1/#ref-for-captured-in-a-view-transition</a>

This also ensures that we only move element layers for content that was successfully captured as opposed to anything with a view-transition-name.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation.html: Added.
* Source/WebCore/dom/Element.h:
(WebCore::Element::capturedInViewTransition const):
(WebCore::Element::setCapturedInViewTransition):
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::activateViewTransition):
(WebCore::ViewTransition::clearViewTransition):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::capturedInViewTransition const):

Canonical link: <a href="https://commits.webkit.org/276396@main">https://commits.webkit.org/276396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/693c56f36bb270d7410531a085ad4a7020c8aac6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47213 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40559 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21028 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38353 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17715 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39498 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2607 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48838 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16050 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42330 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6130 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->