### PR TITLE
[WebGPU] Textures with size greater than 4096 are not cleared correctly

### DIFF
--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -65,6 +65,7 @@ public:
 
     static uint32_t texelBlockWidth(WGPUTextureFormat); // Texels
     static uint32_t texelBlockHeight(WGPUTextureFormat); // Texels
+    static NSUInteger bytesPerRow(WGPUTextureFormat, uint32_t textureWidth);
     // For depth-stencil textures, the input value to texelBlockSize()
     // needs to be the output of aspectSpecificFormat().
     static uint32_t texelBlockSize(WGPUTextureFormat); // Bytes

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2141,6 +2141,18 @@ MTLPixelFormat Texture::pixelFormat(WGPUTextureFormat textureFormat)
     }
 }
 
+NSUInteger Texture::bytesPerRow(WGPUTextureFormat format, uint32_t textureWidth)
+{
+    NSUInteger blockSize = Texture::texelBlockSize(format);
+    NSUInteger blockWidth = Texture::texelBlockWidth(format);
+    if (blockWidth > 1 && (blockSize * textureWidth) % blockWidth) {
+        ASSERT_NOT_REACHED("Compressed texture has unexpected texture width");
+        return 0;
+    }
+
+    return (blockSize * textureWidth) / blockWidth;
+}
+
 uint32_t Texture::texelBlockSize(WGPUTextureFormat format) // Bytes
 {
     // For depth-stencil textures, the input value to this function


### PR DESCRIPTION
#### f3577bf0e0621e26e819f81574c64a363d21db63
<pre>
[WebGPU] Textures with size greater than 4096 are not cleared correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=271303">https://bugs.webkit.org/show_bug.cgi?id=271303</a>
&lt;radar://125068306&gt;

Reviewed by Dan Glastonbury.

We can not use 16 bytes for all texture formats since that will
copy too many bytes and fail the validation layer for texture widths
greater than 4096 when the bytes per pixel is &lt; 16.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::clearTexture):
* Source/WebGPU/WebGPU/Texture.h:
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::bytesPerRow):

Canonical link: <a href="https://commits.webkit.org/276446@main">https://commits.webkit.org/276446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a82188fb96cd1be7461ce778d852cc4a6b7e866

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47313 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40665 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21136 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17778 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18244 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2707 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40871 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48951 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43670 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20944 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42420 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9958 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20613 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->