### PR TITLE
Use std::span more in IndexedDB code

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
@@ -60,12 +60,12 @@ RefPtr<SharedBuffer> serializeIDBKeyPath(const std::optional<IDBKeyPath>& keyPat
     return encoder->finishEncoding();
 }
 
-bool deserializeIDBKeyPath(const uint8_t* data, size_t size, std::optional<IDBKeyPath>& result)
+bool deserializeIDBKeyPath(std::span<const uint8_t> data, std::optional<IDBKeyPath>& result)
 {
-    if (!data || !size)
+    if (data.empty())
         return false;
 
-    auto decoder = KeyedDecoder::decoder(data, size);
+    auto decoder = KeyedDecoder::decoder(data);
 
     KeyPathType type;
     bool succeeded = decoder->decodeEnum("type"_s, type, [](KeyPathType value) {
@@ -98,11 +98,9 @@ bool deserializeIDBKeyPath(const uint8_t* data, size_t size, std::optional<IDBKe
     return true;
 }
 
-static bool isLegacySerializedIDBKeyData(const uint8_t* data, size_t size)
+static bool isLegacySerializedIDBKeyData(std::span<const uint8_t> data)
 {
 #if USE(CF)
-    UNUSED_PARAM(size);
-
     // This is the magic character that begins serialized PropertyLists, and tells us whether
     // the key we're looking at is an old-style key.
     static const uint8_t legacySerializedKeyVersion = 'b';
@@ -110,12 +108,11 @@ static bool isLegacySerializedIDBKeyData(const uint8_t* data, size_t size)
         return true;
 #elif USE(GLIB)
     // KeyedEncoderGLib uses a GVariant dictionary, so check if the given data is a valid GVariant dictionary.
-    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(data, size));
+    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(data.data(), data.size()));
     GRefPtr<GVariant> variant = g_variant_new_from_bytes(G_VARIANT_TYPE("a{sv}"), bytes.get(), FALSE);
     return g_variant_is_normal_form(variant.get());
 #else
     UNUSED_PARAM(data);
-    UNUSED_PARAM(size);
 #endif
     return false;
 }
@@ -195,14 +192,15 @@ template <typename T> static void writeLittleEndian(Vector<uint8_t>& buffer, T v
     }
 }
 
-template <typename T> static bool readLittleEndian(const uint8_t*& ptr, const uint8_t* end, T& value)
+template <typename T> static bool readLittleEndian(std::span<const uint8_t>& data, T& value)
 {
-    if (ptr > end - sizeof(value))
+    if (data.size() < sizeof(value))
         return false;
 
     value = 0;
     for (size_t i = 0; i < sizeof(T); i++)
-        value += ((T)*ptr++) << (i * 8);
+        value += ((T)data[i]) << (i * 8);
+    data = data.subspan(sizeof(T));
     return true;
 }
 #else
@@ -211,13 +209,13 @@ template <typename T> static void writeLittleEndian(Vector<uint8_t>& buffer, T v
     buffer.append(std::span { reinterpret_cast<uint8_t*>(&value), sizeof(value) });
 }
 
-template <typename T> static bool readLittleEndian(const uint8_t*& ptr, const uint8_t* end, T& value)
+template <typename T> static bool readLittleEndian(std::span<const uint8_t>& data, T& value)
 {
-    if (ptr > end - sizeof(value))
+    if (data.size() < sizeof(value))
         return false;
 
-    value = *reinterpret_cast<const T*>(ptr);
-    ptr += sizeof(T);
+    value = *reinterpret_cast<const T*>(data.data());
+    data = data.subspan(sizeof(T));
 
     return true;
 }
@@ -228,9 +226,9 @@ static void writeDouble(Vector<uint8_t>& data, double d)
     writeLittleEndian(data, *reinterpret_cast<uint64_t*>(&d));
 }
 
