### PR TITLE
WebXR should not work from an iFrame unless it is allowed to use the xr-spatial-tracking permissions policy

### DIFF
--- a/LayoutTests/http/tests/webxr/resources/resources/test-only-api.js
+++ b/LayoutTests/http/tests/webxr/resources/resources/test-only-api.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/* Whether the browser is Chromium-based with MojoJS enabled */
+const isChromiumBased = 'MojoInterfaceInterceptor' in self;
+/* Whether the browser is WebKit-based with internal test-only API enabled */
+const isWebKitBased = !isChromiumBased && 'internals' in self;
+
+/**
+ * Loads a script in a window or worker.
+ *
+ * @param {string} path - A script path
+ * @returns {Promise}
+ */
+function loadScript(path) {
+  if (typeof document === 'undefined') {
+    // Workers (importScripts is synchronous and may throw.)
+    importScripts(path);
+    return Promise.resolve();
+  } else {
+    // Window
+    const script = document.createElement('script');
+    script.src = path;
+    script.async = false;
+    const p = new Promise((resolve, reject) => {
+      script.onload = () => { resolve(); };
+      script.onerror = e => { reject(`Error loading ${path}`); };
+    })
+    document.head.appendChild(script);
+    return p;
+  }
+}

--- a/LayoutTests/http/tests/webxr/resources/resources/webxr_test_constants_single_view.js
+++ b/LayoutTests/http/tests/webxr/resources/resources/webxr_test_constants_single_view.js
@@ -1,0 +1,302 @@
+// assert_equals can fail when comparing floats due to precision errors, so
+// use assert_approx_equals with this constant instead
+const FLOAT_EPSILON = 0.001;
+
+// Identity matrix
+const IDENTITY_MATRIX = [1, 0, 0, 0,
+                         0, 1, 0, 0,
+                         0, 0, 1, 0,
+                         0, 0, 0, 1];
+
+const IDENTITY_TRANSFORM = {
+    position: [0, 0, 0],
+    orientation: [0, 0, 0, 1],
+};
+
+// A valid pose matrix/transform for  when we don't care about specific values
+// Note that these two should be identical, just different representations
+const VALID_POSE_MATRIX = [0, 1, 0, 0,
+                           0, 0, 1, 0,
+                           1, 0, 0, 0,
+                           1, 1, 1, 1];
+
+const VALID_POSE_TRANSFORM = {
+    position: [1, 1, 1],
+    orientation: [0.5, 0.5, 0.5, 0.5]
+};
+
+const VALID_PROJECTION_MATRIX =
+    [1, 0, 0, 0, 0, 1, 0, 0, 3, 2, -1, -1, 0, 0, -0.2, 0];
+
+// This is a decomposed version of the above.
+const VALID_FIELD_OF_VIEW = {
+    upDegrees: 71.565,
+    downDegrees: -45,
+    leftDegrees:-63.4349,
+    rightDegrees: 75.9637
+};
+
+// A valid input grip matrix for  when we don't care about specific values
+const VALID_GRIP = [1, 0, 0, 0,
+                    0, 1, 0, 0,
+                    0, 0, 1, 0,
+                    4, 3, 2, 1];
+
+const VALID_GRIP_TRANSFORM = {
+    position: [4, 3, 2],
+    orientation: [0, 0, 0, 1]
+};
+
+const JOINT_COUNT = 25;
+const TEST_HAND_JOINT_RADIUS = 0.02;
+
+const VALID_HAND_JOINT = {
+    pose: VALID_POSE_TRANSFORM,
+    radius: TEST_HAND_JOINT_RADIUS
+};
+
+const VALID_HAND_JOINTS = [
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT
+];
+
+const INVALID_HAND_JOINT = {
+
+};
+
+const HAND_JOINTS_WITH_ONE_INVALID = [
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    VALID_HAND_JOINT,
+    INVALID_HAND_JOINT
+];
+
+// A valid input pointer offset for  when we don't care about specific values
+const VALID_POINTER = [1, 0, 0, 0,
+                       0, 1, 0, 0,
+                       0, 0, 1, 0,
+                       0, 0, 1, 1];
+
+const VALID_POINTER_TRANSFORM = {
+    position: [0, 0, 1],
+    orientation: [0, 0, 0, 1]
+};
+
+// A Valid Local to floor matrix/transform for when we don't care about specific
+// values.  Note that these should be identical, just different representations.
+const VALID_FLOOR_ORIGIN_MATRIX = [1, 0,    0,  0,
+                                     0, 1,    0,  0,
+                                     0, 0,    1,  0,
+                                     1, 1.65, -1, 1];
+
+const VALID_FLOOR_ORIGIN = {
+    position: [-1.0, -1.65, 1.0],
+    orientation: [0, 0, 0, 1]
+};
+
+const VALID_BOUNDS = [
+    { x: 3.0, z: -2.0 },
+    { x: 3.5, z: 0.0 },
+    { x: 3.0, z: 2.0 },
+    { x: -3.0, z: 2.0 },
+    { x: -3.5, z: 0.0 },
+    { x: -3.0, z: -2.0 }
+];
+
+const VALID_RESOLUTION = {
+    width: 200,
+    height: 200
+};
+
+const LEFT_OFFSET = {
+    position: [-0.1, 0, 0],
+    orientation: [0, 0, 0, 1]
+};
+
+const RIGHT_OFFSET = {
+    position: [0.1, 0, 0],
+    orientation: [0, 0, 0, 1]
+};
+
+const VALID_VIEWS = [{
+        eye:"left",
+        projectionMatrix: VALID_PROJECTION_MATRIX,
+        viewOffset: LEFT_OFFSET,
+        resolution: VALID_RESOLUTION
+    }, {
+        eye:"right",
+        projectionMatrix: VALID_PROJECTION_MATRIX,
+        viewOffset: RIGHT_OFFSET,
+        resolution: VALID_RESOLUTION
+    },
+];
+
+const NON_IMMERSIVE_VIEWS = [{
+        eye: "none",
+        projectionMatrix: VALID_PROJECTION_MATRIX,
+        viewOffset: IDENTITY_TRANSFORM,
+        resolution: VALID_RESOLUTION,
+    }
+];
+
+const LEFT_ONLY_IMMERSIVE_VIEWS = [{
+        eye: "left",
+        projectionMatrix: VALID_PROJECTION_MATRIX,
+        viewOffset: IDENTITY_TRANSFORM,
+        resolution: VALID_RESOLUTION,
+    }
+];
+
+const ALL_FEATURES = [
+  'viewer',
+  'local',
+  'local-floor',
+  'bounded-floor',
+  'unbounded',
+  'hit-test',
+  'dom-overlay',
+  'light-estimation',
+  'anchors',
+  'depth-sensing',
+  'hand-tracking',
+];
+
+const ALL_FEATURES_NO_HAND_TRACKING = [
+  'viewer',
+  'local',
+  'local-floor',
+  'bounded-floor',
+  'unbounded',
+  'hit-test',
+  'dom-overlay',
+  'light-estimation',
+  'anchors',
+  'depth-sensing',
+];
+
+const TRACKED_IMMERSIVE_DEVICE = {
+    supportsImmersive: true,
+    supportedModes: [ "inline", "immersive-vr"],
+    views: VALID_VIEWS,
+    viewerOrigin: IDENTITY_TRANSFORM,
+    supportedFeatures: ALL_FEATURES,
+    environmentBlendMode: "opaque",
+    interactionMode: "world-space"
+};
+
+const TRACKED_IMMERSIVE_DEVICE_WITH_HAND_TRACKING = {
+    supportsImmersive: true,
+    supportedModes: [ "inline", "immersive-vr"],
+    views: VALID_VIEWS,
+    viewerOrigin: IDENTITY_TRANSFORM,
+    supportedFeatures: ALL_FEATURES,
+    enabledFeatures: [ "hand-tracking" ],
+    environmentBlendMode: "opaque",
+    interactionMode: "world-space"
+};
+
+const TRACKED_IMMERSIVE_DEVICE_NO_HAND_TRACKING = {
+    supportsImmersive: true,
+    supportedModes: [ "inline", "immersive-vr"],
+    views: VALID_VIEWS,
+    viewerOrigin: IDENTITY_TRANSFORM,
+    supportedFeatures: ALL_FEATURES_NO_HAND_TRACKING,
+    environmentBlendMode: "opaque",
+    interactionMode: "world-space"
+};
+
+const IMMERSIVE_AR_DEVICE = {
+  supportsImmersive: true,
+  supportedModes: [ "inline", "immersive-ar"],
+  views: VALID_VIEWS,
+  viewerOrigin: IDENTITY_TRANSFORM,
+  supportedFeatures: ALL_FEATURES,
+  environmentBlendMode: "additive",
+  interactionMode: "screen-space"
+};
+
+const VALID_NON_IMMERSIVE_DEVICE = {
+    supportsImmersive: false,
+    supportedModes: ["inline"],
+    views: NON_IMMERSIVE_VIEWS,
+    viewerOrigin: IDENTITY_TRANSFORM,
+    supportedFeatures: ALL_FEATURES,
+    environmentBlendMode: "opaque",
+    interactionMode: "screen-space"
+};
+
+const TRACKED_IMMERSIVE_SINGLE_VIEWDEVICE = {
+    supportsImmersive: true,
+    supportedModes: [ "inline", "immersive-vr"],
+    views: LEFT_ONLY_IMMERSIVE_VIEWS,
+    viewerOrigin: IDENTITY_TRANSFORM,
+    supportedFeatures: ALL_FEATURES,
+    environmentBlendMode: "opaque",
+    interactionMode: "world-space"
+};
+
+
+const VALID_CONTROLLER = {
+    handedness: "none",
+    targetRayMode: "tracked-pointer",
+    pointerOrigin: VALID_POINTER_TRANSFORM,
+    profiles: []
+};
+
+const RIGHT_CONTROLLER = {
+    handedness: "right",
+    targetRayMode: "tracked-pointer",
+    pointerOrigin: VALID_POINTER_TRANSFORM,
+    profiles: []
+};
+
+const SCREEN_CONTROLLER = {
+    handedness: "none",
+    targetRayMode: "screen",
+    pointerOrigin: VALID_POINTER_TRANSFORM,
+    profiles: []
+};

