### PR TITLE
[ThreadedCompositor] The compositing thread should not wait for paint threads

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp
@@ -103,4 +103,11 @@ auto BackingStore::takeUpdate() -> TileUpdate
     return WTFMove(m_update.pending);
 }
 
+void BackingStore::waitUntilPaintingComplete()
+{
+    Locker locker { m_update.lock };
+    for (auto& update : m_update.pending.tilesToUpdate)
+        update.buffer->waitUntilPaintingComplete();
+}
+
 } // namespace Nicosia

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h
@@ -113,6 +113,8 @@ public:
     void updateTile(uint32_t, const WebCore::IntRect&, const WebCore::IntRect&, Ref<Buffer>&&) override;
     void removeTile(uint32_t) override;
 
+    void waitUntilPaintingComplete();
+
 private:
     LayerState m_layerState;
     CompositionState m_compositionState;

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaCompositionLayer.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaCompositionLayer.h
@@ -257,6 +257,13 @@ public:
     }
 
     template<typename T>
+    void accessStaging(const T& functor)
+    {
+        Locker locker { PlatformLayer::m_state.lock };
+        functor(m_state.staging);
+    }
+
+    template<typename T>
     void accessCommitted(const T& functor)
     {
         Locker locker { PlatformLayer::m_state.lock };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -56,8 +56,6 @@ void CoordinatedBackingStoreTile::swapBuffers(TextureMapper& textureMapper)
         } else if (update.buffer->supportsAlpha() == m_texture->isOpaque())
             m_texture->reset(update.tileRect.size(), flags);
 
-        update.buffer->waitUntilPaintingComplete();
-
 #if USE(SKIA)
         if (update.buffer->isBackedByOpenGL()) {
             auto& buffer = static_cast<Nicosia::AcceleratedBuffer&>(*update.buffer);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp
@@ -209,6 +209,13 @@ bool CompositingCoordinator::flushPendingLayerChanges(OptionSet<FinalizeRenderin
                 state.rootLayer = m_nicosia.state.rootLayer;
             });
 
+        for (auto& compositionLayer : m_nicosia.state.layers) {
+            compositionLayer->accessStaging([](const Nicosia::CompositionLayer::LayerState& state) {
+                if (state.backingStore)
+                    state.backingStore->waitUntilPaintingComplete();
+            });
+        }
+
         m_client.commitSceneState(m_nicosia.scene);
 #if !HAVE(DISPLAY_LINK)
         m_forceFrameSync = false;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -343,6 +343,15 @@ void DrawingAreaCoordinatedGraphics::triggerRenderingUpdate()
         scheduleDisplay();
 }
 
+#if HAVE(DISPLAY_LINK)
+void DrawingAreaCoordinatedGraphics::didCompleteRenderingUpdateDisplay()
+{
+    if (m_layerTreeHost)
+        m_layerTreeHost->didCompleteRenderingUpdateDisplay();
+    DrawingArea::didCompleteRenderingUpdateDisplay();
+}
+#endif
+
 RefPtr<DisplayRefreshMonitor> DrawingAreaCoordinatedGraphics::createDisplayRefreshMonitor(PlatformDisplayID displayID)
 {
 #if HAVE(DISPLAY_LINK)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -78,6 +78,11 @@ private:
     void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
     void triggerRenderingUpdate() override;
 
+#if HAVE(DISPLAY_LINK)
+    void didCompleteRenderingUpdateDisplay() override;
+#endif
+
+
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID) override;
 
     void activityStateDidChange(OptionSet<WebCore::ActivityState>, ActivityStateChangeID, CompletionHandler<void()>&&) override;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -60,9 +60,6 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage, WebCore::PlatformDisplayID displa
     , m_surface(AcceleratedSurface::create(webPage, *this))
     , m_viewportController(webPage.size())
     , m_layerFlushTimer(RunLoop::main(), this, &LayerTreeHost::layerFlushTimerFired)
-#if HAVE(DISPLAY_LINK)
-    , m_didRenderFrameTimer(RunLoop::main(), this, &LayerTreeHost::didRenderFrameTimerFired)
-#endif
     , m_coordinator(webPage, *this)
 #if !HAVE(DISPLAY_LINK)
     , m_displayID(displayID)
