### PR TITLE
Backdrop-filter forces compositing on the root element and uses extra memory.

### DIFF
--- a/LayoutTests/compositing/filters/backdrop-filter-root-element-no-backdrop-root-expected.txt
+++ b/LayoutTests/compositing/filters/backdrop-filter-root-element-no-backdrop-root-expected.txt
@@ -1,4 +1,3 @@
-foo foobar
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -6,12 +5,10 @@ foo foobar
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
+      (backgroundColor #008000)
       (children 1
         (GraphicsLayer
-          (position 8.00 8.00)
-          (bounds 341.00 318.00)
-          (drawsContent 1)
-          (backdrop layer 0.00, 0.00 100.00 x 200.00)
+          (position 8.00 13.00)
         )
       )
     )

--- a/LayoutTests/compositing/filters/backdrop-filter-root-element-no-backdrop-root.html
+++ b/LayoutTests/compositing/filters/backdrop-filter-root-element-no-backdrop-root.html
@@ -1,0 +1,25 @@
+<!doctype HTML>
+<html style="background-color:green">
+<head>
+  <script type="text/javascript" charset="utf-8">
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    function doTest()
+    {
+        if (window.testRunner) {
+            document.getElementById('layers').innerText = window.internals.layerTreeAsText(document);
+            testRunner.notifyDone();
+        }
+    }
+
+    window.addEventListener('load', doTest, false);
+  </script>
+</head>
+<body>
+<div style="backdrop-filter: blur(20px)"></div>
+<pre id="layers">Layer tree appears here in DRT.</pre>
+</body>
+</html>

--- a/LayoutTests/css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute-expected.txt
+++ b/LayoutTests/css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute-expected.txt
@@ -8,22 +8,16 @@ foo foobar
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 8.00 8.00)
+          (bounds 342.00 318.00)
           (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 8.00 8.00)
-              (bounds 342.00 318.00)
-              (drawsContent 1)
-              (structural layer
-                (position 179.00 167.00)
-                (bounds 342.00 318.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 100.00 200.00)
-              )
-            )
+          (structural layer
+            (position 179.00 167.00)
+            (bounds 342.00 318.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 100.00 200.00)
           )
         )
       )

--- a/LayoutTests/css3/filters/backdrop/backdrop-filter-does-not-size-properly-border-and-padding-expected.txt
+++ b/LayoutTests/css3/filters/backdrop/backdrop-filter-does-not-size-properly-border-and-padding-expected.txt
@@ -8,22 +8,16 @@ foo
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 8.00 8.00)
+          (bounds 180.00 280.00)
           (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 8.00 8.00)
-              (bounds 180.00 280.00)
-              (drawsContent 1)
-              (structural layer
-                (position 98.00 148.00)
-                (bounds 180.00 280.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 180.00 280.00)
-              )
-            )
+          (structural layer
+            (position 98.00 148.00)
+            (bounds 180.00 280.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 180.00 280.00)
           )
         )
       )

--- a/LayoutTests/css3/filters/backdrop/backdrop-filter-with-cliprect-expected.txt
+++ b/LayoutTests/css3/filters/backdrop/backdrop-filter-with-cliprect-expected.txt
@@ -9,22 +9,16 @@ bar
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 8.00 26.00)
+          (bounds 120.00 120.00)
           (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 8.00 26.00)
-              (bounds 120.00 120.00)
-              (drawsContent 1)
-              (structural layer
-                (position 68.00 86.00)
-                (bounds 120.00 120.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 120.00 120.00)
-              )
-            )
+          (structural layer
+            (position 68.00 86.00)
+            (bounds 120.00 120.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 120.00 120.00)
           )
         )
       )

--- a/LayoutTests/css3/filters/backdrop/backdrop-filter-with-mask-expected.txt
+++ b/LayoutTests/css3/filters/backdrop/backdrop-filter-with-mask-expected.txt
@@ -9,27 +9,21 @@ bar
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 8.00 26.00)
+          (bounds 120.00 120.00)
           (drawsContent 1)
-          (children 1
+          (mask layer)
             (GraphicsLayer
-              (position 8.00 26.00)
               (bounds 120.00 120.00)
               (drawsContent 1)
-              (mask layer)
-                (GraphicsLayer
-                  (bounds 120.00 120.00)
-                  (drawsContent 1)
-                )
-              (structural layer
-                (position 68.00 86.00)
-                (bounds 120.00 120.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 120.00 120.00)
-              )
             )
+          (structural layer
+            (position 68.00 86.00)
+            (bounds 120.00 120.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 120.00 120.00)
           )
         )
       )

--- a/LayoutTests/css3/filters/backdrop/backdrop-with-visibility-hidden-changing-expected.txt
+++ b/LayoutTests/css3/filters/backdrop/backdrop-with-visibility-hidden-changing-expected.txt
@@ -8,22 +8,16 @@ Dump when filter is visible:
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 0.00 150.00)
+          (bounds 402.00 52.00)
           (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 0.00 150.00)
-              (bounds 402.00 52.00)
-              (drawsContent 1)
-              (structural layer
-                (position 201.00 176.00)
-                (bounds 402.00 52.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 402.00 52.00)
-              )
-            )
+          (structural layer
+            (position 201.00 176.00)
+            (bounds 402.00 52.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 402.00 52.00)
           )
         )
       )
