### PR TITLE
[Skia] Make GraphicsContextSkia constructor receive a SkCanvas instead of a SkSurface

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -30,16 +30,13 @@
 #include "GraphicsContext.h"
 #include <skia/core/SkCanvas.h>
 #include <skia/effects/SkDashPathEffect.h>
-
-IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
-#include <skia/core/SkSurface.h>
-IGNORE_CLANG_WARNINGS_END
+#include <wtf/CompletionHandler.h>
 
 namespace WebCore {
 
 class WEBCORE_EXPORT GraphicsContextSkia final : public GraphicsContext {
 public:
-    GraphicsContextSkia(sk_sp<SkSurface>&&, RenderingMode, RenderingPurpose);
+    GraphicsContextSkia(SkCanvas&, RenderingMode, RenderingPurpose, CompletionHandler<void()>&& = nullptr);
     virtual ~GraphicsContextSkia();
 
     bool hasPlatformContext() const final;
@@ -106,8 +103,6 @@ public:
     SkPaint createStrokePaint() const;
 
 private:
-    SkCanvas& canvas() const;
-
     bool makeGLContextCurrentIfNeeded() const;
 
     void setupFillSource(SkPaint&) const;
@@ -125,9 +120,10 @@ private:
         } m_stroke;
     };
 
-    sk_sp<SkSurface> m_surface;
+    SkCanvas& m_canvas;
     RenderingMode m_renderingMode { RenderingMode::Accelerated };
     RenderingPurpose m_renderingPurpose { RenderingPurpose::Unspecified };
+    CompletionHandler<void()> m_destroyNotify;
     SkiaState m_skiaState;
     Vector<SkiaState, 1> m_skiaStateStack;
 };

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -57,7 +57,7 @@ std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBac
     auto imageInfo = SkImageInfo::MakeN32Premul(backendSize.width(), backendSize.height());
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
     auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, &properties);
-    if (!surface)
+    if (!surface || !surface->getCanvas())
         return nullptr;
 
     return std::unique_ptr<ImageBufferSkiaAcceleratedBackend>(new ImageBufferSkiaAcceleratedBackend(parameters, WTFMove(surface)));

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp
@@ -61,7 +61,7 @@ size_t ImageBufferSkiaSurfaceBackend::calculateMemoryCost(const Parameters& para
 ImageBufferSkiaSurfaceBackend::ImageBufferSkiaSurfaceBackend(const Parameters& parameters, sk_sp<SkSurface>&& surface, RenderingMode renderingMode)
     : ImageBufferSkiaBackend(parameters)
     , m_surface(WTFMove(surface))
-    , m_context(sk_ref_sp(m_surface.get()), renderingMode, parameters.purpose)
+    , m_context(*m_surface->getCanvas(), renderingMode, parameters.purpose)
 {
 }
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h
@@ -28,8 +28,11 @@
 #if USE(SKIA)
 #include "GraphicsContextSkia.h"
 #include "ImageBufferSkiaBackend.h"
-#include <skia/core/SkSurface.h>
 #include <wtf/Forward.h>
+
+IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
+#include <skia/core/SkSurface.h>
+IGNORE_CLANG_WARNINGS_END
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
@@ -46,6 +46,9 @@ std::unique_ptr<ImageBufferSkiaUnacceleratedBackend> ImageBufferSkiaUnaccelerate
     auto imageInfo = SkImageInfo::MakeN32Premul(backendSize.width(), backendSize.height());
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
     auto surface = SkSurfaces::Raster(imageInfo, &properties);
+    if (!surface || !surface->getCanvas())
+        return nullptr;
+
     return std::unique_ptr<ImageBufferSkiaUnacceleratedBackend>(new ImageBufferSkiaUnacceleratedBackend(parameters, WTFMove(surface)));
 }
 