--- a/LayoutTests/http/tests/webxr/resources/resources/webxr_util.js
+++ b/LayoutTests/http/tests/webxr/resources/resources/webxr_util.js
@@ -1,0 +1,240 @@
+'use strict';
+
+// These tests rely on the User Agent providing an implementation of the
+// WebXR Testing API (https://github.com/immersive-web/webxr-test-api).
+//
+// In Chromium-based browsers, this implementation is provided by a JavaScript
+// shim in order to reduce the amount of test-only code shipped to users. To
+// enable these tests the browser must be run with these options:
+//
+//   --enable-blink-features=MojoJS,MojoJSTest
+
+// Debugging message helper, by default does nothing. Implementations can
+// override this.
+var xr_debug = function(name, msg) {};
+
+function xr_promise_test(name, func, properties, glContextType, glContextProperties) {
+  promise_test(async (t) => {
+    if (glContextType === 'webgl2') {
+      // Fast fail on platforms not supporting WebGL2.
+      assert_implements('WebGL2RenderingContext' in window, 'webgl2 not supported.');
+    }
+    // Perform any required test setup:
+    xr_debug(name, 'setup');
+
+    assert_implements(navigator.xr, 'missing navigator.xr - ensure test is run in a secure context.');
+
+    // Only set up once.
+    if (!navigator.xr.test) {
+      // Load test-only API helpers.
+      const script = document.createElement('script');
+      script.src = 'resources/test-only-api.js';
+      script.async = false;
+      const p = new Promise((resolve, reject) => {
+        script.onload = () => { resolve(); };
+        script.onerror = e => { reject(e); };
+      })
+      document.head.appendChild(script);
+      await p;
+
+      if (isChromiumBased) {
+        // Chrome setup
+        await loadChromiumResources();
+      } else if (isWebKitBased) {
+        // WebKit setup
+        await setupWebKitWebXRTestAPI();
+      }
+    }
+
+    // Either the test api needs to be polyfilled and it's not set up above, or
+    // something happened to one of the known polyfills and it failed to be
+    // setup properly. Either way, the fact that xr_promise_test is being used
+    // means that the tests expect navigator.xr.test to be set. By rejecting now
+    // we can hopefully provide a clearer indication of what went wrong.
+    assert_implements(navigator.xr.test, 'missing navigator.xr.test, even after attempted load');
+
+    let gl = null;
+    let canvas = null;
+    if (glContextType) {
+      canvas = document.createElement('canvas');
+      document.body.appendChild(canvas);
+      gl = canvas.getContext(glContextType, glContextProperties);
+    }
+
+    // Ensure that any devices are disconnected when done. If this were done in
+    // a .then() for the success case, a test that expected failure would
+    // already be marked done at the time that runs and the shutdown would
+    // interfere with the next test.
+    t.add_cleanup(async () => {
+      // Ensure system state is cleaned up.
+      xr_debug(name, 'cleanup');
+      await navigator.xr.test.disconnectAllDevices();
+    });
+
+    xr_debug(name, 'main');
+    return func(t, gl);
+  }, name, properties);
+}
+
+// A utility function for waiting one animation frame before running the callback
+//
+// This is only needed after calling FakeXRDevice methods outside of an animation frame
+//
+// This is so that we can paper over the potential race allowed by the "next animation frame"
+// concept https://immersive-web.github.io/webxr-test-api/#xrsession-next-animation-frame
+function requestSkipAnimationFrame(session, callback) {
+ session.requestAnimationFrame(() => {
+  session.requestAnimationFrame(callback);
+ });
+}
+
+// A test function which runs through the common steps of requesting a session.
+// Calls the passed in test function with the session, the controller for the
+// device, and the test object.
+function xr_session_promise_test(
+    name, func, fakeDeviceInit, sessionMode, sessionInit, properties,
+    glcontextPropertiesParam, gllayerPropertiesParam) {
+  const glcontextProperties = (glcontextPropertiesParam) ? glcontextPropertiesParam : {};
+  const gllayerProperties = (gllayerPropertiesParam) ? gllayerPropertiesParam : {};
+
+  function runTest(t, glContext) {
+    let testSession;
+    let testDeviceController;
+    let sessionObjects = {gl: glContext};
+
+    // Ensure that any pending sessions are ended when done. This needs to
+    // use a cleanup function to ensure proper sequencing. If this were
+    // done in a .then() for the success case, a test that expected
+    // failure would already be marked done at the time that runs, and the
+    // shutdown would interfere with the next test which may have started.
+    t.add_cleanup(async () => {
+      // If a session was created, end it.
+      if (testSession) {
+        await testSession.end().catch(() => {});
+      }
+    });
+
+    return navigator.xr.test.simulateDeviceConnection(fakeDeviceInit)
+        .then((controller) => {
+          testDeviceController = controller;
+          return sessionObjects.gl.makeXRCompatible();
+        })
+        .then(() => new Promise((resolve, reject) => {
+                // Perform the session request in a user gesture.
+                xr_debug(name, 'simulateUserActivation');
+                navigator.xr.test.simulateUserActivation(() => {
+                  xr_debug(name, 'document.hasFocus()=' + document.hasFocus());
+                  navigator.xr.requestSession(sessionMode, sessionInit || {})
+                      .then((session) => {
+                        xr_debug(name, 'session start');
+                        testSession = session;
+                        session.mode = sessionMode;
+                        let glLayer = new XRWebGLLayer(session, sessionObjects.gl, gllayerProperties);
+                        glLayer.context = sessionObjects.gl;
+                        // Session must have a baseLayer or frame requests
+                        // will be ignored.
+                        session.updateRenderState({
+                            baseLayer: glLayer
+                        });
+                        sessionObjects.glLayer = glLayer;
+                        xr_debug(name, 'session.visibilityState=' + session.visibilityState);
+                        try {
+                          resolve(func(session, testDeviceController, t, sessionObjects));
+                        } catch(err) {
+                          reject("Test function failed with: " + err);
+                        }
+                      })
+                      .catch((err) => {
+                        xr_debug(name, 'error: ' + err);
+                        reject(
+                            'Session with params ' +
+                            JSON.stringify(sessionMode) +
+                            ' was rejected on device ' +
+                            JSON.stringify(fakeDeviceInit) +
+                            ' with error: ' + err);
+                      });
+                });
+        }));
+  }
+
+  xr_promise_test(
+    name + ' - webgl',
+    runTest,
+    properties,
+    'webgl',
+    {alpha: false, antialias: false, ...glcontextProperties}
+    );
+  xr_promise_test(
+    name + ' - webgl2',
+    runTest,
+    properties,
+    'webgl2',
+    {alpha: false, antialias: false, ...glcontextProperties});
+}
+
+
+// This function wraps the provided function in a
+// simulateUserActivation() call, and resolves the promise with the
+// result of func(), or an error if one is thrown
+function promise_simulate_user_activation(func) {
+  return new Promise((resolve, reject) => {
+    navigator.xr.test.simulateUserActivation(() => {
+      try { let a = func(); resolve(a); } catch(e) { reject(e); }
+    });
+  });
+}
+
+// This functions calls a callback with each API object as specified
+// by https://immersive-web.github.io/webxr/spec/latest/, allowing
+// checks to be made on all ojects.
+// Arguements:
+//      callback: A callback function with two arguements, the first
+//                being the API object, the second being the name of
+//                that API object.
+function forEachWebxrObject(callback) {
+  callback(window.navigator.xr, 'navigator.xr');
+  callback(window.XRSession, 'XRSession');
+  callback(window.XRSessionCreationOptions, 'XRSessionCreationOptions');
+  callback(window.XRFrameRequestCallback, 'XRFrameRequestCallback');
+  callback(window.XRPresentationContext, 'XRPresentationContext');
+  callback(window.XRFrame, 'XRFrame');
+  callback(window.XRLayer, 'XRLayer');
+  callback(window.XRView, 'XRView');
+  callback(window.XRViewport, 'XRViewport');
+  callback(window.XRViewerPose, 'XRViewerPose');
+  callback(window.XRWebGLLayer, 'XRWebGLLayer');
+  callback(window.XRWebGLLayerInit, 'XRWebGLLayerInit');
+  callback(window.XRCoordinateSystem, 'XRCoordinateSystem');
+  callback(window.XRFrameOfReference, 'XRFrameOfReference');
+  callback(window.XRStageBounds, 'XRStageBounds');
+  callback(window.XRSessionEvent, 'XRSessionEvent');
+  callback(window.XRCoordinateSystemEvent, 'XRCoordinateSystemEvent');
+}
+
+// Code for loading test API in Chromium.
+async function loadChromiumResources() {
+  await loadScript('/resources/chromium/webxr-test-math-helper.js');
+  await import('/resources/chromium/webxr-test.js');
+  await loadScript('/resources/testdriver.js');
+  await loadScript('/resources/testdriver-vendor.js');
+
+  // This infrastructure is also used by Chromium-specific internal tests that
+  // may need additional resources (e.g. internal API extensions), this allows
+  // those tests to rely on this infrastructure while ensuring that no tests
+  // make it into public WPTs that rely on APIs outside of the webxr test API.
+  if (typeof(additionalChromiumResources) !== 'undefined') {
+    for (const path of additionalChromiumResources) {
+      await loadScript(path);
+    }
+  }
+
+  xr_debug = navigator.xr.test.Debug;
+}
+
+function setupWebKitWebXRTestAPI() {
+  // WebKit setup. The internals object is used by the WebKit test runner
+  // to provide JS access to internal APIs. In this case it's used to
+  // ensure that XRTest is only exposed to wpt tests.
+  navigator.xr.test = internals.xrTest;
+  return Promise.resolve();
+}

