### PR TITLE
Include WebKit process extension source files for all SDK variants

### DIFF
--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -440,6 +440,11 @@
 #define USE_SANDBOX_VERSION_3 1
 #endif
 
+// We already enable ExtensionKit when building with the internal SDK. Also enable it in Open Source builds.
+#if !defined(USE_EXTENSIONKIT) && PLATFORM(IOS) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170400 && !USE(APPLE_INTERNAL_SDK)
+#define USE_EXTENSIONKIT 1
+#endif
+
 #if !defined(USE_BROWSERENGINEKIT) && PLATFORM(IOS) && __has_include(<BrowserEngineKit/BETextInput.h>)
 #define USE_BROWSERENGINEKIT 1
 #endif

--- a/Source/WebKit/Configurations/WebKit.xcconfig
+++ b/Source/WebKit/Configurations/WebKit.xcconfig
@@ -238,13 +238,13 @@ WK_EXCLUDED_WEBPUSHD_SANDBOX_YES = com.apple.WebKit.webpushd.mac.sb
 
 EXCLUDED_EXTENSION_SOURCE_FILE_NAMES = Shared/AuxiliaryProcessExtensions/*;
 
-INCLUDED_EXTENSION_SOURCE_FILE_NAMES_YES[sdk=iphone*] = Shared/AuxiliaryProcessExtensions/*;
-INCLUDED_EXTENSION_SOURCE_FILE_NAMES_YES[sdk=iphone*17.0.internal] = ;
-INCLUDED_EXTENSION_SOURCE_FILE_NAMES_YES[sdk=iphone*17.1.internal] = ;
-INCLUDED_EXTENSION_SOURCE_FILE_NAMES_YES[sdk=iphone*17.2.internal] = ;
-INCLUDED_EXTENSION_SOURCE_FILE_NAMES_YES[sdk=iphone*17.3.internal] = ;
-INCLUDED_EXTENSION_SOURCE_FILE_NAMES_YES[sdk=iphone*18.0.internal] = ;
-INCLUDED_EXTENSION_SOURCE_FILE_NAMES_YES[sdk=xr*] = ;
+INCLUDED_EXTENSION_SOURCE_FILE_NAMES[sdk=iphone*] = Shared/AuxiliaryProcessExtensions/*;
+INCLUDED_EXTENSION_SOURCE_FILE_NAMES[sdk=iphone*17.0.internal] = ;
+INCLUDED_EXTENSION_SOURCE_FILE_NAMES[sdk=iphone*17.1.internal] = ;
+INCLUDED_EXTENSION_SOURCE_FILE_NAMES[sdk=iphone*17.2.internal] = ;
+INCLUDED_EXTENSION_SOURCE_FILE_NAMES[sdk=iphone*17.3.internal] = ;
+INCLUDED_EXTENSION_SOURCE_FILE_NAMES[sdk=iphone*18.0.internal] = ;
+INCLUDED_EXTENSION_SOURCE_FILE_NAMES[sdk=xr*] = ;
 
 EXCLUDED_SOURCE_FILE_NAMES = $(EXCLUDED_PRODUCT_DEPENDENCY_NAMES) $(EXCLUDED_IOS_RESOURCE_FILE_NAMES) $(EXCLUDED_MACOS_PLUGIN_FILE_NAMES) $(EXCLUDED_MIGRATED_HEADERS_COCOA_TOUCH_$(WK_IS_COCOA_TOUCH)) $(WK_EXCLUDED_WEBPUSHD_SANDBOX) $(EXCLUDED_EXTENSION_SOURCE_FILE_NAMES);
 
@@ -255,7 +255,7 @@ EXCLUDED_IOS_RESOURCE_FILE_NAMES[sdk=iphone*] = ;
 EXCLUDED_MIGRATED_HEADERS_COCOA_TOUCH_YES = WebDynamicScrollBarsView.h WebEventRegion.h WebIconDatabase.h WebJavaScriptTextInputPanel.h WebNSEventExtras.h WebNSPasteboardExtras.h WebNSWindowExtras.h WebPanelAuthenticationHandler.h WebStringTruncator.h;
 EXCLUDED_MIGRATED_HEADERS_COCOA_TOUCH_NO = AbstractPasteboard.h DOMHTMLTextAreaElementPrivate.h DOMUIKitExtensions.h KeyEventCodesIOS.h WAKAppKitStubs.h WAKResponder.h WAKView.h WAKWindow.h WebCaretChangeListener.h WebCoreThread.h WebCoreThreadMessage.h WebCoreThreadRun.h WebEvent.h WebEventRegion.h WebFixedPositionContent.h WebFrameIOS.h WebFrameIPhone.h WebGeolocationCoreLocationProvider.h WebGeolocationPrivate.h WebGeolocationProviderIOS.h WebItemProviderPasteboard.h WebMIMETypeRegistry.h WebNSStringExtrasIOS.h WebNSStringExtrasIPhone.h WebPDFViewIOS.h WebPDFViewIPhone.h WebPDFViewPlaceholder.h WebSelectionRect.h WebUIKitDelegate.h WebUIKitSupport.h WebVisiblePosition.h WKContentObservation.h WKGraphics.h WKTypes.h;
 
-INCLUDED_SOURCE_FILE_NAMES = $(INCLUDED_MIGRATED_HEADERS_$(USE_INTERNAL_SDK)_$(WK_COCOA_TOUCH)) $(INCLUDED_MIGRATED_HEADERS_$(ENABLE_IOS_TOUCH_EVENTS)) $(INCLUDED_EXTENSION_SOURCE_FILE_NAMES_$(USE_INTERNAL_SDK));
+INCLUDED_SOURCE_FILE_NAMES = $(INCLUDED_MIGRATED_HEADERS_$(USE_INTERNAL_SDK)_$(WK_COCOA_TOUCH)) $(INCLUDED_MIGRATED_HEADERS_$(ENABLE_IOS_TOUCH_EVENTS)) $(INCLUDED_EXTENSION_SOURCE_FILE_NAMES);
 // WebEventRegion.h is migrated when building for an iOS family target with an internal SDK...
 INCLUDED_MIGRATED_HEADERS_YES_cocoatouch = WebEventRegion.h;
 // ...or when --ios-touch-events was passed to build-webkit manually.


### PR DESCRIPTION
#### e0a393ed719c88b2fae6e0b2ffcdaefd13d1fbad
<pre>
Include WebKit process extension source files for all SDK variants
<a href="https://bugs.webkit.org/show_bug.cgi?id=271418">https://bugs.webkit.org/show_bug.cgi?id=271418</a>
<a href="https://rdar.apple.com/125195321">rdar://125195321</a>

Reviewed by Sihui Liu.

* Source/WTF/wtf/PlatformUse.h:
* Source/WebKit/Configurations/WebKit.xcconfig:

Canonical link: <a href="https://commits.webkit.org/276550@main">https://commits.webkit.org/276550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce132ecbac5e9e654ac193a35e9cbdd958df6892

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47606 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40955 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21455 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36898 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21119 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17983 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18542 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/39843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2996 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38148 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/41220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/40145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49278 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44405 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19920 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/16471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21236 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42665 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21577 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51576 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6249 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20915 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->