### PR TITLE
Rename toSpan() / bytes() to span(), and vector() free function to makeVector()

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -331,8 +331,8 @@ public:
     Expected<int64_t, GrowFailReason> grow(VM&, size_t newByteLength);
     Expected<int64_t, GrowFailReason> resize(VM&, size_t newByteLength);
 
-    std::span<const uint8_t> bytes() const { return std::span { static_cast<const uint8_t*>(data()), byteLength() }; }
-    Vector<uint8_t> toVector() const { return { bytes() }; }
+    std::span<const uint8_t> span() const { return { static_cast<const uint8_t*>(data()), byteLength() }; }
+    Vector<uint8_t> toVector() const { return { span() }; }
 
 private:
     static Ref<ArrayBuffer> create(size_t numElements, unsigned elementByteSize, ArrayBufferContents::InitializationPolicy);

--- a/Source/JavaScriptCore/runtime/ArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/ArrayBufferView.h
@@ -77,7 +77,8 @@ public:
     }
 
     void* data() const { return baseAddress(); }
-    std::span<const uint8_t> bytes() const { return { static_cast<const uint8_t*>(data()), byteLength() }; }
+    std::span<const uint8_t> span() const { return { static_cast<const uint8_t*>(data()), byteLength() }; }
+    Vector<uint8_t> toVector() const { return span(); }
 
     size_t byteOffsetRaw() const { return m_byteOffset; }
 

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -256,7 +256,7 @@ public:
     explicit operator bool() const { return !!m_fileData; }
     const void* data() const { return m_fileData; }
     unsigned size() const { return m_fileSize; }
-    std::span<const uint8_t> toSpan() { return { static_cast<const uint8_t *>(data()), size() }; }
+    std::span<const uint8_t> span() { return { static_cast<const uint8_t *>(data()), size() }; }
 
 #if PLATFORM(COCOA)
     void* leakHandle() { return std::exchange(m_fileData, nullptr); }

--- a/Source/WTF/wtf/SHA1.h
+++ b/Source/WTF/wtf/SHA1.h
@@ -59,7 +59,7 @@ public:
 
     void addBytes(const CString& input)
     {
-        addBytes(input.bytes());
+        addBytes(input.span());
     }
 
     void addBytes(const uint8_t* input, size_t length)

--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -83,7 +83,7 @@ public:
         RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!isHashTableDeletedValue());
     }
 
-    std::span<const uint8_t, 16> toSpan() const
+    std::span<const uint8_t, 16> span() const
     {
         return std::span<const uint8_t, 16> { reinterpret_cast<const uint8_t*>(&m_data), 16 };
     }

--- a/Source/WTF/wtf/cf/VectorCF.h
+++ b/Source/WTF/wtf/cf/VectorCF.h
@@ -160,14 +160,14 @@ template<typename MapLambdaType> Vector<typename LambdaTypeTraits<MapLambdaType>
     return vector;
 }
 
-inline std::span<const uint8_t> toSpan(CFDataRef data)
+inline std::span<const uint8_t> span(CFDataRef data)
 {
     return { reinterpret_cast<const uint8_t*>(CFDataGetBytePtr(data)), Checked<size_t>(CFDataGetLength(data)) };
 }
 
-inline Vector<uint8_t> toVector(CFDataRef data)
+inline Vector<uint8_t> makeVector(CFDataRef data)
 {
-    return toSpan(data);
+    return span(data);
 }
 
 // Conversion function implementations. See also StringCF.cpp.