--- a/LayoutTests/http/tests/webxr/resources/webxr-issessionsupported-test.html
+++ b/LayoutTests/http/tests/webxr/resources/webxr-issessionsupported-test.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script src=/resources/testharness.js></script>
+    <script src=/resources/testharnessreport.js></script>
+    <script src="resources/webxr_util.js"></script>
+    <script src="resources/webxr_test_constants_single_view.js"></script>
+    <script>
+        xr_promise_test(
+          "Tests isSessionSupported with immersive device connected",
+          async (t) => {
+            await navigator.xr.test.simulateDeviceConnection(TRACKED_IMMERSIVE_DEVICE);
+            try {
+              const supported = await navigator.xr.isSessionSupported('immersive-vr');
+              top.postMessage({'isSessionSupported': supported}, '*');
+            } catch (e) {
+              top.postMessage({'isSessionSupported': e.name}, '*');
+            }
+          }
+        );
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/resources/webxr-makexrcompatible-test.html
+++ b/LayoutTests/http/tests/webxr/resources/webxr-makexrcompatible-test.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script src=/resources/testharness.js></script>
+    <script src=/resources/testharnessreport.js></script>
+    <script src="resources/webxr_util.js"></script>
+    <script src="resources/webxr_test_constants_single_view.js"></script>
+    <script>
+        async function testMakeXRCompatible(t, gl) {
+          await navigator.xr.test.simulateDeviceConnection(TRACKED_IMMERSIVE_DEVICE);
+          await gl.makeXRCompatible();
+          top.postMessage({'makeXRCompatible': gl.getContextAttributes().xrCompatible}, '*');
+        }
+
+        xr_promise_test(
+          "Tests makeXRCompatible with immersive device connected",
+          testMakeXRCompatible,
+          null,
+          'webgl'
+        );
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/resources/webxr-requestsession-test.html
+++ b/LayoutTests/http/tests/webxr/resources/webxr-requestsession-test.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script src=/resources/testharness.js></script>
+    <script src=/resources/testharnessreport.js></script>
+    <script src="resources/webxr_util.js"></script>
+    <script src="resources/webxr_test_constants_single_view.js"></script>
+    <script>
+        xr_promise_test(
+          "Tests requestSession when connected to immersive device",
+          async (t) => {
+            await navigator.xr.test.simulateDeviceConnection(TRACKED_IMMERSIVE_DEVICE);
+            navigator.xr.test.simulateUserActivation(async () => {
+              window.focus();
+              try {
+                const session = await navigator.xr.requestSession('immersive-vr');
+                top.postMessage({'requestSession': session != null}, '*');
+              } catch (e) {
+                top.postMessage({'requestSession': e.name}, '*');
+              }
+            });
+          }
+        );
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-allowed-by-feature-policy-expected.txt
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-allowed-by-feature-policy-expected.txt
@@ -1,0 +1,10 @@
+Tests that third-party iframes will be allowed webxr session support with xr-spatial-tracking feature policy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS e.data.isSessionSupported is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-allowed-by-feature-policy.html
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-allowed-by-feature-policy.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that third-party iframes will be allowed webxr session support with xr-spatial-tracking feature policy.");
+jsTestIsAsync = true;
+
+onmessage = (_e) => {
+    e = _e;
+    if (e.data.isSessionSupported != undefined) {
+        shouldBeTrue("e.data.isSessionSupported");
+        finishJSTest();
+    }
+};
+</script>
+<iframe src="http://localhost:8000/webxr/resources/webxr-issessionsupported-test.html" allow="xr-spatial-tracking"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-denied-by-insufficient-feature-policy-expected.txt
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-denied-by-insufficient-feature-policy-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Feature policy 'XRSpatialTracking' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
+Tests that third-party iframes will be denied webxr session support without xr-spatial-tracking feature policy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS e.data.isSessionSupported is "SecurityError"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-denied-by-insufficient-feature-policy.html
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-denied-by-insufficient-feature-policy.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that third-party iframes will be denied webxr session support without xr-spatial-tracking feature policy.");
+jsTestIsAsync = true;
+
+onmessage = (_e) => {
+    e = _e;
+    if (e.data.isSessionSupported != undefined) {
+        shouldBeEqualToString("e.data.isSessionSupported", "SecurityError");
+        finishJSTest();
+    }
+};
+</script>
+<iframe src="http://localhost:8000/webxr/resources/webxr-issessionsupported-test.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy-expected.txt
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy-expected.txt
@@ -1,0 +1,10 @@
+Tests that third-party iframes will be allowed to call makeXRCompatible() with xr-spatial-tracking feature policy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS e.data.makeXRCompatible is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy.html
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that third-party iframes will be allowed to call makeXRCompatible() with xr-spatial-tracking feature policy.");
+jsTestIsAsync = true;
+
+onmessage = (_e) => {
+    e = _e;
+    if (e.data.makeXRCompatible != undefined) {
+        shouldBeTrue("e.data.makeXRCompatible");
+        finishJSTest();
+    }
+};
+</script>
+<iframe src="http://localhost:8000/webxr/resources/webxr-makexrcompatible-test.html" allow="xr-spatial-tracking"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-denied-by-insufficient-feature-policy-expected.txt
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-denied-by-insufficient-feature-policy-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Feature policy 'XRSpatialTracking' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
+Tests that third-party iframes will be denied from calling makeXRCompatible() without xr-spatial-tracking feature policy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS e.data.makeXRCompatible is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-denied-by-insufficient-feature-policy.html
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-denied-by-insufficient-feature-policy.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that third-party iframes will be denied from calling makeXRCompatible() without xr-spatial-tracking feature policy.");
+jsTestIsAsync = true;
+
+onmessage = (_e) => {
+    e = _e;
+    if (e.data.makeXRCompatible != undefined) {
+        shouldBeFalse("e.data.makeXRCompatible");
+        finishJSTest();
+    }
+};
+</script>
+<iframe src="http://localhost:8000/webxr/resources/webxr-makexrcompatible-test.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-allowed-by-feature-policy-expected.txt
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-allowed-by-feature-policy-expected.txt
@@ -1,0 +1,10 @@
+Tests that third-party iframes will be allowed to request webxr session with xr-spatial-tracking feature policy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS e.data.requestSession is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-allowed-by-feature-policy.html
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-allowed-by-feature-policy.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that third-party iframes will be allowed to request webxr session with xr-spatial-tracking feature policy.");
+jsTestIsAsync = true;
+
+onmessage = (_e) => {
+    e = _e;
+    if (e.data.requestSession != undefined) {
+        shouldBeTrue("e.data.requestSession");
+        finishJSTest();
+    }
+};
+</script>
+<iframe src="http://localhost:8000/webxr/resources/webxr-requestsession-test.html" allow="xr-spatial-tracking"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy-expected.txt
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Feature policy 'XRSpatialTracking' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
+Tests that third-party iframes will be denied from requesting webxr session without xr-spatial-tracking feature policy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS e.data.requestSession is "NotSupportedError"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy.html
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that third-party iframes will be denied from requesting webxr session without xr-spatial-tracking feature policy.");
+jsTestIsAsync = true;
+
+onmessage = (_e) => {
+    e = _e;
+    if (e.data.requestSession != undefined) {
+        shouldBeEqualToString("e.data.requestSession", "NotSupportedError");
+        finishJSTest();
+    }
+};
+</script>
+<iframe src="http://localhost:8000/webxr/resources/webxr-requestSession-test.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -225,6 +225,7 @@ webkit.org/b/254733 inspector/canvas/shaderProgram-add-remove-webgl.html [ Failu
 webkit.org/b/254733 inspector/canvas/shaderProgram-add-remove-webgl2.html [ Failure ]
 
 # WebXR is not yet supported in GTK
