### PR TITLE
Add more smart pointers to accessibility

### DIFF
--- a/Source/WebCore/accessibility/AccessibilitySlider.cpp
+++ b/Source/WebCore/accessibility/AccessibilitySlider.cpp
@@ -94,15 +94,15 @@ void AccessibilitySlider::addChildren()
     if (!cache)
         return;
 
-    auto& thumb = downcast<AccessibilitySliderThumb>(*cache->create(AccessibilityRole::SliderThumb));
-    thumb.setParent(this);
+    Ref thumb = downcast<AccessibilitySliderThumb>(*cache->create(AccessibilityRole::SliderThumb));
+    thumb->setParent(this);
 
     // Before actually adding the value indicator to the hierarchy,
     // allow the platform to make a final decision about it.
-    if (thumb.accessibilityIsIgnored())
-        cache->remove(thumb.objectID());
+    if (thumb->accessibilityIsIgnored())
+        cache->remove(thumb->objectID());
     else
-        addChild(&thumb);
+        addChild(thumb.ptr());
 }
 
 const AtomString& AccessibilitySlider::getAttribute(const QualifiedName& attribute) const
@@ -146,7 +146,7 @@ float AccessibilitySlider::minValueForRange() const
 
 bool AccessibilitySlider::setValue(const String& value)
 {
-    HTMLInputElement* input = inputElement();
+    RefPtr input = inputElement();
     
     if (input->value() == value)
         return true;

--- a/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableColumn.cpp
@@ -109,15 +109,15 @@ void AccessibilityTableColumn::addChildren()
 
     int numRows = parentTable->rowCount();
     for (int i = 0; i < numRows; ++i) {
-        auto* cell = parentTable->cellForColumnAndRow(m_columnIndex, i);
+        RefPtr cell = parentTable->cellForColumnAndRow(m_columnIndex, i);
         if (!cell)
             continue;
 
         // make sure the last one isn't the same as this one (rowspan cells)
-        if (m_children.size() > 0 && m_children.last() == cell)
+        if (m_children.size() > 0 && m_children.last() == cell.get())
             continue;
-            
-        addChild(cell);
+
+        addChild(cell.get());
     }
 }
     

--- a/Source/WebCore/accessibility/AccessibilityTableRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTableRow.cpp
@@ -135,7 +135,7 @@ AXCoreObject* AccessibilityTableRow::rowHeader()
     if (rowChildren.isEmpty())
         return nullptr;
     
-    auto* firstCell = rowChildren[0].get();
+    RefPtr firstCell = rowChildren[0].get();
     if (!firstCell || !firstCell->node() || !firstCell->node()->hasTagName(thTag))
         return nullptr;
 
@@ -144,7 +144,7 @@ AXCoreObject* AccessibilityTableRow::rowHeader()
     for (const auto& child : rowChildren) {
         // We found a non-header cell, so this is not an entire row of headers -- return the original header cell.
         if (child->node() && !child->node()->hasTagName(thTag))
-            return firstCell;
+            return firstCell.get();
     }
     return nullptr;
 }

--- a/Source/WebCore/accessibility/AccessibilityTree.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTree.cpp
@@ -83,22 +83,22 @@ bool AccessibilityTree::isTreeValid() const
     if (!node)
         return false;
     
-    Deque<Node*> queue;
-    for (auto* child = node->firstChild(); child; child = child->nextSibling())
-        queue.append(child);
+    Deque<RefPtr<Node>> queue;
+    for (RefPtr child = node->firstChild(); child; child = queue.last()->nextSibling())
+        queue.append(WTFMove(child));
 
     while (!queue.isEmpty()) {
         auto child = queue.takeFirst();
 
         if (!is<Element>(*child))
             continue;
-        if (nodeHasRole(child, "treeitem"_s))
+        if (nodeHasRole(child.get(), "treeitem"_s))
             continue;
-        if (!nodeHasRole(child, "group"_s) && !nodeHasRole(child, "presentation"_s))
+        if (!nodeHasRole(child.get(), "group"_s) && !nodeHasRole(child.get(), "presentation"_s))
             return false;
 
-        for (auto* groupChild = child->firstChild(); groupChild; groupChild = groupChild->nextSibling())
-            queue.append(groupChild);
+        for (RefPtr groupChild = child->firstChild(); groupChild; groupChild = queue.last()->nextSibling())
+            queue.append(WTFMove(groupChild));
     }
     return true;
 }


### PR DESCRIPTION
#### acd3844b0421eb9a9780d21e8a5a9255c0eae3ce
<pre>
Add more smart pointers to accessibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=271411">https://bugs.webkit.org/show_bug.cgi?id=271411</a>
<a href="https://rdar.apple.com/125190532">rdar://125190532</a>

Reviewed by Ryosuke Niwa.

Memory safety improvements for  AccessibilityScrollbar.cpp, AccessibilitySlider.cpp, AccessibilityTableColumn.cpp, AccessibilityTableRow.cpp, and AccessibilityTree.cpp

* Source/WebCore/accessibility/AccessibilityScrollbar.cpp:
(WebCore::AccessibilityScrollbar::document const):
* Source/WebCore/accessibility/AccessibilitySlider.cpp:
(WebCore::AccessibilitySlider::addChildren):
(WebCore::AccessibilitySlider::setValue):
* Source/WebCore/accessibility/AccessibilityTableColumn.cpp:
(WebCore::AccessibilityTableColumn::addChildren):
* Source/WebCore/accessibility/AccessibilityTableRow.cpp:
(WebCore::AccessibilityTableRow::rowHeader):
* Source/WebCore/accessibility/AccessibilityTree.cpp:
(WebCore::AccessibilityTree::isTreeValid const):

Canonical link: <a href="https://commits.webkit.org/276528@main">https://commits.webkit.org/276528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ba8681ea6429455405b940b587aa1b2f452addb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47539 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40890 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47188 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/28079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21381 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17936 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18442 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39786 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2932 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41110 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49210 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16394 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43845 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21172 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42607 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/9993 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20846 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->