### PR TITLE
Simplify code by using std::span more

### DIFF
--- a/Source/JavaScriptCore/runtime/GenericTypedArrayView.h
+++ b/Source/JavaScriptCore/runtime/GenericTypedArrayView.h
@@ -35,9 +35,11 @@ class GenericTypedArrayView final : public ArrayBufferView {
 public:
     static Ref<GenericTypedArrayView> create(size_t length);
     static Ref<GenericTypedArrayView> create(const typename Adaptor::Type* array, size_t length);
+    static Ref<GenericTypedArrayView> create(std::span<const typename Adaptor::Type> data) { return create(data.data(), data.size()); }
     static Ref<GenericTypedArrayView> create(RefPtr<ArrayBuffer>&&, size_t byteOffset, std::optional<size_t> length);
     static RefPtr<GenericTypedArrayView> tryCreate(size_t length);
     static RefPtr<GenericTypedArrayView> tryCreate(const typename Adaptor::Type* array, size_t length);
+    static RefPtr<GenericTypedArrayView> tryCreate(std::span<const typename Adaptor::Type> data) { return tryCreate(data.data(), data.size()); }
     static RefPtr<GenericTypedArrayView> tryCreate(RefPtr<ArrayBuffer>&&, size_t byteOffset, std::optional<size_t> length);
     
     static Ref<GenericTypedArrayView> createUninitialized(size_t length);

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -290,9 +290,9 @@ FetchBody::TakenData FetchBody::take()
         return SharedBuffer::create(PAL::TextCodecUTF8::encodeUTF8(urlSearchParamsBody().toString()));
 
     if (isArrayBuffer())
-        return SharedBuffer::create(static_cast<const char*>(arrayBufferBody().data()), arrayBufferBody().byteLength());
+        return SharedBuffer::create(arrayBufferBody().bytes());
     if (isArrayBufferView())
-        return SharedBuffer::create(static_cast<const uint8_t*>(arrayBufferViewBody().baseAddress()), arrayBufferViewBody().byteLength());
+        return SharedBuffer::create(arrayBufferViewBody().bytes());
 
     return nullptr;
 }

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
@@ -105,7 +105,7 @@ void FormDataConsumer::consumeBlob(const URL& blobURL)
         }
 
         if (auto data = loader->arrayBufferResult())
-            weakThis->consume(std::span { static_cast<const uint8_t*>(data->data()), data->byteLength() });
+            weakThis->consume(data->bytes());
     });
 
     m_blobLoader->start(blobURL, m_context.get(), FileReaderLoader::ReadAsArrayBuffer);

--- a/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
@@ -55,7 +55,7 @@ void RTCEncodedFrame::setData(JSC::ArrayBuffer& buffer)
 Ref<RTCRtpTransformableFrame> RTCEncodedFrame::rtcFrame()
 {
     if (m_data) {
-        m_frame->setData({ static_cast<const uint8_t*>(m_data->data()), m_data->byteLength() });
+        m_frame->setData(m_data->bytes());
         m_data = nullptr;
     }
     return m_frame;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -243,9 +243,9 @@ ExceptionOr<void> RTCRtpSFrameTransform::createStreams()
         }, [&](RefPtr<RTCEncodedVideoFrame>& value) {
             transformFrame(*value, globalObject, transformer.get(), *readableStreamSource, context.identifier(), weakThis);
         }, [&](RefPtr<ArrayBuffer>& value) {
-            transformFrame({ static_cast<const uint8_t*>(value->data()), value->byteLength() }, globalObject, transformer.get(), *readableStreamSource, context.identifier(), weakThis);
+            transformFrame(value->bytes(), globalObject, transformer.get(), *readableStreamSource, context.identifier(), weakThis);
         }, [&](RefPtr<ArrayBufferView>& value) {
-            transformFrame({ static_cast<const uint8_t*>(value->data()), value->byteLength() }, globalObject, transformer.get(), *readableStreamSource, context.identifier(), weakThis);
+            transformFrame(value->bytes(), globalObject, transformer.get(), *readableStreamSource, context.identifier(), weakThis);
         });
         return { };
     }));

--- a/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
@@ -200,7 +200,7 @@ bool WebSocketInflater::finish()
         m_buffer.grow(bufferSize.value());
         size_t availableCapacity = m_buffer.size() - writePosition;
         size_t remainingLength = strippedFields.size() - consumedSoFar;
-        setStreamParameter(m_stream.get(), std::span { strippedFields.data() + consumedSoFar, remainingLength }, m_buffer.data() + writePosition, availableCapacity);
+        setStreamParameter(m_stream.get(), std::span { strippedFields }.subspan(consumedSoFar), m_buffer.data() + writePosition, availableCapacity);
         int result = inflate(m_stream.get(), Z_FINISH);
         consumedSoFar += remainingLength - m_stream->avail_in;
         m_buffer.shrink(writePosition + availableCapacity - m_stream->avail_out);

