### PR TITLE
Fix the internal Playstation build after 275728@main

### DIFF
--- a/LayoutTests/fast/text-extraction/extract-rendered-text-with-subframe-expected.txt
+++ b/LayoutTests/fast/text-extraction/extract-rendered-text-with-subframe-expected.txt
@@ -1,4 +1,4 @@
-PASS extractedText is "zero one two three four five"
+PASS extractedText is "zero one two three four 五"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/text-extraction/extract-rendered-text-with-subframe.html
+++ b/LayoutTests/fast/text-extraction/extract-rendered-text-with-subframe.html
@@ -10,7 +10,7 @@
 <div class="container">
     <h1>zero</h1>
     <iframe frameborder="0" width="350" height="200" src="resources/subframe.html"></iframe>
-    <h3>five</h3>
+    <h3>五</h3>
 </div>
 <script>
 jsTestIsAsync = true;
@@ -23,7 +23,7 @@ async function runTestIfPossible() {
     if (--remainingLoadCount)
         return;
     extractedText = await UIHelper.requestRenderedTextForSelector("div.container");
-    shouldBeEqualToString("extractedText", "zero one two three four five");
+    shouldBeEqualToString("extractedText", "zero one two three four 五");
     document.querySelector("div.container").remove();
     finishJSTest();
 }

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -513,7 +513,11 @@ static void extractRenderedText(Vector<StringsAndBlockOffset>& stringsAndOffsets
             Vector<String> strings;
             for (auto token : textRenderer->text().simplifyWhiteSpace(isASCIIWhitespace).split(' ')) {
                 auto candidate = token.removeCharacters([](UChar character) {
+#if PLATFORM(COCOA)
                     return !u_isalpha(character) && !u_isdigit(character);
+#else
+                    return !isASCIIAlphanumeric(character);
+#endif
                 });
                 if (!candidate.isEmpty())
                     strings.append(WTFMove(candidate));


### PR DESCRIPTION
#### eb959bf86cc6340a4635e393c3635eeb6c0e55e1
<pre>
Fix the internal Playstation build after 275728@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=271357">https://bugs.webkit.org/show_bug.cgi?id=271357</a>

Reviewed by NOBODY (OOPS!).

Using `u_isalpha` here appears to break some internal Playstation builds; work around this for now
by falling back to `isASCIIAlphanumeric` instead. Note that the latter isn&apos;t a perfect replacement,
since the existing code (using `u_isalpha`) is intended to preserve non-ASCII/non-Latin &quot;letter&quot;
characters as well (roughly equivalent to `\p{L}`). Since this codepath is not exercised outside of
Cocoa platforms in the first place, this won&apos;t be an issue in practice.

* LayoutTests/fast/text-extraction/extract-rendered-text-with-subframe-expected.txt:
* LayoutTests/fast/text-extraction/extract-rendered-text-with-subframe.html:

Also take the opportunity to update a layout test, to actually exercise extracting non-Latin
rendered text (by replacing &quot;five&quot; with &quot;五&quot; in the test).

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRenderedText):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb959bf86cc6340a4635e393c3635eeb6c0e55e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47338 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21161 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20837 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/39617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2732 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37865 "Build is in progress. Recent messages:") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/39903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/48980 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19643 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/16194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/20970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/38723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->