### PR TITLE
Avoid asserts during constant folding binary ops on 'void' variables.

### DIFF
--- a/Source/ThirdParty/ANGLE/src/compiler/translator/ParseContext.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/ParseContext.cpp
@@ -6727,6 +6727,13 @@ bool TParseContext::binaryOpCommonCheck(TOperator op,
                                         TIntermTyped *right,
                                         const TSourceLoc &loc)
 {
+
+    if (left->getBasicType() == EbtVoid || right->getBasicType() == EbtVoid)
+    {
+        error(loc, "operation with void operands", GetOperatorString(op));
+        return false;
+    }
+
     // Check opaque types are not allowed to be operands in expressions other than array indexing
     // and structure member selection.
     if (IsOpaqueType(left->getBasicType()) || IsOpaqueType(right->getBasicType()))

--- a/Source/ThirdParty/ANGLE/src/tests/compiler_tests/Parse_test.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/compiler_tests/Parse_test.cpp
@@ -85,6 +85,67 @@ class ParseTest : public testing::Test
     std::string mInfoLog;
 };
 
+// Tests that constant folding a division of a void variable does not crash during parsing.
+TEST_F(ParseTest, ConstStructWithVoidAndDivNoCrash)
+{
+    const char kShader[] = R"(
+const struct s { void i; } ss = s();
+void main() {
+    highp vec3 q = ss.i / ss.i;
+})";
+    EXPECT_FALSE(compile(kShader));
+    EXPECT_TRUE(foundErrorInIntermediateTree());
+    EXPECT_TRUE(foundInIntermediateTree("illegal use of type 'void'"));
+    EXPECT_TRUE(foundInIntermediateTree("constructor does not have any arguments"));
+    EXPECT_TRUE(foundInIntermediateTree("operation with void operands"));
+    EXPECT_TRUE(foundInIntermediateTree(
+        "wrong operand types - no operation '/' exists that takes a left-hand operand of type "
+        "'const void' and a right operand of type 'const void'"));
+    EXPECT_TRUE(foundInIntermediateTree(
+        "cannot convert from 'const void' to 'highp 3-component vector of float'"));
+}
+
+// Tests that division of void variable returns the same errors as division of constant
+// void variable (see above).
+TEST_F(ParseTest, StructWithVoidAndDivErrorCheck)
+{
+    const char kShader[] = R"(
+struct s { void i; } ss = s();
+void main() {
+    highp vec3 q = ss.i / ss.i;
+})";
+    EXPECT_FALSE(compile(kShader));
+    EXPECT_TRUE(foundErrorInIntermediateTree());
+    EXPECT_TRUE(foundInIntermediateTree("illegal use of type 'void'"));
+    EXPECT_TRUE(foundInIntermediateTree("constructor does not have any arguments"));
+    EXPECT_TRUE(foundInIntermediateTree("operation with void operands"));
+    EXPECT_TRUE(foundInIntermediateTree(
+        "wrong operand types - no operation '/' exists that takes a left-hand operand of type "
+        "'void' and a right operand of type 'void'"));
+    EXPECT_TRUE(foundInIntermediateTree(
+        "cannot convert from 'void' to 'highp 3-component vector of float'"));
+}
+
+// Tests that imod of const void variable does not crash
+TEST_F(ParseTest, ConstStructVoidAndImodAndNoCrash)
+{
+    const char kShader[] = R"(#version 310 es
+const struct s { void i; } ss = s();
+void main() {
+    highp vec3 q = ss.i % ss.i;
+})";
+    EXPECT_FALSE(compile(kShader));
+    EXPECT_TRUE(foundErrorInIntermediateTree());
+    EXPECT_TRUE(foundInIntermediateTree("illegal use of type 'void'"));
+    EXPECT_TRUE(foundInIntermediateTree("constructor does not have any arguments"));
+    EXPECT_TRUE(foundInIntermediateTree("operation with void operands"));
+    EXPECT_TRUE(foundInIntermediateTree(
+        "wrong operand types - no operation '%' exists that takes a left-hand operand of type "
+        "'const void' and a right operand of type 'const void'"));
+    EXPECT_TRUE(foundInIntermediateTree(
+        "cannot convert from 'const void' to 'highp 3-component vector of float'"));
+}
+
 TEST_F(ParseTest, UnsizedArrayConstructorNoCrash)
 {
     const char kShader[] = R"(#version 310 es\n"


### PR DESCRIPTION
#### 8065ae84ebcd1350b24d83d8b473915ec5e8fb1c
<pre>
Avoid asserts during constant folding binary ops on &apos;void&apos; variables.
<a href="https://bugs.webkit.org/show_bug.cgi?id=271421">https://bugs.webkit.org/show_bug.cgi?id=271421</a>
<a href="https://rdar.apple.com/124085673">rdar://124085673</a>

Reviewed by NOBODY (OOPS!).

Fix asserts for example with / and % during constant folding when
the operands might be &apos;voids&apos;.

* Source/ThirdParty/ANGLE/src/compiler/translator/ParseContext.cpp:
(sh::TParseContext::binaryOpCommonCheck):
* Source/ThirdParty/ANGLE/src/tests/compiler_tests/Parse_test.cpp:
(TEST_F):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8065ae84ebcd1350b24d83d8b473915ec5e8fb1c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48936 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42285 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22833 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37793 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19031 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19850 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40979 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4288 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42554 "Found 1 new API test failure: TestWebKitAPI.DataDetectorTests.LoadWKWebViewWithDataDetectorTypePhoneNumber (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50726 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44976 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22540 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43890 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22907 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22235 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->