### PR TITLE
Update toBufferSource() to take in a std::span

### DIFF
--- a/Source/WebCore/bindings/js/BufferSource.h
+++ b/Source/WebCore/bindings/js/BufferSource.h
@@ -79,9 +79,9 @@ private:
     VariantType m_variant;
 };
 
-inline BufferSource toBufferSource(const uint8_t* data, size_t length)
+inline BufferSource toBufferSource(std::span<const uint8_t> data)
 {
-    return BufferSource(JSC::ArrayBuffer::tryCreate(data, length));
+    return BufferSource(JSC::ArrayBuffer::tryCreate(data));
 }
 
 #if PLATFORM(COCOA) && defined(__OBJC__)

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
@@ -56,7 +56,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParam)
     PublicKeyCredentialCreationOptions::UserEntity user;
     user.name = "johnpsmith@example.com"_s;
     user.icon = "https://pics.acme.com/00/p/aBjjjpqPb.png"_s;
-    user.id = WebCore::toBufferSource(TestData::kUserId, sizeof(TestData::kUserId));
+    user.id = WebCore::toBufferSource(TestData::kUserId);
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
@@ -80,7 +80,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamNoUVNoRK)
     PublicKeyCredentialCreationOptions::UserEntity user;
     user.name = "johnpsmith@example.com"_s;
     user.icon = "https://pics.acme.com/00/p/aBjjjpqPb.png"_s;
-    user.id = WebCore::toBufferSource(TestData::kUserId, sizeof(TestData::kUserId));
+    user.id = WebCore::toBufferSource(TestData::kUserId);
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
@@ -104,7 +104,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamUVRequiredButNotSup
     PublicKeyCredentialCreationOptions::UserEntity user;
     user.name = "johnpsmith@example.com"_s;
     user.icon = "https://pics.acme.com/00/p/aBjjjpqPb.png"_s;
-    user.id = WebCore::toBufferSource(TestData::kUserId, sizeof(TestData::kUserId));
+    user.id = WebCore::toBufferSource(TestData::kUserId);
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
@@ -128,7 +128,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamWithPin)
     PublicKeyCredentialCreationOptions::UserEntity user;
     user.name = "johnpsmith@example.com"_s;
     user.icon = "https://pics.acme.com/00/p/aBjjjpqPb.png"_s;
-    user.id = WebCore::toBufferSource(TestData::kUserId, sizeof(TestData::kUserId));
+    user.id = WebCore::toBufferSource(TestData::kUserId);
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
@@ -156,7 +156,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKPreferred)
     PublicKeyCredentialCreationOptions::UserEntity user;
     user.name = "johnpsmith@example.com"_s;
     user.icon = "https://pics.acme.com/00/p/aBjjjpqPb.png"_s;
-    user.id = WebCore::toBufferSource(TestData::kUserId, sizeof(TestData::kUserId));
+    user.id = WebCore::toBufferSource(TestData::kUserId);
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
@@ -184,7 +184,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKPreferredNotSupported)
     PublicKeyCredentialCreationOptions::UserEntity user;
     user.name = "johnpsmith@example.com"_s;
     user.icon = "https://pics.acme.com/00/p/aBjjjpqPb.png"_s;
-    user.id = WebCore::toBufferSource(TestData::kUserId, sizeof(TestData::kUserId));
+    user.id = WebCore::toBufferSource(TestData::kUserId);
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
@@ -208,7 +208,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKDiscouraged)
     PublicKeyCredentialCreationOptions::UserEntity user;
     user.name = "johnpsmith@example.com"_s;
     user.icon = "https://pics.acme.com/00/p/aBjjjpqPb.png"_s;
-    user.id = WebCore::toBufferSource(TestData::kUserId, sizeof(TestData::kUserId));
+    user.id = WebCore::toBufferSource(TestData::kUserId);
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
@@ -232,7 +232,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithLargeBlob)
     PublicKeyCredentialCreationOptions::UserEntity user;
     user.name = "johnpsmith@example.com"_s;
     user.icon = "https://pics.acme.com/00/p/aBjjjpqPb.png"_s;
-    user.id = WebCore::toBufferSource(TestData::kUserId, sizeof(TestData::kUserId));
+    user.id = WebCore::toBufferSource(TestData::kUserId);
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
@@ -261,7 +261,7 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithUnsupportedLargeBlob
     PublicKeyCredentialCreationOptions::UserEntity user;
     user.name = "johnpsmith@example.com"_s;
     user.icon = "https://pics.acme.com/00/p/aBjjjpqPb.png"_s;
