### PR TITLE
Use std::span more in String code

### DIFF
--- a/Source/JavaScriptCore/builtins/BuiltinNames.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.cpp
@@ -111,7 +111,7 @@ struct CharBufferSeacher {
 
     static bool equal(const String& str, const Buffer& buf)
     {
-        return WTF::equal(str.impl(), buf.characters, buf.length);
+        return WTF::equal(str.impl(), buf.characters);
     }
 };
 
@@ -137,47 +137,47 @@ static SymbolImpl* lookUpWellKnownSymbolImpl(const BuiltinNames::WellKnownSymbol
     return iterator->value;
 }
 
-PrivateSymbolImpl* BuiltinNames::lookUpPrivateName(const LChar* characters, unsigned length) const
+PrivateSymbolImpl* BuiltinNames::lookUpPrivateName(std::span<const LChar> characters) const
 {
-    LCharBuffer buffer { characters, length };
+    LCharBuffer buffer { characters };
     return lookUpPrivateNameImpl(m_privateNameSet, buffer);
 }
 
-PrivateSymbolImpl* BuiltinNames::lookUpPrivateName(const UChar* characters, unsigned length) const
+PrivateSymbolImpl* BuiltinNames::lookUpPrivateName(std::span<const UChar> characters) const
 {
-    UCharBuffer buffer { characters, length };
+    UCharBuffer buffer { characters };
     return lookUpPrivateNameImpl(m_privateNameSet, buffer);
 }
 
 PrivateSymbolImpl* BuiltinNames::lookUpPrivateName(const String& string) const
 {
     if (string.is8Bit()) {
-        LCharBuffer buffer { string.characters8(), string.length(), string.hash() };
+        LCharBuffer buffer { string.span8(), string.hash() };
         return lookUpPrivateNameImpl(m_privateNameSet, buffer);
     }
-    UCharBuffer buffer { string.characters16(), string.length(), string.hash() };
+    UCharBuffer buffer { string.span16(), string.hash() };
     return lookUpPrivateNameImpl(m_privateNameSet, buffer);
 }
 
-SymbolImpl* BuiltinNames::lookUpWellKnownSymbol(const LChar* characters, unsigned length) const
+SymbolImpl* BuiltinNames::lookUpWellKnownSymbol(std::span<const LChar> characters) const
 {
-    LCharBuffer buffer { characters, length };
+    LCharBuffer buffer { characters };
     return lookUpWellKnownSymbolImpl(m_wellKnownSymbolsMap, buffer);
 }
 
-SymbolImpl* BuiltinNames::lookUpWellKnownSymbol(const UChar* characters, unsigned length) const
+SymbolImpl* BuiltinNames::lookUpWellKnownSymbol(std::span<const UChar> characters) const
 {
-    UCharBuffer buffer { characters, length };
+    UCharBuffer buffer { characters };
     return lookUpWellKnownSymbolImpl(m_wellKnownSymbolsMap, buffer);
 }
 
 SymbolImpl* BuiltinNames::lookUpWellKnownSymbol(const String& string) const
 {
     if (string.is8Bit()) {
-        LCharBuffer buffer { string.characters8(), string.length(), string.hash() };
+        LCharBuffer buffer { string.span8(), string.hash() };
         return lookUpWellKnownSymbolImpl(m_wellKnownSymbolsMap, buffer);
     }
-    UCharBuffer buffer { string.characters16(), string.length(), string.hash() };
+    UCharBuffer buffer { string.span16(), string.hash() };
     return lookUpWellKnownSymbolImpl(m_wellKnownSymbolsMap, buffer);
 }
 

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -239,13 +239,13 @@ public:
 
     PrivateSymbolImpl* lookUpPrivateName(const Identifier&) const;
     PrivateSymbolImpl* lookUpPrivateName(const String&) const;
-    PrivateSymbolImpl* lookUpPrivateName(const LChar*, unsigned length) const;
-    PrivateSymbolImpl* lookUpPrivateName(const UChar*, unsigned length) const;
+    PrivateSymbolImpl* lookUpPrivateName(std::span<const LChar>) const;
+    PrivateSymbolImpl* lookUpPrivateName(std::span<const UChar>) const;
 
     SymbolImpl* lookUpWellKnownSymbol(const Identifier&) const;
     SymbolImpl* lookUpWellKnownSymbol(const String&) const;
