### PR TITLE
REGRESSION (276015@main): [iOS] WKHTTPCookieStore.SameSiteWithPatternMatch is a constant failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
@@ -1079,7 +1079,8 @@ TEST(WKHTTPCookieStore, SameSiteWithPatternMatch)
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
     [configuration.get() setWebsiteDataStore:dataStore.get()];
-    [configuration.get() _setCORSDisablingPatterns:@[@"http://site1.example/*"]];
+    [configuration.get() _setCORSDisablingPatterns:@[@"http://site2.example/*"]];
+    configuration.get()._shouldRelaxThirdPartyCookieBlocking = YES;
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://site1.example/set-cookie"]]];
@@ -1088,6 +1089,7 @@ TEST(WKHTTPCookieStore, SameSiteWithPatternMatch)
     [webView _test_waitForDidFinishNavigation];
 
     [webView loadHTMLString:@"<body>body</body>" baseURL:[NSURL URLWithString:@"http://site3.example"]];
+    [webView _test_waitForDidFinishNavigation];
 
     __block bool doneEvaluatingJavaScript { false };
     [webView evaluateJavaScript:@"fetch(\"http://site1.example/get-cookie\").then(() => alert(\"Fetched\")).catch(() => alert(\"Failed\")); true" completionHandler:^(id value, NSError *error) {


### PR DESCRIPTION
#### 408eaa60b003960c066013716a338654f1f07c6f
<pre>
REGRESSION (276015@main): [iOS] WKHTTPCookieStore.SameSiteWithPatternMatch is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=271398">https://bugs.webkit.org/show_bug.cgi?id=271398</a>
<a href="https://rdar.apple.com/125179058">rdar://125179058</a>

Reviewed by Alex Christensen.

The test that I added in 276015@main is buggy. It passes on macOS for strange
and racy reasons, the iOS failure is correct. This change: 1) relaxes
third-party cookie blocking, which is necessary for testing the intended
behavior, 2) waits until a load finishes before proceeding with some tests, and
3) fixes a typo.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/276529@main">https://commits.webkit.org/276529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2b52a4d2d5f57229e8f1e2f6972daace5400144

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47442 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40793 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36803 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38586 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17871 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39722 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2835 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49103 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19754 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43787 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21073 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42554 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9995 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20748 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->