--- a/Source/WebCore/Modules/webtransport/DatagramSink.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramSink.cpp
@@ -53,7 +53,7 @@ void DatagramSink::write(ScriptExecutionContext& context, JSC::JSValue value, DO
         return promise.settle(Exception { ExceptionCode::ExistingExceptionError });
 
     WTF::switchOn(arrayBufferOrView, [&](auto& arrayBufferOrView) {
-        send({ static_cast<const uint8_t*>(arrayBufferOrView->data()), arrayBufferOrView->byteLength() }, [promise = WTFMove(promise)] () mutable {
+        send(arrayBufferOrView->bytes(), [promise = WTFMove(promise)] () mutable {
             // FIXME: Reject if sending failed.
             promise.resolve();
         });

--- a/Source/WebCore/bindings/js/BufferSource.h
+++ b/Source/WebCore/bindings/js/BufferSource.h
@@ -33,6 +33,7 @@
 #include <wtf/RefPtr.h>
 
 #if PLATFORM(COCOA) && defined(__OBJC__)
+#include <wtf/cocoa/SpanCocoa.h>
 OBJC_CLASS NSData;
 #endif
 
@@ -86,7 +87,7 @@ inline BufferSource toBufferSource(const uint8_t* data, size_t length)
 #if PLATFORM(COCOA) && defined(__OBJC__)
 inline BufferSource toBufferSource(NSData *data)
 {
-    return BufferSource(JSC::ArrayBuffer::tryCreate(static_cast<const uint8_t*>(data.bytes), data.length));
+    return BufferSource(JSC::ArrayBuffer::tryCreate(toSpan(data)));
 }
 
 inline RetainPtr<NSData> toNSData(const BufferSource& data)

--- a/Source/WebCore/dom/DecodedDataDocumentParser.cpp
+++ b/Source/WebCore/dom/DecodedDataDocumentParser.cpp
@@ -38,12 +38,12 @@ DecodedDataDocumentParser::DecodedDataDocumentParser(Document& document)
 {
 }
 
-void DecodedDataDocumentParser::appendBytes(DocumentWriter& writer, const uint8_t* data, size_t length)
+void DecodedDataDocumentParser::appendBytes(DocumentWriter& writer, std::span<const uint8_t> data)
 {
-    if (!length)
+    if (data.empty())
         return;
 
-    String decoded = writer.decoder().decode(data, length);
+    String decoded = writer.decoder().decode(data);
     if (decoded.isEmpty())
         return;
 

--- a/Source/WebCore/dom/DecodedDataDocumentParser.h
+++ b/Source/WebCore/dom/DecodedDataDocumentParser.h
@@ -43,7 +43,7 @@ private:
     void append(RefPtr<StringImpl>&&) override = 0;
 
     // appendBytes and flush are used by DocumentWriter (the loader).
-    void appendBytes(DocumentWriter&, const uint8_t* bytes, size_t length) override;
+    void appendBytes(DocumentWriter&, std::span<const uint8_t>) override;
     void flush(DocumentWriter&) override;
 };
 

--- a/Source/WebCore/dom/DocumentParser.h
+++ b/Source/WebCore/dom/DocumentParser.h
@@ -49,7 +49,7 @@ public:
     virtual void insert(SegmentedString&&) = 0;
 
     // appendBytes and flush are used by DocumentWriter (the loader).
-    virtual void appendBytes(DocumentWriter&, const uint8_t* bytes, size_t length) = 0;
+    virtual void appendBytes(DocumentWriter&, std::span<const uint8_t>) = 0;
     virtual void flush(DocumentWriter&) = 0;
 
     virtual void append(RefPtr<StringImpl>&&) = 0;

--- a/Source/WebCore/dom/RawDataDocumentParser.h
+++ b/Source/WebCore/dom/RawDataDocumentParser.h
@@ -47,7 +47,7 @@ private:
     void flush(DocumentWriter& writer) override
     {
         // Make sure appendBytes is called at least once.
-        appendBytes(writer, nullptr, 0);
+        appendBytes(writer, { });
     }
 
     void insert(SegmentedString&&) override

--- a/Source/WebCore/dom/TextEncoder.cpp
+++ b/Source/WebCore/dom/TextEncoder.cpp
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/GenericTypedArrayViewInlines.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>
+#include <wtf/Algorithms.h>
 
 namespace WebCore {
 
@@ -39,7 +40,7 @@ String TextEncoder::encoding() const
 RefPtr<Uint8Array> TextEncoder::encode(String&& input) const
 {
     auto result = input.tryGetUTF8([&](std::span<const char> span) -> RefPtr<Uint8Array> {
-        return Uint8Array::tryCreate(reinterpret_cast<const uint8_t*>(span.data()), span.size());
+        return Uint8Array::tryCreate(spanReinterpretCast<const uint8_t>(span));
     });
     if (result)
         return result.value();

--- a/Source/WebCore/fileapi/NetworkSendQueue.cpp
+++ b/Source/WebCore/fileapi/NetworkSendQueue.cpp
@@ -53,11 +53,10 @@ void NetworkSendQueue::enqueue(CString&& utf8)
 void NetworkSendQueue::enqueue(const JSC::ArrayBuffer& binaryData, unsigned byteOffset, unsigned byteLength)
 {
     if (m_queue.isEmpty()) {
-        auto* data = static_cast<const uint8_t*>(binaryData.data());
-        m_writeRawData(std::span(data + byteOffset, byteLength));
+        m_writeRawData(binaryData.bytes().subspan(byteOffset, byteLength));
         return;
     }
-    m_queue.append(SharedBuffer::create(static_cast<const uint8_t*>(binaryData.data()) + byteOffset, byteLength));
+    m_queue.append(SharedBuffer::create(binaryData.bytes().subspan(byteOffset, byteLength)));
 }
 
 void NetworkSendQueue::enqueue(WebCore::Blob& blob)
@@ -104,7 +103,7 @@ void NetworkSendQueue::processMessages()
             }
 
             if (const auto& result = loader->arrayBufferResult()) {
-                m_writeRawData(std::span(static_cast<const uint8_t*>(result->data()), result->byteLength()));
+                m_writeRawData(result->bytes());
                 return;
             }
             ASSERT(errorCode);

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -92,7 +92,7 @@ private:
 
     ImageDocument& document() const;
 
-    void appendBytes(DocumentWriter&, const uint8_t*, size_t) override;
+    void appendBytes(DocumentWriter&, std::span<const uint8_t>) override;
     void finish() override;
 };
 
@@ -198,7 +198,7 @@ inline ImageDocument& ImageDocumentParser::document() const
     return downcast<ImageDocument>(*RawDataDocumentParser::document());
 }
 
-void ImageDocumentParser::appendBytes(DocumentWriter&, const uint8_t*, size_t)
+void ImageDocumentParser::appendBytes(DocumentWriter&, std::span<const uint8_t>)
 {
     document().updateDuringParsing();
 }

--- a/Source/WebCore/html/MediaDocument.cpp
+++ b/Source/WebCore/html/MediaDocument.cpp
@@ -74,7 +74,7 @@ private:
     {
     }
 
-    void appendBytes(DocumentWriter&, const uint8_t*, size_t) final;
+    void appendBytes(DocumentWriter&, std::span<const uint8_t>) final;
     void createDocumentStructure();
 
     WeakPtr<HTMLMediaElement> m_mediaElement;
@@ -129,7 +129,7 @@ void MediaDocumentParser::createDocumentStructure()
     frame->checkedLoader()->setOutgoingReferrer(document->completeURL(m_outgoingReferrer));
 }
 
-void MediaDocumentParser::appendBytes(DocumentWriter&, const uint8_t*, size_t)
+void MediaDocumentParser::appendBytes(DocumentWriter&, std::span<const uint8_t>)
 {
     if (m_mediaElement)
         return;

--- a/Source/WebCore/html/ModelDocument.cpp
+++ b/Source/WebCore/html/ModelDocument.cpp
@@ -67,7 +67,7 @@ private:
 
     void createDocumentStructure();
 
-    void appendBytes(DocumentWriter&, const uint8_t*, size_t) final;
+    void appendBytes(DocumentWriter&, std::span<const uint8_t>) final;
     void finish() final;
 
     WeakPtr<HTMLModelElement, WeakPtrImplWithEventTargetData> m_modelElement;
@@ -126,7 +126,7 @@ void ModelDocumentParser::createDocumentStructure()
     frame->loader().setOutgoingReferrer(document.completeURL(m_outgoingReferrer));
 }
 
-void ModelDocumentParser::appendBytes(DocumentWriter&, const uint8_t*, size_t)
+void ModelDocumentParser::appendBytes(DocumentWriter&, std::span<const uint8_t>)
 {
     if (!m_modelElement)
         createDocumentStructure();

--- a/Source/WebCore/html/PDFDocument.cpp
+++ b/Source/WebCore/html/PDFDocument.cpp
@@ -71,7 +71,7 @@ private:
 
     PDFDocument& document() const;
 
-    void appendBytes(DocumentWriter&, const uint8_t*, size_t) override;
+    void appendBytes(DocumentWriter&, std::span<const uint8_t>) override;
     void finish() override;
 };
 
@@ -82,7 +82,7 @@ inline PDFDocument& PDFDocumentParser::document() const
     return downcast<PDFDocument>(*RawDataDocumentParser::document());
 }
 
-void PDFDocumentParser::appendBytes(DocumentWriter&, const uint8_t*, size_t)
+void PDFDocumentParser::appendBytes(DocumentWriter&, std::span<const uint8_t>)
 {
     document().updateDuringParsing();
 }

--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -64,7 +64,7 @@ private:
     {
     }
 
-    void appendBytes(DocumentWriter&, const uint8_t*, size_t) final;
+    void appendBytes(DocumentWriter&, std::span<const uint8_t>) final;
     void createDocumentStructure();
     static Ref<HTMLStyleElement> createStyleElement(Document&);
 
@@ -126,7 +126,7 @@ void PluginDocumentParser::createDocumentStructure()
     document.setHasVisuallyNonEmptyCustomContent();
 }
 
-void PluginDocumentParser::appendBytes(DocumentWriter&, const uint8_t*, size_t)
+void PluginDocumentParser::appendBytes(DocumentWriter&, std::span<const uint8_t>)
 {
     if (m_embedElement)
         return;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1144,7 +1144,7 @@ void WebGLRenderingContextBase::bufferData(GCGLenum target, std::optional<Buffer
         return;
 
     std::visit([&](auto& data) {
-        m_context->bufferData(target, std::span(static_cast<const uint8_t*>(data->data()), data->byteLength()), usage);
+        m_context->bufferData(target, data->bytes(), usage);
     }, data.value());
 }
 
@@ -1161,7 +1161,7 @@ void WebGLRenderingContextBase::bufferSubData(GCGLenum target, long long offset,
     }
 
     std::visit([&](auto& data) {
-        m_context->bufferSubData(target, static_cast<GCGLintptr>(offset), std::span(static_cast<const uint8_t*>(data->data()), data->byteLength()));
+        m_context->bufferSubData(target, static_cast<GCGLintptr>(offset), data->bytes());
     }, data);
 }
 
@@ -1248,7 +1248,7 @@ void WebGLRenderingContextBase::compressedTexImage2D(GCGLenum target, GCGLint le
         return;
     if (!validateCompressedTexFormat("compressedTexImage2D", internalformat))
         return;
-    m_context->compressedTexImage2D(target, level, internalformat, width, height, border, data.byteLength(), std::span(static_cast<const uint8_t*>(data.baseAddress()), data.byteLength()));
+    m_context->compressedTexImage2D(target, level, internalformat, width, height, border, data.byteLength(), data.bytes());
 }
 
 void WebGLRenderingContextBase::compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, ArrayBufferView& data)
