### PR TITLE
Move more ivars from WKWebViewConfiguration to API::PageConfiguration

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -316,6 +316,7 @@ UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
 UIProcess/API/Cocoa/APIAttachmentCocoa.mm
 UIProcess/API/Cocoa/APIContentRuleListStoreCocoa.mm
 UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
+UIProcess/API/Cocoa/APIPageConfigurationCocoa.mm
 UIProcess/API/Cocoa/LegacyBundleForClass.mm
 UIProcess/API/Cocoa/NSAttributedString.mm
 UIProcess/API/Cocoa/WKBackForwardList.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/APIPageConfigurationCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIPageConfigurationCocoa.mm
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "APIPageConfiguration.h"
+
+#import "WKWebViewConfigurationInternal.h"
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+
+namespace API {
+
+#if PLATFORM(IOS_FAMILY)
+bool PageConfiguration::Data::defaultShouldDecidePolicyBeforeLoadingQuickLookPreview()
+{
+#if USE(QUICK_LOOK)
+    static bool shouldDecide = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DecidesPolicyBeforeLoadingQuickLookPreview);
+    return shouldDecide;
+#else
+    return false;
+#endif
+}
+
+WebKit::DragLiftDelay PageConfiguration::Data::defaultDragLiftDelay()
+{
+    return fromWKDragLiftDelay(toDragLiftDelay([[NSUserDefaults standardUserDefaults] integerForKey:@"WebKitDebugDragLiftDelay"]));
+}
+#endif
+
+} // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -65,6 +65,7 @@
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/cf/CFURLExtras.h>
 #import <wtf/cocoa/SpanCocoa.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 NSString * const WKActionIsMainFrameKey = @"WKActionIsMainFrameKey";
 NSString * const WKActionNavigationTypeKey = @"WKActionNavigationTypeKey";

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
@@ -37,3 +37,9 @@
 - (Ref<API::PageConfiguration>)copyPageConfiguration;
 
 @end
+
+#if PLATFORM(IOS_FAMILY)
+_WKDragLiftDelay toDragLiftDelay(NSUInteger);
+_WKDragLiftDelay toWKDragLiftDelay(WebKit::DragLiftDelay);
+WebKit::DragLiftDelay fromWKDragLiftDelay(_WKDragLiftDelay);
+#endif

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -27,6 +27,7 @@
 #import "_WKTargetedElementInfo.h"
 
 #import "_WKTargetedElementInfoInternal.h"
+#import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 @implementation _WKTargetedElementInfo

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8237,6 +8237,7 @@
 		FA9CD6342A01B21700EA5CAC /* NetworkOriginAccessPatterns.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkOriginAccessPatterns.h; sourceTree = "<group>"; };
 		FAA4E2FE2A1575A3003F5E50 /* WebFrameLoaderClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebFrameLoaderClient.cpp; sourceTree = "<group>"; };
 		FAA4E2FF2A1575A4003F5E50 /* WebFrameLoaderClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebFrameLoaderClient.h; sourceTree = "<group>"; };
+		FAB751D12BACB65D00AC26DB /* APIPageConfigurationCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = APIPageConfigurationCocoa.mm; sourceTree = "<group>"; };
 		FAB955F92B75E43D0060829C /* CoreIPCNull.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCNull.h; sourceTree = "<group>"; };
 		FAB955FA2B75E43D0060829C /* CoreIPCNull.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCNull.serialization.in; sourceTree = "<group>"; };
 		FABBDE9D2B85550000EFAFC4 /* CoreIPCNSURLCredential.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCNSURLCredential.h; sourceTree = "<group>"; };
@@ -11456,6 +11457,7 @@
 				41C5378F21F1362D008B1FAD /* _WKWebsiteDataStoreDelegate.h */,
 				F41056612130699A0092281D /* APIAttachmentCocoa.mm */,
 				7CEFA9601AC0999300B910FD /* APIContentRuleListStoreCocoa.mm */,
