### PR TITLE
Update PAL::CryptoDigest to accept std::span arguments

### DIFF
--- a/Source/WTF/wtf/persistence/PersistentEncoder.cpp
+++ b/Source/WTF/wtf/persistence/PersistentEncoder.cpp
@@ -45,7 +45,7 @@ void Encoder::updateChecksumForData(SHA1& sha1, std::span<const uint8_t> span)
 {
     auto typeSalt = Salt<uint8_t*>::value;
     sha1.addBytes(reinterpret_cast<uint8_t*>(&typeSalt), sizeof(typeSalt));
-    sha1.addBytes(span.data(), span.size());
+    sha1.addBytes(span);
 }
 
 void Encoder::encodeFixedLengthData(std::span<const uint8_t> span)

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -48,7 +48,7 @@ Vector<uint8_t> produceRpIdHash(const String& rpId)
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto rpIdUTF8 = rpId.utf8();
-    crypto->addBytes(rpIdUTF8.data(), rpIdUTF8.length());
+    crypto->addBytes(rpIdUTF8.bytes());
     return crypto->computeHash();
 }
 

--- a/Source/WebCore/Modules/webauthn/fido/Pin.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.cpp
@@ -248,7 +248,7 @@ std::optional<TokenRequest> TokenRequest::tryCreate(const CString& pin, const Cr
         return std::nullopt;
 
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    crypto->addBytes(sharedKeyResult->data(), sharedKeyResult->size());
+    crypto->addBytes(sharedKeyResult->span());
     auto sharedKeyHash = crypto->computeHash();
 
     auto sharedKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, WTFMove(sharedKeyHash), true, CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt);
