### PR TITLE
Implement an initial heuristic to find targeted elements for remote inspection

### DIFF
--- a/Source/WebCore/page/ElementTargeting.cpp
+++ b/Source/WebCore/page/ElementTargeting.cpp
@@ -26,11 +26,301 @@
 #include "config.h"
 #include "ElementTargeting.h"
 
+#include "DOMTokenList.h"
+#include "Document.h"
+#include "ElementAncestorIteratorInlines.h"
+#include "ElementChildIteratorInlines.h"
+#include "ElementInlines.h"
+#include "ElementTargetingTypes.h"
+#include "FloatPoint.h"
+#include "HTMLBodyElement.h"
+#include "HTMLNames.h"
+#include "HitTestRequest.h"
+#include "HitTestResult.h"
+#include "LocalFrame.h"
+#include "LocalFrameView.h"
+#include "NodeList.h"
+#include "Page.h"
+#include "TextExtraction.h"
+#include "TypedElementDescendantIteratorInlines.h"
+
 namespace WebCore {
 
-Vector<TargetedElementInfo> findTargetedElements(Page&, TargetedElementRequest&&)
+static inline bool elementAndAncestorsAreOnlyChildren(const Element& element)
 {
+    for (auto& ancestor : ancestorsOfType<Element>(element)) {
+        if (!ancestor.hasOneChild())
+            return false;
+    }
+    return true;
+}
+
+static inline bool querySelectorMatchesOneElement(Document& document, const String& selector)
+{
+    auto result = document.querySelectorAll(selector);
+    return !result.hasException() && result.returnValue()->length() == 1;
+}
+
+struct ChildElementPosition {
+    size_t index { notFound };
+    size_t childCountOfType { 0 };
+};
+
+static inline ChildElementPosition childIndexByType(Element& element, Element& parent)
+{
+    ChildElementPosition result;
+    auto elementTagName = element.tagName();
+    for (auto& child : childrenOfType<Element>(parent)) {
+        if (child.tagName() != elementTagName)
+            continue;
+
+        if (&child == &element)
+            result.index = result.childCountOfType;
+
+        result.childCountOfType++;
+    }
+
+    return result;
+}
+
+static inline String computeIDSelector(Element& element)
+{
+    if (element.hasID()) {
+        auto elementID = element.getIdAttribute();
+        if (auto* matches = element.document().getAllElementsById(elementID); matches && matches->size() == 1)
+            return makeString('#', elementID);
+    }
     return { };
+}
+
+static inline String computeClassSelector(Element& element)
+{
+    if (element.hasClass()) {
+        static constexpr auto maxNumberOfClasses = 5;
+        auto& classList = element.classList();
+        Vector<String> classes;
+        classes.reserveInitialCapacity(classList.length());
+        for (unsigned i = 0; i < std::min<unsigned>(maxNumberOfClasses, classList.length()); ++i)
+            classes.append(classList.item(i));
+        auto selector = makeString('.', makeStringByJoining(classes, "."_s));
+        if (querySelectorMatchesOneElement(element.document(), selector))
+            return selector;
+    }
+    return { };
+}
+
+static String parentRelativeSelectorRecursive(Element&);
+static String selectorForElementRecursive(Element& element)
+{
+    if (auto selector = computeIDSelector(element); !selector.isEmpty())
+        return selector;
+
+    if (auto selector = computeClassSelector(element); !selector.isEmpty())
+        return selector;
+
+    if (querySelectorMatchesOneElement(element.document(), element.tagName()))
+        return element.tagName();
+
+    return parentRelativeSelectorRecursive(element);
+}
+
+static String parentRelativeSelectorRecursive(Element& element)
+{
+    RefPtr parent = element.parentElement();
+    if (!parent)
+        return { };
+
+    if (auto selector = selectorForElementRecursive(*parent); !selector.isEmpty()) {
+        auto selectorPrefix = makeString(WTFMove(selector), " > "_s, element.tagName());
+        auto [childIndex, childCountOfType] = childIndexByType(element, *parent);
+        if (childIndex == notFound)
+            return { };
+
+        if (childCountOfType == 1)
+            return selectorPrefix;
+
+        if (!childIndex)
+            return makeString(WTFMove(selectorPrefix), ":first-of-type"_s);
+
+        if (childIndex == childCountOfType - 1)
+            return makeString(WTFMove(selectorPrefix), ":last-of-type"_s);
+
+        return makeString(WTFMove(selectorPrefix), ":nth-child("_s, childIndex + 1, ')');
+    }
+
+    return { };
+}
+
+// Returns multiple CSS selectors that uniquely match the target element.
+static Vector<String> selectorsForTarget(Element& element)
+{
+    Vector<String> selectors;
+    if (auto selector = computeIDSelector(element); !selector.isEmpty())
+        selectors.append(WTFMove(selector));
+
+    if (auto selector = computeClassSelector(element); !selector.isEmpty())
+        selectors.append(WTFMove(selector));
+
+    if (querySelectorMatchesOneElement(element.document(), element.tagName()))
+        selectors.append(element.tagName());
+
+    if (selectors.isEmpty()) {
+        // Only fall back on the parent relative selector as a last resort.
+        if (auto selector = parentRelativeSelectorRecursive(element); !selector.isEmpty())
+            selectors.append(WTFMove(selector));
+    }
+
+    return selectors;
+}
+
+static inline RectEdges<bool> computeOffsetEdges(const RenderStyle& style)
+{
+    return {
+        style.top().isSpecified(),
+        style.right().isSpecified(),
+        style.bottom().isSpecified(),
+        style.left().isSpecified()
+    };
+}
+
+static TargetedElementInfo targetedElementInfo(Element& element)
+{
+    CheckedPtr renderer = element.renderer();
+    return {
+        .elementIdentifier = element.identifier(),
+        .documentIdentifier = element.document().identifier(),
+        .offsetEdges = computeOffsetEdges(renderer->style()),
+        .renderedText = TextExtraction::extractRenderedText(element),
+        .selectors = selectorsForTarget(element),
+        .boundsInRootView = element.boundingBoxInRootViewCoordinates(),
+        .positionType = renderer->style().position()
+    };
+}
+
+Vector<TargetedElementInfo> findTargetedElements(Page& page, TargetedElementRequest&& request)
+{
+    RefPtr mainFrame = dynamicDowncast<LocalFrame>(page.mainFrame());
+    if (!mainFrame)
+        return { };
+
+    RefPtr document = mainFrame->document();
+    if (!document)
+        return { };
+
+    RefPtr view = mainFrame->view();
+    if (!view)
+        return { };
+
+    RefPtr bodyElement = document->body();
+    if (!bodyElement)
+        return { };
+
+    RefPtr documentElement = document->documentElement();
+    if (!documentElement)
+        return { };
+
+    FloatSize viewportSize = view->baseLayoutViewportSize();
+    auto viewportArea = viewportSize.area();
+
+    static constexpr OptionSet hitTestOptions {
+        HitTestRequest::Type::ReadOnly,
+        HitTestRequest::Type::DisallowUserAgentShadowContent,
+        HitTestRequest::Type::IgnoreCSSPointerEventsProperty,
+        HitTestRequest::Type::CollectMultipleElements,
+        HitTestRequest::Type::IncludeAllElementsUnderPoint
+    };
+
+    HitTestResult result { LayoutPoint { view->rootViewToContents(request.pointInRootView) } };
+    document->hitTest(hitTestOptions, result);
+
+    RefPtr<Element> onlyMainElement;
+    for (auto& descendant : descendantsOfType<HTMLElement>(*bodyElement)) {
+        if (!descendant.hasTagName(HTMLNames::mainTag))
+            continue;
+
+        if (onlyMainElement) {
+            onlyMainElement = nullptr;
+            break;
+        }
+
+        onlyMainElement = &descendant;
+    }
+
+    auto candidates = [&] {
+        auto& results = result.listBasedTestResult();
+        Vector<Ref<Element>> elements;
+        elements.reserveInitialCapacity(results.size());
+        for (auto& node : results) {
+            RefPtr element = dynamicDowncast<Element>(node);
+            if (!element)
+                continue;
+
+            if (!element->renderer())
+                continue;
+
+            if (element == document->body())
+                continue;
+
+            if (element == document->documentElement())
+                continue;
+
+            if (elementAndAncestorsAreOnlyChildren(*element))
+                continue;
+
+            if (onlyMainElement && (onlyMainElement == element || element->contains(*onlyMainElement)))
+                continue;
+
+            elements.append(element.releaseNonNull());
+        }
+        return elements;
+    }();
+
+    Vector<Ref<Element>> targets; // The front-most target is last in this list.
+    auto addTarget = [&](Element& newTarget) {
+        targets.append(newTarget);
+        candidates.removeAllMatching([&](auto& element) {
+            return &newTarget == element.ptr() || newTarget.contains(element);
+        });
+    };
+
+    static constexpr auto areaRatioForAbsolutelyPositionedContent = 0.75;
+    static constexpr auto areaRatioForInFlowContent = 0.5;
+    static constexpr auto minimumAreaForNonFixedOrStickyContent = 10000;
+
+    // Prioritize parent elements over their children by traversing backwards over the candidates.
+    // This allows us to target only the top-most container elements that satisfy the criteria.
+    while (!candidates.isEmpty()) {
+        Ref element = candidates.takeLast();
+        CheckedPtr renderer = element->renderer();
+        if (renderer->isFixedPositioned() || renderer->isStickilyPositioned()) {
+            addTarget(element);
+            continue;
+        }
+
+        auto boundingBox = element->boundingBoxInRootViewCoordinates();
+        auto area = boundingBox.area<RecordOverflow>();
+        if (!area.hasOverflowed() && area.value() < minimumAreaForNonFixedOrStickyContent)
+            continue;
+
+        auto elementAreaRatio = area.hasOverflowed() ? std::numeric_limits<float>::max() : area.value() / viewportArea;
+        if (renderer->isAbsolutelyPositioned() && elementAreaRatio < areaRatioForAbsolutelyPositionedContent) {
+            addTarget(element);
+            continue;
+        }
+
+        if (elementAreaRatio < areaRatioForInFlowContent)
+            addTarget(element);
+    }
+
+    if (targets.isEmpty())
+        return { };
+
+    Vector<TargetedElementInfo> results;
+    results.reserveInitialCapacity(targets.size());
+    for (auto iterator = targets.rbegin(); iterator != targets.rend(); ++iterator)
+        results.append(targetedElementInfo(*iterator));
+
+    return results;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -502,6 +502,17 @@ static void extractRenderedText(Vector<StringsAndBlockOffset>& stringsAndOffsets
     }
 
     auto frameView = renderer->view().protectedFrameView();
+    auto appendReplacedRenderer = [&](RenderObject& renderer) {
+        ASSERT(renderer.isRenderReplaced());
+        auto bounds = frameView->contentsToRootView(renderer.absoluteBoundingBoxRect());
+        appendStrings({ makeString('{', bounds.width(), ',', bounds.height(), '}') }, bounds);
+    };
+
+    if (renderer->isRenderReplaced()) {
+        appendReplacedRenderer(*renderer);
+        return;
+    }
+
     for (auto& descendant : descendantsOfType<RenderObject>(*renderer)) {
         if (descendant.style().visibility() == Visibility::Hidden)
             continue;
@@ -529,8 +540,7 @@ static void extractRenderedText(Vector<StringsAndBlockOffset>& stringsAndOffsets
         }
 
         if (descendant.isRenderReplaced()) {
-            auto bounds = frameView->contentsToRootView(descendant.absoluteBoundingBoxRect());
-            appendStrings({ makeString('{', bounds.width(), ',', bounds.height(), '}') }, bounds);
+            appendReplacedRenderer(descendant);
             continue;
         }
     }
@@ -550,13 +560,18 @@ Expected<String, ExceptionCode> extractRenderedText(LocalFrame& frame, String&& 
     if (!element)
         return makeUnexpected(ExceptionCode::NotFoundError);
 
-    if (!element->renderer())
+    return extractRenderedText(*element);
+}
+
+String extractRenderedText(Element& element)
+{
+    if (!element.renderer())
         return emptyString();
 
-    auto direction = element->renderer()->style().blockFlowDirection();
+    auto direction = element.renderer()->style().blockFlowDirection();
 
     Vector<StringsAndBlockOffset> stringsAndOffsets;
-    extractRenderedText(stringsAndOffsets, *element, direction);
+    extractRenderedText(stringsAndOffsets, element, direction);
 
     bool ascendingOrder = [&] {
         switch (direction) {

--- a/Source/WebCore/page/text-extraction/TextExtraction.h
+++ b/Source/WebCore/page/text-extraction/TextExtraction.h
@@ -30,6 +30,7 @@
 
 namespace WebCore {
 
+class Element;
 class LocalFrame;
 class Page;
 enum class ExceptionCode : uint8_t;
@@ -39,6 +40,7 @@ namespace TextExtraction {
 WEBCORE_EXPORT Item extractItem(std::optional<WebCore::FloatRect>&& collectionRectInRootView, Page&);
 
 WEBCORE_EXPORT Expected<String, ExceptionCode> extractRenderedText(LocalFrame&, String&& selector);
+String extractRenderedText(Element&);
 
 } // namespace TextExtraction
 } // namespace WebCore

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -108,6 +108,7 @@ Tests/WebKitCocoa/DownloadProgress.mm
 Tests/WebKitCocoa/DragAndDropTests.mm
 Tests/WebKitCocoa/DuplicateCompletionHandlerCalls.mm
 Tests/WebKitCocoa/EditorStateTests.mm
+Tests/WebKitCocoa/ElementTargetingTests.mm
 Tests/WebKitCocoa/EventAttribution.mm
 Tests/WebKitCocoa/ExitFullscreenOnEnterPiP.mm
 Tests/WebKitCocoa/ExitPiPOnSuspendVideoElement.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1263,6 +1263,7 @@
 		F4D5E4E81F0C5D38008C1A49 /* dragstart-clear-selection.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D5E4E71F0C5D27008C1A49 /* dragstart-clear-selection.html */; };
 		F4D65DA81F5E4704009D8C27 /* selected-text-image-link-and-editable.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D65DA71F5E46C0009D8C27 /* selected-text-image-link-and-editable.html */; };
 		F4D9818F2196B920008230FC /* editable-nested-lists.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4D9818E2196B911008230FC /* editable-nested-lists.html */; };
+		F4DADD072BABAD0F008B398F /* element-targeting-1.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4DADCFF2BABA80C008B398F /* element-targeting-1.html */; };
 		F4DEF6ED1E9B4DB60048EF61 /* image-in-link-and-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4DEF6EC1E9B4D950048EF61 /* image-in-link-and-input.html */; };
 		F4E0A28B211E4A2B00AF7C7F /* full-page-dropzone.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F46128D8211E496300D9FADB /* full-page-dropzone.html */; };
 		F4E0A28F211E5D5B00AF7C7F /* DragAndDropTestsMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4E0A28E211E5D5B00AF7C7F /* DragAndDropTestsMac.mm */; };