-    user.id = WebCore::toBufferSource(TestData::kUserId, sizeof(TestData::kUserId));
+    user.id = WebCore::toBufferSource(TestData::kUserId);
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
@@ -295,7 +295,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequest)
         0x34, 0x85, 0x8a, 0xc7, 0x5b, 0xed, 0x3f, 0xd5, 0x80, 0xbf, 0x98,
         0x08, 0xd9, 0x4f, 0xcb, 0xee, 0x82, 0xb9, 0xb2, 0xef, 0x66, 0x77,
         0xaf, 0x0a, 0xdc, 0xc3, 0x58, 0x52, 0xea, 0x6b, 0x9e };
-    descriptor1.id = WebCore::toBufferSource(id1, sizeof(id1));
+    descriptor1.id = WebCore::toBufferSource(id1);
     options.allowCredentials.append(descriptor1);
 
     PublicKeyCredentialDescriptor descriptor2;
@@ -306,7 +306,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequest)
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03 };
-    descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
+    descriptor2.id = WebCore::toBufferSource(id2);
     options.allowCredentials.append(descriptor2);
 
     options.userVerification = UserVerificationRequirement::Required;
@@ -333,7 +333,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestNoUV)
         0x34, 0x85, 0x8a, 0xc7, 0x5b, 0xed, 0x3f, 0xd5, 0x80, 0xbf, 0x98,
         0x08, 0xd9, 0x4f, 0xcb, 0xee, 0x82, 0xb9, 0xb2, 0xef, 0x66, 0x77,
         0xaf, 0x0a, 0xdc, 0xc3, 0x58, 0x52, 0xea, 0x6b, 0x9e };
-    descriptor1.id = WebCore::toBufferSource(id1, sizeof(id1));
+    descriptor1.id = WebCore::toBufferSource(id1);
     options.allowCredentials.append(descriptor1);
 
     PublicKeyCredentialDescriptor descriptor2;
@@ -344,7 +344,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestNoUV)
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03 };
-    descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
+    descriptor2.id = WebCore::toBufferSource(id2);
     options.allowCredentials.append(descriptor2);
 
     options.userVerification = UserVerificationRequirement::Discouraged;
@@ -371,7 +371,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestUVRequiredButNotSupported)
         0x34, 0x85, 0x8a, 0xc7, 0x5b, 0xed, 0x3f, 0xd5, 0x80, 0xbf, 0x98,
         0x08, 0xd9, 0x4f, 0xcb, 0xee, 0x82, 0xb9, 0xb2, 0xef, 0x66, 0x77,
         0xaf, 0x0a, 0xdc, 0xc3, 0x58, 0x52, 0xea, 0x6b, 0x9e };
-    descriptor1.id = WebCore::toBufferSource(id1, sizeof(id1));
+    descriptor1.id = WebCore::toBufferSource(id1);
     options.allowCredentials.append(descriptor1);
 
     PublicKeyCredentialDescriptor descriptor2;
@@ -382,7 +382,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestUVRequiredButNotSupported)
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03 };
-    descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
+    descriptor2.id = WebCore::toBufferSource(id2);
     options.allowCredentials.append(descriptor2);
 
     options.userVerification = UserVerificationRequirement::Required;
@@ -409,7 +409,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestWithPin)
         0x34, 0x85, 0x8a, 0xc7, 0x5b, 0xed, 0x3f, 0xd5, 0x80, 0xbf, 0x98,
         0x08, 0xd9, 0x4f, 0xcb, 0xee, 0x82, 0xb9, 0xb2, 0xef, 0x66, 0x77,
         0xaf, 0x0a, 0xdc, 0xc3, 0x58, 0x52, 0xea, 0x6b, 0x9e };
-    descriptor1.id = WebCore::toBufferSource(id1, sizeof(id1));
+    descriptor1.id = WebCore::toBufferSource(id1);
     options.allowCredentials.append(descriptor1);
 
     PublicKeyCredentialDescriptor descriptor2;
@@ -420,7 +420,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestWithPin)
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03 };
-    descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
+    descriptor2.id = WebCore::toBufferSource(id2);
     options.allowCredentials.append(descriptor2);
 
     options.userVerification = UserVerificationRequirement::Required;