@@ -40,23 +34,17 @@ Dump when filter is hidden:
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
-          (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 0.00 150.00)
-              (bounds 402.00 52.00)
-              (contentsVisible 0)
-              (structural layer
-                (position 201.00 176.00)
-                (bounds 402.00 52.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 402.00 52.00)
-                (hidden)
-              )
-            )
+          (position 0.00 150.00)
+          (bounds 402.00 52.00)
+          (contentsVisible 0)
+          (structural layer
+            (position 201.00 176.00)
+            (bounds 402.00 52.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 402.00 52.00)
+            (hidden)
           )
         )
       )
@@ -73,22 +61,16 @@ Dump when filter is visible again:
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 0.00 150.00)
+          (bounds 402.00 52.00)
           (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 0.00 150.00)
-              (bounds 402.00 52.00)
-              (drawsContent 1)
-              (structural layer
-                (position 201.00 176.00)
-                (bounds 402.00 52.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 402.00 52.00)
-              )
-            )
+          (structural layer
+            (position 201.00 176.00)
+            (bounds 402.00 52.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 402.00 52.00)
           )
         )
       )

--- a/LayoutTests/css3/filters/backdrop/backdrop-with-visibility-hidden-expected.txt
+++ b/LayoutTests/css3/filters/backdrop/backdrop-with-visibility-hidden-expected.txt
@@ -7,23 +7,17 @@
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
-          (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 0.00 150.00)
-              (bounds 402.00 52.00)
-              (contentsVisible 0)
-              (structural layer
-                (position 201.00 176.00)
-                (bounds 402.00 52.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 402.00 52.00)
-                (hidden)
-              )
-            )
+          (position 0.00 150.00)
+          (bounds 402.00 52.00)
+          (contentsVisible 0)
+          (structural layer
+            (position 201.00 176.00)
+            (bounds 402.00 52.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 402.00 52.00)
+            (hidden)
           )
         )
       )