@@ -188,7 +188,6 @@ inline std::optional<float> makeVectorElement(const float*, CFNumberRef cfNumber
 
 using WTF::createCFArray;
 using WTF::makeVector;
-using WTF::toSpan;
-using WTF::toVector;
+using WTF::span;
 
 #endif // USE(CF)

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -107,12 +107,12 @@ std::pair<String, PlatformFileHandle> openTemporaryFile(StringView prefix, Strin
     ASSERT(temporaryFilePath.last() == '/');
 
     // Append the file name.
-    temporaryFilePath.append(prefix.utf8().bytes());
+    temporaryFilePath.append(prefix.utf8().span());
     temporaryFilePath.append("XXXXXX"_span);
     
     // Append the file name suffix.
     CString suffixUTF8 = suffix.utf8();
-    temporaryFilePath.append(suffixUTF8.bytesInludingNullTerminator());
+    temporaryFilePath.append(suffixUTF8.spanIncludingNullTerminator());
 
     platformFileHandle = mkstemps(temporaryFilePath.data(), suffixUTF8.length());
     if (platformFileHandle == invalidPlatformFileHandle)

--- a/Source/WTF/wtf/cocoa/SpanCocoa.h
+++ b/Source/WTF/wtf/cocoa/SpanCocoa.h
@@ -29,7 +29,7 @@
 
 namespace WTF {
 
-inline std::span<const uint8_t> toSpan(NSData *data)
+inline std::span<const uint8_t> span(NSData *data)
 {
     if (!data)
         return { };
@@ -38,4 +38,4 @@ inline std::span<const uint8_t> toSpan(NSData *data)
 
 } // namespace WTF
 
-using WTF::toSpan;
+using WTF::span;

--- a/Source/WTF/wtf/cocoa/VectorCocoa.h
+++ b/Source/WTF/wtf/cocoa/VectorCocoa.h
@@ -113,13 +113,12 @@ template<typename MapFunctionType> Vector<typename std::invoke_result_t<MapFunct
     return vector;
 }
 
-inline Vector<uint8_t> toVector(NSData *data)
+inline Vector<uint8_t> makeVector(NSData *data)
 {
-    return toSpan(data);
+    return span(data);
 }
 
 } // namespace WTF
 
 using WTF::createNSArray;
 using WTF::makeVector;
-using WTF::toVector;

--- a/Source/WTF/wtf/persistence/PersistentEncoder.h
+++ b/Source/WTF/wtf/persistence/PersistentEncoder.h
@@ -71,7 +71,7 @@ public:
 
     const uint8_t* buffer() const { return m_buffer.data(); }
     size_t bufferSize() const { return m_buffer.size(); }
-    std::span<const uint8_t> bytes() const { return m_buffer.span(); }
+    std::span<const uint8_t> span() const { return m_buffer.span(); }
 
     WTF_EXPORT_PRIVATE static void updateChecksumForData(SHA1&, std::span<const uint8_t>);
     template <typename Type> static void updateChecksumForNumber(SHA1&, Type);

--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -132,7 +132,7 @@ inline Vector<uint8_t> base64EncodeToVector(std::span<const char> input, Base64E
 
 inline Vector<uint8_t> base64EncodeToVector(const CString& input, Base64EncodeMode mode)
 {
-    return base64EncodeToVector(input.bytes(), mode);
+    return base64EncodeToVector(input.span(), mode);
 }
 
 inline Vector<uint8_t> base64EncodeToVector(const void* input, unsigned length, Base64EncodeMode mode)
@@ -157,12 +157,12 @@ inline String base64EncodeToString(std::span<const char> input, Base64EncodeMode
 
 inline String base64EncodeToString(const CString& input, Base64EncodeMode mode)
 {
-    return base64EncodeToString(input.bytes(), mode);
+    return base64EncodeToString(input.span(), mode);
 }
 
 inline String base64EncodeToStringReturnNullIfOverflow(const CString& input, Base64EncodeMode mode)
 {
-    return base64EncodeToStringReturnNullIfOverflow(input.bytes(), mode);
+    return base64EncodeToStringReturnNullIfOverflow(input.span(), mode);
 }
 
 inline String base64EncodeToString(const void* input, unsigned length, Base64EncodeMode mode)
@@ -305,7 +305,7 @@ inline Base64Specification base64Encoded(std::span<const uint8_t> input, Base64E
 
 inline Base64Specification base64Encoded(const CString& input, Base64EncodeMode mode)
 {
-    return base64Encoded(input.bytes(), mode);
+    return base64Encoded(input.span(), mode);
 }
 
 inline Base64Specification base64Encoded(const void* input, unsigned length, Base64EncodeMode mode)

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -78,14 +78,14 @@ public:
 
     const uint8_t* dataAsUInt8Ptr() const { return reinterpret_cast<const uint8_t*>(data()); }
 
-    std::span<const uint8_t> bytes() const
+    std::span<const uint8_t> span() const
     {
         if (m_buffer)
             return { reinterpret_cast<const uint8_t*>(m_buffer->data()), m_buffer->length() };
         return { };
     }
 
-    std::span<const uint8_t> bytesInludingNullTerminator() const
+    std::span<const uint8_t> spanIncludingNullTerminator() const
     {
         if (m_buffer)
             return { reinterpret_cast<const uint8_t*>(m_buffer->data()), m_buffer->length() + 1 };

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -648,7 +648,7 @@ Vector<char> asciiDebug(StringImpl* impl)
         }
     }
     CString narrowString = buffer.toString().ascii();
-    return { narrowString.bytesInludingNullTerminator() };
+    return { narrowString.spanIncludingNullTerminator() };
 }
 
 Vector<char> asciiDebug(String& string)

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
@@ -41,7 +41,7 @@ ClipboardItem::~ClipboardItem() = default;
 
 Ref<Blob> ClipboardItem::blobFromString(ScriptExecutionContext* context, const String& stringData, const String& type)
 {
-    return Blob::create(context, Vector(stringData.utf8().bytes()), Blob::normalizedContentType(type));
+    return Blob::create(context, Vector(stringData.utf8().span()), Blob::normalizedContentType(type));
 }
 
 static ClipboardItem::PresentationStyle clipboardItemPresentationStyle(const PasteboardItemInfo& info)

--- a/Source/WebCore/Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
+++ b/Source/WebCore/Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm
@@ -41,7 +41,7 @@ void ClipboardImageReader::readBuffer(const String&, const String&, Ref<SharedBu
     if (m_mimeType == "image/png"_s) {
         auto image = adoptNS([PAL::allocUIImageInstance() initWithData:buffer->createNSData().get()]);
         if (auto nsData = UIImagePNGRepresentation(image.get()))
-            m_result = Blob::create(m_document.get(), toVector(nsData), m_mimeType);
+            m_result = Blob::create(m_document.get(), makeVector(nsData), m_mimeType);
     }
 }
 

--- a/Source/WebCore/Modules/async-clipboard/mac/ClipboardImageReaderMac.mm
+++ b/Source/WebCore/Modules/async-clipboard/mac/ClipboardImageReaderMac.mm
@@ -41,7 +41,7 @@ void ClipboardImageReader::readBuffer(const String&, const String&, Ref<SharedBu
         if (auto cgImage = [image CGImageForProposedRect:nil context:nil hints:nil]) {
             auto representation = adoptNS([[NSBitmapImageRep alloc] initWithCGImage:cgImage]);
             NSData* nsData = [representation representationUsingType:NSBitmapImageFileTypePNG properties:@{ }];
-            m_result = Blob::create(m_document.get(), toVector(nsData), m_mimeType);
+            m_result = Blob::create(m_document.get(), makeVector(nsData), m_mimeType);
         }
     }
 }

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp
@@ -61,7 +61,7 @@ RefPtr<Uint8Array> CDMSessionClearKey::generateKeyRequest(const String& mimeType
     m_initData = initData;
 
     bool sawError = false;
-    String keyID = PAL::UTF8Encoding().decode(m_initData->bytes(), true, sawError);
+    String keyID = PAL::UTF8Encoding().decode(m_initData->span(), true, sawError);
     if (sawError) {
         errorCode = WebKitMediaKeyError::MEDIA_KEYERR_CLIENT;
         return nullptr;

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -202,13 +202,13 @@ void FetchBody::consumeAsStream(FetchBodyOwner& owner, FetchBodySource& source)
 
 void FetchBody::consumeArrayBuffer(FetchBodyOwner& owner, Ref<DeferredPromise>&& promise)
 {
-    m_consumer.resolveWithData(WTFMove(promise), owner.contentType(), arrayBufferBody().bytes());
+    m_consumer.resolveWithData(WTFMove(promise), owner.contentType(), arrayBufferBody().span());
     m_data = nullptr;
 }
 
 void FetchBody::consumeArrayBufferView(FetchBodyOwner& owner, Ref<DeferredPromise>&& promise)
 {
-    m_consumer.resolveWithData(WTFMove(promise), owner.contentType(), arrayBufferViewBody().bytes());
+    m_consumer.resolveWithData(WTFMove(promise), owner.contentType(), arrayBufferViewBody().span());
     m_data = nullptr;
 }
 
@@ -254,13 +254,13 @@ RefPtr<FormData> FetchBody::bodyAsFormData() const
         return body;
     }
     if (isArrayBuffer())
-        return FormData::create(arrayBufferBody().bytes());
+        return FormData::create(arrayBufferBody().span());
     if (isArrayBufferView())
-        return FormData::create(arrayBufferViewBody().bytes());
+        return FormData::create(arrayBufferViewBody().span());
     if (isFormData())
         return &const_cast<FormData&>(formDataBody());
     if (auto* data = m_consumer.data())
-        return FormData::create(data->makeContiguous()->bytes());
+        return FormData::create(data->makeContiguous()->span());
 
     ASSERT_NOT_REACHED();
     return nullptr;
@@ -290,9 +290,9 @@ FetchBody::TakenData FetchBody::take()
         return SharedBuffer::create(PAL::TextCodecUTF8::encodeUTF8(urlSearchParamsBody().toString()));
 
     if (isArrayBuffer())
-        return SharedBuffer::create(arrayBufferBody().bytes());
+        return SharedBuffer::create(arrayBufferBody().span());
     if (isArrayBufferView())
-        return SharedBuffer::create(arrayBufferViewBody().bytes());
+        return SharedBuffer::create(arrayBufferViewBody().span());
 
     return nullptr;
 }

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -271,7 +271,7 @@ void FetchBodyConsumer::resolveWithData(Ref<DeferredPromise>&& promise, const St
 void FetchBodyConsumer::resolveWithFormData(Ref<DeferredPromise>&& promise, const String& contentType, const FormData& formData, ScriptExecutionContext* context)
 {
     if (auto sharedBuffer = formData.asSharedBuffer()) {
-        resolveWithData(WTFMove(promise), contentType, sharedBuffer->makeContiguous()->bytes());
+        resolveWithData(WTFMove(promise), contentType, sharedBuffer->makeContiguous()->span());
         return;
     }
 
@@ -289,7 +289,7 @@ void FetchBodyConsumer::resolveWithFormData(Ref<DeferredPromise>&& promise, cons
         if (value.empty()) {
             auto protectedPromise = WTFMove(promise);
             auto buffer = builder.takeAsContiguous();
-            resolveWithData(WTFMove(protectedPromise), contentType, buffer->bytes());
+            resolveWithData(WTFMove(protectedPromise), contentType, buffer->span());
             return;
         }
 
@@ -348,7 +348,7 @@ void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& co
             if (!chunk) {
                 auto protectedPromise = WTFMove(promise);
                 auto buffer = data.takeAsContiguous();
-                resolveWithTypeAndData(WTFMove(protectedPromise), type, contentType, buffer->bytes());
+                resolveWithTypeAndData(WTFMove(protectedPromise), type, contentType, buffer->span());
                 return;
             }
 
@@ -383,7 +383,7 @@ void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& co
         return;
     case FetchBodyConsumer::Type::FormData: {
         auto buffer = takeData();
-        if (auto formData = packageFormData(promise->scriptExecutionContext(), contentType, buffer ? buffer->makeContiguous()->bytes() : std::span<const uint8_t> { }))
+        if (auto formData = packageFormData(promise->scriptExecutionContext(), contentType, buffer ? buffer->makeContiguous()->span() : std::span<const uint8_t> { }))
             promise->resolve<IDLInterface<DOMFormData>>(*formData);
         else
             promise->reject(ExceptionCode::TypeError);
@@ -438,7 +438,7 @@ String FetchBodyConsumer::takeAsText()
         return String();
 
     auto buffer = m_buffer.takeAsContiguous();
-    auto text = TextResourceDecoder::textFromUTF8(buffer->bytes());
+    auto text = TextResourceDecoder::textFromUTF8(buffer->span());
     return text;
 }
 

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -366,7 +366,7 @@ void FetchResponse::Loader::didReceiveData(const SharedBuffer& buffer)
     ASSERT(m_response.m_readableStreamSource || m_consumeDataCallback);
 
     if (m_consumeDataCallback) {
-        auto chunk = buffer.bytes();
+        auto chunk = buffer.span();
         m_consumeDataCallback(&chunk);
         return;
     }
@@ -422,7 +422,7 @@ void FetchResponse::Loader::consumeDataByChunk(ConsumeDataByChunkCallback&& cons
         return;
 
     auto contiguousBuffer = data->makeContiguous();
-    auto chunk = contiguousBuffer->bytes();
+    auto chunk = contiguousBuffer->span();
     m_consumeDataCallback(&chunk);
 }
 

--- a/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FormDataConsumer.cpp
@@ -105,7 +105,7 @@ void FormDataConsumer::consumeBlob(const URL& blobURL)
         }
 
         if (auto data = loader->arrayBufferResult())
-            weakThis->consume(data->bytes());
+            weakThis->consume(data->span());
     });
 
     m_blobLoader->start(blobURL, m_context.get(), FileReaderLoader::ReadAsArrayBuffer);

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -696,7 +696,7 @@ bool SQLiteIDBBackingStore::addExistingIndex(IDBObjectStoreInfo& objectStoreInfo
             || sql->bindInt64(1, info.identifier()) != SQLITE_OK
             || sql->bindText(2, info.name()) != SQLITE_OK
             || sql->bindInt64(3, info.objectStoreIdentifier()) != SQLITE_OK
-            || sql->bindBlob(4, keyPathBlob->bytes()) != SQLITE_OK
+            || sql->bindBlob(4, keyPathBlob->span()) != SQLITE_OK
             || sql->bindInt(5, info.unique()) != SQLITE_OK
             || sql->bindInt(6, info.multiEntry()) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
@@ -1170,7 +1170,7 @@ IDBError SQLiteIDBBackingStore::createObjectStore(const IDBResourceIdentifier& t
         if (!sql
             || sql->bindInt64(1, info.identifier()) != SQLITE_OK
             || sql->bindText(2, info.name()) != SQLITE_OK
-            || sql->bindBlob(3, keyPathBlob->bytes()) != SQLITE_OK
+            || sql->bindBlob(3, keyPathBlob->span()) != SQLITE_OK
             || sql->bindInt(4, info.autoIncrement()) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
             LOG_ERROR("Could not add object store '%s' to ObjectStoreInfo table (%i) - %s", info.name().utf8().data(), m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
@@ -1384,7 +1384,7 @@ IDBError SQLiteIDBBackingStore::createIndex(const IDBResourceIdentifier& transac
             || sql->bindInt64(1, info.identifier()) != SQLITE_OK
             || sql->bindText(2, info.name()) != SQLITE_OK
             || sql->bindInt64(3, info.objectStoreIdentifier()) != SQLITE_OK
-            || sql->bindBlob(4, keyPathBlob->bytes()) != SQLITE_OK
+            || sql->bindBlob(4, keyPathBlob->span()) != SQLITE_OK
             || sql->bindInt(5, info.unique()) != SQLITE_OK
             || sql->bindInt(6, info.multiEntry()) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
@@ -1458,7 +1458,7 @@ IDBError SQLiteIDBBackingStore::uncheckedHasIndexRecord(const IDBIndexInfo& info
     auto sql = cachedStatement(SQL::HasIndexRecord, "SELECT rowid FROM IndexRecords WHERE indexID = ? AND key = CAST(? AS TEXT);"_s);
     if (!sql
         || sql->bindInt64(1, info.identifier()) != SQLITE_OK
-        || sql->bindBlob(2, indexKeyBuffer->bytes()) != SQLITE_OK) {
+        || sql->bindBlob(2, indexKeyBuffer->span()) != SQLITE_OK) {
         LOG_ERROR("Error checking for index record in database");
         return IDBError { ExceptionCode::UnknownError, "Error checking for index record in database"_s };
     }
@@ -1535,8 +1535,8 @@ IDBError SQLiteIDBBackingStore::uncheckedPutIndexRecord(int64_t objectStoreID, i
         if (!sql
             || sql->bindInt64(1, indexID) != SQLITE_OK
             || sql->bindInt64(2, objectStoreID) != SQLITE_OK
-            || sql->bindBlob(3, indexKeyBuffer->bytes()) != SQLITE_OK
-            || sql->bindBlob(4, valueBuffer->bytes()) != SQLITE_OK
+            || sql->bindBlob(3, indexKeyBuffer->span()) != SQLITE_OK
+            || sql->bindBlob(4, valueBuffer->span()) != SQLITE_OK
             || sql->bindInt64(5, recordID) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
             LOG_ERROR("Could not put index record for index %" PRIi64 " in object store %" PRIi64 " in Records table (%i) - %s", indexID, objectStoreID, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
@@ -1655,7 +1655,7 @@ IDBError SQLiteIDBBackingStore::keyExistsInObjectStore(const IDBResourceIdentifi
     auto sql = cachedStatement(SQL::KeyExistsInObjectStore, "SELECT key FROM Records WHERE objectStoreID = ? AND key = CAST(? AS TEXT) LIMIT 1;"_s);
     if (!sql
         || sql->bindInt64(1, objectStoreID) != SQLITE_OK
-        || sql->bindBlob(2, keyBuffer->bytes()) != SQLITE_OK) {
+        || sql->bindBlob(2, keyBuffer->span()) != SQLITE_OK) {
         LOG_ERROR("Could not get record from object store %" PRIi64 " from Records table (%i) - %s", objectStoreID, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
         return IDBError { ExceptionCode::UnknownError, "Unable to check for existence of IDBKey in object store"_s };
     }
@@ -1741,7 +1741,7 @@ IDBError SQLiteIDBBackingStore::deleteRecord(SQLiteIDBTransaction& transaction, 
 
         if (!sql
             || sql->bindInt64(1, objectStoreID) != SQLITE_OK
-            || sql->bindBlob(2, keyBuffer->bytes()) != SQLITE_OK) {
+            || sql->bindBlob(2, keyBuffer->span()) != SQLITE_OK) {
             LOG_ERROR("Could not delete record from object store %" PRIi64 " (%i) - %s", objectStoreID, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
             return IDBError { ExceptionCode::UnknownError, "Failed to delete record from object store"_s };
         }
@@ -1788,7 +1788,7 @@ IDBError SQLiteIDBBackingStore::deleteRecord(SQLiteIDBTransaction& transaction, 
 
         if (!sql
             || sql->bindInt64(1, objectStoreID) != SQLITE_OK
-            || sql->bindBlob(2, keyBuffer->bytes()) != SQLITE_OK
+            || sql->bindBlob(2, keyBuffer->span()) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
             LOG_ERROR("Could not delete record from object store %" PRIi64 " (%i) - %s", objectStoreID, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
             return IDBError { ExceptionCode::UnknownError, "Failed to delete record from object store"_s };
@@ -1959,7 +1959,7 @@ IDBError SQLiteIDBBackingStore::addRecord(const IDBResourceIdentifier& transacti
         auto sql = cachedStatement(SQL::AddObjectStoreRecord, "INSERT INTO Records VALUES (?, CAST(? AS TEXT), ?, NULL);"_s);
         if (!sql
             || sql->bindInt64(1, objectStoreInfo.identifier()) != SQLITE_OK
-            || sql->bindBlob(2, keyBuffer->bytes()) != SQLITE_OK
+            || sql->bindBlob(2, keyBuffer->span()) != SQLITE_OK
             || sql->bindBlob(3, *value.data().data()) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
             LOG_ERROR("Could not put record for object store %" PRIi64 " in Records table (%i) - %s", objectStoreInfo.identifier(), m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
@@ -1975,7 +1975,7 @@ IDBError SQLiteIDBBackingStore::addRecord(const IDBResourceIdentifier& transacti
         auto sql = cachedStatement(SQL::DeleteObjectStoreRecord, "DELETE FROM Records WHERE objectStoreID = ? AND key = CAST(? AS TEXT);"_s);
         if (!sql
             || sql->bindInt64(1, objectStoreInfo.identifier()) != SQLITE_OK
-            || sql->bindBlob(2, keyBuffer->bytes()) != SQLITE_OK
+            || sql->bindBlob(2, keyBuffer->span()) != SQLITE_OK
             || sql->step() != SQLITE_DONE) {
             LOG_ERROR("Indexing new object store record failed, but unable to remove the object store record itself");
             return IDBError { ExceptionCode::UnknownError, "Indexing new object store record failed, but unable to remove the object store record itself"_s };
@@ -2160,8 +2160,8 @@ IDBError SQLiteIDBBackingStore::getRecord(const IDBResourceIdentifier& transacti
 
         if (!sql
             || sql->bindInt64(1, objectStoreID) != SQLITE_OK
-            || sql->bindBlob(2, lowerBuffer->bytes()) != SQLITE_OK
-            || sql->bindBlob(3, upperBuffer->bytes()) != SQLITE_OK) {
+            || sql->bindBlob(2, lowerBuffer->span()) != SQLITE_OK
+            || sql->bindBlob(3, upperBuffer->span()) != SQLITE_OK) {
             LOG_ERROR("Could not get key range record from object store %" PRIi64 " from Records table (%i) - %s", objectStoreID, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
             return IDBError { ExceptionCode::UnknownError, "Failed to look up record in object store by key range"_s };
         }
@@ -2277,8 +2277,8 @@ IDBError SQLiteIDBBackingStore::getAllObjectStoreRecords(const IDBResourceIdenti
     auto sql = cachedStatementForGetAllObjectStoreRecords(getAllRecordsData);
     if (!sql
         || sql->bindInt64(1, getAllRecordsData.objectStoreIdentifier) != SQLITE_OK
-        || sql->bindBlob(2, lowerBuffer->bytes()) != SQLITE_OK
-        || sql->bindBlob(3, upperBuffer->bytes()) != SQLITE_OK) {
+        || sql->bindBlob(2, lowerBuffer->span()) != SQLITE_OK
+        || sql->bindBlob(3, upperBuffer->span()) != SQLITE_OK) {
         LOG_ERROR("Could not get key range record from object store %" PRIi64 " from Records table (%i) - %s", getAllRecordsData.objectStoreIdentifier, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
         return IDBError { ExceptionCode::UnknownError, "Failed to look up record in object store by key range"_s };
     }
@@ -2443,7 +2443,7 @@ IDBError SQLiteIDBBackingStore::uncheckedGetIndexRecordForOneKey(int64_t indexID
 
     if (!sql
         || sql->bindInt64(1, indexID) != SQLITE_OK
-        || sql->bindBlob(2, buffer->bytes()) != SQLITE_OK) {
+        || sql->bindBlob(2, buffer->span()) != SQLITE_OK) {
         LOG_ERROR("Unable to lookup index record in database");
         return IDBError { ExceptionCode::UnknownError, "Unable to lookup index record in database"_s };
     }
@@ -2525,8 +2525,8 @@ IDBError SQLiteIDBBackingStore::getCount(const IDBResourceIdentifier& transactio
         
         if (!statement
             || statement->bindInt64(1, objectStoreIdentifier) != SQLITE_OK
-            || statement->bindBlob(2, lowerBuffer->bytes()) != SQLITE_OK
-            || statement->bindBlob(3, upperBuffer->bytes()) != SQLITE_OK) {
+            || statement->bindBlob(2, lowerBuffer->span()) != SQLITE_OK
+            || statement->bindBlob(3, upperBuffer->span()) != SQLITE_OK) {
             LOG_ERROR("Could not count records in object store %" PRIi64 " from Records table (%i) - %s", objectStoreIdentifier, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
             return IDBError { ExceptionCode::UnknownError, "Unable to count records in object store due to binding failure"_s };
         }
@@ -2542,8 +2542,8 @@ IDBError SQLiteIDBBackingStore::getCount(const IDBResourceIdentifier& transactio
 
         if (!statement
             || statement->bindInt64(1, indexIdentifier) != SQLITE_OK
-            || statement->bindBlob(2, lowerBuffer->bytes()) != SQLITE_OK
-            || statement->bindBlob(3, upperBuffer->bytes()) != SQLITE_OK) {
+            || statement->bindBlob(2, lowerBuffer->span()) != SQLITE_OK
+            || statement->bindBlob(3, upperBuffer->span()) != SQLITE_OK) {
             LOG_ERROR("Could not count records with index %" PRIi64 " from IndexRecords table (%i) - %s", indexIdentifier, m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
             return IDBError { ExceptionCode::UnknownError, "Unable to count records for index due to binding failure"_s };
         }

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
@@ -272,13 +272,13 @@ bool SQLiteIDBCursor::bindArguments()
     }
 
     auto buffer = serializeIDBKeyData(m_currentLowerKey);
-    if (m_statement->bindBlob(currentBindArgument++, buffer->bytes()) != SQLITE_OK) {
+    if (m_statement->bindBlob(currentBindArgument++, buffer->span()) != SQLITE_OK) {
         LOG_ERROR("Could not create cursor statement (lower key)");
         return false;
     }
 
     buffer = serializeIDBKeyData(m_currentUpperKey);
-    if (m_statement->bindBlob(currentBindArgument++, buffer->bytes()) != SQLITE_OK) {
+    if (m_statement->bindBlob(currentBindArgument++, buffer->span()) != SQLITE_OK) {
         LOG_ERROR("Could not create cursor statement (upper key)");
         return false;
     }
@@ -318,13 +318,13 @@ bool SQLiteIDBCursor::resetAndRebindPreIndexStatementIfNecessary()
     }
 
     auto buffer = serializeIDBKeyData(key);
-    if (m_preIndexStatement->bindBlob(currentBindArgument++, buffer->bytes()) != SQLITE_OK) {
+    if (m_preIndexStatement->bindBlob(currentBindArgument++, buffer->span()) != SQLITE_OK) {
         LOG_ERROR("Could not bind id argument to pre statement (key)");
         return false;
     }
 
     buffer = serializeIDBKeyData(m_currentIndexRecordValue);
-    if (m_preIndexStatement->bindBlob(currentBindArgument++, buffer->bytes()) != SQLITE_OK) {
+    if (m_preIndexStatement->bindBlob(currentBindArgument++, buffer->span()) != SQLITE_OK) {
         LOG_ERROR("Could not bind id argument to pre statement (value)");
         return false;
     }

--- a/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedFrame.cpp
@@ -55,7 +55,7 @@ void RTCEncodedFrame::setData(JSC::ArrayBuffer& buffer)
 Ref<RTCRtpTransformableFrame> RTCEncodedFrame::rtcFrame()
 {
     if (m_data) {
-        m_frame->setData(m_data->bytes());
+        m_frame->setData(m_data->span());
         m_data = nullptr;
     }
     return m_frame;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -243,9 +243,9 @@ ExceptionOr<void> RTCRtpSFrameTransform::createStreams()
         }, [&](RefPtr<RTCEncodedVideoFrame>& value) {
             transformFrame(*value, globalObject, transformer.get(), *readableStreamSource, context.identifier(), weakThis);
         }, [&](RefPtr<ArrayBuffer>& value) {
-            transformFrame(value->bytes(), globalObject, transformer.get(), *readableStreamSource, context.identifier(), weakThis);
+            transformFrame(value->span(), globalObject, transformer.get(), *readableStreamSource, context.identifier(), weakThis);
         }, [&](RefPtr<ArrayBufferView>& value) {
-            transformFrame(value->bytes(), globalObject, transformer.get(), *readableStreamSource, context.identifier(), weakThis);
+            transformFrame(value->span(), globalObject, transformer.get(), *readableStreamSource, context.identifier(), weakThis);
         });
         return { };
     }));

--- a/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
@@ -90,7 +90,7 @@ std::optional<NotificationData> NotificationData::fromDictionary(NSDictionary *d
         return std::nullopt;
     }
 
-    NotificationData data { URL { String { defaultActionURL } }, title, body, iconURL, tag, language, direction, originString, URL { String { serviceWorkerRegistrationURL } }, *uuid, contextIdentifier, PAL::SessionID { sessionID.unsignedLongLongValue }, { }, toVector(notificationData), nsValueToOptionalBool(dictionary[WebNotificationSilentKey]) };
+    NotificationData data { URL { String { defaultActionURL } }, title, body, iconURL, tag, language, direction, originString, URL { String { serviceWorkerRegistrationURL } }, *uuid, contextIdentifier, PAL::SessionID { sessionID.unsignedLongLongValue }, { }, makeVector(notificationData), nsValueToOptionalBool(dictionary[WebNotificationSilentKey]) };
     return WTFMove(data);
 }
 

--- a/Source/WebCore/Modules/push-api/PushDatabase.cpp
+++ b/Source/WebCore/Modules/push-api/PushDatabase.cpp
@@ -349,7 +349,7 @@ static std::span<const uint8_t> uuidToSpan(const std::optional<WTF::UUID>& uuid)
         return std::span(&junk, static_cast<size_t>(0));
     }
 
-    return uuid->toSpan();
+    return uuid->span();
 }
 
 static std::optional<WTF::UUID> uuidFromSpan(std::span<const uint8_t> span)

--- a/Source/WebCore/Modules/push-api/PushEvent.cpp
+++ b/Source/WebCore/Modules/push-api/PushEvent.cpp
@@ -41,13 +41,13 @@ static Vector<uint8_t> dataFromPushMessageDataInit(PushMessageDataInit& data)
     return WTF::switchOn(data, [](RefPtr<JSC::ArrayBuffer>& value) -> Vector<uint8_t> {
         if (!value)
             return { };
-        return value->bytes();
+        return value->span();
     }, [](RefPtr<JSC::ArrayBufferView>& value) -> Vector<uint8_t> {
         if (!value)
             return { };
-        return value->bytes();
+        return value->span();
     }, [](String& value) -> Vector<uint8_t> {
-        return value.utf8().bytes();
+        return value.utf8().span();
     });
 }
 

--- a/Source/WebCore/Modules/push-api/PushManager.cpp
+++ b/Source/WebCore/Modules/push-api/PushManager.cpp
@@ -86,9 +86,9 @@ void PushManager::subscribe(ScriptExecutionContext& context, std::optional<PushS
 
         using KeyDataResult = ExceptionOr<Vector<uint8_t>>;
         auto keyDataResult = WTF::switchOn(*options->applicationServerKey, [](RefPtr<JSC::ArrayBuffer>& value) -> KeyDataResult {
-            return value ? Vector<uint8_t>(value->bytes()) : Vector<uint8_t>();
+            return value ? value->toVector() : Vector<uint8_t>();
         }, [](RefPtr<JSC::ArrayBufferView>& value) -> KeyDataResult {
-            return value ? Vector<uint8_t>(value->bytes()) : Vector<uint8_t>();
+            return value ? value->toVector() : Vector<uint8_t>();
         }, [](String& value) -> KeyDataResult {
             auto decoded = base64URLDecode(value);
             if (!decoded)

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -48,7 +48,7 @@ Vector<uint8_t> produceRpIdHash(const String& rpId)
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto rpIdUTF8 = rpId.utf8();
-    crypto->addBytes(rpIdUTF8.bytes());
+    crypto->addBytes(rpIdUTF8.span());
     return crypto->computeHash();
 }
 

--- a/Source/WebCore/Modules/webauthn/cbor/CBORValue.cpp
+++ b/Source/WebCore/Modules/webauthn/cbor/CBORValue.cpp
@@ -103,7 +103,7 @@ CBORValue::CBORValue(BinaryValue&& inBytes)
 
 CBORValue::CBORValue(const WebCore::BufferSource& bufferSource)
     : m_type(Type::ByteString)
-    , m_byteStringValue(bufferSource.bytes())
+    , m_byteStringValue(bufferSource.span())
 {
 }
 

--- a/Source/WebCore/Modules/webauthn/cbor/CBORWriter.cpp
+++ b/Source/WebCore/Modules/webauthn/cbor/CBORWriter.cpp
@@ -88,7 +88,7 @@ bool CBORWriter::encodeCBOR(const CBORValue& node, int maxNestingLevel)
         auto utf8String = node.getString().utf8();
         startItem(CBORValue::Type::String, static_cast<uint64_t>(utf8String.length()));
         // Add the characters.
-        m_encodedCBOR->append(utf8String.bytes());
+        m_encodedCBOR->append(utf8String.span());
         return true;
     }
     // Represents an array.

--- a/Source/WebCore/Modules/webauthn/fido/Pin.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.cpp
@@ -261,7 +261,7 @@ std::optional<TokenRequest> TokenRequest::tryCreate(const CString& pin, const Cr
 
     // The following calculates a SHA-256 digest of the PIN, and shrink to the left 16 bytes.
     crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    crypto->addBytes(pin.bytes());
+    crypto->addBytes(pin.span());
     auto pinHash = crypto->computeHash();
     pinHash.shrink(16);
 
@@ -327,7 +327,7 @@ std::optional<SetPinRequest> SetPinRequest::tryCreate(const String& inputPin, co
     const size_t minPaddedPinLength = 64;
     Vector<uint8_t> paddedPin;
     paddedPin.reserveInitialCapacity(minPaddedPinLength);
-    paddedPin.append(inputPin.utf8().bytes());
+    paddedPin.append(inputPin.utf8().span());
     for (int i = paddedPin.size(); i < 64; i++)
         paddedPin.append('\0');
 

--- a/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
@@ -71,7 +71,7 @@ static std::optional<Vector<uint8_t>> constructU2fSignCommand(const Vector<uint8
     data.appendVector(challengeParameter);
     data.appendVector(applicationParameter);
     data.append(static_cast<uint8_t>(keyHandle.length()));
-    data.append(keyHandle.bytes());
+    data.append(keyHandle.span());
 
     apdu::ApduCommand command;
     command.setIns(static_cast<uint8_t>(U2fApduInstruction::kSign));

--- a/Source/WebCore/Modules/webauthn/fido/U2fResponseConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/U2fResponseConverter.cpp
@@ -178,7 +178,7 @@ RefPtr<AuthenticatorAssertionResponse> readU2fSignResponse(const String& rpId, c
 
     // FIXME: Find a way to remove the need of constructing a vector here.
     auto signature = u2fData.subvector(signatureIndex);
-    Vector<uint8_t> keyHandleVector { keyHandle.bytes() };
+    Vector<uint8_t> keyHandleVector { keyHandle.span() };
     return AuthenticatorAssertionResponse::create(keyHandleVector, authData, signature, { }, attachment);
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
@@ -43,7 +43,7 @@ ExceptionOr<Ref<WebCodecsAudioData>> WebCodecsAudioData::create(ScriptExecutionC
     if (!isValidAudioDataInit(init))
         return Exception { ExceptionCode::TypeError, "Invalid init data"_s };
 
-    auto rawData = init.data.bytes();
+    auto rawData = init.data.span();
     auto data = PlatformRawAudioData::create(WTFMove(rawData), init.format, init.sampleRate, init.timestamp, init.numberOfFrames, init.numberOfChannels);
 
     if (!data)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 WebCodecsEncodedAudioChunk::WebCodecsEncodedAudioChunk(Init&& init)
-    : m_storage { WebCodecsEncodedAudioChunkStorage::create(init.type, init.timestamp, init.duration, init.data.bytes()) }
+    : m_storage { WebCodecsEncodedAudioChunkStorage::create(init.type, init.timestamp, init.duration, init.data.span()) }
 {
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 WebCodecsEncodedVideoChunk::WebCodecsEncodedVideoChunk(Init&& init)
-    : m_storage { WebCodecsEncodedVideoChunkStorage::create(init.type, init.timestamp, init.duration, init.data.bytes()) }
+    : m_storage { WebCodecsEncodedVideoChunkStorage::create(init.type, init.timestamp, init.duration, init.data.span()) }
 {
 }
 

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -560,7 +560,7 @@ void WebSocket::didReceiveMessage(String&& message)
         if (UNLIKELY(InspectorInstrumentation::hasFrontends())) {
             if (auto* inspector = m_channel->channelInspector()) {
                 auto utf8Message = message.utf8();
-                inspector->didReceiveWebSocketFrame(WebSocketChannelInspector::createFrame(utf8Message.bytes(), WebSocketFrame::OpCode::OpCodeText));
+                inspector->didReceiveWebSocketFrame(WebSocketChannelInspector::createFrame(utf8Message.span(), WebSocketFrame::OpCode::OpCodeText));
             }
         }
         ASSERT(scriptExecutionContext());

--- a/Source/WebCore/Modules/websockets/WebSocketDeflateFramer.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflateFramer.cpp
@@ -165,7 +165,7 @@ std::unique_ptr<DeflateResultHolder> WebSocketDeflateFramer::deflate(WebSocketFr
         return result;
     }
     frame.compress = true;
-    frame.payload = m_deflater->bytes();
+    frame.payload = m_deflater->span();
     return result;
 }
 
@@ -193,7 +193,7 @@ std::unique_ptr<InflateResultHolder> WebSocketDeflateFramer::inflate(WebSocketFr
         return result;
     }
     frame.compress = false;
-    frame.payload = m_inflater->bytes();
+    frame.payload = m_inflater->span();
     return result;
 }
 

--- a/Source/WebCore/Modules/websockets/WebSocketDeflater.h
+++ b/Source/WebCore/Modules/websockets/WebSocketDeflater.h
@@ -53,7 +53,7 @@ public:
     bool finish();
     const uint8_t* data() { return m_buffer.data(); }
     size_t size() const { return m_buffer.size(); }
-    std::span<const uint8_t> bytes() const { return m_buffer.span(); }
+    std::span<const uint8_t> span() const { return m_buffer.span(); }
     void reset();
 
 private:
@@ -74,7 +74,7 @@ public:
     bool finish();
     const uint8_t* data() const { return m_buffer.data(); }
     size_t size() const { return m_buffer.size(); }
-    std::span<const uint8_t> bytes() const { return m_buffer.span(); }
+    std::span<const uint8_t> span() const { return m_buffer.span(); }
     void reset();
 
 private:

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -103,7 +103,7 @@ String WebSocketHandshake::getExpectedWebSocketAccept(const String& secWebSocket
     constexpr uint8_t webSocketKeyGUID[] = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
     SHA1 sha1;
     CString keyData = secWebSocketKey.ascii();
-    sha1.addBytes(keyData.bytes());
+    sha1.addBytes(keyData.span());
     sha1.addBytes(webSocketKeyGUID, std::size(webSocketKeyGUID) - 1);
     SHA1::Digest hash;
     sha1.computeHash(hash);

--- a/Source/WebCore/Modules/webtransport/DatagramSink.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramSink.cpp
@@ -53,7 +53,7 @@ void DatagramSink::write(ScriptExecutionContext& context, JSC::JSValue value, DO
         return promise.settle(Exception { ExceptionCode::ExistingExceptionError });
 
     WTF::switchOn(arrayBufferOrView, [&](auto& arrayBufferOrView) {
-        send(arrayBufferOrView->bytes(), [promise = WTFMove(promise)] () mutable {
+        send(arrayBufferOrView->span(), [promise = WTFMove(promise)] () mutable {
             // FIXME: Reject if sending failed.
             promise.resolve();
         });

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -760,7 +760,7 @@ std::span<const uint8_t> AXRemoteFrame::generateRemoteToken() const
     if (auto* parent = parentObject()) {
         // We use the parent's wrapper so that the remote frame acts as a pass through for the remote token bridge.
         NSData *data = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:parent->wrapper()];
-        return toSpan(data);
+        return span(data);
     }
 
     return std::span<const uint8_t> { };

--- a/Source/WebCore/bindings/js/BufferSource.h
+++ b/Source/WebCore/bindings/js/BufferSource.h
@@ -73,7 +73,7 @@ public:
         }, m_variant);
     }
 
-    std::span<const uint8_t> bytes() const { return { data(), length() }; }
+    std::span<const uint8_t> span() const { return { data(), length() }; }
 
 private:
     VariantType m_variant;
@@ -87,7 +87,7 @@ inline BufferSource toBufferSource(std::span<const uint8_t> data)
 #if PLATFORM(COCOA) && defined(__OBJC__)
 inline BufferSource toBufferSource(NSData *data)
 {
-    return BufferSource(JSC::ArrayBuffer::tryCreate(toSpan(data)));
+    return BufferSource(JSC::ArrayBuffer::tryCreate(span(data)));
 }
 
 inline RetainPtr<NSData> toNSData(const BufferSource& data)

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -569,7 +569,7 @@ static JSC::JSPromise* handleResponseOnStreamingAction(JSC::JSGlobalObject* glob
     WTF::switchOn(body, [&](Ref<FormData>&) {
         RELEASE_ASSERT_NOT_REACHED();
     }, [&](Ref<SharedBuffer>& buffer) {
-        compiler->addBytes(buffer->bytes());
+        compiler->addBytes(buffer->span());
         compiler->finalize(globalObject);
     }, [&](std::nullptr_t&) {
         compiler->finalize(globalObject);

--- a/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
@@ -64,7 +64,7 @@ public:
         if (!m_containsOnlyASCII) {
             m_containsOnlyASCII = charactersAreAllASCII(m_contiguousBuffer->data(), m_contiguousBuffer->size());
             if (*m_containsOnlyASCII)
-                m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(m_contiguousBuffer->bytes());
+                m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(m_contiguousBuffer->span());
         }
         if (*m_containsOnlyASCII)
             return { m_contiguousBuffer->data(), static_cast<unsigned>(m_contiguousBuffer->size()) };

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1611,7 +1611,7 @@ private:
             return;
         }
         write(byteLength);
-        write(arrayBuffer->bytes());
+        write(arrayBuffer->span());
     }
 
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
@@ -1854,7 +1854,7 @@ private:
                     return true;
                 }
                 write(dataLength);
-                write(data->data().bytes());
+                write(data->data().span());
                 write(data->colorSpace());
                 return true;
             }
@@ -1975,7 +1975,7 @@ private:
                     write(byteLength);
                     uint64_t maxByteLength = arrayBuffer->maxByteLength().value_or(0);
                     write(maxByteLength);
-                    write(arrayBuffer->bytes());
+                    write(arrayBuffer->span());
                     return true;
                 }
 
@@ -1983,7 +1983,7 @@ private:
                 write(ArrayBufferTag);
                 uint64_t byteLength = arrayBuffer->byteLength();
                 write(byteLength);
-                write(arrayBuffer->bytes());
+                write(arrayBuffer->span());
                 return true;
             }
             if (obj->inherits<JSArrayBufferView>()) {
@@ -2378,9 +2378,9 @@ private:
 #if PLATFORM(COCOA)
     void write(const RetainPtr<CFDataRef>& data)
     {
-        auto span = toSpan(data.get());
-        write(static_cast<uint32_t>(span.size()));
-        write(span);
+        auto dataSpan = span(data.get());
+        write(static_cast<uint32_t>(dataSpan.size()));
+        write(dataSpan);
     }
 #endif
 

--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -48,7 +48,7 @@ static void append(Vector<uint8_t>& vector, size_t length)
 
 static void append(Vector<uint8_t>& vector, const CString& string)
 {
-    vector.append(string.bytes());
+    vector.append(string.span());
 }
 
 static size_t deserializeLength(std::span<const uint8_t> span, size_t offset)

--- a/Source/WebCore/contentextensions/ContentExtensionStringSerialization.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionStringSerialization.cpp
@@ -42,7 +42,7 @@ void serializeString(Vector<uint8_t>& actions, const String& string)
     uint32_t serializedLength = sizeof(uint32_t) + utf8.length();
     actions.reserveCapacity(actions.size() + serializedLength);
     actions.append(std::span { reinterpret_cast<const uint8_t*>(&serializedLength), sizeof(serializedLength) });
-    actions.append(utf8.bytes());
+    actions.append(utf8.span());
 }
 
 size_t stringSerializedLength(std::span<const uint8_t> span)

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -545,7 +545,7 @@ static std::optional<KeyData> toKeyData(SubtleCrypto::KeyFormat format, SubtleCr
                 return std::nullopt;
             },
             [] (auto& bufferSource) -> std::optional<KeyData> {
-                return KeyData { Vector(bufferSource->bytes()) };
+                return KeyData { Vector(bufferSource->span()) };
             }
         );
     case SubtleCrypto::KeyFormat::Jwk:
@@ -566,7 +566,7 @@ static std::optional<KeyData> toKeyData(SubtleCrypto::KeyFormat format, SubtleCr
 
 static Vector<uint8_t> copyToVector(BufferSource&& data)
 {
-    return data.bytes();
+    return data.span();
 }
 
 static bool isSupportedExportKey(JSGlobalObject& state, CryptoAlgorithmIdentifier identifier)
@@ -1129,7 +1129,7 @@ void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoK
             // FIXME: Converting to JS just to JSON-Stringify seems inefficient. We should find a way to go directly from the struct to JSON.
             auto jwk = toJS<IDLDictionary<JsonWebKey>>(*(promise->globalObject()), *(promise->globalObject()), WTFMove(std::get<JsonWebKey>(key)));
             String jwkString = JSONStringify(promise->globalObject(), jwk, 0);
-            bytes.append(jwkString.utf8(StrictConversion).bytes());
+            bytes.append(jwkString.utf8(StrictConversion).span());
         }
         }
 

--- a/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
+++ b/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
@@ -255,7 +255,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!serialization)
         return false;
 
-    result = toVector(serialization);
+    result = makeVector(serialization);
     return true;
 }
 
@@ -276,17 +276,17 @@ bool unwrapSerializedCryptoKey(const Vector<uint8_t>& masterKey, const Vector<ui
     id wrappedKEKObject = [dictionary objectForKey:wrappedKEKKey];
     if (![wrappedKEKObject isKindOfClass:[NSData class]])
         return false;
-    Vector<uint8_t> wrappedKEK = toVector(wrappedKEKObject);
+    auto wrappedKEK = span(wrappedKEKObject);
 
     id encryptedKeyObject = [dictionary objectForKey:encryptedKeyKey];
     if (![encryptedKeyObject isKindOfClass:[NSData class]])
         return false;
-    Vector<uint8_t> encryptedKey = toVector(encryptedKeyObject);
+    auto encryptedKey = span(encryptedKeyObject);
 
     id tagObject = [dictionary objectForKey:tagKey];
     if (![tagObject isKindOfClass:[NSData class]])
         return false;
-    Vector<uint8_t> tag = toVector(tagObject);
+    auto tag = span(tagObject);
     if (tag.size() != 16)
         return false;
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h
@@ -42,7 +42,7 @@ public:
         if (!m_ivVector.isEmpty() || !iv.length())
             return m_ivVector;
 
-        m_ivVector.append(iv.bytes());
+        m_ivVector.append(iv.span());
         return m_ivVector;
     }
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h
@@ -43,7 +43,7 @@ public:
         if (!m_counterVector.isEmpty() || !counter.length())
             return m_counterVector;
 
-        m_counterVector.append(counter.bytes());
+        m_counterVector.append(counter.span());
         return m_counterVector;
     }
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h
@@ -45,7 +45,7 @@ public:
         if (!m_ivVector.isEmpty() || !iv.length())
             return m_ivVector;
 
-        m_ivVector.append(iv.bytes());
+        m_ivVector.append(iv.span());
         return m_ivVector;
     }
 
@@ -59,7 +59,7 @@ public:
         if (!additionalDataBuffer.length())
             return m_additionalDataVector;
 
-        m_additionalDataVector.append(additionalDataBuffer.bytes());
+        m_additionalDataVector.append(additionalDataBuffer.span());
         return m_additionalDataVector;
     }
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h
@@ -46,7 +46,7 @@ public:
         if (!m_saltVector.isEmpty() || !salt.length())
             return m_saltVector;
 
-        m_saltVector.append(salt.bytes());
+        m_saltVector.append(salt.span());
         return m_saltVector;
     }
 
@@ -55,7 +55,7 @@ public:
         if (!m_infoVector.isEmpty() || !info.length())
             return m_infoVector;
 
-        m_infoVector.append(info.bytes());
+        m_infoVector.append(info.span());
         return m_infoVector;
     }
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h
@@ -46,7 +46,7 @@ public:
         if (!m_saltVector.isEmpty() || !salt.length())
             return m_saltVector;
 
-        m_saltVector.append(salt.bytes());
+        m_saltVector.append(salt.span());
         return m_saltVector;
     }
 

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
@@ -43,7 +43,7 @@ public:
         if (!m_publicExponentVector.isEmpty() || !publicExponent->byteLength())
             return m_publicExponentVector;
 
-        m_publicExponentVector.append(publicExponent->bytes());
+        m_publicExponentVector.append(publicExponent->span());
         return m_publicExponentVector;
     }
 private:

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
@@ -48,7 +48,7 @@ public:
         if (!labelBuffer.length())
             return m_labelVector;
 
-        m_labelVector.append(labelBuffer.bytes());
+        m_labelVector.append(labelBuffer.span());
         return m_labelVector;
     }
 

--- a/Source/WebCore/dom/TextDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoder.cpp
@@ -56,7 +56,7 @@ ExceptionOr<String> TextDecoder::decode(std::optional<BufferSource::VariantType>
     std::span<const uint8_t> data;
     if (input) {
         inputBuffer = BufferSource(WTFMove(input.value()));
-        data = inputBuffer->bytes();
+        data = inputBuffer->span();
     }
 
     if (!m_codec) {

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -515,7 +515,7 @@ static String sanitizeMarkupWithArchive(LocalFrame& frame, Document& destination
             subframeMainResource.releaseNonNull(), subframeArchive.copyRef() };
         auto subframeMarkup = sanitizeMarkupWithArchive(frame, destinationDocument, subframeContent, MSOListQuirks::Disabled, canShowMIMETypeAsHTML);
 
-        auto blob = Blob::create(&destinationDocument, Vector(subframeMarkup.utf8().bytes()), type);
+        auto blob = Blob::create(&destinationDocument, Vector(subframeMarkup.utf8().span()), type);
 
         String subframeBlobURL = DOMURL::createObjectURL(destinationDocument, blob);
         blobURLMap.set(AtomString { subframeURL.string() }, AtomString { subframeBlobURL });

--- a/Source/WebCore/fileapi/BlobBuilder.cpp
+++ b/Source/WebCore/fileapi/BlobBuilder.cpp
@@ -50,14 +50,14 @@ void BlobBuilder::append(RefPtr<ArrayBuffer>&& arrayBuffer)
 {
     if (!arrayBuffer)
         return;
-    m_appendableData.append(arrayBuffer->bytes());
+    m_appendableData.append(arrayBuffer->span());
 }
 
 void BlobBuilder::append(RefPtr<ArrayBufferView>&& arrayBufferView)
 {
     if (!arrayBufferView)
         return;
-    m_appendableData.append(arrayBufferView->bytes());
+    m_appendableData.append(arrayBufferView->span());
 }
 
 void BlobBuilder::append(RefPtr<Blob>&& blob)

--- a/Source/WebCore/fileapi/NetworkSendQueue.cpp
+++ b/Source/WebCore/fileapi/NetworkSendQueue.cpp
@@ -53,10 +53,10 @@ void NetworkSendQueue::enqueue(CString&& utf8)
 void NetworkSendQueue::enqueue(const JSC::ArrayBuffer& binaryData, unsigned byteOffset, unsigned byteLength)
 {
     if (m_queue.isEmpty()) {
-        m_writeRawData(binaryData.bytes().subspan(byteOffset, byteLength));
+        m_writeRawData(binaryData.span().subspan(byteOffset, byteLength));
         return;
     }
-    m_queue.append(SharedBuffer::create(binaryData.bytes().subspan(byteOffset, byteLength)));
+    m_queue.append(SharedBuffer::create(binaryData.span().subspan(byteOffset, byteLength)));
 }
 
 void NetworkSendQueue::enqueue(WebCore::Blob& blob)
@@ -103,7 +103,7 @@ void NetworkSendQueue::processMessages()
             }
 
             if (const auto& result = loader->arrayBufferResult()) {
-                m_writeRawData(result->bytes());
+                m_writeRawData(result->span());
                 return;
             }
             ASSERT(errorCode);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1144,7 +1144,7 @@ void WebGLRenderingContextBase::bufferData(GCGLenum target, std::optional<Buffer
         return;
 
     std::visit([&](auto& data) {
-        m_context->bufferData(target, data->bytes(), usage);
+        m_context->bufferData(target, data->span(), usage);
     }, data.value());
 }
 
@@ -1161,7 +1161,7 @@ void WebGLRenderingContextBase::bufferSubData(GCGLenum target, long long offset,
     }
 
     std::visit([&](auto& data) {
-        m_context->bufferSubData(target, static_cast<GCGLintptr>(offset), data->bytes());
+        m_context->bufferSubData(target, static_cast<GCGLintptr>(offset), data->span());
     }, data);
 }
 
@@ -1248,7 +1248,7 @@ void WebGLRenderingContextBase::compressedTexImage2D(GCGLenum target, GCGLint le
         return;
     if (!validateCompressedTexFormat("compressedTexImage2D", internalformat))
         return;
-    m_context->compressedTexImage2D(target, level, internalformat, width, height, border, data.byteLength(), data.bytes());
+    m_context->compressedTexImage2D(target, level, internalformat, width, height, border, data.byteLength(), data.span());
 }
 
 void WebGLRenderingContextBase::compressedTexSubImage2D(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum format, ArrayBufferView& data)
@@ -1259,7 +1259,7 @@ void WebGLRenderingContextBase::compressedTexSubImage2D(GCGLenum target, GCGLint
         return;
     if (!validateCompressedTexFormat("compressedTexSubImage2D", format))
         return;
-    m_context->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, data.byteLength(), data.bytes());
+    m_context->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, data.byteLength(), data.span());
 }
 
 bool WebGLRenderingContextBase::validateSettableTexInternalFormat(const char* functionName, GCGLenum internalFormat)
@@ -3899,7 +3899,7 @@ std::optional<std::span<const uint8_t>> WebGLRenderingContextBase::validateTexFu
         return std::nullopt;
     }
     ASSERT(!offset.hasOverflowed()); // Checked already as part of `total.hasOverflowed()` check.
-    return pixels->bytes().subspan(offset.value(), dataLength);
+    return pixels->span().subspan(offset.value(), dataLength);
 }
 
 bool WebGLRenderingContextBase::validateTexFuncParameters(TexImageFunctionID functionID,

--- a/Source/WebCore/inspector/DOMPatchSupport.cpp
+++ b/Source/WebCore/inspector/DOMPatchSupport.cpp
@@ -398,7 +398,7 @@ ExceptionOr<void> DOMPatchSupport::innerPatchChildren(ContainerNode& parentNode,
 
 static void addStringToSHA1(SHA1& sha1, const String& string)
 {
-    sha1.addBytes(string.utf8().bytes());
+    sha1.addBytes(string.utf8().span());
 }
 
 std::unique_ptr<DOMPatchSupport::Digest> DOMPatchSupport::createDigest(Node& node, UnusedNodesMap* unusedNodesMap)

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -105,12 +105,12 @@ bool InspectorPageAgent::mainResourceContent(LocalFrame* frame, bool withBase64E
     RefPtr<FragmentedSharedBuffer> buffer = frame->loader().documentLoader()->mainResourceData();
     if (!buffer)
         return false;
-    return InspectorPageAgent::dataContent(buffer->makeContiguous()->bytes(), frame->document()->encoding(), withBase64Encode, result);
+    return InspectorPageAgent::dataContent(buffer->makeContiguous()->span(), frame->document()->encoding(), withBase64Encode, result);
 }
 
 bool InspectorPageAgent::sharedBufferContent(RefPtr<FragmentedSharedBuffer>&& buffer, const String& textEncodingName, bool withBase64Encode, String* result)
 {
-    return dataContent(buffer ? buffer->makeContiguous()->bytes() : std::span<const uint8_t> { }, textEncodingName, withBase64Encode, result);
+    return dataContent(buffer ? buffer->makeContiguous()->span() : std::span<const uint8_t> { }, textEncodingName, withBase64Encode, result);
 }
 
 bool InspectorPageAgent::dataContent(std::span<const uint8_t> data, const String& textEncodingName, bool withBase64Encode, String* result)

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -95,7 +95,7 @@ void DocumentWriter::replaceDocumentWithResultOfExecutingJavascriptURL(const Str
         }
 
         if (RefPtr parser = frame->document()->parser())
-            parser->appendBytes(*this, source.utf8().bytes());
+            parser->appendBytes(*this, source.utf8().span());
     }
 
     end();
@@ -315,7 +315,7 @@ void DocumentWriter::addData(const SharedBuffer& data)
         return;
     }
     ASSERT(m_parser);
-    protectedParser()->appendBytes(*this, data.bytes());
+    protectedParser()->appendBytes(*this, data.span());
 }
 
 void DocumentWriter::insertDataSynchronously(const String& markup)

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -815,7 +815,7 @@ bool ApplicationCacheStorage::store(ApplicationCacheResource* resource, unsigned
     } else {
         if (resource->data().size()) {
             auto contiguousData = resource->data().makeContiguous();
-            dataStatement->bindBlob(1, contiguousData->bytes());
+            dataStatement->bindBlob(1, contiguousData->span());
         }
     }
     

--- a/Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp
@@ -210,7 +210,7 @@ RefPtr<ArchiveResource> MHTMLParser::parseNextPart(const MIMEHeader& mimeHeader,
         break;
     case MIMEHeader::SevenBit:
     case MIMEHeader::Binary:
-        data.append(contiguousContent->bytes());
+        data.append(contiguousContent->span());
         break;
     default:
         LOG_ERROR("Invalid encoding for MHTML part.");

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -75,7 +75,7 @@ FontParsingPolicy CachedFont::policyForCustomFont(const Ref<SharedBuffer>& data)
     if (!m_loader || !m_loader->frame())
         return FontParsingPolicy::Deny;
 
-    return fontBinaryParsingPolicy(data->bytes(), m_loader->frame()->settings().downloadableBinaryFontTrustedTypes());
+    return fontBinaryParsingPolicy(data->span(), m_loader->frame()->settings().downloadableBinaryFontTrustedTypes());
 }
 
 void CachedFont::finishLoading(const FragmentedSharedBuffer* data, const NetworkLoadMetrics& metrics)

--- a/Source/WebCore/loader/cache/CachedScript.cpp
+++ b/Source/WebCore/loader/cache/CachedScript.cpp
@@ -78,7 +78,7 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
         setDecodedSize(0);
         stopDecodedDataDeletionTimer();
 
-        m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(contiguousData->bytes());
+        m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(contiguousData->span());
     }
 
     if (m_decodingState == DataAndDecodedStringHaveSameBytes)

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -79,7 +79,7 @@ class DataSegment : public ThreadSafeRefCounted<DataSegment> {
 public:
     WEBCORE_EXPORT const uint8_t* data() const;
     WEBCORE_EXPORT size_t size() const;
-    std::span<const uint8_t> bytes() const { return std::span { data(), size() }; }
+    std::span<const uint8_t> span() const { return std::span { data(), size() }; }
 
     WEBCORE_EXPORT static Ref<DataSegment> create(Vector<uint8_t>&&);
 
@@ -313,7 +313,7 @@ public:
     WEBCORE_EXPORT const uint8_t* data() const;
     WEBCORE_EXPORT const uint8_t& operator[](size_t) const;
     const char* dataAsCharPtr() const { return reinterpret_cast<const char*>(data()); }
-    std::span<const uint8_t> bytes() const { return std::span(data(), size()); }
+    std::span<const uint8_t> span() const { return std::span(data(), size()); }
     WTF::Persistence::Decoder decoder() const;
 
     enum class MayUseFileMapping : bool { No, Yes };

--- a/Source/WebCore/platform/SharedBufferChunkReader.cpp
+++ b/Source/WebCore/platform/SharedBufferChunkReader.cpp
@@ -131,7 +131,7 @@ size_t SharedBufferChunkReader::peek(Vector<uint8_t>& data, size_t requestedSize
 
     while (requestedSize && ++currentSegment != m_iteratorEnd) {
         size_t lengthInSegment = std::min(currentSegment->segment->size(), requestedSize);
-        data.append(currentSegment->segment->bytes().first(lengthInSegment));
+        data.append(currentSegment->segment->span().first(lengthInSegment));
         readBytesCount += lengthInSegment;
         requestedSize -= lengthInSegment;
     }

--- a/Source/WebCore/platform/WebCorePersistentCoders.cpp
+++ b/Source/WebCore/platform/WebCorePersistentCoders.cpp
@@ -344,9 +344,9 @@ namespace WTF::Persistence {
 
 static void encodeCFData(Encoder& encoder, CFDataRef data)
 {
-    auto span = toSpan(data);
-    encoder << static_cast<uint64_t>(span.size());
-    encoder.encodeFixedLengthData(span);
+    auto dataSpan = span(data);
+    encoder << static_cast<uint64_t>(dataSpan.size());
+    encoder.encodeFixedLengthData(dataSpan);
 }
 
 static std::optional<RetainPtr<CFDataRef>> decodeCFData(Decoder& decoder)

--- a/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
@@ -85,9 +85,8 @@ ContentFilterUnblockHandler::ContentFilterUnblockHandler(
 // FIXME: Remove the conversion to and from Vector<uint8_t> and serialize individual members when rdar://107281862 is resolved.
 Vector<uint8_t> ContentFilterUnblockHandler::webFilterEvaluatorData() const
 {
-    NSError *error { nil };
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:m_webFilterEvaluator.get() requiringSecureCoding:YES error:&error];
-    return toVector(data);
+    NSError *error = nil;
+    return makeVector([NSKeyedArchiver archivedDataWithRootObject:m_webFilterEvaluator.get() requiringSecureCoding:YES error:&error]);
 }
 
 RetainPtr<WebFilterEvaluator> ContentFilterUnblockHandler::unpackWebFilterEvaluatorData(Vector<uint8_t>&& vector)

--- a/Source/WebCore/platform/graphics/ImageBackingStore.h
+++ b/Source/WebCore/platform/graphics/ImageBackingStore.h
@@ -205,7 +205,7 @@ private:
         , m_premultiplyAlpha(other.m_premultiplyAlpha)
     {
         ASSERT(!m_size.isEmpty() && !isOverSize(m_size));
-        Vector<uint8_t> buffer(other.m_pixels->bytes());
+        Vector<uint8_t> buffer(other.m_pixels->span());
         m_pixels = FragmentedSharedBuffer::DataSegment::create(WTFMove(buffer));
         m_pixelsPtr = reinterpret_cast<uint32_t*>(const_cast<uint8_t*>(m_pixels->data()));
     }

--- a/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
+++ b/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
@@ -80,7 +80,7 @@ void MediaResourceSniffer::dataReceived(PlatformMediaResource&, const SharedBuff
     m_received += buffer.size();
     m_content.append(buffer);
     auto contiguousBuffer = m_content.get()->makeContiguous();
-    auto mimeType = MIMESniffer::getMIMETypeFromContent(contiguousBuffer->bytes());
+    auto mimeType = MIMESniffer::getMIMETypeFromContent(contiguousBuffer->span());
     if (mimeType.isEmpty() && m_received < m_maxSize)
         return;
     if (!m_producer.isSettled())
@@ -100,7 +100,7 @@ void MediaResourceSniffer::loadFinished(PlatformMediaResource&, const NetworkLoa
     if (m_producer.isSettled())
         return;
     Ref contiguousBuffer = m_content.takeAsContiguous();
-    auto mimeType = MIMESniffer::getMIMETypeFromContent(contiguousBuffer->bytes());
+    auto mimeType = MIMESniffer::getMIMETypeFromContent(contiguousBuffer->span());
     m_producer.resolve(ContentType { WTFMove(mimeType) });
     cancel();
 }

--- a/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
+++ b/Source/WebCore/platform/graphics/WOFFFileFormat.cpp
@@ -265,7 +265,7 @@ bool convertWOFFToSfnt(SharedBuffer& woff, Vector<uint8_t>& sfnt)
 
         if (tableCompLength == tableOrigLength) {
             // The table is not compressed.
-            if (!sfnt.tryAppend(woff.bytes().subspan(tableOffset, tableCompLength)))
+            if (!sfnt.tryAppend(woff.span().subspan(tableOffset, tableCompLength)))
                 return false;
         } else {
             uLongf destLen = tableOrigLength;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -210,7 +210,7 @@ void CDMSessionAVContentKeySession::releaseKeys()
             if (m_sessionId == String(playbackSessionIdValue)) {
                 ALWAYS_LOG(LOGIDENTIFIER, "found session, sending expiration message");
                 m_expiredSession = expiredSessionData;
-                m_client->sendMessage(Uint8Array::create(toSpan(m_expiredSession.get())).ptr(), emptyString());
+                m_client->sendMessage(Uint8Array::create(span(m_expiredSession.get())).ptr(), emptyString());
                 break;
             }
         }
@@ -334,7 +334,7 @@ bool CDMSessionAVContentKeySession::update(Uint8Array* key, RefPtr<Uint8Array>& 
         }
 
         ALWAYS_LOG(LOGIDENTIFIER, "generated key request");
-        nextMessage = Uint8Array::tryCreate(toSpan(requestData.get()));
+        nextMessage = Uint8Array::tryCreate(span(requestData.get()));
         return false;
     }
 
@@ -423,7 +423,7 @@ RefPtr<Uint8Array> CDMSessionAVContentKeySession::generateKeyReleaseMessage(unsi
     errorCode = 0;
     systemCode = 0;
     m_expiredSession = [expiredSessions firstObject];
-    return Uint8Array::tryCreate(toSpan(m_expiredSession.get()));
+    return Uint8Array::tryCreate(span(m_expiredSession.get()));
 }
 
 bool CDMSessionAVContentKeySession::hasContentKeyRequest() const

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
@@ -330,7 +330,7 @@ bool parseOpusPrivateData(size_t codecPrivateSize, const uint8_t* codecPrivateDa
 static Vector<uint8_t> cookieFromOpusCookieContents(const OpusCookieContents& cookie)
 {
 #if HAVE(AUDIOFORMATPROPERTY_VARIABLEPACKET_SUPPORTED)
-    return { cookie.cookieData->bytes() };
+    return { cookie.cookieData->span() };
 #else
     auto samplesPerPacket = cookie.framesPerPacket * (cookie.frameDuration.seconds() * cookie.sampleRate);
 

--- a/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
@@ -137,7 +137,7 @@ std::optional<Ref<FontCustomPlatformData>> FontCustomPlatformData::tryMakeFromSe
 
 FontCustomPlatformSerializedData FontCustomPlatformData::serializedData() const
 {
-    return FontCustomPlatformSerializedData { { creationData.fontFaceData->bytes() }, creationData.itemInCollection, m_renderingResourceIdentifier };
+    return FontCustomPlatformSerializedData { { creationData.fontFaceData->span() }, creationData.itemInCollection, m_renderingResourceIdentifier };
 }
 
 bool FontCustomPlatformData::supportsFormat(const String& format)

--- a/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp
@@ -320,7 +320,7 @@ FontPlatformData::PlatformDataVariant FontPlatformData::platformSerializationDat
 
     const auto& data = creationData();
     if (data)
-        return FontPlatformSerializedCreationData { { data->fontFaceData->bytes() }, attributes, data->itemInCollection };
+        return FontPlatformSerializedCreationData { { data->fontFaceData->span() }, attributes, data->itemInCollection };
 
     auto options = CTFontDescriptorGetOptions(fontDescriptor.get());
     auto referenceURL = adoptCF(static_cast<CFURLRef>(CTFontCopyAttribute(ctFont, kCTFontReferenceURLAttribute)));

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterCocoa.mm
@@ -76,14 +76,14 @@
 - (void)assetWriter:(AVAssetWriter *)assetWriter didProduceFragmentedHeaderData:(NSData *)fragmentedHeaderData
 {
     UNUSED_PARAM(assetWriter);
-    m_writer->appendData(toSpan(fragmentedHeaderData));
+    m_writer->appendData(span(fragmentedHeaderData));
 }
 
 - (void)assetWriter:(AVAssetWriter *)assetWriter didProduceFragmentedMediaData:(NSData *)fragmentedMediaData fragmentedMediaDataReport:(AVFragmentedMediaDataReport *)fragmentedMediaDataReport
 {
     UNUSED_PARAM(assetWriter);
     UNUSED_PARAM(fragmentedMediaDataReport);
-    m_writer->appendData(toSpan(fragmentedMediaData));
+    m_writer->appendData(span(fragmentedMediaData));
 }
 
 - (void)close

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -1152,7 +1152,7 @@ void AVVideoCaptureSource::captureOutputDidFinishProcessingPhoto(RetainPtr<AVCap
     }
 
     NSData* data = [photo fileDataRepresentation];
-    resolvePendingPhotoRequest(toVector(data), "image/jpeg"_s);
+    resolvePendingPhotoRequest(makeVector(data), "image/jpeg"_s);
 }
 
 void AVVideoCaptureSource::captureSessionIsRunningDidChange(bool state)

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -64,7 +64,7 @@ Ref<FormData> FormData::create(std::span<const uint8_t> data)
 
 Ref<FormData> FormData::create(const CString& string)
 {
-    return create(string.bytes());
+    return create(string.span());
 }
 
 Ref<FormData> FormData::create(Vector<uint8_t>&& vector)
@@ -317,7 +317,7 @@ static void appendBlobResolved(BlobRegistryImpl* blobRegistry, FormData& formDat
     for (const auto& blobItem : blobData->items()) {
         if (blobItem.type() == BlobDataItem::Type::Data) {
             ASSERT(blobItem.data());
-            formData.appendData(blobItem.data()->bytes().subspan(blobItem.offset(), blobItem.length()));
+            formData.appendData(blobItem.data()->span().subspan(blobItem.offset(), blobItem.length()));
         } else if (blobItem.type() == BlobDataItem::Type::File)
             formData.appendFileRange(blobItem.file()->path(), blobItem.offset(), blobItem.length(), blobItem.file()->expectedModificationTime());
         else

--- a/Source/WebCore/platform/network/FormDataBuilder.cpp
+++ b/Source/WebCore/platform/network/FormDataBuilder.cpp
@@ -55,7 +55,7 @@ static inline void append(Vector<uint8_t>& buffer, const char* string)
 
 static inline void append(Vector<uint8_t>& buffer, const CString& string)
 {
-    buffer.append(string.bytes());
+    buffer.append(string.span());
 }
 
 static inline void append(Vector<uint8_t>& buffer, const Vector<uint8_t>& string)

--- a/Source/WebCore/platform/network/SynchronousLoaderClient.cpp
+++ b/Source/WebCore/platform/network/SynchronousLoaderClient.cpp
@@ -74,7 +74,7 @@ void SynchronousLoaderClient::didReceiveResponseAsync(ResourceHandle*, ResourceR
 
 void SynchronousLoaderClient::didReceiveData(ResourceHandle*, const SharedBuffer& buffer, int /*encodedDataLength*/)
 {
-    m_data.append(buffer.bytes());
+    m_data.append(buffer.span());
 }
 
 void SynchronousLoaderClient::didFinishLoading(ResourceHandle* handle, const NetworkLoadMetrics&)

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -211,7 +211,7 @@ void ResourceRequest::doUpdateResourceRequest()
 void ResourceRequest::doUpdateResourceHTTPBody()
 {
     if (NSData* bodyData = [m_nsRequest HTTPBody])
-        m_httpBody = FormData::create(toSpan(bodyData));
+        m_httpBody = FormData::create(span(bodyData));
     else if (NSInputStream* bodyStream = [m_nsRequest HTTPBodyStream]) {
         FormData* formData = httpBodyFromStream(bodyStream);
         // There is no FormData object if a client provided a custom data stream.

--- a/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
+++ b/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
@@ -150,7 +150,7 @@ String SQLiteFileSystem::computeHashForFileName(StringView fileName)
 {
     auto cryptoDigest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto utf8FileName = fileName.utf8();
-    cryptoDigest->addBytes(utf8FileName.bytes());
+    cryptoDigest->addBytes(utf8FileName.span());
     auto digest = cryptoDigest->computeHash();
     
     // Convert digest to hex.

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -218,7 +218,7 @@ static void append(Vector<char>& vector, const char* string)
 
 static void append(Vector<char>& vector, const CString& string)
 {
-    vector.append(string.bytes());
+    vector.append(string.span());
 }
 
 // Find the markup between "<!--StartFragment -->" and "<!--EndFragment -->", accounting for browser quirks.

--- a/Source/WebCore/storage/StorageUtilities.cpp
+++ b/Source/WebCore/storage/StorageUtilities.cpp
@@ -92,7 +92,7 @@ String encodeSecurityOriginForFileName(FileSystem::Salt salt, const SecurityOrig
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto originString = origin.toString().utf8();
-    crypto->addBytes(originString.bytes());
+    crypto->addBytes(originString.span());
     crypto->addBytes(salt.data(), salt.size());
     auto hash = crypto->computeHash();
     return base64URLEncodeToString(hash.data(), hash.size());

--- a/Source/WebCore/testing/MockContentFilter.cpp
+++ b/Source/WebCore/testing/MockContentFilter.cpp
@@ -149,7 +149,7 @@ void MockContentFilter::maybeDetermineStatus(DecisionPoint decisionPoint)
     if (m_state != State::Blocked)
         return;
 
-    m_replacementData = settings().blockedString().utf8().bytes();
+    m_replacementData = settings().blockedString().utf8().span();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/testing/ServiceWorkerInternals.cpp
+++ b/Source/WebCore/testing/ServiceWorkerInternals.cpp
@@ -72,7 +72,7 @@ void ServiceWorkerInternals::schedulePushEvent(const String& message, RefPtr<Def
     std::optional<Vector<uint8_t>> data;
     if (!message.isNull()) {
         auto utf8 = message.utf8();
-        data = Vector(utf8.bytes());
+        data = Vector(utf8.span());
     }
     callOnMainThread([identifier = m_identifier, data = WTFMove(data), weakThis = WeakPtr { *this }, counter]() mutable {
         SWContextManager::singleton().firePushEvent(identifier, WTFMove(data), std::nullopt, [identifier, weakThis = WTFMove(weakThis), counter](bool result, std::optional<NotificationPayload>&&) mutable {

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
@@ -483,7 +483,7 @@ void BackgroundFetch::doStore(CompletionHandler<void(BackgroundFetchStore::Store
         encoder << record->isCompleted();
     }
 
-    m_store->storeFetch(m_registrationKey, m_identifier, m_options.downloadTotal, m_uploadTotal, responseBodyIndexToClear, { encoder.bytes() }, WTFMove(callback));
+    m_store->storeFetch(m_registrationKey, m_identifier, m_options.downloadTotal, m_uploadTotal, responseBodyIndexToClear, { encoder.span() }, WTFMove(callback));
 }
 
 std::unique_ptr<BackgroundFetch> BackgroundFetch::createFromStore(std::span<const uint8_t> data, SWServer& server, Ref<BackgroundFetchStore>&& store, NotificationCallback&& notificationCallback)

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -53,7 +53,7 @@ String SWScriptStorage::sha2Hash(const String& input) const
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     crypto->addBytes(m_salt.data(), m_salt.size());
     auto inputUTF8 = input.utf8();
-    crypto->addBytes(inputUTF8.bytes());
+    crypto->addBytes(inputUTF8.span());
     auto hash = crypto->computeHash();
     return base64URLEncodeToString(hash.data(), hash.size());
 }

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -568,12 +568,12 @@ ExceptionOr<void> XMLHttpRequest::send(ArrayBuffer& body)
 {
     ASCIILiteral consoleMessage { "ArrayBuffer is deprecated in XMLHttpRequest.send(). Use ArrayBufferView instead."_s };
     scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, consoleMessage);
-    return sendBytesData(body.bytes());
+    return sendBytesData(body.span());
 }
 
 ExceptionOr<void> XMLHttpRequest::send(ArrayBufferView& body)
 {
-    return sendBytesData(body.bytes());
+    return sendBytesData(body.span());
 }
 
 ExceptionOr<void> XMLHttpRequest::sendBytesData(std::span<const uint8_t> data)

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -504,7 +504,7 @@ static void* openFunc(const char* uri)
     if (!data)
         return &globalDescriptor;
 
-    return new OffsetBuffer(Vector(data->bytes()));
+    return new OffsetBuffer(Vector(data->span()));
 }
 
 static int readFunc(void* context, char* buffer, int len)

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -70,7 +70,7 @@ void Download::platformCancelNetworkLoad(CompletionHandler<void(std::span<const 
     ASSERT(m_downloadTask);
     [m_downloadTask cancelByProducingResumeData:makeBlockPtr([completionHandler = WTFMove(completionHandler)] (NSData *resumeData) mutable {
         ensureOnMainRunLoop([resumeData = retainPtr(resumeData), completionHandler = WTFMove(completionHandler)] () mutable  {
-            completionHandler(toSpan(resumeData.get()));
+            completionHandler(span(resumeData.get()));
         });
     }).get()];
 }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -122,7 +122,7 @@ static void sendReplyToSynchronousRequest(NetworkResourceLoader::SynchronousLoad
 
     Vector<uint8_t> responseBuffer;
     if (buffer && buffer->size())
-        responseBuffer.append(buffer->makeContiguous()->bytes());
+        responseBuffer.append(buffer->makeContiguous()->span());
 
     data.response.setDeprecatedNetworkLoadMetrics(Box<NetworkLoadMetrics>::create(metrics));
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -924,7 +924,7 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
             }
         }
 
-        auto resumeDataReference = toSpan(resumeData);
+        auto resumeDataReference = span(resumeData);
         download->didFail(error, resumeDataReference);
     }
 }
@@ -2183,7 +2183,7 @@ void NetworkSessionCocoa::setProxyConfigData(const Vector<std::pair<Vector<uint8
     bool recreateSessions = false;
     for (auto& config : proxyConfigurations) {
         uuid_t identifier;
-        memcpy(identifier, config.second.toSpan().data(), sizeof(uuid_t));
+        memcpy(identifier, config.second.span().data(), sizeof(uuid_t));
 
         auto nwProxyConfig = adoptNS(createProxyConfig(config.first.data(), config.first.size(), identifier));
 

--- a/Source/WebKit/NetworkProcess/cocoa/WKURLSessionTaskDelegate.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WKURLSessionTaskDelegate.mm
@@ -97,7 +97,7 @@
     RefPtr connection = [self connection];
     if (!connection)
         return;
-    connection->send(Messages::NetworkProcessProxy::DataTaskDidReceiveData(_identifier, toSpan(data)), 0);
+    connection->send(Messages::NetworkProcessProxy::DataTaskDidReceiveData(_identifier, span(data)), 0);
 }
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -92,7 +92,7 @@ void WebSocketTask::readNextMessage()
         if (message.type == NSURLSessionWebSocketMessageTypeString)
             m_channel.didReceiveText(message.string);
         else
-            m_channel.didReceiveBinaryData(toSpan(message.data));
+            m_channel.didReceiveBinaryData(span(message.data));
 
         readNextMessage();
     }).get()];

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -269,7 +269,7 @@ bool WebSocketTask::appendReceivedBuffer(const WebCore::SharedBuffer& buffer)
     if (newBufferSize < m_receiveBuffer.size())
         return false;
 
-    m_receiveBuffer.append(buffer.bytes());
+    m_receiveBuffer.append(buffer.span());
     return true;
 }
 
@@ -405,7 +405,7 @@ void WebSocketTask::sendClosingHandshakeIfNeeded(int32_t code, const String& rea
         unsigned char lowByte = static_cast<unsigned short>(code);
         buf.append(static_cast<char>(highByte));
         buf.append(static_cast<char>(lowByte));
-        buf.append(reason.utf8().bytes());
+        buf.append(reason.utf8().span());
     }
 
     if (!sendFrame(WebCore::WebSocketFrame::OpCodeClose, buf.span()))

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -144,7 +144,7 @@ static bool writeSizeFile(const String& sizeDirectoryPath, uint64_t size)
 
     auto sizeFilePath = FileSystem::pathByAppendingComponent(sizeDirectoryPath, sizeFileName);
     auto value = String::number(size).utf8();
-    return FileSystem::overwriteEntireFile(sizeFilePath, value.bytes()) != -1;
+    return FileSystem::overwriteEntireFile(sizeFilePath, value.span()) != -1;
 }
 
 static String saltFilePath(const String& saltDirectory)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -82,7 +82,7 @@ static String encode(const String& string, FileSystem::Salt salt)
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto utf8String = string.utf8();
-    crypto->addBytes(utf8String.bytes());
+    crypto->addBytes(utf8String.span());
     crypto->addBytes(salt.data(), salt.size());
     auto hash = crypto->computeHash();
     return base64URLEncodeToString(hash.data(), hash.size());

--- a/Source/WebKit/Shared/API/APIData.h
+++ b/Source/WebKit/Shared/API/APIData.h
@@ -87,7 +87,7 @@ public:
     }
 
     size_t size() const { return m_span.size(); }
-    std::span<const uint8_t> bytes() const { return m_span; }
+    std::span<const uint8_t> span() const { return m_span; }
 
 private:
     Data(std::span<const uint8_t> span, FreeDataFunction freeDataFunction, const void* context)

--- a/Source/WebKit/Shared/API/APIData.serialization.in
+++ b/Source/WebKit/Shared/API/APIData.serialization.in
@@ -21,5 +21,5 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [RefCounted, CustomHeader] class API::Data {
-    std::span<const uint8_t> bytes()
+    std::span<const uint8_t> span()
 };

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -1146,7 +1146,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
     }
 
     *length = data->size();
-    return data->bytes().data();
+    return data->span().data();
 }
 
 - (BOOL)requiresSecureCoding

--- a/Source/WebKit/Shared/API/c/WKData.cpp
+++ b/Source/WebKit/Shared/API/c/WKData.cpp
@@ -41,7 +41,7 @@ WKDataRef WKDataCreate(const unsigned char* bytes, size_t size)
 
 const unsigned char* WKDataGetBytes(WKDataRef dataRef)
 {
-    return WebKit::toImpl(dataRef)->bytes().data();
+    return WebKit::toImpl(dataRef)->span().data();
 }
 
 size_t WKDataGetSize(WKDataRef dataRef)

--- a/Source/WebKit/Shared/APIWebArchive.mm
+++ b/Source/WebKit/Shared/APIWebArchive.mm
@@ -83,7 +83,7 @@ WebArchive::WebArchive(WebArchiveResource* mainResource, RefPtr<API::Array>&& su
 
 WebArchive::WebArchive(API::Data* data)
 {
-    m_legacyWebArchive = LegacyWebArchive::create(SharedBuffer::create(data->bytes()).get());
+    m_legacyWebArchive = LegacyWebArchive::create(SharedBuffer::create(data->span()).get());
 }
 
 WebArchive::WebArchive(RefPtr<LegacyWebArchive>&& legacyWebArchive)

--- a/Source/WebKit/Shared/APIWebArchiveResource.mm
+++ b/Source/WebKit/Shared/APIWebArchiveResource.mm
@@ -47,7 +47,7 @@ Ref<WebArchiveResource> WebArchiveResource::create(RefPtr<ArchiveResource>&& arc
 }
 
 WebArchiveResource::WebArchiveResource(API::Data* data, const String& url, const String& MIMEType, const String& textEncoding)
-    : m_archiveResource(ArchiveResource::create(SharedBuffer::create(data->bytes()), WTF::URL { url }, MIMEType, textEncoding, String()))
+    : m_archiveResource(ArchiveResource::create(SharedBuffer::create(data->span()), WTF::URL { url }, MIMEType, textEncoding, String()))
 {
 }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFURL.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFURL.h
@@ -47,7 +47,7 @@ public:
     }
 
     std::optional<CoreIPCCFURL> baseURL() const;
-    Vector<uint8_t> bytes() const;
+    Vector<uint8_t> toVector() const;
 
     RetainPtr<CFURLRef> createCFURL() const { return m_cfURL; }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFURL.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFURL.mm
@@ -50,7 +50,7 @@ std::optional<CoreIPCCFURL> CoreIPCCFURL::baseURL() const
     return std::nullopt;
 }
 
-Vector<uint8_t> CoreIPCCFURL::bytes() const
+Vector<uint8_t> CoreIPCCFURL::toVector() const
 {
     auto bytesLength = CFURLGetBytes(m_cfURL.get(), nullptr, 0);
     RELEASE_ASSERT(bytesLength != -1);

--- a/Source/WebKit/Shared/Cocoa/CoreIPCCFURL.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCCFURL.serialization.in
@@ -26,7 +26,7 @@ webkit_platform_headers: "CoreIPCCFURL.h"
 
 [WebKitPlatform, CreateUsing=createWithBaseURLAndBytes, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCCFURL {
     std::optional<WebKit::CoreIPCCFURL> baseURL();
-    Vector<uint8_t> bytes();
+    Vector<uint8_t> toVector();
 }
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -243,7 +243,7 @@ auto SandboxExtension::createHandleForTemporaryFile(StringView prefix, Type type
     ASSERT(path.last() == '/');
 
     // Append the file name.
-    path.append(prefix.utf8().bytes());
+    path.append(prefix.utf8().span());
     path.append('\0');
 
     auto pathString = String::fromUTF8(path.data());

--- a/Source/WebKit/Shared/Cocoa/WKNSData.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSData.mm
@@ -51,7 +51,7 @@
 
 - (const void*)bytes
 {
-    return _data->bytes().data();
+    return _data->span().data();
 }
 
 #pragma mark NSCopying protocol implementation

--- a/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
@@ -74,7 +74,7 @@ std::optional<WebPushMessage> WebPushMessage::fromDictionary(NSDictionary *dicti
 #endif
 
     if (isData)
-        message.pushData = toVector((NSData *)pushData);
+        message.pushData = makeVector((NSData *)pushData);
 
     return message;
 }

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -28,7 +28,7 @@ webkit_platform_headers: "StreamConnectionEncoder.h"
 
 header: <wtf/text/CString.h>
 [CustomHeader] class WTF::CString {
-   std::span<const uint8_t> bytes()
+   std::span<const uint8_t> span()
 }
 
 [AdditionalEncoder=StreamConnectionEncoder] class WTF::MediaTime {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4134,7 +4134,7 @@ enum class WebCore::MediaDecodingType : uint8_t {
 enum class WebCore::MediaEncodingType : bool;
 
 class WebCore::BufferSource {
-    std::span<const uint8_t> bytes()
+    std::span<const uint8_t> span()
 }
 
 struct WebCore::FontShadow {

--- a/Source/WebKit/Shared/WebPushMessage.cpp
+++ b/Source/WebKit/Shared/WebPushMessage.cpp
@@ -53,7 +53,7 @@ WebCore::NotificationData WebPushMessage::notificationPayloadToCoreData() const
         silent = notificationPayload->options->silent;
 
         CString dataCString = notificationPayload->options->dataJSONString.utf8();
-        dataJSON = dataCString.bytes();
+        dataJSON = dataCString.span();
     }
 
     return {

--- a/Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm
+++ b/Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm
@@ -49,9 +49,7 @@ RetainPtr<CFHTTPCookieStorageRef> cookieStorageFromIdentifyingData(const Vector<
 Vector<uint8_t> identifyingDataFromCookieStorage(CFHTTPCookieStorageRef cookieStorage)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
-
-    auto cfData = adoptCF(CFHTTPCookieStorageCreateIdentifyingData(kCFAllocatorDefault, cookieStorage));
-    return toVector(cfData.get());
+    return makeVector(adoptCF(CFHTTPCookieStorageCreateIdentifyingData(kCFAllocatorDefault, cookieStorage)).get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
+++ b/Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm
@@ -425,7 +425,7 @@ static SandboxProfilePtr compileAndCacheSandboxProfile(const SandboxInfo& info)
     Vector<char> cacheFile;
     cacheFile.reserveInitialCapacity(expectedFileSize);
     cacheFile.append(std::span { bitwise_cast<uint8_t*>(&cachedHeader), sizeof(CachedSandboxHeader) });
-    cacheFile.append(info.header.bytes());
+    cacheFile.append(info.header.span());
     if (haveBuiltin)
         cacheFile.append(std::span { sandboxProfile->builtin, cachedHeader.builtinSize });
     cacheFile.append(std::span { sandboxProfile->data, cachedHeader.dataSize });

--- a/Source/WebKit/UIProcess/API/C/WKNotification.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotification.cpp
@@ -98,7 +98,7 @@ WKStringRef WKNotificationCopyDataStoreIdentifier(WKNotificationRef notification
 WKDataRef WKNotificationCopyCoreIDForTesting(WKNotificationRef notification)
 {
     auto identifier = toImpl(notification)->coreNotificationID();
-    auto span = identifier.toSpan();
+    auto span = identifier.span();
     return WKDataCreate(span.data(), span.size());
 }
 

--- a/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
@@ -57,7 +57,7 @@ void WKNotificationManagerProviderDidClickNotification(WKNotificationManagerRef 
 
 void WKNotificationManagerProviderDidClickNotification_b(WKNotificationManagerRef managerRef, WKDataRef identifier)
 {
-    auto span = toImpl(identifier)->bytes();
+    auto span = toImpl(identifier)->span();
     if (span.size() != 16)
         return;
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -243,13 +243,13 @@ void WKPageLoadFileWithUserData(WKPageRef pageRef, WKURLRef fileURL, WKURLRef re
 void WKPageLoadData(WKPageRef pageRef, WKDataRef dataRef, WKStringRef MIMETypeRef, WKStringRef encodingRef, WKURLRef baseURLRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->loadData(toImpl(dataRef)->bytes(), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef));
+    toImpl(pageRef)->loadData(toImpl(dataRef)->span(), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef));
 }
 
 void WKPageLoadDataWithUserData(WKPageRef pageRef, WKDataRef dataRef, WKStringRef MIMETypeRef, WKStringRef encodingRef, WKURLRef baseURLRef, WKTypeRef userDataRef)
 {
     CRASH_IF_SUSPENDED;
-    toImpl(pageRef)->loadData(toImpl(dataRef)->bytes(), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef), toImpl(userDataRef));
+    toImpl(pageRef)->loadData(toImpl(dataRef)->span(), toWTFString(MIMETypeRef), toWTFString(encodingRef), toWTFString(baseURLRef), toImpl(userDataRef));
 }
 
 static String encodingOf(const String& string)
@@ -582,7 +582,7 @@ static void restoreFromSessionState(WKPageRef pageRef, WKTypeRef sessionStateRef
 
     // FIXME: This is for backwards compatibility with Safari. Remove it once Safari no longer depends on it.
     if (toImpl(sessionStateRef)->type() == API::Object::Type::Data) {
-        if (!decodeLegacySessionState(toImpl(static_cast<WKDataRef>(sessionStateRef))->bytes(), sessionState))
+        if (!decodeLegacySessionState(toImpl(static_cast<WKDataRef>(sessionStateRef))->span(), sessionState))
             return;
     } else {
         ASSERT(toImpl(sessionStateRef)->type() == API::Object::Type::SessionState);

--- a/Source/WebKit/UIProcess/API/C/WKSessionStateRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKSessionStateRef.cpp
@@ -40,7 +40,7 @@ WKTypeID WKSessionStateGetTypeID()
 WKSessionStateRef WKSessionStateCreateFromData(WKDataRef data)
 {
     WebKit::SessionState sessionState;
-    if (!WebKit::decodeLegacySessionState(WebKit::toImpl(data)->bytes(), sessionState))
+    if (!WebKit::decodeLegacySessionState(WebKit::toImpl(data)->span(), sessionState))
         return nullptr;
 
     return WebKit::toAPI(&API::SessionState::create(WTFMove(sessionState)).leakRef());

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -178,7 +178,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         wkUserData = WebKit::ObjCObjectGraph::create(userData);
 
     NSData *data = [HTMLString dataUsingEncoding:NSUTF8StringEncoding];
-    _page->loadData(toSpan(data), "text/html"_s, "UTF-8"_s, bytesAsString(bridge_cast(baseURL)), wkUserData.get());
+    _page->loadData(span(data), "text/html"_s, "UTF-8"_s, bytesAsString(bridge_cast(baseURL)), wkUserData.get());
 }
 
 - (void)loadAlternateHTMLString:(NSString *)string baseURL:(NSURL *)baseURL forUnreachableURL:(NSURL *)unreachableURL
@@ -198,7 +198,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (userData)
         wkUserData = WebKit::ObjCObjectGraph::create(userData);
 
-    _page->loadData(toSpan(data), MIMEType, encodingName, bytesAsString(bridge_cast(baseURL)), wkUserData.get());
+    _page->loadData(span(data), MIMEType, encodingName, bytesAsString(bridge_cast(baseURL)), wkUserData.get());
 }
 
 - (void)stopLoading

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -256,7 +256,7 @@ static RetainPtr<WKProcessPool>& sharedProcessPool()
         [_processPool->ensureBundleParameters() removeObjectForKey:parameter];
 
     auto data = keyedArchiver.get().encodedData;
-    _processPool->sendToAllProcesses(Messages::WebProcess::SetInjectedBundleParameter(parameter, toSpan(data)));
+    _processPool->sendToAllProcesses(Messages::WebProcess::SetInjectedBundleParameter(parameter, span(data)));
 }
 
 - (void)_setObjectsForBundleParametersWithDictionary:(NSDictionary *)dictionary
@@ -274,7 +274,7 @@ static RetainPtr<WKProcessPool>& sharedProcessPool()
     [_processPool->ensureBundleParameters() setValuesForKeysWithDictionary:copy.get()];
 
     auto data = keyedArchiver.get().encodedData;
-    _processPool->sendToAllProcesses(Messages::WebProcess::SetInjectedBundleParameters(toSpan(data)));
+    _processPool->sendToAllProcesses(Messages::WebProcess::SetInjectedBundleParameters(span(data)));
 }
 
 #if !TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -780,7 +780,7 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
     if (_page->isServiceWorkerPage())
         [NSException raise:NSInternalInconsistencyException format:@"The WKWebView was used to load a service worker"];
 
-    return wrapper(_page->loadData(toSpan(data), MIMEType, characterEncodingName, baseURL.absoluteString)).autorelease();
+    return wrapper(_page->loadData(span(data), MIMEType, characterEncodingName, baseURL.absoluteString)).autorelease();
 }
 
 - (void)startDownloadUsingRequest:(NSURLRequest *)request completionHandler:(void(^)(WKDownload *))completionHandler
@@ -1872,7 +1872,7 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 - (WKNavigation *)loadSimulatedRequest:(NSURLRequest *)request response:(NSURLResponse *)response responseData:(NSData *)data
 {
     THROW_IF_SUSPENDED;
-    return wrapper(_page->loadSimulatedRequest(request, response, toSpan(data))).autorelease();
+    return wrapper(_page->loadSimulatedRequest(request, response, span(data))).autorelease();
 }
 
 // FIXME(223658): Remove this once adopters have moved to the final API.
@@ -2776,7 +2776,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 - (WKNavigation *)_loadData:(NSData *)data MIMEType:(NSString *)MIMEType characterEncodingName:(NSString *)characterEncodingName baseURL:(NSURL *)baseURL userData:(id)userData
 {
     THROW_IF_SUSPENDED;
-    return wrapper(_page->loadData(toSpan(data), MIMEType, characterEncodingName, baseURL.absoluteString, WebKit::ObjCObjectGraph::create(userData).ptr())).autorelease();
+    return wrapper(_page->loadData(span(data), MIMEType, characterEncodingName, baseURL.absoluteString, WebKit::ObjCObjectGraph::create(userData).ptr())).autorelease();
 }
 
 - (WKNavigation *)_loadRequest:(NSURLRequest *)request shouldOpenExternalURLs:(BOOL)shouldOpenExternalURLs
@@ -3069,7 +3069,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 
     // FIXME: This should not use the legacy session state decoder.
     WebKit::SessionState sessionState;
-    if (!WebKit::decodeLegacySessionState(toSpan(sessionStateData), sessionState))
+    if (!WebKit::decodeLegacySessionState(span(sessionStateData), sessionState))
         return;
 
     _page->restoreFromSessionState(WTFMove(sessionState), true);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -100,7 +100,7 @@ private:
         RetainPtr<NSData> result = [m_delegate webCryptoMasterKey];
         if (!result)
             return std::nullopt;
-        return toVector(result.get());
+        return makeVector(result.get());
     }
 
     void requestStorageSpace(const WebCore::SecurityOriginData& topOrigin, const WebCore::SecurityOriginData& frameOrigin, uint64_t quota, uint64_t currentSize, uint64_t spaceRequired, CompletionHandler<void(std::optional<uint64_t>)>&& completionHandler) final
@@ -506,7 +506,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
         uuid_t proxyIdentifier;
         nw_proxy_config_get_identifier(proxyConfig, proxyIdentifier);
 
-        configDataVector.append({ toVector(agentData.get()), WTF::UUID(proxyIdentifier) });
+        configDataVector.append({ makeVector(agentData.get()), WTF::UUID(proxyIdentifier) });
     }
     
     _websiteDataStore->setProxyConfigData(WTFMove(configDataVector));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -95,7 +95,7 @@ static RetainPtr<NSData> produceClientDataJson(_WKWebAuthenticationType type, NS
         clientDataType = WebCore::ClientDataType::Get;
         break;
     }
-    auto challengeBuffer = ArrayBuffer::tryCreate(toSpan(challenge));
+    auto challengeBuffer = ArrayBuffer::tryCreate(span(challenge));
     auto securityOrigin = WebCore::SecurityOrigin::createFromString(origin);
 
     auto clientDataJson = buildClientDataJson(clientDataType, WebCore::BufferSource(challengeBuffer), securityOrigin, scope, topOrigin);
@@ -282,7 +282,7 @@ static RetainPtr<NSArray> getAllLocalAuthenticatorCredentialsImpl(NSString *acce
 
     auto result = adoptNS([[NSMutableArray alloc] init]);
     for (NSDictionary *attributes in (NSArray *)attributesArrayRef) {
-        auto decodedResponse = cbor::CBORReader::read(toVector(attributes[bridge_id_cast(kSecAttrApplicationTag)]));
+        auto decodedResponse = cbor::CBORReader::read(makeVector(attributes[bridge_id_cast(kSecAttrApplicationTag)]));
         if (!decodedResponse || !decodedResponse->isMap()) {
             ASSERT_NOT_REACHED();
             return nullptr;
@@ -428,7 +428,7 @@ static RetainPtr<NSArray> getAllLocalAuthenticatorCredentialsImpl(NSString *acce
         return;
     }
     auto attributes = adoptNS((__bridge NSDictionary *)attributesArrayRef);
-    auto decodedResponse = cbor::CBORReader::read(toVector(attributes.get()[bridge_id_cast(kSecAttrApplicationTag)]));
+    auto decodedResponse = cbor::CBORReader::read(makeVector(attributes.get()[bridge_id_cast(kSecAttrApplicationTag)]));
     if (!decodedResponse || !decodedResponse->isMap()) {
         ASSERT_NOT_REACHED();
         return;
@@ -491,7 +491,7 @@ static RetainPtr<NSArray> getAllLocalAuthenticatorCredentialsImpl(NSString *acce
         return;
     }
     auto attributes = adoptNS((__bridge NSDictionary *)attributesArrayRef);
-    auto decodedResponse = cbor::CBORReader::read(toVector(attributes.get()[bridge_id_cast(kSecAttrApplicationTag)]));
+    auto decodedResponse = cbor::CBORReader::read(makeVector(attributes.get()[bridge_id_cast(kSecAttrApplicationTag)]));
     if (!decodedResponse || !decodedResponse->isMap()) {
         ASSERT_NOT_REACHED();
         return;
@@ -549,7 +549,7 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
 + (NSData *)importLocalAuthenticatorWithAccessGroup:(NSString *)accessGroup credential:(NSData *)credentialBlob error:(NSError **)error
 {
 #if ENABLE(WEB_AUTHN)
-    auto credential = cbor::CBORReader::read(toVector(credentialBlob));
+    auto credential = cbor::CBORReader::read(makeVector(credentialBlob));
     if (!credential || !credential->isMap()) {
         createNSErrorFromWKErrorIfNecessary(error, WKErrorMalformedCredential);
         return nullptr;
@@ -728,7 +728,7 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
     credentialMap[cbor::CBORValue(WebCore::keyTypeKey)] = cbor::CBORValue(keyType);
     credentialMap[cbor::CBORValue(WebCore::keySizeKey)] = cbor::CBORValue(keySize);
     credentialMap[cbor::CBORValue(WebCore::relyingPartyKey)] = cbor::CBORValue(String(attributes.get()[bridge_id_cast(kSecAttrLabel)]));
-    auto decodedResponse = cbor::CBORReader::read(toVector(attributes.get()[bridge_id_cast(kSecAttrApplicationTag)]));
+    auto decodedResponse = cbor::CBORReader::read(makeVector(attributes.get()[bridge_id_cast(kSecAttrApplicationTag)]));
     if (!decodedResponse || !decodedResponse->isMap()) {
         createNSErrorFromWKErrorIfNecessary(error, WKErrorMalformedCredential);
         return nullptr;
@@ -934,7 +934,7 @@ static WebCore::MediationRequirement toWebCore(_WKWebAuthenticationMediationRequ
         result.authenticatorSelection = authenticatorSelectionCriteria(options.authenticatorSelection);
     result.attestation = attestationConveyancePreference(options.attestation);
     if (options.extensionsCBOR)
-        result.extensions = WebCore::AuthenticationExtensionsClientInputs::fromCBOR(toSpan(options.extensionsCBOR));
+        result.extensions = WebCore::AuthenticationExtensionsClientInputs::fromCBOR(span(options.extensionsCBOR));
     else
         result.extensions = authenticationExtensionsClientInputs(options.extensions);
 #endif
@@ -996,7 +996,7 @@ static RetainPtr<_WKAuthenticatorAttestationResponse> wkAuthenticatorAttestation
             handler(nil, [NSError errorWithDomain:WKErrorDomain code:static_cast<NSInteger>(exception.code) userInfo:@{ NSLocalizedDescriptionKey: exception.message }]);
         });
     };
-    _panel->handleRequest({ toVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:options], nullptr, WebKit::WebAuthenticationPanelResult::Unavailable, nullptr, std::nullopt, { }, String(), nullptr, toWebCore(mediation), std::nullopt }, WTFMove(callback));
+    _panel->handleRequest({ makeVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:options], nullptr, WebKit::WebAuthenticationPanelResult::Unavailable, nullptr, std::nullopt, { }, String(), nullptr, toWebCore(mediation), std::nullopt }, WTFMove(callback));
 #endif
 }
 
@@ -1017,7 +1017,7 @@ static RetainPtr<_WKAuthenticatorAttestationResponse> wkAuthenticatorAttestation
     if (options.allowCredentials)
         result.allowCredentials = publicKeyCredentialDescriptors(options.allowCredentials);
     if (options.extensionsCBOR)
-        result.extensions = WebCore::AuthenticationExtensionsClientInputs::fromCBOR(toSpan(options.extensionsCBOR));
+        result.extensions = WebCore::AuthenticationExtensionsClientInputs::fromCBOR(span(options.extensionsCBOR));
     else
         result.extensions = authenticationExtensionsClientInputs(options.extensions);
     result.userVerification = userVerification(options.userVerification);
@@ -1064,7 +1064,7 @@ static RetainPtr<_WKAuthenticatorAssertionResponse> wkAuthenticatorAssertionResp
             handler(nil, [NSError errorWithDomain:WKErrorDomain code:static_cast<NSInteger>(exception.code) userInfo:@{ NSLocalizedDescriptionKey: exception.message }]);
         });
     };
-    _panel->handleRequest({ toVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:options], nullptr, WebKit::WebAuthenticationPanelResult::Unavailable, nullptr, std::nullopt, { }, String(), nullptr, toWebCore(mediation), std::nullopt }, WTFMove(callback));
+    _panel->handleRequest({ makeVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:options], nullptr, WebKit::WebAuthenticationPanelResult::Unavailable, nullptr, std::nullopt, { }, String(), nullptr, toWebCore(mediation), std::nullopt }, WTFMove(callback));
 #endif
 }
 
@@ -1147,7 +1147,7 @@ static RetainPtr<_WKAuthenticatorAssertionResponse> wkAuthenticatorAssertionResp
 {
     RetainPtr<NSData> encodedCommand;
 #if ENABLE(WEB_AUTHN)
-    auto encodedVector = fido::encodeMakeCredentialRequestAsCBOR(toVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:options], coreUserVerificationAvailability(userVerificationAvailability), fido::AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, makeVector<String>(authenticatorSupportedExtensions), std::nullopt);
+    auto encodedVector = fido::encodeMakeCredentialRequestAsCBOR(makeVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:options], coreUserVerificationAvailability(userVerificationAvailability), fido::AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported, makeVector<String>(authenticatorSupportedExtensions), std::nullopt);
     encodedCommand = adoptNS([[NSData alloc] initWithBytes:encodedVector.data() length:encodedVector.size()]);
 #endif
 
@@ -1163,7 +1163,7 @@ static RetainPtr<_WKAuthenticatorAssertionResponse> wkAuthenticatorAssertionResp
 {
     RetainPtr<NSData> encodedCommand;
 #if ENABLE(WEB_AUTHN)
-    auto encodedVector = fido::encodeGetAssertionRequestAsCBOR(toVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:options], coreUserVerificationAvailability(userVerificationAvailability), makeVector<String>(authenticatorSupportedExtensions), std::nullopt);
+    auto encodedVector = fido::encodeGetAssertionRequestAsCBOR(makeVector(clientDataHash), [_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:options], coreUserVerificationAvailability(userVerificationAvailability), makeVector<String>(authenticatorSupportedExtensions), std::nullopt);
     encodedCommand = adoptNS([[NSData alloc] initWithBytes:encodedVector.data() length:encodedVector.size()]);
 #endif
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp
@@ -149,7 +149,7 @@ void webkitFaviconDatabaseSetIconForPageURL(WebKitFaviconDatabase* database, con
     if (!webkitFaviconDatabaseIsOpen(database))
         return;
 
-    database->priv->iconDatabase->setIconForPageURL(icon.url.string(), iconData.bytes(), pageURL,
+    database->priv->iconDatabase->setIconForPageURL(icon.url.string(), iconData.span(), pageURL,
         isEphemeral ? IconDatabase::AllowDatabaseWrite::No : IconDatabase::AllowDatabaseWrite::Yes,
         [database = GRefPtr<WebKitFaviconDatabase>(database), url = icon.url.string().isolatedCopy(), pageURL = pageURL.isolatedCopy()](bool success) {
             if (!webkitFaviconDatabaseIsOpen(database.get()) || !success)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp
@@ -361,7 +361,7 @@ static void resourceDataCallback(API::Data* wkData, GTask* task)
 
     ResourceGetDataAsyncData* data = static_cast<ResourceGetDataAsyncData*>(g_task_get_task_data(task));
     data->webData = wkData;
-    if (!wkData->bytes().data())
+    if (!wkData->span().data())
         data->webData = API::Data::create(reinterpret_cast<const unsigned char*>(""), 1);
     g_task_return_boolean(task, TRUE);
 }
@@ -422,7 +422,7 @@ guchar* webkit_web_resource_get_data_finish(WebKitWebResource* resource, GAsyncR
     if (length)
         *length = data->webData->size();
 
-    auto bytes = data->webData->bytes();
+    auto bytes = data->webData->span();
     if (bytes.empty())
         return nullptr;
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -4684,7 +4684,7 @@ static void getContentsAsMHTMLDataCallback(API::Data* wkData, GTask* taskPtr)
     if (g_task_get_source_tag(task.get()) == webkit_web_view_save_to_file) {
         ASSERT(G_IS_FILE(data->file.get()));
         GCancellable* cancellable = g_task_get_cancellable(task.get());
-        g_file_replace_contents_async(data->file.get(), reinterpret_cast<const gchar*>(data->webData->bytes().data()), data->webData->size(),
+        g_file_replace_contents_async(data->file.get(), reinterpret_cast<const gchar*>(data->webData->span().data()), data->webData->size(),
             0, FALSE, G_FILE_CREATE_REPLACE_DESTINATION, cancellable, fileReplaceContentsCallback, task.leakRef());
         return;
     }
@@ -4750,7 +4750,7 @@ GInputStream* webkit_web_view_save_finish(WebKitWebView* webView, GAsyncResult* 
 
     GInputStream* dataStream = g_memory_input_stream_new();
     ViewSaveAsyncData* data = static_cast<ViewSaveAsyncData*>(g_task_get_task_data(task));
-    auto bytes = data->webData->bytes();
+    auto bytes = data->webData->span();
     if (!bytes.empty())
         g_memory_input_stream_add_data(G_MEMORY_INPUT_STREAM(dataStream), fastMemDup(bytes.data(), bytes.size()), bytes.size(), fastFree);
 

--- a/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm
@@ -109,7 +109,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!_customProtocolManagerProxy)
         return;
 
-    _customProtocolManagerProxy->didLoadData(_customProtocolID, toSpan(data));
+    _customProtocolManagerProxy->didLoadData(_customProtocolID, span(data));
 }
 
 - (NSURLRequest *)connection:(NSURLConnection *)connection willSendRequest:(NSURLRequest *)request redirectResponse:(NSURLResponse *)redirectResponse

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/RedirectSOAuthorizationSession.mm
@@ -87,7 +87,7 @@ void RedirectSOAuthorizationSession::completeInternal(const ResourceResponse& re
         if (!navigationAction->isProcessingUserGesture()) {
             page->setShouldSuppressSOAuthorizationInNextNavigationPolicyDecision();
             auto html = makeString("<script>location = '", response.httpHeaderFields().get(HTTPHeaderName::Location), "'</script>").utf8();
-            page->loadData(html.bytes(), "text/html"_s, "UTF-8"_s, navigationAction->request().url().string(), nullptr, navigationAction->shouldOpenExternalURLsPolicy());
+            page->loadData(html.span(), "text/html"_s, "UTF-8"_s, navigationAction->request().url().string(), nullptr, navigationAction->shouldOpenExternalURLsPolicy());
             return;
         }
 #endif
@@ -97,7 +97,7 @@ void RedirectSOAuthorizationSession::completeInternal(const ResourceResponse& re
     if (response.httpStatusCode() == httpStatus200OK) {
         invokeCallback(true);
         page->setShouldSuppressSOAuthorizationInNextNavigationPolicyDecision();
-        page->loadData(toSpan(data), "text/html"_s, "UTF-8"_s, response.url().string(), nullptr, navigationAction->shouldOpenExternalURLsPolicy());
+        page->loadData(span(data), "text/html"_s, "UTF-8"_s, response.url().string(), nullptr, navigationAction->shouldOpenExternalURLsPolicy());
         return;
     }
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -92,7 +92,7 @@ void SubFrameSOAuthorizationSession::completeInternal(const WebCore::ResourceRes
         fallBackToWebPathInternal();
         return;
     }
-    appendRequestToLoad(URL(response.url()), toVector(data));
+    appendRequestToLoad(URL(response.url()), makeVector(data));
 }
 
 void SubFrameSOAuthorizationSession::beforeStart()

--- a/Source/WebKit/UIProcess/Cocoa/SessionStateCoding.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SessionStateCoding.mm
@@ -39,7 +39,7 @@ RetainPtr<NSData> encodeSessionState(const SessionState& sessionState)
 
 bool decodeSessionState(NSData *data, SessionState& state)
 {
-    return decodeLegacySessionState(toSpan(data), state);
+    return decodeLegacySessionState(span(data), state);
 }
 
 }

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -957,7 +957,7 @@ bool WebPageProxy::isQuarantinedAndNotUserApproved(const String& fileURLString)
 
 void WebPageProxy::insertMultiRepresentationHEIC(NSData *data)
 {
-    send(Messages::WebPage::InsertMultiRepresentationHEIC(toSpan(data)));
+    send(Messages::WebPage::InsertMultiRepresentationHEIC(span(data)));
 
 }
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -253,7 +253,7 @@ void WebNotificationManagerProxy::providerDidCloseNotifications(API::Array* glob
             if (!dataValue)
                 continue;
 
-            auto span = dataValue->bytes();
+            auto span = dataValue->span();
             if (span.size() != 16)
                 continue;
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
@@ -118,7 +118,7 @@ void CcidConnection::transact(Vector<uint8_t>&& data, DataReceivedCallback&& cal
             return;
         [m_smartCard transmitRequest:adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]).autorelease() reply:makeBlockPtr([this, callback = WTFMove(callback)](NSData * _Nullable nsResponse, NSError * _Nullable error) mutable {
             [m_smartCard endSession];
-            callOnMainRunLoop([response = toVector(nsResponse), callback = WTFMove(callback)] () mutable {
+            callOnMainRunLoop([response = makeVector(nsResponse), callback = WTFMove(callback)] () mutable {
                 callback(WTFMove(response));
             });
         }).get()];

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -137,7 +137,7 @@ static inline RetainPtr<NSData> toNSData(ArrayBuffer* buffer)
 
 static inline Ref<ArrayBuffer> toArrayBuffer(NSData *data)
 {
-    return ArrayBuffer::create(toSpan(data));
+    return ArrayBuffer::create(span(data));
 }
 
 static inline Ref<ArrayBuffer> toArrayBuffer(const Vector<uint8_t>& data)
@@ -171,7 +171,7 @@ static std::optional<Vector<Ref<AuthenticatorAssertionResponse>>> getExistingCre
     Vector<Ref<AuthenticatorAssertionResponse>> result;
     result.reserveInitialCapacity(sortedAttributesArray.count);
     for (NSDictionary *attributes in sortedAttributesArray) {
-        auto decodedResponse = cbor::CBORReader::read(toVector(attributes[(id)kSecAttrApplicationTag]));
+        auto decodedResponse = cbor::CBORReader::read(makeVector(attributes[(id)kSecAttrApplicationTag]));
         if (!decodedResponse || !decodedResponse->isMap()) {
             ASSERT_NOT_REACHED();
             return std::nullopt;
@@ -395,7 +395,7 @@ std::optional<WebCore::ExceptionData> LocalAuthenticator::processLargeBlobExtens
         auto retainAttributesArray = adoptCF(attributesArrayRef);
         NSDictionary *dict = (NSDictionary *)attributesArrayRef;
 
-        auto decodedResponse = cbor::CBORReader::read(toVector(dict[(id)kSecAttrApplicationTag]));
+        auto decodedResponse = cbor::CBORReader::read(makeVector(dict[(id)kSecAttrApplicationTag]));
         if (!decodedResponse || !decodedResponse->isMap()) {
             ASSERT_NOT_REACHED();
             return WebCore::ExceptionData { ExceptionCode::UnknownError, "Could not read credential."_s };
@@ -582,7 +582,7 @@ void LocalAuthenticator::continueMakeCredentialAfterAttested(Vector<uint8_t>&& c
     {
         Vector<cbor::CBORValue> cborArray;
         for (size_t i = 0; i < [certificates count]; i++)
-            cborArray.append(cbor::CBORValue(toVector((NSData *)adoptCF(SecCertificateCopyData((__bridge SecCertificateRef)certificates[i])).get())));
+            cborArray.append(cbor::CBORValue(makeVector((NSData *)adoptCF(SecCertificateCopyData((__bridge SecCertificateRef)certificates[i])).get())));
         attestationStatementMap[cbor::CBORValue("x5c")] = cbor::CBORValue(WTFMove(cborArray));
     }
     auto attestationObject = buildAttestationObject(WTFMove(authData), "apple"_s, WTFMove(attestationStatementMap), creationOptions.attestation);

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
@@ -93,7 +93,7 @@ Vector<uint8_t> NfcConnection::transact(Vector<uint8_t>&& data) const
 {
     // The method will return an empty NSData if the tag is disconnected.
     auto *responseData = [m_session transceive:adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]).get()];
-    return toVector(responseData);
+    return makeVector(responseData);
 }
 
 void NfcConnection::stop() const

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -836,7 +836,7 @@ static std::optional<AuthenticationExtensionsClientOutputs> toExtensionOutputs(N
 {
     if (!extensionOutputsCBOR)
         return std::nullopt;
-    return AuthenticationExtensionsClientOutputs::fromCBOR(toVector(extensionOutputsCBOR));
+    return AuthenticationExtensionsClientOutputs::fromCBOR(makeVector(extensionOutputsCBOR));
 }
 
 bool WebAuthenticatorCoordinatorProxy::isASCAvailable()

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
@@ -141,7 +141,7 @@ Vector<uint8_t> signatureForPrivateKey(RetainPtr<SecKeyRef> privateKey, const Ve
         ASSERT(!errorRef);
     }
 
-    return toVector((NSData *)signature.get());
+    return makeVector((NSData *)signature.get());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8826,7 +8826,7 @@ void WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon(const Vect
     send(Messages::WebPage::ExtendSandboxForFilesFromOpenPanel(WTFMove(sandboxExtensionHandles)));
 #endif
 
-    send(Messages::WebPage::DidChooseFilesForOpenPanelWithDisplayStringAndIcon(fileURLs, displayString, iconData ? iconData->bytes() : std::span<const uint8_t>()));
+    send(Messages::WebPage::DidChooseFilesForOpenPanelWithDisplayStringAndIcon(fileURLs, displayString, iconData ? iconData->span() : std::span<const uint8_t>()));
 
     RefPtr openPanelResultListener = std::exchange(m_openPanelResultListener, nullptr);
     openPanelResultListener->invalidate();
@@ -11239,7 +11239,7 @@ std::optional<Vector<uint8_t>> WebPageProxy::getWebCryptoMasterKey()
     if (auto keyData = m_websiteDataStore->client().webCryptoMasterKey())
         return keyData;
     if (auto keyData = m_navigationClient->webCryptoMasterKey(*this))
-        return Vector(keyData->bytes());
+        return Vector(keyData->span());
     return std::nullopt;
 }
 
@@ -12895,7 +12895,7 @@ void WebPageProxy::loadServiceWorker(const URL& url, bool usingModules, Completi
     else
         html = makeString("<script>navigator.serviceWorker.register('", url.string(), "');</script>").utf8();
 
-    loadData(html.bytes(), "text/html"_s, "UTF-8"_s, url.protocolHostAndPort());
+    loadData(html.span(), "text/html"_s, "UTF-8"_s, url.protocolHostAndPort());
 }
 
 #if !PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
+++ b/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
@@ -215,7 +215,7 @@ auto WebURLSchemeTask::didComplete(const ResourceError& error) -> ExceptionType
     m_completed = true;
 
     if (isSync()) {
-        Vector<uint8_t> data = m_syncData.takeAsContiguous()->bytes();
+        Vector<uint8_t> data = m_syncData.takeAsContiguous()->span();
         m_syncCompletionHandler(m_syncResponse, error, WTFMove(data));
     }
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2476,7 +2476,7 @@ void WebsiteDataStore::resumeDownload(const DownloadProxy& downloadProxy, const 
             sandboxExtensionHandle = WTFMove(*handle);
     }
 
-    protectedNetworkProcess()->send(Messages::NetworkProcess::ResumeDownload(m_sessionID, downloadProxy.downloadID(), resumeData.bytes(), path, WTFMove(sandboxExtensionHandle), callDownloadDidStart), 0);
+    protectedNetworkProcess()->send(Messages::NetworkProcess::ResumeDownload(m_sessionID, downloadProxy.downloadID(), resumeData.span(), path, WTFMove(sandboxExtensionHandle), callDownloadDidStart), 0);
 }
 
 bool WebsiteDataStore::hasActivePages()

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -792,7 +792,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
         [self _updateRemoteAccessibilityRegistration:YES];
         storeAccessibilityRemoteConnectionInformation(self, _page->process().processID(), uuid);
 
-        auto elementToken = toSpan(remoteElementToken);
+        auto elementToken = span(remoteElementToken);
         _page->registerUIProcessAccessibilityTokens(elementToken, elementToken);
     }
 }

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5272,7 +5272,7 @@ static void selectionChangedWithTouch(WKTextInteractionWrapper *interaction, con
 
         auto [elementContext, image, preferredMIMEType] = *data;
         if (auto [data, type] = WebKit::imageDataForRemoveBackground(image.get(), preferredMIMEType.createCFString().get()); data)
-            view->_page->replaceImageForRemoveBackground(elementContext, { String { type.get() } }, toSpan(data.get()));
+            view->_page->replaceImageForRemoveBackground(elementContext, { String { type.get() } }, span(data.get()));
     }];
 }
 

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -292,7 +292,7 @@ static void pageDidDrawToImage(std::optional<WebCore::ShareableBitmap::Handle>&&
             ASSERT(view->_printedPagesData.isEmpty());
             ASSERT(!view->_printedPagesPDFDocument);
             if (data)
-                view->_printedPagesData.append(data->bytes());
+                view->_printedPagesData.append(data->span());
             view->_expectedPrintCallback = { };
             view->_printingCallbackCondition.notifyOne();
         }

--- a/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
+++ b/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm
@@ -130,7 +130,7 @@
 
     if ([item isKindOfClass:[NSAttributedString class]]) {
         NSData *data = [item RTFDFromRange:NSMakeRange(0, [item length]) documentAttributes:@{ }];
-        dataReference = toSpan(data);
+        dataReference = span(data);
 
         types.append(NSPasteboardTypeRTFD);
         types.append(WebCore::legacyRTFDPasteboardType());
@@ -142,7 +142,7 @@
         if (!image)
             return;
 
-        dataReference = toSpan(data);
+        dataReference = span(data);
         types.append(NSPasteboardTypeTIFF);
     } else if ([item isKindOfClass:[NSItemProvider class]]) {
         NSItemProvider *itemProvider = (NSItemProvider *)item;

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -386,7 +386,7 @@ void WebContextMenuProxyMac::removeBackgroundFromControlledImage()
     if (!data)
         return;
 
-    page()->replaceImageForRemoveBackground(*elementContext, { String(type.get()) }, toSpan(data.get()));
+    page()->replaceImageForRemoveBackground(*elementContext, { String(type.get()) }, span(data.get()));
 #endif // ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3535,7 +3535,7 @@ void WebViewImpl::accessibilityRegisterUIProcessTokens()
     // Initialize remote accessibility when the window connection has been established.
     NSData *remoteElementToken = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:m_view.getAutoreleased()];
     NSData *remoteWindowToken = [NSAccessibilityRemoteUIElement remoteTokenForLocalUIElement:[m_view window]];
-    m_page->registerUIProcessAccessibilityTokens(toSpan(remoteElementToken), toSpan(remoteWindowToken));
+    m_page->registerUIProcessAccessibilityTokens(span(remoteElementToken), span(remoteWindowToken));
 }
 
 id WebViewImpl::accessibilityFocusedUIElement()

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
@@ -208,7 +208,7 @@ WKDataRef WKBundleCopyWebNotificationID(WKBundleRef bundleRef, JSContextRef cont
     if (!identifier)
         return nullptr;
 
-    auto span = identifier->toSpan();
+    auto span = identifier->span();
     return WKDataCreate(span.data(), span.size());
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp
@@ -156,7 +156,7 @@ void InjectedBundlePageEditorClient::getPasteboardDataForRange(WebPage& page, co
             pasteboardTypes.append(type->string());
 
         for (auto item : dataArray->elementsOfType<API::Data>()) {
-            auto buffer = SharedBuffer::create(item->bytes());
+            auto buffer = SharedBuffer::create(item->span());
             pasteboardData.append(WTFMove(buffer));
         }
     }

--- a/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
@@ -88,7 +88,7 @@ static RetainPtr<NSKeyedUnarchiver> createUnarchiver(std::span<const uint8_t> da
 
 static RetainPtr<NSKeyedUnarchiver> createUnarchiver(const API::Data& data)
 {
-    return createUnarchiver(data.bytes());
+    return createUnarchiver(data.span());
 }
 
 bool InjectedBundle::decodeBundleParameters(API::Data* bundleParameterDataPtr)

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -63,7 +63,7 @@ void WebSocketChannel::notifySendFrame(WebSocketFrame::OpCode opCode, std::span<
 NetworkSendQueue WebSocketChannel::createMessageQueue(Document& document, WebSocketChannel& channel)
 {
     return { document, [&channel](auto& utf8String) {
-        auto data = utf8String.bytes();
+        auto data = utf8String.span();
         channel.notifySendFrame(WebSocketFrame::OpCode::OpCodeText, data);
         channel.sendMessage(Messages::NetworkSocketChannel::SendString { data }, utf8String.length());
     }, [&channel](auto span) {

--- a/Source/WebKit/WebProcess/Network/WebTransportSendStreamSink.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSendStreamSink.cpp
@@ -61,7 +61,7 @@ void WebTransportSendStreamSink::write(WebCore::ScriptExecutionContext& context,
         return promise.settle(WebCore::Exception { WebCore::ExceptionCode::ExistingExceptionError });
 
     WTF::switchOn(arrayBufferOrView, [&](auto& arrayBufferOrView) {
-        sendBytes(arrayBufferOrView->bytes(), [promise = WTFMove(promise)] () mutable {
+        sendBytes(arrayBufferOrView->span(), [promise = WTFMove(promise)] () mutable {
             promise.resolve();
         });
     });

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
@@ -226,7 +226,7 @@ void RTCDataChannelRemoteManager::RemoteSourceConnection::didChangeReadyState(We
 void RTCDataChannelRemoteManager::RemoteSourceConnection::didReceiveStringData(WebCore::RTCDataChannelIdentifier identifier, const String& string)
 {
     auto text = string.utf8();
-    m_connection->send(Messages::RTCDataChannelRemoteManagerProxy::ReceiveData { identifier, false, text.bytes() }, 0);
+    m_connection->send(Messages::RTCDataChannelRemoteManagerProxy::ReceiveData { identifier, false, text.span() }, 0);
 }
 
 void RTCDataChannelRemoteManager::RemoteSourceConnection::didReceiveRawData(WebCore::RTCDataChannelIdentifier identifier, const uint8_t* data, size_t size)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -224,7 +224,7 @@ void PDFPluginStreamLoaderClient::didReceiveData(NetscapePlugInStreamLoader* str
     if (!request)
         return;
 
-    request->addData(data.bytes());
+    request->addData(data.span());
 }
 
 void PDFPluginStreamLoaderClient::didFail(NetscapePlugInStreamLoader* streamLoader, const ResourceError&)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -984,11 +984,6 @@ bool PDFPluginBase::hudEnabled() const
     return false;
 }
 
-static std::span<const uint8_t> span(NSData *data)
-{
-    return { static_cast<const uint8_t*>(data.bytes), data.length };
-}
-
 void PDFPluginBase::save(CompletionHandler<void(const String&, const URL&, std::span<const uint8_t>)>&& completionHandler)
 {
     NSData *data = liveData();

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -423,7 +423,7 @@ void WebPage::clearDictationAlternatives(Vector<DictationContext>&& contexts)
 
 void WebPage::accessibilityTransferRemoteToken(RetainPtr<NSData> remoteToken, FrameIdentifier frameID)
 {
-    send(Messages::WebPageProxy::RegisterWebProcessAccessibilityToken(toSpan(remoteToken.get()), frameID));
+    send(Messages::WebPageProxy::RegisterWebProcessAccessibilityToken(span(remoteToken.get()), frameID));
 }
 
 void WebPage::accessibilityManageRemoteElementStatus(bool registerStatus, int processIdentifier)
@@ -462,7 +462,7 @@ void WebPage::bindRemoteAccessibilityFrames(int processIdentifier, WebCore::Fram
     registerRemoteFrameAccessibilityTokens(processIdentifier, dataToken);
 
     // Get our remote token data and send back to the RemoteFrame.
-    completionHandler(toSpan(accessibilityRemoteTokenData().get()), getpid());
+    completionHandler(span(accessibilityRemoteTokenData().get()), getpid());
 }
 
 #if ENABLE(APPLE_PAY)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -590,7 +590,7 @@ String WebFrame::source() const
     RefPtr<FragmentedSharedBuffer> mainResourceData = documentLoader->mainResourceData();
     if (!mainResourceData)
         return String();
-    return decoder->encoding().decode(mainResourceData->makeContiguous()->bytes());
+    return decoder->encoding().decode(mainResourceData->makeContiguous()->span());
 }
 
 String WebFrame::contentsAsString() const 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -265,7 +265,7 @@ RetainPtr<NSData> WebPage::accessibilityRemoteTokenData() const
 
 void WebPage::relayAccessibilityNotification(const String& notificationName, const RetainPtr<NSData>& notificationData)
 {
-    send(Messages::WebPageProxy::RelayAccessibilityNotification(notificationName, toSpan(notificationData.get())));
+    send(Messages::WebPageProxy::RelayAccessibilityNotification(notificationName, span(notificationData.get())));
 }
 
 static void computeEditableRootHasContentAndPlainText(const VisibleSelection& selection, EditorState::PostLayoutData& data)

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -764,7 +764,7 @@ void WebPage::handleSelectionServiceClick(FrameSelection& selection, const Vecto
     NSData *selectionData = [attributedSelection RTFDFromRange:NSMakeRange(0, [attributedSelection length]) documentAttributes:@{ }];
 
     flushPendingEditorStateUpdate();
-    send(Messages::WebPageProxy::ShowContextMenu(ContextMenuContextData(point, toVector(selectionData), phoneNumbers, selection.selection().isContentEditable()), UserData()));
+    send(Messages::WebPageProxy::ShowContextMenu(ContextMenuContextData(point, makeVector(selectionData), phoneNumbers, selection.selection().isContentEditable()), UserData()));
 }
 
 void WebPage::handleImageServiceClick(const IntPoint& point, Image& image, HTMLImageElement& element)

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -858,7 +858,7 @@ static void registerLogHook()
 
             auto connectionID = WebProcess::singleton().networkProcessConnectionID();
             if (connectionID)
-                IPC::Connection::send(connectionID, Messages::NetworkConnectionToWebProcess::LogOnBehalfOfWebContent(logChannel.bytesInludingNullTerminator(), logCategory.bytesInludingNullTerminator(), logString, type, getpid()), 0, { }, qos);
+                IPC::Connection::send(connectionID, Messages::NetworkConnectionToWebProcess::LogOnBehalfOfWebContent(logChannel.spanIncludingNullTerminator(), logCategory.spanIncludingNullTerminator(), logString, type, getpid()), 0, { }, qos);
 
             free(messageString);
         }, qos);

--- a/Source/WebKit/webpushd/ApplePushServiceConnection.mm
+++ b/Source/WebKit/webpushd/ApplePushServiceConnection.mm
@@ -51,7 +51,7 @@
     ASSERT(isMainRunLoop());
 
     if (_connection && publicToken.length)
-        _connection->didReceivePublicToken(toVector(publicToken));
+        _connection->didReceivePublicToken(makeVector(publicToken));
 }
 
 - (void)connection:(APSConnection *)connection didReceiveIncomingMessage:(APSIncomingMessage *)message

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -415,9 +415,9 @@ void WebPushDaemon::getPendingPushMessages(PushClientConnection& connection, Com
         for (auto& message : iterator->value) {
             auto data = message.payload.utf8();
 #if ENABLE(DECLARATIVE_WEB_PUSH)
-            resultMessages.append(WebKit::WebPushMessage { Vector(data.bytes()), message.pushPartitionString, message.registrationURL, WTFMove(message.parsedPayload) });
+            resultMessages.append(WebKit::WebPushMessage { Vector(data.span()), message.pushPartitionString, message.registrationURL, WTFMove(message.parsedPayload) });
 #else
-            resultMessages.append(WebKit::WebPushMessage { Vector(data.bytes()), message.pushPartitionString, message.registrationURL, { } });
+            resultMessages.append(WebKit::WebPushMessage { Vector(data.span()), message.pushPartitionString, message.registrationURL, { } });
 #endif
         }
         m_testingPushMessages.remove(iterator);
@@ -523,7 +523,7 @@ void WebPushDaemon::setPublicTokenForTesting(const String& publicToken, Completi
             return;
         }
 
-        m_pushService->setPublicTokenForTesting(Vector<uint8_t> { publicToken.utf8().bytes() });
+        m_pushService->setPublicTokenForTesting(Vector<uint8_t> { publicToken.utf8().span() });
         replySender();
     });
 }

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp
@@ -60,7 +60,7 @@ void SocketStreamHandle::sendHandshake(CString&& handshake, std::optional<Cookie
 {
     if (m_state == Connecting || m_state == Closing)
         return completionHandler(false, false);
-    platformSendHandshake(handshake.bytes(), WTFMove(headerFieldProxy), WTFMove(completionHandler));
+    platformSendHandshake(handshake.span(), WTFMove(headerFieldProxy), WTFMove(completionHandler));
 }
 
 void SocketStreamHandle::close()

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.cpp
@@ -88,7 +88,7 @@ static std::optional<std::pair<Vector<uint8_t>, bool>> cookieDataForHandshake(co
         return std::pair<Vector<uint8_t>, bool> { { }, secureCookiesAccessed };
 
     Vector<uint8_t> data = { 'C', 'o', 'o', 'k', 'i', 'e', ':', ' ' };
-    data.append(cookieDataString.utf8().bytes());
+    data.append(cookieDataString.utf8().span());
     data.append("\r\n\r\n"_span);
 
     return std::pair<Vector<uint8_t>, bool> { data, secureCookiesAccessed };

--- a/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm
+++ b/Source/WebKitLegacy/WebCoreSupport/WebCryptoClient.mm
@@ -29,15 +29,14 @@
 #import "WebUIDelegatePrivate.h"
 #import <WebCore/SerializedCryptoKeyWrap.h>
 #import <optional>
-#import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/cocoa/VectorCocoa.h>
 
 std::optional<Vector<uint8_t>> WebCryptoClient::wrapCryptoKey(const Vector<uint8_t>& key) const
 {
     SEL selector = @selector(webCryptoMasterKeyForWebView:);
     Vector<uint8_t> wrappedKey;
     if ([[m_webView UIDelegate] respondsToSelector:selector]) {
-        NSData *keyData = CallUIDelegate(m_webView, selector);
-        Vector<uint8_t> masterKey(toSpan(keyData));
+        auto masterKey = makeVector(CallUIDelegate(m_webView, selector));
         if (!WebCore::wrapSerializedCryptoKey(masterKey, key, wrappedKey))
             return std::nullopt;
         return wrappedKey;
@@ -56,8 +55,7 @@ std::optional<Vector<uint8_t>> WebCryptoClient::unwrapCryptoKey(const Vector<uin
     SEL selector = @selector(webCryptoMasterKeyForWebView:);
     Vector<uint8_t> key;
     if ([[m_webView UIDelegate] respondsToSelector:selector]) {
-        NSData *keyData = CallUIDelegate(m_webView, selector);
-        Vector<uint8_t> masterKey(toSpan(keyData));
+        auto masterKey = makeVector(CallUIDelegate(m_webView, selector));
         if (!WebCore::unwrapSerializedCryptoKey(masterKey, wrappedKey, key))
             return std::nullopt;
         return key;

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1772,7 +1772,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     PAL::TextEncoding encoding(textEncodingName);
     if (!encoding.isValid())
         encoding = PAL::WindowsLatin1Encoding();
-    return encoding.decode(toSpan(data));
+    return encoding.decode(span(data));
 }
 
 - (NSRect)caretRectAtNode:(DOMNode *)node offset:(int)offset affinity:(NSSelectionAffinity)affinity

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
@@ -240,7 +240,7 @@ using JSC::Yarr::RegularExpression;
     NSData *data = [_private->dataSource data];
     if (!data)
         return nil;
-    return decoder->encoding().decode(toSpan(data));
+    return decoder->encoding().decode(span(data));
 }
 
 - (NSString *)title

--- a/Source/WebKitLegacy/mac/WebView/WebResource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebResource.mm
@@ -371,7 +371,7 @@ static NSString * const WebResourceResponseKey =          @"WebResourceResponse"
     RefPtr coreData = _private->coreResource ? &_private->coreResource->data() : nullptr;
     if (!coreData)
         return @"";
-    return encoding.decode(coreData->makeContiguous()->bytes());
+    return encoding.decode(coreData->makeContiguous()->span());
 }
 
 @end

--- a/Tools/TestWebKitAPI/Tests/WTF/cf/VectorCF.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/cf/VectorCF.cpp
@@ -155,7 +155,7 @@ TEST(VectorCF, VectorFromCFData)
     EXPECT_EQ(elementCount, byteLength);
     auto cfData = adoptCF(CFDataCreate(nullptr, static_cast<const UInt8*>(&bytes[0]), Checked<CFIndex>(byteLength)));
 
-    auto vectorData = toVector(cfData.get());
+    auto vectorData = makeVector(cfData.get());
 
     CFIndex cfDataLength = CFDataGetLength(cfData.get());
     EXPECT_EQ(byteLength, Checked<size_t>(cfDataLength));

--- a/Tools/TestWebKitAPI/Tests/WebCore/KeyedCoding.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/KeyedCoding.cpp
@@ -54,7 +54,7 @@ TEST(KeyedCoding, SetAndGetBytes)
     encoder->encodeBytes("data-size1"_s, data, dataLengthOne);
     auto encodedBuffer = encoder->finishEncoding();
 
-    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->bytes());
+    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->span());
 
     bool success;
     const uint8_t* buffer;
@@ -82,7 +82,7 @@ bool testSimpleValue(EncodeFunctionType encode, bool (WebCore::KeyedDecoder::* d
     (encoder.get()->*encode)("key"_s, value);
 
     auto encodedBuffer = encoder->finishEncoding();
-    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->bytes());
+    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->span());
 
     DecodeValueType decodedValue;
     bool success = (decoder.get()->*decode)("key"_s, decodedValue);
@@ -159,7 +159,7 @@ TEST(KeyedCoding, GetNonExistingRecord)
     encoder->encodeBool("bool-true"_s, true);
 
     auto encodedBuffer = encoder->finishEncoding();
-    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->bytes());
+    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->span());
 
     bool success, boolValue;
     success = decoder->decodeBool("bool-true"_s, boolValue);
@@ -246,7 +246,7 @@ TEST(KeyedCoding, SetAndGetObject)
     encoder->encodeObject("user1"_s, user1, KeyedCodingTestObject::encode);
     auto encodedBuffer = encoder->finishEncoding();
 
-    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->bytes());
+    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->span());
     bool success;
     KeyedCodingTestObject decodedUser0, decodedUser1;
 
@@ -269,7 +269,7 @@ TEST(KeyedCoding, SetAndGetObjects)
     encoder->encodeObjects("users"_s, users.begin(), users.end(), KeyedCodingTestObject::encode);
     auto encodedBuffer = encoder->finishEncoding();
 
-    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->bytes());
+    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->span());
     Vector<KeyedCodingTestObject> decodedUsers;
 
     bool success = decoder->decodeObjects("users"_s, decodedUsers, KeyedCodingTestObject::decode);
@@ -283,7 +283,7 @@ TEST(KeyedCoding, SetAndGetWithEmptyKey)
     encoder->encodeBool(emptyString(), false);
 
     auto encodedBuffer = encoder->finishEncoding();
-    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->bytes());
+    auto decoder = WebCore::KeyedDecoder::decoder(encodedBuffer->span());
 
     bool success, boolValue;
     success = decoder->decodeBool(emptyString(), boolValue);

--- a/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
@@ -38,7 +38,7 @@ namespace Curl {
 
 using namespace WebCore;
 
-static std::span<const uint8_t> toSpan(const ASCIILiteral& data)
+static std::span<const uint8_t> span(const ASCIILiteral& data)
 {
     return { reinterpret_cast<const uint8_t*>(data.characters()), data.length() };
 }
@@ -144,7 +144,7 @@ TEST(CurlMultipartHandleTests, SimpleMessage)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -175,7 +175,7 @@ TEST(CurlMultipartHandleTests, NoHeader)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 0);
 
     handle->completeHeaderProcessing();
@@ -197,7 +197,7 @@ TEST(CurlMultipartHandleTests, NoBody)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -230,7 +230,7 @@ TEST(CurlMultipartHandleTests, TransportPadding)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -262,7 +262,7 @@ TEST(CurlMultipartHandleTests, NoEndOfBoundary)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -296,7 +296,7 @@ TEST(CurlMultipartHandleTests, NoEndOfBoundaryAfterCompleted)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
 
@@ -330,7 +330,7 @@ TEST(CurlMultipartHandleTests, NoCloseDelimiter)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -365,7 +365,7 @@ TEST(CurlMultipartHandleTests, NoCloseDelimiterAfterCompleted)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
 
@@ -399,7 +399,7 @@ TEST(CurlMultipartHandleTests, CloseDelimiter)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -432,7 +432,7 @@ TEST(CurlMultipartHandleTests, CloseDelimiterAfterCompleted)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
 
@@ -467,10 +467,10 @@ TEST(CurlMultipartHandleTests, DivideFirstDelimiter)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 0);
 
-    handle->didReceiveMessage(toSpan(nextData));
+    handle->didReceiveMessage(span(nextData));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -504,7 +504,7 @@ TEST(CurlMultipartHandleTests, DivideSecondDelimiter)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -512,7 +512,7 @@ TEST(CurlMultipartHandleTests, DivideSecondDelimiter)
     handle->completeHeaderProcessing();
     EXPECT_EQ(client.headers().size(), 0);
 
-    handle->didReceiveMessage(toSpan(nextData));
+    handle->didReceiveMessage(span(nextData));
     EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
@@ -541,7 +541,7 @@ TEST(CurlMultipartHandleTests, DivideLastDelimiter)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -557,7 +557,7 @@ TEST(CurlMultipartHandleTests, DivideLastDelimiter)
     EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<h", 2));
     EXPECT_TRUE(!client.complete());
 
-    handle->didReceiveMessage(toSpan(nextData));
+    handle->didReceiveMessage(span(nextData));
     EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
 
     handle->didCompleteMessage();
@@ -579,7 +579,7 @@ TEST(CurlMultipartHandleTests, DivideCloseDelimiter)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -595,7 +595,7 @@ TEST(CurlMultipartHandleTests, DivideCloseDelimiter)
     EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<h", 2));
     EXPECT_TRUE(!client.complete());
 
-    handle->didReceiveMessage(toSpan(nextData));
+    handle->didReceiveMessage(span(nextData));
     EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
 
     handle->didCompleteMessage();
@@ -618,7 +618,7 @@ TEST(CurlMultipartHandleTests, DivideTransportPadding)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -627,7 +627,7 @@ TEST(CurlMultipartHandleTests, DivideTransportPadding)
     EXPECT_EQ(client.headers().size(), 0);
     EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
 
-    handle->didReceiveMessage(toSpan(nextData));
+    handle->didReceiveMessage(span(nextData));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
     client.clear();
@@ -655,7 +655,7 @@ TEST(CurlMultipartHandleTests, DivideHeader)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -664,7 +664,7 @@ TEST(CurlMultipartHandleTests, DivideHeader)
     EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
     EXPECT_EQ(client.headers().size(), 0);
 
-    handle->didReceiveMessage(toSpan(nextData));
+    handle->didReceiveMessage(span(nextData));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
     client.clear();
@@ -694,7 +694,7 @@ TEST(CurlMultipartHandleTests, DivideBody)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     client.clear();
@@ -702,7 +702,7 @@ TEST(CurlMultipartHandleTests, DivideBody)
     handle->completeHeaderProcessing();
     EXPECT_EQ(client.data().size(), 0);
 
-    handle->didReceiveMessage(toSpan(secondData));
+    handle->didReceiveMessage(span(secondData));
     EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "ABCDEF", 6));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/html\r\n"_s);
@@ -711,7 +711,7 @@ TEST(CurlMultipartHandleTests, DivideBody)
     handle->completeHeaderProcessing();
     EXPECT_EQ(client.data().size(), 0);
 
-    handle->didReceiveMessage(toSpan(lastData));
+    handle->didReceiveMessage(span(lastData));
     EXPECT_TRUE(!memcmp(static_cast<const void*>(client.data().data()), "<html></html>", 13));
     EXPECT_TRUE(!client.complete());
 
@@ -735,17 +735,17 @@ TEST(CurlMultipartHandleTests, CompleteWhileHeaderProcessing)
     auto curlResponse = createCurlResponse();
     auto handle = CurlMultipartHandle::createIfNeeded(client, curlResponse);
 
-    handle->didReceiveMessage(toSpan(data));
+    handle->didReceiveMessage(span(data));
     EXPECT_EQ(client.headers().size(), 1);
     EXPECT_TRUE(client.headers().at(0) == "Content-type: text/plain\r\n"_s);
     EXPECT_EQ(client.data().size(), 0);
     client.clear();
 
-    handle->didReceiveMessage(toSpan(secondData));
+    handle->didReceiveMessage(span(secondData));
     EXPECT_EQ(client.headers().size(), 0);
     EXPECT_EQ(client.data().size(), 0);
 
-    handle->didReceiveMessage(toSpan(lastData));
+    handle->didReceiveMessage(span(lastData));
     EXPECT_EQ(client.headers().size(), 0);
     EXPECT_EQ(client.data().size(), 0);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -260,7 +260,7 @@ static void signUnlinkableTokenAndSendSecretToken(TokenSigningParty signingParty
         (__bridge id)kSecAttrKeyType: (__bridge id)kSecAttrKeyTypeRSA,
         (__bridge id)kSecAttrKeyClass: (__bridge id)kSecAttrKeyClassPublic
     }, nil));
-    auto wrappedKeyBytes = wrapPublicKeyWithRSAPSSOID(toVector(publicKey.get()));
+    auto wrappedKeyBytes = wrapPublicKeyWithRSAPSSOID(makeVector(publicKey.get()));
 
     auto keyData = base64URLEncodeToString(wrappedKeyBytes.data(), wrappedKeyBytes.size());
     // The server.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm
@@ -134,7 +134,7 @@ constexpr auto videoPlayTestHTML ="<script>"
 
 static Vector<uint8_t> testVideoBytes()
 {
-    return toVector([NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"mp4" subdirectory:@"TestWebKitAPI.resources"]]);
+    return makeVector([NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"test" withExtension:@"mp4" subdirectory:@"TestWebKitAPI.resources"]]);
 }
 
 static void runVideoTest(NSURLRequest *request, const char* expectedMessage)
@@ -203,7 +203,7 @@ TEST(MediaLoading, LockdownModeHLS)
     "<body onload='createVideoElement()'></body>"_s;
 
     auto testTransportStreamBytes = [&] () -> Vector<uint8_t> {
-        return toVector([NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"start-offset" withExtension:@"ts" subdirectory:@"TestWebKitAPI.resources"]]);
+        return makeVector([NSData dataWithContentsOfURL:[[NSBundle mainBundle] URLForResource:@"start-offset" withExtension:@"ts" subdirectory:@"TestWebKitAPI.resources"]]);
     };
 
     HTTPServer server({

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -710,8 +710,8 @@ static void respondToRangeRequests(const TestWebKitAPI::Connection& connection, 
             rangeBegin, rangeEnd, static_cast<uint64_t>(data.get().length), rangeEnd - rangeBegin];
         NSData *responseHeader = [responseHeaderString dataUsingEncoding:NSUTF8StringEncoding];
         NSData *responseBody = [data subdataWithRange:NSMakeRange(rangeBegin, rangeEnd - rangeBegin)];
-        auto response = toVector(responseHeader);
-        response.append(toSpan(responseBody));
+        auto response = makeVector(responseHeader);
+        response.append(span(responseBody));
         connection.send(WTFMove(response), [=] {
             respondToRangeRequests(connection, data);
         });

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -356,7 +356,7 @@ static Vector<uint8_t> vectorFromData(dispatch_data_t content)
 
 static void appendUTF8ToVector(Vector<uint8_t>& vector, const String& string)
 {
-    vector.append(string.utf8().bytes());
+    vector.append(string.utf8().span());
 }
 
 String HTTPServer::parsePath(const Vector<char>& request)

--- a/Tools/WebKitTestRunner/DataFunctions.h
+++ b/Tools/WebKitTestRunner/DataFunctions.h
@@ -48,7 +48,7 @@ inline WTF::UUID dataToUUID(WKDataRef data)
 
 inline WKRetainPtr<WKDataRef> uuidToData(const WTF::UUID& uuid)
 {
-    auto span = uuid.toSpan();
+    auto span = uuid.span();
     return adoptWK(WKDataCreate(span.data(), span.size()));
 }
 


### PR DESCRIPTION
#### c614496679dcd71dcd262219b126183fb4de86cd
<pre>
Rename toSpan() / bytes() to span(), and vector() free function to makeVector()
<a href="https://bugs.webkit.org/show_bug.cgi?id=271383">https://bugs.webkit.org/show_bug.cgi?id=271383</a>

Reviewed by Darin Adler.

Rename toSpan() / bytes() to span(), and vector() free function to makeVector(),
for consistency.

* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/JavaScriptCore/runtime/ArrayBufferView.h:
(JSC::ArrayBufferView::span const):
(JSC::ArrayBufferView::vector const):
(JSC::ArrayBufferView::bytes const): Deleted.
* Source/WTF/wtf/FileSystem.h:
(WTF::FileSystemImpl::MappedFileData::span):
(WTF::FileSystemImpl::MappedFileData::toSpan): Deleted.
* Source/WTF/wtf/SHA1.h:
(WTF::SHA1::addBytes):
* Source/WTF/wtf/UUID.h:
(WTF::UUID::span const):
(WTF::UUID::toSpan const): Deleted.
* Source/WTF/wtf/cf/VectorCF.h:
(WTF::span):
(WTF::vector):
(WTF::toSpan): Deleted.
(WTF::toVector): Deleted.
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::openTemporaryFile):
* Source/WTF/wtf/cocoa/SpanCocoa.h:
(WTF::span):
(WTF::toSpan): Deleted.
* Source/WTF/wtf/cocoa/VectorCocoa.h:
(WTF::vector):
(WTF::toVector): Deleted.
* Source/WTF/wtf/persistence/PersistentEncoder.h:
(WTF::Persistence::Encoder::span const):
(WTF::Persistence::Encoder::bytes const): Deleted.
* Source/WTF/wtf/text/Base64.h:
(WTF::base64EncodeToVector):
(WTF::base64EncodeToString):
(WTF::base64EncodeToStringReturnNullIfOverflow):
(WTF::base64Encoded):
* Source/WTF/wtf/text/CString.h:
* Source/WTF/wtf/text/WTFString.cpp:
(asciiDebug):
* Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp:
(WebCore::ClipboardItem::blobFromString):
* Source/WebCore/Modules/async-clipboard/ios/ClipboardImageReaderIOS.mm:
(WebCore::ClipboardImageReader::readBuffer):
* Source/WebCore/Modules/async-clipboard/mac/ClipboardImageReaderMac.mm:
(WebCore::ClipboardImageReader::readBuffer):
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp:
(WebCore::CDMSessionClearKey::generateKeyRequest):
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::consumeArrayBuffer):
(WebCore::FetchBody::consumeArrayBufferView):
(WebCore::FetchBody::bodyAsFormData const):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::resolveWithFormData):
(WebCore::FetchBodyConsumer::resolve):
(WebCore::FetchBodyConsumer::takeAsText):
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::Loader::didReceiveData):
(WebCore::FetchResponse::Loader::consumeDataByChunk):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::addExistingIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::createObjectStore):
(WebCore::IDBServer::SQLiteIDBBackingStore::createIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedHasIndexRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedPutIndexRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::keyExistsInObjectStore):
(WebCore::IDBServer::SQLiteIDBBackingStore::deleteRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::addRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::getRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::getAllObjectStoreRecords):
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedGetIndexRecordForOneKey):
(WebCore::IDBServer::SQLiteIDBBackingStore::getCount):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp:
(WebCore::IDBServer::SQLiteIDBCursor::bindArguments):
(WebCore::IDBServer::SQLiteIDBCursor::resetAndRebindPreIndexStatementIfNecessary):
* Source/WebCore/Modules/notifications/NotificationDataCocoa.mm:
(WebCore::NotificationData::fromDictionary):
* Source/WebCore/Modules/push-api/PushDatabase.cpp:
(WebCore::uuidToSpan):
* Source/WebCore/Modules/push-api/PushEvent.cpp:
(WebCore::dataFromPushMessageDataInit):
* Source/WebCore/Modules/push-api/PushManager.cpp:
(WebCore::PushManager::subscribe):
* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp:
(WebCore::AuthenticationExtensionsClientOutputs::toCBOR const):
* Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp:
(WebCore::coseKeyForAttestationObject):
(WebCore::AuthenticatorAttestationResponse::getAuthenticatorData const):
* Source/WebCore/Modules/webauthn/cbor/CBORValue.cpp:
(cbor::CBORValue::CBORValue):
* Source/WebCore/Modules/webauthn/cbor/CBORWriter.cpp:
(cbor::CBORWriter::encodeCBOR):
* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
(fido::pin::SetPinRequest::tryCreate):
* Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp:
(fido::WebCore::constructU2fSignCommand):
* Source/WebCore/Modules/webauthn/fido/U2fResponseConverter.cpp:
(fido::readU2fSignResponse):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp:
(WebCore::WebCodecsAudioData::create):
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp:
(WebCore::WebCodecsEncodedAudioChunk::WebCodecsEncodedAudioChunk):
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp:
(WebCore::WebCodecsEncodedVideoChunk::WebCodecsEncodedVideoChunk):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::didReceiveMessage):
* Source/WebCore/Modules/websockets/WebSocketDeflateFramer.cpp:
(WebCore::WebSocketDeflateFramer::deflate):
(WebCore::WebSocketDeflateFramer::inflate):
* Source/WebCore/Modules/websockets/WebSocketDeflater.h:
(WebCore::WebSocketDeflater::span const):
(WebCore::WebSocketInflater::span const):
(WebCore::WebSocketDeflater::bytes const): Deleted.
(WebCore::WebSocketInflater::bytes const): Deleted.
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AXRemoteFrame::generateRemoteToken const):
* Source/WebCore/bindings/js/BufferSource.h:
(WebCore::BufferSource::span const):
(WebCore::BufferSource::bytes const): Deleted.
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::handleResponseOnStreamingAction):
* Source/WebCore/bindings/js/ScriptBufferSourceProvider.h:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpImageBitmap):
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneSerializer::write):
* Source/WebCore/contentextensions/ContentExtensionActions.cpp:
(WebCore::ContentExtensions::append):
* Source/WebCore/contentextensions/ContentExtensionStringSerialization.cpp:
(WebCore::ContentExtensions::serializeString):
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::toKeyData):
(WebCore::copyToVector):
(WebCore::SubtleCrypto::wrapKey):
* Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm:
(WebCore::wrapSerializedCryptoKey):
(WebCore::unwrapSerializedCryptoKey):
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h:
(WebCore::CryptoAlgorithmRsaKeyGenParams::publicExponentVector const):
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h:
* Source/WebCore/dom/TextDecoder.cpp:
(WebCore::TextDecoder::decode):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::sanitizeMarkupWithArchive):
* Source/WebCore/fileapi/BlobBuilder.cpp:
(WebCore::BlobBuilder::append):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::mainResourceContent):
(WebCore::InspectorPageAgent::sharedBufferContent):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::ApplicationCacheStorage::store):
* Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp:
(WebCore::MHTMLParser::parseNextPart):
* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::policyForCustomFont):
* Source/WebCore/loader/cache/CachedScript.cpp:
(WebCore::CachedScript::script):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::combineSegmentsData):
(WebCore::FragmentedSharedBuffer::getContiguousData const):
(WebCore::FragmentedSharedBuffer::read const):
* Source/WebCore/platform/SharedBuffer.h:
(WebCore::DataSegment::span const):
(WebCore::SharedBuffer::span const):
(WebCore::DataSegment::bytes const): Deleted.
(WebCore::SharedBuffer::bytes const): Deleted.
* Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm:
(WebCore::ContentFilterUnblockHandler::webFilterEvaluatorData const):
* Source/WebCore/platform/graphics/ImageBackingStore.h:
(WebCore::ImageBackingStore::ImageBackingStore):
* Source/WebCore/platform/graphics/WOFFFileFormat.cpp:
(WebCore::convertWOFFToSfnt):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::shouldWaitForLoadingOfResource):
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::cookieFromOpusCookieContents):
* Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp:
(WebCore::FontCustomPlatformData::serializedData const):
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::FontPlatformData::platformSerializationData const):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::captureOutputDidFinishProcessingPhoto):
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormData::create):
(WebCore::appendBlobResolved):
* Source/WebCore/platform/network/FormDataBuilder.cpp:
(WebCore::FormDataBuilder::append):
* Source/WebCore/platform/network/SynchronousLoaderClient.cpp:
(WebCore::SynchronousLoaderClient::didReceiveData):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdateResourceHTTPBody):
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::append):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::deserializeBuffer const):
(WebCore::Internals::createPushSubscription):
* Source/WebCore/testing/MockContentFilter.cpp:
(WebCore::MockContentFilter::maybeDetermineStatus):
* Source/WebCore/testing/ServiceWorkerInternals.cpp:
(WebCore::ServiceWorkerInternals::schedulePushEvent):
(WebCore::ServiceWorkerInternals::createPushSubscription):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
(WebCore::BackgroundFetch::doStore):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::send):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::openFunc):
* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::constantMatrix):
(WGSL::CONSTANT_FUNCTION):
* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::ConstantValue::vector const):
(WGSL::ConstantValue::toVector const): Deleted.
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::conversionRank):
* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::platformCancelNetworkLoad):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::sendReplyToSynchronousRequest):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:task:didCompleteWithError:]):
(WebKit::NetworkSessionCocoa::setProxyConfigData):
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm:
(WebKit::WebSocketTask::readNextMessage):
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::appendReceivedBuffer):
(WebKit::WebSocketTask::sendClosingHandshakeIfNeeded):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::CacheStorageDiskStore::readAllRecordInfos):
(WebKit::CacheStorageDiskStore::readRecords):
(WebKit::encodeRecordHeader):
(WebKit::encodeRecordBody):
(WebKit::encodeRecord):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::writeSizeFile):
* Source/WebKit/Shared/API/APIData.h:
(API::Data::span const):
(API::Data::bytes const): Deleted.
* Source/WebKit/Shared/API/APIData.serialization.in:
* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(-[WKRemoteObjectDecoder decodeBytesForKey:returnedLength:]):
* Source/WebKit/Shared/API/c/WKData.cpp:
(WKDataGetBytes):
* Source/WebKit/Shared/APIWebArchive.mm:
(API::WebArchive::WebArchive):
* Source/WebKit/Shared/APIWebArchiveResource.mm:
(API::WebArchiveResource::WebArchiveResource):
* Source/WebKit/Shared/Cocoa/CoreIPCCFURL.h:
* Source/WebKit/Shared/Cocoa/CoreIPCCFURL.mm:
(WebKit::CoreIPCCFURL::vector const):
(WebKit::CoreIPCCFURL::bytes const): Deleted.
* Source/WebKit/Shared/Cocoa/CoreIPCCFURL.serialization.in:
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtension::createHandleForTemporaryFile):
* Source/WebKit/Shared/Cocoa/WKNSData.mm:
(-[WKNSData bytes]):
* Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm:
(WebKit::WebPushMessage::fromDictionary):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPushMessage.cpp:
(WebKit::WebPushMessage::notificationPayloadToCoreData const):
* Source/WebKit/Shared/cf/CookieStorageUtilsCF.mm:
(WebKit::identifyingDataFromCookieStorage):
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::compileAndCacheSandboxProfile):
* Source/WebKit/UIProcess/API/C/WKNotification.cpp:
(WKNotificationCopyCoreIDForTesting):
* Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp:
(WKNotificationManagerProviderDidClickNotification_b):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageLoadData):
(WKPageLoadDataWithUserData):
(restoreFromSessionState):
* Source/WebKit/UIProcess/API/C/WKSessionStateRef.cpp:
(WKSessionStateCreateFromData):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(-[WKProcessPool _setObject:forBundleParameter:]):
(-[WKProcessPool _setObjectsForBundleParametersWithDictionary:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _restoreFromSessionStateData:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore setProxyConfigurations:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(getAllLocalAuthenticatorCredentialsImpl):
(+[_WKWebAuthenticationPanel setDisplayNameForLocalCredentialWithGroupAndID:credential:displayName:]):
(+[_WKWebAuthenticationPanel setNameForLocalCredentialWithGroupAndID:credential:name:]):
(+[_WKWebAuthenticationPanel importLocalAuthenticatorWithAccessGroup:credential:error:]):
(+[_WKWebAuthenticationPanel exportLocalAuthenticatorCredentialWithGroupAndID:credential:error:]):
(-[_WKWebAuthenticationPanel makeCredentialWithMediationRequirement:clientDataHash:options:completionHandler:]):
(-[_WKWebAuthenticationPanel getAssertionWithMediationRequirement:clientDataHash:options:completionHandler:]):
(+[_WKWebAuthenticationPanel encodeMakeCredentialCommandWithClientDataHash:options:userVerificationAvailability:authenticatorSupportedExtensions:]):
(+[_WKWebAuthenticationPanel encodeGetAssertionCommandWithClientDataHash:options:userVerificationAvailability:authenticatorSupportedExtensions:]):
* Source/WebKit/UIProcess/API/glib/WebKitFaviconDatabase.cpp:
(webkitFaviconDatabaseSetIconForPageURL):
* Source/WebKit/UIProcess/API/glib/WebKitWebResource.cpp:
(resourceDataCallback):
(webkit_web_resource_get_data_finish):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(getContentsAsMHTMLDataCallback):
(webkit_web_view_save_finish):
* Source/WebKit/UIProcess/Cocoa/LegacyCustomProtocolManagerClient.mm:
(-[WKCustomProtocolLoader connection:didReceiveData:]):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm:
(WebKit::SubFrameSOAuthorizationSession::completeInternal):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::providerDidCloseNotifications):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm:
(WebKit::CcidConnection::transact const):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::getExistingCredentials):
(WebKit::LocalAuthenticator::processLargeBlobExtension):
(WebKit::LocalAuthenticator::continueMakeCredentialAfterAttested):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm:
(WebKit::NfcConnection::transact const):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::toExtensionOutputs):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm:
(WebKit::signatureForPrivateKey):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didChooseFilesForOpenPanelWithDisplayStringAndIcon):
(WebKit::WebPageProxy::getWebCryptoMasterKey):
* Source/WebKit/UIProcess/WebURLSchemeTask.cpp:
(WebKit::WebURLSchemeTask::didComplete):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::resumeDownload):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _accessibilityRegisterUIProcessTokens]):
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView _preparePDFDataForPrintingOnSecondaryThread]):
* Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm:
(-[WKSharingServicePickerDelegate sharingService:didShareItems:]):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::removeBackgroundFromControlledImage):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::accessibilityRegisterUIProcessTokens):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp:
(WKBundleCopyWebNotificationID):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageEditorClient.cpp:
(WebKit::InjectedBundlePageEditorClient::getPasteboardDataForRange):
* Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm:
(WebKit::createUnarchiver):
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::createMessageQueue):
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp:
(WebKit::RTCDataChannelRemoteManager::RemoteSourceConnection::didReceiveStringData):
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::PDFPluginStreamLoaderClient::didReceiveData):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::accessibilityTransferRemoteToken):
(WebKit::WebPage::bindRemoteAccessibilityFrames):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::source const):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::handleSelectionServiceClick):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::registerLogHook):
* Source/WebKit/webpushd/ApplePushServiceConnection.mm:
(-[_WKAPSConnectionDelegate connection:didReceivePublicToken:]):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::getPendingPushMessages):
(WebPushD::WebPushDaemon::setPublicTokenForTesting):
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp:
(WebCore::SocketStreamHandle::sendHandshake):
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.cpp:
(WebCore::cookieDataForHandshake):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::send):
(WebCore::WebSocketChannel::startClosingHandshake):
(WebCore::WebSocketChannel::processOutgoingFrameQueue):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(+[WebFrame stringWithData:textEncodingName:]):
* Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm:
(-[WebHTMLRepresentation documentSource]):
* Source/WebKitLegacy/mac/WebView/WebResource.mm:
(-[WebResource _stringValue]):
* Tools/TestWebKitAPI/Tests/WTF/cf/VectorCF.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/CtapResponseTest.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/KeyedCoding.cpp:
(TestWebKitAPI::TEST):
(TestWebKitAPI::testSimpleValue):
* Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp:
(TestWebKitAPI::Curl::span):
(TestWebKitAPI::Curl::TEST):
(TestWebKitAPI::Curl::toSpan): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm:
(TestWebKitAPI::signUnlinkableTokenAndSendSecretToken):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm:
(TestWebKitAPI::testVideoBytes):
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(respondToRangeRequests):
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::appendUTF8ToVector):
* Tools/WebKitTestRunner/DataFunctions.h:
(WTR::uuidToData):

Canonical link: <a href="https://commits.webkit.org/276520@main">https://commits.webkit.org/276520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3e6c9b295e9339b359fed6d8840e93768ee5a8b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47541 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40892 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21383 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21034 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17943 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39791 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2934 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/38087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41114 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49212 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/44343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19855 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/16396 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51515 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6226 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20848 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10454 "Passed tests") | 
<!--EWS-Status-Bubble-End-->