### PR TITLE
Simplify use of WKWebViewContentProviderRegistry on iOS

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -382,7 +382,6 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
 
     _contentView = adoptNS([[WKContentView alloc] initWithFrame:self.bounds processPool:processPool configuration:pageConfiguration.copyRef() webView:self]);
     _page = [_contentView page];
-    [[_configuration _contentProviderRegistry] addPage:*_page];
 
     [self _setupScrollAndContentViews];
     if (!self.opaque || !pageConfiguration->drawsBackground())
@@ -654,7 +653,6 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
 
 #if PLATFORM(IOS_FAMILY)
     [_remoteObjectRegistry _invalidate];
-    [[_configuration _contentProviderRegistry] removePage:*_page];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [_scrollView setInternalDelegate:nil];
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
@@ -32,9 +32,6 @@
 
 @interface WKWebViewConfiguration ()
 
-#if PLATFORM(IOS_FAMILY)
-@property (nonatomic, setter=_setContentProviderRegistry:) WKWebViewContentProviderRegistry *_contentProviderRegistry;
-#endif
 @property (nonatomic, readonly) NSString *_applicationNameForDesktopUserAgent;
 
 - (Ref<API::PageConfiguration>)copyPageConfiguration;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -240,7 +240,7 @@ struct PerWebProcessState {
     RetainPtr<WKContentView> _contentView;
     std::unique_ptr<WebKit::ViewGestureController> _gestureController;
     Vector<BlockPtr<void ()>> _visibleContentRectUpdateCallbacks;
-
+    RetainPtr<WKWebViewContentProviderRegistry> _contentProviderRegistry;
 #if ENABLE(FULLSCREEN_API)
     RetainPtr<WKFullScreenWindowController> _fullScreenWindowController;
 #endif

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -479,7 +479,9 @@ static CGSize roundScrollViewContentSize(const WebKit::WebPageProxy& page, CGSiz
 
 - (WKWebViewContentProviderRegistry *)_contentProviderRegistry
 {
-    return [_configuration _contentProviderRegistry];
+    if (!self->_contentProviderRegistry)
+        self->_contentProviderRegistry = adoptNS([[WKWebViewContentProviderRegistry alloc] initWithConfiguration:self.configuration]);
+    return self->_contentProviderRegistry.get();
 }
 
 - (WKSelectionGranularity)_selectionGranularity
@@ -491,7 +493,7 @@ static CGSize roundScrollViewContentSize(const WebKit::WebPageProxy& page, CGSiz
 {
     Class representationClass = nil;
     if (pageHasCustomContentView)
-        representationClass = [[_configuration _contentProviderRegistry] providerForMIMEType:mimeType];
+        representationClass = [[self _contentProviderRegistry] providerForMIMEType:mimeType];
 
     if (pageHasCustomContentView && representationClass) {
         [_customContentView removeFromSuperview];
@@ -3922,7 +3924,7 @@ static bool isLockdownModeWarningNeeded()
 - (BOOL)_isDisplayingPDF
 {
     for (auto& type : WebCore::MIMETypeRegistry::pdfMIMETypes()) {
-        Class providerClass = [[_configuration _contentProviderRegistry] providerForMIMEType:@(type.characters())];
+        Class providerClass = [[self _contentProviderRegistry] providerForMIMEType:@(type.characters())];
         if ([_customContentView isKindOfClass:providerClass])
             return YES;
     }

--- a/Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.h
@@ -27,11 +27,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
-#import <wtf/text/WTFString.h>
-
-namespace WebKit {
-class WebPageProxy;
-}
+#import <wtf/Forward.h>
 
 @class WKWebViewConfiguration;
 @protocol WKWebViewContentProvider;
@@ -40,10 +36,6 @@ class WebPageProxy;
 
 - (instancetype)initWithConfiguration:(WKWebViewConfiguration *)configuration;
 
-- (void)addPage:(WebKit::WebPageProxy&)page;
-- (void)removePage:(WebKit::WebPageProxy&)page;
-
-- (void)registerProvider:(Class <WKWebViewContentProvider>)contentProvider forMIMEType:(const String&)mimeType;
 - (Class <WKWebViewContentProvider>)providerForMIMEType:(const String&)mimeType;
 
 - (Vector<String>)_mimeTypesWithCustomContentProviders;

--- a/Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm
@@ -43,7 +43,6 @@
 
 @implementation WKWebViewContentProviderRegistry {
     HashMap<String, Class <WKWebViewContentProvider>, ASCIICaseInsensitiveHash> _contentProviderForMIMEType;
-    HashCountedSet<WebKit::WebPageProxy*> _pages;
 }
 
 - (instancetype)initWithConfiguration:(WKWebViewConfiguration *)configuration
@@ -68,24 +67,9 @@
     return self;
 }
 
-- (void)addPage:(WebKit::WebPageProxy&)page
-{
-    ASSERT(!_pages.contains(&page));
-    _pages.add(&page);
-}
-
-- (void)removePage:(WebKit::WebPageProxy&)page
-{
-    ASSERT(_pages.contains(&page));
-    _pages.remove(&page);
-}
-
 - (void)registerProvider:(Class <WKWebViewContentProvider>)contentProvider forMIMEType:(const String&)mimeType
 {
     _contentProviderForMIMEType.set(mimeType, contentProvider);
-
-    for (auto& page : _pages)
-        page.key->addMIMETypeWithCustomContentProvider(mimeType);
 }
 
 - (Class <WKWebViewContentProvider>)providerForMIMEType:(const String&)mimeType

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11273,11 +11273,6 @@ void WebPageProxy::unwrapCryptoKey(const Vector<uint8_t>& wrappedKey, Completion
     completionHandler(std::optional<Vector<uint8_t>>());
 }
 
-void WebPageProxy::addMIMETypeWithCustomContentProvider(const String& mimeType)
-{
-    send(Messages::WebPage::AddMIMETypeWithCustomContentProvider(mimeType));
-}
-
 void WebPageProxy::changeFontAttributes(WebCore::FontAttributeChanges&& changes)
 {
     if (!hasRunningProcess())

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -894,8 +894,6 @@ public:
 
     WindowKind windowKind() const;
 
-    void addMIMETypeWithCustomContentProvider(const String& mimeType);
-
     void selectAll();
     void executeEditCommand(const String& commandName, const String& argument = String());
     void executeEditCommand(const String& commandName, const String& argument, CompletionHandler<void()>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5878,11 +5878,6 @@ bool WebPage::mainFrameHasCustomContentProvider() const
     return false;
 }
 
-void WebPage::addMIMETypeWithCustomContentProvider(const String& mimeType)
-{
-    m_mimeTypesWithCustomContentProviders.add(mimeType);
-}
-
 void WebPage::updateMainFrameScrollOffsetPinning()
 {
     RefPtr frameView = localMainFrameView();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1200,7 +1200,6 @@ public:
     void updateMainFrameScrollOffsetPinning();
 
     bool mainFrameHasCustomContentProvider() const;
-    void addMIMETypeWithCustomContentProvider(const String&);
 
     void mainFrameDidLayout();
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -353,8 +353,6 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     RequestRectForFoundTextRange(struct WebKit::WebFoundTextRange range) -> (WebCore::FloatRect rect)
     AddLayerForFindOverlay() -> (WebCore::PlatformLayerIdentifier findLayerID)
     RemoveLayerForFindOverlay() -> ()
-    
-    AddMIMETypeWithCustomContentProvider(String mimeType)
 
     # Drag and drop.
 #if PLATFORM(GTK) && ENABLE(DRAG_SUPPORT)


### PR DESCRIPTION
#### 29b1ce3d4b3f123118c251175d50cdf2dbce9453
<pre>
Simplify use of WKWebViewContentProviderRegistry on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=271397">https://bugs.webkit.org/show_bug.cgi?id=271397</a>
<a href="https://rdar.apple.com/125177028">rdar://125177028</a>

Reviewed by Tim Horton.

WKWebViewContentProviderRegistry is a small and simple class that allows a
WKWebView to get an ObjC class from a MIME type based on its preferences.
It does not need to be a member of WKWebViewConfiguration.
It does not need to know about its pages.
It does not need to add MIME types with the WebPage::AddMIMETypeWithCustomContentProvider
message because all the MIME types are sent in WebPageCreationParameters&apos;s
mimeTypesWithCustomContentProviders.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
(-[WKWebView dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration copyWithZone:]):
(-[WKWebViewConfiguration setLimitsNavigationsToAppBoundDomains:]):
(-[WKWebViewConfiguration _contentProviderRegistry]): Deleted.
(-[WKWebViewConfiguration _setContentProviderRegistry:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _contentProviderRegistry]):
(-[WKWebView _setHasCustomContentView:loadedMIMEType:]):
(-[WKWebView _isDisplayingPDF]):
* Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.h:
* Source/WebKit/UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm:
(-[WKWebViewContentProviderRegistry registerProvider:forMIMEType:]):
(-[WKWebViewContentProviderRegistry addPage:]): Deleted.
(-[WKWebViewContentProviderRegistry removePage:]): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::addMIMETypeWithCustomContentProvider): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::addMIMETypeWithCustomContentProvider): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/276486@main">https://commits.webkit.org/276486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfe8779f42f294f75b502036ac6dc96a88f76057

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47254 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47430 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40781 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21264 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17864 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18378 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41018 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/39997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49091 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16327 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21061 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42527 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6204 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20735 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->