### PR TITLE
Move more ivars from WKWebViewConfiguration to API::PageConfiguration

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "APIObject.h"
+#include "WebPreferencesDefaultValues.h"
 #include "WebURLSchemeHandler.h"
 #include <WebCore/ContentSecurityPolicy.h>
 #include <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
@@ -186,8 +187,11 @@ public:
     void setOverrideContentSecurityPolicy(const WTF::String& overrideContentSecurityPolicy) { m_data.overrideContentSecurityPolicy = overrideContentSecurityPolicy; }
 
 #if PLATFORM(COCOA)
-    const WTF::Vector<WTF::String>& additionalSupportedImageTypes() const { return m_data.additionalSupportedImageTypes; }
-    void setAdditionalSupportedImageTypes(WTF::Vector<WTF::String>&& additionalSupportedImageTypes) { m_data.additionalSupportedImageTypes = WTFMove(additionalSupportedImageTypes); }
+    ClassStructPtr attachmentFileWrapperClass() const { return m_data.attachmentFileWrapperClass.get(); }
+    void setAttachmentFileWrapperClass(ClassStructPtr c) { m_data.attachmentFileWrapperClass = c; }
+
+    const std::optional<Vector<WTF::String>>& additionalSupportedImageTypes() const { return m_data.additionalSupportedImageTypes; }
+    void setAdditionalSupportedImageTypes(std::optional<Vector<WTF::String>>&& additionalSupportedImageTypes) { m_data.additionalSupportedImageTypes = WTFMove(additionalSupportedImageTypes); }
 
     bool clientNavigationsRunAtForegroundPriority() const { return m_data.clientNavigationsRunAtForegroundPriority; }
     void setClientNavigationsRunAtForegroundPriority(bool value) { m_data.clientNavigationsRunAtForegroundPriority = value; }
@@ -250,6 +254,31 @@ public:
     bool contextMenuQRCodeDetectionEnabled() const { return m_data.contextMenuQRCodeDetectionEnabled; }
     void setContextMenuQRCodeDetectionEnabled(bool enabled) { m_data.contextMenuQRCodeDetectionEnabled = enabled; }
 #endif
+
+#if ENABLE(APPLE_PAY)
+    bool applePayEnabled() const { return m_data.applePayEnabled; }
+    void setApplePayEnabled(bool enabled) { m_data.applePayEnabled = enabled; }
+#endif
+
+#if ENABLE(APP_HIGHLIGHTS)
+    bool appHighlightsEnabled() const { return m_data.appHighlightsEnabled; }
+    void setAppHighlightsEnabled(bool enabled) { m_data.appHighlightsEnabled = enabled; }
+#endif
+
+    const WTF::String& groupIdentifier() const { return m_data.groupIdentifier; }
+    void setGroupIdentifier(WTF::String&& identifier) { m_data.groupIdentifier = WTFMove(identifier); }
+
+    const WTF::String& mediaContentTypesRequiringHardwareSupport() const { return m_data.mediaContentTypesRequiringHardwareSupport; }
+    void setMediaContentTypesRequiringHardwareSupport(WTF::String&& types) { m_data.mediaContentTypesRequiringHardwareSupport = WTFMove(types); }
+
+    const std::optional<WTF::String>& applicationNameForUserAgent() const { return m_data.applicationNameForUserAgent; }
+    void setApplicationNameForUserAgent(std::optional<WTF::String>&& name) { m_data.applicationNameForUserAgent = WTFMove(name); }
+
+    double sampledPageTopColorMaxDifference() const { return m_data.sampledPageTopColorMaxDifference; }
+    void setSampledPageTopColorMaxDifference(double difference) { m_data.sampledPageTopColorMaxDifference = difference; }
+
+    double sampledPageTopColorMinHeight() const { return m_data.sampledPageTopColorMinHeight; }
+    void setSampledPageTopColorMinHeight(double height) { m_data.sampledPageTopColorMinHeight = height; }
 
     double incrementalRenderingSuppressionTimeout() const { return m_data.incrementalRenderingSuppressionTimeout; }
     void setIncrementalRenderingSuppressionTimeout(double timeout) { m_data.incrementalRenderingSuppressionTimeout = timeout; }
@@ -370,21 +399,21 @@ private:
         LazyInitializedRef<WebKit::WebPreferences, createWebPreferences> preferences;
         LazyInitializedRef<WebKit::VisitedLinkStore, createVisitedLinkStore> visitedLinkStore;
         LazyInitializedRef<WebsitePolicies, createWebsitePolicies> defaultWebsitePolicies;