--- a/Source/WebCore/platform/graphics/skia/PathSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PathSkia.cpp
@@ -283,7 +283,8 @@ bool PathSkia::strokeContains(const FloatPoint& point, const Function<void(Graph
     if (isEmpty() || !std::isfinite(point.x()) || !std::isfinite(point.y()))
         return false;
 
-    GraphicsContextSkia graphicsContext(SkSurfaces::Null(1, 1), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified);
+    auto surface = SkSurfaces::Null(1, 1);
+    GraphicsContextSkia graphicsContext(*surface->getCanvas(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified);
     strokeStyleApplier(graphicsContext);
 
     // FIXME: Compute stroke precision.
@@ -308,7 +309,8 @@ FloatRect PathSkia::strokeBoundingRect(const Function<void(GraphicsContext&)>& s
     if (isEmpty())
         return { };
 
-    GraphicsContextSkia graphicsContext(SkSurfaces::Null(1, 1), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified);
+    auto surface = SkSurfaces::Null(1, 1);
+    GraphicsContextSkia graphicsContext(*surface->getCanvas(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified);
     strokeStyleApplier(graphicsContext);
 
     // Skia stroke resolution scale for reduced-precision requirements.

--- a/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
@@ -56,7 +56,12 @@ std::unique_ptr<GraphicsContext> ShareableBitmap::createGraphicsContext()
     auto surface = SkSurfaces::WrapPixels(m_configuration.imageInfo(), data(), bytesPerRow(), [](void*, void* context) {
         static_cast<ShareableBitmap*>(context)->deref();
     }, this, &properties);
-    return makeUnique<GraphicsContextSkia>(WTFMove(surface), RenderingMode::Unaccelerated, RenderingPurpose::ShareableSnapshot);
+
+    auto* canvas = surface->getCanvas();
+    if (!canvas)
+        return nullptr;
+
+    return makeUnique<GraphicsContextSkia>(*canvas, RenderingMode::Unaccelerated, RenderingPurpose::ShareableSnapshot, [surface = WTFMove(surface)] { });
 }
 
 void ShareableBitmap::paint(GraphicsContext& context, const IntPoint& dstPoint, const IntRect& srcRect)


### PR DESCRIPTION
#### 867737f23957b13585997afb13f21ebfe1d3be80
<pre>
[Skia] Make GraphicsContextSkia constructor receive a SkCanvas instead of a SkSurface
<a href="https://bugs.webkit.org/show_bug.cgi?id=271309">https://bugs.webkit.org/show_bug.cgi?id=271309</a>

Reviewed by Alejandro G. Castro.

For printing we won&apos;t have a SkSurface to pass. The constructor now
receives a reference to a SkCanvas, so callers need to ensure the canvas
will be alive, which is always the case except for ShareableBitmap. For
that case we also include an optional destroy notify parameter that is
used to release the associated SkSurface when the graphics context is
destroyed.

* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::GraphicsContextSkia):
(WebCore::GraphicsContextSkia::hasPlatformContext const):
(WebCore::GraphicsContextSkia::getCTM const):
(WebCore::GraphicsContextSkia::platformContext const):
(WebCore::GraphicsContextSkia::save):
(WebCore::GraphicsContextSkia::restore):
(WebCore::GraphicsContextSkia::drawRect):
(WebCore::GraphicsContextSkia::drawNativeImageInternal):
(WebCore::GraphicsContextSkia::drawLine):
(WebCore::GraphicsContextSkia::drawEllipse):
(WebCore::GraphicsContextSkia::fillPath):
(WebCore::GraphicsContextSkia::strokePath):
(WebCore::GraphicsContextSkia::fillRect):
(WebCore::GraphicsContextSkia::clip):
(WebCore::GraphicsContextSkia::clipPath):
(WebCore::GraphicsContextSkia::clipBounds const):
(WebCore::GraphicsContextSkia::clipToImageBuffer):
(WebCore::GraphicsContextSkia::drawDotsForDocumentMarker):
(WebCore::GraphicsContextSkia::translate):
(WebCore::GraphicsContextSkia::concatCTM):
(WebCore::GraphicsContextSkia::setCTM):
(WebCore::GraphicsContextSkia::beginTransparencyLayer):
(WebCore::GraphicsContextSkia::endTransparencyLayer):
(WebCore::GraphicsContextSkia::clearRect):
(WebCore::GraphicsContextSkia::strokeRect):
(WebCore::GraphicsContextSkia::clipOut):
(WebCore::GraphicsContextSkia::rotate):
(WebCore::GraphicsContextSkia::scale):
(WebCore::GraphicsContextSkia::fillRoundedRectImpl):
(WebCore::GraphicsContextSkia::fillRectWithRoundedHole):
(WebCore::GraphicsContextSkia::drawPattern):
(WebCore::GraphicsContextSkia::canvas const): Deleted.
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::create):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.cpp:
(WebCore::ImageBufferSkiaSurfaceBackend::ImageBufferSkiaSurfaceBackend):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaSurfaceBackend.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp:
(WebCore::ImageBufferSkiaUnacceleratedBackend::create):
* Source/WebCore/platform/graphics/skia/PathSkia.cpp:
(WebCore::PathSkia::strokeContains const):
(WebCore::PathSkia::strokeBoundingRect const):
* Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp:
(WebCore::ShareableBitmap::createGraphicsContext):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayerSkia.cpp:
(WebCore::CoordinatedGraphicsLayer::paintTile):
(WebCore::CoordinatedGraphicsLayer::paintImage):
* Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp:
(WebKit::BackingStore::incorporateUpdate):

Canonical link: <a href="https://commits.webkit.org/276408@main">https://commits.webkit.org/276408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca11f56c0d322c3a4001d7708aab39b307dfa517

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44583 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47237 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40581 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21054 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20725 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17733 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39524 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2629 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40791 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48866 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16075 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43600 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/navigation-redirect.https.html?client (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20871 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42357 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21199 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6137 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->