@@ -1259,7 +1259,7 @@ void WebGLRenderingContextBase::compressedTexSubImage2D(GCGLenum target, GCGLint
         return;
     if (!validateCompressedTexFormat("compressedTexSubImage2D", format))
         return;
-    m_context->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, data.byteLength(), std::span(static_cast<const uint8_t*>(data.baseAddress()), data.byteLength()));
+    m_context->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, data.byteLength(), data.bytes());
 }
 
 bool WebGLRenderingContextBase::validateSettableTexInternalFormat(const char* functionName, GCGLenum internalFormat)
@@ -3899,7 +3899,7 @@ std::optional<std::span<const uint8_t>> WebGLRenderingContextBase::validateTexFu
         return std::nullopt;
     }
     ASSERT(!offset.hasOverflowed()); // Checked already as part of `total.hasOverflowed()` check.
-    return std::span(static_cast<const uint8_t*>(pixels->baseAddress()) + offset.value(), dataLength);
+    return pixels->bytes().subspan(offset.value(), dataLength);
 }
 
 bool WebGLRenderingContextBase::validateTexFuncParameters(TexImageFunctionID functionID,

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -543,7 +543,7 @@ private:
             if (m_parsingBuffer.atEnd() || !isCharAfterTagNameOrAttribute(*m_parsingBuffer))
                 return didFail(HTMLFastPathResult::FailedParsingTagName, ElementName::Unknown);
             skipWhile<isASCIIWhitespace>(m_parsingBuffer);
-            return findHTMLElementName(std::span { m_charBuffer.data(), m_charBuffer.size() });
+            return findHTMLElementName(m_charBuffer.span());
         }
         auto tagName = findHTMLElementName(std::span { start, static_cast<size_t>(m_parsingBuffer.position() - start) });
         skipWhile<isASCIIWhitespace>(m_parsingBuffer);

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -94,10 +94,8 @@ void DocumentWriter::replaceDocumentWithResultOfExecutingJavascriptURL(const Str
             frame->protectedDocument()->setCompatibilityMode(DocumentCompatibilityMode::NoQuirksMode);
         }
 
