### PR TITLE
Crash under UniqueIDBDatabaseTransaction::commit

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -182,7 +182,7 @@ private:
 
     Ref<IDBRequest> requestIndexRecord(IDBIndex&, IndexedDB::IndexRecordType, const IDBKeyRangeData&);
 
-    void commitOnServer(IDBClient::TransactionOperation&, uint64_t pendingRequestCount);
+    void commitOnServer(IDBClient::TransactionOperation&, uint64_t handledRequestResultsCount);
     void abortOnServerAndCancelRequests(IDBClient::TransactionOperation&);
 
     void createObjectStoreOnServer(IDBClient::TransactionOperation&, const IDBObjectStoreInfo&);
@@ -269,6 +269,7 @@ private:
     uint64_t m_lastWriteOperationID { 0 };
     std::optional<IDBResourceIdentifier> m_lastTransactionOperationBeforeCommit;
     std::optional<IDBError> m_commitResult;
+    uint64_t m_handledRequestResultsCount { 0 };
 };
 
 class TransactionActivator {

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -346,7 +346,7 @@ void IDBConnectionProxy::didStartTransaction(const IDBResourceIdentifier& transa
     transaction->performCallbackOnOriginThread(*transaction, &IDBTransaction::didStart, error);
 }
 
-void IDBConnectionProxy::commitTransaction(IDBTransaction& transaction, uint64_t pendingRequestCount)
+void IDBConnectionProxy::commitTransaction(IDBTransaction& transaction, uint64_t handledRequestResultsCount)
 {
     {
         Locker locker { m_transactionMapLock };
@@ -354,7 +354,7 @@ void IDBConnectionProxy::commitTransaction(IDBTransaction& transaction, uint64_t
         m_committingTransactions.set(transaction.info().identifier(), &transaction);
     }
 
-    callConnectionOnMainThread(&IDBConnectionToServer::commitTransaction, transaction.info().identifier(), pendingRequestCount);
+    callConnectionOnMainThread(&IDBConnectionToServer::commitTransaction, transaction.info().identifier(), handledRequestResultsCount);
 }
 
 void IDBConnectionProxy::didCommitTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError& error)

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -92,7 +92,7 @@ public:
     void openDBRequestCancelled(const IDBOpenRequestData&);
 
     void establishTransaction(IDBTransaction&);
-    void commitTransaction(IDBTransaction&, uint64_t pendingRequestCount);
+    void commitTransaction(IDBTransaction&, uint64_t handledRequestResultsCount);
     void abortTransaction(IDBTransaction&);
 
     void didStartTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError&);

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
@@ -357,13 +357,13 @@ void IDBConnectionToServer::establishTransaction(IDBDatabaseConnectionIdentifier
         m_delegate->establishTransaction(databaseConnectionIdentifier, info);
 }
 
