### PR TITLE
[web-animations] account for `display` animations when resolving style

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-interpolation-expected.txt
@@ -15,14 +15,14 @@ PASS CSS Animations: property <display> from [block] to [none] at (-1) should be
 PASS CSS Animations: property <display> from [block] to [none] at (0) should be [block]
 PASS CSS Animations: property <display> from [block] to [none] at (0.1) should be [block]
 PASS CSS Animations: property <display> from [block] to [none] at (0.9) should be [block]
-FAIL CSS Animations: property <display> from [block] to [none] at (1) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [block] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "block "
+PASS CSS Animations: property <display> from [block] to [none] at (1) should be [none]
+PASS CSS Animations: property <display> from [block] to [none] at (1.5) should be [none]
 PASS Web Animations: property <display> from [block] to [none] at (-1) should be [block]
 PASS Web Animations: property <display> from [block] to [none] at (0) should be [block]
 PASS Web Animations: property <display> from [block] to [none] at (0.1) should be [block]
 PASS Web Animations: property <display> from [block] to [none] at (0.9) should be [block]
-FAIL Web Animations: property <display> from [block] to [none] at (1) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [block] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "block "
+PASS Web Animations: property <display> from [block] to [none] at (1) should be [none]
+PASS Web Animations: property <display> from [block] to [none] at (1.5) should be [none]
 PASS CSS Transitions: property <display> from [none] to [block] at (-1) should be [block]
 PASS CSS Transitions: property <display> from [none] to [block] at (0) should be [block]
 PASS CSS Transitions: property <display> from [none] to [block] at (0.1) should be [block]
