### PR TITLE
[Skia] Check if glFence is available before using it

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2105,6 +2105,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/graphics/egl/GLContext.h
     platform/graphics/egl/GLContextWrapper.h
+    platform/graphics/egl/GLFence.h
 
     platform/graphics/filters/DistantLightSource.h
     platform/graphics/filters/FEBlend.h

--- a/Source/WebCore/PlatformPlayStation.cmake
+++ b/Source/WebCore/PlatformPlayStation.cmake
@@ -39,6 +39,7 @@ list(APPEND WebCore_SOURCES
     platform/graphics/egl/GLContext.cpp
     platform/graphics/egl/GLContextLibWPE.cpp
     platform/graphics/egl/GLContextWrapper.cpp
+    platform/graphics/egl/GLFence.cpp
 
     platform/graphics/libwpe/PlatformDisplayLibWPE.cpp
 

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -61,6 +61,7 @@ platform/graphics/angle/PlatformDisplayANGLE.cpp @no-unify
 
 platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextWrapper.cpp @no-unify
+platform/graphics/egl/GLFence.cpp @no-unify
 platform/graphics/egl/PlatformDisplaySurfaceless.cpp @no-unify
 
 platform/graphics/gbm/GBMBufferSwapchain.cpp

--- a/Source/WebCore/SourcesWPE.txt
+++ b/Source/WebCore/SourcesWPE.txt
@@ -62,6 +62,7 @@ platform/graphics/wpe/SystemFontDatabaseWPE.cpp
 platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextLibWPE.cpp @no-unify
 platform/graphics/egl/GLContextWrapper.cpp @no-unify
+platform/graphics/egl/GLFence.cpp @no-unify
 platform/graphics/egl/PlatformDisplaySurfaceless.cpp @no-unify
 
 platform/graphics/gbm/GBMBufferSwapchain.cpp

--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -537,6 +537,7 @@ const GLContext::GLExtensions& GLContext::glExtensions() const
         const char* extensionsString = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
         m_glExtensions.OES_texture_npot = isExtensionSupported(extensionsString, "GL_OES_texture_npot");
         m_glExtensions.EXT_unpack_subimage = isExtensionSupported(extensionsString, "GL_EXT_unpack_subimage");
+        m_glExtensions.APPLE_sync = isExtensionSupported(extensionsString, "GL_APPLE_sync");
     });
     return m_glExtensions;
 }

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -76,6 +76,7 @@ public:
     struct GLExtensions {
         bool OES_texture_npot { false };
         bool EXT_unpack_subimage { false };
+        bool APPLE_sync { false };
     };
     const GLExtensions& glExtensions() const;
 

--- a/Source/WebCore/platform/graphics/egl/GLFence.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLFence.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#include "config.h"
+#include "GLFence.h"
+
+#include "GLContext.h"
+
+#if USE(LIBEPOXY)
+#include <epoxy/gl.h>
+#else
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+#endif
+
+namespace WebCore {
+
+std::unique_ptr<GLFence> GLFence::create()
+{
+    auto* context = GLContext::current();
+    if (!context)
+        return nullptr;
+
+    if (context->version() >= 300 || context->glExtensions().APPLE_sync) {
+        if (auto* sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0))
+            return makeUnique<GLFence>(sync);
+        return nullptr;
+    }
+
+    return nullptr;
+}
+
+GLFence::GLFence(GLsync sync)
+    : m_sync(sync)
+{
+}
+
+GLFence::~GLFence()
+{
+    if (m_sync)
+        glDeleteSync(m_sync);
+}
+
+unsigned GLFence::wait(FlushCommands flushCommands)
+{
+    return glClientWaitSync(m_sync, flushCommands == FlushCommands::Yes ? GL_SYNC_FLUSH_COMMANDS_BIT : 0, GL_TIMEOUT_IGNORED);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/egl/GLFence.h
+++ b/Source/WebCore/platform/graphics/egl/GLFence.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA
+ */
+
+#pragma once
+
+#include <wtf/FastMalloc.h>
+#include <wtf/Noncopyable.h>
+
+typedef struct __GLsync* GLsync;
+
+namespace WebCore {
+
+class GLFence {
+    WTF_MAKE_NONCOPYABLE(GLFence);
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    WEBCORE_EXPORT static std::unique_ptr<GLFence> create();
+    explicit GLFence(GLsync);
+    ~GLFence();
+
+    enum class FlushCommands : bool { No, Yes };
+    unsigned wait(FlushCommands);
+
+private:
+    GLsync m_sync;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.h
@@ -39,9 +39,11 @@
 IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
 #include <skia/core/SkSurface.h>
 IGNORE_CLANG_WARNINGS_END
-
-typedef struct __GLsync* GLsync;
 #endif
+
+namespace WebCore {
+class GLFence;
+}
 
 namespace Nicosia {
 
@@ -139,7 +141,7 @@ private:
     void waitUntilPaintingComplete() final;
 
     unsigned m_textureID { 0 };
-    GLsync m_sync { nullptr };
+    std::unique_ptr<WebCore::GLFence> m_fence;
 };
 #endif
 


### PR DESCRIPTION
#### c4b3e26f6881ae3d97a0ac8f1cb09a105cd95522
<pre>
[Skia] Check if glFence is available before using it
<a href="https://bugs.webkit.org/show_bug.cgi?id=271376">https://bugs.webkit.org/show_bug.cgi?id=271376</a>

Reviewed by Miguel Gomez.

If not available we need to call GrDirectContext::submit() with
GrSyncCpu=kYes. This patch adds a helper class GLFence to wrap it, that
can be extended in the future to support nvidia fences if needed too.

* Source/WebCore/Headers.cmake:
* Source/WebCore/PlatformPlayStation.cmake:
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/SourcesWPE.txt:
* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::glExtensions const):
* Source/WebCore/platform/graphics/egl/GLContext.h:
* Source/WebCore/platform/graphics/egl/GLFence.cpp: Added.
(WebCore::GLFence::create):
(WebCore::GLFence::GLFence):
(WebCore::GLFence::~GLFence):
(WebCore::GLFence::wait):
* Source/WebCore/platform/graphics/egl/GLFence.h: Added.
* Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp:
(Nicosia::AcceleratedBuffer::beginPainting):
(Nicosia::AcceleratedBuffer::completePainting):
(Nicosia::AcceleratedBuffer::waitUntilPaintingComplete):
(Nicosia::AcceleratedBuffer::~AcceleratedBuffer): Deleted.
* Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.h:

Canonical link: <a href="https://commits.webkit.org/276463@main">https://commits.webkit.org/276463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a10bf0143115d1e849120752ca281314be81c9e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47210 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47391 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40742 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21221 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17838 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39671 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2784 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/40976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39961 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49051 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19700 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/16266 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43753 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21022 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42499 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21359 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6181 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20695 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->