### PR TITLE
`--site-isolation` should not load file URLs into iframes

### DIFF
--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -22,7 +22,6 @@ displaylists [ Skip ]
 dom [ Skip ]
 editing [ Skip ]
 fast [ Skip ]
-fetch [ Skip ]
 fonts [ Skip ]
 fullscreen [ Skip ]
 gamepad [ Skip ]
@@ -232,6 +231,10 @@ http/tests/site-isolation/selection-focus.html [ Skip ]
 #######################
 # Tests that time out #
 #######################
+fetch/body-init.html [ Skip ]
+fetch/fetch-blob-unbounded-range.html [ Skip ]
+fetch/fetch-error-messages.html [ Skip ]
+fetch/fetch-url-serialization.html [ Skip ]
 http/tests/loading/basic-auth-remove-credentials.html [ Skip ]
 http/tests/loading/main-resource-delegates-on-back-navigation.html [ Skip ]
 http/tests/loading/sizes/preload-image-sizes-2x.html [ Skip ]

--- a/Tools/Scripts/webkitpy/port/driver.py
+++ b/Tools/Scripts/webkitpy/port/driver.py
@@ -351,7 +351,7 @@ class Driver(object):
     WEBKIT_WEB_PLATFORM_TEST_SERVER_ROUTE = "WebKit/"
 
     def is_http_test(self, driver_input):
-        if driver_input.self_comparison_header and "runInCrossOriginFrame=true" in driver_input.self_comparison_header:
+        if driver_input.additional_header and "runInCrossOriginFrame=true" in driver_input.additional_header:
             return True
         return driver_input.test_name.startswith(self.HTTP_DIR) and not driver_input.test_name.startswith(self.HTTP_LOCAL_DIR)
 

--- a/Tools/Scripts/webkitpy/port/driver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/driver_unittest.py
@@ -117,7 +117,7 @@ class DriverTest(unittest.TestCase):
         driver = Driver(port, None, pixel_tests=False)
 
         self.assertEqual(driver.test_to_uri(DriverInput('foo/bar.html', 1000, None, None)), 'file://%s/foo/bar.html' % port.layout_tests_dir())
-        self.assertEqual(driver.test_to_uri(DriverInput('foo/bar.html', 1000, None, None, self_comparison_header='runInCrossOriginFrame=true')), 'http://127.0.0.1:8000/root/foo/bar.html')
+        self.assertEqual(driver.test_to_uri(DriverInput('foo/bar.html', 1000, None, None, additional_header='runInCrossOriginFrame=true')), 'http://127.0.0.1:8000/root/foo/bar.html')
         self.assertEqual(driver.test_to_uri(DriverInput('http/tests/foo.html', 1000, None, None)), 'http://127.0.0.1:8000/foo.html')
         self.assertEqual(driver.test_to_uri(DriverInput('http/tests/ssl/bar.html', 1000, None, None)), 'https://127.0.0.1:8443/ssl/bar.html')
         self.assertEqual(driver.test_to_uri(DriverInput('imported/w3c/web-platform-tests/foo/bar.html', 1000, None, None)), 'http://localhost:8800/foo/bar.html')


### PR DESCRIPTION
#### c0c0f3af02a0132d4b9cc84483418d64132932b8
<pre>
`--site-isolation` should not load file URLs into iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=271429">https://bugs.webkit.org/show_bug.cgi?id=271429</a>
<a href="https://rdar.apple.com/125202486">rdar://125202486</a>

Reviewed by Pascoe.

`-—site-isolation` does not use `-—self-comparison-header` after 276416@main, instead this should
check `additional_header`. This is needed to have coverage for tests outside of http/.

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Tools/Scripts/webkitpy/port/driver.py:
(Driver.is_http_test):

Canonical link: <a href="https://commits.webkit.org/276514@main">https://commits.webkit.org/276514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1819104e4c22c2b539cfc82813e1517425db1b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47534 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40885 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21376 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21026 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/17933 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/44747 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/39789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2927 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/41106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/40082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49203 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19848 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/16393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6220 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->