### PR TITLE
Add FixedSizeCache for CSS color values

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -838,6 +838,7 @@
 		E38C41281EB4E0680042957D /* CPUTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38C41261EB4E0680042957D /* CPUTime.cpp */; };
 		E38D6E271F5522E300A75CC4 /* StringBuilderJSON.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E38D6E261F5522E300A75CC4 /* StringBuilderJSON.cpp */; };
 		E392FA2722E92BFF00ECDC73 /* ResourceUsageCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E392FA2622E92BFF00ECDC73 /* ResourceUsageCocoa.cpp */; };
+		E3A1438D2BABEE0300A4737E /* FixedSizeCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A1438C2BABEE0300A4737E /* FixedSizeCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3B8E6032961EA7600A8AEE3 /* AccessibleAddress.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B8E6012961EA7600A8AEE3 /* AccessibleAddress.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3BE09A724A5854D009DF2B4 /* ICUHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3BE09A624A58545009DF2B4 /* ICUHelpers.cpp */; };
 		E3DA37E7287AD1A10066808F /* StringCommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3DA37E6287AD1A10066808F /* StringCommon.cpp */; };
@@ -1780,6 +1781,7 @@
 		E38C41271EB4E0680042957D /* CPUTime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CPUTime.h; sourceTree = "<group>"; };
 		E38D6E261F5522E300A75CC4 /* StringBuilderJSON.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringBuilderJSON.cpp; sourceTree = "<group>"; };
 		E392FA2622E92BFF00ECDC73 /* ResourceUsageCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResourceUsageCocoa.cpp; sourceTree = "<group>"; };
+		E3A1438C2BABEE0300A4737E /* FixedSizeCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FixedSizeCache.h; sourceTree = "<group>"; };
 		E3A32BC31FC830E2007D7E76 /* JSValueMalloc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSValueMalloc.h; sourceTree = "<group>"; };
 		E3B8E6012961EA7600A8AEE3 /* AccessibleAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessibleAddress.h; sourceTree = "<group>"; };
 		E3BE09A624A58545009DF2B4 /* ICUHelpers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ICUHelpers.cpp; sourceTree = "<group>"; };
@@ -2138,6 +2140,7 @@
 				A331D95A21F24992009F02AA /* FileSystem.cpp */,
 				A331D95921F24992009F02AA /* FileSystem.h */,
 				FF910E972979FE6F00D1A24D /* FixedBitVector.h */,
+				E3A1438C2BABEE0300A4737E /* FixedSizeCache.h */,
 				E3E0F04F26197157004640FC /* FixedVector.h */,
 				33479C1C27236F2000B2E1B7 /* FixedWidthDouble.h */,
 				0F2B66A517B6B4F700A7AE3F /* FlipBytes.h */,
@@ -3164,6 +3167,7 @@
 				DD3DC8F827A4BF8E007E5B61 /* FileSystem.h in Headers */,
 				DDF306FB27C086CC006A526F /* fixed-dtoa.h in Headers */,
 				FF910E982979FE6F00D1A24D /* FixedBitVector.h in Headers */,
