### PR TITLE
[JSC] Emit dyld tracepoint to tell system profiler about JIT code region

### DIFF
--- a/Source/WTF/wtf/ByteOrder.h
+++ b/Source/WTF/wtf/ByteOrder.h
@@ -34,13 +34,16 @@
 #include <arpa/inet.h>
 #endif
 
-#if OS(WINDOWS)
-
 namespace WTF {
+
 inline uint32_t wswap32(uint32_t x) { return ((x & 0xffff0000) >> 16) | ((x & 0x0000ffff) << 16); }
+inline uint64_t bswap64(uint64_t x) { return ((x & 0xff00000000000000ULL) >> 56) | ((x & 0x00ff000000000000ULL) >> 40) | ((x & 0x0000ff0000000000ULL) >> 24) | ((x & 0x000000ff00000000ULL) >> 8) | ((x & 0x00000000ff000000ULL) << 8) | ((x & 0x0000000000ff0000ULL) << 24) | ((x & 0x000000000000ff00ULL) << 40) | ((x & 0x00000000000000ffULL) << 56); }
 inline uint32_t bswap32(uint32_t x) { return ((x & 0xff000000) >> 24) | ((x & 0x00ff0000) >> 8) | ((x & 0x0000ff00) << 8) | ((x & 0x000000ff) << 24); }
 inline uint16_t bswap16(uint16_t x) { return ((x & 0xff00) >> 8) | ((x & 0x00ff) << 8); }
+
 } // namespace WTF
+
+#if OS(WINDOWS)
 
 #if CPU(BIG_ENDIAN)
 inline uint16_t ntohs(uint16_t x) { return x; }

--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -33,6 +33,7 @@
 #include <wtf/Hasher.h>
 #include <wtf/HexNumber.h>
 #include <wtf/Int128.h>
+#include <wtf/SHA1.h>
 #include <wtf/text/WTFString.h>
 
 #ifdef __OBJC__
@@ -58,7 +59,10 @@ public:
     {
         return UUID { generateWeakRandomUUIDVersion4() };
     }
-    
+
+    WTF_EXPORT_PRIVATE static UUID createVersion5(const SHA1::Digest&);
+    WTF_EXPORT_PRIVATE static UUID createVersion5(UUID, std::span<const uint8_t>);
+
 #ifdef __OBJC__
     WTF_EXPORT_PRIVATE operator NSUUID *() const;
     WTF_EXPORT_PRIVATE static std::optional<UUID> fromNSUUID(NSUUID *);


### PR DESCRIPTION
#### 2645a1e90e1c5a900b1df995cd44e6c29ee06ad6
<pre>
[JSC] Emit dyld tracepoint to tell system profiler about JIT code region
<a href="https://bugs.webkit.org/show_bug.cgi?id=271419">https://bugs.webkit.org/show_bug.cgi?id=271419</a>
<a href="https://rdar.apple.com/125196249">rdar://125196249</a>

Reviewed by Justin Michaud.

This patch emits fake dyld tracepoint which tells our system profiler (see SystemTracing.h) about JIT code region.
We need to assign good UUID to this JIT code region. And since this is JIT code, each process has different JIT code.
Thus, we create v5 UUID from process ID and namespace UUID and attach it to JIT code region.

* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::initializeJITPageReservation):
* Source/WTF/wtf/ByteOrder.h:
(WTF::bswap64):
* Source/WTF/wtf/UUID.cpp:
(WTF::UUID::createVersion5):
* Source/WTF/wtf/UUID.h:

Canonical link: <a href="https://commits.webkit.org/276524@main">https://commits.webkit.org/276524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/564f5371d5f8dc616256a9ea28350d9b4cc35e7c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47542 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40893 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21384 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21033 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17940 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18445 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39793 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2935 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/38088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41113 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49213 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/44344 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16397 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42613 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51516 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6228 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20849 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10455 "Passed tests") | 
<!--EWS-Status-Bubble-End-->