### PR TITLE
[ews] Improve description for upload-file-to-s3 step

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1429,11 +1429,11 @@ class UploadFileToS3(shell.ShellCommandNewStyle):
 
     def getResultSummary(self):
         if self.results == FAILURE:
-            return {'step': 'Failed to upload archive to S3. Please inform an admin.'}
+            return {'step': f'Failed to upload {self.file} to S3. Please inform an admin.'}
         if self.results == SKIPPED:
             return {'step': 'Skipped upload to S3'}
         if self.results in [SUCCESS, WARNINGS]:
-            return {'step': 'Uploaded archive to S3'}
+            return {'step': f'Uploaded {self.file} to S3'}
         return super().getResultSummary()
 
 

--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -1786,7 +1786,7 @@ class TestUploadFileToS3(BuildStepMixinAdditions, unittest.TestCase):
                         )
             + 0,
         )
-        self.expectOutcome(result=SUCCESS, state_string='Uploaded archive to S3')
+        self.expectOutcome(result=SUCCESS, state_string='Uploaded WebKitBuild/release.zip to S3')
         with current_hostname(BUILD_WEBKIT_HOSTNAMES[0]):
             return self.runStep()
 
@@ -1803,7 +1803,7 @@ class TestUploadFileToS3(BuildStepMixinAdditions, unittest.TestCase):
                         )
             + 0,
         )
-        self.expectOutcome(result=SUCCESS, state_string='Uploaded archive to S3')
+        self.expectOutcome(result=SUCCESS, state_string='Uploaded build-log.txt to S3')
         with current_hostname(BUILD_WEBKIT_HOSTNAMES[0]):
             return self.runStep()
 
@@ -1821,7 +1821,7 @@ response: <Response [403]>, 403, Forbidden
 exit 1''')
             + 2,
         )
-        self.expectOutcome(result=FAILURE, state_string='Failed to upload archive to S3. Please inform an admin.')
+        self.expectOutcome(result=FAILURE, state_string='Failed to upload WebKitBuild/release.zip to S3. Please inform an admin.')
         with current_hostname(BUILD_WEBKIT_HOSTNAMES[0]):
             return self.runStep()
 

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5024,11 +5024,11 @@ class UploadFileToS3(shell.ShellCommandNewStyle, AddToLogMixin):
 
     def getResultSummary(self):
         if self.results == FAILURE:
-            return {'step': 'Failed to upload archive to S3. Please inform an admin.'}
+            return {'step': f'Failed to upload {self.file} to S3. Please inform an admin.'}
         if self.results == SKIPPED:
             return {'step': 'Skipped upload to S3'}
         if self.results in [SUCCESS, WARNINGS]:
-            return {'step': 'Uploaded archive to S3'}
+            return {'step': f'Uploaded {self.file} to S3'}
         return super().getResultSummary()
 
 

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -4777,7 +4777,7 @@ class TestUploadFileToS3(BuildStepMixinAdditions, unittest.TestCase):
                         )
             + 0,
         )
-        self.expectOutcome(result=SUCCESS, state_string='Uploaded archive to S3')
+        self.expectOutcome(result=SUCCESS, state_string='Uploaded WebKitBuild/release.zip to S3')
         with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
@@ -4794,7 +4794,7 @@ class TestUploadFileToS3(BuildStepMixinAdditions, unittest.TestCase):
                         )
             + 0,
         )
-        self.expectOutcome(result=SUCCESS, state_string='Uploaded archive to S3')
+        self.expectOutcome(result=SUCCESS, state_string='Uploaded build-log.txt to S3')
         with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 
@@ -4812,7 +4812,7 @@ response: <Response [403]>, 403, Forbidden
 exit 1''')
             + 2,
         )
-        self.expectOutcome(result=FAILURE, state_string='Failed to upload archive to S3. Please inform an admin.')
+        self.expectOutcome(result=FAILURE, state_string='Failed to upload WebKitBuild/release.zip to S3. Please inform an admin.')
         with current_hostname(EWS_BUILD_HOSTNAMES[0]):
             return self.runStep()
 


### PR DESCRIPTION
#### 2410d135f758a2ca46b01d47073fa4ec54f2da4a
<pre>
[ews] Improve description for upload-file-to-s3 step
<a href="https://bugs.webkit.org/show_bug.cgi?id=271417">https://bugs.webkit.org/show_bug.cgi?id=271417</a>
<a href="https://rdar.apple.com/125197122">rdar://125197122</a>

Reviewed by Aakash Jain.

Adds filename to the description of upload-file-to-s3 for ews-build and build-webkit.

* Tools/CISupport/build-webkit-org/steps.py:
(UploadFileToS3.getResultSummary):
* Tools/CISupport/build-webkit-org/steps_unittest.py:
* Tools/CISupport/ews-build/steps.py:
(UploadFileToS3.getResultSummary):
* Tools/CISupport/ews-build/steps_unittest.py:
(TestUploadFileToS3.test_success):
(TestUploadFileToS3.test_success_content_type):

Canonical link: <a href="https://commits.webkit.org/276499@main">https://commits.webkit.org/276499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06638460059e77f6c0b437a95faea4f1be32f5c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/44852 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/23951 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/47342 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/47506 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/40857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/47155 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/28002 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/21348 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/47506 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/45430 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/28002 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/47342 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/47506 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/28002 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/47342 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/2899 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/28002 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/47342 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/49172 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/19820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/21348 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/49172 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/44896 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/47342 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/49172 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6210 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20813 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->