### PR TITLE
[view-transitions] Skip view transition on hidden pages

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7468,12 +7468,10 @@ imported/w3c/web-platform-tests/css/css-view-transitions/paint-holding-in-iframe
 imported/w3c/web-platform-tests/css/css-view-transitions/iframe-transition.sub.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/fragmented-during-transition-skips.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-view-transitions/root-element-display-none-during-transition-crash.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html [ Skip ]
 
 # Flakes
 imported/w3c/web-platform-tests/css/css-view-transitions/synchronous-callback-skipped-before-run.html [ Failure Pass ]
 imported/w3c/web-platform-tests/css/css-view-transitions/old-content-intrinsic-aspect-ratio.html [ ImageOnlyFailure Pass ]
-imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html [ Failure Pass ]
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-ctor.html [ Failure Pass ]
 
 # Reftests with variants are not supported
@@ -7494,6 +7492,7 @@ imported/w3c/web-platform-tests/css/css-view-transitions/navigation/chromium-pai
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/root-element-transition-iframe-with-startVT-on-main.html [ ImageOnlyFailure ]
 # https://github.com/w3c/csswg-drafts/issues/10800
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-long-delay.html [ Failure ]
+webkit.org/b/278028 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html [ Failure ]
 
 # prerender not supported.
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/prerender-removed-during-navigation.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL A view transition should be immediately skipped if started when document is hidden assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL A view transition should be skipped when a document becomes hidden while processing update callback assert_equals: expected "rejected" but got "fulfilled"
-FAIL A view transition should be skipped when a document becomes hidden while animating assert_equals: expected "finished" but got "timeout"
+PASS A view transition should be immediately skipped if started when document is hidden
+PASS A view transition should be skipped when a document becomes hidden while processing update callback
+PASS A view transition should be skipped when a document becomes hidden while animating
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html
@@ -21,8 +21,8 @@
       await wsc.minimize();
       assert_true(document.hidden);
       const transition = document.startViewTransition();
-      await wsc.restore();
       await promise_rejects_dom(t, "InvalidStateError", transition.ready);
+      await wsc.restore();
     }, "A view transition should be immediately skipped if started when document is hidden");
 
     promise_test(async t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition-before-ready.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition-before-ready.html
@@ -34,6 +34,12 @@ promise_test(async t => {
       popup_win = window.open('about:blank', 'popup', 'width=300,height=300');
   });
 
+  if (popup_win.document.visibilityState == "hidden") {
+    await new Promise((resolve) => {
+      popup_win.document.addEventListener("visibilitychange", resolve, { once: true });
+    });
+  }
+
   // Resize the window while the update callback is running (i.e. before
   // capturing the new state).
   let transition = popup_win.document.startViewTransition(async () => {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition.html
@@ -45,6 +45,12 @@ promise_test(async t => {
         html::view-transition-old(*) {animation-duration: 10s;opacity: 1;}
       </style>`;
 
+    if (popupDoc.visibilityState == "hidden") {
+      await new Promise((resolve) => {
+        popupDoc.addEventListener("visibilitychange", resolve, { once: true });
+      });
+    }
+
     // Start a transition inside the popup.
     let transition = popupDoc.startViewTransition(() => {
       popupDoc.documentElement.classList.add('new');

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1337,6 +1337,8 @@ fast/css/variables/env/ios [ Pass ]
 
 # Tests use resizable popups which are not a thing on iOS.
 imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition-before-ready.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html [ Failure ]
 
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/pageswap-push-from-click.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1789,9 +1789,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/new-content-intrinsic-a
 tiled-drawing/scrolling/overflow/overflow-scrolled-down-tile-coverage.html [ Pass Failure ]
 tiled-drawing/scrolling/overflow/overflow-scrolled-up-tile-coverage.html [ Pass Failure ]
 
-# rdar://133772823 ([Sonoma wk2] imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html is a flaky failure
-[ Sonoma+ ] imported/w3c/web-platform-tests/css/css-view-transitions/navigation/hide-before-reveal.html [ Pass Failure ]
-
 # webkit.org/b/278178  [macOS Debug] imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-smooth-positions.html is a flaky failure
 imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-smooth-positions.html [ Pass Failure ]
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1588,6 +1588,7 @@ compositing/visible-rect/scrolled.html [ Failure ]
 compositing/video/video-border-radius-clipping.html [ Pass ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-visibility-mixed-descendants.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html [ Skip ]
 
 webkit.org/b/272224 imported/w3c/web-platform-tests/selection/textcontrols/selectionchange.html [ Failure ]
 

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -35,6 +35,7 @@
 #include "Styleable.h"
 #include "ViewTransitionTypeSet.h"
 #include "ViewTransitionUpdateCallback.h"
+#include "VisibilityChangeClient.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
@@ -150,7 +151,7 @@ public:
     float initialPageZoom;
 };
 
-class ViewTransition : public RefCounted<ViewTransition>, public CanMakeWeakPtr<ViewTransition>, public ActiveDOMObject {
+class ViewTransition : public RefCounted<ViewTransition>, public VisibilityChangeClient, public ActiveDOMObject {
     WTF_MAKE_TZONE_ALLOCATED(ViewTransition);
 public:
     static Ref<ViewTransition> createSamePage(Document&, RefPtr<ViewTransitionUpdateCallback>&&, Vector<AtomString>&&);
@@ -207,6 +208,9 @@ private:
     ExceptionOr<void> checkForViewportSizeChange();
 
     void clearViewTransition();
+
+    // VisibilityChangeClient.
+    void visibilityStateChanged() final;
 
     // ActiveDOMObject.
     void stop() final;


### PR DESCRIPTION
#### d985c516523226282a19453a8d26b07dcfe9c119
<pre>
[view-transitions] Skip view transition on hidden pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=271248">https://bugs.webkit.org/show_bug.cgi?id=271248</a>
<a href="https://rdar.apple.com/125017653">rdar://125017653</a>

Reviewed by Matt Woodrow.

Follow:
- <a href="https://drafts.csswg.org/css-view-transitions-1/#page-visibility-change-steps">https://drafts.csswg.org/css-view-transitions-1/#page-visibility-change-steps</a>
- <a href="https://github.com/w3c/csswg-drafts/issues/9543">https://github.com/w3c/csswg-drafts/issues/9543</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transition-in-hidden-page.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition-before-ready.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/window-resize-aborts-transition.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations: Remove duplicate test expectations to reduce confusion.
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::visibilityStateChanged): Make this more robust to allow unregistering clients while iterating.
(WebCore::Document::resolveViewTransitionRule):
(WebCore::Document::reveal):
(WebCore::Document::startViewTransition):
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::ViewTransition):
(WebCore::ViewTransition::stop):
(WebCore::ViewTransition::visibilityStateChanged):
* Source/WebCore/dom/ViewTransition.h:

Canonical link: <a href="https://commits.webkit.org/283084@main">https://commits.webkit.org/283084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89117a2076e5e7a92ca060e02c9ec4c6bbd6774f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/65175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/44542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/17789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/69199 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/15781 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/67293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/52325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/16063 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/52363 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10922 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/68241 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/41180 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/56421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32988 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/37851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/13792 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/14657 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/59744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/14131 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/70904 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/9127 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/13609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/59693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/9159 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/56481 "Exiting early after 10 failures. 84 tests run. 1 flakes") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/59968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14371 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7547 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/1220 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/40354 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/41431 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/42612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/41175 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->