-    SymbolImpl* lookUpWellKnownSymbol(const LChar*, unsigned length) const;
-    SymbolImpl* lookUpWellKnownSymbol(const UChar*, unsigned length) const;
+    SymbolImpl* lookUpWellKnownSymbol(std::span<const LChar>) const;
+    SymbolImpl* lookUpWellKnownSymbol(std::span<const UChar>) const;
     
     void appendExternalName(const Identifier& publicName, const Identifier& privateName);
 

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3047,9 +3047,9 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateNonRopeNonAtomString, (JSGlobalObject* gl
 
     if (source.impl()->isAtom()) {
         if (source.is8Bit())
-            source = StringImpl::create(source.characters8(), source.length());
+            source = StringImpl::create(source.span8());
         else
-            source = StringImpl::create(source.characters16(), source.length());
+            source = StringImpl::create(source.span16());
     }
 
     RELEASE_ASSERT(!source.impl()->isAtom());

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -973,17 +973,16 @@ template <bool shouldCreateIdentifier> ALWAYS_INLINE JSTokenType Lexer<LChar>::p
     const Identifier* ident = nullptr;
     
     if (shouldCreateIdentifier || m_parsingBuiltinFunction) {
-        int identifierLength = currentSourcePtr() - identifierStart;
-        ident = makeIdentifier(identifierStart, identifierLength);
+        std::span identifierSpan { identifierStart, static_cast<size_t>(currentSourcePtr() - identifierStart) };
         if (m_parsingBuiltinFunction && isBuiltinName) {
             if (isWellKnownSymbol)
-                ident = &m_arena->makeIdentifier(m_vm, m_vm.propertyNames->builtinNames().lookUpWellKnownSymbol(identifierStart, identifierLength));
+                ident = &m_arena->makeIdentifier(m_vm, m_vm.propertyNames->builtinNames().lookUpWellKnownSymbol(identifierSpan));
             else
-                ident = &m_arena->makeIdentifier(m_vm, m_vm.propertyNames->builtinNames().lookUpPrivateName(identifierStart, identifierLength));
+                ident = &m_arena->makeIdentifier(m_vm, m_vm.propertyNames->builtinNames().lookUpPrivateName(identifierSpan));
             if (!ident)
                 return INVALID_PRIVATE_NAME_ERRORTOK;
         } else {
-            ident = makeIdentifier(identifierStart, identifierLength);
+            ident = makeIdentifier(identifierSpan);
             if (m_parsingBuiltinFunction) {
                 if (!isSafeBuiltinIdentifier(m_vm, ident)) {
                     m_lexErrorMessage = makeString("The use of '"_s, ident->string(), "' is disallowed in builtin functions."_s);

--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -155,8 +155,11 @@ private:
 
     ALWAYS_INLINE void setCodeStart(StringView);
 
-    ALWAYS_INLINE const Identifier* makeIdentifier(const LChar* characters, size_t length);
-    ALWAYS_INLINE const Identifier* makeIdentifier(const UChar* characters, size_t length);
+    template<typename CharacterType>
+    ALWAYS_INLINE const Identifier* makeIdentifier(const CharacterType* characters, size_t length);
+    template<typename CharacterType>
+    ALWAYS_INLINE const Identifier* makeIdentifier(std::span<const CharacterType> characters);
+
     ALWAYS_INLINE const Identifier* makeLCharIdentifier(const LChar* characters, size_t length);
     ALWAYS_INLINE const Identifier* makeLCharIdentifier(const UChar* characters, size_t length);
     ALWAYS_INLINE const Identifier* makeRightSizedIdentifier(const UChar* characters, size_t length, UChar orAllChars);
@@ -273,16 +276,19 @@ inline UChar Lexer<T>::convertUnicode(int c1, int c2, int c3, int c4)
     return (convertHex(c1, c2) << 8) | convertHex(c3, c4);
 }
 
-template <typename T>
-ALWAYS_INLINE const Identifier* Lexer<T>::makeIdentifier(const LChar* characters, size_t length)
+// FIXME: Port call sites to the overload taking a span and drop this one.
+template<typename T>
+template<typename CharacterType>
+ALWAYS_INLINE const Identifier* Lexer<T>::makeIdentifier(const CharacterType* characters, size_t length)
 {
     return &m_arena->makeIdentifier(m_vm, characters, length);
 }
 
-template <typename T>
-ALWAYS_INLINE const Identifier* Lexer<T>::makeIdentifier(const UChar* characters, size_t length)
+template<typename T>
+template<typename CharacterType>
+ALWAYS_INLINE const Identifier* Lexer<T>::makeIdentifier(std::span<const CharacterType> characters)
 {
-    return &m_arena->makeIdentifier(m_vm, characters, length);
+    return &m_arena->makeIdentifier(m_vm, characters.data(), characters.size());
 }
 
 template <>

--- a/Source/JavaScriptCore/runtime/Identifier.cpp
+++ b/Source/JavaScriptCore/runtime/Identifier.cpp
@@ -38,7 +38,7 @@ Ref<AtomStringImpl> Identifier::add8(VM& vm, const UChar* s, int length)
     if (!length)
         return *static_cast<AtomStringImpl*>(StringImpl::empty());
 
-    return *AtomStringImpl::add(s, length);
+    return *AtomStringImpl::add(std::span { s, static_cast<size_t>(length) });
 }
 
 Identifier Identifier::from(VM& vm, unsigned value)

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -180,8 +180,8 @@ private:
     static bool equal(const Identifier& a, const Identifier& b) { return a.m_string.impl() == b.m_string.impl(); }
     static bool equal(const Identifier& a, const LChar* b) { return equal(a.m_string.impl(), b); }
 
-    template <typename T> static Ref<AtomStringImpl> add(VM&, const T*, int length);
-    static Ref<AtomStringImpl> add8(VM&, const UChar*, int length);
+    template <typename T> static Ref<AtomStringImpl> add(VM&, const T*, int length); // FIXME: This should take in a span<const T>.
+    static Ref<AtomStringImpl> add8(VM&, const UChar*, int length); // FIXME: This should take in a span<const UChar>.
     template <typename T> ALWAYS_INLINE static constexpr bool canUseSingleCharacterString(T);
 
     static Ref<AtomStringImpl> add(VM&, StringImpl*);
@@ -216,7 +216,7 @@ Ref<AtomStringImpl> Identifier::add(VM& vm, const T* s, int length)
     if (!length)
         return *static_cast<AtomStringImpl*>(StringImpl::empty());
 
-    return *AtomStringImpl::add(s, length);
+    return *AtomStringImpl::add(std::span { s, static_cast<size_t>(length) });
 }
 
 inline Ref<AtomStringImpl> Identifier::add(VM& vm, ASCIILiteral literal)

--- a/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
@@ -45,6 +45,7 @@ public:
 
     using Cache = std::array<Slot, capacity>;
 
+    // FIXME: This should take in a std::span<const CharacterType>.
     template<typename CharacterType>
     ALWAYS_INLINE Ref<AtomStringImpl> makeIdentifier(const CharacterType* characters, unsigned length)
     {
@@ -59,6 +60,7 @@ public:
     VM& vm() const;
 
 private:
+    // FIXME: This should take in a std::span<const CharacterType>.
     template<typename CharacterType>
     Ref<AtomStringImpl> make(const CharacterType*, unsigned length);
 

--- a/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
@@ -43,12 +43,12 @@ ALWAYS_INLINE Ref<AtomStringImpl> JSONAtomStringCache::make(const CharacterType*
         if (firstCharacter <= maxSingleCharacterString)
             return vm().smallStrings.singleCharacterStringRep(firstCharacter);
     } else if (UNLIKELY(length > maxStringLengthForCache))
-        return AtomStringImpl::add(characters, length).releaseNonNull();
+        return AtomStringImpl::add(std::span { characters, length }).releaseNonNull();
 
     auto lastCharacter = characters[length - 1];
     auto& slot = cacheSlot(firstCharacter, lastCharacter, length);
     if (UNLIKELY(slot.m_length != length || !equal(slot.m_buffer, characters, length))) {
-        auto result = AtomStringImpl::add(characters, length);
+        auto result = AtomStringImpl::add(std::span { characters, length });
         slot.m_impl = result;
         slot.m_length = length;
         WTF::copyElements(slot.m_buffer, characters, length);

--- a/Source/JavaScriptCore/runtime/JSString.cpp
+++ b/Source/JavaScriptCore/runtime/JSString.cpp
@@ -207,11 +207,11 @@ RefPtr<AtomStringImpl> JSRopeString::resolveRopeToExistingAtomString(JSGlobalObj
         if (is8Bit()) {
             LChar buffer[maxLengthForOnStackResolve];
             resolveRopeInternalNoSubstring(buffer, stackLimit);
-            existingAtomString = AtomStringImpl::lookUp(buffer, length());
+            existingAtomString = AtomStringImpl::lookUp(std::span { buffer, length() });
         } else {
             UChar buffer[maxLengthForOnStackResolve];
             resolveRopeInternalNoSubstring(buffer, stackLimit);
-            existingAtomString = AtomStringImpl::lookUp(buffer, length());
+            existingAtomString = AtomStringImpl::lookUp(std::span { buffer, length() });
         }
     } else
         existingAtomString = StringView { substringBase()->valueInternal() }.substring(substringOffset(), length()).toExistingAtomString().releaseImpl();

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -776,7 +776,7 @@ ALWAYS_INLINE JSString* jsSingleCharacterString(VM& vm, UChar c)
         vm.verifyCanGC();
     if (c <= maxSingleCharacterString)
         return vm.smallStrings.singleCharacterString(c);
-    return JSString::create(vm, StringImpl::create(&c, 1));
+    return JSString::create(vm, StringImpl::create(std::span { &c, 1 }));
 }
 
 ALWAYS_INLINE JSString* jsSingleCharacterString(VM& vm, LChar c)
@@ -942,7 +942,7 @@ inline JSString* jsString(VM& vm, StringView s)
         if (auto c = s.characterAt(0); c <= maxSingleCharacterString)
             return vm.smallStrings.singleCharacterString(c);
     }
-    auto impl = s.is8Bit() ? StringImpl::create(s.characters8(), s.length()) : StringImpl::create(s.characters16(), s.length());
+    auto impl = s.is8Bit() ? StringImpl::create(s.span8()) : StringImpl::create(s.span16());
     return JSString::create(vm, WTFMove(impl));
 }
 

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -282,11 +282,11 @@ inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* st
         };
 
         if (string->valueInternal().is8Bit()) {
-            WTF::HashTranslatorCharBuffer<LChar> buffer { string->valueInternal().characters8(), length, string->valueInternal().hash() };
+            WTF::HashTranslatorCharBuffer<LChar> buffer { string->valueInternal().span8(), string->valueInternal().hash() };
             return vm.keyAtomStringCache.make(vm, buffer, createFromNonRope);
         }
 