@@ -132,10 +129,12 @@ void LayerTreeHost::scheduleLayerFlush()
     if (m_webPage.size().isEmpty())
         return;
 
+#if !HAVE(DISPLAY_LINK)
     if (m_isWaitingForRenderer) {
         m_scheduledWhileWaitingForRenderer = true;
         return;
     }
+#endif
 
     if (!m_layerFlushTimer.isActive())
         m_layerFlushTimer.startOneShot(0_s);
@@ -151,8 +150,10 @@ void LayerTreeHost::layerFlushTimerFired()
     if (m_isSuspended)
         return;
 
+#if !HAVE(DISPLAY_LINK)
     if (m_isWaitingForRenderer)
         return;
+#endif
 
 #if !HAVE(DISPLAY_LINK)
     // If a force-repaint callback was registered, we should force a 'frame sync' that
@@ -213,7 +214,12 @@ void LayerTreeHost::forceRepaint()
     // We need to schedule another flush, otherwise the forced paint might cancel a later expected flush.
     scheduleLayerFlush();
 
-    if (!m_isWaitingForRenderer) {
+#if HAVE(DISPLAY_LINK)
+    bool shouldFlushPendingLayerChanges = true;
+#else
+    bool shouldFlushPendingLayerChanges = !m_isWaitingForRenderer;
+#endif
+    if (shouldFlushPendingLayerChanges) {
         OptionSet<FinalizeRenderingUpdateFlags> flags;
 #if PLATFORM(GTK)
         if (!m_transientZoom)
@@ -236,7 +242,9 @@ void LayerTreeHost::forceRepaintAsync(CompletionHandler<void()>&& callback)
     // to finish an update, we'll have to schedule another flush when it's done.
     ASSERT(!m_forceRepaintAsync.callback);
     m_forceRepaintAsync.callback = WTFMove(callback);
+#if !HAVE(DISPLAY_LINK)
     m_forceRepaintAsync.needsFreshFlush = m_scheduledWhileWaitingForRenderer;
+#endif
 }
 
 void LayerTreeHost::sizeDidChange(const IntSize& size)
@@ -358,7 +366,9 @@ void LayerTreeHost::didFlushRootLayer(const FloatRect& visibleContentRect)
 
 void LayerTreeHost::commitSceneState(const RefPtr<Nicosia::Scene>& state)
 {
+#if !HAVE(DISPLAY_LINK)
     m_isWaitingForRenderer = true;
+#endif
     m_compositor->updateSceneState(state);
 }
 
@@ -415,26 +425,23 @@ void LayerTreeHost::clearIfNeeded()
 void LayerTreeHost::didRenderFrame()
 {
     m_surface->didRenderFrame();
-#if HAVE(DISPLAY_LINK)
-    if (!m_didRenderFrameTimer.isActive())
-        m_didRenderFrameTimer.startOneShot(0_s);
-#endif
     RunLoop::main().dispatch([webPage = Ref { m_webPage }] {
         if (auto* drawingArea = webPage->drawingArea())
             drawingArea->didCompleteRenderingUpdateDisplay();
     });
 }
 
-#if HAVE(DISPLAY_LINK)
-void LayerTreeHost::didRenderFrameTimerFired()
-{
-    renderNextFrame(false);
-}
-#endif
-
 void LayerTreeHost::displayDidRefresh(PlatformDisplayID displayID)
 {
     WebProcess::singleton().eventDispatcher().notifyScrollingTreesDisplayDidRefresh(displayID);
+}
+
+void LayerTreeHost::didCompleteRenderingUpdateDisplay()
+{
+#if HAVE(DISPLAY_LINK)
+    if (m_forceRepaintAsync.callback)
+        m_forceRepaintAsync.callback();
+#endif
 }
 
 #if !HAVE(DISPLAY_LINK)
@@ -453,7 +460,6 @@ void LayerTreeHost::handleDisplayRefreshMonitorUpdate(bool hasBeenRescheduled)
     // that will cause the display refresh notification to come.
     renderNextFrame(hasBeenRescheduled);
 }