+webkit.org/b/208988 http/tests/webxr [ Skip ]
 webkit.org/b/208988 http/wpt/webxr [ Skip ]
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr [ Skip ]
 webkit.org/b/208988 webxr [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4412,6 +4412,7 @@ http/tests/misc/heic-accept-header.html [ Pass ]
 
 webkit.org/b/254044 webxr [ Skip ]
 webkit.org/b/254044 imported/w3c/web-platform-tests/webxr [ Skip ]
+webkit.org/b/254044 http/tests/webxr [ Skip ]
 webkit.org/b/254044 http/wpt/webxr [ Skip ]
 webkit.org/b/254044 imported/w3c/web-platform-tests/feature-policy/reporting/xr-reporting.https.html [ Skip ]
 

--- a/LayoutTests/platform/mac-gpup/TestExpectations
+++ b/LayoutTests/platform/mac-gpup/TestExpectations
@@ -5,6 +5,7 @@ compositing/images/direct-image-object-fit.html [ Skip ]
 compositing/reflections/direct-image-object-fit-reflected.html [ Skip ]
 
 # rdar://102067140 WebXR tests crash
+http/tests/webxr [ Skip ]
 http/wpt/webxr [ Skip ]
 imported/w3c/web-platform-tests/webxr [ Skip ]
 webxr [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2326,6 +2326,7 @@ http/tests/misc/heic-accept-header.html [ Pass ]
 
 webkit.org/b/254044 webxr [ Skip ]
 webkit.org/b/254044 imported/w3c/web-platform-tests/webxr [ Skip ]
+webkit.org/b/254044 http/tests/webxr [ Skip ]
 webkit.org/b/254044 http/wpt/webxr [ Skip ]
 webkit.org/b/254044 imported/w3c/web-platform-tests/feature-policy/reporting/xr-reporting.https.html [ Skip ]
 

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -912,6 +912,8 @@ http/tests/websocket/tests/hybi/send-object-tostring-check.html [ Pass Failure ]
 http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-ws-redirect.html [ Failure ]
 http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party.html [ Failure ]
 
+http/tests/webxr [ Skip ]
+
 # Needs curl download support
 http/tests/workers/service/service-worker-download-async-delegates.https.html [ Failure ]
 http/tests/workers/service/service-worker-download.https.html [ Failure ]

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -105,6 +105,7 @@ private:
     bool immersiveSessionRequestIsAllowedForGlobalObject(LocalDOMWindow&, Document&) const;
     bool inlineSessionRequestIsAllowedForGlobalObject(LocalDOMWindow&, Document&, const XRSessionInit&) const;
 
+    bool isFeaturePermitted(PlatformXR::SessionFeature) const;
     bool isFeatureSupported(PlatformXR::SessionFeature, XRSessionMode, const PlatformXR::Device&) const;
     struct ResolvedRequestedFeatures;
     std::optional<ResolvedRequestedFeatures> resolveRequestedFeatures(XRSessionMode, const XRSessionInit&, RefPtr<PlatformXR::Device>, JSC::JSGlobalObject&) const;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -92,6 +92,7 @@
 #include "OESTextureHalfFloatLinear.h"
 #include "OESVertexArrayObject.h"
 #include "Page.h"
+#include "PermissionsPolicy.h"
 #include "RenderBox.h"
 #include "Settings.h"
 #include "WebCodecsVideoFrame.h"
@@ -2851,9 +2852,16 @@ void WebGLRenderingContextBase::makeXRCompatible(MakeXRCompatiblePromise&& promi
         return;
     }
 
-    // 1. Let promise be a new Promise.
-    // 2. Let context be the target WebGLRenderingContextBase object.
-    // 3. Ensure an immersive XR device is selected.
+    // 1. If the requesting document’s origin is not allowed to use the "xr-spatial-tracking"
+    // permissions policy, resolve promise and return it.
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::XRSpatialTracking, canvas->document(), LogPermissionsPolicyFailure::Yes)) {
+        promise.resolve();
+        return;
+    }
+
+    // 2. Let promise be a new Promise.
+    // 3. Let context be the target WebGLRenderingContextBase object.
+    // 4. Ensure an immersive XR device is selected.
     auto& xrSystem = NavigatorWebXR::xr(window->navigator());
     xrSystem.ensureImmersiveXRDeviceIsSelected([this, protectedThis = Ref { *this }, promise = WTFMove(promise), protectedXrSystem = Ref { xrSystem }]() mutable {
         auto rejectPromiseWithInvalidStateError = makeScopeExit([&]() {


### PR DESCRIPTION
#### 4343a7fe54ac1bc089ee575b0b78ae8050430026
<pre>
WebXR should not work from an iFrame unless it is allowed to use the xr-spatial-tracking permissions policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=271363">https://bugs.webkit.org/show_bug.cgi?id=271363</a>
<a href="https://rdar.apple.com/122963817">rdar://122963817</a>

Reviewed by NOBODY (OOPS!).

Follow the latest WebXR spec and check whether &apos;xr-spatial-tracking&apos; is enabled for
the requesting document&apos;s origin in WebGLRenderingContextBase::makeXRCompatible and
WebXRSystem::resolveRequestedFeatures.

Added layout tests to verify &apos;xr-spatial-tracking&apos; permissions policy is checked
properly for xr.isSessionSupported, xr.requestSession, and WebGLRenderingContextBase::makeXRCompatible.
Copied webxr related scripts from wpt to http/test/webxr/resources/resources so the
pages embedded in the iframes can reference them.

* LayoutTests/http/tests/webxr/resources/resources/test-only-api.js: Added.
(loadScript):
* LayoutTests/http/tests/webxr/resources/resources/webxr_test_constants_single_view.js: Added.
* LayoutTests/http/tests/webxr/resources/resources/webxr_util.js: Added.
(xr_debug):
(async requestSkipAnimationFrame):
(async return):
(async loadChromiumResources):
(setupWebKitWebXRTestAPI):
* LayoutTests/http/tests/webxr/resources/webxr-issessionsupported-test.html: Added.
* LayoutTests/http/tests/webxr/resources/webxr-makexrcompatible-test.html: Added.
* LayoutTests/http/tests/webxr/resources/webxr-requestsession-test.html: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-allowed-by-feature-policy-expected.txt: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-allowed-by-feature-policy.html: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-denied-by-insufficient-feature-policy-expected.txt: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-denied-by-insufficient-feature-policy.html: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy-expected.txt: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy.html: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-denied-by-insufficient-feature-policy-expected.txt: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-denied-by-insufficient-feature-policy.html: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-allowed-by-feature-policy-expected.txt: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-allowed-by-feature-policy.html: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy-expected.txt: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-gpup/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* LayoutTests/platform/wincairo/TestExpectations:
Skip http/tests/webxr tests in the same places where we&apos;ve skipped other webxr layout tests.
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::isFeaturePermitted const):
(WebCore::WebXRSystem::resolveRequestedFeatures const):
* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::makeXRCompatible):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4343a7fe54ac1bc089ee575b0b78ae8050430026

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40794 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36823 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20962 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17878 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18383 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39719 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2836 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49105 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16331 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43788 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21074 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42538 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21414 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->