-void IDBConnectionToServer::commitTransaction(const IDBResourceIdentifier& transactionIdentifier, uint64_t pendingRequestCount)
+void IDBConnectionToServer::commitTransaction(const IDBResourceIdentifier& transactionIdentifier, uint64_t handledRequestResultsCount)
 {
     LOG(IndexedDB, "IDBConnectionToServer::commitTransaction");
     ASSERT(isMainThread());
 
     if (m_serverConnectionIsValid)
-        m_delegate->commitTransaction(transactionIdentifier, pendingRequestCount);
+        m_delegate->commitTransaction(transactionIdentifier, handledRequestResultsCount);
     else {
         callOnMainThread([this, protectedThis = Ref { *this }, transactionIdentifier] {
             didCommitTransaction(transactionIdentifier, IDBError::serverConnectionLostError());

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
@@ -110,7 +110,7 @@ public:
     void iterateCursor(const IDBRequestData&, const IDBIterateCursorData&);
     WEBCORE_EXPORT void didIterateCursor(const IDBResultData&);
 
-    void commitTransaction(const IDBResourceIdentifier& transactionIdentifier, uint64_t pendingRequestCount);
+    void commitTransaction(const IDBResourceIdentifier& transactionIdentifier, uint64_t handledRequestResultsCount);
     WEBCORE_EXPORT void didCommitTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError&);
 
     void didFinishHandlingVersionChangeTransaction(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier&);

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h
@@ -64,7 +64,7 @@ public:
     virtual void deleteDatabase(const IDBOpenRequestData&) = 0;
     virtual void openDatabase(const IDBOpenRequestData&) = 0;
     virtual void abortTransaction(const IDBResourceIdentifier&) = 0;
-    virtual void commitTransaction(const IDBResourceIdentifier&, uint64_t pendingRequestCount) = 0;
+    virtual void commitTransaction(const IDBResourceIdentifier&, uint64_t handledRequestResultsCount) = 0;
     virtual void didFinishHandlingVersionChangeTransaction(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier&) = 0;
     virtual void createObjectStore(const IDBRequestData&, const IDBObjectStoreInfo&) = 0;
     virtual void deleteObjectStore(const IDBRequestData&, const String& objectStoreName) = 0;

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
@@ -396,7 +396,7 @@ void IDBServer::establishTransaction(IDBDatabaseConnectionIdentifier databaseCon
         m_uniqueIDBDatabaseMap.remove(database->identifier());
 }
 
-void IDBServer::commitTransaction(const IDBResourceIdentifier& transactionIdentifier, uint64_t pendingRequestCount)
+void IDBServer::commitTransaction(const IDBResourceIdentifier& transactionIdentifier, uint64_t handledRequestResultsCount)
 {
     LOG(IndexedDB, "IDBServer::commitTransaction");
     ASSERT(!isMainThread());
@@ -409,7 +409,7 @@ void IDBServer::commitTransaction(const IDBResourceIdentifier& transactionIdenti
         return;
     }
 
-    transaction->commit(pendingRequestCount);
+    transaction->commit(handledRequestResultsCount);
 }
 
 void IDBServer::didFinishHandlingVersionChangeTransaction(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const IDBResourceIdentifier& transactionIdentifier)

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.h
@@ -60,7 +60,7 @@ public:
     WEBCORE_EXPORT void openDatabase(const IDBOpenRequestData&);
     WEBCORE_EXPORT void deleteDatabase(const IDBOpenRequestData&);
     WEBCORE_EXPORT void abortTransaction(const IDBResourceIdentifier&);
-    WEBCORE_EXPORT void commitTransaction(const IDBResourceIdentifier&, uint64_t pendingRequestCount);
+    WEBCORE_EXPORT void commitTransaction(const IDBResourceIdentifier&, uint64_t handledRequestResultsCount);
     WEBCORE_EXPORT void didFinishHandlingVersionChangeTransaction(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier&);
     WEBCORE_EXPORT void createObjectStore(const IDBRequestData&, const IDBObjectStoreInfo&);
     WEBCORE_EXPORT void renameObjectStore(const IDBRequestData&, uint64_t objectStoreIdentifier, const String& newName);

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -98,7 +98,7 @@ public:
     void deleteRecord(const IDBRequestData&, const IDBKeyRangeData&, ErrorCallback, SpaceCheckResult = SpaceCheckResult::Unknown);
     void openCursor(const IDBRequestData&, const IDBCursorInfo&, GetResultCallback, SpaceCheckResult = SpaceCheckResult::Unknown);
     void iterateCursor(const IDBRequestData&, const IDBIterateCursorData&, GetResultCallback, SpaceCheckResult = SpaceCheckResult::Unknown);
-    void commitTransaction(UniqueIDBDatabaseTransaction&, ErrorCallback, SpaceCheckResult = SpaceCheckResult::Unknown);
+    void commitTransaction(UniqueIDBDatabaseTransaction&, uint64_t handledRequestResultsCount, ErrorCallback, SpaceCheckResult = SpaceCheckResult::Unknown);
     void abortTransaction(UniqueIDBDatabaseTransaction&, ErrorCallback, SpaceCheckResult = SpaceCheckResult::Unknown);
 
     void didFinishHandlingVersionChange(UniqueIDBDatabaseConnection&, const IDBResourceIdentifier& transactionIdentifier);

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
@@ -117,7 +117,20 @@ bool UniqueIDBDatabaseTransaction::isReadOnly() const
     return m_transactionInfo.mode() == IDBTransactionMode::Readonly;
 }   
 
-void UniqueIDBDatabaseTransaction::commit(uint64_t pendingRequestCount)
+bool UniqueIDBDatabaseTransaction::shouldAbortDueToUnhandledRequestError(uint64_t handledRequestResultsCount) const
+{
+    if (handledRequestResultsCount > m_requestResults.size()) {
+        RELEASE_LOG_ERROR(IndexedDB, "%p - UniqueIDBDatabaseTransaction::shouldAbortDueToUnhandledRequestError: finished request count (%" PRIu64 ") is bigger than total request count %zu", this, handledRequestResultsCount, m_requestResults.size());
+        return false;
+    }
+
+    auto pendingRequestResults = m_requestResults.subspan(handledRequestResultsCount);
+    return WTF::anyOf(pendingRequestResults, [&] (auto& error) {
+        return !error.isNull();
+    });
+}
+
+void UniqueIDBDatabaseTransaction::commit(uint64_t handledRequestResultsCount)
 {
     LOG(IndexedDB, "UniqueIDBDatabaseTransaction::commit");
 
@@ -125,26 +138,7 @@ void UniqueIDBDatabaseTransaction::commit(uint64_t pendingRequestCount)
     if (!database)
         return;
 
-    std::optional<IDBError> errorInPendingRequests;
-    while (pendingRequestCount--) {
-        auto error = m_requestResults.takeLast();
-        if (!error.isNull()) {
-            errorInPendingRequests = error;
-            break;
-        }
-    }
-
-    if (errorInPendingRequests) {
-        database->abortTransaction(*this, [this, weakThis = WeakPtr { *this }, &errorInPendingRequests](auto&) {
-            LOG(IndexedDB, "UniqueIDBDatabaseTransaction::commit with error (callback)");
-
-            if (weakThis && m_databaseConnection)
-                m_databaseConnection->didCommitTransaction(*this, *errorInPendingRequests);
-        });
-        return;
-    }
-
-    database->commitTransaction(*this, [this, weakThis = WeakPtr { *this }](auto& error) {
+    database->commitTransaction(*this, handledRequestResultsCount, [this, weakThis = WeakPtr { *this }](auto& error) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::commit (callback)");
 
         if (weakThis && m_databaseConnection)
@@ -168,8 +162,6 @@ void UniqueIDBDatabaseTransaction::createObjectStore(const IDBRequestData& reque
 
         if (!weakThis || !m_databaseConnection)
             return;
-
-        m_requestResults.append(error);
 
         if (error.isNull())
             m_databaseConnection->didCreateObjectStore(IDBResultData::createObjectStoreSuccess(requestData.requestIdentifier()));
@@ -221,8 +213,6 @@ void UniqueIDBDatabaseTransaction::renameObjectStore(const IDBRequestData& reque
         if (!weakThis || !m_databaseConnection)
             return;
 
-        m_requestResults.append(error);
-
         if (error.isNull())
             m_databaseConnection->didRenameObjectStore(IDBResultData::renameObjectStoreSuccess(requestData.requestIdentifier()));
         else
@@ -272,8 +262,6 @@ void UniqueIDBDatabaseTransaction::createIndex(const IDBRequestData& requestData
         if (!weakThis || !m_databaseConnection)
             return;
 
-        m_requestResults.append(error);
-
         if (error.isNull())
             m_databaseConnection->didCreateIndex(IDBResultData::createIndexSuccess(requestData.requestIdentifier()));
         else
@@ -298,8 +286,6 @@ void UniqueIDBDatabaseTransaction::deleteIndex(const IDBRequestData& requestData
         if (!weakThis || !m_databaseConnection)
             return;
 
-        m_requestResults.append(error);
-
         if (error.isNull())
             m_databaseConnection->didDeleteIndex(IDBResultData::deleteIndexSuccess(requestData.requestIdentifier()));
         else
@@ -323,8 +309,6 @@ void UniqueIDBDatabaseTransaction::renameIndex(const IDBRequestData& requestData
 
         if (!weakThis || !m_databaseConnection)
             return;
-
-        m_requestResults.append(error);
 
         if (error.isNull())
             m_databaseConnection->didRenameIndex(IDBResultData::renameIndexSuccess(requestData.requestIdentifier()));

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
@@ -68,7 +68,8 @@ public:
 
     WEBCORE_EXPORT void abort();
     WEBCORE_EXPORT void abortWithoutCallback();
-    WEBCORE_EXPORT void commit(uint64_t pendingRequestCount);
+    bool shouldAbortDueToUnhandledRequestError(uint64_t handledRequestResultsCount) const;
+    WEBCORE_EXPORT void commit(uint64_t handledRequestResultsCount);
 
     WEBCORE_EXPORT void createObjectStore(const IDBRequestData&, const IDBObjectStoreInfo&);
     WEBCORE_EXPORT void deleteObjectStore(const IDBRequestData&, const String& objectStoreName);
@@ -103,7 +104,7 @@ private:
     Vector<uint64_t> m_objectStoreIdentifiers;
 
     std::optional<IDBError> m_suspensionAbortResult;
-    Deque<IDBError> m_requestResults;
+    Vector<IDBError> m_requestResults;
 };
 
 } // namespace IDBServer

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1485,10 +1485,10 @@ void NetworkStorageManager::abortTransaction(const WebCore::IDBResourceIdentifie
         transaction->abort();
 }
 
-void NetworkStorageManager::commitTransaction(const WebCore::IDBResourceIdentifier& transactionIdentifier, uint64_t pendingRequestCount)
+void NetworkStorageManager::commitTransaction(const WebCore::IDBResourceIdentifier& transactionIdentifier, uint64_t handledRequestResultsCount)
 {
     if (auto transaction = m_idbStorageRegistry->transaction(transactionIdentifier))
-        transaction->commit(pendingRequestCount);
+        transaction->commit(handledRequestResultsCount);
 }
 
 void NetworkStorageManager::didFinishHandlingVersionChangeTransaction(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& transactionIdentifier)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -191,7 +191,7 @@ private:
     void abortOpenAndUpgradeNeeded(WebCore::IDBDatabaseConnectionIdentifier, const std::optional<WebCore::IDBResourceIdentifier>& transactionIdentifier);
     void didFireVersionChangeEvent(WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer);
     void abortTransaction(const WebCore::IDBResourceIdentifier&);
-    void commitTransaction(const WebCore::IDBResourceIdentifier&, uint64_t pendingRequestCount);
+    void commitTransaction(const WebCore::IDBResourceIdentifier&, uint64_t handledRequestResultsCount);
     void didFinishHandlingVersionChangeTransaction(WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBResourceIdentifier&);
     void createObjectStore(const WebCore::IDBRequestData&, const WebCore::IDBObjectStoreInfo&);
     void deleteObjectStore(const WebCore::IDBRequestData&, const String& objectStoreName);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -61,7 +61,7 @@
     DidFireVersionChangeEvent(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, WebCore::IDBResourceIdentifier requestIdentifier, WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer connectionClosedOnBehalfOfServer)
     DidFinishHandlingVersionChangeTransaction(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, WebCore::IDBResourceIdentifier transactionIdentifier)
     AbortTransaction(WebCore::IDBResourceIdentifier transactionIdentifier)
-    CommitTransaction(WebCore::IDBResourceIdentifier transactionIdentifier, uint64_t pendingRequestCount)
+    CommitTransaction(WebCore::IDBResourceIdentifier transactionIdentifier, uint64_t handledRequestResultsCount)
     CreateObjectStore(WebCore::IDBRequestData requestData, WebCore::IDBObjectStoreInfo info)
     DeleteObjectStore(WebCore::IDBRequestData requestData, String objectStoreName)
     RenameObjectStore(WebCore::IDBRequestData requestData, uint64_t objectStoreIdentifier, String newName)

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
@@ -95,9 +95,9 @@ void WebIDBConnectionToServer::abortTransaction(const IDBResourceIdentifier& tra
     send(Messages::NetworkStorageManager::AbortTransaction(transactionIdentifier));
 }
 
-void WebIDBConnectionToServer::commitTransaction(const IDBResourceIdentifier& transactionIdentifier, uint64_t pendingRequestCount)
+void WebIDBConnectionToServer::commitTransaction(const IDBResourceIdentifier& transactionIdentifier, uint64_t handledRequestResultsCount)
 {
-    send(Messages::NetworkStorageManager::CommitTransaction(transactionIdentifier, pendingRequestCount));
+    send(Messages::NetworkStorageManager::CommitTransaction(transactionIdentifier, handledRequestResultsCount));
 }
 
 void WebIDBConnectionToServer::didFinishHandlingVersionChangeTransaction(IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const IDBResourceIdentifier& transactionIdentifier)

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
@@ -55,7 +55,7 @@ private:
     void deleteDatabase(const WebCore::IDBOpenRequestData&) final;
     void openDatabase(const WebCore::IDBOpenRequestData&) final;
     void abortTransaction(const WebCore::IDBResourceIdentifier&) final;
-    void commitTransaction(const WebCore::IDBResourceIdentifier&, uint64_t pendingRequestCount) final;
+    void commitTransaction(const WebCore::IDBResourceIdentifier&, uint64_t handledRequestResultsCount) final;
     void didFinishHandlingVersionChangeTransaction(WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBResourceIdentifier&) final;
     void createObjectStore(const WebCore::IDBRequestData&, const WebCore::IDBObjectStoreInfo&) final;
     void deleteObjectStore(const WebCore::IDBRequestData&, const String& objectStoreName) final;


### PR DESCRIPTION
#### a2fdb85c4c4a5bfba20550813bc8dfb7b7691b3a
<pre>
Crash under UniqueIDBDatabaseTransaction::commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=271300">https://bugs.webkit.org/show_bug.cgi?id=271300</a>
<a href="https://rdar.apple.com/114552467">rdar://114552467</a>

Reviewed by Per Arne Vollan and Chris Dumez.

From crash reports, we know UniqueIDBDatabaseTransaction tries to take item from m_requestResults while it is empty,
which means pendingRequestCount is bigger than the size of m_requestResults. In current implementation, the parameter
pendingRequestCount indicates the number of request that client has not received result when submitting transaction
commit. UniqueIDBDatabaseTransaction will search whether there is an error in the last pendingRequestCount results
before submitting the commit operation to database. If there is no error, it asks database to commit transaction; if
there is an error, it asks database to abort the transaction as the error is not handled by client.

Chris pointed out an issue that m_requestResults is updated after async quota check in UniqueIDBDatabase, while
searching error in m_requestResults happens before the async quota check, which can be a direct cause to this issue.
To fix that, this patch moves the check (UniqueIDBDatabaseTransaction::shouldAbortDueToUnhandledRequestError) to inside
UniqueIDBDatabase::commitTransaction and after quota check. This guarantees the search happens after all requests
complete.

There are two other problems. One is that client is using the number of unfinished requests as pendingRequestCount and
server is recording all request results in m_requestResults, but one request may generate multiple results (e.g. a
cursor request could generate one result for each advancing operation). The patch fixes this by making client track
count of handled request results (IDBTransaction::m_handledRequestResultsCount) and pass thatto server. Another is that
certain operations (like createObjectStore) are not associated with request, so their result should not be put in
m_requestResults. This patch fixes that by removing the calls in UniqueIDBDatabaseTransaction.

* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::finishedDispatchEventForRequest):
(WebCore::IDBTransaction::commitInternal):
(WebCore::IDBTransaction::commitOnServer):
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp:
(WebCore::IDBClient::IDBConnectionProxy::commitTransaction):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp:
(WebCore::IDBClient::IDBConnectionToServer::commitTransaction):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h:
* Source/WebCore/Modules/indexeddb/server/IDBServer.cpp:
(WebCore::IDBServer::IDBServer::commitTransaction):
* Source/WebCore/Modules/indexeddb/server/IDBServer.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::commitTransaction):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::shouldAbortDueToUnhandledRequestError const):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::commit):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::createObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::renameObjectStore):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::createIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::deleteIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::renameIndex):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::commitTransaction):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp:
(WebKit::WebIDBConnectionToServer::commitTransaction):
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h:

Canonical link: <a href="https://commits.webkit.org/276489@main">https://commits.webkit.org/276489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4ee111d5eb1da4236f984a0c1beb7770ac270a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40792 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21277 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38582 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39717 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2834 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40008 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49102 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16325 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42534 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9980 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20747 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->