@@ -470,7 +470,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobRead)
         0x34, 0x85, 0x8a, 0xc7, 0x5b, 0xed, 0x3f, 0xd5, 0x80, 0xbf, 0x98,
         0x08, 0xd9, 0x4f, 0xcb, 0xee, 0x82, 0xb9, 0xb2, 0xef, 0x66, 0x77,
         0xaf, 0x0a, 0xdc, 0xc3, 0x58, 0x52, 0xea, 0x6b, 0x9e };
-    descriptor1.id = WebCore::toBufferSource(id1, sizeof(id1));
+    descriptor1.id = WebCore::toBufferSource(id1);
     options.allowCredentials.append(descriptor1);
 
     PublicKeyCredentialDescriptor descriptor2;
@@ -481,7 +481,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobRead)
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03 };
-    descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
+    descriptor2.id = WebCore::toBufferSource(id2);
     options.allowCredentials.append(descriptor2);
     options.extensions = AuthenticationExtensionsClientInputs {
         .largeBlob = AuthenticationExtensionsClientInputs::LargeBlobInputs {
@@ -513,7 +513,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestUnsupportedLargeBlobRead)
         0x34, 0x85, 0x8a, 0xc7, 0x5b, 0xed, 0x3f, 0xd5, 0x80, 0xbf, 0x98,
         0x08, 0xd9, 0x4f, 0xcb, 0xee, 0x82, 0xb9, 0xb2, 0xef, 0x66, 0x77,
         0xaf, 0x0a, 0xdc, 0xc3, 0x58, 0x52, 0xea, 0x6b, 0x9e };
-    descriptor1.id = WebCore::toBufferSource(id1, sizeof(id1));
+    descriptor1.id = WebCore::toBufferSource(id1);
     options.allowCredentials.append(descriptor1);
 
     PublicKeyCredentialDescriptor descriptor2;
@@ -524,7 +524,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestUnsupportedLargeBlobRead)
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03 };
-    descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
+    descriptor2.id = WebCore::toBufferSource(id2);
     options.allowCredentials.append(descriptor2);
     options.extensions = AuthenticationExtensionsClientInputs {
         .largeBlob = AuthenticationExtensionsClientInputs::LargeBlobInputs {
@@ -556,7 +556,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobWrite)
         0x34, 0x85, 0x8a, 0xc7, 0x5b, 0xed, 0x3f, 0xd5, 0x80, 0xbf, 0x98,
         0x08, 0xd9, 0x4f, 0xcb, 0xee, 0x82, 0xb9, 0xb2, 0xef, 0x66, 0x77,
         0xaf, 0x0a, 0xdc, 0xc3, 0x58, 0x52, 0xea, 0x6b, 0x9e };
-    descriptor1.id = WebCore::toBufferSource(id1, sizeof(id1));
+    descriptor1.id = WebCore::toBufferSource(id1);
     options.allowCredentials.append(descriptor1);
 
     PublicKeyCredentialDescriptor descriptor2;
@@ -567,7 +567,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobWrite)
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
         0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03 };
-    descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
+    descriptor2.id = WebCore::toBufferSource(id2);
     options.allowCredentials.append(descriptor2);
 
     const uint8_t blob[] = {
@@ -575,7 +575,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobWrite)
     };
     options.extensions = AuthenticationExtensionsClientInputs {
         .largeBlob = AuthenticationExtensionsClientInputs::LargeBlobInputs {
-            .write = WebCore::toBufferSource(blob, sizeof(blob)),
+            .write = WebCore::toBufferSource(blob),
         }
     };
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp
@@ -337,7 +337,7 @@ Vector<uint8_t> getTestCorruptedSignResponse(size_t length)
 // Return a key handle used for GetAssertion request.
 BufferSource getTestCredentialRawIdBytes()
 {
-    return WebCore::toBufferSource(TestData::kU2fSignKeyHandle, sizeof(TestData::kU2fSignKeyHandle));
+    return WebCore::toBufferSource(TestData::kU2fSignKeyHandle);
 }
 
 // Return a malformed U2fRegisterResponse.

--- a/Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp
@@ -50,7 +50,7 @@ PublicKeyCredentialCreationOptions constructMakeCredentialRequest()
     rp.name = "acme.com"_s;
 
     PublicKeyCredentialCreationOptions::UserEntity user;
-    user.id = WebCore::toBufferSource(TestData::kUserId, sizeof(TestData::kUserId));
+    user.id = WebCore::toBufferSource(TestData::kUserId);
     user.name = "johnpsmith@example.com"_s;
     user.displayName = "John P. Smith"_s;
     user.icon = "https://pics.acme.com/00/p/aBjjjpqPb.png"_s;
