### PR TITLE
Add an internal API to return the last DecodingOptions of an image

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2280,6 +2280,8 @@ fast/images/jpegxl-as-image.html [ Skip ]
 fast/images/jpegxl-with-color-profile.html [ Skip ]
 fast/images/animated-jpegxl-loop-count.html [ Skip ]
 
+webkit.org/b/270330 fast/images/async-image-intersect-different-size-for-drawing.html [ Failure ]
+
 # Experimental H265 support.
 webrtc/h265.html [ Pass Failure ]
 

--- a/LayoutTests/fast/images/async-image-intersect-different-size-for-drawing-expected.txt
+++ b/LayoutTests/fast/images/async-image-intersect-different-size-for-drawing-expected.txt
@@ -1,0 +1,11 @@
+Ensures a renderer will decode its image synchronously if it intersects with another renderer with a different sizeForDrawing.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS decodingOptions is "{ decodingMode : Asynchronous, sizeForDrawing : { 500, 500 } }"
+PASS decodingOptions is "{ decodingMode : Synchronous, sizeForDrawing : { 1000, 1000 } }"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/images/async-image-intersect-different-size-for-drawing.html
+++ b/LayoutTests/fast/images/async-image-intersect-different-size-for-drawing.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html>
+<script src="../../resources/js-test.js"></script>
+<style>
+    .container {
+        width: 500px;
+        height: 500px;
+        border: 1px solid black;
+        overflow: hidden;
+        position: relative;
+    }
+    .intial-box {
+        width: 100%;
+        height: 100%;
+        top: 0;
+        left: 0;
+        position: absolute;
+        will-change: transform;
+        display: none;
+    }
+    .final-box {
+        left: -50%;
+        top: -50%;
+        width: 200%;
+        height: 200%;
+        position: absolute;
+        transform: scale(0.5);
+        will-change: transform;
+        display: none;
+        background-color: red;
+    }
+    img {
+        width: 100%;
+        height: 100%;
+        display: block;
+    }
+</style>
+<body>
+    <div class="container">
+        <div class="intial-box"></div>
+        <div class="final-box"></div>
+    </div>
+    <script>
+        description("Ensures a renderer will decode its image synchronously if it intersects with another renderer with a different sizeForDrawing.");
+        window.jsTestIsAsync = true;
+ 
+         function loadImageAndDraw(box, image, src) {
+            return new Promise((resolve) => {
+                image.onload = (() => {
+                    if (!window.internals) {
+                        box.style.display = "block";
+                        resolve();
+                        return;
+                    }
+
+                    box.style.display = "block";
+
+                    // Force layout and display so the image gets drawn.
+                    document.body.offsetHeight;
+                    testRunner.display();
+
+                    image.addEventListener("webkitImageFrameReady", function() {
+                        resolve();
+                    }, false);
+                });
+
+                image.src = src;
+            });
+        }
+
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.settings.setWebkitImageReadyEventEnabled(true);
+            internals.settings.setLargeImageAsyncDecodingEnabled(true);
+        }
+ 
+        let intialBox = document.querySelector(".intial-box");
+        let finalBox = document.querySelector(".final-box");
+
+        let image1 = new Image;
+        intialBox.appendChild(image1);
+ 
+        loadImageAndDraw(intialBox, image1, "resources/green-400x400.png").then(() => {
+            requestAnimationFrame(() => {
+                decodingOptions = internals.imageLastDecodingOptions(image1);
+                shouldBeEqualToString("decodingOptions", "{ decodingMode : Asynchronous, sizeForDrawing : { 500, 500 } }");
+
+                finalBox.appendChild(image1.cloneNode(true));
+                finalBox.style.display = "block";
+
+                // Force layout and display so the image gets drawn.
+                document.body.offsetHeight;
+                if (window.testRunner)
+                    testRunner.display();
+
+                requestAnimationFrame(() => {
+                    decodingOptions = internals.imageLastDecodingOptions(image1);
+                    shouldBeEqualToString("decodingOptions", "{ decodingMode : Synchronous, sizeForDrawing : { 1000, 1000 } }");
+                    finishJSTest();
+                });
+            });
+        });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -223,6 +223,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
         // it is currently being decoded. New data may have been received since the previous request was made.
         if ((!frameIsCompatible && !frameIsBeingDecoded) || m_currentFrameDecodingStatus == DecodingStatus::Invalid) {
             LOG(Images, "BitmapImage::%s - %p - url: %s [requesting large async decoding]", __FUNCTION__, this, sourceURL().string().utf8().data());
+            m_lastDecodingOptionsForTesting = { options.decodingMode(), sizeForDrawing };
             m_source->requestFrameAsyncDecodingAtIndex(m_currentFrame, m_currentSubsamplingLevel, sizeForDrawing);
             m_currentFrameDecodingStatus = DecodingStatus::Decoding;
         }