--- a/LayoutTests/css3/filters/backdrop/resource-use-add-more-layers-expected.txt
+++ b/LayoutTests/css3/filters/backdrop/resource-use-add-more-layers-expected.txt
@@ -5,179 +5,174 @@
     (GraphicsLayer
       (bounds 1243.00 2209.00)
       (contentsOpaque 1)
-      (children 1
+      (children 3
         (GraphicsLayer
-          (bounds 1243.00 2209.00)
-          (children 3
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+          (children 10
             (GraphicsLayer
+              (position 1.00 1.00)
               (bounds 1242.00 2208.00)
               (usingTiledLayer 1)
               (drawsContent 1)
               (structural layer
-                (position 621.00 1104.00)
+                (position 622.00 1105.00)
                 (bounds 1242.00 2208.00)
               )
               (backdrop layer
                 (position 0.00 0.00)
                 (bounds 1242.00 2208.00)
               )
-              (children 10
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (usingTiledLayer 1)
-                  (drawsContent 1)
-                  (structural layer
-                    (position 622.00 1105.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                  (backdrop layer
-                    (position 0.00 0.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (usingTiledLayer 1)
-                  (drawsContent 1)
-                  (structural layer
-                    (position 622.00 1105.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                  (backdrop layer
-                    (position 0.00 0.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (usingTiledLayer 1)
-                  (drawsContent 1)
-                  (structural layer
-                    (position 622.00 1105.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                  (backdrop layer
-                    (position 0.00 0.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (usingTiledLayer 1)
-                  (drawsContent 1)
-                  (structural layer
-                    (position 622.00 1105.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                  (backdrop layer
-                    (position 0.00 0.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (usingTiledLayer 1)
-                  (drawsContent 1)
-                  (structural layer
-                    (position 622.00 1105.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                  (backdrop layer
-                    (position 0.00 0.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (usingTiledLayer 1)
-                  (drawsContent 1)
-                  (structural layer
-                    (position 622.00 1105.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                  (backdrop layer
-                    (position 0.00 0.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (usingTiledLayer 1)
-                  (drawsContent 1)
-                  (structural layer
-                    (position 622.00 1105.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                  (backdrop layer
-                    (position 0.00 0.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (usingTiledLayer 1)
-                  (drawsContent 1)
-                  (structural layer
-                    (position 622.00 1105.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                  (backdrop layer
-                    (position 0.00 0.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (usingTiledLayer 1)
-                  (drawsContent 1)
-                  (structural layer
-                    (position 622.00 1105.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                  (backdrop layer
-                    (position 0.00 0.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (usingTiledLayer 1)
-                  (drawsContent 1)
-                  (structural layer
-                    (position 622.00 1105.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                )
-              )
             )
             (GraphicsLayer
+              (position 1.00 1.00)
               (bounds 1242.00 2208.00)
               (usingTiledLayer 1)
               (drawsContent 1)
               (structural layer
-                (position 621.00 1104.00)
+                (position 622.00 1105.00)
+                (bounds 1242.00 2208.00)
+              )
+              (backdrop layer
+                (position 0.00 0.00)
                 (bounds 1242.00 2208.00)
               )
             )
             (GraphicsLayer
+              (position 1.00 1.00)
               (bounds 1242.00 2208.00)
               (usingTiledLayer 1)
               (drawsContent 1)
               (structural layer
-                (position 621.00 1104.00)
+                (position 622.00 1105.00)
+                (bounds 1242.00 2208.00)
+              )
+              (backdrop layer
+                (position 0.00 0.00)
                 (bounds 1242.00 2208.00)
               )
             )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (usingTiledLayer 1)
+              (drawsContent 1)
+              (structural layer
+                (position 622.00 1105.00)
+                (bounds 1242.00 2208.00)
+              )
+              (backdrop layer
+                (position 0.00 0.00)
+                (bounds 1242.00 2208.00)
+              )
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (usingTiledLayer 1)
+              (drawsContent 1)
+              (structural layer
+                (position 622.00 1105.00)
+                (bounds 1242.00 2208.00)
+              )
+              (backdrop layer
+                (position 0.00 0.00)
+                (bounds 1242.00 2208.00)
+              )
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (usingTiledLayer 1)
+              (drawsContent 1)
+              (structural layer
+                (position 622.00 1105.00)
+                (bounds 1242.00 2208.00)
+              )
+              (backdrop layer
+                (position 0.00 0.00)
+                (bounds 1242.00 2208.00)
+              )
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (usingTiledLayer 1)
+              (drawsContent 1)
+              (structural layer
+                (position 622.00 1105.00)
+                (bounds 1242.00 2208.00)
+              )
+              (backdrop layer
+                (position 0.00 0.00)
+                (bounds 1242.00 2208.00)
+              )
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (usingTiledLayer 1)
+              (drawsContent 1)
+              (structural layer
+                (position 622.00 1105.00)
+                (bounds 1242.00 2208.00)
+              )
+              (backdrop layer
+                (position 0.00 0.00)
+                (bounds 1242.00 2208.00)
+              )
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (usingTiledLayer 1)
+              (drawsContent 1)
+              (structural layer
+                (position 622.00 1105.00)
+                (bounds 1242.00 2208.00)
+              )
+              (backdrop layer
+                (position 0.00 0.00)
+                (bounds 1242.00 2208.00)
+              )
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (usingTiledLayer 1)
+              (drawsContent 1)
+              (structural layer
+                (position 622.00 1105.00)
+                (bounds 1242.00 2208.00)
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
           )
         )
       )

--- a/LayoutTests/css3/filters/backdrop/resource-use-excessive-expected.txt
+++ b/LayoutTests/css3/filters/backdrop/resource-use-excessive-expected.txt
@@ -5,16 +5,40 @@
     (GraphicsLayer
       (bounds 1245.00 2211.00)
       (contentsOpaque 1)
-      (children 1
+      (children 8
         (GraphicsLayer
-          (bounds 1245.00 2211.00)
-          (children 8
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+          (children 1
             (GraphicsLayer
+              (position 1.00 1.00)
               (bounds 1242.00 2208.00)
               (usingTiledLayer 1)
               (drawsContent 1)
               (structural layer
-                (position 621.00 1104.00)
+                (position 622.00 1105.00)
                 (bounds 1242.00 2208.00)
               )
               (backdrop layer
@@ -22,54 +46,41 @@
                 (bounds 1242.00 2208.00)
               )
             )
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+          (children 1
             (GraphicsLayer
+              (position 1.00 1.00)
               (bounds 1242.00 2208.00)
               (usingTiledLayer 1)
               (drawsContent 1)
               (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 1242.00 2208.00)
-              )
-              (children 1
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (usingTiledLayer 1)
-                  (drawsContent 1)
-                  (structural layer
-                    (position 622.00 1105.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                  (backdrop layer
-                    (position 0.00 0.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                )
-              )
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 1242.00 2208.00)
-              )
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
+                (position 622.00 1105.00)
                 (bounds 1242.00 2208.00)
               )
               (backdrop layer
@@ -104,83 +115,67 @@
                         (position 0.00 0.00)
                         (bounds 1242.00 2208.00)
                       )
-                      (children 1
-                        (GraphicsLayer
-                          (position 1.00 1.00)
-                          (bounds 1242.00 2208.00)
-                          (usingTiledLayer 1)
-                          (drawsContent 1)
-                          (structural layer
-                            (position 622.00 1105.00)
-                            (bounds 1242.00 2208.00)
-                          )
-                          (backdrop layer
-                            (position 0.00 0.00)
-                            (bounds 1242.00 2208.00)
-                          )
-                        )
-                      )
                     )
                   )
                 )
               )
             )
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (children 1
             (GraphicsLayer
+              (position 1.00 1.00)
               (bounds 1242.00 2208.00)
               (usingTiledLayer 1)
               (drawsContent 1)
               (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
+                (position 622.00 1105.00)
                 (bounds 1242.00 2208.00)
               )
             )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 1242.00 2208.00)
-              )
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (children 1
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (usingTiledLayer 1)
-                  (drawsContent 1)
-                  (structural layer
-                    (position 622.00 1105.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                )
-              )
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-            )
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
           )
         )
       )

--- a/LayoutTests/css3/filters/backdrop/resource-use-ok-expected.txt
+++ b/LayoutTests/css3/filters/backdrop/resource-use-ok-expected.txt
@@ -5,16 +5,40 @@
     (GraphicsLayer
       (bounds 1243.00 2209.00)
       (contentsOpaque 1)
-      (children 1
+      (children 3
         (GraphicsLayer
-          (bounds 1243.00 2209.00)
-          (children 3
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+          (children 1
             (GraphicsLayer
+              (position 1.00 1.00)
               (bounds 1242.00 2208.00)
               (usingTiledLayer 1)
               (drawsContent 1)
               (structural layer
-                (position 621.00 1104.00)
+                (position 622.00 1105.00)
                 (bounds 1242.00 2208.00)
               )
               (backdrop layer
@@ -22,48 +46,19 @@
                 (bounds 1242.00 2208.00)
               )
             )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 1242.00 2208.00)
-              )
-              (children 1
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (usingTiledLayer 1)
-                  (drawsContent 1)
-                  (structural layer
-                    (position 622.00 1105.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                  (backdrop layer
-                    (position 0.00 0.00)
-                    (bounds 1242.00 2208.00)
-                  )
-                )
-              )
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 1242.00 2208.00)
-              )
-            )
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
           )
         )
       )

--- a/LayoutTests/css3/filters/backdrop/resource-use-remove-some-layers-expected.txt
+++ b/LayoutTests/css3/filters/backdrop/resource-use-remove-some-layers-expected.txt
@@ -5,101 +5,96 @@
     (GraphicsLayer
       (bounds 1242.00 2208.00)
       (contentsOpaque 1)
-      (children 1
+      (children 7
         (GraphicsLayer
           (bounds 1242.00 2208.00)
-          (children 7
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 1242.00 2208.00)
-              )
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 1242.00 2208.00)
-              )
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 1242.00 2208.00)
-              )
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 1242.00 2208.00)
-              )
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 1242.00 2208.00)
-              )
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 1242.00 2208.00)
-              )
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (usingTiledLayer 1)
-              (drawsContent 1)
-              (structural layer
-                (position 621.00 1104.00)
-                (bounds 1242.00 2208.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 1242.00 2208.00)
-              )
-            )
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (usingTiledLayer 1)
+          (drawsContent 1)
+          (structural layer
+            (position 621.00 1104.00)
+            (bounds 1242.00 2208.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 1242.00 2208.00)
           )
         )
       )

--- a/LayoutTests/platform/glib/compositing/filters/backdrop-filter-root-element-no-backdrop-root-expected.txt
+++ b/LayoutTests/platform/glib/compositing/filters/backdrop-filter-root-element-no-backdrop-root-expected.txt
@@ -1,4 +1,3 @@
-foo foobar
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -8,10 +7,7 @@ foo foobar
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (position 8.00 8.00)
-          (bounds 341.00 318.00)
-          (drawsContent 1)
-          (backdrop layer 0.00, 0.00 100.00 x 200.00)
+          (position 8.00 13.00)
         )
       )
     )

--- a/LayoutTests/platform/glib/css3/filters/backdrop/backdrop-filter-does-not-size-properly-border-and-padding-expected.txt
+++ b/LayoutTests/platform/glib/css3/filters/backdrop/backdrop-filter-does-not-size-properly-border-and-padding-expected.txt
@@ -8,16 +8,10 @@ foo
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 8.00 8.00)
+          (bounds 180.00 280.00)
           (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 8.00 8.00)
-              (bounds 180.00 280.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 180.00 x 280.00)
-            )
-          )
+          (backdrop layer 0.00, 0.00 180.00 x 280.00)
         )
       )
     )

--- a/LayoutTests/platform/glib/css3/filters/backdrop/backdrop-filter-with-cliprect-expected.txt
+++ b/LayoutTests/platform/glib/css3/filters/backdrop/backdrop-filter-with-cliprect-expected.txt
@@ -9,16 +9,10 @@ bar
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 8.00 26.00)
+          (bounds 120.00 120.00)
           (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 8.00 26.00)
-              (bounds 120.00 120.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 120.00 x 120.00)
-            )
-          )
+          (backdrop layer 0.00, 0.00 120.00 x 120.00)
         )
       )
     )

--- a/LayoutTests/platform/glib/css3/filters/backdrop/backdrop-filter-with-mask-expected.txt
+++ b/LayoutTests/platform/glib/css3/filters/backdrop/backdrop-filter-with-mask-expected.txt
@@ -9,21 +9,15 @@ bar
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 8.00 26.00)
+          (bounds 120.00 120.00)
           (drawsContent 1)
-          (children 1
+          (mask layer)
             (GraphicsLayer
-              (position 8.00 26.00)
               (bounds 120.00 120.00)
               (drawsContent 1)
-              (mask layer)
-                (GraphicsLayer
-                  (bounds 120.00 120.00)
-                  (drawsContent 1)
-                )
-              (backdrop layer 0.00, 0.00 120.00 x 120.00)
             )
-          )
+          (backdrop layer 0.00, 0.00 120.00 x 120.00)
         )
       )
     )

--- a/LayoutTests/platform/glib/css3/filters/backdrop/backdrop-with-visibility-hidden-changing-expected.txt
+++ b/LayoutTests/platform/glib/css3/filters/backdrop/backdrop-with-visibility-hidden-changing-expected.txt
@@ -8,16 +8,10 @@ Dump when filter is visible:
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 0.00 150.00)
+          (bounds 402.00 52.00)
           (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 0.00 150.00)
-              (bounds 402.00 52.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 402.00 x 52.00)
-            )
-          )
+          (backdrop layer 0.00, 0.00 402.00 x 52.00)
         )
       )
     )
@@ -33,16 +27,10 @@ Dump when filter is hidden:
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
-          (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 0.00 150.00)
-              (bounds 402.00 52.00)
-              (contentsVisible 0)
-              (backdrop layer 0.00, 0.00 402.00 x 52.00 hidden)
-            )
-          )
+          (position 0.00 150.00)
+          (bounds 402.00 52.00)
+          (contentsVisible 0)
+          (backdrop layer 0.00, 0.00 402.00 x 52.00 hidden)
         )
       )
     )