-        WTF::HashTranslatorCharBuffer<UChar> buffer { string->valueInternal().characters16(), length, string->valueInternal().hash() };
+        WTF::HashTranslatorCharBuffer<UChar> buffer { string->valueInternal().span16(), string->valueInternal().hash() };
         return vm.keyAtomStringCache.make(vm, buffer, createFromNonRope);
     }
 
@@ -309,21 +309,21 @@ inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* st
         if (ropeString->is8Bit()) {
             LChar characters[KeyAtomStringCache::maxStringLengthForCache];
             JSRopeString::resolveToBuffer(fiber0, fiber1, fiber2, characters, length, stackLimit);
-            WTF::HashTranslatorCharBuffer<LChar> buffer { characters, length };
+            WTF::HashTranslatorCharBuffer<LChar> buffer { std::span { characters, length } };
             return vm.keyAtomStringCache.make(vm, buffer, createFromRope);
         }
         UChar characters[KeyAtomStringCache::maxStringLengthForCache];
         JSRopeString::resolveToBuffer(fiber0, fiber1, fiber2, characters, length, stackLimit);
-        WTF::HashTranslatorCharBuffer<UChar> buffer { characters, length };
+        WTF::HashTranslatorCharBuffer<UChar> buffer { std::span { characters, length } };
         return vm.keyAtomStringCache.make(vm, buffer, createFromRope);
     }
 
     auto view = StringView { ropeString->substringBase()->valueInternal() }.substring(ropeString->substringOffset(), length);
     if (view.is8Bit()) {
-        WTF::HashTranslatorCharBuffer<LChar> buffer { view.characters8(), length };
+        WTF::HashTranslatorCharBuffer<LChar> buffer { view.span8() };
         return vm.keyAtomStringCache.make(vm, buffer, createFromRope);
     }
-    WTF::HashTranslatorCharBuffer<UChar> buffer { view.characters16(), length };
+    WTF::HashTranslatorCharBuffer<UChar> buffer { view.span16() };
     return vm.keyAtomStringCache.make(vm, buffer, createFromRope);
 }
 
@@ -400,12 +400,12 @@ inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* s1
     if (s1->is8Bit() && s2->is8Bit()) {
         LChar characters[KeyAtomStringCache::maxStringLengthForCache];
         resolveWith2Fibers(s1, s2, characters, length);
-        WTF::HashTranslatorCharBuffer<LChar> buffer { characters, length };
+        WTF::HashTranslatorCharBuffer<LChar> buffer { std::span { characters, length } };
         return vm.keyAtomStringCache.make(vm, buffer, createFromFibers);
     }
     UChar characters[KeyAtomStringCache::maxStringLengthForCache];
     resolveWith2Fibers(s1, s2, characters, length);
-    WTF::HashTranslatorCharBuffer<UChar> buffer { characters, length };
+    WTF::HashTranslatorCharBuffer<UChar> buffer { std::span { characters, length } };
     return vm.keyAtomStringCache.make(vm, buffer, createFromFibers);
 }
 
@@ -459,12 +459,12 @@ inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* s1
     if (s1->is8Bit() && s2->is8Bit() && s3->is8Bit()) {
         LChar characters[KeyAtomStringCache::maxStringLengthForCache];
         resolveWith3Fibers(s1, s2, s3, characters, length);
-        WTF::HashTranslatorCharBuffer<LChar> buffer { characters, length };
+        WTF::HashTranslatorCharBuffer<LChar> buffer { std::span { characters, length } };
         return vm.keyAtomStringCache.make(vm, buffer, createFromFibers);
     }
     UChar characters[KeyAtomStringCache::maxStringLengthForCache];
     resolveWith3Fibers(s1, s2, s3, characters, length);
-    WTF::HashTranslatorCharBuffer<UChar> buffer { characters, length };
+    WTF::HashTranslatorCharBuffer<UChar> buffer { std::span { characters, length } };
     return vm.keyAtomStringCache.make(vm, buffer, createFromFibers);
 }
 