-#endif
 
 void LayerTreeHost::renderNextFrame(bool forceRepaint)
 {
@@ -476,13 +482,12 @@ void LayerTreeHost::renderNextFrame(bool forceRepaint)
 
     if (scheduledWhileWaitingForRenderer || m_layerFlushTimer.isActive() || forceRepaint) {
         m_layerFlushTimer.stop();
-#if !HAVE(DISPLAY_LINK)
         if (forceRepaint)
             m_coordinator.forceFrameSync();
-#endif
         layerFlushTimerFired();
     }
 }
+#endif
 
 #if PLATFORM(GTK)
 FloatPoint LayerTreeHost::constrainTransientZoomOrigin(double scale, FloatPoint origin) const

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -102,6 +102,8 @@ public:
     void deviceOrPageScaleFactorChanged();
     void backgroundColorDidChange();
 
+    void didCompleteRenderingUpdateDisplay();
+
 #if !HAVE(DISPLAY_LINK)
     RefPtr<WebCore::DisplayRefreshMonitor> createDisplayRefreshMonitor(WebCore::PlatformDisplayID);
     WebCore::PlatformDisplayID displayID() const { return m_displayID; }
@@ -119,10 +121,9 @@ private:
 #if USE(COORDINATED_GRAPHICS)
     void layerFlushTimerFired();
     void didChangeViewport();
-#if HAVE(DISPLAY_LINK)
-    void didRenderFrameTimerFired();
-#endif
+#if !HAVE(DISPLAY_LINK)
     void renderNextFrame(bool);
+#endif
 
     // CompositingCoordinator::Client
     void didFlushRootLayer(const WebCore::FloatRect& visibleContentRect) override;
@@ -162,8 +163,10 @@ private:
 #if USE(COORDINATED_GRAPHICS)
     bool m_layerFlushSchedulingEnabled { true };
     bool m_isSuspended { false };
+#if !HAVE(DISPLAY_LINK)
     bool m_isWaitingForRenderer { false };
     bool m_scheduledWhileWaitingForRenderer { false };
+#endif
     float m_lastPageScaleFactor { 1 };
     WebCore::IntPoint m_lastScrollPosition;
     WebCore::GraphicsLayer* m_viewOverlayRootLayer { nullptr };
@@ -172,12 +175,11 @@ private:
     SimpleViewportController m_viewportController;
     struct {
         CompletionHandler<void()> callback;
+#if !HAVE(DISPLAY_LINK)
         bool needsFreshFlush { false };
+#endif
     } m_forceRepaintAsync;
     RunLoop::Timer m_layerFlushTimer;
-#if HAVE(DISPLAY_LINK)
-    RunLoop::Timer m_didRenderFrameTimer;
-#endif
     CompositingCoordinator m_coordinator;
 #endif // USE(COORDINATED_GRAPHICS)
 #if !HAVE(DISPLAY_LINK)


### PR DESCRIPTION
#### 221f37113e3cb2208feada1dbacd4a683889ca3b
<pre>
[ThreadedCompositor] The compositing thread should not wait for paint threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=264090">https://bugs.webkit.org/show_bug.cgi?id=264090</a>

Reviewed by NOBODY (OOPS!).

If there&apos;s an async scrolling request the compositing thread might be
busy just waiting for the painting threads. We can wait for them in the
main thread, which is already expected to be blocked painting.

* Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.cpp:
(Nicosia::BackingStore::waitUntilPaintingComplete):
* Source/WebCore/platform/graphics/nicosia/NicosiaBackingStore.h:
* Source/WebCore/platform/graphics/nicosia/NicosiaCompositionLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStoreTile::swapBuffers):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CompositingCoordinator.cpp:
(WebKit::CompositingCoordinator::flushPendingLayerChanges):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::didCompleteRenderingUpdateDisplay):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::scheduleLayerFlush):
(WebKit::LayerTreeHost::layerFlushTimerFired):
(WebKit::LayerTreeHost::forceRepaint):
(WebKit::LayerTreeHost::forceRepaintAsync):
(WebKit::LayerTreeHost::commitSceneState):
(WebKit::LayerTreeHost::didRenderFrame):
(WebKit::LayerTreeHost::displayDidRefresh):
(WebKit::LayerTreeHost::didCompleteRenderingUpdateDisplay):
(WebKit::LayerTreeHost::handleDisplayRefreshMonitorUpdate):
(WebKit::LayerTreeHost::renderNextFrame):
(WebKit::LayerTreeHost::didRenderFrameTimerFired): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
</pre>