### PR TITLE
[web-animations] add support for canceling style-originated animations silently

### DIFF
--- a/Source/WebCore/animation/StyleOriginatedAnimation.cpp
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.cpp
@@ -201,7 +201,7 @@ void StyleOriginatedAnimation::setTimeline(RefPtr<AnimationTimeline>&& newTimeli
     WebAnimation::setTimeline(WTFMove(newTimeline));
 }
 
-void StyleOriginatedAnimation::cancel()
+void StyleOriginatedAnimation::cancel(WebAnimation::Silently silently)
 {
     auto cancelationTime = 0_s;
 
@@ -213,14 +213,14 @@ void StyleOriginatedAnimation::cancel()
         }
     }
 
-    WebAnimation::cancel();
+    WebAnimation::cancel(silently);
 
     invalidateDOMEvents(shouldFireEvents, cancelationTime);
 }
 
-void StyleOriginatedAnimation::cancelFromStyle()
+void StyleOriginatedAnimation::cancelFromStyle(WebAnimation::Silently silently)
 {
-    cancel();
+    cancel(silently);
     disassociateFromOwningElement();
 }
 

--- a/Source/WebCore/animation/StyleOriginatedAnimation.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.h
@@ -50,7 +50,7 @@ public:
     const std::optional<const Styleable> owningElement() const;
     const Animation& backingAnimation() const { return m_backingAnimation; }
     void setBackingAnimation(const Animation&);
-    void cancelFromStyle();
+    void cancelFromStyle(WebAnimation::Silently = WebAnimation::Silently::No);
 
     std::optional<double> bindingsStartTime() const final;
     std::optional<double> bindingsCurrentTime() const final;
@@ -63,7 +63,7 @@ public:
     ExceptionOr<void> bindingsPause() override;
 
     void setTimeline(RefPtr<AnimationTimeline>&&) final;
-    void cancel() final;
+    void cancel(WebAnimation::Silently = WebAnimation::Silently::No) final;
 
     void tick() override;
 

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -706,7 +706,7 @@ Seconds WebAnimation::effectEndTime() const
     return m_effect ? m_effect->endTime() : 0_s;
 }
 
-void WebAnimation::cancel()
+void WebAnimation::cancel(Silently silently)
 {
     LOG_WITH_STREAM(Animations, stream << "WebAnimation " << this << " cancel() (current time is " << currentTime() << ")");
 
@@ -762,7 +762,7 @@ void WebAnimation::cancel()
     // 3. Make animation's start time unresolved.
     m_startTime = std::nullopt;
 
-    timingDidChange(DidSeek::No, SynchronouslyNotify::No);
+    timingDidChange(DidSeek::No, SynchronouslyNotify::No, silently);
 
     invalidateEffect();
 

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -102,7 +102,8 @@ public:
     using FinishedPromise = DOMPromiseProxyWithResolveCallback<IDLInterface<WebAnimation>>;
     FinishedPromise& finished() { return m_finishedPromise.get(); }
 
-    virtual void cancel();
+    enum class Silently : bool { No, Yes };
+    virtual void cancel(Silently = Silently::No);
     ExceptionOr<void> finish();
     ExceptionOr<void> play();
     void updatePlaybackRate(double);
@@ -175,7 +176,6 @@ protected:
 private:
     enum class DidSeek : bool { No, Yes };
     enum class SynchronouslyNotify : bool { No, Yes };
-    enum class Silently : bool { No, Yes };
     enum class RespectHoldTime : bool { No, Yes };
     enum class AutoRewind : bool { No, Yes };
     enum class TimeToRunPendingTask : uint8_t { NotScheduled, ASAP, WhenReady };

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -303,12 +303,12 @@ void Styleable::willChangeRenderer() const
     }
 }
 
-void Styleable::cancelStyleOriginatedAnimations() const
+void Styleable::cancelStyleOriginatedAnimations(const WeakStyleOriginatedAnimations& animationsToCancelSilently) const
 {
     if (auto* animations = this->animations()) {
         for (auto& animation : *animations) {
             if (auto* styleOriginatedAnimation = dynamicDowncast<StyleOriginatedAnimation>(animation.get())) {
-                styleOriginatedAnimation->cancelFromStyle();
+                styleOriginatedAnimation->cancelFromStyle(animationsToCancelSilently.contains(styleOriginatedAnimation) ? WebAnimation::Silently::Yes : WebAnimation::Silently::No);
                 setLastStyleChangeEventStyle(nullptr);
             }
         }

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -177,7 +177,7 @@ struct Styleable {
     void elementWasRemoved() const;
 
     void willChangeRenderer() const;
-    void cancelStyleOriginatedAnimations() const;
+    void cancelStyleOriginatedAnimations(const WeakStyleOriginatedAnimations& = { }) const;
 
     void animationWasAdded(WebAnimation&) const;
     void animationWasRemoved(WebAnimation&) const;


### PR DESCRIPTION
#### 28a06fc72f32a1ccbb5a3a09924253efb4a5469e
<pre>
[web-animations] add support for canceling style-originated animations silently
<a href="https://bugs.webkit.org/show_bug.cgi?id=271365">https://bugs.webkit.org/show_bug.cgi?id=271365</a>

Reviewed by Antti Koivisto.

When we will be adding animation support for the `display` property (see bug 267762) we will
need to resolve animations even when the underlying style has `display: none` to see whether
animations yield a different value. In that process, we may create style-originated animations
that will ultimately be canceled once we&apos;re certain `display: none` is still set.

In 276414@main we created a list of style-originated animations created during a style update.

We now add support for canceling that group of style-originated animations in a way that is not
script observable, or &quot;silently&quot; in Web Animations parlance.

Once we get to add animation support for the `display` property proper, we will add a call to
`StyleOriginatedAnimation::cancelFromStyle()` with the list of newly-created style-originated
animations that require silent cancelation.

* Source/WebCore/animation/StyleOriginatedAnimation.cpp:
(WebCore::StyleOriginatedAnimation::cancel):
(WebCore::StyleOriginatedAnimation::cancelFromStyle):
* Source/WebCore/animation/StyleOriginatedAnimation.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::cancel):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::cancelStyleOriginatedAnimations const):
* Source/WebCore/style/Styleable.h:
(WebCore::Styleable::cancelStyleOriginatedAnimations):

Canonical link: <a href="https://commits.webkit.org/276453@main">https://commits.webkit.org/276453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebfbed8c0b5c97acea5be365c0174f040b610e9f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47361 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21188 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17809 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18295 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/39643 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2755 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49011 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16219 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43715 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/20993 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21329 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6166 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->