@@ -93,7 +93,7 @@ TEST(U2fCommandConstructorTest, TestConvertCtapMakeCredentialToU2fCheckOnlySign)
     auto makeCredentialParam = constructMakeCredentialRequest();
     PublicKeyCredentialDescriptor credentialDescriptor;
     credentialDescriptor.type = PublicKeyCredentialType::PublicKey;
-    credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle, sizeof(TestData::kU2fSignKeyHandle));
+    credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle);
     Vector<PublicKeyCredentialDescriptor> excludeList;
     excludeList.append(credentialDescriptor);
     makeCredentialParam.excludeCredentials = WTFMove(excludeList);
@@ -109,7 +109,7 @@ TEST(U2fCommandConstructorTest, TestConvertCtapMakeCredentialToU2fCheckOnlySignW
     auto makeCredentialParam = constructMakeCredentialRequest();
     PublicKeyCredentialDescriptor credentialDescriptor;
     credentialDescriptor.type = static_cast<PublicKeyCredentialType>(-1);
-    credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle, sizeof(TestData::kU2fSignKeyHandle));
+    credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle);
     Vector<PublicKeyCredentialDescriptor> excludeList;
     excludeList.append(credentialDescriptor);
     makeCredentialParam.excludeCredentials = WTFMove(excludeList);
@@ -126,7 +126,7 @@ TEST(U2fCommandConstructorTest, TestU2fRegisterCredentialAlgorithmRequirement)
     rp.name = "acme.com"_s;
 
     PublicKeyCredentialCreationOptions::UserEntity user;
-    user.id = WebCore::toBufferSource(TestData::kUserId, sizeof(TestData::kUserId));
+    user.id = WebCore::toBufferSource(TestData::kUserId);
     user.name = "johnpsmith@example.com"_s;
     user.displayName = "John P. Smith"_s;
     user.icon = "https://pics.acme.com/00/p/aBjjjpqPb.png"_s;
@@ -168,13 +168,13 @@ TEST(U2fCommandConstructorTest, TestConvertCtapGetAssertionToU2fSignRequest)
     auto getAssertionReq = constructGetAssertionRequest();
     PublicKeyCredentialDescriptor credentialDescriptor;
     credentialDescriptor.type = PublicKeyCredentialType::PublicKey;
-    credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle, sizeof(TestData::kU2fSignKeyHandle));
+    credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle);
     Vector<PublicKeyCredentialDescriptor> allowedList;
     allowedList.append(WTFMove(credentialDescriptor));
     getAssertionReq.allowCredentials = WTFMove(allowedList);
     EXPECT_TRUE(isConvertibleToU2fSignCommand(getAssertionReq));
 
-    const auto u2fSignCommand = convertToU2fSignCommand(convertBytesToVector(TestData::kClientDataHash, sizeof(TestData::kClientDataHash)), getAssertionReq, WebCore::toBufferSource(TestData::kU2fSignKeyHandle, sizeof(TestData::kU2fSignKeyHandle)));
+    const auto u2fSignCommand = convertToU2fSignCommand(convertBytesToVector(TestData::kClientDataHash, sizeof(TestData::kClientDataHash)), getAssertionReq, WebCore::toBufferSource(TestData::kU2fSignKeyHandle));
     ASSERT_TRUE(u2fSignCommand);
     EXPECT_EQ(*u2fSignCommand, convertBytesToVector(TestData::kU2fSignCommandApdu, sizeof(TestData::kU2fSignCommandApdu)));
 }
@@ -184,7 +184,7 @@ TEST(U2fCommandConstructorTest, TestConvertCtapGetAssertionWithAppIDToU2fSignReq
     auto getAssertionReq = constructGetAssertionRequest();
     PublicKeyCredentialDescriptor credentialDescriptor;
     credentialDescriptor.type = PublicKeyCredentialType::PublicKey;
-    credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle, sizeof(TestData::kU2fSignKeyHandle));
+    credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle);
     Vector<PublicKeyCredentialDescriptor> allowedList;
     allowedList.append(WTFMove(credentialDescriptor));
     getAssertionReq.allowCredentials = WTFMove(allowedList);