@@ -1620,6 +1621,7 @@
 				F4352F9F26D403DE00E605E4 /* editable-responsive-body.html in Copy Resources */,
 				F44D06451F395C26001A0E29 /* editor-state-test-harness.html in Copy Resources */,
 				F4BDA43027F8D19C00F9647D /* element-fullscreen.html in Copy Resources */,
+				F4DADD072BABAD0F008B398F /* element-targeting-1.html in Copy Resources */,
 				51C8E1A91F27F49600BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist in Copy Resources */,
 				49D902B328209B3300E2C3B8 /* emptyTable.html in Copy Resources */,
 				A14AAB651E78DC5400C1ADC2 /* encrypted.pdf in Copy Resources */,
@@ -3650,6 +3652,8 @@
 		F4D5E4E71F0C5D27008C1A49 /* dragstart-clear-selection.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "dragstart-clear-selection.html"; sourceTree = "<group>"; };
 		F4D65DA71F5E46C0009D8C27 /* selected-text-image-link-and-editable.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "selected-text-image-link-and-editable.html"; sourceTree = "<group>"; };
 		F4D9818E2196B911008230FC /* editable-nested-lists.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "editable-nested-lists.html"; sourceTree = "<group>"; };
+		F4DADCF62BABA65B008B398F /* ElementTargetingTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ElementTargetingTests.mm; sourceTree = "<group>"; };
+		F4DADCFF2BABA80C008B398F /* element-targeting-1.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-targeting-1.html"; sourceTree = "<group>"; };
 		F4DD79E12AD4BDCB000C6821 /* InitializeWebViewWhenChangingUserDefaults.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = InitializeWebViewWhenChangingUserDefaults.mm; sourceTree = "<group>"; };
 		F4DEF6EC1E9B4D950048EF61 /* image-in-link-and-input.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "image-in-link-and-input.html"; sourceTree = "<group>"; };
 		F4E0A28E211E5D5B00AF7C7F /* DragAndDropTestsMac.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DragAndDropTestsMac.mm; sourceTree = "<group>"; };
@@ -4068,6 +4072,7 @@
 				F46128D6211E489C00D9FADB /* DragAndDropTests.mm */,
 				A15502281E05020B00A24C57 /* DuplicateCompletionHandlerCalls.mm */,
 				F44D06461F395C4D001A0E29 /* EditorStateTests.mm */,