-        if (RefPtr parser = frame->document()->parser()) {
-            auto utf8Source = source.utf8();
-            parser->appendBytes(*this, reinterpret_cast<const uint8_t*>(utf8Source.data()), utf8Source.length());
-        }
+        if (RefPtr parser = frame->document()->parser())
+            parser->appendBytes(*this, source.utf8().bytes());
     }
 
     end();
@@ -317,7 +315,7 @@ void DocumentWriter::addData(const SharedBuffer& data)
         return;
     }
     ASSERT(m_parser);
-    protectedParser()->appendBytes(*this, data.data(), data.size());
+    protectedParser()->appendBytes(*this, data.bytes());
 }
 
 void DocumentWriter::insertDataSynchronously(const String& markup)

--- a/Source/WebCore/loader/SinkDocument.cpp
+++ b/Source/WebCore/loader/SinkDocument.cpp
@@ -48,7 +48,7 @@ private:
     }
 
     // Ignore all data.
-    void appendBytes(DocumentWriter&, const uint8_t*, size_t) override
+    void appendBytes(DocumentWriter&, std::span<const uint8_t>) override
     {
     }
 };

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -165,7 +165,7 @@ auto FragmentedSharedBuffer::toIPCData() const -> IPCData
 {
     if (useUnixDomainSockets || size() < minimumPageSize) {
         return WTF::map(m_segments, [](auto& segment) {
-            return std::span { segment.segment->data(), segment.segment->size() };
+            return segment.segment->bytes();
         });
     }
 

--- a/Source/WebCore/platform/SharedBufferChunkReader.cpp
+++ b/Source/WebCore/platform/SharedBufferChunkReader.cpp
@@ -76,7 +76,7 @@ bool SharedBufferChunkReader::nextChunk(Vector<uint8_t>& chunk, bool includeSepa
             if (currentCharacter != m_separator[m_separatorIndex]) {
                 if (m_separatorIndex > 0) {
                     ASSERT_WITH_SECURITY_IMPLICATION(m_separatorIndex <= m_separator.size());
-                    chunk.append(std::span { m_separator.data(), m_separatorIndex });
+                    chunk.append(m_separator.span().first(m_separatorIndex));
                     m_separatorIndex = 0;
                 }
                 chunk.append(currentCharacter);
@@ -130,9 +130,8 @@ size_t SharedBufferChunkReader::peek(Vector<uint8_t>& data, size_t requestedSize
     auto currentSegment = m_iteratorCurrent;
 
     while (requestedSize && ++currentSegment != m_iteratorEnd) {
-        const uint8_t* segment = currentSegment->segment->data();
         size_t lengthInSegment = std::min(currentSegment->segment->size(), requestedSize);
-        data.append(std::span { segment, lengthInSegment });
+        data.append(currentSegment->segment->bytes().first(lengthInSegment));
         readBytesCount += lengthInSegment;
         requestedSize -= lengthInSegment;
     }

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -113,6 +113,8 @@ public:
         return m_data;
     }
 
+    std::span<const uint8_t> bytes() const { return { static_cast<const uint8_t*>(m_data), m_size }; }
+
 #if OS(WINDOWS)
     HANDLE handle() const { return m_handle.get(); }
 #endif

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -41,6 +41,7 @@
 #include <wtf/persistence/PersistentCoders.h>
 
 #if PLATFORM(COCOA)
+#include <wtf/cf/VectorCF.h>
 #include <wtf/spi/cocoa/SecuritySPI.h>
 #endif
 
@@ -343,11 +344,9 @@ namespace WTF::Persistence {
 
 static void encodeCFData(Encoder& encoder, CFDataRef data)
 {
-    uint64_t length = CFDataGetLength(data);
-    const uint8_t* bytePtr = CFDataGetBytePtr(data);
-
-    encoder << length;
-    encoder.encodeFixedLengthData({ bytePtr, static_cast<size_t>(length) });
+    auto span = toSpan(data);
+    encoder << static_cast<uint64_t>(span.size());
+    encoder.encodeFixedLengthData(span);
 }
 
 static std::optional<RetainPtr<CFDataRef>> decodeCFData(Decoder& decoder)

--- a/Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp
+++ b/Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp
@@ -27,6 +27,7 @@
 #include "KeyedEncoderGeneric.h"
 
 #include "SharedBuffer.h"
+#include <wtf/Algorithms.h>
 #include <wtf/persistence/PersistentEncoder.h>
 
 namespace WebCore {
@@ -40,7 +41,7 @@ void KeyedEncoderGeneric::encodeString(const String& key)
 {
     auto result = key.tryGetUTF8([&](std::span<const char> span) -> bool {
         m_encoder << span.size();
-        m_encoder.encodeFixedLengthData({ bitwise_cast<const uint8_t*>(span.data()), span.size() });
+        m_encoder.encodeFixedLengthData(spanReinterpretCast<const uint8_t>(span));
         return true;
     });
     RELEASE_ASSERT(result);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -210,7 +210,7 @@ void CDMSessionAVContentKeySession::releaseKeys()
             if (m_sessionId == String(playbackSessionIdValue)) {
                 ALWAYS_LOG(LOGIDENTIFIER, "found session, sending expiration message");
                 m_expiredSession = expiredSessionData;
-                m_client->sendMessage(Uint8Array::create(static_cast<const uint8_t*>([m_expiredSession bytes]), [m_expiredSession length]).ptr(), emptyString());
+                m_client->sendMessage(Uint8Array::create(toSpan(m_expiredSession.get())).ptr(), emptyString());
                 break;
             }
         }
@@ -334,7 +334,7 @@ bool CDMSessionAVContentKeySession::update(Uint8Array* key, RefPtr<Uint8Array>& 
         }
 
         ALWAYS_LOG(LOGIDENTIFIER, "generated key request");
-        nextMessage = Uint8Array::tryCreate(static_cast<const uint8_t*>([requestData bytes]), [requestData length]);
+        nextMessage = Uint8Array::tryCreate(toSpan(requestData.get()));
         return false;
     }
 
@@ -423,7 +423,7 @@ RefPtr<Uint8Array> CDMSessionAVContentKeySession::generateKeyReleaseMessage(unsi
     errorCode = 0;
     systemCode = 0;
     m_expiredSession = [expiredSessions firstObject];
-    return Uint8Array::tryCreate(static_cast<const uint8_t*>([m_expiredSession bytes]), [m_expiredSession length]);
+    return Uint8Array::tryCreate(toSpan(m_expiredSession.get()));
 }
 
 bool CDMSessionAVContentKeySession::hasContentKeyRequest() const

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.h
@@ -74,7 +74,7 @@ public:
     void pause();
     void resume();
 
-    void appendData(const uint8_t*, size_t);
+    void appendData(std::span<const uint8_t>);
 
     const String& mimeType() const;
     unsigned audioBitRate() const;

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm
@@ -46,6 +46,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/FileSystem.h>
 #include <wtf/cf/TypeCastsCF.h>
+#include <wtf/cocoa/SpanCocoa.h>
 
 #include <pal/cf/CoreMediaSoftLink.h>
 #include <pal/cocoa/AVFoundationSoftLink.h>
@@ -75,14 +76,14 @@
 - (void)assetWriter:(AVAssetWriter *)assetWriter didProduceFragmentedHeaderData:(NSData *)fragmentedHeaderData
 {
     UNUSED_PARAM(assetWriter);
-    m_writer->appendData(static_cast<const uint8_t*>([fragmentedHeaderData bytes]), [fragmentedHeaderData length]);
+    m_writer->appendData(toSpan(fragmentedHeaderData));
 }
 
 - (void)assetWriter:(AVAssetWriter *)assetWriter didProduceFragmentedMediaData:(NSData *)fragmentedMediaData fragmentedMediaDataReport:(AVFragmentedMediaDataReport *)fragmentedMediaDataReport
 {
     UNUSED_PARAM(assetWriter);
     UNUSED_PARAM(fragmentedMediaDataReport);
-    m_writer->appendData(static_cast<const uint8_t*>([fragmentedMediaData bytes]), [fragmentedMediaData length]);
+    m_writer->appendData(toSpan(fragmentedMediaData));
 }
 
 - (void)close
@@ -535,10 +536,10 @@ void MediaRecorderPrivateWriter::completeFetchData()
     m_fetchDataCompletionHandler(takeData(), currentTimeCode);
 }
 
-void MediaRecorderPrivateWriter::appendData(const uint8_t* data, size_t size)
+void MediaRecorderPrivateWriter::appendData(std::span<const uint8_t> data)
 {
     Locker locker { m_dataLock };
-    m_data.append(data, size);
+    m_data.append(data);
 }
 
 RefPtr<FragmentedSharedBuffer> MediaRecorderPrivateWriter::takeData()

--- a/Source/WebKit/NetworkProcess/cocoa/WKURLSessionTaskDelegate.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WKURLSessionTaskDelegate.mm
@@ -39,6 +39,7 @@
 #import <WebCore/ResourceRequest.h>
 #import <WebCore/ResourceResponse.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 @implementation WKURLSessionTaskDelegate {
     WebKit::DataTaskIdentifier _identifier;
@@ -96,7 +97,7 @@
     RefPtr connection = [self connection];
     if (!connection)
         return;
-    connection->send(Messages::NetworkProcessProxy::DataTaskDidReceiveData(_identifier, { reinterpret_cast<const uint8_t*>(data.bytes), data.length }), 0);
+    connection->send(Messages::NetworkProcessProxy::DataTaskDidReceiveData(_identifier, toSpan(data)), 0);
 }
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error

--- a/Source/WebKit/Shared/WebCompiledContentRuleList.cpp
+++ b/Source/WebKit/Shared/WebCompiledContentRuleList.cpp
@@ -69,7 +69,7 @@ std::span<const uint8_t> WebCompiledContentRuleList::serializedActions() const
 std::span<const uint8_t> WebCompiledContentRuleList::spanWithOffsetAndLength(size_t offset, size_t length) const
 {
     RELEASE_ASSERT(offset + length <= m_data.data->size());
-    return { static_cast<const uint8_t*>(m_data.data->data()) + offset, length };
+    return m_data.data->bytes().subspan(offset, length);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -64,6 +64,7 @@
 #import <wtf/NeverDestroyed.h>
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cf/CFURLExtras.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 NSString * const WKActionIsMainFrameKey = @"WKActionIsMainFrameKey";
 NSString * const WKActionNavigationTypeKey = @"WKActionNavigationTypeKey";
@@ -176,7 +177,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         wkUserData = WebKit::ObjCObjectGraph::create(userData);
 
     NSData *data = [HTMLString dataUsingEncoding:NSUTF8StringEncoding];
-    _page->loadData({ static_cast<const uint8_t*>(data.bytes), data.length }, "text/html"_s, "UTF-8"_s, bytesAsString(bridge_cast(baseURL)), wkUserData.get());
+    _page->loadData(toSpan(data), "text/html"_s, "UTF-8"_s, bytesAsString(bridge_cast(baseURL)), wkUserData.get());
 }
 
 - (void)loadAlternateHTMLString:(NSString *)string baseURL:(NSURL *)baseURL forUnreachableURL:(NSURL *)unreachableURL
@@ -196,7 +197,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (userData)
         wkUserData = WebKit::ObjCObjectGraph::create(userData);
 
-    _page->loadData({ static_cast<const uint8_t*>(data.bytes), data.length }, MIMEType, encodingName, bytesAsString(bridge_cast(baseURL)), wkUserData.get());
+    _page->loadData(toSpan(data), MIMEType, encodingName, bytesAsString(bridge_cast(baseURL)), wkUserData.get());
 }
 
 - (void)stopLoading

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -782,7 +782,7 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
     if (_page->isServiceWorkerPage())
         [NSException raise:NSInternalInconsistencyException format:@"The WKWebView was used to load a service worker"];
 
-    return wrapper(_page->loadData({ static_cast<const uint8_t*>(data.bytes), data.length }, MIMEType, characterEncodingName, baseURL.absoluteString)).autorelease();
+    return wrapper(_page->loadData(toSpan(data), MIMEType, characterEncodingName, baseURL.absoluteString)).autorelease();
 }
 
 - (void)startDownloadUsingRequest:(NSURLRequest *)request completionHandler:(void(^)(WKDownload *))completionHandler
