### PR TITLE
[Skia] Create the font manager on demand when first needed

### DIFF
--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -199,7 +199,7 @@ public:
 
 #if USE(SKIA)
     static Vector<hb_feature_t> computeFeatures(const FontDescription&, const FontCreationContext&);
-    SkFontMgr* fontManager() const { return m_fontManager.get(); }
+    SkFontMgr& fontManager() const;
     SkiaHarfBuzzFontCache& harfBuzzFontCache() { return m_harfBuzzFontCache; }
 #endif
 
@@ -268,7 +268,7 @@ private:
 #endif
 
 #if USE(SKIA)
-    sk_sp<SkFontMgr> m_fontManager;
+    mutable sk_sp<SkFontMgr> m_fontManager;
     SkiaHarfBuzzFontCache m_harfBuzzFontCache;
 #endif
 

--- a/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp
@@ -39,7 +39,14 @@ namespace WebCore {
 
 void FontCache::platformInit()
 {
-    m_fontManager = SkFontMgr_New_FontConfig(FcConfigReference(nullptr));
+}
+
+SkFontMgr& FontCache::fontManager() const
+{
+    if (!m_fontManager)
+        m_fontManager = SkFontMgr_New_FontConfig(FcConfigReference(nullptr));
+    RELEASE_ASSERT(m_fontManager);
+    return *m_fontManager.get();
 }
 
 RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription& description, const Font&, IsForPlatformFont, PreferColoredFont, StringView stringView)
@@ -61,19 +68,20 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
 
     // FIXME: handle synthetic properties.
     auto features = computeFeatures(description, { });
-    auto typeface = m_fontManager->matchFamilyStyleCharacter(nullptr, { }, bcp47.data(), bcp47.size(), baseCharacter);
+    auto typeface = fontManager().matchFamilyStyleCharacter(nullptr, { }, bcp47.data(), bcp47.size(), baseCharacter);
     FontPlatformData alternateFontData(WTFMove(typeface), description.computedSize(), false /* syntheticBold */, false /* syntheticOblique */, description.orientation(), description.widthVariant(), description.textRenderingMode(), WTFMove(features));
     return fontForPlatformData(alternateFontData);
 }
 
 Vector<String> FontCache::systemFontFamilies()
 {
-    int count = m_fontManager->countFamilies();
+    auto& manager = fontManager();
+    int count = manager.countFamilies();
     Vector<String> fontFamilies;
     fontFamilies.reserveInitialCapacity(count);
     for (int i = 0; i < count; ++i) {
         SkString familyName;
-        m_fontManager->getFamilyName(i, &familyName);
+        manager.getFamilyName(i, &familyName);
         fontFamilies.append(String::fromUTF8(familyName.data()));
     }
     return fontFamilies;
@@ -319,7 +327,7 @@ static SkFontStyle skiaFontStyle(const FontDescription& fontDescription)
 std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDescription& fontDescription, const AtomString& family, const FontCreationContext& fontCreationContext)
 {
     auto familyName = getFamilyNameStringFromFamily(family);
-    auto typeface = m_fontManager->matchFamilyStyle(familyName.utf8().data(), skiaFontStyle(fontDescription));
+    auto typeface = fontManager().matchFamilyStyle(familyName.utf8().data(), skiaFontStyle(fontDescription));
     if (!typeface)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp
@@ -101,7 +101,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
 
 RefPtr<FontCustomPlatformData> FontCustomPlatformData::create(SharedBuffer& buffer, const String& itemInCollection)
 {
-    sk_sp<SkTypeface> typeface = FontCache::forCurrentThread().fontManager()->makeFromData(buffer.createSkData());
+    sk_sp<SkTypeface> typeface = FontCache::forCurrentThread().fontManager().makeFromData(buffer.createSkData());
     if (!typeface)
         return nullptr;
 


### PR DESCRIPTION
#### 82bbfe731a36c812693c8326286281b561b52377
<pre>
[Skia] Create the font manager on demand when first needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=271396">https://bugs.webkit.org/show_bug.cgi?id=271396</a>

Reviewed by Adrian Perez de Castro.

We are creating the font manager in FontCache::platformInit(), but
that&apos;s only called once for all the instances. This makes all offscreen
canvas tests rendering text to crash, because the FontCache in the
worker thread doesn&apos;t have a font manager.

* Source/WebCore/platform/graphics/FontCache.h:
(WebCore::FontCache::fontManager const): Deleted.
* Source/WebCore/platform/graphics/skia/FontCacheSkia.cpp:
(WebCore::FontCache::platformInit):
(WebCore::FontCache::fontManager const):
(WebCore::FontCache::systemFallbackForCharacterCluster):
(WebCore::FontCache::systemFontFamilies):
(WebCore::FontCache::createFontPlatformData):
* Source/WebCore/platform/graphics/skia/FontCustomPlatformDataSkia.cpp:
(WebCore::FontCustomPlatformData::create):

Canonical link: <a href="https://commits.webkit.org/276483@main">https://commits.webkit.org/276483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebe3abec7de6e5b365025c6eeabcb36f9ee169ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23867 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47427 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40778 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21260 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20956 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17861 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39701 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2820 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49088 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19738 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16313 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42524 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6202 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20732 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->