### PR TITLE
[web-animations] make the `display` property animatable

### DIFF
--- a/LayoutTests/imported/blink/fast/css-generated-content/pseudo-animation-display-expected.txt
+++ b/LayoutTests/imported/blink/fast/css-generated-content/pseudo-animation-display-expected.txt
@@ -1,4 +1,4 @@
 Tests that an attempt to animate the display property of a pseudo element is ignored, and that the animation proceeds as expected.
 PASS: left was 100px
-PASS: display was block
+FAIL: display was not block
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-interpolation-expected.txt
@@ -1,14 +1,14 @@
 
-FAIL CSS Transitions: property <display> from [block] to [none] at (-1) should be [block] assert_equals: expected "block " but got "none "
-FAIL CSS Transitions: property <display> from [block] to [none] at (0) should be [block] assert_equals: expected "block " but got "none "
-FAIL CSS Transitions: property <display> from [block] to [none] at (0.1) should be [block] assert_equals: expected "block " but got "none "
-FAIL CSS Transitions: property <display> from [block] to [none] at (0.9) should be [block] assert_equals: expected "block " but got "none "
+PASS CSS Transitions: property <display> from [block] to [none] at (-1) should be [block]
+PASS CSS Transitions: property <display> from [block] to [none] at (0) should be [block]
+PASS CSS Transitions: property <display> from [block] to [none] at (0.1) should be [block]
+PASS CSS Transitions: property <display> from [block] to [none] at (0.9) should be [block]
 PASS CSS Transitions: property <display> from [block] to [none] at (1) should be [none]
 PASS CSS Transitions: property <display> from [block] to [none] at (1.5) should be [none]
-FAIL CSS Transitions with transition: all: property <display> from [block] to [none] at (-1) should be [block] assert_equals: expected "block " but got "none "
-FAIL CSS Transitions with transition: all: property <display> from [block] to [none] at (0) should be [block] assert_equals: expected "block " but got "none "
-FAIL CSS Transitions with transition: all: property <display> from [block] to [none] at (0.1) should be [block] assert_equals: expected "block " but got "none "
-FAIL CSS Transitions with transition: all: property <display> from [block] to [none] at (0.9) should be [block] assert_equals: expected "block " but got "none "
+PASS CSS Transitions with transition: all: property <display> from [block] to [none] at (-1) should be [block]
+PASS CSS Transitions with transition: all: property <display> from [block] to [none] at (0) should be [block]
+PASS CSS Transitions with transition: all: property <display> from [block] to [none] at (0.1) should be [block]
+PASS CSS Transitions with transition: all: property <display> from [block] to [none] at (0.9) should be [block]
 PASS CSS Transitions with transition: all: property <display> from [block] to [none] at (1) should be [none]
 PASS CSS Transitions with transition: all: property <display> from [block] to [none] at (1.5) should be [none]
 PASS CSS Animations: property <display> from [block] to [none] at (-1) should be [block]