@@ -1884,7 +1884,7 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 - (WKNavigation *)loadSimulatedRequest:(NSURLRequest *)request response:(NSURLResponse *)response responseData:(NSData *)data
 {
     THROW_IF_SUSPENDED;
-    return wrapper(_page->loadSimulatedRequest(request, response, { static_cast<const uint8_t*>(data.bytes), data.length })).autorelease();
+    return wrapper(_page->loadSimulatedRequest(request, response, toSpan(data))).autorelease();
 }
 
 // FIXME(223658): Remove this once adopters have moved to the final API.
@@ -2788,7 +2788,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 - (WKNavigation *)_loadData:(NSData *)data MIMEType:(NSString *)MIMEType characterEncodingName:(NSString *)characterEncodingName baseURL:(NSURL *)baseURL userData:(id)userData
 {
     THROW_IF_SUSPENDED;
-    return wrapper(_page->loadData({ static_cast<const uint8_t*>(data.bytes), data.length }, MIMEType, characterEncodingName, baseURL.absoluteString, WebKit::ObjCObjectGraph::create(userData).ptr())).autorelease();
+    return wrapper(_page->loadData(toSpan(data), MIMEType, characterEncodingName, baseURL.absoluteString, WebKit::ObjCObjectGraph::create(userData).ptr())).autorelease();
 }
 
 - (WKNavigation *)_loadRequest:(NSURLRequest *)request shouldOpenExternalURLs:(BOOL)shouldOpenExternalURLs

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -95,7 +95,7 @@ static RetainPtr<NSData> produceClientDataJson(_WKWebAuthenticationType type, NS
         clientDataType = WebCore::ClientDataType::Get;
         break;
     }
