### PR TITLE
Read from the cached `display: none` style in select call sites of `Element::renderOrDisplayContentsStyle()`

### DIFF
--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -671,8 +671,10 @@ public:
     LayoutRect absoluteEventHandlerBounds(bool& includesFixedPositionElements) override;
 
     const RenderStyle* existingComputedStyle() const;
-    WEBCORE_EXPORT const RenderStyle* renderOrDisplayContentsStyle() const;
-    WEBCORE_EXPORT const RenderStyle* renderOrDisplayContentsStyle(const std::optional<Style::PseudoElementIdentifier>&) const;
+    const RenderStyle* renderOrDisplayContentsStyle() const;
+    const RenderStyle* renderOrDisplayContentsStyle(const std::optional<Style::PseudoElementIdentifier>&) const;
+    WEBCORE_EXPORT const RenderStyle* renderOrDisplayContentsOrNoneStyle() const;
+    WEBCORE_EXPORT const RenderStyle* renderOrDisplayContentsOrNoneStyle(const std::optional<Style::PseudoElementIdentifier>&) const;
 
     void clearBeforePseudoElement();
     void clearAfterPseudoElement();

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -143,7 +143,7 @@ void RenderTreeUpdater::GeneratedContent::updatePseudoElement(Element& current, 
     if (!updateStyle)
         return;
 
-    auto* existingStyle = pseudoElement ? pseudoElement->renderOrDisplayContentsStyle() : nullptr;
+    auto* existingStyle = pseudoElement ? pseudoElement->renderOrDisplayContentsOrNoneStyle() : nullptr;
 
     auto styleChange = existingStyle ? Style::determineChange(*updateStyle, *existingStyle) : Style::Change::Renderer;
     if (styleChange == Style::Change::None)

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -190,7 +190,7 @@ static bool affectsRenderedSubtree(Element& element, const RenderStyle& newStyle
 {
     if (newStyle.display() != DisplayType::None)
         return true;
-    if (element.renderOrDisplayContentsStyle())
+    if (element.renderOrDisplayContentsOrNoneStyle())
         return true;
     if (element.rendererIsNeeded(newStyle))
         return true;
@@ -244,7 +244,7 @@ static bool styleChangeAffectsRelativeUnits(const RenderStyle& style, const Rend
 
 auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingStyle, ResolutionType resolutionType) -> std::pair<ElementUpdate, DescendantsToResolve>
 {
-    if (m_didSeePendingStylesheet && !element.renderOrDisplayContentsStyle() && !m_document.isIgnoringPendingStylesheets()) {
+    if (m_didSeePendingStylesheet && !element.renderOrDisplayContentsOrNoneStyle() && !m_document.isIgnoringPendingStylesheets()) {
         m_document.setHasNodesWithMissingStyle();
         return { };
     }
@@ -436,7 +436,7 @@ std::optional<ElementUpdate> TreeResolver::resolveAncestorPseudoElement(Element&
     if (!pseudoElementStyle)
         return { };
 
-    auto* oldStyle = element.renderOrDisplayContentsStyle(pseudoElementIdentifier);
+    auto* oldStyle = element.renderOrDisplayContentsOrNoneStyle(pseudoElementIdentifier);
     auto change = oldStyle ? determineChange(*oldStyle, *pseudoElementStyle->style) : Change::Renderer;
     auto resolutionContext = makeResolutionContextForPseudoElement(elementUpdate, pseudoElementIdentifier);
 
@@ -1072,7 +1072,7 @@ void TreeResolver::resolveComposedTree()
 
 const RenderStyle* TreeResolver::existingStyle(const Element& element)
 {
-    auto* style = element.renderOrDisplayContentsStyle();
+    auto* style = element.renderOrDisplayContentsOrNoneStyle();
 
     if (style && &element == m_document.documentElement()) {
         // Document element style may have got adjusted based on body style but we don't want to inherit those adjustments.
@@ -1102,7 +1102,7 @@ auto TreeResolver::updateStateForQueryContainer(Element& element, const RenderSt
         return QueryContainerAction::Continue;
     }
 
-    auto* existingStyle = element.renderOrDisplayContentsStyle();
+    auto* existingStyle = element.renderOrDisplayContentsOrNoneStyle();
     if (style->containerType() != ContainerType::Normal || (existingStyle && existingStyle->containerType() != ContainerType::Normal)) {
         // If any of the queries use font-size relative units then a font size change may affect their evaluation.
         if (styleChangeAffectsRelativeUnits(*style, existingStyle))

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1249,9 +1249,9 @@ void WebPage::commitPotentialTap(OptionSet<WebEventModifier> modifiers, Transact
     if (!invalidTargetForSingleClick) {
         bool targetRenders = m_potentialTapNode->renderer();
         if (RefPtr element = dynamicDowncast<Element>(m_potentialTapNode); element && !targetRenders)
-            targetRenders = element->renderOrDisplayContentsStyle();
+            targetRenders = element->renderOrDisplayContentsOrNoneStyle();
         if (RefPtr shadowRoot = dynamicDowncast<ShadowRoot>(m_potentialTapNode); shadowRoot && !targetRenders)
-            targetRenders = shadowRoot->host()->renderOrDisplayContentsStyle();
+            targetRenders = shadowRoot->host()->renderOrDisplayContentsOrNoneStyle();
         invalidTargetForSingleClick = !targetRenders && !is<HTMLAreaElement>(m_potentialTapNode);
     }
     if (invalidTargetForSingleClick) {


### PR DESCRIPTION
#### 16a1d875a6792dc190670da99828a53d3e39034b
<pre>
Read from the cached `display: none` style in select call sites of `Element::renderOrDisplayContentsStyle()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=271310">https://bugs.webkit.org/show_bug.cgi?id=271310</a>

Reviewed by NOBODY (OOPS!).

In 273288@main we started caching `display: none` styles in a similar fashion we do `display: contents` styles.
One of the way the cached `display: contents` style is used is through the `Element::renderOrDisplayContentsStyle()`
method. We add a new `Element::renderOrDisplayContentsOrNoneStyle()` method that also checks for the `display: none`
cached styles and use it instead of `Element::renderOrDisplayContentsStyle()` except in two select places where
the `display: none` cached style is irrelevant or wrong:

- the static function `nextListItemHelper()` in `RenderListItem`
- the `Style::TreeResolver::createAnimatedElementUpdate()` method where, in preparation for animation support
for the `display` property (see bug 267762), we must ensure we do not use cached styles for `display: none`
elements.

No test change since this code change should not result in behavior change until we add support for the `display`
property.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::storeDisplayContentsOrNoneStyle):
(WebCore::Element::existingComputedStyle const):
(WebCore::Element::renderOrDisplayContentsOrNoneStyle const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updatePseudoElement):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::affectsRenderedSubtree):
(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::resolveAncestorPseudoElement):
(WebCore::Style::TreeResolver::existingStyle):
(WebCore::Style::TreeResolver::updateStateForQueryContainer):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::commitPotentialTap):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16a1d875a6792dc190670da99828a53d3e39034b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47238 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27695 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21055 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17732 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39525 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2630 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40793 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48875 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16076 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20872 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42365 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21200 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20538 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->