-        mutable RefPtr<WebKit::WebsiteDataStore> websiteDataStore { };
+        mutable RefPtr<WebKit::WebsiteDataStore> websiteDataStore;
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-        WTF::URL requiredWebExtensionBaseURL { };
-        RefPtr<WebKit::WebExtensionController> webExtensionController { };
-        WeakPtr<WebKit::WebExtensionController> weakWebExtensionController { };
+        WTF::URL requiredWebExtensionBaseURL;
+        RefPtr<WebKit::WebExtensionController> webExtensionController;
+        WeakPtr<WebKit::WebExtensionController> weakWebExtensionController;
 #endif
-        RefPtr<WebKit::WebPageGroup> pageGroup { };
-        RefPtr<WebKit::WebPageProxy> relatedPage { };
-        WeakPtr<WebKit::WebPageProxy> pageToCloneSessionStorageFrom { };
+        RefPtr<WebKit::WebPageGroup> pageGroup;
+        RefPtr<WebKit::WebPageProxy> relatedPage;
+        WeakPtr<WebKit::WebPageProxy> pageToCloneSessionStorageFrom;
 
 #if PLATFORM(IOS_FAMILY)
         bool canShowWhileLocked { false };
         WebKit::AttributionOverrideTesting appInitiatedOverrideValueForTesting { WebKit::AttributionOverrideTesting::NoOverride };
-        RetainPtr<_UIClickInteractionDriving> clickInteractionDriverForTesting { };
+        RetainPtr<_UIClickInteractionDriving> clickInteractionDriverForTesting;
         bool allowsInlineMediaPlayback { !PAL::currentUserInterfaceIdiomIsSmallScreen() };
         bool inlineMediaPlaybackRequiresPlaysInlineAttribute { !allowsInlineMediaPlayback };
         bool allowsInlineMediaPlaybackAfterFullscreen { !allowsInlineMediaPlayback };
@@ -407,29 +436,30 @@ private:
         bool drawsBackground { true };
         bool controlledByAutomation { false };
         bool allowTestOnlyIPC { false };
-        std::optional<bool> delaysWebProcessLaunchUntilFirstLoad { };
-        std::optional<double> cpuLimit { };
-        std::optional<std::pair<uint16_t, uint16_t>> portsForUpgradingInsecureSchemeForTesting { };
+        std::optional<bool> delaysWebProcessLaunchUntilFirstLoad;
+        std::optional<double> cpuLimit;
+        std::optional<std::pair<uint16_t, uint16_t>> portsForUpgradingInsecureSchemeForTesting;
 
-        WTF::String overrideContentSecurityPolicy { };
+        WTF::String overrideContentSecurityPolicy;
 
 #if PLATFORM(COCOA)
-        WTF::Vector<WTF::String> additionalSupportedImageTypes { };
+        RetainPtr<ClassStructPtr> attachmentFileWrapperClass;
+        std::optional<WTF::Vector<WTF::String>> additionalSupportedImageTypes;
         bool clientNavigationsRunAtForegroundPriority { true };
 #endif
 
 #if ENABLE(APPLICATION_MANIFEST)
-        RefPtr<ApplicationManifest> applicationManifest { };
+        RefPtr<ApplicationManifest> applicationManifest;
 #endif
 
-        HashMap<WTF::String, Ref<WebKit::WebURLSchemeHandler>> urlSchemeHandlers { };
-        Vector<WTF::String> corsDisablingPatterns { };
-        HashSet<WTF::String> maskedURLSchemes { };
+        HashMap<WTF::String, Ref<WebKit::WebURLSchemeHandler>> urlSchemeHandlers;
+        Vector<WTF::String> corsDisablingPatterns;
+        HashSet<WTF::String> maskedURLSchemes;
         bool userScriptsShouldWaitUntilNotification { true };
         bool crossOriginAccessControlCheckEnabled { true };
-        WTF::String processDisplayName { };
+        WTF::String processDisplayName;
         bool loadsSubresources { true };
-        std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<WTF::String>> allowedNetworkHosts { };
+        std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<WTF::String>> allowedNetworkHosts;
 
 #if ENABLE(APP_BOUND_DOMAINS)
         bool ignoresAppBoundDomains { false };
@@ -445,7 +475,17 @@ private:
         bool imageControlsEnabled { false };
         bool contextMenuQRCodeDetectionEnabled { false };
 #endif
-
+#if ENABLE(APPLE_PAY)
+        bool applePayEnabled { DEFAULT_VALUE_FOR_ApplePayEnabled };
+#endif
+#if ENABLE(APP_HIGHLIGHTS)
+        bool appHighlightsEnabled { DEFAULT_VALUE_FOR_AppHighlightsEnabled };
+#endif
+        WTF::String groupIdentifier;
+        WTF::String mediaContentTypesRequiringHardwareSupport;
+        std::optional<WTF::String> applicationNameForUserAgent;
+        double sampledPageTopColorMaxDifference { DEFAULT_VALUE_FOR_SampledPageTopColorMaxDifference };
+        double sampledPageTopColorMinHeight { DEFAULT_VALUE_FOR_SampledPageTopColorMinHeight };
         double incrementalRenderingSuppressionTimeout { 5 };
         bool allowsJavaScriptMarkup { true };
         bool convertsPositionStyleOnCopy { false };
