### PR TITLE
REGRESSION (275819@main): 5 Tests in TestWebKitAPI.WKWebExtensionAPIWebRequest sometimes timeout (270812).

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -456,7 +456,7 @@ public:
     bool safeToLoadBackgroundContent() const { return m_safeToLoadBackgroundContent; }
 
     bool decidePolicyForNavigationAction(WKWebView *, WKNavigationAction *);
-    void didFinishNavigation(WKWebView *, WKNavigation *);
+    void didFinishDocumentLoad(WKWebView *, WKNavigation *);
     void didFailNavigation(WKWebView *, WKNavigation *, NSError *);
     void webViewWebContentProcessDidTerminate(WKWebView *);
 


### PR DESCRIPTION
#### 3fd7495076360b9c977af182f895ac3c1a62eaaf
<pre>
REGRESSION (275819@main): 5 Tests in TestWebKitAPI.WKWebExtensionAPIWebRequest sometimes timeout (270812).
<a href="https://webkit.org/b/271392">https://webkit.org/b/271392</a>
<a href="https://rdar.apple.com/124401551">rdar://124401551</a>

Reviewed by Brian Weinstein.

Change from using webView:didFinishNavigation: to _webView:navigationDidFinishDocumentLoad: for
tracking when the background page has finished loading. This will properly fire after modules have
executed, or any async script elements in a custom background page.

This allows us to remove the arbitrary delay we had before, which was wholly inadequate across different
machines, and was firing too soon for slow machines. By waiting for the document load, we know any
background content event listeners will be registered and can properly dispatch events.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(-[_WKWebExtensionContextDelegate _webView:navigationDidFinishDocumentLoad:]): Added.
(WebKit::WebExtensionContext::performTasksAfterBackgroundContentLoads): Removed dispatch_after().
(WebKit::WebExtensionContext::didFinishDocumentLoad):
(-[_WKWebExtensionContextDelegate webView:didFinishNavigation:]): Deleted.
(WebKit::WebExtensionContext::didFinishNavigation): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:

Canonical link: <a href="https://commits.webkit.org/276487@main">https://commits.webkit.org/276487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2c7c42e28a785955735ccde01a939a09a533e45

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47419 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40770 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21252 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17857 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18362 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2812 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41007 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49080 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16300 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43771 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21050 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42518 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6205 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20724 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->