@@ -492,7 +492,7 @@ inline JSString* jsSubstringOfResolved(VM& vm, GCDeferralContext* deferralContex
                 return JSString::create(vm, deferralContext, impl.releaseNonNull());
             };
             LChar buf[] = { static_cast<LChar>(first), static_cast<LChar>(second) };
-            WTF::HashTranslatorCharBuffer<LChar> buffer { buf, length };
+            WTF::HashTranslatorCharBuffer<LChar> buffer { std::span { buf, length } };
             return vm.keyAtomStringCache.make(vm, buffer, createFromSubstring);
         }
     }

--- a/Source/JavaScriptCore/runtime/KeyAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/KeyAtomStringCacheInlines.h
@@ -35,20 +35,20 @@ namespace JSC {
 template<typename Buffer, typename Func>
 ALWAYS_INLINE JSString* KeyAtomStringCache::make(VM& vm, Buffer& buffer, const Func& func)
 {
-    if (!buffer.length)
+    if (buffer.characters.empty())
         return jsEmptyString(vm);
 
-    if (buffer.length == 1) {
+    if (buffer.characters.size() == 1) {
         auto firstCharacter = buffer.characters[0];
         if (firstCharacter <= maxSingleCharacterString)
             return vm.smallStrings.singleCharacterString(firstCharacter);
     }
 
-    ASSERT(buffer.length <= maxStringLengthForCache);
+    ASSERT(buffer.characters.size() <= maxStringLengthForCache);
     auto& slot = m_cache[buffer.hash % capacity];
     if (slot) {
         auto* impl = slot->tryGetValueImpl();
-        if (impl->hash() == buffer.hash && equal(impl, buffer.characters, buffer.length))
+        if (impl->hash() == buffer.hash && equal(impl, buffer.characters))
             return slot;
     }
 

--- a/Source/JavaScriptCore/runtime/SmallStrings.cpp
+++ b/Source/JavaScriptCore/runtime/SmallStrings.cpp
@@ -47,8 +47,8 @@ void SmallStrings::initializeCommonStrings(VM& vm)
 
     for (unsigned i = 0; i < singleCharacterStringCount; ++i) {
         ASSERT(!m_singleCharacterStrings[i]);
-        const LChar string[] = { static_cast<LChar>(i) };
-        m_singleCharacterStrings[i] = JSString::createHasOtherOwner(vm, AtomStringImpl::add(string, 1).releaseNonNull());
+        std::array<const LChar, 1> string = { static_cast<LChar>(i) };
+        m_singleCharacterStrings[i] = JSString::createHasOtherOwner(vm, AtomStringImpl::add(string).releaseNonNull());
         ASSERT(m_needsToBeVisited);
     }
 
@@ -118,8 +118,8 @@ Ref<AtomStringImpl> SmallStrings::singleCharacterStringRep(unsigned char charact
 {
     if (LIKELY(m_isInitialized))
         return *static_cast<AtomStringImpl*>(const_cast<StringImpl*>(m_singleCharacterStrings[character]->tryGetValueImpl()));
-    const LChar string[] = { static_cast<LChar>(character) };
-    return AtomStringImpl::add(string, 1).releaseNonNull();
+    std::array<const LChar, 1> string = { static_cast<LChar>(character) };
+    return AtomStringImpl::add(string).releaseNonNull();
 }
 
 void SmallStrings::initialize(VM* vm, JSString*& string, ASCIILiteral value)

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -113,7 +113,7 @@ ALLOW_NONLITERAL_FORMAT_BEGIN
 
 ALLOW_NONLITERAL_FORMAT_END
 
-    return StringImpl::create(reinterpret_cast<const LChar*>(buffer.data()), length);
+    return StringImpl::create(std::span { reinterpret_cast<const LChar*>(buffer.data()), length });
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -49,7 +49,7 @@ public:
 
     AtomString(ASCIILiteral);
 
-    static AtomString lookUp(const UChar* characters, unsigned length) { return AtomStringImpl::lookUp(characters, length); }
+    static AtomString lookUp(const UChar* characters, unsigned length) { return AtomStringImpl::lookUp(std::span { characters, length }); }
 
     // Hash table deleted values, which are only constructed and never copied or destroyed.
     AtomString(WTF::HashTableDeletedValueType) : m_string(WTF::HashTableDeletedValue) { }
@@ -177,12 +177,12 @@ inline AtomString::AtomString(const char* string)
 }
 
 inline AtomString::AtomString(const LChar* string, unsigned length)
-    : m_string(AtomStringImpl::add(string, length))
+    : m_string(AtomStringImpl::add(std::span { string, length }))
 {
 }
 
 inline AtomString::AtomString(const UChar* string, unsigned length)
-    : m_string(AtomStringImpl::add(string, length))
+    : m_string(AtomStringImpl::add(std::span { string, length }))
 {
 }
 
@@ -265,7 +265,7 @@ inline const AtomString& nullAtom() { return *reinterpret_cast<const AtomString*
 inline const AtomString& emptyAtom() { return *reinterpret_cast<const AtomString*>(&emptyAtomData); }
 
 inline AtomString::AtomString(ASCIILiteral literal)
-    : m_string(literal.length() ? AtomStringImpl::add(literal.characters(), literal.length()) : Ref { *emptyAtom().impl() })
+    : m_string(literal.length() ? AtomStringImpl::add(literal.span8()) : Ref { *emptyAtom().impl() })
 {
 }
 

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -97,12 +97,12 @@ struct UCharBufferTranslator {
 
     static bool equal(AtomStringTable::StringEntry const& str, const UCharBuffer& buf)
     {
-        return WTF::equal(str.get(), buf.characters, buf.length);
+        return WTF::equal(str.get(), buf.characters);
     }
 
     static void translate(AtomStringTable::StringEntry& location, const UCharBuffer& buf, unsigned hash)
     {
-        auto* pointer = &StringImpl::create8BitIfPossible(buf.characters, buf.length).leakRef();
+        auto* pointer = &StringImpl::create8BitIfPossible(buf.characters).leakRef();
         pointer->setHash(hash);
         pointer->setIsAtom(true);
         location = pointer;
@@ -170,7 +170,7 @@ struct HashAndUTF8CharactersTranslator {
             RELEASE_ASSERT_NOT_REACHED();
 
         if (containsOnlyASCII)
-            newString = StringImpl::create(buffer.characters, buffer.length);
+            newString = StringImpl::create(std::span { buffer.characters, buffer.length });
 
         auto* pointer = &newString.leakRef();
         pointer->setHash(hash);
@@ -179,24 +179,24 @@ struct HashAndUTF8CharactersTranslator {
     }
 };
 
-RefPtr<AtomStringImpl> AtomStringImpl::add(const UChar* characters, unsigned length)
+RefPtr<AtomStringImpl> AtomStringImpl::add(std::span<const UChar> characters)
 {
-    if (!characters)
+    if (!characters.data())
         return nullptr;
 
-    if (!length)
+    if (characters.empty())
         return static_cast<AtomStringImpl*>(StringImpl::empty());
 
-    UCharBuffer buffer { characters, length };
+    UCharBuffer buffer { characters };
     return addToStringTable<UCharBuffer, UCharBufferTranslator>(buffer);
 }
 
 RefPtr<AtomStringImpl> AtomStringImpl::add(HashTranslatorCharBuffer<UChar>& buffer)
 {
-    if (!buffer.characters)
+    if (!buffer.characters.data())
         return nullptr;
 
-    if (!buffer.length)
+    if (buffer.characters.empty())
         return static_cast<AtomStringImpl*>(StringImpl::empty());
 
     return addToStringTable<UCharBuffer, UCharBufferTranslator>(buffer);
@@ -272,12 +272,12 @@ struct LCharBufferTranslator {
 
     static bool equal(AtomStringTable::StringEntry const& str, const LCharBuffer& buf)
     {
-        return WTF::equal(str.get(), buf.characters, buf.length);
+        return WTF::equal(str.get(), buf.characters);
     }
 
     static void translate(AtomStringTable::StringEntry& location, const LCharBuffer& buf, unsigned hash)
     {
-        auto* pointer = &StringImpl::create(buf.characters, buf.length).leakRef();
+        auto* pointer = &StringImpl::create(buf.characters).leakRef();
         pointer->setHash(hash);
         pointer->setIsAtom(true);
         location = pointer;
@@ -294,12 +294,12 @@ struct BufferFromStaticDataTranslator {
 
     static bool equal(AtomStringTable::StringEntry const& str, const Buffer& buf)
     {
-        return WTF::equal(str.get(), buf.characters, buf.length);
+        return WTF::equal(str.get(), buf.characters);
     }
 
     static void translate(AtomStringTable::StringEntry& location, const Buffer& buf, unsigned hash)
     {
-        auto* pointer = &StringImpl::createWithoutCopying(buf.characters, buf.length).leakRef();
+        auto* pointer = &StringImpl::createWithoutCopying(buf.characters).leakRef();
         pointer->setHash(hash);
         pointer->setIsAtom(true);
         location = pointer;
@@ -308,24 +308,24 @@ struct BufferFromStaticDataTranslator {
 
 RefPtr<AtomStringImpl> AtomStringImpl::add(HashTranslatorCharBuffer<LChar>& buffer)
 {
-    if (!buffer.characters)
+    if (!buffer.characters.data())
         return nullptr;
 
-    if (!buffer.length)
+    if (buffer.characters.empty())
         return static_cast<AtomStringImpl*>(StringImpl::empty());
 
     return addToStringTable<LCharBuffer, LCharBufferTranslator>(buffer);
 }
 
-RefPtr<AtomStringImpl> AtomStringImpl::add(const LChar* characters, unsigned length)
+RefPtr<AtomStringImpl> AtomStringImpl::add(std::span<const LChar> characters)
 {
-    if (!characters)
+    if (!characters.data())
         return nullptr;
 
-    if (!length)
+    if (characters.empty())
         return static_cast<AtomStringImpl*>(StringImpl::empty());
 
-    LCharBuffer buffer { characters, length };
+    LCharBuffer buffer { characters };
     return addToStringTable<LCharBuffer, LCharBufferTranslator>(buffer);
 }
 
@@ -334,7 +334,7 @@ Ref<AtomStringImpl> AtomStringImpl::addLiteral(const char* characters, unsigned 
     ASSERT(characters);
     ASSERT(length);
 
-    LCharBuffer buffer { reinterpret_cast<const LChar*>(characters), length };
+    LCharBuffer buffer { std::span { reinterpret_cast<const LChar*>(characters), length } };
     return addToStringTable<LCharBuffer, BufferFromStaticDataTranslator<LChar>>(buffer);
 }
 
@@ -361,10 +361,10 @@ static Ref<AtomStringImpl> addStatic(AtomStringTableLocker& locker, StringTableI
     ASSERT(base.isStatic());
 
     if (base.is8Bit()) {
-        LCharBuffer buffer { base.characters8(), base.length(), base.hash() };
+        LCharBuffer buffer { base.span8(), base.hash() };
         return addToStringTable<LCharBuffer, BufferFromStaticDataTranslator<LChar>>(locker, atomStringTable, buffer);
     }
-    UCharBuffer buffer { base.characters16(), base.length(), base.hash() };
+    UCharBuffer buffer { base.span16(), base.hash() };
     return addToStringTable<UCharBuffer, BufferFromStaticDataTranslator<UChar>>(locker, atomStringTable, buffer);
 }
 
@@ -508,24 +508,24 @@ RefPtr<AtomStringImpl> AtomStringImpl::addUTF8(const char* charactersStart, cons
     return addToStringTable<HashAndUTF8Characters, HashAndUTF8CharactersTranslator>(buffer);
 }
 
-RefPtr<AtomStringImpl> AtomStringImpl::lookUp(const LChar* characters, unsigned length)
+RefPtr<AtomStringImpl> AtomStringImpl::lookUp(std::span<const LChar> characters)
 {
     AtomStringTableLocker locker;
     auto& table = stringTable();
 
-    LCharBuffer buffer = { characters, length };
+    LCharBuffer buffer { characters };
     auto iterator = table.find<LCharBufferTranslator>(buffer);
     if (iterator != table.end())
         return static_cast<AtomStringImpl*>(iterator->get());
     return nullptr;
 }
 
-RefPtr<AtomStringImpl> AtomStringImpl::lookUp(const UChar* characters, unsigned length)
+RefPtr<AtomStringImpl> AtomStringImpl::lookUp(std::span<const UChar> characters)
 {
     AtomStringTableLocker locker;
     auto& table = stringTable();
 
-    UCharBuffer buffer { characters, length };
+    UCharBuffer buffer { characters };
     auto iterator = table.find<UCharBufferTranslator>(buffer);
     if (iterator != table.end())
         return static_cast<AtomStringImpl*>(iterator->get());

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -28,8 +28,8 @@ class AtomStringTable;
 
 class AtomStringImpl final : public UniquedStringImpl {
 public:
-    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> lookUp(const LChar*, unsigned length);
-    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> lookUp(const UChar*, unsigned length);
+    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> lookUp(std::span<const LChar>);
+    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> lookUp(std::span<const UChar>);
     static RefPtr<AtomStringImpl> lookUp(StringImpl* string)
     {
         if (!string || string->isAtom())
@@ -39,9 +39,9 @@ public:
 
     static void remove(AtomStringImpl*);
 
-    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(const LChar*, unsigned length);
-    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(const UChar*, unsigned length);
-    ALWAYS_INLINE static RefPtr<AtomStringImpl> add(const char* s, unsigned length) { return add(reinterpret_cast<const LChar*>(s), length); }
+    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(std::span<const LChar>);
+    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(std::span<const UChar>);
+    ALWAYS_INLINE static RefPtr<AtomStringImpl> add(std::span<const char> characters) { return add({ reinterpret_cast<const LChar*>(characters.data()), characters.size() }); }
 
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(HashTranslatorCharBuffer<LChar>&);
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(HashTranslatorCharBuffer<UChar>&);
@@ -63,7 +63,7 @@ public:
     ALWAYS_INLINE static Ref<AtomStringImpl> add(ASCIILiteral literal) { return addLiteral(literal.characters(), literal.length()); }
 
     // Not using the add() naming to encourage developers to call add(ASCIILiteral) when they have a string literal.
-    ALWAYS_INLINE static RefPtr<AtomStringImpl> addCString(const char* s) { return s ? add(s, strlen(s)) : nullptr; }
+    ALWAYS_INLINE static RefPtr<AtomStringImpl> addCString(const char* s) { return s ? add(std::span { s, strlen(s) }) : nullptr; }
 
     // Returns null if the input data contains an invalid UTF-8 sequence.
     static RefPtr<AtomStringImpl> addUTF8(const char* start, const char* end);

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -253,31 +253,31 @@ Expected<Ref<StringImpl>, UTF8ConversionError> StringImpl::tryReallocate(Ref<Str
     return reallocateInternal(WTFMove(originalString), length, data);
 }
 
-template<typename CharacterType> inline Ref<StringImpl> StringImpl::createInternal(const CharacterType* characters, unsigned length)
+template<typename CharacterType> inline Ref<StringImpl> StringImpl::createInternal(std::span<const CharacterType> characters)
 {
-    if (!characters || !length)
+    if (characters.empty())
         return *empty();
     CharacterType* data;
-    auto string = createUninitializedInternalNonEmpty(length, data);
-    copyCharacters(data, characters, length);
+    auto string = createUninitializedInternalNonEmpty(characters.size(), data);
+    copyCharacters(data, characters.data(), characters.size());
     return string;
 }
 
-Ref<StringImpl> StringImpl::create(const UChar* characters, unsigned length)
+Ref<StringImpl> StringImpl::create(std::span<const UChar> characters)
 {
-    return createInternal(characters, length);
+    return createInternal(characters);
 }
 
-Ref<StringImpl> StringImpl::create(const LChar* characters, unsigned length)
+Ref<StringImpl> StringImpl::create(std::span<const LChar> characters)
 {
-    return createInternal(characters, length);
+    return createInternal(characters);
 }
 
 Ref<StringImpl> StringImpl::createStaticStringImpl(const LChar* characters, unsigned length)
 {
     if (!length)
         return *empty();
-    Ref<StringImpl> result = createInternal(characters, length);
+    Ref<StringImpl> result = createInternal(std::span { characters, length });
     result->hash();
     result->m_refCount |= s_refCountFlagIsStaticString;
     return result;
@@ -303,7 +303,7 @@ Ref<StringImpl> StringImpl::create8BitIfPossible(const UChar* characters, unsign
 
     for (size_t i = 0; i < length; ++i) {
         if (!isLatin1(characters[i]))
-            return create(characters, length);
+            return create(std::span { characters, length });
         data[i] = static_cast<LChar>(characters[i]);
     }
 
@@ -321,9 +321,9 @@ Ref<StringImpl> StringImpl::substring(unsigned start, unsigned length)
         length = maxLength;
     }
     if (is8Bit())
-        return create(m_data8 + start, length);
+        return create(std::span { m_data8 + start, length });
 
-    return create(m_data16 + start, length);
+    return create(std::span { m_data16 + start, length });
 }
 
 char32_t StringImpl::characterStartingAt(unsigned i)
@@ -756,8 +756,8 @@ template<typename CodeUnitPredicate> inline Ref<StringImpl> StringImpl::trimMatc
     if (!start && end == m_length - 1)
         return *this;
     if (is8Bit())
-        return create(m_data8 + start, end + 1 - start);
-    return create(m_data16 + start, end + 1 - start);
+        return create(std::span { m_data8 + start, end + 1 - start });
+    return create(std::span { m_data16 + start, end + 1 - start });
 }
 
 Ref<StringImpl> StringImpl::trim(CodeUnitMatchFunction predicate)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -668,8 +668,8 @@ inline AtomString StringView::toAtomString() const
 inline AtomString StringView::toExistingAtomString() const
 {
     if (is8Bit())
-        return AtomStringImpl::lookUp(characters8(), m_length);
-    return AtomStringImpl::lookUp(characters16(), m_length);
+        return AtomStringImpl::lookUp(span8());
+    return AtomStringImpl::lookUp(span16());
 }
 
 inline float StringView::toFloat(bool& isValid) const

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -41,18 +41,18 @@ using namespace Unicode;
 
 // Construct a string with UTF-16 data.
 String::String(const UChar* characters, unsigned length)
-    : m_impl(characters ? RefPtr { StringImpl::create(characters, length) } : nullptr)
+    : m_impl(characters ? RefPtr { StringImpl::create(std::span { characters, length }) } : nullptr)
 {
 }
 
 // Construct a string with latin1 data.
 String::String(const LChar* characters, unsigned length)
-    : m_impl(characters ? RefPtr { StringImpl::create(characters, length) } : nullptr)
+    : m_impl(characters ? RefPtr { StringImpl::create(std::span { characters, length }) } : nullptr)
 {
 }
 
 String::String(const char* characters, unsigned length)
-    : m_impl(characters ? RefPtr { StringImpl::create(reinterpret_cast<const LChar*>(characters), length) } : nullptr)
+    : m_impl(characters ? RefPtr { StringImpl::create(std::span { reinterpret_cast<const LChar*>(characters), length }) } : nullptr)
 {
 }
 
@@ -488,7 +488,7 @@ String fromUTF8Impl(const LChar* stringStart, size_t length)
         return emptyString();
 
     if (charactersAreAllASCII(stringStart, length))
-        return StringImpl::create(stringStart, length);
+        return StringImpl::create(std::span { stringStart, length });
 
     Vector<UChar, 1024> buffer(length);
     UChar* bufferStart = buffer.data();
@@ -501,7 +501,7 @@ String fromUTF8Impl(const LChar* stringStart, size_t length)
 
     unsigned utf16Length = bufferCurrent - bufferStart;
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(utf16Length <= length);
-    return StringImpl::create(bufferStart, utf16Length);
+    return StringImpl::create(std::span { bufferStart, utf16Length });
 }
 
 String String::fromUTF8(const LChar* stringStart, size_t length)

--- a/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
+++ b/Source/WTF/wtf/text/cf/AtomStringImplCF.cpp
@@ -38,17 +38,17 @@ RefPtr<AtomStringImpl> AtomStringImpl::add(CFStringRef string)
     if (!string)
         return nullptr;
 
-    CFIndex length = CFStringGetLength(string);
+    size_t length = CFStringGetLength(string);
 
     if (const LChar* ptr = reinterpret_cast<const LChar*>(CFStringGetCStringPtr(string, kCFStringEncodingISOLatin1)))
-        return add(ptr, length);
+        return add(std::span { ptr, length });
 
     if (const UniChar* ptr = CFStringGetCharactersPtr(string))
-        return add(reinterpret_cast<const UChar*>(ptr), length);
+        return add(std::span { reinterpret_cast<const UChar*>(ptr), length });
 
     Vector<UniChar, 1024> ucharBuffer(length);
     CFStringGetCharacters(string, CFRangeMake(0, length), ucharBuffer.data());
-    return add(reinterpret_cast<const UChar*>(ucharBuffer.data()), length);
+    return add(std::span { reinterpret_cast<const UChar*>(ucharBuffer.data()), length });
 }
 
 } // namespace WTF

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -108,7 +108,8 @@ TEST(WTF, StringImplEqualIgnoringASCIICaseBasic)
     auto b = StringImpl::create("ABCDEFG"_s);
     auto c = StringImpl::create("abcdefg"_s);
     constexpr auto d = "aBcDeFG"_s;
-    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
+    constexpr size_t zeroLength = 0; // LLVM bug workaround.
+    auto empty = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
     auto shorter = StringImpl::create("abcdef"_s);
     auto different = StringImpl::create("abcrefg"_s);
 
@@ -151,8 +152,9 @@ TEST(WTF, StringImplEqualIgnoringASCIICaseWithNull)
 
 TEST(WTF, StringImplEqualIgnoringASCIICaseWithEmpty)
 {
-    auto a = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
-    auto b = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
+    constexpr size_t zeroLength = 0; // LLVM bug workaround.
+    auto a = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
+    auto b = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
     ASSERT_TRUE(equalIgnoringASCIICase(a.ptr(), b.ptr()));
     ASSERT_TRUE(equalIgnoringASCIICase(b.ptr(), a.ptr()));
 }
@@ -330,7 +332,8 @@ TEST(WTF, StringImplFindIgnoringASCIICaseOnNull)
 TEST(WTF, StringImplFindIgnoringASCIICaseOnEmpty)
 {
     auto reference = stringFromUTF8("ABCÉEFG");
-    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
+    constexpr size_t zeroLength = 0; // LLVM bug workaround.
+    auto empty = StringImpl::create({ reinterpret_cast<const LChar*>(""), zeroLength });
     EXPECT_EQ(static_cast<size_t>(0), reference->findIgnoringASCIICase(empty.ptr()));
     EXPECT_EQ(static_cast<size_t>(0), reference->findIgnoringASCIICase(empty.ptr(), 0));
     EXPECT_EQ(static_cast<size_t>(3), reference->findIgnoringASCIICase(empty.ptr(), 3));
@@ -406,14 +409,16 @@ TEST(WTF, StringImplStartsWithIgnoringASCIICaseWithNull)
     auto reference = StringImpl::create("aBcDeFG"_s);
     ASSERT_FALSE(reference->startsWithIgnoringASCIICase(StringView { }));
 
-    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
+    constexpr size_t zeroLength = 0; // LLVM bug workaround.
+    auto empty = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
     ASSERT_FALSE(empty->startsWithIgnoringASCIICase(StringView { }));
 }
 
 TEST(WTF, StringImplStartsWithIgnoringASCIICaseWithEmpty)
 {
     auto reference = StringImpl::create("aBcDeFG"_s);
-    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
+    constexpr size_t zeroLength = 0; // LLVM bug workaround.
+    auto empty = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
     ASSERT_TRUE(reference->startsWithIgnoringASCIICase(empty.ptr()));
     ASSERT_TRUE(reference->startsWithIgnoringASCIICase(*empty.ptr()));
     ASSERT_TRUE(empty->startsWithIgnoringASCIICase(empty.ptr()));
@@ -495,14 +500,16 @@ TEST(WTF, StringImplEndsWithIgnoringASCIICaseWithNull)
     auto reference = StringImpl::create("aBcDeFG"_s);
     ASSERT_FALSE(reference->endsWithIgnoringASCIICase(StringView { }));
 
-    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
+    constexpr size_t zeroLength = 0; // LLVM bug workaround.
+    auto empty = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
     ASSERT_FALSE(empty->endsWithIgnoringASCIICase(StringView { }));
 }
 
 TEST(WTF, StringImplEndsWithIgnoringASCIICaseWithEmpty)
 {
     auto reference = StringImpl::create("aBcDeFG"_s);
-    auto empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
+    constexpr size_t zeroLength = 0; // LLVM bug workaround.
+    auto empty = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
     ASSERT_TRUE(reference->endsWithIgnoringASCIICase(empty.ptr()));
     ASSERT_TRUE(reference->endsWithIgnoringASCIICase(*empty.ptr()));
     ASSERT_TRUE(empty->endsWithIgnoringASCIICase(empty.ptr()));

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -338,7 +338,8 @@ TEST(WTF, StringViewEqualIgnoringASCIICaseBasic)
     RefPtr<StringImpl> b = StringImpl::create("ABCDEFG"_s);
     RefPtr<StringImpl> c = StringImpl::create("abcdefg"_s);
     constexpr auto d = "aBcDeFG"_s;
-    RefPtr<StringImpl> empty = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
+    constexpr size_t zeroLength = 0; // LLVM bug workaround.
+    RefPtr<StringImpl> empty = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
     RefPtr<StringImpl> shorter = StringImpl::create("abcdef"_s);
     RefPtr<StringImpl> different = StringImpl::create("abcrefg"_s);
 
@@ -383,8 +384,9 @@ TEST(WTF, StringViewEqualIgnoringASCIICaseBasic)
 
 TEST(WTF, StringViewEqualIgnoringASCIICaseWithEmpty)
 {
-    RefPtr<StringImpl> a = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
-    RefPtr<StringImpl> b = StringImpl::create(reinterpret_cast<const LChar*>(""), 0);
+    constexpr size_t zeroLength = 0; // LLVM bug workaround.
+    RefPtr<StringImpl> a = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
+    RefPtr<StringImpl> b = StringImpl::create(std::span { reinterpret_cast<const LChar*>(""), zeroLength });
     StringView stringViewA(*a.get());
     StringView stringViewB(*b.get());
     ASSERT_TRUE(equalIgnoringASCIICase(stringViewA, stringViewB));
@@ -393,10 +395,10 @@ TEST(WTF, StringViewEqualIgnoringASCIICaseWithEmpty)
 
 TEST(WTF, StringViewEqualIgnoringASCIICaseWithLatin1Characters)
 {
-    RefPtr<StringImpl> a = StringImpl::create(reinterpret_cast<const LChar*>("aBcéeFG"), 7);
-    RefPtr<StringImpl> b = StringImpl::create(reinterpret_cast<const LChar*>("ABCÉEFG"), 7);
-    RefPtr<StringImpl> c = StringImpl::create(reinterpret_cast<const LChar*>("ABCéEFG"), 7);
-    RefPtr<StringImpl> d = StringImpl::create(reinterpret_cast<const LChar*>("abcéefg"), 7);
+    RefPtr<StringImpl> a = StringImpl::create(std::span { reinterpret_cast<const LChar*>("aBcéeFG"), 7 });
+    RefPtr<StringImpl> b = StringImpl::create(std::span { reinterpret_cast<const LChar*>("ABCÉEFG"), 7 });
+    RefPtr<StringImpl> c = StringImpl::create(std::span { reinterpret_cast<const LChar*>("ABCéEFG"), 7 });
+    RefPtr<StringImpl> d = StringImpl::create(std::span { reinterpret_cast<const LChar*>("abcéefg"), 7 });
     StringView stringViewA(*a.get());
     StringView stringViewB(*b.get());
     StringView stringViewC(*c.get());


### PR DESCRIPTION
#### b30437d6f97ba7085dc93252a86f12c725fb1a0c
<pre>
Use std::span more in String code
<a href="https://bugs.webkit.org/show_bug.cgi?id=271354">https://bugs.webkit.org/show_bug.cgi?id=271354</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/builtins/BuiltinNames.cpp:
(JSC::CharBufferSeacher::equal):
(JSC::BuiltinNames::lookUpPrivateName const):
(JSC::BuiltinNames::lookUpWellKnownSymbol const):
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;LChar&gt;::parseIdentifier):
* Source/JavaScriptCore/parser/Lexer.h:
(JSC::Lexer&lt;T&gt;::makeIdentifier):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedUniquedStringImplBase::decode const):
(JSC::CachedUniquedStringImplBase::span8 const):
(JSC::CachedUniquedStringImplBase::span16 const):
* Source/JavaScriptCore/runtime/Identifier.cpp:
(JSC::Identifier::add8):
* Source/JavaScriptCore/runtime/Identifier.h:
(JSC::Identifier::add):
* Source/JavaScriptCore/runtime/JSONAtomStringCache.h:
* Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h:
(JSC::JSONAtomStringCache::make):
* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC::JSRopeString::resolveRopeToExistingAtomString const):
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::jsSingleCharacterString):
(JSC::jsString):
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::jsAtomString):
(JSC::jsSubstringOfResolved):
* Source/JavaScriptCore/runtime/KeyAtomStringCacheInlines.h:
(JSC::KeyAtomStringCache::make):
* Source/JavaScriptCore/runtime/SmallStrings.cpp:
(JSC::SmallStrings::initializeCommonStrings):
(JSC::SmallStrings::singleCharacterStringRep):
* Source/WTF/wtf/Assertions.cpp:
(WTF::createWithFormatAndArguments):
* Source/WTF/wtf/text/AtomString.h:
(WTF::AtomString::AtomString):
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::UCharBufferTranslator::equal):
(WTF::UCharBufferTranslator::translate):
(WTF::HashAndUTF8CharactersTranslator::translate):
(WTF::AtomStringImpl::add):
(WTF::LCharBufferTranslator::equal):
(WTF::LCharBufferTranslator::translate):
(WTF::BufferFromStaticDataTranslator::equal):
(WTF::BufferFromStaticDataTranslator::translate):
(WTF::AtomStringImpl::addLiteral):
(WTF::addStatic):
(WTF::AtomStringImpl::lookUp):
* Source/WTF/wtf/text/AtomStringImpl.h:
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::createInternal):
(WTF::StringImpl::create):
(WTF::StringImpl::createStaticStringImpl):
(WTF::StringImpl::create8BitIfPossible):
(WTF::StringImpl::substring):
(WTF::StringImpl::trimMatchedCharacters):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::create):
(WTF::StringImpl::create8BitIfPossible):
(WTF::StringImpl::createFromCString):
(WTF::StringImpl::createWithoutCopying):
(WTF::HashTranslatorCharBuffer::HashTranslatorCharBuffer):
(WTF::equal):
(WTF::StringImpl::isolatedCopy const):
(WTF::StringImpl::createSubstringSharingImpl):
(WTF::StringImpl::adopt):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::toExistingAtomString const):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::String):
(WTF::fromUTF8Impl):
* Source/WTF/wtf/text/cf/AtomStringImplCF.cpp:
(WTF::AtomStringImpl::add):
* Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/276458@main">https://commits.webkit.org/276458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f4b8d09ebd5ac539a46e7d2ad9be012ce4e848f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47332 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40684 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36739 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20833 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17792 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39606 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2726 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37859 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48971 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44127 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43684 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20964 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42428 "Found 3 new API test failures: /TestWTF:WTF_ParkingLot.UnparkOneOneFast, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21296 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51306 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6175 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20633 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10410 "Passed tests") | 
<!--EWS-Status-Bubble-End-->