+				E3A1438D2BABEE0300A4737E /* FixedSizeCache.h in Headers */,
 				DD3DC96527A4BF8E007E5B61 /* FixedVector.h in Headers */,
 				339B7B1127C45EF50072BF9A /* FixedWidthDouble.h in Headers */,
 				DD3DC8D327A4BF8E007E5B61 /* FlipBytes.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -83,6 +83,7 @@ set(WTF_PUBLIC_HEADERS
     FilePrintStream.h
     FileSystem.h
     FixedBitVector.h
+    FixedSizeCache.h
     FixedVector.h
     FixedWidthDouble.h
     FlipBytes.h

--- a/Source/WTF/wtf/FixedSizeCache.h
+++ b/Source/WTF/wtf/FixedSizeCache.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2023 The Chromium Authors
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// A cache of fixed size, which will automatically evict members
+// when there is no room for them. This is a simple 2-way associative
+// cache; i.e., every element can go into one out of two neighboring
+// slots. An inserted element is always overwriting whatever is in
+// slot 1 (unless slot 0 is empty); on a successful lookup,
+// it is moved to slot 0. This gives preference to the elements that are
+// actually used, and the scheme is simple enough that it's faster than
+// using a standard HashMap.
+//
+// There are no heap allocations after the initial setup. Deletions
+// and overwrites (inserting the same key more than once) are not
+// supported. Uses the given hash traits, so you should never try to
+// insert or search for EmptyValue(). It can hold Oilpan members.
+
+#pragma once
+
+#include <array>
+#include <wtf/HashFunctions.h>
+#include <wtf/HashTraits.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WTF {
+
+template<typename Key, typename Value, unsigned cacheSize, typename Hash, typename KeyTraitsArg, typename MappedTraitsArg>
+class FixedSizeCache final {
+    WTF_MAKE_FAST_ALLOCATED;
+    static_assert(!(cacheSize & (cacheSize - 1)), "cacheSize should be a power of two");
+    static_assert(cacheSize >= 2);
+public:
+    using KeyTraits = KeyTraitsArg;
+    using MappedTraits = MappedTraitsArg;
+    using KeyType = Key;
+    using MappedType = Value;
+    using HashFunctions = Hash;
+    using MappedPeekType = typename MappedTraits::PeekType;
+
+    FixedSizeCache()
+    {
+        clear();
+    }
+
+    void clear()
+    {
+        m_cache.fill(std::pair { KeyTraits::emptyValue(), MappedTraits::emptyValue() });
+    }
+
+    MappedPeekType get(const Key& key) { return find(key, Hash::hash(key)); }
+
+    MappedPeekType get(const Key& key, unsigned hash)
+    {
+        ASSERT(!isHashTraitsEmptyValue<KeyTraits>(key));
+        ASSERT(Hash::hash(key) == hash);
+        unsigned bucketSet = (hash % cacheSize) & ~1;
+        uint8_t prefilter = prefilterHash(hash);
+
+        // Search, moving to front if we find a match.
+        if (m_prefilter[bucketSet] == prefilter && m_cache[bucketSet].first == key)
+            return MappedTraits::peek(m_cache[bucketSet].second);
+
+        if (m_prefilter[bucketSet + 1] == prefilter && m_cache[bucketSet + 1].first == key) {
+            using std::swap;
+            swap(m_prefilter[bucketSet], m_prefilter[bucketSet + 1]);
+            swap(m_cache[bucketSet], m_cache[bucketSet + 1]);
+            return MappedTraits::peek(m_cache[bucketSet].second);
+        }
+
+        return MappedTraits::peek(MappedTraits::emptyValue());
+    }
+
+    Value& insert(const Key& key, Value&& value)
+    {
+        unsigned hash = Hash::hash(key);
+        return insert(key, std::forward<Value>(value), hash);
+    }
+
+    // Returns a reference to the newly inserted value.
+    Value& insert(const Key& key, Value&& value, unsigned hash)
+    {
+        ASSERT(!isHashTraitsEmptyValue<KeyTraits>(key));
+        ASSERT(Hash::hash(key) == hash);
+        unsigned slot = (hash % cacheSize) & ~1;
+
+        // Overwrites are not supported (if so, use find()
+        // and modify the resulting value).
+        ASSERT(m_cache[slot].first != key);
+        ASSERT(m_cache[slot + 1].first != key);
+
+        if (m_prefilter[slot])
+            ++slot; // Not empty.
+
+        m_prefilter[slot] = prefilterHash(hash);
+        m_cache[slot] = std::pair { key, std::forward<Value>(value) };
+        return m_cache[slot].second;
+    }
+
+private:
+    static constexpr uint8_t prefilterHash(unsigned hash)
+    {
+        // Use the bits we didn't use for the bucket set.
+        return ((hash / cacheSize) & 0xff) | 1;
+    }
+
+    // Contains some extra bits of the hash (those not used for bucketing),
+    // as an extra filter before operator==, which may be expensive.
+    // This is especially useful in the case where we keep missing the cache,
+    // and don't want to burn the CPU's L1 cache on repeated useless lookups
+    // into m_cache, especially if Key or Value are large. (This is why it's
+    // kept as a separate array.)
+    //
+    // The lower bit is always set to 1 for a non-empty value.
+    std::array<uint8_t, cacheSize> m_prefilter { };
+    std::array<std::pair<Key, Value>, cacheSize> m_cache;
+};
+
+} // namespace WTF
+
+using WTF::FixedSizeCache;

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -133,6 +133,7 @@ template<typename Value, typename = DefaultHash<Value>, typename = HashTraits<Va
 template<typename KeyArg, typename MappedArg, typename = DefaultHash<KeyArg>, typename = HashTraits<KeyArg>, typename = HashTraits<MappedArg>, typename = HashTableTraits> class HashMap;
 template<typename ValueArg, typename = DefaultHash<ValueArg>, typename = HashTraits<ValueArg>, typename = HashTableTraits> class HashSet;
 template<typename ResolveValueT, typename RejectValueT, unsigned options = 0> class NativePromise;
+template<typename Key, typename Value, unsigned, typename = DefaultHash<Key>, typename = HashTraits<Key>, typename = HashTraits<Value>> class FixedSizeCache;
 using GenericPromise = NativePromise<void, void>;
 using GenericNonExclusivePromise = NativePromise<void, void, 1>;
 class NativePromiseRequest;

--- a/Source/WebCore/css/CSSValuePool.h
+++ b/Source/WebCore/css/CSSValuePool.h
@@ -27,6 +27,7 @@
 
 #include "CSSPrimitiveValue.h"
 #include "ColorHash.h"
+#include <wtf/FixedSizeCache.h>
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/AtomStringHash.h>
@@ -77,7 +78,10 @@ public:
     Ref<CSSPrimitiveValue> createFontFamilyValue(const AtomString&);
 
 private:
-    HashMap<Color, Ref<CSSPrimitiveValue>> m_colorValueCache;
+    static constexpr unsigned maximumColorCacheSize = 512;
+    using ColorCache = FixedSizeCache<Color, RefPtr<CSSPrimitiveValue>, maximumColorCacheSize>;
+
+    ColorCache m_colorValueCache;
     HashMap<AtomString, RefPtr<CSSValueList>> m_fontFaceValueCache;
     HashMap<AtomString, Ref<CSSPrimitiveValue>> m_fontFamilyValueCache;
 };


### PR DESCRIPTION
#### ab499c21c21c0d1048db4df1e5f122ce85813bcd
<pre>
Add FixedSizeCache for CSS color values
<a href="https://bugs.webkit.org/show_bug.cgi?id=271364">https://bugs.webkit.org/show_bug.cgi?id=271364</a>
<a href="https://rdar.apple.com/125143312">rdar://125143312</a>

Reviewed by NOBODY (OOPS!).

WIP Cherry-pick <a href="https://chromium.googlesource.com/chromium/src/+/e555ed6aefeaaa7ad70ccf69dd1efe205b6ab5fd.">https://chromium.googlesource.com/chromium/src/+/e555ed6aefeaaa7ad70ccf69dd1efe205b6ab5fd.</a>

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/FixedSizeCache.h: Added.
* Source/WTF/wtf/Forward.h:
* Source/WebCore/css/CSSValuePool.cpp:
(WebCore::CSSValuePool::createColorValue):
* Source/WebCore/css/CSSValuePool.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab499c21c21c0d1048db4df1e5f122ce85813bcd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44710 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47364 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36759 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17814 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18305 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39650 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2757 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/37899 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40944 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49013 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44162 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/repro_1289.js.wasm-omg (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19672 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16221 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43722 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20995 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42466 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21332 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51338 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20668 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10419 "Passed tests") | 
<!--EWS-Status-Bubble-End-->