### PR TITLE
Make `selectorText` non-nullable in `CSSPageRule.idl`

### DIFF
--- a/LayoutTests/fast/dom/css-element-attribute-js-null-expected.txt
+++ b/LayoutTests/fast/dom/css-element-attribute-js-null-expected.txt
@@ -4,6 +4,8 @@ TEST SUCCEEDED: The value was the string '.foo { color: black; }'. [tested CSSRu
 
 TEST SUCCEEDED: The value was the string 'null'. [tested CSSStyleRule.selectorText]
 
+TEST SUCCEEDED: The value was the string '@page null'. [tested CSSPageRule.selectorText]
+
 TEST SUCCEEDED: The value was the empty string. [tested CSSStyleDeclaration.cssText]
 
 TEST SUCCEEDED: The value was the empty string. [tested MediaList.mediaText]

--- a/LayoutTests/fast/dom/css-element-attribute-js-null.html
+++ b/LayoutTests/fast/dom/css-element-attribute-js-null.html
@@ -9,6 +9,7 @@
         @media screen {
             .bar { color: blue; }
         }
+        @page { }
         </style>
     <script>
         function printOut(msg) {
@@ -50,7 +51,8 @@
             var rules = document.styleSheets[1].cssRules;
 
             var rule = rules[0];
-            var mediaRule = rules[1];            
+            var mediaRule = rules[1];
+            var pageRule = rules[2];           
             var style = rule.style;
             var mediaList = mediaRule.media;
 
@@ -72,6 +74,13 @@
                     ]
                 },
                 {
+                    type: 'CSSPageRule',
+                    elementToUse: pageRule,
+                    attributes: [
+                         {name: 'selectorText', expectedNull: '@page null'}
+                    ]
+                },
+                {
                     type: 'CSSStyleDeclaration',
                     elementToUse: style,
                     attributes: [
@@ -86,13 +95,6 @@
                         {name: 'mediaText', expectedNull: ''}
                     ]
                 }
-                // ,{
-                //     type: 'PageRule',
-                //     elementToUse: mediaList,
-                //     attributes: [
-                //         {name: 'cssText', expectedNull: ''}
-                //     ]
-                // }
             ];
             
             for (element in listing) {

--- a/Source/WebCore/css/CSSPageRule.idl
+++ b/Source/WebCore/css/CSSPageRule.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006, 2007 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -18,12 +18,17 @@
  * Boston, MA 02110-1301, USA.
  */
 
-// Introduced in DOM Level 2:
+// https://drafts.csswg.org/cssom/#the-csspagerule-interface
+// FIXME: CSSPageRule should derive from 'CSSGroupingRule' below:
+// https://bugs.webkit.org/show_bug.cgi?id=216940.
+
 [
     Exposed=Window
 ] interface CSSPageRule : CSSRule {
-    attribute DOMString? selectorText;
+    attribute DOMString selectorText;
 
+    // FIXME: Add [SameObject] for `style`.
+    // https://bugs.webkit.org/show_bug.cgi?id=163414
     [PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };
 


### PR DESCRIPTION
<pre>
Make `selectorText` non-nullable in `CSSPageRule.idl`
<a href="https://bugs.webkit.org/show_bug.cgi?id=271432">https://bugs.webkit.org/show_bug.cgi?id=271432</a>

Reviewed by NOBODY (OOPS!).

This patch is to align WebKit with Gecko / Firefox, Blink / Chromium and
Web Specification [1]:

[1] <a href="https://drafts.csswg.org/cssom/#the-csspagerule-interface">https://drafts.csswg.org/cssom/#the-csspagerule-interface</a>

As per Web Specification, the `selectorText` should be non-nullable. Hence,
this removes `?`.

For Test (Partial Merge): <a href="https://src.chromium.org/viewvc/blink?view=revision&revision=163424">https://src.chromium.org/viewvc/blink?view=revision&revision=163424</a>

I took opportunity to add FIXME comments with bug references for future
work.

* Source/WebCore/css/CSSPageRule.idl:
* LayoutTests/fast/dom/css-element-attribute-js-null.html: Rebaselined
* LayoutTests/fast/dom/css-element-attribute-js-null-expected.txt: Rebaselined
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d55edf8ca432e075b9a35760b8336bd276eecc8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/23975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47530 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40881 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36844 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38640 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17929 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18439 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39784 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2923 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41105 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49199 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19844 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16391 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43848 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42627 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20837 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->