### PR TITLE
Expand the list of valid cursor types for Interaction Regions

### DIFF
--- a/LayoutTests/interaction-region/cursors-expected.txt
+++ b/LayoutTests/interaction-region/cursors-expected.txt
@@ -1,0 +1,23 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction (36,20) width=432 height=52),
+        (interaction (36,156) width=432 height=52),
+        (interaction (36,292) width=432 height=52),
+        (interaction (36,428) width=432 height=52),
+        (interaction (36,496) width=432 height=52)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/cursors.html
+++ b/LayoutTests/interaction-region/cursors.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 20px; }
+    div {
+        margin: 1em;
+        padding: 1em;
+        width: 400px;
+        background: rgba(0, 0, 0, 0.5);
+    }
+</style>
+<body>
+<section id="test">
+    <div style="cursor:pointer;">pointer</div>
+    <div style="cursor:help;">help</div>
+    <div style="cursor:grab;">grab</div>
+    <div style="cursor:not-allowed;">not allowed</div>
+    <div style="cursor:text;">text</div>
+    <div style="cursor:wait;">wait</div>
+    <div style="cursor:vertical-text;">vertical text</div>
+    <div style="cursor:move;">move</div>
+</section>
+
+<pre id="results"></pre>
+<script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals) {
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+       document.getElementById('test').remove();
+    }
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### ba39cbd5f1cf28d107379ec19cd52267916918ec
<pre>
Expand the list of valid cursor types for Interaction Regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=271416">https://bugs.webkit.org/show_bug.cgi?id=271416</a>
&lt;<a href="https://rdar.apple.com/118882598">rdar://118882598</a>&gt;

Reviewed by Tim Horton.

Add support for a few more cursor types instead of just `pointer`.
Starting with `move`, `grab`, `text` and `vertical-text`.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::hasInteractiveCursorType):
(WebCore::cursorTypeForElement): Deleted.
Rename the function and make it return a bool instead.
(WebCore::interactionRegionForRenderedRegion):
Use the new function.
(WebCore::shouldAllowNonInteractiveCursorForElement):
(WebCore::shouldAllowNonPointerCursorForElement): Deleted.
Rename the function to remove the &quot;pointer&quot; reference.

* LayoutTests/interaction-region/cursors-expected.txt: Added.
* LayoutTests/interaction-region/cursors.html: Added.
Add tests for for the cursors.

Canonical link: <a href="https://commits.webkit.org/276511@main">https://commits.webkit.org/276511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f60fd4e1e8f3c507397ab6d351a5e965f08e2e15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47499 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40850 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/27992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21342 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17902 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18417 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39754 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2892 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49164 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16364 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43813 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42570 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9988 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->