@@ -35,14 +35,14 @@ PASS CSS Transitions with transition: all: property <display> from [none] to [bl
 PASS CSS Transitions with transition: all: property <display> from [none] to [block] at (0.9) should be [block]
 PASS CSS Transitions with transition: all: property <display> from [none] to [block] at (1) should be [block]
 PASS CSS Transitions with transition: all: property <display> from [none] to [block] at (1.5) should be [block]
-FAIL CSS Animations: property <display> from [none] to [block] at (-1) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [none] to [block] at (0) should be [none] assert_equals: expected "none " but got "block "
+PASS CSS Animations: property <display> from [none] to [block] at (-1) should be [none]
+PASS CSS Animations: property <display> from [none] to [block] at (0) should be [none]
 PASS CSS Animations: property <display> from [none] to [block] at (0.1) should be [block]
 PASS CSS Animations: property <display> from [none] to [block] at (0.9) should be [block]
 PASS CSS Animations: property <display> from [none] to [block] at (1) should be [block]
 PASS CSS Animations: property <display> from [none] to [block] at (1.5) should be [block]
-FAIL Web Animations: property <display> from [none] to [block] at (-1) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [block] at (0) should be [none] assert_equals: expected "none " but got "block "
+PASS Web Animations: property <display> from [none] to [block] at (-1) should be [none]
+PASS Web Animations: property <display> from [none] to [block] at (0) should be [none]
 PASS Web Animations: property <display> from [none] to [block] at (0.1) should be [block]
 PASS Web Animations: property <display> from [none] to [block] at (0.9) should be [block]
 PASS Web Animations: property <display> from [none] to [block] at (1) should be [block]
@@ -111,16 +111,16 @@ PASS CSS Transitions with transition: all: property <display> from [none] to [no
 PASS CSS Transitions with transition: all: property <display> from [none] to [none] at (0.9) should be [none]
 PASS CSS Transitions with transition: all: property <display> from [none] to [none] at (1) should be [none]
 PASS CSS Transitions with transition: all: property <display> from [none] to [none] at (1.5) should be [none]
-FAIL CSS Animations: property <display> from [none] to [none] at (-1) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [none] to [none] at (0) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [none] to [none] at (0.1) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [none] to [none] at (0.9) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [none] to [none] at (1) should be [none] assert_equals: expected "none " but got "block "
-FAIL CSS Animations: property <display> from [none] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [none] at (-1) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [none] at (0) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [none] at (0.1) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [none] at (0.9) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [none] at (1) should be [none] assert_equals: expected "none " but got "block "
-FAIL Web Animations: property <display> from [none] to [none] at (1.5) should be [none] assert_equals: expected "none " but got "block "
+PASS CSS Animations: property <display> from [none] to [none] at (-1) should be [none]
+PASS CSS Animations: property <display> from [none] to [none] at (0) should be [none]
+PASS CSS Animations: property <display> from [none] to [none] at (0.1) should be [none]
+PASS CSS Animations: property <display> from [none] to [none] at (0.9) should be [none]
+PASS CSS Animations: property <display> from [none] to [none] at (1) should be [none]
+PASS CSS Animations: property <display> from [none] to [none] at (1.5) should be [none]
+PASS Web Animations: property <display> from [none] to [none] at (-1) should be [none]
+PASS Web Animations: property <display> from [none] to [none] at (0) should be [none]
+PASS Web Animations: property <display> from [none] to [none] at (0.1) should be [none]
+PASS Web Animations: property <display> from [none] to [none] at (0.9) should be [none]
+PASS Web Animations: property <display> from [none] to [none] at (1) should be [none]
+PASS Web Animations: property <display> from [none] to [none] at (1.5) should be [none]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative-expected.txt
@@ -1,8 +1,8 @@
 hello hello
 
-FAIL display:none animating to display:inline should be inline for the whole animation. assert_equals: The display should be inline during the animation. expected "inline" but got "block"
-FAIL A CSS variable of display:none animating to display:inline should be inline for the whole animation. assert_equals: The display should be inline during the animation. expected "inline" but got "block"
-FAIL Animating from display:none to display:none should not cancel the animation. assert_equals: The display should be none and the animation should keep running. expected "none" but got "block"
-FAIL Animating from display:none to display:none with an intermediate variable should not cancel the animation. assert_equals: The display should be none and the animation should keep running. expected "none" but got "block"
-FAIL Animating a variable of "none" which gets set to display elsewhere should not cancel the animation. assert_equals: The display should be none and the animation should keep running. expected "none" but got "block"
+PASS display:none animating to display:inline should be inline for the whole animation.
+PASS A CSS variable of display:none animating to display:inline should be inline for the whole animation.
+PASS Animating from display:none to display:none should not cancel the animation.
+PASS Animating from display:none to display:none with an intermediate variable should not cancel the animation.
+PASS Animating a variable of "none" which gets set to display elsewhere should not cancel the animation.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation-expected.txt
@@ -13,15 +13,15 @@ PASS CSS Transitions with transition: all: property <display> from [none] to [fl
 PASS CSS Transitions with transition: all: property <display> from [none] to [flex] at (0.6) should be [flex]
 PASS CSS Transitions with transition: all: property <display> from [none] to [flex] at (1) should be [flex]
 PASS CSS Transitions with transition: all: property <display> from [none] to [flex] at (1.5) should be [flex]
-PASS CSS Animations: property <display> from [none] to [flex] at (-0.3) should be [block]
-PASS CSS Animations: property <display> from [none] to [flex] at (0) should be [block]
+FAIL CSS Animations: property <display> from [none] to [flex] at (-0.3) should be [block] assert_equals: expected "block " but got "none "
+FAIL CSS Animations: property <display> from [none] to [flex] at (0) should be [block] assert_equals: expected "block " but got "none "
 FAIL CSS Animations: property <display> from [none] to [flex] at (0.3) should be [block] assert_equals: expected "block " but got "flex "
 FAIL CSS Animations: property <display> from [none] to [flex] at (0.5) should be [block] assert_equals: expected "block " but got "flex "
 FAIL CSS Animations: property <display> from [none] to [flex] at (0.6) should be [block] assert_equals: expected "block " but got "flex "
 FAIL CSS Animations: property <display> from [none] to [flex] at (1) should be [block] assert_equals: expected "block " but got "flex "
 FAIL CSS Animations: property <display> from [none] to [flex] at (1.5) should be [block] assert_equals: expected "block " but got "flex "
-PASS Web Animations: property <display> from [none] to [flex] at (-0.3) should be [block]
-PASS Web Animations: property <display> from [none] to [flex] at (0) should be [block]
+FAIL Web Animations: property <display> from [none] to [flex] at (-0.3) should be [block] assert_equals: expected "block " but got "none "
+FAIL Web Animations: property <display> from [none] to [flex] at (0) should be [block] assert_equals: expected "block " but got "none "
 FAIL Web Animations: property <display> from [none] to [flex] at (0.3) should be [block] assert_equals: expected "block " but got "flex "
 FAIL Web Animations: property <display> from [none] to [flex] at (0.5) should be [block] assert_equals: expected "block " but got "flex "
 FAIL Web Animations: property <display> from [none] to [flex] at (0.6) should be [block] assert_equals: expected "block " but got "flex "

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/display.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/display.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Display can be held by animation assert_equals: Display when progress = 0 expected "block" but got "none"
+PASS Display can be held by animation
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2303,7 +2303,7 @@ bool KeyframeEffect::ticksContinuouslyWhileActive() const
     auto targetHasDisplayContents = [&]() {
         return m_target && !m_pseudoElementIdentifier && m_target->hasDisplayContents();
     };
-    if (!renderer() && !targetHasDisplayContents())
+    if (!renderer() && !m_blendingKeyframes.properties().contains(CSSPropertyDisplay) && !targetHasDisplayContents())
         return false;
 
     if (isCompletelyAccelerated() && isRunningAccelerated()) {

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -46,6 +46,7 @@ struct ElementUpdate {
     std::unique_ptr<RenderStyle> style;
     Change change { Change::None };
     bool recompositeLayer { false };
+    bool animationsAffectedDisplay { false };
 };
 
 struct TextUpdate {

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -346,7 +346,7 @@ void Styleable::updateCSSAnimations(const RenderStyle* currentStyle, const Rende
     auto& keyframeEffectStack = ensureKeyframeEffectStack();
 
     // In case this element is newly getting a "display: none" we need to cancel all of its animations and disregard new ones.
-    if (currentStyle && currentStyle->display() != DisplayType::None && newStyle.display() == DisplayType::None) {
+    if ((!currentStyle || currentStyle->display() != DisplayType::None) && newStyle.display() == DisplayType::None) {
         for (auto& cssAnimation : animationsCreatedByMarkup())
             cssAnimation->cancelFromStyle();
         keyframeEffectStack.setCSSAnimationList(nullptr);
@@ -725,6 +725,10 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
 
 void Styleable::updateCSSTransitions(const RenderStyle& currentStyle, const RenderStyle& newStyle, WeakStyleOriginatedAnimations& newStyleOriginatedAnimations) const
 {
+    // In case this element previous had "display: none" we can stop considering transitions altogether.
+    if (currentStyle.display() == DisplayType::None)
+        return;
+
     // In case this element is newly getting a "display: none" we need to cancel all of its transitions and disregard new ones.
     if (currentStyle.hasTransitions() && currentStyle.display() != DisplayType::None && newStyle.display() == DisplayType::None) {
         if (hasRunningTransitions()) {


### PR DESCRIPTION
#### 6778ef1c00cecfa2d9a145d371db33d01fd3a388
<pre>
[web-animations] account for `display` animations when resolving style
<a href="https://bugs.webkit.org/show_bug.cgi?id=271386">https://bugs.webkit.org/show_bug.cgi?id=271386</a>

Reviewed by Antti Koivisto.

While we added animation support for the `display` property in bug 271372 / 276464@main, we are
not yet fully accounting for the possibility that the `display` property is animated when resolving
styles in Style::TreeResolver.

There are some subtleties there since, historically, transitions could not be started on an element
with `display: none` and setting `display: none` on an element with running style-originated animations
would cancel those animations.

In this patch we now call `createAnimatedElementUpdate()` under `Style::TreeResolver::resolveElement()`
even when the non-animated style has `display: none`. Within `createAnimatedElementUpdate()`, we now
keep track of the non-animated `display` value prior to updating animations, and when we&apos;re done compare
this value to its animated counterpart to determine whether animations affected `display`.

If after updating animations `display: none` is set and that value was not affected by animations, we
cancel any animation created in the process silently (see bug 271365 / 276453@main) such that Web content
may not observe that those animations ever were created.

We also make sure to keep track of whether `display` was affected by updating animations as a new member
of the `ElementUpdate` struct such that when updating renderers in `RenderTreeUpdater::updateElementRenderer()`
we only cancel style-originated animations with a `display: none` style if that that `display` value did not
come from an animation. Otherwise, style-originated animations setting `display: none` would cancel themselves.

These changes allow us to pass the remainder of the WPT test coverage for animating `display`.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/display-none-dont-cancel.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/animations/display-interpolation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/display.tentative-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::ticksContinuouslyWhileActive const):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateElementRenderer):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::affectsRenderedSubtree):
(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):
* Source/WebCore/style/StyleUpdate.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::updateCSSAnimations const):
(WebCore::Styleable::updateCSSTransitions const):

Canonical link: <a href="https://commits.webkit.org/276531@main">https://commits.webkit.org/276531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71f32c7878486748b2ac779e7a623f333f2404f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47412 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40763 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21245 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36790 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20931 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38564 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17856 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39707 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2805 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49073 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43766 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21043 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42513 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21382 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6232 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->