-    auto challengeBuffer = ArrayBuffer::tryCreate(reinterpret_cast<const uint8_t*>(challenge.bytes), challenge.length);
+    auto challengeBuffer = ArrayBuffer::tryCreate(toSpan(challenge));
     auto securityOrigin = WebCore::SecurityOrigin::createFromString(origin);
 
     auto clientDataJson = buildClientDataJson(clientDataType, WebCore::BufferSource(challengeBuffer), securityOrigin, scope, topOrigin);
@@ -916,13 +916,6 @@ static WebCore::MediationRequirement toWebCore(_WKWebAuthenticationMediationRequ
 }
 #endif
 
-#if ENABLE(WEB_AUTHN)
-static std::span<const uint8_t> asUInt8Span(NSData* data)
-{
-    return { reinterpret_cast<const uint8_t*>(data.bytes), data.length };
-}
-#endif
-
 + (WebCore::PublicKeyCredentialCreationOptions)convertToCoreCreationOptionsWithOptions:(_WKPublicKeyCredentialCreationOptions *)options
 {
     WebCore::PublicKeyCredentialCreationOptions result;
@@ -941,7 +934,7 @@ static std::span<const uint8_t> asUInt8Span(NSData* data)
         result.authenticatorSelection = authenticatorSelectionCriteria(options.authenticatorSelection);
     result.attestation = attestationConveyancePreference(options.attestation);
     if (options.extensionsCBOR)
-        result.extensions = WebCore::AuthenticationExtensionsClientInputs::fromCBOR(asUInt8Span(options.extensionsCBOR));
+        result.extensions = WebCore::AuthenticationExtensionsClientInputs::fromCBOR(toSpan(options.extensionsCBOR));
     else
         result.extensions = authenticationExtensionsClientInputs(options.extensions);
 #endif
@@ -1024,7 +1017,7 @@ static RetainPtr<_WKAuthenticatorAttestationResponse> wkAuthenticatorAttestation
     if (options.allowCredentials)
         result.allowCredentials = publicKeyCredentialDescriptors(options.allowCredentials);
     if (options.extensionsCBOR)
-        result.extensions = WebCore::AuthenticationExtensionsClientInputs::fromCBOR(asUInt8Span(options.extensionsCBOR));
+        result.extensions = WebCore::AuthenticationExtensionsClientInputs::fromCBOR(toSpan(options.extensionsCBOR));
     else
         result.extensions = authenticationExtensionsClientInputs(options.extensions);
     result.userVerification = userVerification(options.userVerification);

--- a/Source/WebKit/UIProcess/Cocoa/SessionStateCoding.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SessionStateCoding.mm
@@ -28,13 +28,9 @@
 
 #import "LegacySessionStateCoding.h"
 #import "WKNSData.h"
+#include <wtf/cocoa/SpanCocoa.h>
 
 namespace WebKit {
-
-static std::span<const uint8_t> span(NSData *data)
-{
-    return { static_cast<const uint8_t*>(data.bytes), data.length };
-}
 
 RetainPtr<NSData> encodeSessionState(const SessionState& sessionState)
 {
@@ -43,7 +39,7 @@ RetainPtr<NSData> encodeSessionState(const SessionState& sessionState)
 
 bool decodeSessionState(NSData *data, SessionState& state)
 {
-    return decodeLegacySessionState(span(data), state);
+    return decodeLegacySessionState(toSpan(data), state);
 }
 
 }

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -79,6 +79,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/cf/TypeCastsCF.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 #if ENABLE(MEDIA_USAGE)
 #import "MediaUsageManagerCocoa.h"
@@ -938,14 +939,9 @@ bool WebPageProxy::isQuarantinedAndNotUserApproved(const String& fileURLString)
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
 
-static std::span<const uint8_t> span(NSData *data)
-{
-    return { static_cast<const uint8_t*>(data.bytes), data.length };
-}
-
 void WebPageProxy::insertMultiRepresentationHEIC(NSData *data)
 {
-    send(Messages::WebPage::InsertMultiRepresentationHEIC(span(data)));
+    send(Messages::WebPage::InsertMultiRepresentationHEIC(toSpan(data)));
 
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -137,7 +137,7 @@ static inline RetainPtr<NSData> toNSData(ArrayBuffer* buffer)
 
 static inline Ref<ArrayBuffer> toArrayBuffer(NSData *data)
 {
-    return ArrayBuffer::create(reinterpret_cast<const uint8_t*>(data.bytes), data.length);
+    return ArrayBuffer::create(toSpan(data));
 }
 
 static inline Ref<ArrayBuffer> toArrayBuffer(const Vector<uint8_t>& data)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12893,7 +12893,7 @@ void WebPageProxy::loadServiceWorker(const URL& url, bool usingModules, Completi
     else
         html = makeString("<script>navigator.serviceWorker.register('", url.string(), "');</script>").utf8();
 
-    loadData({ reinterpret_cast<const uint8_t*>(html.data()), html.length() }, "text/html"_s, "UTF-8"_s, url.protocolHostAndPort());
+    loadData(html.bytes(), "text/html"_s, "UTF-8"_s, url.protocolHostAndPort());
 }
 
 #if !PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5272,7 +5272,7 @@ static void selectionChangedWithTouch(WKTextInteractionWrapper *interaction, con
 
         auto [elementContext, image, preferredMIMEType] = *data;
         if (auto [data, type] = WebKit::imageDataForRemoveBackground(image.get(), preferredMIMEType.createCFString().get()); data)
-            view->_page->replaceImageForRemoveBackground(elementContext, { String { type.get() } }, { static_cast<const uint8_t*>([data bytes]), [data length] });
+            view->_page->replaceImageForRemoveBackground(elementContext, { String { type.get() } }, toSpan(data.get()));
     }];
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -1581,7 +1581,7 @@ void RemoteGraphicsContextGLProxy::bufferData(GCGLenum target, std::span<const u
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData1(target, std::span(reinterpret_cast<const uint8_t*>(data.data()), data.size()), usage));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferData1(target, data, usage));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1592,7 +1592,7 @@ void RemoteGraphicsContextGLProxy::bufferSubData(GCGLenum target, GCGLintptr off
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferSubData(target, static_cast<uint64_t>(offset), std::span(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::BufferSubData(target, static_cast<uint64_t>(offset), data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1614,7 +1614,7 @@ void RemoteGraphicsContextGLProxy::texImage2D(GCGLenum target, GCGLint level, GC
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D0(target, level, internalformat, width, height, border, format, type, std::span(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage2D0(target, level, internalformat, width, height, border, format, type, pixels));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1636,7 +1636,7 @@ void RemoteGraphicsContextGLProxy::texSubImage2D(GCGLenum target, GCGLint level,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D0(target, level, xoffset, yoffset, width, height, format, type, std::span(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage2D0(target, level, xoffset, yoffset, width, height, format, type, pixels));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1658,7 +1658,7 @@ void RemoteGraphicsContextGLProxy::compressedTexImage2D(GCGLenum target, GCGLint
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D0(target, level, internalformat, width, height, border, imageSize, std::span(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage2D0(target, level, internalformat, width, height, border, imageSize, data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1680,7 +1680,7 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage2D(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D0(target, level, xoffset, yoffset, width, height, format, imageSize, std::span(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage2D0(target, level, xoffset, yoffset, width, height, format, imageSize, data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1895,7 +1895,7 @@ void RemoteGraphicsContextGLProxy::texImage3D(GCGLenum target, GCGLint level, GC
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D0(target, level, internalformat, width, height, depth, border, format, type, std::span(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexImage3D0(target, level, internalformat, width, height, depth, border, format, type, pixels));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1917,7 +1917,7 @@ void RemoteGraphicsContextGLProxy::texSubImage3D(GCGLenum target, GCGLint level,
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, std::span(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::TexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1950,7 +1950,7 @@ void RemoteGraphicsContextGLProxy::compressedTexImage3D(GCGLenum target, GCGLint
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D0(target, level, internalformat, width, height, depth, border, imageSize, std::span(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexImage3D0(target, level, internalformat, width, height, depth, border, imageSize, data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1972,7 +1972,7 @@ void RemoteGraphicsContextGLProxy::compressedTexSubImage3D(GCGLenum target, GCGL
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, std::span(reinterpret_cast<const uint8_t*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CompressedTexSubImage3D0(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;

--- a/Source/WebKit/WebProcess/Network/WebTransportSendStreamSink.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSendStreamSink.cpp
@@ -61,7 +61,7 @@ void WebTransportSendStreamSink::write(WebCore::ScriptExecutionContext& context,
         return promise.settle(WebCore::Exception { WebCore::ExceptionCode::ExistingExceptionError });
 
     WTF::switchOn(arrayBufferOrView, [&](auto& arrayBufferOrView) {
-        sendBytes({ static_cast<const uint8_t*>(arrayBufferOrView->data()), arrayBufferOrView->byteLength() }, [promise = WTFMove(promise)] () mutable {
+        sendBytes(arrayBufferOrView->bytes(), [promise = WTFMove(promise)] () mutable {
             promise.resolve();
         });
     });

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -162,6 +162,7 @@
 #import <wtf/Scope.h>
 #import <wtf/SetForScope.h>
 #import <wtf/cocoa/Entitlements.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/StringToIntegerConversion.h>
 #import <wtf/text/TextBreakIterator.h>
 #import <wtf/text/TextStream.h>
@@ -264,10 +265,7 @@ RetainPtr<NSData> WebPage::accessibilityRemoteTokenData() const
 
 void WebPage::relayAccessibilityNotification(const String& notificationName, const RetainPtr<NSData>& notificationData)
 {
-    std::span<const uint8_t> dataToken;
-    if ([notificationData length])
-        dataToken = { reinterpret_cast<const uint8_t*>([notificationData bytes]), [notificationData length] };
-    send(Messages::WebPageProxy::RelayAccessibilityNotification(notificationName, dataToken));
+    send(Messages::WebPageProxy::RelayAccessibilityNotification(notificationName, toSpan(notificationData.get())));
 }
 
 static void computeEditableRootHasContentAndPlainText(const VisibleSelection& selection, EditorState::PostLayoutData& data)


### PR DESCRIPTION
#### c448798e6ae8525f4bb62d6a86326c0ac358b734
<pre>
Simplify code by using std::span more
<a href="https://bugs.webkit.org/show_bug.cgi?id=271338">https://bugs.webkit.org/show_bug.cgi?id=271338</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/runtime/GenericTypedArrayView.h:
* Source/WTF/wtf/Algorithms.h:
(WTF::spanReinterpretCast): Deleted.
* Source/WTF/wtf/StdLibExtras.h:
(WTF::spanReinterpretCast):
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::take):
* Source/WebCore/Modules/fetch/FormDataConsumer.cpp:
(WebCore::FormDataConsumer::consumeBlob):
* Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp:
(WebCore::RTCEncodedFrame::rtcFrame):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
(WebCore::RTCRtpSFrameTransform::createStreams):
* Source/WebCore/Modules/websockets/WebSocketDeflater.cpp:
(WebCore::WebSocketInflater::finish):
* Source/WebCore/Modules/webtransport/DatagramSink.cpp:
(WebCore::DatagramSink::write):
* Source/WebCore/bindings/js/BufferSource.h:
(WebCore::toBufferSource):
* Source/WebCore/dom/DocumentParser.h:
(WebCore::DocumentParser::appendBytes):
* Source/WebCore/dom/TextEncoder.cpp:
(WebCore::TextEncoder::encode const):
* Source/WebCore/fileapi/NetworkSendQueue.cpp:
(WebCore::NetworkSendQueue::enqueue):
(WebCore::NetworkSendQueue::processMessages):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::bufferData):
(WebCore::WebGLRenderingContextBase::bufferSubData):
(WebCore::WebGLRenderingContextBase::compressedTexImage2D):
(WebCore::WebGLRenderingContextBase::compressedTexSubImage2D):
(WebCore::WebGLRenderingContextBase::validateTexFuncData):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::scanTagName):
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::replaceDocumentWithResultOfExecutingJavascriptURL):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::toIPCData const):
* Source/WebCore/platform/SharedBufferChunkReader.cpp:
(WebCore::SharedBufferChunkReader::nextChunk):
(WebCore::SharedBufferChunkReader::peek):
* Source/WebCore/platform/SharedMemory.h:
(WebCore::SharedMemory::bytes const):
* Source/WebCore/platform/WebCorePersistentCoders.cpp:
(WTF::Persistence::encodeCFData):
* Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp:
(WebCore::KeyedEncoderGeneric::encodeString):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::releaseKeys):
(WebCore::CDMSessionAVContentKeySession::update):
(WebCore::CDMSessionAVContentKeySession::generateKeyReleaseMessage):
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm:
(-[WebAVAssetWriterDelegate assetWriter:didProduceFragmentedHeaderData:]):
(-[WebAVAssetWriterDelegate assetWriter:didProduceFragmentedMediaData:fragmentedMediaDataReport:]):
(WebCore::MediaRecorderPrivateWriter::appendData):
* Source/WebKit/NetworkProcess/cocoa/WKURLSessionTaskDelegate.mm:
(-[WKURLSessionTaskDelegate URLSession:dataTask:didReceiveData:]):
* Source/WebKit/Shared/WebCompiledContentRuleList.cpp:
(WebKit::WebCompiledContentRuleList::spanWithOffsetAndLength const):
* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
(-[WKBrowsingContextController loadHTMLString:baseURL:userData:]):
(-[WKBrowsingContextController loadData:MIMEType:textEncodingName:baseURL:userData:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView loadData:MIMEType:characterEncodingName:baseURL:]):
(-[WKWebView loadSimulatedRequest:response:responseData:]):
(-[WKWebView _loadData:MIMEType:characterEncodingName:baseURL:userData:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(produceClientDataJson):
(+[_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:]):
(+[_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:]):
(asUInt8Span): Deleted.
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm:
(WebKit::RedirectSOAuthorizationSession::completeInternal):
(WebKit::span): Deleted.
* Source/WebKit/UIProcess/Cocoa/SessionStateCoding.mm:
(WebKit::decodeSessionState):
(WebKit::span): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::insertMultiRepresentationHEIC):
(WebKit::span): Deleted.
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::toArrayBuffer):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::loadServiceWorker):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView removeBackgroundMenu]):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::bufferData):
(WebKit::RemoteGraphicsContextGLProxy::bufferSubData):
(WebKit::RemoteGraphicsContextGLProxy::texImage2D):
(WebKit::RemoteGraphicsContextGLProxy::texSubImage2D):
(WebKit::RemoteGraphicsContextGLProxy::compressedTexImage2D):
(WebKit::RemoteGraphicsContextGLProxy::compressedTexSubImage2D):
(WebKit::RemoteGraphicsContextGLProxy::texImage3D):
(WebKit::RemoteGraphicsContextGLProxy::texSubImage3D):
(WebKit::RemoteGraphicsContextGLProxy::compressedTexImage3D):
(WebKit::RemoteGraphicsContextGLProxy::compressedTexSubImage3D):
* Source/WebKit/WebProcess/Network/WebTransportSendStreamSink.cpp:
(WebKit::WebTransportSendStreamSink::write):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::relayAccessibilityNotification):

Canonical link: <a href="https://commits.webkit.org/276479@main">https://commits.webkit.org/276479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/442a0319c959f71bda50574449bd75cbdd589db1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47395 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36778 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38541 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17843 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39677 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2788 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/37938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49056 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44215 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19706 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16274 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21026 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42509 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21363 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51369 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6198 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20701 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10426 "Passed tests") | 
<!--EWS-Status-Bubble-End-->