@@ -195,7 +195,7 @@ TEST(U2fCommandConstructorTest, TestConvertCtapGetAssertionWithAppIDToU2fSignReq
     extensions.appid = "https://www.example.com/appid"_s;
     getAssertionReq.extensions = WTFMove(extensions);
 
-    const auto u2fSignCommand = convertToU2fSignCommand(convertBytesToVector(TestData::kClientDataHash, sizeof(TestData::kClientDataHash)), getAssertionReq, WebCore::toBufferSource(TestData::kU2fSignKeyHandle, sizeof(TestData::kU2fSignKeyHandle)), true);
+    const auto u2fSignCommand = convertToU2fSignCommand(convertBytesToVector(TestData::kClientDataHash, sizeof(TestData::kClientDataHash)), getAssertionReq, WebCore::toBufferSource(TestData::kU2fSignKeyHandle), true);
     ASSERT_TRUE(u2fSignCommand);
     EXPECT_EQ(*u2fSignCommand, convertBytesToVector(TestData::kU2fAppIDSignCommandApdu, sizeof(TestData::kU2fAppIDSignCommandApdu)));
 }
@@ -211,7 +211,7 @@ TEST(U2fCommandConstructorTest, TestU2fSignUserVerificationRequirement)
     auto getAssertionReq = constructGetAssertionRequest();
     PublicKeyCredentialDescriptor credentialDescriptor;
     credentialDescriptor.type = PublicKeyCredentialType::PublicKey;
-    credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle, sizeof(TestData::kU2fSignKeyHandle));
+    credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle);
     Vector<PublicKeyCredentialDescriptor> allowedList;
     allowedList.append(WTFMove(credentialDescriptor));
     getAssertionReq.allowCredentials = WTFMove(allowedList);
@@ -225,18 +225,18 @@ TEST(U2fCommandConstructorTest, TestCreateSignWithIncorrectKeyHandle)
     auto getAssertionReq = constructGetAssertionRequest();
     PublicKeyCredentialDescriptor credentialDescriptor;
     credentialDescriptor.type = PublicKeyCredentialType::PublicKey;
-    credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle, sizeof(TestData::kU2fSignKeyHandle));
+    credentialDescriptor.id = WebCore::toBufferSource(TestData::kU2fSignKeyHandle);
     Vector<PublicKeyCredentialDescriptor> allowedList;
     allowedList.append(WTFMove(credentialDescriptor));
     getAssertionReq.allowCredentials = WTFMove(allowedList);
     ASSERT_TRUE(isConvertibleToU2fSignCommand(getAssertionReq));
 
     Vector<uint8_t> keyHandle(kMaxKeyHandleLength, 0xff);
-    const auto validSignCommand = convertToU2fSignCommand(convertBytesToVector(TestData::kClientDataHash, sizeof(TestData::kClientDataHash)), getAssertionReq, WebCore::toBufferSource(keyHandle.data(), keyHandle.size()));
+    const auto validSignCommand = convertToU2fSignCommand(convertBytesToVector(TestData::kClientDataHash, sizeof(TestData::kClientDataHash)), getAssertionReq, WebCore::toBufferSource(keyHandle.span()));
     EXPECT_TRUE(validSignCommand);
 
     keyHandle.append(0xff);
-    const auto invalidSignCommand = convertToU2fSignCommand(convertBytesToVector(TestData::kClientDataHash, sizeof(TestData::kClientDataHash)), getAssertionReq, WebCore::toBufferSource(keyHandle.data(), keyHandle.size()));
+    const auto invalidSignCommand = convertToU2fSignCommand(convertBytesToVector(TestData::kClientDataHash, sizeof(TestData::kClientDataHash)), getAssertionReq, WebCore::toBufferSource(keyHandle.span()));
     EXPECT_FALSE(invalidSignCommand);
 }
 


### PR DESCRIPTION
#### 893e0c7a3b6bd1b57c8bdb744b7057d67c5fd4ee
<pre>
Update toBufferSource() to take in a std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=271356">https://bugs.webkit.org/show_bug.cgi?id=271356</a>

Reviewed by Darin Adler.

* Source/WebCore/bindings/js/BufferSource.h:
(WebCore::toBufferSource):
* Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp:
(TestWebKitAPI::constructMakeCredentialRequest):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/276480@main">https://commits.webkit.org/276480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9b1f33d73d48761221af997404867342393ba5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47396 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40747 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21228 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36777 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45320 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20909 "Found 2 new test failures: fast/forms/datalist/datalist-option-labels.html, fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17841 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39680 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2789 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40982 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49057 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16275 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21027 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42510 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21364 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6199 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20700 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->