### PR TITLE
[@starting-style] Assert when inspecting @starting-style in debug build

### DIFF
--- a/LayoutTests/inspector/css/getMatchedStylesForNode.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNode.html
@@ -14,6 +14,7 @@ window.internals.insertUserCSS("div { z-index: 500; }");
     @media (min-width: 1px) { body { color: red; } }
     @media (min-width: 2px) { @supports(display: block) { body { color: red; } } }
     @media screen { @counter-style foo { foo:bar; } }
+    @starting-style { bar { color: black; } }
 </style>
 <style media="(min-width: 3px)">
     body { color: red;}

--- a/Source/WebCore/css/CSSGroupingRule.h
+++ b/Source/WebCore/css/CSSGroupingRule.h
@@ -51,6 +51,7 @@ protected:
     RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&) override;
 
 private:
+    bool isGroupingRule() const final { return true; }
     void appendCSSTextForItemsInternal(StringBuilder&, StringBuilder&) const;
     void cssTextForRules(StringBuilder&) const;
     void cssTextForRulesWithReplacementURLs(StringBuilder&, const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const;
@@ -61,3 +62,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::CSSGroupingRule)
+    static bool isType(const WebCore::CSSRule& rule) { return rule.isGroupingRule(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -42,6 +42,7 @@ public:
     WEBCORE_EXPORT unsigned short typeForCSSOM() const;
 
     virtual StyleRuleType styleRuleType() const = 0;
+    virtual bool isGroupingRule() const { return false; }
     virtual String cssText() const = 0;
     virtual String cssTextWithReplacementURLs(const HashMap<String, String>&, const HashMap<RefPtr<CSSStyleSheet>, String>&) const { return cssText(); }
     virtual void reattach(StyleRuleBase&) = 0;

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -578,20 +578,11 @@ static RefPtr<CSSRuleList> asCSSRuleList(CSSRule* rule)
     if (auto* styleRule = dynamicDowncast<CSSStyleRule>(rule))
         return &styleRule->cssRules();
 
-    if (is<CSSMediaRule>(*rule))
-        return &downcast<CSSMediaRule>(*rule).cssRules();
+    if (auto* keyframesRule = dynamicDowncast<CSSKeyframesRule>(*rule))
+        return &keyframesRule->cssRules();
 
-    if (is<CSSKeyframesRule>(*rule))
-        return &downcast<CSSKeyframesRule>(*rule).cssRules();
-
-    if (is<CSSSupportsRule>(*rule))
-        return &downcast<CSSSupportsRule>(*rule).cssRules();
-
-    if (is<CSSLayerBlockRule>(*rule))
-        return &downcast<CSSLayerBlockRule>(*rule).cssRules();
-
-    if (auto* containerRule = dynamicDowncast<CSSContainerRule>(rule))
-        return &containerRule->cssRules();
+    if (auto* groupingRule = dynamicDowncast<CSSGroupingRule>(*rule))
+        return &groupingRule->cssRules();
 
     return nullptr;
 }


### PR DESCRIPTION
#### e746fbb46234fae9004489e4e05173f0b4ce9ae3
<pre>
[@starting-style] Assert when inspecting @starting-style in debug build
<a href="https://bugs.webkit.org/show_bug.cgi?id=271373">https://bugs.webkit.org/show_bug.cgi?id=271373</a>
<a href="https://rdar.apple.com/125156125">rdar://125156125</a>

Reviewed by Antoine Quint.

* LayoutTests/inspector/css/getMatchedStylesForNode.html:
* Source/WebCore/css/CSSGroupingRule.h:
(isType):

Add type test.

* Source/WebCore/css/CSSRule.h:
(WebCore::CSSRule::isGroupingRule const):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::asCSSRuleList):

Return the rule list for @starting-style rules.
Refactor to handle all grouping rules uniformly.

Canonical link: <a href="https://commits.webkit.org/276456@main">https://commits.webkit.org/276456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5c6726f89ef7882af937789e580a243c8cc8025

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47382 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40733 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21211 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17829 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39666 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2775 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40963 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49046 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19691 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16249 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42496 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9966 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->