@@ -58,16 +46,10 @@ Dump when filter is visible again:
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 0.00 150.00)
+          (bounds 402.00 52.00)
           (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 0.00 150.00)
-              (bounds 402.00 52.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 402.00 x 52.00)
-            )
-          )
+          (backdrop layer 0.00, 0.00 402.00 x 52.00)
         )
       )
     )

--- a/LayoutTests/platform/glib/css3/filters/backdrop/backdrop-with-visibility-hidden-expected.txt
+++ b/LayoutTests/platform/glib/css3/filters/backdrop/backdrop-with-visibility-hidden-expected.txt
@@ -7,16 +7,10 @@
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
-          (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 0.00 150.00)
-              (bounds 402.00 52.00)
-              (contentsVisible 0)
-              (backdrop layer 0.00, 0.00 402.00 x 52.00 hidden)
-            )
-          )
+          (position 0.00 150.00)
+          (bounds 402.00 52.00)
+          (contentsVisible 0)
+          (backdrop layer 0.00, 0.00 402.00 x 52.00 hidden)
         )
       )
     )

--- a/LayoutTests/platform/glib/css3/filters/backdrop/resource-use-add-more-layers-expected.txt
+++ b/LayoutTests/platform/glib/css3/filters/backdrop/resource-use-add-more-layers-expected.txt
@@ -5,88 +5,83 @@
     (GraphicsLayer
       (bounds 1243.00 2209.00)
       (contentsOpaque 1)
-      (children 1
+      (children 3
         (GraphicsLayer
-          (bounds 1243.00 2209.00)
-          (children 3
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+          (children 10
             (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-              (children 10
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (drawsContent 1)
-                  (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (drawsContent 1)
-                  (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (drawsContent 1)
-                  (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (drawsContent 1)
-                  (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (drawsContent 1)
-                  (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (drawsContent 1)
-                  (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (drawsContent 1)
-                  (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (drawsContent 1)
-                  (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (drawsContent 1)
-                  (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                )
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (drawsContent 1)
-                  (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                )
-              )
-            )
-            (GraphicsLayer
+              (position 1.00 1.00)
               (bounds 1242.00 2208.00)
               (drawsContent 1)
               (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
             )
             (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (drawsContent 1)
+              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (drawsContent 1)
+              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (drawsContent 1)
+              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (drawsContent 1)
+              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (drawsContent 1)
+              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (drawsContent 1)
+              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (drawsContent 1)
+              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 1242.00 2208.00)
+              (drawsContent 1)
+              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
               (bounds 1242.00 2208.00)
               (drawsContent 1)
               (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
             )
           )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
         )
       )
     )

--- a/LayoutTests/platform/glib/css3/filters/backdrop/resource-use-excessive-expected.txt
+++ b/LayoutTests/platform/glib/css3/filters/backdrop/resource-use-excessive-expected.txt
@@ -5,34 +5,37 @@
     (GraphicsLayer
       (bounds 1245.00 2211.00)
       (contentsOpaque 1)
-      (children 1
+      (children 8
         (GraphicsLayer
-          (bounds 1245.00 2211.00)
-          (children 8
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+          (children 1
             (GraphicsLayer
+              (position 1.00 1.00)
               (bounds 1242.00 2208.00)
               (drawsContent 1)
               (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
             )
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+          (children 1
             (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-              (children 1
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (drawsContent 1)
-                  (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                )
-              )
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-            )
-            (GraphicsLayer
+              (position 1.00 1.00)
               (bounds 1242.00 2208.00)
               (drawsContent 1)
               (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
@@ -48,48 +51,40 @@
                       (bounds 1242.00 2208.00)
                       (drawsContent 1)
                       (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                      (children 1
-                        (GraphicsLayer
-                          (position 1.00 1.00)
-                          (bounds 1242.00 2208.00)
-                          (drawsContent 1)
-                          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                        )
-                      )
                     )
                   )
                 )
               )
             )
+          )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+          (children 1
             (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-              (children 1
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (drawsContent 1)
-                  (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                )
-              )
-            )
-            (GraphicsLayer
+              (position 1.00 1.00)
               (bounds 1242.00 2208.00)
               (drawsContent 1)
               (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
             )
           )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
         )
       )
     )

--- a/LayoutTests/platform/glib/css3/filters/backdrop/resource-use-ok-expected.txt
+++ b/LayoutTests/platform/glib/css3/filters/backdrop/resource-use-ok-expected.txt
@@ -5,34 +5,29 @@
     (GraphicsLayer
       (bounds 1243.00 2209.00)
       (contentsOpaque 1)
-      (children 1
+      (children 3
         (GraphicsLayer
-          (bounds 1243.00 2209.00)
-          (children 3
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+          (children 1
             (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-              (children 1
-                (GraphicsLayer
-                  (position 1.00 1.00)
-                  (bounds 1242.00 2208.00)
-                  (drawsContent 1)
-                  (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-                )
-              )
-            )
-            (GraphicsLayer
+              (position 1.00 1.00)
               (bounds 1242.00 2208.00)
               (drawsContent 1)
               (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
             )
           )
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
         )
       )
     )

--- a/LayoutTests/platform/glib/css3/filters/backdrop/resource-use-remove-some-layers-expected.txt
+++ b/LayoutTests/platform/glib/css3/filters/backdrop/resource-use-remove-some-layers-expected.txt
@@ -5,46 +5,41 @@
     (GraphicsLayer
       (bounds 1242.00 2208.00)
       (contentsOpaque 1)
-      (children 1
+      (children 7
         (GraphicsLayer
           (bounds 1242.00 2208.00)
-          (children 7
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-            )
-            (GraphicsLayer
-              (bounds 1242.00 2208.00)
-              (drawsContent 1)
-              (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
-            )
-          )
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
+        )
+        (GraphicsLayer
+          (bounds 1242.00 2208.00)
+          (drawsContent 1)
+          (backdrop layer 0.00, 0.00 1242.00 x 2208.00)
         )
       )
     )

--- a/LayoutTests/platform/ios/css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute-expected.txt
+++ b/LayoutTests/platform/ios/css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute-expected.txt
@@ -8,22 +8,16 @@ foo foobar
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 8.00 8.00)
+          (bounds 342.00 320.00)
           (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 8.00 8.00)
-              (bounds 342.00 320.00)
-              (drawsContent 1)
-              (structural layer
-                (position 179.00 168.00)
-                (bounds 342.00 320.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 100.00 200.00)
-              )
-            )
+          (structural layer
+            (position 179.00 168.00)
+            (bounds 342.00 320.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 100.00 200.00)
           )
         )
       )

--- a/LayoutTests/platform/ios/css3/filters/backdrop/backdrop-filter-with-cliprect-expected.txt
+++ b/LayoutTests/platform/ios/css3/filters/backdrop/backdrop-filter-with-cliprect-expected.txt
@@ -9,22 +9,16 @@ bar
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 8.00 28.00)
+          (bounds 120.00 120.00)
           (drawsContent 1)
-          (children 1
-            (GraphicsLayer
-              (position 8.00 28.00)
-              (bounds 120.00 120.00)
-              (drawsContent 1)
-              (structural layer
-                (position 68.00 88.00)
-                (bounds 120.00 120.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 120.00 120.00)
-              )
-            )
+          (structural layer
+            (position 68.00 88.00)
+            (bounds 120.00 120.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 120.00 120.00)
           )
         )
       )

--- a/LayoutTests/platform/ios/css3/filters/backdrop/backdrop-filter-with-mask-expected.txt
+++ b/LayoutTests/platform/ios/css3/filters/backdrop/backdrop-filter-with-mask-expected.txt
@@ -9,27 +9,21 @@ bar
       (contentsOpaque 1)
       (children 1
         (GraphicsLayer
-          (bounds 800.00 600.00)
+          (position 8.00 28.00)
+          (bounds 120.00 120.00)
           (drawsContent 1)
-          (children 1
+          (mask layer)
             (GraphicsLayer
-              (position 8.00 28.00)
               (bounds 120.00 120.00)
               (drawsContent 1)
-              (mask layer)
-                (GraphicsLayer
-                  (bounds 120.00 120.00)
-                  (drawsContent 1)
-                )
-              (structural layer
-                (position 68.00 88.00)
-                (bounds 120.00 120.00)
-              )
-              (backdrop layer
-                (position 0.00 0.00)
-                (bounds 120.00 120.00)
-              )
             )
+          (structural layer
+            (position 68.00 88.00)
+            (bounds 120.00 120.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 120.00 120.00)
           )
         )
       )

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2832,3 +2832,12 @@ webkit.org/b/271423 [ Sonoma+ arm64 ] imported/w3c/web-platform-tests/html/canva
 webkit.org/b/271423 [ Sonoma+ arm64 ] imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/imagebitmap-replication-exif-orientation.html [ Failure ]
 
 webkit.org/b/271770 imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm [ Pass Failure ]
+
+# Unprefixed backdrop filter disabled on WK1
+imported/w3c/web-platform-tests/css/filter-effects [ Skip ]
+compositing/filters/backdrop-filter-root-element-no-backdrop-root.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backdrop-filter.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-will-change/will-change-abspos-cb-003.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-will-change/will-change-fixedpos-cb-004.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-backdrop-filter-1.html [ ImageOnlyFailure ]
+

--- a/LayoutTests/platform/mac-wk1/compositing/layer-creation/will-change-on-normal-flow-content-expected.txt
+++ b/LayoutTests/platform/mac-wk1/compositing/layer-creation/will-change-on-normal-flow-content-expected.txt
@@ -1,0 +1,28 @@
+opacity
+mask
+backdrop-filter
+filter
+clip-path
+(GraphicsLayer
+(anchor 0.00 0.00)
+(bounds 800.00 600.00)
+(children 1
+(GraphicsLayer
+(bounds 800.00 600.00)
+(contentsOpaque 1)
+(children 2
+(GraphicsLayer
+(position 8.00 8.00)
+(bounds 784.00 18.00)
+(drawsContent 1)
+)
+(GraphicsLayer
+(position 8.00 62.00)
+(bounds 784.00 18.00)
+(drawsContent 1)
+)
+)
+)
+)
+)
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -19,7 +19,6 @@ PASS animation-timeline
 PASS animation-timing-function
 PASS appearance
 PASS aspect-ratio
-PASS backdrop-filter
 PASS backface-visibility
 PASS background-attachment
 PASS background-blend-mode

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -16,7 +16,6 @@ PASS animation-timeline
 PASS animation-timing-function
 PASS appearance
 PASS aspect-ratio
-PASS backdrop-filter
 PASS backface-visibility
 PASS background-attachment
 PASS background-blend-mode

--- a/LayoutTests/platform/mac-wk1/layer-creation/will-change-on-normal-flow-content-expected.txt
+++ b/LayoutTests/platform/mac-wk1/layer-creation/will-change-on-normal-flow-content-expected.txt
@@ -1,0 +1,28 @@
+opacity
+mask
+backdrop-filter
+filter
+clip-path
+(GraphicsLayer
+(anchor 0.00 0.00)
+(bounds 800.00 600.00)
+(children 1
+(GraphicsLayer
+(bounds 800.00 600.00)
+(contentsOpaque 1)
+(children 2
+(GraphicsLayer
+(position 8.00 8.00)
+(bounds 784.00 18.00)
+(drawsContent 1)
+)
+(GraphicsLayer
+(position 8.00 62.00)
+(bounds 784.00 18.00)
+(drawsContent 1)
+)
+)
+)
+)
+)
+

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1335,7 +1335,6 @@ CSSUnprefixedBackdropFilterEnabled:
   humanReadableDescription: "Enable unprefixed backdrop-filter CSS property"
   defaultValue:
     WebKitLegacy:
-      "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true
       default: false
     WebKit:
       "ENABLE(UNPREFIXED_BACKDROP_FILTER)": true

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -605,14 +605,18 @@ bool RenderLayer::computeCanBeBackdropRoot() const
     if (!renderer().settings().cssUnprefixedBackdropFilterEnabled())
         return false;
 
-    return renderer().isTransparent()
+    // In order to match other impls and not the spec, the document element should
+    // only be a backdrop root (and be isolated from the base background color) if
+    // another group rendering effect is present.
+    // https://github.com/w3c/fxtf-drafts/issues/557
+    return isRenderViewLayer()
+        || renderer().isTransparent()
         || renderer().hasBackdropFilter()
         || renderer().hasClipPath()
         || renderer().hasFilter()
         || renderer().hasBlendMode()
         || renderer().hasMask()
-        || renderer().hasViewTransitionName()
-        || renderer().isDocumentElementRenderer()
+        || (renderer().hasViewTransitionName() && !renderer().isDocumentElementRenderer())
         || (renderer().style().willChange() && renderer().style().willChange()->canBeBackdropRoot());
 }
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -804,9 +804,12 @@ void RenderLayerBacking::updateBackdropFiltersGeometry()
 
 bool RenderLayerBacking::updateBackdropRoot()
 {
-    if (m_graphicsLayer->isBackdropRoot() == m_owningLayer.isBackdropRoot())
+    // Don't try to make the RenderView's layer a backdrop root if it's going to
+    // paint into the window since it won't work (WebKitLegacy only).
+    bool willBeBackdropRoot = m_owningLayer.isBackdropRoot() && !paintsIntoWindow();
+    if (m_graphicsLayer->isBackdropRoot() == willBeBackdropRoot)
         return false;
-    m_graphicsLayer->setIsBackdropRoot(m_owningLayer.isBackdropRoot());
+    m_graphicsLayer->setIsBackdropRoot(willBeBackdropRoot);
     return true;
 }
 

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -678,8 +678,11 @@ bool RenderView::rootElementShouldPaintBaseBackground() const
     if (RenderElement* rootRenderer = documentElement ? documentElement->renderer() : nullptr) {
         // The document element's renderer is currently forced to be a block, but may not always be.
         auto* rootBox = dynamicDowncast<RenderBox>(*rootRenderer);
-        if (rootBox && rootBox->hasLayer() && rootBox->layer()->isolatesBlending())
-            return false;
+        if (rootBox && rootBox->hasLayer()) {
+            RenderLayer* layer = rootBox->layer();
+            if (layer->isolatesBlending() || layer->isBackdropRoot())
+                return false;
+        }
     }
     return shouldPaintBaseBackground();
 }

--- a/Tools/DumpRenderTree/TestOptions.cpp
+++ b/Tools/DumpRenderTree/TestOptions.cpp
@@ -67,7 +67,6 @@ const TestFeatures& TestOptions::defaults()
             // These are non-experimental WebPreference values that must always be set as they
             // differ from the default set in the WebPreferences*.yaml configuration.
             { "AllowsInlineMediaPlayback", true },
-            { "CSSUnprefixedBackdropFilterEnabled", true },
             { "CanvasUsesAcceleratedDrawing", true },
             { "ColorFilterEnabled", true },
             { "CustomPasteboardDataEnabled", true },


### PR DESCRIPTION
#### 7ffc7f9fd02ae05936e368c7a7c2d6774ff1f6a9
<pre>
Backdrop-filter forces compositing on the root element and uses extra memory.
<a href="https://bugs.webkit.org/show_bug.cgi?id=271340">https://bugs.webkit.org/show_bug.cgi?id=271340</a>
&lt;<a href="https://rdar.apple.com/123831236">rdar://123831236</a>&gt;

Reviewed by Simon Fraser.

The backdrop-filter spec requires that the root element be a backdrop root, and creates a separate
compositing layer, separate from the base background color of the view. However, most tests are
expecting the base white color to be included in the captured backdrop.

I&apos;ve filed <a href="https://github.com/w3c/fxtf-drafts/issues/557">https://github.com/w3c/fxtf-drafts/issues/557</a> to try resolve the spec/implementation mismatch.

This change makes the root element only a backdrop root if it also has one of the other grouping
graphics properties. Notably not included is the &apos;view-transition-name&apos; property, since this is
present on the root as a default UA style.

It also changes RenderView::rootElementShouldPaintBaseBackground so that we don&apos;t paint the base
background color as part of the root element&apos;s background, if we did end up making the root element
a backdrop root.

It also ensures the default value of CSSUnprefixedBackdropFilterEnabled is always false for
WebKitLegacy, rather than correctly support root background rendering with backdrop filter.

* LayoutTests/compositing/filters/backdrop-filter-root-element-no-backdrop-root-expected.txt: Added.
* LayoutTests/compositing/filters/backdrop-filter-root-element-no-backdrop-root.html: Added.
* LayoutTests/css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute-expected.txt:
* LayoutTests/css3/filters/backdrop/backdrop-filter-does-not-size-properly-border-and-padding-expected.txt:
* LayoutTests/css3/filters/backdrop/backdrop-filter-with-cliprect-expected.txt:
* LayoutTests/css3/filters/backdrop/backdrop-filter-with-mask-expected.txt:
* LayoutTests/css3/filters/backdrop/backdrop-with-visibility-hidden-changing-expected.txt:
* LayoutTests/css3/filters/backdrop/backdrop-with-visibility-hidden-expected.txt:
* LayoutTests/css3/filters/backdrop/resource-use-add-more-layers-expected.txt:
* LayoutTests/css3/filters/backdrop/resource-use-excessive-expected.txt:
* LayoutTests/css3/filters/backdrop/resource-use-ok-expected.txt:
* LayoutTests/css3/filters/backdrop/resource-use-remove-some-layers-expected.txt:
* LayoutTests/platform/glib/compositing/filters/backdrop-filter-root-element-no-backdrop-root-expected.txt: Added.
* LayoutTests/platform/glib/css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute-expected.txt:
* LayoutTests/platform/glib/css3/filters/backdrop/backdrop-filter-does-not-size-properly-border-and-padding-expected.txt:
* LayoutTests/platform/glib/css3/filters/backdrop/backdrop-filter-with-cliprect-expected.txt:
* LayoutTests/platform/glib/css3/filters/backdrop/backdrop-filter-with-mask-expected.txt:
* LayoutTests/platform/glib/css3/filters/backdrop/backdrop-with-visibility-hidden-changing-expected.txt:
* LayoutTests/platform/glib/css3/filters/backdrop/backdrop-with-visibility-hidden-expected.txt:
* LayoutTests/platform/glib/css3/filters/backdrop/resource-use-add-more-layers-expected.txt:
* LayoutTests/platform/glib/css3/filters/backdrop/resource-use-excessive-expected.txt:
* LayoutTests/platform/glib/css3/filters/backdrop/resource-use-ok-expected.txt:
* LayoutTests/platform/glib/css3/filters/backdrop/resource-use-remove-some-layers-expected.txt:
* LayoutTests/platform/ios/css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute-expected.txt:
* LayoutTests/platform/ios/css3/filters/backdrop/backdrop-filter-with-cliprect-expected.txt:
* LayoutTests/platform/ios/css3/filters/backdrop/backdrop-filter-with-mask-expected.txt:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::computeCanBeBackdropRoot const):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::rootElementShouldPaintBaseBackground const):

Canonical link: <a href="https://commits.webkit.org/276749@main">https://commits.webkit.org/276749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03c5d2872a0c756ca0e4dd93188e4d236f6a5a2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45574 "Failed to checkout and rebase branch from PR 26211") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48111 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/48242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/41584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47880 "Failed to checkout and rebase branch from PR 26211") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22092 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/48242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46152 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/21780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/39314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/48242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/40402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3618 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/38801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/41884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/40731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49979 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45041 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/20560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/39466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/43255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52199 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6341 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/21554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10666 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->