+				FAB751D12BACB65D00AC26DB /* APIPageConfigurationCocoa.mm */,
 				FED3C1DA1B447AE800E0EB7F /* APISerializedScriptValueCocoa.mm */,
 				1AFDE64319510B5500C48FFA /* LegacyBundleForClass.mm */,
 				1C20935E22318CB000026A39 /* NSAttributedString.h */,


### PR DESCRIPTION
#### b2db7454f86da1a03978a6d4460b02c8b9245558
<pre>
Move more ivars from WKWebViewConfiguration to API::PageConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=271405">https://bugs.webkit.org/show_bug.cgi?id=271405</a>
<a href="https://rdar.apple.com/125186260">rdar://125186260</a>

Reviewed by Charlie Wolfe.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::inlineMediaPlaybackRequiresPlaysInlineAttribute const):
(API::PageConfiguration::setInlineMediaPlaybackRequiresPlaysInlineAttribute):
(API::PageConfiguration::allowsInlineMediaPlaybackAfterFullscreen const):
(API::PageConfiguration::setAllowsInlineMediaPlaybackAfterFullscreen):
(API::PageConfiguration::mediaDataLoadsAutomatically const):
(API::PageConfiguration::setMediaDataLoadsAutomatically):
(API::PageConfiguration::dragLiftDelay const):
(API::PageConfiguration::setDragLiftDelay):
(API::PageConfiguration::textInteractionGesturesEnabled const):
(API::PageConfiguration::setTextInteractionGesturesEnabled):
(API::PageConfiguration::longPressActionsEnabled const):
(API::PageConfiguration::setLongPressActionsEnabled):
(API::PageConfiguration::systemPreviewEnabled const):
(API::PageConfiguration::setSystemPreviewEnabled):
(API::PageConfiguration::shouldDecidePolicyBeforeLoadingQuickLookPreview const):
(API::PageConfiguration::setShouldDecidePolicyBeforeLoadingQuickLookPreview):
* Source/WebKit/UIProcess/API/Cocoa/APIPageConfigurationCocoa.mm: Added.
(API::PageConfiguration::Data::defaultShouldDecidePolicyBeforeLoadingQuickLookPreview):
(API::PageConfiguration::Data::defaultDragLiftDelay):
* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(toDragLiftDelay):
(toWKDragLiftDelay):
(fromWKDragLiftDelay):
(-[WKWebViewConfiguration init]):
(-[WKWebViewConfiguration copyWithZone:]):
(-[WKWebViewConfiguration _inlineMediaPlaybackRequiresPlaysInlineAttribute]):
(-[WKWebViewConfiguration _setInlineMediaPlaybackRequiresPlaysInlineAttribute:]):
(-[WKWebViewConfiguration _allowsInlineMediaPlaybackAfterFullscreen]):
(-[WKWebViewConfiguration _setAllowsInlineMediaPlaybackAfterFullscreen:]):
(-[WKWebViewConfiguration _dragLiftDelay]):
(-[WKWebViewConfiguration _setDragLiftDelay:]):
(-[WKWebViewConfiguration _longPressActionsEnabled]):
(-[WKWebViewConfiguration _setLongPressActionsEnabled:]):
(-[WKWebViewConfiguration _systemPreviewEnabled]):
(-[WKWebViewConfiguration _setSystemPreviewEnabled:]):
(-[WKWebViewConfiguration _shouldDecidePolicyBeforeLoadingQuickLookPreview]):
(-[WKWebViewConfiguration _setShouldDecidePolicyBeforeLoadingQuickLookPreview:]):
(-[WKWebViewConfiguration _mediaDataLoadsAutomatically]):
(-[WKWebViewConfiguration _setMediaDataLoadsAutomatically:]):
(-[WKWebViewConfiguration _textInteractionGesturesEnabled]):
(-[WKWebViewConfiguration _setTextInteractionGesturesEnabled:]):
(defaultShouldDecidePolicyBeforeLoadingQuickLookPreview): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/276517@main">https://commits.webkit.org/276517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/781cf7bf5e49ed237934f084fc12393aab8dd0ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47529 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40880 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21371 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21025 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17927 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18437 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41103 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40075 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49198 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16388 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6222 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->