### PR TITLE
Network process should be able to resolve its own registered mDNS names

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp
@@ -55,6 +55,13 @@ struct NetworkMDNSRegister::DNSServiceDeallocator {
 void NetworkMDNSRegister::unregisterMDNSNames(WebCore::ScriptExecutionContextIdentifier documentIdentifier)
 {
     m_services.remove(documentIdentifier);
+    for (auto& name : m_perDocumentRegisteredNames.take(documentIdentifier))
+        m_registeredNames.remove(name);
+}
+
+bool NetworkMDNSRegister::hasRegisteredName(const String& name) const
+{
+    return m_registeredNames.contains(name);
 }
 
 struct PendingRegistrationRequest {
@@ -107,6 +114,11 @@ static void registerMDNSNameCallback(DNSServiceRef service, DNSRecordRef record,
 void NetworkMDNSRegister::registerMDNSName(WebCore::ScriptExecutionContextIdentifier documentIdentifier, const String& ipAddress, CompletionHandler<void(const String&, std::optional<WebCore::MDNSRegisterError>)>&& completionHandler)
 {
     auto name = makeString(WTF::UUID::createVersion4(), ".local"_s);
+
+    m_registeredNames.add(name);
+    m_perDocumentRegisteredNames.ensure(documentIdentifier, [] {
+        return Vector<String>();
+    }).iterator->value.append(name);
 
     DNSServiceRef service;
     auto iterator = m_services.find(documentIdentifier);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h
@@ -34,6 +34,7 @@
 #include <wtf/Expected.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 
 #if PLATFORM(COCOA) && defined __has_include && __has_include(<dns_sd.h>)
 #define ENABLE_MDNS 1
@@ -73,6 +74,8 @@ public:
     void closeAndForgetService(DNSServiceRef);
 #endif
 
+    bool hasRegisteredName(const String&) const;
+
 private:
     void unregisterMDNSNames(WebCore::ScriptExecutionContextIdentifier);
     void registerMDNSName(WebCore::ScriptExecutionContextIdentifier, const String& ipAddress, CompletionHandler<void(const String&, std::optional<WebCore::MDNSRegisterError>)>&&);
@@ -80,6 +83,10 @@ private:
     PAL::SessionID sessionID() const;
 
     WeakRef<NetworkConnectionToWebProcess> m_connection;
+    HashSet<String> m_registeredNames;
+
+    HashMap<WebCore::ScriptExecutionContextIdentifier, Vector<String>> m_perDocumentRegisteredNames;
+
 #if ENABLE_MDNS
     struct DNSServiceDeallocator;
     HashMap<WebCore::ScriptExecutionContextIdentifier, std::unique_ptr<_DNSServiceRef_t, DNSServiceDeallocator>> m_services;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -51,6 +51,9 @@ public:
     void addListener(NetworkRTCMonitor&);
     void removeListener(NetworkRTCMonitor&);
 
+    const RTCNetwork::IPAddress& ipv4() const { return m_ipv4; }
+    const RTCNetwork::IPAddress& ipv6()  const { return m_ipv6; }
+
 private:
     void onNetworksChanged();
 
@@ -136,6 +139,16 @@ void NetworkManagerWrapper::onNetworksChanged()
 NetworkRTCMonitor::~NetworkRTCMonitor()
 {
     ASSERT(!m_manager);
+}
+
+const RTCNetwork::IPAddress& NetworkRTCMonitor::ipv4() const
+{
+    return networkManager().ipv4();
+}
+
+const RTCNetwork::IPAddress& NetworkRTCMonitor::ipv6()  const
+{
+    return networkManager().ipv6();
 }
 
 void NetworkRTCMonitor::startUpdatingIfNeeded()

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.h
@@ -60,6 +60,9 @@ public:
 
     void onNetworksChanged(const Vector<RTCNetwork>&, const RTCNetwork::IPAddress&, const RTCNetwork::IPAddress&);
 
+    const RTCNetwork::IPAddress& ipv4() const;
+    const RTCNetwork::IPAddress& ipv6()  const;
+
 private:
     void startUpdatingIfNeeded();
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -305,6 +305,18 @@ void NetworkRTCProvider::createResolver(LibWebRTCResolverIdentifier identifier, 
         });
         return;
     }
+
+    RefPtr connection = m_connection.get();
+    if (connection && connection->mdnsRegister().hasRegisteredName(address)) {
+        Vector<WebKit::RTC::Network::IPAddress> ipAddresses;
+        if (!m_rtcMonitor.ipv4().isUnspecified())
+            ipAddresses.append(m_rtcMonitor.ipv4());
+        if (!m_rtcMonitor.ipv6().isUnspecified())
+            ipAddresses.append(m_rtcMonitor.ipv6());
+        connection->connection().send(Messages::WebRTCResolver::SetResolvedAddress(ipAddresses), identifier);
+        return;
+    }
+
     WebCore::DNSCompletionHandler completionHandler = [connection = m_connection, identifier](auto&& result) {
         ASSERT(isMainRunLoop());
         if (!connection)

--- a/Source/WebKit/Shared/RTCNetwork.h
+++ b/Source/WebKit/Shared/RTCNetwork.h
@@ -53,6 +53,8 @@ struct IPAddress {
 
     rtc::IPAddress rtcAddress() const;
 
+    bool isUnspecified() const { return std::holds_alternative<UnspecifiedFamily>(value); }
+
     std::variant<UnspecifiedFamily, uint32_t, std::array<uint32_t, 4>> value;
 };
 


### PR DESCRIPTION
#### 8ceefda7940b252c0f7e190fa586232cce3b3368
<pre>
Network process should be able to resolve its own registered mDNS names
<a href="https://bugs.webkit.org/show_bug.cgi?id=271368">https://bugs.webkit.org/show_bug.cgi?id=271368</a>
<a href="https://rdar.apple.com/112834753">rdar://112834753</a>

Reviewed by Chris Dumez.

Store the registered mdns names in a HashSet.
In case of a mDNS resolution, we check the hashset and if there is a match, we use the current local address directly.
This ensures that mDNS resolution with Safari works even if mDNS registration fails.
We add a mechanism to remove the mdns names from the HashSet whenever the document goes away, to keep the same mDNS lifetime as before.

* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.cpp:
(WebKit::NetworkMDNSRegister::unregisterMDNSNames):
(WebKit::NetworkMDNSRegister::hasRegisteredName):
(WebKit::NetworkMDNSRegister::registerMDNSName):
* Source/WebKit/NetworkProcess/webrtc/NetworkMDNSRegister.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:
(WebKit::NetworkRTCProvider::createResolver):
* Source/WebKit/Shared/RTCNetwork.h:
(WebKit::RTC::Network::IPAddress::isUnspecified const):

Canonical link: <a href="https://commits.webkit.org/276556@main">https://commits.webkit.org/276556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f01182f06acae35ff5fc34effe3d41b3bda16d07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47616 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40965 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/28166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21465 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36906 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17992 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18548 "Unexpected infrastructure issue, retrying build") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3006 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41225 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49288 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16480 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43904 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21246 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42673 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10008 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->