### PR TITLE
NEW TEST(276140@main): [ MacOS WK1 Debug ] media/media-source/worker/media-managedmse-worker.html  is a constant crash

### DIFF
--- a/LayoutTests/media/media-source/worker/media-managedmse-worker-expected.txt
+++ b/LayoutTests/media/media-source/worker/media-managedmse-worker-expected.txt
@@ -1,4 +1,5 @@
 
+EXPECTED (ManagedMediaSource.canConstructInDedicatedWorker == 'true') OK
 RUN(video.disableRemotePlayback = true)
 received handle message: [object MediaSourceHandle] OK
 info message from worker: sourceopen event received OK

--- a/LayoutTests/media/media-source/worker/media-managedmse-worker.html
+++ b/LayoutTests/media/media-source/worker/media-managedmse-worker.html
@@ -7,18 +7,23 @@
     window.addEventListener('load', async event => {
         findMediaElement();
 
+        testExpected('ManagedMediaSource.canConstructInDedicatedWorker', true);
         const worker = new Worker('worker.js');
         worker.onmessage = msg => {
             switch (msg.data.topic) {
-                case 'handle':
+            case 'handle':
                 logResult(true, 'received handle message: ' + msg.data.arg);
                 video.srcObject = msg.data.arg;
                 break;
-                case 'info':
+            case 'info':
                 logResult(true, 'info message from worker: ' + msg.data.arg);
                 endTest();
                 break;
-                default:
+            case 'error':
+                logResult(false, 'error message from worker: ' + msg.data.arg);
+                endTest();
+                break;
+            default:
                 logResult(false, 'error: Unrecognized topic in message from worker');
                 break;
             }

--- a/LayoutTests/media/media-source/worker/worker.js
+++ b/LayoutTests/media/media-source/worker/worker.js
@@ -2,15 +2,22 @@ function logToMain(msg) {
     postMessage({topic: 'info', arg: msg});
 }
 
-onmessage = (e) => {
-    const ms = new ManagedMediaSource();
-    const handle = ms.handle;
+function logErrorToMain(msg) {
+    postMessage({topic: 'error', arg: msg});
+}
 
-    ms.onsourceopen = () => {
-        logToMain("sourceopen event received");
-    };
-    // Transfer the MediaSourceHandle to the main thread for use in attaching to
-    // the main thread media element that will play the content being buffered
-    // here in the worker.
-    postMessage({topic: 'handle', arg: handle}, [handle]);
+onmessage = (e) => {
+    try {
+        const ms = new ManagedMediaSource();
+        const handle = ms.handle;
+        ms.onsourceopen = () => {
+            logToMain("sourceopen event received");
+        };
+        // Transfer the MediaSourceHandle to the main thread for use in attaching to
+        // the main thread media element that will play the content being buffered
+        // here in the worker.
+        postMessage({topic: 'handle', arg: handle}, [handle]);
+    } catch (e) {
+        logErrorToMain('MSE not supported');
+    }
 };

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2823,8 +2823,6 @@ webkit.org/b/270385 [ Sonoma+ ] fast/images/jpegxl-with-color-profile.html [ Ima
 
 webkit.org/b/259485 [ Ventura ] http/tests/media/hls/track-in-band-multiple-cues.html [ Skip ]
 
-webkit.org/b/271323 [ Debug ] media/media-source/worker/media-managedmse-worker.html [ Skip ]
-
 # webkit.org/b/270199 [ MacOS WK1 Debug ] fast/frames/lots-of-iframes.html and fast/frames/lots-of-objects.html are consistent/flaky timeouts
 [ Debug ] fast/frames/lots-of-iframes.html [ Pass Timeout ]
 [ Debug ] fast/frames/lots-of-objects.html [ Pass Timeout ]

--- a/LayoutTests/platform/mac-wk1/media/media-source/worker/media-managedmse-worker-expected.txt
+++ b/LayoutTests/platform/mac-wk1/media/media-source/worker/media-managedmse-worker-expected.txt
@@ -1,0 +1,6 @@
+
+EXPECTED (ManagedMediaSource.canConstructInDedicatedWorker == 'true'), OBSERVED 'false' FAIL
+RUN(video.disableRemotePlayback = true)
+error message from worker: MSE not supported FAIL
+END OF TEST
+

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4300,6 +4300,7 @@ MediaSourceInWorkerEnabled:
   humanReadableName: "MediaSource in a Worker"
   humanReadableDescription: "MediaSource in a Worker"
   condition: ENABLE(MEDIA_SOURCE_IN_WORKERS)
+  exposed: [ WebCore, WebKit ]
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -54,6 +54,8 @@
 #endif
 #include "MediaSourcePrivate.h"
 #include "MediaSourceRegistry.h"
+#include "MediaStrategy.h"
+#include "PlatformStrategies.h"
 #include "Quirks.h"
 #include "ScriptExecutionContext.h"
 #include "Settings.h"
@@ -1579,7 +1581,7 @@ bool MediaSource::enabledForContext(ScriptExecutionContext& context)
     UNUSED_PARAM(context);
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
     if (context.isWorkerGlobalScope())
-        return context.settingsValues().mediaSourceInWorkerEnabled;
+        return context.settingsValues().mediaSourceInWorkerEnabled && platformStrategies()->mediaStrategy().hasThreadSafeMediaSourceSupport();
 #endif
 
     ASSERT(context.isDocument());
@@ -1601,7 +1603,7 @@ Ref<MediaSourceHandle> MediaSource::handle()
 
 bool MediaSource::canConstructInDedicatedWorker(ScriptExecutionContext& context)
 {
-    return context.settingsValues().mediaSourceInWorkerEnabled;
+    return context.settingsValues().mediaSourceInWorkerEnabled && platformStrategies()->mediaStrategy().hasThreadSafeMediaSourceSupport();
 }
 
 #endif

--- a/Source/WebCore/platform/MediaStrategy.cpp
+++ b/Source/WebCore/platform/MediaStrategy.cpp
@@ -51,6 +51,11 @@ void MediaStrategy::resetMediaEngines()
     m_mockMediaSourceEnabled = false;
 }
 
+bool MediaStrategy::hasThreadSafeMediaSourceSupport() const
+{
+    return false;
+}
+
 #if ENABLE(MEDIA_SOURCE)
 void MediaStrategy::enableMockMediaSource()
 {

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -44,6 +44,7 @@ public:
 #endif
     virtual std::unique_ptr<NowPlayingManager> createNowPlayingManager() const;
     void resetMediaEngines();
+    virtual bool hasThreadSafeMediaSourceSupport() const;
 #if ENABLE(MEDIA_SOURCE)
     virtual void enableMockMediaSource();
     bool mockMediaSourceEnabled() const;

--- a/Source/WebCore/platform/PlatformStrategies.h
+++ b/Source/WebCore/platform/PlatformStrategies.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <mutex>
+
 namespace WebCore {
 
 class BlobRegistry;
@@ -53,8 +55,9 @@ public:
 
     MediaStrategy& mediaStrategy()
     {
-        if (!m_mediaStrategy)
+        std::call_once(m_onceKeyForMediaStrategies, [&] {
             m_mediaStrategy = createMediaStrategy();
+        });
         return *m_mediaStrategy;
     }
 
@@ -89,6 +92,7 @@ private:
 
     LoaderStrategy* m_loaderStrategy { };
     PasteboardStrategy* m_pasteboardStrategy { };
+    std::once_flag m_onceKeyForMediaStrategies;
     MediaStrategy* m_mediaStrategy { };
     BlobRegistry* m_blobRegistry { };
 

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -55,6 +55,7 @@ WebMediaStrategy::~WebMediaStrategy() = default;
 Ref<WebCore::AudioDestination> WebMediaStrategy::createAudioDestination(WebCore::AudioIOCallback& callback, const String& inputDeviceId,
     unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate)
 {
+    ASSERT(isMainRunLoop());
 #if ENABLE(GPU_PROCESS)
     if (m_useGPUProcess)
         return WebCore::SharedAudioDestination::create(callback, numberOfOutputChannels, sampleRate, [inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate] (WebCore::AudioIOCallback& callback) {
@@ -67,6 +68,7 @@ Ref<WebCore::AudioDestination> WebMediaStrategy::createAudioDestination(WebCore:
 
 std::unique_ptr<WebCore::NowPlayingManager> WebMediaStrategy::createNowPlayingManager() const
 {
+    ASSERT(isMainRunLoop());
 #if ENABLE(GPU_PROCESS)
     if (m_useGPUProcess) {
         class NowPlayingInfoForGPUManager : public WebCore::NowPlayingManager {
@@ -88,9 +90,19 @@ std::unique_ptr<WebCore::NowPlayingManager> WebMediaStrategy::createNowPlayingMa
     return WebCore::MediaStrategy::createNowPlayingManager();
 }
 
+bool WebMediaStrategy::hasThreadSafeMediaSourceSupport() const
+{
+#if ENABLE(GPU_PROCESS)
+    return m_useGPUProcess;
+#else
+    return false;
+#endif
+}
+
 #if ENABLE(MEDIA_SOURCE)
 void WebMediaStrategy::enableMockMediaSource()
 {
+    ASSERT(isMainRunLoop());
 #if USE(AVFOUNDATION)
     WebCore::DeprecatedGlobalSettings::setAVFoundationEnabled(false);
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/MediaStrategy.h>
+#include <atomic>
 
 namespace WebKit {
 
@@ -43,12 +44,13 @@ private:
         const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate) override;
 #endif
     std::unique_ptr<WebCore::NowPlayingManager> createNowPlayingManager() const final;
+    bool hasThreadSafeMediaSourceSupport() const final;
 #if ENABLE(MEDIA_SOURCE)
     void enableMockMediaSource() final;
 #endif
 
 #if ENABLE(GPU_PROCESS)
-    bool m_useGPUProcess { false };
+    std::atomic<bool> m_useGPUProcess { false };
 #endif
 };
 


### PR DESCRIPTION
#### b7d8be7a8274318250bdbb161a6eee6daab33991
<pre>
NEW TEST(276140@main): [ MacOS WK1 Debug ] media/media-source/worker/media-managedmse-worker.html  is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=271323">https://bugs.webkit.org/show_bug.cgi?id=271323</a>
<a href="https://rdar.apple.com/125100787">rdar://125100787</a>

Reviewed by Youenn Fablet.

WebPreferences are always set when running LayoutTests. MediaSource in a Worker is not functional
unless the GPU process is active and the MediaPlayers are to run in the GPU process.
MediaSource in a Worker can only work with a MediaSourcePrivate that is designed to be thread-safe
and at present there&apos;s only one kind: MediaSourcePrivateRemote.
As it is possible for a WebPreference to be turned on, we need to handle the case where it has
been accidentally set on a non-supported platform.
To achieve this we add a new MediaStrategy API: `hasThreadSafeSupport()` which will be checked
in addition to the `mediaSourceInWorkerEnabled` preference.

Updated existing test to ensure that enabling the pref on a non-supported configuration is
behaving properly.

* LayoutTests/media/media-source/worker/media-managedmse-worker-expected.txt:
* LayoutTests/media/media-source/worker/media-managedmse-worker.html:
* LayoutTests/media/media-source/worker/worker.js:
(onmessage):
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk1/media/media-source/worker/media-managedmse-worker-expected.txt: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::enabledForContext):
(WebCore::MediaSource::canConstructInDedicatedWorker):
* Source/WebCore/platform/MediaStrategy.cpp:
(WebCore::MediaStrategy::hasThreadSafeMediaSourceSupport const):
* Source/WebCore/platform/MediaStrategy.h:
* Source/WebCore/platform/PlatformStrategies.h:
(WebCore::PlatformStrategies::mediaStrategy): Allow creation of the MediaStrategy object on any threads, in practice this MediaStrategy creation is only
ever done on the main thread, but this could be different in the future.
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::createAudioDestination):
(WebKit::WebMediaStrategy::createNowPlayingManager const):
(WebKit::WebMediaStrategy::hasThreadSafeMediaSourceSupport const):
(WebKit::WebMediaStrategy::enableMockMediaSource):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h:

Canonical link: <a href="https://commits.webkit.org/276534@main">https://commits.webkit.org/276534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59819db0b9986d3ffb56abbc54f3a9d09670da28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44882 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47536 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40887 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36849 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18443 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39787 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2929 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38082 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41111 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49206 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44338 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43843 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42605 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9997 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21507 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51510 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20843 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10453 "Passed tests") | 
<!--EWS-Status-Bubble-End-->