@@ -261,7 +261,7 @@ std::optional<TokenRequest> TokenRequest::tryCreate(const CString& pin, const Cr
 
     // The following calculates a SHA-256 digest of the PIN, and shrink to the left 16 bytes.
     crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    crypto->addBytes(pin.data(), pin.length());
+    crypto->addBytes(pin.bytes());
     auto pinHash = crypto->computeHash();
     pinHash.shrink(16);
 
@@ -313,7 +313,7 @@ std::optional<SetPinRequest> SetPinRequest::tryCreate(const String& inputPin, co
         return std::nullopt;
 
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    crypto->addBytes(sharedKeyResult->data(), sharedKeyResult->size());
+    crypto->addBytes(sharedKeyResult->span());
     auto sharedKeyHash = crypto->computeHash();
 
     auto sharedKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, Vector { sharedKeyHash }, true, CryptoKeyUsageEncrypt | CryptoKeyUsageDecrypt);

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -103,7 +103,7 @@ String WebSocketHandshake::getExpectedWebSocketAccept(const String& secWebSocket
     constexpr uint8_t webSocketKeyGUID[] = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
     SHA1 sha1;
     CString keyData = secWebSocketKey.ascii();
-    sha1.addBytes(keyData.dataAsUInt8Ptr(), keyData.length());
+    sha1.addBytes(keyData.bytes());
     sha1.addBytes(webSocketKeyGUID, std::size(webSocketKeyGUID) - 1);
     SHA1::Digest hash;
     sha1.computeHash(hash);

--- a/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
@@ -47,6 +47,7 @@ public:
     PAL_EXPORT static std::unique_ptr<CryptoDigest> create(Algorithm);
     PAL_EXPORT ~CryptoDigest();
 
+    void addBytes(std::span<const uint8_t>);
     PAL_EXPORT void addBytes(const void* input, size_t length);
     PAL_EXPORT Vector<uint8_t> computeHash();
     PAL_EXPORT String toHexString();
@@ -56,5 +57,10 @@ public:
 private:
     std::unique_ptr<CryptoDigestContext> m_context;
 };
+
+inline void CryptoDigest::addBytes(std::span<const uint8_t> input)
+{
+    return addBytes(input.data(), input.size());
+}
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.mm
+++ b/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.mm
@@ -222,7 +222,7 @@ std::optional<Vector<uint8_t>> CryptoDigest::computeHash(CryptoDigest::Algorithm
     ASSERT(digest->m_context);
     digest->m_context->algorithm = algo;
     digest->m_context->ccContext = createCryptoDigest(algo);
-    digest->addBytes(data.data(), data.size());
+    digest->addBytes(data.span());
     return digest->computeHash();
 }
 } // namespace PAL

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA224.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA224.cpp
@@ -50,7 +50,7 @@ void CryptoAlgorithmSHA224::digest(Vector<uint8_t>&& message, VectorCallback&& c
     }
 
     workQueue.dispatch([digest = WTFMove(digest), message = WTFMove(message), callback = WTFMove(callback), contextIdentifier = context.identifier()]() mutable {
-        digest->addBytes(message.data(), message.size());
+        digest->addBytes(message.span());
         auto result = digest->computeHash();
         ScriptExecutionContext::postTaskTo(contextIdentifier, [callback = WTFMove(callback), result = WTFMove(result)](auto&) {
             callback(result);

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
@@ -46,7 +46,7 @@ static ExceptionOr<Vector<uint8_t>> signECDSA(CryptoAlgorithmIdentifier hash, co
     auto digest = PAL::CryptoDigest::create(*cryptoDigestAlgorithm);
     if (!digest)
         return Exception { ExceptionCode::OperationError };
-    digest->addBytes(data.data(), data.size());
+    digest->addBytes(data.span());
     auto digestData = digest->computeHash();
 
     // The signature produced by CCECCryptorSignHash is in DER format.
@@ -107,7 +107,7 @@ static ExceptionOr<bool> verifyECDSA(CryptoAlgorithmIdentifier hash, const Platf
     auto digest = PAL::CryptoDigest::create(*cryptoDigestAlgorithm);
     if (!digest)
         return Exception { ExceptionCode::OperationError };
-    digest->addBytes(data.data(), data.size());
+    digest->addBytes(data.span());
     auto digestData = digest->computeHash();
 
     if (signature.size() != keyLengthInBytes * 2)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSASSA_PKCS1_v1_5Mac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSASSA_PKCS1_v1_5Mac.cpp
@@ -44,7 +44,7 @@ static ExceptionOr<Vector<uint8_t>> signRSASSA_PKCS1_v1_5(CryptoAlgorithmIdentif
     auto digest = PAL::CryptoDigest::create(*cryptoDigestAlgorithm);
     if (!digest)
         return Exception { ExceptionCode::OperationError };
-    digest->addBytes(data.data(), data.size());
+    digest->addBytes(data.span());
     auto digestData = digest->computeHash();
 
     Vector<uint8_t> signature(keyLength / 8); // Per https://tools.ietf.org/html/rfc3447#section-8.2.1
@@ -69,7 +69,7 @@ static ExceptionOr<bool> verifyRSASSA_PKCS1_v1_5(CryptoAlgorithmIdentifier hash,
     auto digest = PAL::CryptoDigest::create(*cryptoDigestAlgorithm);
     if (!digest)
         return Exception { ExceptionCode::OperationError };
-    digest->addBytes(data.data(), data.size());
+    digest->addBytes(data.span());
     auto digestData = digest->computeHash();
 
     auto status = CCRSACryptorVerify(key, ccPKCS1Padding, digestData.data(), digestData.size(), digestAlgorithm, 0, signature.data(), signature.size());

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_PSSMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_PSSMac.cpp
@@ -47,7 +47,7 @@ static ExceptionOr<Vector<uint8_t>> signRSA_PSS(CryptoAlgorithmIdentifier hash, 
     auto digest = PAL::CryptoDigest::create(*cryptoDigestAlgorithm);
     if (!digest)
         return Exception { ExceptionCode::OperationError };
-    digest->addBytes(data.data(), data.size());
+    digest->addBytes(data.span());
     auto digestData = digest->computeHash();
 
     Vector<uint8_t> signature(keyLength / 8); // Per https://tools.ietf.org/html/rfc3447#section-8.1.1
@@ -72,7 +72,7 @@ static ExceptionOr<bool> verifyRSA_PSS(CryptoAlgorithmIdentifier hash, const Pla
     auto digest = PAL::CryptoDigest::create(*cryptoDigestAlgorithm);
     if (!digest)
         return Exception { ExceptionCode::OperationError };
-    digest->addBytes(data.data(), data.size());
+    digest->addBytes(data.span());
     auto digestData = digest->computeHash();
 
     auto status = CCRSACryptorVerify(key, ccRSAPSSPadding, digestData.data(), digestData.size(), digestAlgorithm, saltLength, signature.data(), signature.size());

--- a/Source/WebCore/inspector/DOMPatchSupport.cpp
+++ b/Source/WebCore/inspector/DOMPatchSupport.cpp
@@ -398,8 +398,7 @@ ExceptionOr<void> DOMPatchSupport::innerPatchChildren(ContainerNode& parentNode,
 
 static void addStringToSHA1(SHA1& sha1, const String& string)
 {
-    CString cString = string.utf8();
-    sha1.addBytes(cString.dataAsUInt8Ptr(), cString.length());
+    sha1.addBytes(string.utf8().bytes());
 }
 
 std::unique_ptr<DOMPatchSupport::Digest> DOMPatchSupport::createDigest(Node& node, UnusedNodesMap* unusedNodesMap)

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1905,7 +1905,7 @@ static String computeContentSecurityPolicySHA256Hash(const Element& element)
     const PAL::TextEncoding& encodingToUse = documentEncoding.isValid() ? documentEncoding : PAL::UTF8Encoding();
     auto content = encodingToUse.encode(TextNodeTraversal::contentsAsString(element), PAL::UnencodableHandling::Entities);
     auto cryptoDigest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    cryptoDigest->addBytes(content.data(), content.size());
+    cryptoDigest->addBytes(content.span());
     auto digest = cryptoDigest->computeHash();
     return makeString("sha256-", base64Encoded(digest.data(), digest.size()));
 }

--- a/Source/WebCore/loader/ResourceCryptographicDigest.cpp
+++ b/Source/WebCore/loader/ResourceCryptographicDigest.cpp
@@ -160,7 +160,7 @@ ResourceCryptographicDigest cryptographicDigestForSharedBuffer(ResourceCryptogra
     auto cryptoDigest = PAL::CryptoDigest::create(toCryptoDigestAlgorithm(algorithm));
     if (buffer) {
         buffer->forEachSegment([&](auto segment) {
-            cryptoDigest->addBytes(segment.data(), segment.size());
+            cryptoDigest->addBytes(segment);
         });
     }
     return { algorithm, cryptoDigest->computeHash() };

--- a/Source/WebCore/loader/cache/TrustedFonts.cpp
+++ b/Source/WebCore/loader/cache/TrustedFonts.cpp
@@ -862,7 +862,7 @@ static const MemoryCompactLookupOnlyRobinHoodHashSet<AtomString>& trustedFontHas
 static AtomString hashForFontData(const void* data, size_t size)
 {
     auto cryptoDigest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    cryptoDigest->addBytes(data, size);
+    cryptoDigest->addBytes(std::span { reinterpret_cast<const uint8_t*>(data), size });
     auto digest = cryptoDigest->computeHash();
     return makeAtomString(base64Encoded(digest.data(), digest.size()));
 }

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -156,7 +156,7 @@ static void addStringToSHA1(SHA1& sha1, const String& string)
 
     if (string.is8Bit() && string.containsOnlyASCII()) {
         const uint8_t nullByte = 0;
-        sha1.addBytes(string.characters8(), string.length());
+        sha1.addBytes(string.span8());
         sha1.addBytes(&nullByte, 1);
         return;
     }

--- a/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
+++ b/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
@@ -150,7 +150,7 @@ String SQLiteFileSystem::computeHashForFileName(StringView fileName)
 {
     auto cryptoDigest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto utf8FileName = fileName.utf8();
-    cryptoDigest->addBytes(utf8FileName.data(), utf8FileName.length());
+    cryptoDigest->addBytes(utf8FileName.bytes());
     auto digest = cryptoDigest->computeHash();
     
     // Convert digest to hex.

--- a/Source/WebCore/storage/StorageUtilities.cpp
+++ b/Source/WebCore/storage/StorageUtilities.cpp
@@ -92,7 +92,7 @@ String encodeSecurityOriginForFileName(FileSystem::Salt salt, const SecurityOrig
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto originString = origin.toString().utf8();
-    crypto->addBytes(originString.data(), originString.length());
+    crypto->addBytes(originString.bytes());
     crypto->addBytes(salt.data(), salt.size());
     auto hash = crypto->computeHash();
     return base64URLEncodeToString(hash.data(), hash.size());

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -53,7 +53,7 @@ String SWScriptStorage::sha2Hash(const String& input) const
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(m_salt.data(), m_salt.size());
     auto inputUTF8 = input.utf8();
-    crypto->addBytes(inputUTF8.data(), inputUTF8.length());
+    crypto->addBytes(inputUTF8.bytes());
     auto hash = crypto->computeHash();
     return base64URLEncodeToString(hash.data(), hash.size());
 }

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
@@ -497,7 +497,7 @@ void PrivateClickMeasurementManager::fireConversionRequest(const PrivateClickMea
                 return;
 
             auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-            crypto->addBytes(publicKeyData->data(), publicKeyData->size());
+            crypto->addBytes(publicKeyData->span());
             auto publicKeyDataHash = crypto->computeHash();
 
             auto keyID = base64URLEncodeToString(publicKeyDataHash.data(), publicKeyDataHash.size());
@@ -517,7 +517,7 @@ void PrivateClickMeasurementManager::fireConversionRequest(const PrivateClickMea
                         return;
 
                     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-                    crypto->addBytes(publicKeyData->data(), publicKeyData->size());
+                    crypto->addBytes(publicKeyData->span());
                     auto publicKeyDataHash = crypto->computeHash();
 
                     auto keyID = base64URLEncodeToString(publicKeyDataHash.data(), publicKeyDataHash.size());
@@ -543,7 +543,7 @@ void PrivateClickMeasurementManager::fireConversionRequest(const PrivateClickMea
             return;
 
         auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-        crypto->addBytes(publicKeyData->data(), publicKeyData->size());
+        crypto->addBytes(publicKeyData->span());
         auto publicKeyDataHash = crypto->computeHash();
 
         auto keyID = base64URLEncodeToString(publicKeyDataHash.data(), publicKeyDataHash.size());

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
@@ -84,7 +84,7 @@ SHA1::Digest computeSHA1(const Data& data, const Salt& salt)
     SHA1 sha1;
     sha1.addBytes(salt.data(), salt.size());
     data.apply([&sha1](std::span<const uint8_t> span) {
-        sha1.addBytes(span.data(), span.size());
+        sha1.addBytes(span);
         return true;
     });
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp
@@ -88,7 +88,7 @@ static void hashString(SHA1& sha1, const String& string)
 
     if (string.is8Bit() && string.containsOnlyASCII()) {
         const uint8_t nullByte = 0;
-        sha1.addBytes(string.characters8(), string.length());
+        sha1.addBytes(string.span8());
         sha1.addBytes(&nullByte, 1);
         return;
     }

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -55,7 +55,7 @@ static SHA1::Digest computeSHA1(std::span<const uint8_t> span, FileSystem::Salt 
 {
     SHA1 sha1;
     sha1.addBytes(salt.data(), salt.size());
-    sha1.addBytes(span.data(), span.size());
+    sha1.addBytes(span);
     SHA1::Digest digest;
     sha1.computeHash(digest);
     return digest;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -82,7 +82,7 @@ static String encode(const String& string, FileSystem::Salt salt)
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto utf8String = string.utf8();
-    crypto->addBytes(utf8String.data(), utf8String.length());
+    crypto->addBytes(utf8String.bytes());
     crypto->addBytes(salt.data(), salt.size());
     auto hash = crypto->computeHash();
     return base64URLEncodeToString(hash.data(), hash.size());

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
@@ -134,7 +134,7 @@ TEST(CtapPinTest, TestSetPinRequest)
     EXPECT_TRUE(sharedKeyResult);
 
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    crypto->addBytes(sharedKeyResult->data(), sharedKeyResult->size());
+    crypto->addBytes(sharedKeyResult->span());
     auto sharedKeyHash = crypto->computeHash();
 
     auto aesKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, WTFMove(sharedKeyHash), true, CryptoKeyUsageDecrypt);
@@ -322,7 +322,7 @@ TEST(CtapPinTest, TestTokenRequest)
     EXPECT_TRUE(sharedKeyResult);
 
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    crypto->addBytes(sharedKeyResult->data(), sharedKeyResult->size());
+    crypto->addBytes(sharedKeyResult->span());
     auto sharedKeyHash = crypto->computeHash();
 
     auto aesKey = CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier::AES_CBC, WTFMove(sharedKeyHash), true, CryptoKeyUsageDecrypt);


### PR DESCRIPTION
#### 7638ebd719852209c343015eb41ff30279fc4cfa
<pre>
Update PAL::CryptoDigest to accept std::span arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=249414">https://bugs.webkit.org/show_bug.cgi?id=249414</a>
&lt;<a href="https://rdar.apple.com/problem/103643663">rdar://problem/103643663</a>&gt;

Reviewed by Chris Dumez.

Update the implementation of PAL::CryptoDigest to accept std:span arguments.

* Source/WTF/wtf/persistence/PersistentEncoder.cpp:
(WTF::Persistence::Encoder::updateChecksumForData):
* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp:
(WebCore::produceRpIdHash):
* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
(fido::pin::TokenRequest::tryCreate):
(fido::pin::SetPinRequest::tryCreate):
* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::WebSocketHandshake::getExpectedWebSocketAccept):
* Source/WebCore/PAL/pal/crypto/CryptoDigest.h:
* Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.mm:
(PAL::CryptoDigest::addBytes):
(PAL::CryptoDigest::computeHash):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmSHA224.cpp:
(WebCore::CryptoAlgorithmSHA224::digest):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp:
(WebCore::signECDSA):
(WebCore::verifyECDSA):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmRSASSA_PKCS1_v1_5Mac.cpp:
(WebCore::signRSASSA_PKCS1_v1_5):
(WebCore::verifyRSASSA_PKCS1_v1_5):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmRSA_PSSMac.cpp:
(WebCore::signRSA_PSS):
(WebCore::verifyRSA_PSS):
* Source/WebCore/inspector/DOMPatchSupport.cpp:
(WebCore::addStringToSHA1):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::computeContentSecurityPolicySHA256Hash):
* Source/WebCore/loader/ResourceCryptographicDigest.cpp:
(WebCore::cryptographicDigestForSharedBuffer):
* Source/WebCore/loader/cache/TrustedFonts.cpp:
(WebCore::hashForFontData):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::addStringToSHA1):
* Source/WebCore/platform/sql/SQLiteFileSystem.cpp:
(WebCore::SQLiteFileSystem::computeHashForFileName):
* Source/WebCore/storage/StorageUtilities.cpp:
(WebCore::StorageUtilities::encodeSecurityOriginForFileName):
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::sha2Hash const):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp:
(WebKit::PrivateClickMeasurementManager::fireConversionRequest):
* Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp:
(WebKit::NetworkCache::computeSHA1):
* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp:
(WebKit::NetworkCache::hashString):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::computeSHA1):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::encode):
* Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/276507@main">https://commits.webkit.org/276507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d72ffb8f739d631fdea9d7b3a2cd0d10660c349

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47461 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40812 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21298 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38585 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17877 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18390 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39721 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2854 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38011 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41047 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49125 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44263 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16337 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21092 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42552 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21432 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51435 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6217 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20768 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10437 "Passed tests") | 
<!--EWS-Status-Bubble-End-->