### PR TITLE
Update RTCDataChannelHandlerClient::didReceiveRawData() to take in a std::span

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -70,7 +70,7 @@ NetworkSendQueue RTCDataChannel::createMessageQueue(ScriptExecutionContext& cont
         if (!channel.m_handler->sendStringData(utf8))
             channel.scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Error sending string through RTCDataChannel."_s);
     }, [&channel](auto span) {
-        if (!channel.m_handler->sendRawData(span.data(), span.size()))
+        if (!channel.m_handler->sendRawData(span))
             channel.scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Error sending binary data through RTCDataChannel."_s);
     }, [&channel](ExceptionCode errorCode) {
         if (RefPtr context = channel.scriptExecutionContext()) {
@@ -206,14 +206,14 @@ void RTCDataChannel::didReceiveStringData(const String& text)
     scheduleDispatchEvent(MessageEvent::create(text));
 }
 
-void RTCDataChannel::didReceiveRawData(const uint8_t* data, size_t dataLength)
+void RTCDataChannel::didReceiveRawData(std::span<const uint8_t> data)
 {
     switch (m_binaryType) {
     case BinaryType::Blob:
-        scheduleDispatchEvent(MessageEvent::create(Blob::create(scriptExecutionContext(), Vector(std::span { data, dataLength }), emptyString()), { }));
+        scheduleDispatchEvent(MessageEvent::create(Blob::create(scriptExecutionContext(), Vector(data), emptyString()), { }));
         return;
     case BinaryType::Arraybuffer:
-        scheduleDispatchEvent(MessageEvent::create(ArrayBuffer::create(data, dataLength)));
+        scheduleDispatchEvent(MessageEvent::create(ArrayBuffer::create(data)));
         return;
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -114,7 +114,7 @@ private:
     // RTCDataChannelHandlerClient API
     void didChangeReadyState(RTCDataChannelState) final;
     void didReceiveStringData(const String&) final;
-    void didReceiveRawData(const uint8_t*, size_t) final;
+    void didReceiveRawData(std::span<const uint8_t>) final;
     void didDetectError(Ref<RTCError>&&) final;
     void bufferedAmountIsDecreasing(size_t) final;
 

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp
@@ -60,9 +60,9 @@ void RTCDataChannelRemoteHandler::didReceiveStringData(String&& text)
     m_client->didReceiveStringData(text);
 }
 
-void RTCDataChannelRemoteHandler::didReceiveRawData(const uint8_t* data, size_t size)
+void RTCDataChannelRemoteHandler::didReceiveRawData(std::span<const uint8_t> data)
 {
-    m_client->didReceiveRawData(data, size);
+    m_client->didReceiveRawData(data);
 }
 
 void RTCDataChannelRemoteHandler::didDetectError(Ref<RTCError>&& error)
@@ -80,7 +80,7 @@ void RTCDataChannelRemoteHandler::readyToSend()
     m_isReadyToSend = true;
 
     for (auto& message : m_pendingMessages)
-        m_connection->sendData(m_remoteIdentifier, message.isRaw, message.buffer->makeContiguous()->data(), message.buffer->size());
+        m_connection->sendData(m_remoteIdentifier, message.isRaw, message.buffer->makeContiguous()->span());
     m_pendingMessages.clear();
 
     if (m_isPendingClose)
@@ -97,20 +97,20 @@ void RTCDataChannelRemoteHandler::setClient(RTCDataChannelHandlerClient& client,
 bool RTCDataChannelRemoteHandler::sendStringData(const CString& text)
 {
     if (!m_isReadyToSend) {
-        m_pendingMessages.append(Message { false, SharedBuffer::create(text.data(), text.length()) });
+        m_pendingMessages.append(Message { false, SharedBuffer::create(text.span()) });
         return true;
     }
-    m_connection->sendData(m_remoteIdentifier, false, text.dataAsUInt8Ptr(), text.length());
+    m_connection->sendData(m_remoteIdentifier, false, text.span());
     return true;
 }
 
-bool RTCDataChannelRemoteHandler::sendRawData(const uint8_t* data, size_t size)
+bool RTCDataChannelRemoteHandler::sendRawData(std::span<const uint8_t> data)
 {
     if (!m_isReadyToSend) {
-        m_pendingMessages.append(Message { true, SharedBuffer::create(data, size) });
+        m_pendingMessages.append(Message { true, SharedBuffer::create(data) });
         return true;
     }
-    m_connection->sendData(m_remoteIdentifier, true, data, size);
+    m_connection->sendData(m_remoteIdentifier, true, data);
     return true;
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h
@@ -50,7 +50,7 @@ public:
 
     WEBCORE_EXPORT void didChangeReadyState(RTCDataChannelState);
     WEBCORE_EXPORT void didReceiveStringData(String&&);
-    WEBCORE_EXPORT void didReceiveRawData(const uint8_t*, size_t);
+    WEBCORE_EXPORT void didReceiveRawData(std::span<const uint8_t>);
     WEBCORE_EXPORT void didDetectError(Ref<RTCError>&&);
     WEBCORE_EXPORT void bufferedAmountIsDecreasing(size_t);
 
@@ -62,7 +62,7 @@ private:
     // RTCDataChannelHandler
     void setClient(RTCDataChannelHandlerClient&, ScriptExecutionContextIdentifier) final;
     bool sendStringData(const CString&) final;
-    bool sendRawData(const uint8_t*, size_t) final;
+    bool sendRawData(std::span<const uint8_t>) final;
     void close() final;
 
     RTCDataChannelIdentifier m_remoteIdentifier;

--- a/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.h
@@ -42,7 +42,7 @@ public:
     ~RTCDataChannelRemoteSource();
 
     void sendStringData(const CString& text) { m_handler->sendStringData(text); }
-    void sendRawData(const uint8_t* data, size_t size) { m_handler->sendRawData(data, size); }
+    void sendRawData(std::span<const uint8_t> data) { m_handler->sendRawData(data); }
     void close() { m_handler->close(); }
 
 private:
@@ -50,7 +50,7 @@ private:
     // RTCDataChannelHandlerClient
     void didChangeReadyState(RTCDataChannelState state) final { m_connection->didChangeReadyState(m_identifier, state); }
     void didReceiveStringData(const String& text) final { m_connection->didReceiveStringData(m_identifier, text); }
-    void didReceiveRawData(const uint8_t* data, size_t size) final { m_connection->didReceiveRawData(m_identifier, data, size); }
+    void didReceiveRawData(std::span<const uint8_t> data) final { m_connection->didReceiveRawData(m_identifier, data); }
     void didDetectError(Ref<RTCError>&& error) final { m_connection->didDetectError(m_identifier, error->errorDetail(), error->message()); }
     void bufferedAmountIsDecreasing(size_t amount) final { m_connection->bufferedAmountIsDecreasing(m_identifier, amount); }
     size_t bufferedAmount() const final { return 0; }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
@@ -55,7 +55,7 @@ private:
     // RTCDataChannelHandler API
     void setClient(RTCDataChannelHandlerClient&, ScriptExecutionContextIdentifier) final;
     bool sendStringData(const CString&) final;
-    bool sendRawData(const uint8_t*, size_t) final;
+    bool sendRawData(std::span<const uint8_t>) final;
     std::optional<unsigned short> id() const final;
     void close() final;
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
@@ -100,7 +100,8 @@ void LibWebRTCDataChannelHandler::setClient(RTCDataChannelHandlerClient& client,
 
     for (auto& message : m_bufferedMessages) {
         switchOn(message, [&](Ref<FragmentedSharedBuffer>& data) {
-            client.didReceiveRawData(data->makeContiguous()->data(), data->size());
+            Ref contiguousData = data->makeContiguous();
+            client.didReceiveRawData(contiguousData->span());
         }, [&](String& text) {
             client.didReceiveStringData(text);
         }, [&](StateChange stateChange) {
@@ -119,9 +120,9 @@ bool LibWebRTCDataChannelHandler::sendStringData(const CString& utf8Text)
     return m_channel->Send({ rtc::CopyOnWriteBuffer(utf8Text.data(), utf8Text.length()), false });
 }
 
-bool LibWebRTCDataChannelHandler::sendRawData(const uint8_t* data, size_t length)
+bool LibWebRTCDataChannelHandler::sendRawData(std::span<const uint8_t> data)
 {
-    return m_channel->Send({ rtc::CopyOnWriteBuffer(data, length), true });
+    return m_channel->Send({ rtc::CopyOnWriteBuffer(data.data(), data.size()), true });
 }
 
 void LibWebRTCDataChannelHandler::close()
@@ -195,11 +196,11 @@ void LibWebRTCDataChannelHandler::OnMessage(const webrtc::DataBuffer& buffer)
         if (!client)
             return;
 
-        auto* data = buffer->data.data<uint8_t>();
+        std::span data { buffer->data.data<uint8_t>(), buffer->size() };
         if (buffer->binary)
-            client->didReceiveRawData(data, buffer->size());
+            client->didReceiveRawData(data);
         else
-            client->didReceiveStringData(String::fromUTF8(data, buffer->size()));
+            client->didReceiveStringData(String::fromUTF8(data));
     });
 }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.h
@@ -70,7 +70,7 @@ private:
     // RTCDataChannelHandler API
     void setClient(RTCDataChannelHandlerClient&, ScriptExecutionContextIdentifier) final;
     bool sendStringData(const CString&) final;
-    bool sendRawData(const uint8_t*, size_t) final;
+    bool sendRawData(std::span<const uint8_t>) final;
     void close() final;
     std::optional<unsigned short> id() const final;
 

--- a/Source/WebCore/platform/mediastream/RTCDataChannelHandler.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelHandler.h
@@ -69,7 +69,7 @@ public:
     virtual void setClient(RTCDataChannelHandlerClient&, ScriptExecutionContextIdentifier) = 0;
 
     virtual bool sendStringData(const CString&) = 0;
-    virtual bool sendRawData(const uint8_t*, size_t) = 0;
+    virtual bool sendRawData(std::span<const uint8_t>) = 0;
     virtual void close() = 0;
 
     virtual std::optional<unsigned short> id() const { return { }; }

--- a/Source/WebCore/platform/mediastream/RTCDataChannelHandlerClient.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelHandlerClient.h
@@ -42,7 +42,7 @@ public:
 
     virtual void didChangeReadyState(RTCDataChannelState) = 0;
     virtual void didReceiveStringData(const String&) = 0;
-    virtual void didReceiveRawData(const uint8_t*, size_t) = 0;
+    virtual void didReceiveRawData(std::span<const uint8_t>) = 0;
     virtual void didDetectError(Ref<RTCError>&&) = 0;
     virtual void bufferedAmountIsDecreasing(size_t) = 0;
     virtual size_t bufferedAmount() const { return 0; }

--- a/Source/WebCore/platform/mediastream/RTCDataChannelRemoteHandlerConnection.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelRemoteHandlerConnection.h
@@ -38,7 +38,7 @@ public:
     virtual ~RTCDataChannelRemoteHandlerConnection() = default;
 
     virtual void connectToSource(RTCDataChannelRemoteHandler&, ScriptExecutionContextIdentifier, RTCDataChannelIdentifier, RTCDataChannelIdentifier) = 0;
-    virtual void sendData(RTCDataChannelIdentifier, bool isRaw, const unsigned char*, size_t) = 0;
+    virtual void sendData(RTCDataChannelIdentifier, bool isRaw, std::span<const uint8_t>) = 0;
     virtual void close(RTCDataChannelIdentifier) = 0;
 };
 

--- a/Source/WebCore/platform/mediastream/RTCDataChannelRemoteSourceConnection.h
+++ b/Source/WebCore/platform/mediastream/RTCDataChannelRemoteSourceConnection.h
@@ -40,7 +40,7 @@ public:
 
     virtual void didChangeReadyState(RTCDataChannelIdentifier, RTCDataChannelState) = 0;
     virtual void didReceiveStringData(RTCDataChannelIdentifier, const String&) = 0;
-    virtual void didReceiveRawData(RTCDataChannelIdentifier, const uint8_t*, size_t) = 0;
+    virtual void didReceiveRawData(RTCDataChannelIdentifier, std::span<const uint8_t>) = 0;
     virtual void didDetectError(RTCDataChannelIdentifier, RTCErrorDetailType, const String&) = 0;
     virtual void bufferedAmountIsDecreasing(RTCDataChannelIdentifier, size_t) = 0;
 };

--- a/Source/WebCore/platform/mock/RTCDataChannelHandlerMock.cpp
+++ b/Source/WebCore/platform/mock/RTCDataChannelHandlerMock.cpp
@@ -55,9 +55,9 @@ bool RTCDataChannelHandlerMock::sendStringData(const CString& string)
     return true;
 }
 
-bool RTCDataChannelHandlerMock::sendRawData(const uint8_t* data, size_t size)
+bool RTCDataChannelHandlerMock::sendRawData(std::span<const uint8_t> data)
 {
-    m_client->didReceiveRawData(data, size);
+    m_client->didReceiveRawData(data);
     return true;
 }
 

--- a/Source/WebCore/platform/mock/RTCDataChannelHandlerMock.h
+++ b/Source/WebCore/platform/mock/RTCDataChannelHandlerMock.h
@@ -41,7 +41,7 @@ private:
     void setClient(RTCDataChannelHandlerClient&, ScriptExecutionContextIdentifier) final;
 
     bool sendStringData(const CString&) final;
-    bool sendRawData(const uint8_t*, size_t) final;
+    bool sendRawData(std::span<const uint8_t>) final;
     void close() final;
 
     RTCDataChannelHandlerClient* m_client { nullptr };

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h
@@ -69,7 +69,7 @@ private:
         static Ref<RemoteHandlerConnection> create(Ref<WorkQueue>&&);
 
         void connectToSource(WebCore::RTCDataChannelRemoteHandler&, WebCore::ScriptExecutionContextIdentifier, WebCore::RTCDataChannelIdentifier, WebCore::RTCDataChannelIdentifier) final;
-        void sendData(WebCore::RTCDataChannelIdentifier, bool isRaw, const unsigned char*, size_t) final;
+        void sendData(WebCore::RTCDataChannelIdentifier, bool isRaw, std::span<const uint8_t>) final;
         void close(WebCore::RTCDataChannelIdentifier) final;
 
     private:
@@ -88,7 +88,7 @@ private:
 
         void didChangeReadyState(WebCore::RTCDataChannelIdentifier, WebCore::RTCDataChannelState) final;
         void didReceiveStringData(WebCore::RTCDataChannelIdentifier, const String&) final;
-        void didReceiveRawData(WebCore::RTCDataChannelIdentifier, const uint8_t*, size_t) final;
+        void didReceiveRawData(WebCore::RTCDataChannelIdentifier, std::span<const uint8_t>) final;
         void didDetectError(WebCore::RTCDataChannelIdentifier, WebCore::RTCErrorDetailType, const String&) final;
         void bufferedAmountIsDecreasing(WebCore::RTCDataChannelIdentifier, size_t) final;
 


### PR DESCRIPTION
#### 1bf31f611455b721dd37583785c4975d378cf31f
<pre>
Update RTCDataChannelHandlerClient::didReceiveRawData() to take in a std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=271444">https://bugs.webkit.org/show_bug.cgi?id=271444</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::createMessageQueue):
(WebCore::RTCDataChannel::didReceiveRawData):
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.cpp:
(WebCore::RTCDataChannelRemoteHandler::didReceiveRawData):
(WebCore::RTCDataChannelRemoteHandler::readyToSend):
(WebCore::RTCDataChannelRemoteHandler::sendStringData):
(WebCore::RTCDataChannelRemoteHandler::sendRawData):
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteHandler.h:
* Source/WebCore/Modules/mediastream/RTCDataChannelRemoteSource.h:
(WebCore::RTCDataChannelRemoteSource::sendRawData):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
(WebCore::GStreamerDataChannelHandler::setClient):
(WebCore::GStreamerDataChannelHandler::sendRawData):
(WebCore::GStreamerDataChannelHandler::onMessageData):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp:
(WebCore::LibWebRTCDataChannelHandler::setClient):
(WebCore::LibWebRTCDataChannelHandler::sendRawData):
(WebCore::LibWebRTCDataChannelHandler::OnMessage):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.h:
* Source/WebCore/platform/mediastream/RTCDataChannelHandler.h:
* Source/WebCore/platform/mediastream/RTCDataChannelHandlerClient.h:
* Source/WebCore/platform/mediastream/RTCDataChannelRemoteHandlerConnection.h:
* Source/WebCore/platform/mediastream/RTCDataChannelRemoteSourceConnection.h:
* Source/WebCore/platform/mock/RTCDataChannelHandlerMock.cpp:
(WebCore::RTCDataChannelHandlerMock::sendRawData):
* Source/WebCore/platform/mock/RTCDataChannelHandlerMock.h:
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp:
(WebKit::RTCDataChannelRemoteManager::sendData):
(WebKit::RTCDataChannelRemoteManager::receiveData):
(WebKit::RTCDataChannelRemoteManager::RemoteHandlerConnection::sendData):
(WebKit::RTCDataChannelRemoteManager::RemoteSourceConnection::didReceiveRawData):
* Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.h:

Canonical link: <a href="https://commits.webkit.org/276541@main">https://commits.webkit.org/276541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2204af21220f7d7e1a4741c19dbdb6b6a3b6312d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47573 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40922 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36870 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45495 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38669 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39816 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2964 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49243 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43865 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21204 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42631 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/10002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21543 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6237 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->