### PR TITLE
[Skia] Implement TestController::takeViewPortSnapshot()

### DIFF
--- a/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
@@ -35,6 +35,12 @@
 
 #if USE(CAIRO)
 #include <cairo.h>
+#elif USE(SKIA)
+#include <skia/core/SkData.h>
+
+IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
+#include <skia/encode/SkPngEncoder.h>
+IGNORE_CLANG_WARNINGS_END
 #endif
 
 namespace WTR {
@@ -150,16 +156,18 @@ TestFeatures TestController::platformSpecificFeatureDefaultsForTest(const TestCo
 
 WKRetainPtr<WKStringRef> TestController::takeViewPortSnapshot()
 {
-    Vector<unsigned char> output;
 #if USE(CAIRO)
+    Vector<unsigned char> output;
     cairo_surface_write_to_png_stream(mainWebView()->windowSnapshotImage(), [](void* output, const unsigned char* data, unsigned length) -> cairo_status_t {
         reinterpret_cast<Vector<unsigned char>*>(output)->append(std::span { data, length });
         return CAIRO_STATUS_SUCCESS;
     }, &output);
-#elif USE(SKIA)
-    // FIXME: implement
-#endif
     auto uri = makeString("data:image/png;base64,", base64Encoded(output.data(), output.size()));
+#elif USE(SKIA)
+    sk_sp<SkImage> image(mainWebView()->windowSnapshotImage());
+    auto data = SkPngEncoder::Encode(nullptr, image.get(), { });
+    auto uri = makeString("data:image/png;base64,", base64Encoded(data->data(), data->size()));
+#endif
     return adoptWK(WKStringCreateWithUTF8CString(uri.utf8().data()));
 }
 


### PR DESCRIPTION
#### 143ff2a9a2aee70e3eb4fb2b8576acabff66c93e
<pre>
[Skia] Implement TestController::takeViewPortSnapshot()
<a href="https://bugs.webkit.org/show_bug.cgi?id=271312">https://bugs.webkit.org/show_bug.cgi?id=271312</a>

Reviewed by Alejandro G. Castro.

* Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp:
(WTR::TestController::takeViewPortSnapshot):
* Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp:
(WTR::TestController::takeViewPortSnapshot):

Canonical link: <a href="https://commits.webkit.org/276407@main">https://commits.webkit.org/276407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f3d650c8569001861511e21b469164f8137e6e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47241 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40584 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21058 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17737 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/39535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2632 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40803 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48872 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16079 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43605 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20874 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42362 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21202 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6134 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20540 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->