@@ -466,7 +506,7 @@ private:
         bool allowsInlinePredictions { false };
 
         WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
-        WTF::String attributedBundleIdentifier { };
+        WTF::String attributedBundleIdentifier;
 
 #if HAVE(TOUCH_BAR)
         bool requiresUserActionForEditingControlsManager { false };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10015,7 +10015,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 
 #if PLATFORM(COCOA)
     parameters.smartInsertDeleteEnabled = m_isSmartInsertDeleteEnabled;
-    parameters.additionalSupportedImageTypes = m_configuration->additionalSupportedImageTypes();
+    parameters.additionalSupportedImageTypes = m_configuration->additionalSupportedImageTypes().value_or(Vector<String>());
 
 #if !ENABLE(WEBCONTENT_GPU_SANDBOX_EXTENSIONS_BLOCKING)
     if (!shouldBlockIOKit(preferences(), drawingArea.type())) {


### PR DESCRIPTION
#### f3a7825e8d6e739ddbcda9db8f7b1a1c992843c6
<pre>
Move more ivars from WKWebViewConfiguration to API::PageConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=271438">https://bugs.webkit.org/show_bug.cgi?id=271438</a>

Reviewed by Charlie Wolfe.

* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::attachmentFileWrapperClass const):
(API::PageConfiguration::setAttachmentFileWrapperClass):
(API::PageConfiguration::additionalSupportedImageTypes const):
(API::PageConfiguration::setAdditionalSupportedImageTypes):
(API::PageConfiguration::applePayEnabled const):
(API::PageConfiguration::setApplePayEnabled):
(API::PageConfiguration::appHighlightsEnabled const):
(API::PageConfiguration::setAppHighlightsEnabled):
(API::PageConfiguration::groupIdentifier const):
(API::PageConfiguration::setGroupIdentifier):
(API::PageConfiguration::mediaContentTypesRequiringHardwareSupport const):
(API::PageConfiguration::setMediaContentTypesRequiringHardwareSupport):
(API::PageConfiguration::applicationNameForUserAgent const):
(API::PageConfiguration::setApplicationNameForUserAgent):
(API::PageConfiguration::sampledPageTopColorMaxDifference const):
(API::PageConfiguration::setSampledPageTopColorMaxDifference):
(API::PageConfiguration::sampledPageTopColorMinHeight const):
(API::PageConfiguration::setSampledPageTopColorMinHeight):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration init]):
(-[WKWebViewConfiguration encodeWithCoder:]):
(-[WKWebViewConfiguration copyWithZone:]):
(-[WKWebViewConfiguration _applicationNameForDesktopUserAgent]):
(-[WKWebViewConfiguration applicationNameForUserAgent]):
(-[WKWebViewConfiguration setApplicationNameForUserAgent:]):
(-[WKWebViewConfiguration _groupIdentifier]):
(-[WKWebViewConfiguration _setGroupIdentifier:]):
(-[WKWebViewConfiguration _attachmentFileWrapperClass]):
(-[WKWebViewConfiguration _setAttachmentFileWrapperClass:]):
(-[WKWebViewConfiguration _isControlledByAutomation]):
(-[WKWebViewConfiguration _setControlledByAutomation:]):
(-[WKWebViewConfiguration _applePayEnabled]):
(-[WKWebViewConfiguration _setApplePayEnabled:]):
(-[WKWebViewConfiguration _mediaContentTypesRequiringHardwareSupport]):
(-[WKWebViewConfiguration _setMediaContentTypesRequiringHardwareSupport:]):
(-[WKWebViewConfiguration _additionalSupportedImageTypes]):
(-[WKWebViewConfiguration _setAdditionalSupportedImageTypes:]):
(-[WKWebViewConfiguration _setAppHighlightsEnabled:]):
(-[WKWebViewConfiguration _appHighlightsEnabled]):
(-[WKWebViewConfiguration _setSampledPageTopColorMaxDifference:]):
(-[WKWebViewConfiguration _sampledPageTopColorMaxDifference]):
(-[WKWebViewConfiguration _setSampledPageTopColorMinHeight:]):
(-[WKWebViewConfiguration _sampledPageTopColorMinHeight]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):

Canonical link: <a href="https://commits.webkit.org/276532@main">https://commits.webkit.org/276532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f04413a13dce4cca1183fa7a5314fc39d4fdff56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47559 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40910 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21401 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17951 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18467 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2952 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41132 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40101 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49231 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16412 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21192 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42619 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6233 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->