### PR TITLE
[WTR][Skia] Add support for web contents pixel results

### DIFF
--- a/Source/WebKit/Shared/API/c/cairo/WKImageCairo.h
+++ b/Source/WebKit/Shared/API/c/cairo/WKImageCairo.h
@@ -27,6 +27,8 @@
 #ifndef WKImageCairo_h
 #define WKImageCairo_h
 
+#if USE(CAIRO)
+
 #include <WebKit/WKBase.h>
 #include <WebKit/WKImage.h>
 
@@ -43,5 +45,7 @@ WK_EXPORT WKImageRef WKImageCreateFromCairoSurface(cairo_surface_t* surface, WKI
 #ifdef __cplusplus
 }
 #endif
+
+#endif // USE(CAIRO)
 
 #endif /* WKImageCairo_h */

--- a/Source/WebKit/Shared/API/c/skia/WKImageSkia.h
+++ b/Source/WebKit/Shared/API/c/skia/WKImageSkia.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2010 Apple Inc. All rights reserved.
- * Copyright (C) 2011 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,37 +23,22 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "WKImageCairo.h"
+#pragma once
 
-#if USE(CAIRO)
-#include "WKSharedAPICast.h"
-#include "WebImage.h"
-#include <WebCore/GraphicsContextCairo.h>
-#include <WebCore/ShareableBitmap.h>
-#include <cairo.h>
+#if USE(SKIA)
 
-cairo_surface_t* WKImageCreateCairoSurface(WKImageRef imageRef)
-{
-    // We cannot pass a RefPtr through the API here, so we just leak the reference.
-    return WebKit::toImpl(imageRef)->createCairoSurface().leakRef();
+#include <WebKit/WKBase.h>
+#include <WebKit/WKImage.h>
+#include <skia/core/SkImage.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WK_EXPORT SkImage* WKImageCreateSkImage(WKImageRef image);
+
+#ifdef __cplusplus
 }
+#endif
 
-WKImageRef WKImageCreateFromCairoSurface(cairo_surface_t* surface, WKImageOptions options)
-{
-    WebCore::IntSize imageSize(cairo_image_surface_get_width(surface), cairo_image_surface_get_height(surface));
-    auto webImage = WebKit::WebImage::create(imageSize, WebKit::toImageOptions(options), WebCore::DestinationColorSpace::SRGB());
-    if (!webImage->context())
-        return nullptr;
-    auto& graphicsContext = *webImage->context();
-
-    cairo_t* cr = graphicsContext.platformContext()->cr();
-    cairo_set_source_surface(cr, surface, 0, 0);
-    cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
-    cairo_rectangle(cr, 0, 0, imageSize.width(), imageSize.height());
-    cairo_fill(cr);
-
-    return toAPI(webImage.leakRef());
-}
-
-#endif // USE(CAIRO)
+#endif // USE(SKIA)

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -74,6 +74,8 @@ Shared/API/glib/WebKitURIRequest.cpp @no-unify
 Shared/API/glib/WebKitURIResponse.cpp @no-unify
 Shared/API/glib/WebKitUserMessage.cpp @no-unify
 
+Shared/API/c/skia/WKImageSkia.cpp
+
 Shared/CoordinatedGraphics/CoordinatedGraphicsScene.cpp
 Shared/CoordinatedGraphics/SimpleViewportController.cpp
 

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -124,6 +124,8 @@ UIProcess/API/C/glib/WKTextCheckerGLib.cpp
 UIProcess/API/C/wpe/WKView.cpp
 UIProcess/API/C/wpe/WKPagePrivateWPE.cpp
 
+Shared/API/c/skia/WKImageSkia.cpp
+
 Shared/API/c/wpe/WKEventWPE.cpp
 
 UIProcess/API/glib/APIContentRuleListStoreGLib.cpp @no-unify

--- a/Tools/WebKitTestRunner/gtk/PlatformWebViewGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/PlatformWebViewGtk.cpp
@@ -29,7 +29,6 @@
 #include "PlatformWebView.h"
 
 #include <WebCore/GtkVersioning.h>
-#include <WebKit/WKImageCairo.h>
 #include <WebKit/WKPageConfigurationRef.h>
 #include <WebKit/WKView.h>
 #include <WebKit/WKViewPrivate.h>

--- a/Tools/WebKitTestRunner/skia/TestInvocationSkia.cpp
+++ b/Tools/WebKitTestRunner/skia/TestInvocationSkia.cpp
@@ -30,6 +30,7 @@
 #include "PixelDumpSupport.h"
 #include "PlatformWebView.h"
 #include "TestController.h"
+#include <WebKit/WKImageSkia.h>
 #include <skia/core/SkCanvas.h>
 #include <skia/core/SkStream.h>
 IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
@@ -67,12 +68,12 @@ static void dumpPixmap(const SkPixmap& pixmap, const std::string& checksum)
     printPNG(data->bytes(), data->size(), checksum.c_str());
 }
 
-void TestInvocation::dumpPixelsAndCompareWithExpected(SnapshotResultType snapshotType, WKArrayRef repaintRects, WKImageRef)
+void TestInvocation::dumpPixelsAndCompareWithExpected(SnapshotResultType snapshotType, WKArrayRef repaintRects, WKImageRef webImage)
 {
     sk_sp<SkImage> image;
     switch (snapshotType) {
     case SnapshotResultType::WebContents:
-        // FIXME: implement.
+        image.reset(WKImageCreateSkImage(webImage));
         break;
     case SnapshotResultType::WebView:
         image.reset(TestController::singleton().mainWebView()->windowSnapshotImage());


### PR DESCRIPTION
#### bcddb3eea6b4257f6a974f9f78efdfedf9e68c8f
<pre>
[WTR][Skia] Add support for web contents pixel results
<a href="https://bugs.webkit.org/show_bug.cgi?id=271239">https://bugs.webkit.org/show_bug.cgi?id=271239</a>

Reviewed by Alejandro G. Castro.

Add WKImageSkia with WKImageCreateSkImage() to be used from
dumpPixelsAndCompareWithExpected().

* Source/WebKit/Shared/API/c/cairo/WKImageCairo.cpp:
(WKImageCreateCairoSurface):
(WKImageCreateFromCairoSurface):
* Source/WebKit/Shared/API/c/cairo/WKImageCairo.h:
* Source/WebKit/Shared/API/c/skia/WKImageSkia.cpp: Copied from Source/WebKit/Shared/API/c/cairo/WKImageCairo.h.
(WKImageCreateSkImage):
* Source/WebKit/Shared/API/c/skia/WKImageSkia.h: Copied from Source/WebKit/Shared/API/c/cairo/WKImageCairo.h.
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Tools/WebKitTestRunner/gtk/PlatformWebViewGtk.cpp:
* Tools/WebKitTestRunner/skia/TestInvocationSkia.cpp:
(WTR::TestInvocation::dumpPixelsAndCompareWithExpected):

Canonical link: <a href="https://commits.webkit.org/276401@main">https://commits.webkit.org/276401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/239ccf09e41493fa4d6fe97638b12f3091a38c9b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47222 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40568 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46875 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21039 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20706 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38365 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17719 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39510 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2616 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48850 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16061 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20858 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42347 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21186 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6132 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->