-static bool readDouble(const uint8_t*& data, const uint8_t* end, double& d)
+static bool readDouble(std::span<const uint8_t>& data, double& d)
 {
-    return readLittleEndian(data, end, *reinterpret_cast<uint64_t*>(&d));
+    return readLittleEndian(data, *reinterpret_cast<uint64_t*>(&d));
 }
 
 static void encodeKey(Vector<uint8_t>& data, const IDBKeyData& key)
@@ -291,12 +289,13 @@ RefPtr<SharedBuffer> serializeIDBKeyData(const IDBKeyData& key)
     return SharedBuffer::create(WTFMove(data));
 }
 
-static WARN_UNUSED_RETURN bool decodeKey(const uint8_t*& data, const uint8_t* end, IDBKeyData& result)
+static WARN_UNUSED_RETURN bool decodeKey(std::span<const uint8_t>& data, IDBKeyData& result)
 {
-    if (!data || data >= end)
+    if (data.empty())
         return false;
 
-    SIDBKeyType type = static_cast<SIDBKeyType>(data++[0]);
+    SIDBKeyType type = static_cast<SIDBKeyType>(data[0]);
+    data = data.subspan(1);
     switch (type) {
     case SIDBKeyType::Min:
         result = IDBKeyData::minimum();
@@ -306,7 +305,7 @@ static WARN_UNUSED_RETURN bool decodeKey(const uint8_t*& data, const uint8_t* en
         return true;
     case SIDBKeyType::Number: {
         double d;
-        if (!readDouble(data, end, d))
+        if (!readDouble(data, d))
             return false;
 
         result.setNumberValue(d);
@@ -314,7 +313,7 @@ static WARN_UNUSED_RETURN bool decodeKey(const uint8_t*& data, const uint8_t* en
     }
     case SIDBKeyType::Date: {
         double d;
-        if (!readDouble(data, end, d))
+        if (!readDouble(data, d))
             return false;
 
         result.setDateValue(d);
@@ -322,17 +321,17 @@ static WARN_UNUSED_RETURN bool decodeKey(const uint8_t*& data, const uint8_t* en
     }
     case SIDBKeyType::String: {
         uint32_t length;
-        if (!readLittleEndian(data, end, length))
+        if (!readLittleEndian(data, length))
             return false;
 
-        if (static_cast<uint64_t>(end - data) < length * 2)
+        if (data.size() < length * 2)
             return false;
 
         Vector<UChar> buffer;
         buffer.reserveInitialCapacity(length);
         for (size_t i = 0; i < length; i++) {
             uint16_t ch;
-            if (!readLittleEndian(data, end, ch))
+            if (!readLittleEndian(data, ch))
                 return false;
             buffer.append(ch);
         }
@@ -343,25 +342,25 @@ static WARN_UNUSED_RETURN bool decodeKey(const uint8_t*& data, const uint8_t* en
     }
     case SIDBKeyType::Binary: {
         uint64_t size64;
-        if (!readLittleEndian(data, end, size64))
+        if (!readLittleEndian(data, size64))
             return false;
 
-        if (static_cast<uint64_t>(end - data) < size64)
+        if (data.size() < size64)
             return false;
 
         if (size64 > std::numeric_limits<size_t>::max())
             return false;
 
         size_t size = static_cast<size_t>(size64);
-        Vector<uint8_t> dataVector(std::span<const uint8_t>(data, size));
-        data += size;
+        Vector<uint8_t> dataVector(data);
+        data = data.subspan(size);
 
         result.setBinaryValue(ThreadSafeDataBuffer::create(WTFMove(dataVector)));
         return true;
     }
     case SIDBKeyType::Array: {
         uint64_t size64;
-        if (!readLittleEndian(data, end, size64))
+        if (!readLittleEndian(data, size64))
             return false;
 
         if (size64 > std::numeric_limits<size_t>::max())
@@ -373,7 +372,7 @@ static WARN_UNUSED_RETURN bool decodeKey(const uint8_t*& data, const uint8_t* en
 
         for (size_t i = 0; i < size; ++i) {
             IDBKeyData keyData;
-            if (!decodeKey(data, end, keyData))
+            if (!decodeKey(data, keyData))
                 return false;
 
             ASSERT(keyData.isValid());
@@ -390,26 +389,25 @@ static WARN_UNUSED_RETURN bool decodeKey(const uint8_t*& data, const uint8_t* en
     }
 }
 
-bool deserializeIDBKeyData(const uint8_t* data, size_t size, IDBKeyData& result)
+bool deserializeIDBKeyData(std::span<const uint8_t> data, IDBKeyData& result)
 {
-    if (!data || !size)
+    if (data.empty())
         return false;
 
-    if (isLegacySerializedIDBKeyData(data, size)) {
-        auto decoder = KeyedDecoder::decoder(data, size);
+    if (isLegacySerializedIDBKeyData(data)) {
+        auto decoder = KeyedDecoder::decoder(data);
         return IDBKeyData::decode(*decoder, result);
     }
 
     // Verify this is a SerializedIDBKey version we understand.
-    const uint8_t* current = data;
-    const uint8_t* end = data + size;
-    if (current++[0] != SIDBKeyVersion)
+    if (data[0] != SIDBKeyVersion)
         return false;
 
-    if (decodeKey(current, end, result)) {
+    data = data.subspan(1);
+    if (decodeKey(data, result)) {
         // Even if we successfully decoded a key, the deserialize is only successful
         // if we actually consumed all input data.
-        return current == end;
+        return data.empty();
     }
 
     return false;

--- a/Source/WebCore/Modules/indexeddb/server/IDBSerialization.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBSerialization.h
@@ -33,9 +33,9 @@ namespace WebCore {
 class IDBKeyData;
 
 RefPtr<SharedBuffer> serializeIDBKeyPath(const std::optional<IDBKeyPath>&);
-bool deserializeIDBKeyPath(const uint8_t* buffer, size_t bufferSize, std::optional<IDBKeyPath>&);
+bool deserializeIDBKeyPath(std::span<const uint8_t> buffer, std::optional<IDBKeyPath>&);
 
 RefPtr<SharedBuffer> serializeIDBKeyData(const IDBKeyData&);
-bool deserializeIDBKeyData(const uint8_t* buffer, size_t bufferSize, IDBKeyData&);
+bool deserializeIDBKeyData(std::span<const uint8_t> buffer, IDBKeyData&);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
@@ -511,7 +511,7 @@ SQLiteIDBCursor::FetchResult SQLiteIDBCursor::internalFetchNextRecord(SQLiteCurs
     ASSERT(record.rowID);
     auto keyDataSpan = statement->columnBlobAsSpan(1);
 
-    if (!deserializeIDBKeyData(keyDataSpan.data(), keyDataSpan.size(), record.record.key)) {
+    if (!deserializeIDBKeyData(keyDataSpan, record.record.key)) {
         LOG_ERROR("Unable to deserialize key data from database while advancing cursor");
         markAsErrored(record);
         return FetchResult::Failure;
@@ -534,7 +534,7 @@ SQLiteIDBCursor::FetchResult SQLiteIDBCursor::internalFetchNextRecord(SQLiteCurs
         if (m_cursorType == IndexedDB::CursorType::KeyAndValue)
             record.record.value = { ThreadSafeDataBuffer::create(WTFMove(keyData)), blobURLs, blobFilePaths };
     } else {
-        if (!deserializeIDBKeyData(keyData.data(), keyData.size(), record.record.primaryKey)) {
+        if (!deserializeIDBKeyData(keyData.span(), record.record.primaryKey)) {
             LOG_ERROR("Unable to deserialize value data from database while advancing index cursor");
             markAsErrored(record);
             return FetchResult::Failure;

--- a/Source/WebCore/platform/KeyedCoding.h
+++ b/Source/WebCore/platform/KeyedCoding.h
@@ -36,7 +36,7 @@ class SharedBuffer;
 class KeyedDecoder {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WEBCORE_EXPORT static std::unique_ptr<KeyedDecoder> decoder(const uint8_t* data, size_t);
+    WEBCORE_EXPORT static std::unique_ptr<KeyedDecoder> decoder(std::span<const uint8_t> data);
 
     virtual ~KeyedDecoder() = default;
 

--- a/Source/WebCore/platform/cf/KeyedDecoderCF.cpp
+++ b/Source/WebCore/platform/cf/KeyedDecoderCF.cpp
@@ -31,14 +31,14 @@
 
 namespace WebCore {
 
-std::unique_ptr<KeyedDecoder> KeyedDecoder::decoder(const uint8_t* data, size_t size)
+std::unique_ptr<KeyedDecoder> KeyedDecoder::decoder(std::span<const uint8_t> data)
 {
-    return makeUnique<KeyedDecoderCF>(data, size);
+    return makeUnique<KeyedDecoderCF>(data);
 }
 
-KeyedDecoderCF::KeyedDecoderCF(const uint8_t* data, size_t size)
+KeyedDecoderCF::KeyedDecoderCF(std::span<const uint8_t> data)
 {
-    auto cfData = adoptCF(CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, data, size, kCFAllocatorNull));
+    auto cfData = adoptCF(CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, data.data(), data.size(), kCFAllocatorNull));
     auto cfPropertyList = adoptCF(CFPropertyListCreateWithData(kCFAllocatorDefault, cfData.get(), kCFPropertyListImmutable, nullptr, nullptr));
 
     if (dynamic_cf_cast<CFDictionaryRef>(cfPropertyList.get()))

--- a/Source/WebCore/platform/cf/KeyedDecoderCF.h
+++ b/Source/WebCore/platform/cf/KeyedDecoderCF.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class KeyedDecoderCF final : public KeyedDecoder {
 public:
-    explicit KeyedDecoderCF(const uint8_t* data, size_t);
+    explicit KeyedDecoderCF(std::span<const uint8_t> data);
     ~KeyedDecoderCF() override;
 
 private:

--- a/Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp
+++ b/Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp
@@ -83,14 +83,14 @@ static bool readSimpleValue(WTF::Persistence::Decoder& decoder, KeyedDecoderGene
     return true;
 }
 
-std::unique_ptr<KeyedDecoder> KeyedDecoder::decoder(const uint8_t* data, size_t size)
+std::unique_ptr<KeyedDecoder> KeyedDecoder::decoder(std::span<const uint8_t> data)
 {
-    return makeUnique<KeyedDecoderGeneric>(data, size);
+    return makeUnique<KeyedDecoderGeneric>(data);
 }
 
-KeyedDecoderGeneric::KeyedDecoderGeneric(const uint8_t* data, size_t size)
+KeyedDecoderGeneric::KeyedDecoderGeneric(std::span<const uint8_t> data)
 {
-    WTF::Persistence::Decoder decoder({ data, size });
+    WTF::Persistence::Decoder decoder(data);
 
     m_rootDictionary = makeUnique<Dictionary>();
     m_dictionaryStack.append(m_rootDictionary.get());

--- a/Source/WebCore/platform/generic/KeyedDecoderGeneric.h
+++ b/Source/WebCore/platform/generic/KeyedDecoderGeneric.h
@@ -31,7 +31,7 @@ namespace WebCore {
 
 class KeyedDecoderGeneric final : public KeyedDecoder {
 public:
-    KeyedDecoderGeneric(const uint8_t* data, size_t);
+    KeyedDecoderGeneric(std::span<const uint8_t> data);
 
     class Dictionary;
     using Array = Vector<std::unique_ptr<Dictionary>>;

--- a/Source/WebCore/platform/glib/KeyedDecoderGlib.cpp
+++ b/Source/WebCore/platform/glib/KeyedDecoderGlib.cpp
@@ -30,14 +30,14 @@
 
 namespace WebCore {
 
-std::unique_ptr<KeyedDecoder> KeyedDecoder::decoder(const uint8_t* data, size_t size)
+std::unique_ptr<KeyedDecoder> KeyedDecoder::decoder(std::span<const uint8_t> data)
 {
-    return makeUnique<KeyedDecoderGlib>(data, size);
+    return makeUnique<KeyedDecoderGlib>(data);
 }
 
-KeyedDecoderGlib::KeyedDecoderGlib(const uint8_t* data, size_t size)
+KeyedDecoderGlib::KeyedDecoderGlib(std::span<const uint8_t> data)
 {
-    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(data, size));
+    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new(data.data(), data.size()));
     GRefPtr<GVariant> variant = g_variant_new_from_bytes(G_VARIANT_TYPE("a{sv}"), bytes.get(), TRUE);
     m_dictionaryStack.append(dictionaryFromGVariant(variant.get()));
 }

--- a/Source/WebCore/platform/glib/KeyedDecoderGlib.h
+++ b/Source/WebCore/platform/glib/KeyedDecoderGlib.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class KeyedDecoderGlib final : public KeyedDecoder {
 public:
-    KeyedDecoderGlib(const uint8_t* data, size_t);
+    KeyedDecoderGlib(std::span<const uint8_t> data);
     ~KeyedDecoderGlib() override;
 
 private:

--- a/Source/WebKit/Shared/PersistencyUtils.cpp
+++ b/Source/WebKit/Shared/PersistencyUtils.cpp
@@ -43,7 +43,7 @@ std::unique_ptr<KeyedDecoder> createForFile(const String& path)
     if (!buffer)
         return nullptr;
 
-    return KeyedDecoder::decoder(buffer->data(), buffer->size());
+    return KeyedDecoder::decoder(buffer->span());
 }
 
 void writeToDisk(std::unique_ptr<KeyedEncoder>&& encoder, String&& path)

--- a/Tools/TestWebKitAPI/Tests/WebCore/KeyedCoding.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/KeyedCoding.cpp
@@ -54,7 +54,7 @@ TEST(KeyedCoding, SetAndGetBytes)
     encoder->encodeBytes("data-size1"_s, data, dataLengthOne);
     auto encodedBuffer = encoder->finishEncoding();
 
-    auto decoder = WebCore::KeyedDecoder::decoder(reinterpret_cast<const uint8_t*>(encodedBuffer->data()), encodedBuffer->size());
+    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->bytes());
 
     bool success;
     const uint8_t* buffer;
@@ -82,7 +82,7 @@ bool testSimpleValue(EncodeFunctionType encode, bool (WebCore::KeyedDecoder::* d
     (encoder.get()->*encode)("key"_s, value);
 
     auto encodedBuffer = encoder->finishEncoding();
-    auto decoder = WebCore::KeyedDecoder::decoder(reinterpret_cast<const uint8_t*>(encodedBuffer->data()), encodedBuffer->size());
+    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->bytes());
 
     DecodeValueType decodedValue;
     bool success = (decoder.get()->*decode)("key"_s, decodedValue);
@@ -159,7 +159,7 @@ TEST(KeyedCoding, GetNonExistingRecord)
     encoder->encodeBool("bool-true"_s, true);
 
     auto encodedBuffer = encoder->finishEncoding();
-    auto decoder = WebCore::KeyedDecoder::decoder(reinterpret_cast<const uint8_t*>(encodedBuffer->data()), encodedBuffer->size());
+    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->bytes());
 
     bool success, boolValue;
     success = decoder->decodeBool("bool-true"_s, boolValue);
@@ -246,7 +246,7 @@ TEST(KeyedCoding, SetAndGetObject)
     encoder->encodeObject("user1"_s, user1, KeyedCodingTestObject::encode);
     auto encodedBuffer = encoder->finishEncoding();
 
-    auto decoder = WebCore::KeyedDecoder::decoder(reinterpret_cast<const uint8_t*>(encodedBuffer->data()), encodedBuffer->size());
+    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->bytes());
     bool success;
     KeyedCodingTestObject decodedUser0, decodedUser1;
 
@@ -269,7 +269,7 @@ TEST(KeyedCoding, SetAndGetObjects)
     encoder->encodeObjects("users"_s, users.begin(), users.end(), KeyedCodingTestObject::encode);
     auto encodedBuffer = encoder->finishEncoding();
 
-    auto decoder = WebCore::KeyedDecoder::decoder(reinterpret_cast<const uint8_t*>(encodedBuffer->data()), encodedBuffer->size());
+    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->bytes());
     Vector<KeyedCodingTestObject> decodedUsers;
 
     bool success = decoder->decodeObjects("users"_s, decodedUsers, KeyedCodingTestObject::decode);
@@ -283,7 +283,7 @@ TEST(KeyedCoding, SetAndGetWithEmptyKey)
     encoder->encodeBool(emptyString(), false);
 
     auto encodedBuffer = encoder->finishEncoding();
-    auto decoder = WebCore::KeyedDecoder::decoder(reinterpret_cast<const uint8_t*>(encodedBuffer->data()), encodedBuffer->size());
+    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->bytes());
 
     bool success, boolValue;
     success = decoder->decodeBool(emptyString(), boolValue);
@@ -306,7 +306,7 @@ TEST(KeyedCoding, DecodeRandomData)
     for (auto i = 0; i < 10; ++i) {
         auto data = generateRandomData();
         // Don't crash.
-        WebCore::KeyedDecoder::decoder(data.data(), data.size());
+        WebCore::KeyedDecoder::decoder(data.span());
     }
 }
 


### PR DESCRIPTION
#### 2c844da0386ff67d69fe0982a84ef6df8533571b
<pre>
Use std::span more in IndexedDB code
<a href="https://bugs.webkit.org/show_bug.cgi?id=271362">https://bugs.webkit.org/show_bug.cgi?id=271362</a>

Reviewed by Sihui Liu.

* Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp:
(WebCore::deserializeIDBKeyPath):
(WebCore::isLegacySerializedIDBKeyData):
(WebCore::readLittleEndian):
(WebCore::readDouble):
(WebCore::decodeKey):
(WebCore::deserializeIDBKeyData):
* Source/WebCore/Modules/indexeddb/server/IDBSerialization.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::idbKeyCollate):
(WebCore::IDBServer::SQLiteIDBBackingStore::addExistingIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::extractExistingDatabaseInfo):
(WebCore::IDBServer::SQLiteIDBBackingStore::getOrEstablishDatabaseInfo):
(WebCore::IDBServer::SQLiteIDBBackingStore::getRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::getAllObjectStoreRecords):
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedGetIndexRecordForOneKey):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp:
(WebCore::IDBServer::SQLiteIDBCursor::internalFetchNextRecord):
* Source/WebCore/platform/KeyedCoding.h:
* Source/WebCore/platform/cf/KeyedDecoderCF.cpp:
(WebCore::KeyedDecoder::decoder):
(WebCore::KeyedDecoderCF::KeyedDecoderCF):
* Source/WebCore/platform/cf/KeyedDecoderCF.h:
* Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp:
(WebCore::KeyedDecoder::decoder):
(WebCore::KeyedDecoderGeneric::KeyedDecoderGeneric):
* Source/WebCore/platform/generic/KeyedDecoderGeneric.h:
* Source/WebCore/platform/glib/KeyedDecoderGlib.cpp:
(WebCore::KeyedDecoder::decoder):
(WebCore::KeyedDecoderGlib::KeyedDecoderGlib):
* Source/WebCore/platform/glib/KeyedDecoderGlib.h:
* Source/WebKit/Shared/PersistencyUtils.cpp:
(WebKit::createForFile):
* Tools/TestWebKitAPI/Tests/WebCore/KeyedCoding.cpp:
(TestWebKitAPI::TEST):
(TestWebKitAPI::testSimpleValue):

Canonical link: <a href="https://commits.webkit.org/276459@main">https://commits.webkit.org/276459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5699550d1c00f6c93249eb54f2bd403f1e773747

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23783 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47347 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40699 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/46996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36749 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17802 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39627 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2741 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40918 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49016 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43721 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20979 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42465 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21312 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6170 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20649 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->