@@ -61,16 +61,16 @@ PASS CSS Transitions with transition: all: property <display> from [inline] to [
 PASS CSS Transitions with transition: all: property <display> from [inline] to [block] at (0.6) should be [block]
 PASS CSS Transitions with transition: all: property <display> from [inline] to [block] at (1) should be [block]
 PASS CSS Transitions with transition: all: property <display> from [inline] to [block] at (1.5) should be [block]
-FAIL CSS Animations: property <display> from [inline] to [block] at (-0.3) should be [inline] assert_equals: expected "inline " but got "block "
-FAIL CSS Animations: property <display> from [inline] to [block] at (0) should be [inline] assert_equals: expected "inline " but got "block "
-FAIL CSS Animations: property <display> from [inline] to [block] at (0.3) should be [inline] assert_equals: expected "inline " but got "block "
+PASS CSS Animations: property <display> from [inline] to [block] at (-0.3) should be [inline]
+PASS CSS Animations: property <display> from [inline] to [block] at (0) should be [inline]
+PASS CSS Animations: property <display> from [inline] to [block] at (0.3) should be [inline]
 PASS CSS Animations: property <display> from [inline] to [block] at (0.5) should be [block]
 PASS CSS Animations: property <display> from [inline] to [block] at (0.6) should be [block]
 PASS CSS Animations: property <display> from [inline] to [block] at (1) should be [block]
 PASS CSS Animations: property <display> from [inline] to [block] at (1.5) should be [block]
-FAIL Web Animations: property <display> from [inline] to [block] at (-0.3) should be [inline] assert_equals: expected "inline " but got "block "
-FAIL Web Animations: property <display> from [inline] to [block] at (0) should be [inline] assert_equals: expected "inline " but got "block "
-FAIL Web Animations: property <display> from [inline] to [block] at (0.3) should be [inline] assert_equals: expected "inline " but got "block "
+PASS Web Animations: property <display> from [inline] to [block] at (-0.3) should be [inline]
+PASS Web Animations: property <display> from [inline] to [block] at (0) should be [inline]
+PASS Web Animations: property <display> from [inline] to [block] at (0.3) should be [inline]
 PASS Web Animations: property <display> from [inline] to [block] at (0.5) should be [block]
 PASS Web Animations: property <display> from [inline] to [block] at (0.6) should be [block]
 PASS Web Animations: property <display> from [inline] to [block] at (1) should be [block]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative-expected.txt
@@ -1,7 +1,4 @@
-hello
-hello
-hello
-hello
+hello hello
 
 FAIL display:none animating to display:inline should be inline for the whole animation. assert_equals: The display should be inline during the animation. expected "inline" but got "block"
 FAIL A CSS variable of display:none animating to display:inline should be inline for the whole animation. assert_equals: The display should be inline during the animation. expected "inline" but got "block"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation-expected.txt
@@ -15,16 +15,16 @@ PASS CSS Transitions with transition: all: property <display> from [none] to [fl
 PASS CSS Transitions with transition: all: property <display> from [none] to [flex] at (1.5) should be [flex]
 PASS CSS Animations: property <display> from [none] to [flex] at (-0.3) should be [block]
 PASS CSS Animations: property <display> from [none] to [flex] at (0) should be [block]
-PASS CSS Animations: property <display> from [none] to [flex] at (0.3) should be [block]
-PASS CSS Animations: property <display> from [none] to [flex] at (0.5) should be [block]
-PASS CSS Animations: property <display> from [none] to [flex] at (0.6) should be [block]
-PASS CSS Animations: property <display> from [none] to [flex] at (1) should be [block]
-PASS CSS Animations: property <display> from [none] to [flex] at (1.5) should be [block]
+FAIL CSS Animations: property <display> from [none] to [flex] at (0.3) should be [block] assert_equals: expected "block " but got "flex "
+FAIL CSS Animations: property <display> from [none] to [flex] at (0.5) should be [block] assert_equals: expected "block " but got "flex "
+FAIL CSS Animations: property <display> from [none] to [flex] at (0.6) should be [block] assert_equals: expected "block " but got "flex "
+FAIL CSS Animations: property <display> from [none] to [flex] at (1) should be [block] assert_equals: expected "block " but got "flex "
+FAIL CSS Animations: property <display> from [none] to [flex] at (1.5) should be [block] assert_equals: expected "block " but got "flex "
 PASS Web Animations: property <display> from [none] to [flex] at (-0.3) should be [block]
 PASS Web Animations: property <display> from [none] to [flex] at (0) should be [block]
-PASS Web Animations: property <display> from [none] to [flex] at (0.3) should be [block]
-PASS Web Animations: property <display> from [none] to [flex] at (0.5) should be [block]
-PASS Web Animations: property <display> from [none] to [flex] at (0.6) should be [block]
-PASS Web Animations: property <display> from [none] to [flex] at (1) should be [block]
-PASS Web Animations: property <display> from [none] to [flex] at (1.5) should be [block]
+FAIL Web Animations: property <display> from [none] to [flex] at (0.3) should be [block] assert_equals: expected "block " but got "flex "
+FAIL Web Animations: property <display> from [none] to [flex] at (0.5) should be [block] assert_equals: expected "block " but got "flex "
+FAIL Web Animations: property <display> from [none] to [flex] at (0.6) should be [block] assert_equals: expected "block " but got "flex "
+FAIL Web Animations: property <display> from [none] to [flex] at (1) should be [block] assert_equals: expected "block " but got "flex "
+FAIL Web Animations: property <display> from [none] to [flex] at (1.5) should be [block] assert_equals: expected "block " but got "flex "
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation.tentative-expected.txt
@@ -1,16 +1,16 @@
 
-FAIL CSS Animations: property <display> from [grid] to [flex] at (-0.3) should be [grid] assert_equals: expected "grid " but got "block "
-FAIL CSS Animations: property <display> from [grid] to [flex] at (0) should be [grid] assert_equals: expected "grid " but got "block "
-FAIL CSS Animations: property <display> from [grid] to [flex] at (0.3) should be [grid] assert_equals: expected "grid " but got "block "
-FAIL CSS Animations: property <display> from [grid] to [flex] at (0.5) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL CSS Animations: property <display> from [grid] to [flex] at (0.6) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL CSS Animations: property <display> from [grid] to [flex] at (1) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL CSS Animations: property <display> from [grid] to [flex] at (1.5) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (-0.3) should be [grid] assert_equals: expected "grid " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (0) should be [grid] assert_equals: expected "grid " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (0.3) should be [grid] assert_equals: expected "grid " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (0.5) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (0.6) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (1) should be [flex] assert_equals: expected "flex " but got "block "
-FAIL Web Animations: property <display> from [grid] to [flex] at (1.5) should be [flex] assert_equals: expected "flex " but got "block "
+PASS CSS Animations: property <display> from [grid] to [flex] at (-0.3) should be [grid]
+PASS CSS Animations: property <display> from [grid] to [flex] at (0) should be [grid]
+PASS CSS Animations: property <display> from [grid] to [flex] at (0.3) should be [grid]
+PASS CSS Animations: property <display> from [grid] to [flex] at (0.5) should be [flex]
+PASS CSS Animations: property <display> from [grid] to [flex] at (0.6) should be [flex]
+PASS CSS Animations: property <display> from [grid] to [flex] at (1) should be [flex]
+PASS CSS Animations: property <display> from [grid] to [flex] at (1.5) should be [flex]
+PASS Web Animations: property <display> from [grid] to [flex] at (-0.3) should be [grid]
+PASS Web Animations: property <display> from [grid] to [flex] at (0) should be [grid]
+PASS Web Animations: property <display> from [grid] to [flex] at (0.3) should be [grid]
+PASS Web Animations: property <display> from [grid] to [flex] at (0.5) should be [flex]
+PASS Web Animations: property <display> from [grid] to [flex] at (0.6) should be [flex]
+PASS Web Animations: property <display> from [grid] to [flex] at (1) should be [flex]
+PASS Web Animations: property <display> from [grid] to [flex] at (1.5) should be [flex]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001-expected.txt
@@ -15,7 +15,6 @@ PASS non-animatable property 'transitionProperty' is not accessed when using a p
 PASS non-animatable property 'transitionTimingFunction' is not accessed when using a property-indexed keyframe object
 PASS non-animatable property 'contain' is not accessed when using a property-indexed keyframe object
 PASS non-animatable property 'direction' is not accessed when using a property-indexed keyframe object
-PASS non-animatable property 'display' is not accessed when using a property-indexed keyframe object
 PASS non-animatable property 'textCombineUpright' is not accessed when using a property-indexed keyframe object
 PASS non-animatable property 'textOrientation' is not accessed when using a property-indexed keyframe object
 PASS non-animatable property 'unicodeBidi' is not accessed when using a property-indexed keyframe object
@@ -40,7 +39,6 @@ PASS non-animatable property 'transitionProperty' is not accessed when using a k
 PASS non-animatable property 'transitionTimingFunction' is not accessed when using a keyframe sequence
 PASS non-animatable property 'contain' is not accessed when using a keyframe sequence
 PASS non-animatable property 'direction' is not accessed when using a keyframe sequence
-PASS non-animatable property 'display' is not accessed when using a keyframe sequence
 PASS non-animatable property 'textCombineUpright' is not accessed when using a keyframe sequence
 PASS non-animatable property 'textOrientation' is not accessed when using a keyframe sequence
 PASS non-animatable property 'unicodeBidi' is not accessed when using a keyframe sequence

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
@@ -37,7 +37,6 @@ const gNonAnimatableProps = [
   'transitionTimingFunction',
   'contain',
   'direction',
-  'display',
   'textCombineUpright',
   'textOrientation',
   'unicodeBidi',

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1542,6 +1542,8 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyClear);
         if (first.position != second.position)
             changingProperties.m_properties.set(CSSPropertyPosition);
+        if (first.effectiveDisplay != second.effectiveDisplay)
+            changingProperties.m_properties.set(CSSPropertyDisplay);
         if (first.floating != second.floating)
             changingProperties.m_properties.set(CSSPropertyFloat);
         if (first.tableLayout != second.tableLayout)
@@ -1550,7 +1552,6 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyTextDecorationLine);
 
         // Non animated styles are followings.
-        // effectiveDisplay
         // originalDisplay
         // unicodeBidi
         // usesViewportUnits


### PR DESCRIPTION
#### 531dc1cbbb66a57f3f8a0dfd97add5f2e1ed4a5c
<pre>
[web-animations] make the `display` property animatable
<a href="https://bugs.webkit.org/show_bug.cgi?id=271372">https://bugs.webkit.org/show_bug.cgi?id=271372</a>

Reviewed by Tim Nguyen.

As part of the work to add interpolation support for the `display` property (see bug 267762) we need
to make that property animatable. We add basic support with a new wrapper in CSSPropertyAnimation.cpp,
but more work will be needed to deal with the more tricky aspects of `display: none` values encountered
before and after applying animations during style resolution.

It is expected that the WPT test `css/css-display/animations/display-interpolation.html` now has FAIL
results since this test is not aware of `display` being an animatable property. That test is superseded
by `css/css-display/animations/display-interpolation.tentative.html` but both tests currently co-exist
in the WPT suite so we retain both of them.

Likewise, we alter the WPT test `web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html`
to no longer assume the `display` property is not animatable.

Finally, the test `imported/blink/fast/css-generated-content/pseudo-animation-display.html` now fails.
That test also fails in Chrome [0] after they&apos;ve added animation support for the `display` property, but our
failures aren&apos;t the same. I&apos;ve filed an issue with the CSS WG [1] to discuss this and ensure we get WPT coverage.

[0] <a href="https://source.chromium.org/chromium/chromium/src/+/main">https://source.chromium.org/chromium/chromium/src/+/main</a>:third_party/blink/web_tests/TestExpectations;l=3487;bpv=1;bpt=1
[1] <a href="https://github.com/w3c/csswg-drafts/issues/10111">https://github.com/w3c/csswg-drafts/issues/10111</a>

* LayoutTests/imported/blink/fast/css-generated-content/pseudo-animation-display-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendFunc):
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):

Canonical link: <a href="https://commits.webkit.org/276464@main">https://commits.webkit.org/276464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d010ec79436127e47ab49d6bf31913f7238283e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47196 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47378 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40729 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36765 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17823 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39658 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2771 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/40957 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49032 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43734 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21009 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38760 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42476 "Found 2 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21346 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6182 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->