### PR TITLE
Adding a test to check loading of a disconnected HTML plugin

### DIFF
--- a/LayoutTests/fast/html/disconnected-html-plugin-expected.txt
+++ b/LayoutTests/fast/html/disconnected-html-plugin-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not hit any debug assertions or crash.
+
+PASS

--- a/LayoutTests/fast/html/disconnected-html-plugin.html
+++ b/LayoutTests/fast/html/disconnected-html-plugin.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<body onload="main()">
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+function main() {
+    embed.type = "video/mp4";
+    let object = document.getElementById("object");
+    iframe.contentDocument.body.appendChild(object);
+    embed.height = "50%";
+    embed.type = "image/png";
+    container.prepend("A");
+    object.validity;
+    document.body.remove();
+    setTimeout(() => {
+        document.write("This test passes if WebKit does not hit any debug assertions or crash.<br><br>PASS");
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 100);
+}
+</script>
+<object id="object"></object>
+<iframe id="iframe"></iframe>
+<div id="container"><embed id="embed"></div>
+</body>


### PR DESCRIPTION
#### 85534d1cfd22306695c4869c541f33f5940bf077
<pre>
Adding a test to check loading of a disconnected HTML plugin
<a href="https://bugs.webkit.org/show_bug.cgi?id=271349">https://bugs.webkit.org/show_bug.cgi?id=271349</a>
<a href="https://rdar.apple.com/124083166">rdar://124083166</a>

Reviewed by Ryosuke Niwa.

Adding a test to check loading of a disconnected HTML plugin.
This issue was fixed by checking &apos;isConnected&apos; under HTMLPlugInImageElement::requestObject API.

* LayoutTests/fast/html/disconnected-html-plugin-expected.txt: Added.
* LayoutTests/fast/html/disconnected-html-plugin.html: Added.

Canonical link: <a href="https://commits.webkit.org/276567@main">https://commits.webkit.org/276567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/645f1683c903ab9ddc05450b7e639b4d7c91ccc8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47638 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40987 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21487 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21149 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18007 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39864 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3028 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/41252 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49311 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/19953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16498 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21268 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38957 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42690 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6259 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->