+				F4DADCF62BABA65B008B398F /* ElementTargetingTests.mm */,
 				6B25A75125DC8D4E0070744F /* EventAttribution.mm */,
 				CDA29B2820FD2A9900F15CED /* ExitFullscreenOnEnterPiP.mm */,
 				1D12BEBF245BEF85004C0B7A /* ExitPiPOnSuspendVideoElement.mm */,
@@ -4814,6 +4819,7 @@
 				F4352F9E26D4037000E605E4 /* editable-responsive-body.html */,
 				F44D06441F395C0D001A0E29 /* editor-state-test-harness.html */,
 				F4BDA42F27F8CF5600F9647D /* element-fullscreen.html */,
+				F4DADCFF2BABA80C008B398F /* element-targeting-1.html */,
 				51C8E1A81F27F47300BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist */,
 				F4C2AB211DD6D94100E06D5B /* enormous-video-with-sound.html */,
 				F407FE381F1D0DE60017CF25 /* enormous.svg */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "PlatformUtilities.h"
+#import "TestWKWebView.h"
+#import <WebKit/_WKTargetedElementInfo.h>
+#import <WebKit/_WKTargetedElementRequest.h>
+
+@interface WKWebView (ElementTargeting)
+- (NSArray<_WKTargetedElementInfo *> *)targetedElementInfoAt:(CGPoint)point;
+@end
+
+@implementation WKWebView (ElementTargeting)
+
+- (NSArray<_WKTargetedElementInfo *> *)targetedElementInfoAt:(CGPoint)point
+{
+    __block RetainPtr<NSArray<_WKTargetedElementInfo *>> result;
+    auto request = adoptNS([_WKTargetedElementRequest new]);
+    [request setPoint:point];
+    __block bool done = false;
+    [self _requestTargetedElementInfo:request.get() completionHandler:^(NSArray<_WKTargetedElementInfo *> *elements) {
+        result = elements;
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    return result.autorelease();
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+TEST(ElementTargeting, BasicElementTargeting)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    [webView synchronouslyLoadTestPageNamed:@"element-targeting-1"];
+
+    auto elements = [webView targetedElementInfoAt:CGPointMake(150, 150)];
+    EXPECT_EQ(elements.count, 3U);
+    {
+        EXPECT_EQ(elements[0].positionType, _WKTargetedElementPositionFixed);
+        EXPECT_WK_STREQ(".fixed.container", elements[0].selectors.firstObject);
+        EXPECT_TRUE([elements[0].renderedText containsString:@"The round pegs"]);
+        EXPECT_EQ(elements[0].renderedText.length, 70U);
+        EXPECT_EQ(elements[0].offsetEdges, _WKRectEdgeLeft | _WKRectEdgeTop);
+    }
+    {
+        EXPECT_EQ(elements[1].positionType, _WKTargetedElementPositionAbsolute);
+        EXPECT_WK_STREQ("#absolute", elements[1].selectors.firstObject);
+        EXPECT_TRUE([elements[1].renderedText containsString:@"the crazy ones"]);
+        EXPECT_EQ(elements[1].renderedText.length, 64U);
+        EXPECT_EQ(elements[1].offsetEdges, _WKRectEdgeRight | _WKRectEdgeBottom);
+    }
+    {
+        EXPECT_EQ(elements[2].positionType, _WKTargetedElementPositionStatic);
+        EXPECT_WK_STREQ("MAIN > SECTION:first-of-type", elements[2].selectors.firstObject);
+        EXPECT_TRUE([elements[2].renderedText containsString:@"Lorem ipsum"]);
+        EXPECT_EQ(elements[2].renderedText.length, 896U);
+        EXPECT_EQ(elements[2].offsetEdges, _WKRectEdgeNone);
+    }
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-1.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-1.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<style>
+body, html {
+    width: 100%;
+    height: 100%;
+    font-size: 16px;
+    -webkit-text-size-adjust: none;
+}
+
+.container {
+    color: white;
+    text-align: center;
+    opacity: 0.75;
+}
+
+.fixed {
+    width: 300px;
+    height: 300px;
+    position: fixed;
+    top: 1em;
+    left: 1vw;
+    background: tomato;
+    pointer-events: none;
+    z-index: 100;
+}
+
+#absolute {
+    width: 50%;
+    height: 100%;
+    position: absolute;
+    bottom: 0;
+    right: 50%;
+    background: blueviolet;
+}
+
+main {
+    line-height: 200%;
+}
+</style>
+</head>
+<body>
+    <div class="fixed container">
+        <p>The round pegs in the square holes. <a href="https://webkit.org">The ones who see things differently</a>.</p>
+    </div>
+    <div id="absolute" class="container">
+        <p>Here’s to the crazy ones. <strong>The misfits.</strong> The rebels. The troublemakers.
+    </div>
+    <main>
+        <section><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Libero id faucibus nisl tincidunt eget nullam non nisi est. A cras semper auctor neque vitae tempus quam pellentesque nec. Amet risus nullam eget felis eget nunc lobortis mattis aliquam. Sagittis purus sit amet volutpat consequat mauris nunc congue. Dictum fusce ut placerat orci nulla pellentesque dignissim enim. Laoreet non curabitur gravida arcu ac. Lorem ipsum dolor sit amet. Ultrices in iaculis nunc sed augue lacus viverra. Eu feugiat pretium nibh ipsum consequat nisl vel. Neque ornare aenean euismod elementum nisi quis eleifend quam adipiscing. Semper quis lectus nulla at volutpat diam ut. Bibendum ut tristique et egestas quis ipsum suspendisse ultrices. Rhoncus dolor purus non enim praesent elementum facilisis leo. Ultrices vitae auctor eu augue ut lectus arcu bibendum at.</p></section>
+        <section><p>Sem viverra aliquet eget sit amet tellus cras adipiscing. Sit amet cursus sit amet dictum sit amet justo donec. Viverra nibh cras pulvinar mattis nunc sed blandit libero volutpat. Porttitor eget dolor morbi non arcu risus quis. Diam vulputate ut pharetra sit amet aliquam id diam maecenas. Et pharetra pharetra massa massa ultricies mi quis hendrerit. Amet consectetur adipiscing elit ut aliquam purus sit. Erat pellentesque adipiscing commodo elit at imperdiet. Consectetur adipiscing elit pellentesque habitant morbi tristique senectus et netus. Cras ornare arcu dui vivamus arcu felis bibendum. Blandit aliquam etiam erat velit scelerisque in. Tellus integer feugiat scelerisque varius morbi enim. Maecenas accumsan lacus vel facilisis volutpat est velit egestas dui. Egestas erat imperdiet sed euismod nisi porta lorem mollis aliquam. Volutpat commodo sed egestas egestas fringilla phasellus faucibus. Congue nisi vitae suscipit tellus mauris a. Faucibus vitae aliquet nec ullamcorper sit amet risus nullam eget. Nibh venenatis cras sed felis eget.</p></section>
+        <section><p>Nibh venenatis cras sed felis. Nunc congue nisi vitae suscipit tellus mauris a diam maecenas. Ultrices gravida dictum fusce ut placerat orci nulla pellentesque. Fermentum iaculis eu non diam. Molestie nunc non blandit massa enim nec dui nunc mattis. Arcu cursus euismod quis viverra nibh. Morbi non arcu risus quis varius quam. Sed velit dignissim sodales ut eu sem. Massa id neque aliquam vestibulum morbi blandit. Sit amet venenatis urna cursus eget nunc scelerisque. Non enim praesent elementum facilisis leo vel fringilla. Orci a scelerisque purus semper eget duis at. Donec massa sapien faucibus et molestie. Enim ut sem viverra aliquet eget. Elementum curabitur vitae nunc sed velit dignissim sodales ut. In massa tempor nec feugiat nisl pretium fusce id. Habitant morbi tristique senectus et netus et malesuada fames ac. Volutpat maecenas volutpat blandit aliquam etiam erat velit scelerisque in. Nulla pellentesque dignissim enim sit amet venenatis. Et malesuada fames ac turpis egestas integer eget.</p></section>
+        <section><p>Sollicitudin aliquam ultrices sagittis orci a. Mattis pellentesque id nibh tortor id aliquet lectus proin nibh. Duis at consectetur lorem donec massa sapien faucibus. Massa tincidunt dui ut ornare lectus sit amet est placerat. In ante metus dictum at. Urna nec tincidunt praesent semper feugiat nibh sed. Tempus quam pellentesque nec nam. Sapien pellentesque habitant morbi tristique senectus et netus et malesuada. Orci sagittis eu volutpat odio facilisis. Morbi tristique senectus et netus et malesuada. Phasellus vestibulum lorem sed risus ultricies tristique nulla aliquet. Sem nulla pharetra diam sit. Rhoncus urna neque viverra justo nec. Ultrices vitae auctor eu augue ut lectus arcu bibendum at.</p></section>
+        <section><p>Turpis egestas integer eget aliquet nibh praesent tristique. Diam volutpat commodo sed egestas egestas fringilla phasellus faucibus. Enim diam vulputate ut pharetra sit amet aliquam. Congue nisi vitae suscipit tellus mauris a diam. Placerat vestibulum lectus mauris ultrices eros in cursus turpis. Consequat mauris nunc congue nisi vitae suscipit. Est ullamcorper eget nulla facilisi etiam. Nisl nisi scelerisque eu ultrices. Ut tortor pretium viverra suspendisse potenti nullam ac. Sagittis eu volutpat odio facilisis mauris sit amet massa vitae. Aliquet nec ullamcorper sit amet risus. Pretium vulputate sapien nec sagittis. Vel facilisis volutpat est velit egestas dui. Id semper risus in hendrerit gravida rutrum quisque non tellus. Mauris ultrices eros in cursus turpis. Amet consectetur adipiscing elit ut aliquam.</p></section>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
#### b29e92ba5f100cd7808852be5e206b2df4bba6ea
<pre>
Implement an initial heuristic to find targeted elements for remote inspection
<a href="https://bugs.webkit.org/show_bug.cgi?id=271344">https://bugs.webkit.org/show_bug.cgi?id=271344</a>

Reviewed by Abrar Rahman Protyasha.

Implement an initial, basic version of an element targeting heuristic in `ElementTargeting.cpp`.
This heuristic performs a piercing hit-test for main frame content at the given location, and
returns an array of `_WKTargetedElementInfo` results, with the frontmost hit-tested element first.

Test: ElementTargeting.BasicElementTargeting

* Source/WebCore/page/ElementTargeting.cpp:
(WebCore::elementAndAncestorsAreOnlyChildren):
(WebCore::querySelectorMatchesOneElement):
(WebCore::childIndexByType):
(WebCore::computeIDSelector):
(WebCore::computeClassSelector):
(WebCore::selectorForElementRecursive):
(WebCore::parentRelativeSelectorRecursive):
(WebCore::selectorsForTarget):

Implement an algorithm to find one or more suitable CSS selectors that uniquely match the given
target element. This works by checking whether:

1.  The ID (if present) is unique in the document.
2.  The first several classes (if present) can be combined to form a selector that uniquely matches
    the target.
3.  The tag name is unique in the document.
4.  If none of the above are true, but we&apos;ve found a unique selector for the parent element
    (recursively using this definition), then use an `nth-child` selector (or `last`/`first-child`,
    in the case where the element is the last or first of its type) to establish a unique selector
    for this element, relative to the parent.

(WebCore::computeOffsetEdges):
(WebCore::targetedElementInfo):
(WebCore::findTargetedElements):

Perform the piercing hit-test here, discarding some elements that are too large or small.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRenderedText):

Refactor this helper method, so that we&apos;re able to perform rendered text extraction for a specific
DOM element. Use this in the `ElementTargeting` heuristic, to compute the `-renderedText` property
on the targeted element info.

* Source/WebCore/page/text-extraction/TextExtraction.h:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm: Added.
(-[WKWebView targetedElementInfoAt:]):
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-1.html: Added.

Canonical link: <a href="https://commits.webkit.org/276508@main">https://commits.webkit.org/276508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/891fede49b2791fb2fdeb03ca21cb4de0ad03ed8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47436 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36802 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/20953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17870 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39715 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2829 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49097 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16321 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43784 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21067 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42532 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9987 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->