@@ -266,6 +267,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
             }
             return ImageDrawResult::DidRequestDecoding;
         } else {
+            m_lastDecodingOptionsForTesting = { options.decodingMode(), sizeForDrawing };
             image = nativeImageAtIndexCacheIfNeeded(m_currentFrame, m_currentSubsamplingLevel, options.decodingMode());
             LOG(Images, "BitmapImage::%s - %p - url: %s [an image frame will be decoded synchronously]", __FUNCTION__, this, sourceURL().string().utf8().data());
         }
@@ -630,6 +632,11 @@ DestinationColorSpace BitmapImage::colorSpace()
 unsigned BitmapImage::decodeCountForTesting() const
 {
     return m_decodeCountForTesting;
+}
+
+DecodingOptions BitmapImage::lastDecodingOptionsForTesting() const
+{
+    return m_lastDecodingOptionsForTesting;
 }
 
 void BitmapImage::dump(TextStream& ts) const

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -107,6 +107,7 @@ public:
     DestinationColorSpace colorSpace() final;
 
     WEBCORE_EXPORT unsigned decodeCountForTesting() const;
+    WEBCORE_EXPORT DecodingOptions lastDecodingOptionsForTesting() const;
 
     WEBCORE_EXPORT RefPtr<NativeImage> nativeImage(const DestinationColorSpace& = DestinationColorSpace::SRGB()) override;
     RefPtr<NativeImage> nativeImageForCurrentFrame() override;
@@ -195,6 +196,7 @@ private:
 #endif
 
     unsigned m_decodeCountForTesting { 0 };
+    DecodingOptions m_lastDecodingOptionsForTesting;
 
     RefPtr<NativeImage> m_cachedImage;
 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1175,6 +1175,27 @@ unsigned Internals::imageDecodeCount(HTMLImageElement& element)
     return bitmapImage ? bitmapImage->decodeCountForTesting() : 0;
 }
 
+AtomString Internals::imageLastDecodingOptions(HTMLImageElement& element)
+{
+    auto* bitmapImage = bitmapImageFromImageElement(element);
+    if (!bitmapImage)
+        return { };
+
+    auto options = bitmapImage->lastDecodingOptionsForTesting();
+    StringBuilder builder;
+    builder.append("{ decodingMode : ");
+    builder.append(options.decodingMode() == DecodingMode::Asynchronous ? "Asynchronous" : "Synchronous");
+    if (auto sizeForDrawing = options.sizeForDrawing()) {
+        builder.append(", sizeForDrawing : { ");
+        builder.append(sizeForDrawing->width());
+        builder.append(", ");
+        builder.append(sizeForDrawing->height());
+        builder.append(" }");
+    }
+    builder.append(" }");
+    return builder.toAtomString();
+}
+
 unsigned Internals::imageCachedSubimageCreateCount(HTMLImageElement& element)
 {
 #if USE(CG)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -243,6 +243,7 @@ public:
     unsigned imagePendingDecodePromisesCountForTesting(HTMLImageElement&);
     void setClearDecoderAfterAsyncFrameRequestForTesting(HTMLImageElement&, bool enabled);
     unsigned imageDecodeCount(HTMLImageElement&);
+    AtomString imageLastDecodingOptions(HTMLImageElement&);
     unsigned imageCachedSubimageCreateCount(HTMLImageElement&);
     unsigned remoteImagesCountForTesting() const;
     void setAsyncDecodingEnabledForTesting(HTMLImageElement&, bool enabled);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -667,6 +667,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     unsigned long imagePendingDecodePromisesCountForTesting(HTMLImageElement element);
     undefined setClearDecoderAfterAsyncFrameRequestForTesting(HTMLImageElement element, boolean enabled);
     unsigned long imageDecodeCount(HTMLImageElement element);
+    DOMString imageLastDecodingOptions(HTMLImageElement element);
     unsigned long imageCachedSubimageCreateCount(HTMLImageElement element);
     unsigned long remoteImagesCountForTesting();
     undefined setAsyncDecodingEnabledForTesting(HTMLImageElement element, boolean enabled);


### PR DESCRIPTION
#### 81c32dcdf889206dd5f1709058eab565c0798153
<pre>
Add an internal API to return the last DecodingOptions of an image
<a href="https://bugs.webkit.org/show_bug.cgi?id=271355">https://bugs.webkit.org/show_bug.cgi?id=271355</a>
<a href="https://rdar.apple.com/125133851">rdar://125133851</a>

Reviewed by Simon Fraser.

This will help ensuing the decoding mode heuristics are working as expected. The
layout test is expected to fail. It will be unskipped by the fix of bug 270330.

* LayoutTests/TestExpectations:
* LayoutTests/fast/images/async-image-intersect-different-size-for-drawing-expected.txt: Added.
* LayoutTests/fast/images/async-image-intersect-different-size-for-drawing.html: Added.
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
(WebCore::BitmapImage::lastDecodingOptionsForTesting const):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::imageLastDecodingOptions):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/276451@main">https://commits.webkit.org/276451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ed5d002046a130a93d40ea2e5391eaf25c19054

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23801 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47365 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40716 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21192 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38504 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17818 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18299 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39647 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2758 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40943 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49015 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16224 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38750 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9960 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->