### PR TITLE
Drop TextResourceDecoder member functions taking in raw pointers

### DIFF
--- a/Source/WebCore/fileapi/FileReaderLoader.cpp
+++ b/Source/WebCore/fileapi/FileReaderLoader.cpp
@@ -341,9 +341,9 @@ void FileReaderLoader::convertToText()
     if (!m_decoder)
         m_decoder = TextResourceDecoder::create("text/plain"_s, m_encoding.isValid() ? m_encoding : PAL::UTF8Encoding());
     if (isCompleted())
-        m_stringResult = m_decoder->decodeAndFlush(static_cast<const char*>(m_rawData->data()), m_bytesLoaded);
+        m_stringResult = m_decoder->decodeAndFlush(m_rawData->span().first(m_bytesLoaded));
     else
-        m_stringResult = m_decoder->decode(static_cast<const char*>(m_rawData->data()), m_bytesLoaded);
+        m_stringResult = m_decoder->decode(m_rawData->span().first(m_bytesLoaded));
 }
 
 void FileReaderLoader::convertToDataURL()

--- a/Source/WebCore/html/track/InbandTextTrack.h
+++ b/Source/WebCore/html/track/InbandTextTrack.h
@@ -84,7 +84,7 @@ private:
     void removeGenericCue(InbandGenericCue&) override { ASSERT_NOT_REACHED(); }
 
     void parseWebVTTFileHeader(String&&) override { ASSERT_NOT_REACHED(); }
-    void parseWebVTTCueData(const uint8_t*, unsigned) override { ASSERT_NOT_REACHED(); }
+    void parseWebVTTCueData(std::span<const uint8_t>) override { ASSERT_NOT_REACHED(); }
     void parseWebVTTCueData(ISOWebVTTCue&&) override { ASSERT_NOT_REACHED(); }
 };
 

--- a/Source/WebCore/html/track/InbandWebVTTTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandWebVTTTextTrack.cpp
@@ -62,9 +62,9 @@ WebVTTParser& InbandWebVTTTextTrack::parser()
     return *m_webVTTParser;
 }
 
-void InbandWebVTTTextTrack::parseWebVTTCueData(const uint8_t* data, unsigned length)
+void InbandWebVTTTextTrack::parseWebVTTCueData(std::span<const uint8_t> data)
 {
-    parser().parseBytes(data, length);
+    parser().parseBytes(data);
 }
 
 void InbandWebVTTTextTrack::parseWebVTTCueData(ISOWebVTTCue&& cueData)

--- a/Source/WebCore/html/track/InbandWebVTTTextTrack.h
+++ b/Source/WebCore/html/track/InbandWebVTTTextTrack.h
@@ -43,7 +43,7 @@ private:
     InbandWebVTTTextTrack(ScriptExecutionContext&, InbandTextTrackPrivate&);
 
     WebVTTParser& parser();
-    void parseWebVTTCueData(const uint8_t* data, unsigned length) final;
+    void parseWebVTTCueData(std::span<const uint8_t>) final;
     void parseWebVTTCueData(ISOWebVTTCue&&) final;
 
     void newCuesParsed() final;

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -125,9 +125,9 @@ void WebVTTParser::parseFileHeader(String&& data)
         m_client.newStyleSheetsParsed();
 }
 
-void WebVTTParser::parseBytes(const uint8_t* data, unsigned length)
+void WebVTTParser::parseBytes(std::span<const uint8_t> data)
 {
-    m_lineReader.append(m_decoder->decode(data, length));
+    m_lineReader.append(m_decoder->decode(data));
     parse();
 }
 
@@ -231,8 +231,7 @@ void WebVTTParser::parse()
 void WebVTTParser::fileFinished()
 {
     ASSERT(m_state != Finished);
-    constexpr uint8_t endLines[] = { '\n', '\n' };
-    parseBytes(endLines, 2);
+    parseBytes("\n\n"_span);
     m_state = Finished;
 }
 

--- a/Source/WebCore/html/track/WebVTTParser.h
+++ b/Source/WebCore/html/track/WebVTTParser.h
@@ -130,7 +130,7 @@ public:
     static bool parseFloatPercentageValuePair(VTTScanner& valueScanner, char, FloatPoint&);
 
     // Input data to the parser to parse.
-    void parseBytes(const uint8_t*, unsigned);
+    void parseBytes(std::span<const uint8_t>);
     void parseFileHeader(String&&);
     void parseCueData(const ISOWebVTTCue&);
     void flush();

--- a/Source/WebCore/inspector/NetworkResourcesData.cpp
+++ b/Source/WebCore/inspector/NetworkResourcesData.cpp
@@ -101,17 +101,16 @@ unsigned NetworkResourcesData::ResourceData::decodeDataToContent()
     ASSERT(!hasContent());
 
     auto buffer = m_dataBuffer.takeAsContiguous();
-    size_t dataLength = buffer->size();
 
     if (m_decoder) {
         m_base64Encoded = false;
-        m_content = m_decoder->decodeAndFlush(buffer->data(), dataLength);
+        m_content = m_decoder->decodeAndFlush(buffer->span());
     } else {
         m_base64Encoded = true;
-        m_content = base64EncodeToString(buffer->data(), dataLength);
+        m_content = base64EncodeToString(buffer->span());
     }
 
-    return m_content.sizeInBytes() - dataLength;
+    return m_content.sizeInBytes() - buffer->size();
 }
 
 NetworkResourcesData::NetworkResourcesData()

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -132,7 +132,7 @@ public:
         if (buffer.isEmpty())
             return;
 
-        m_responseText.append(m_decoder->decode(buffer.data(), buffer.size()));
+        m_responseText.append(m_decoder->decode(buffer.span()));
     }
 
     void didFinishLoading(ResourceLoaderIdentifier, const NetworkLoadMetrics&) override
@@ -1475,12 +1475,12 @@ bool InspectorNetworkAgent::cachedResourceContent(CachedResource& resource, Stri
         if (InspectorNetworkAgent::shouldTreatAsText(resource.mimeType())) {
             auto decoder = InspectorNetworkAgent::createTextDecoder(resource.mimeType(), resource.response().textEncodingName());
             *base64Encoded = false;
-            *result = decoder->decodeAndFlush(buffer->makeContiguous()->data(), buffer->size());
+            *result = decoder->decodeAndFlush(buffer->makeContiguous()->span());
             return true;
         }
 
         *base64Encoded = true;
-        *result = base64EncodeToString(buffer->makeContiguous()->data(), buffer->size());
+        *result = base64EncodeToString(buffer->makeContiguous()->span());
         return true;
     }
 }

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -330,8 +330,10 @@ static inline bool shouldPrependBOM(std::span<const uint8_t> data)
 String TextResourceDecoder::textFromUTF8(std::span<const uint8_t> data)
 {
     auto decoder = TextResourceDecoder::create("text/plain"_s, "UTF-8");
-    if (shouldPrependBOM(data))
-        decoder->decode("\xef\xbb\xbf", 3);
+    if (shouldPrependBOM(data)) {
+        constexpr auto bom = std::to_array<uint8_t>({ 0xEF, 0xBB, 0xBF });
+        decoder->decode(bom);
+    }
     return decoder->decodeAndFlush(data);
 }
 

--- a/Source/WebCore/loader/TextResourceDecoder.h
+++ b/Source/WebCore/loader/TextResourceDecoder.h
@@ -57,13 +57,8 @@ public:
     bool hasEqualEncodingForCharset(const String& charset) const;
 
     WEBCORE_EXPORT String decode(std::span<const uint8_t>);
-    String decode(const char* data, size_t length) { return decode(std::span { reinterpret_cast<const uint8_t*>(data), length }); }
-    String decode(const uint8_t* data, size_t length) { return decode(std::span { data, length }); }
     WEBCORE_EXPORT String flush();
-
     WEBCORE_EXPORT String decodeAndFlush(std::span<const uint8_t>);
-    String decodeAndFlush(const char* data, size_t length) { return decodeAndFlush(std::span { reinterpret_cast<const uint8_t*>(data), length }); }
-    String decodeAndFlush(const uint8_t* data, size_t length) { return decodeAndFlush(std::span { data, length }); }
 
     void setHintEncoding(const TextResourceDecoder* parentFrameDecoder);
    

--- a/Source/WebCore/loader/TextTrackLoader.cpp
+++ b/Source/WebCore/loader/TextTrackLoader.cpp
@@ -92,7 +92,7 @@ void TextTrackLoader::processNewCueData(CachedResource& resource)
 
     while (m_parseOffset < buffer->size()) {
         auto data = buffer->getSomeData(m_parseOffset);
-        m_cueParser->parseBytes(data.data(), data.size());
+        m_cueParser->parseBytes(data.span());
         m_parseOffset += data.size();
     }
 }

--- a/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp
@@ -617,7 +617,7 @@ void ApplicationCacheGroup::didFinishLoadingManifest()
         }
     }
     
-    auto manifest = parseApplicationCacheManifest(m_manifestURL, m_manifestResource->response().mimeType(), m_manifestResource->data().makeContiguous()->data(), m_manifestResource->data().size());
+    auto manifest = parseApplicationCacheManifest(m_manifestURL, m_manifestResource->response().mimeType(), m_manifestResource->data().makeContiguous()->span());
     if (!manifest) {
         // At the time of this writing, lack of "CACHE MANIFEST" signature is the only reason for parseManifest to fail.
         m_frame->document()->addConsoleMessage(MessageSource::AppCache, MessageLevel::Error, "Application Cache manifest could not be parsed. Does it start with CACHE MANIFEST?"_s);

--- a/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
@@ -72,13 +72,13 @@ template<typename CharacterType> static constexpr CharacterType cacheModeIdentif
 template<typename CharacterType> static constexpr CharacterType fallbackModeIdentifier[] = { 'F', 'A', 'L', 'L', 'B', 'A', 'C', 'K' };
 template<typename CharacterType> static constexpr CharacterType networkModeIdentifier[] = { 'N', 'E', 'T', 'W', 'O', 'R', 'K' };
 
-std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL& manifestURL, const String& manifestMIMEType, const uint8_t* data, int length)
+std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL& manifestURL, const String& manifestMIMEType, std::span<const uint8_t> data)
 {
     static constexpr auto cacheManifestMIMEType = "text/cache-manifest"_s;
     bool allowFallbackNamespaceOutsideManifestPath = equalLettersIgnoringASCIICase(manifestMIMEType, cacheManifestMIMEType);
     auto manifestPath = WebCore::manifestPath(manifestURL);
 
-    auto manifestString = TextResourceDecoder::create(cacheManifestMIMEType, "UTF-8")->decodeAndFlush(data, length);
+    auto manifestString = TextResourceDecoder::create(cacheManifestMIMEType, "UTF-8")->decodeAndFlush(data);
 
     return readCharactersForParsing(manifestString, [&](auto buffer) -> std::optional<ApplicationCacheManifest> {
         using CharacterType = typename decltype(buffer)::CharacterType;

--- a/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.h
+++ b/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.h
@@ -41,6 +41,6 @@ struct ApplicationCacheManifest {
     bool allowAllNetworkRequests { false }; // Wildcard found in NETWORK section.
 };
 
-std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL& manifestURL, const String& manifestMIMEType, const uint8_t* data, int length);
+std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL& manifestURL, const String& manifestMIMEType, std::span<const uint8_t> data);
 
 } // namespace WebCore

--- a/Source/WebCore/loader/cache/CachedApplicationManifest.cpp
+++ b/Source/WebCore/loader/cache/CachedApplicationManifest.cpp
@@ -45,7 +45,7 @@ void CachedApplicationManifest::finishLoading(const FragmentedSharedBuffer* data
     if (data) {
         Ref contiguousData = data->makeContiguous();
         setEncodedSize(data->size());
-        m_text = protectedDecoder()->decodeAndFlush(contiguousData->data(), data->size());
+        m_text = protectedDecoder()->decodeAndFlush(contiguousData->span());
         m_data = WTFMove(contiguousData);
     } else {
         m_data = nullptr;

--- a/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp
@@ -89,7 +89,7 @@ const String CachedCSSStyleSheet::sheetText(MIMETypeCheckHint mimeTypeCheckHint,
         return m_decodedSheetText;
 
     // Don't cache the decoded text, regenerating is cheap and it can use quite a bit of memory.
-    return protectedDecoder()->decodeAndFlush(m_data->makeContiguous()->data(), m_data->size());
+    return protectedDecoder()->decodeAndFlush(m_data->makeContiguous()->span());
 }
 
 void CachedCSSStyleSheet::setBodyDataFrom(const CachedResource& resource)
@@ -111,7 +111,7 @@ void CachedCSSStyleSheet::finishLoading(const FragmentedSharedBuffer* data, cons
         Ref contiguousData = data->makeContiguous();
         setEncodedSize(data->size());
         // Decode the data to find out the encoding and keep the sheet text around during checkNotify()
-        m_decodedSheetText = protectedDecoder()->decodeAndFlush(contiguousData->data(), data->size());
+        m_decodedSheetText = protectedDecoder()->decodeAndFlush(contiguousData->span());
         m_data = WTFMove(contiguousData);
     } else {
         m_data = nullptr;

--- a/Source/WebCore/loader/cache/CachedSVGDocument.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGDocument.cpp
@@ -63,7 +63,7 @@ void CachedSVGDocument::finishLoading(const FragmentedSharedBuffer* data, const 
     if (data) {
         // We don't need to create a new frame because the new document belongs to the parent UseElement.
         Ref document = SVGDocument::create(nullptr, m_settings.copyRef(), response().url());
-        document->setMarkupUnsafe(protectedDecoder()->decodeAndFlush(data->makeContiguous()->data(), data->size()), { ParserContentPolicy::AllowDeclarativeShadowRoots });
+        document->setMarkupUnsafe(protectedDecoder()->decodeAndFlush(data->makeContiguous()->span()), { ParserContentPolicy::AllowDeclarativeShadowRoots });
         m_document = WTFMove(document);
     }
     CachedResource::finishLoading(data, metrics);

--- a/Source/WebCore/loader/cache/CachedSVGFont.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGFont.cpp
@@ -82,7 +82,7 @@ bool CachedSVGFont::ensureCustomFontData()
 
             ScriptDisallowedScope::DisableAssertionsInScope disabledScope;
 
-            externalSVGDocument->setMarkupUnsafe(decoder->decodeAndFlush(m_data->makeContiguous()->data(), m_data->size()), { ParserContentPolicy::AllowDeclarativeShadowRoots });
+            externalSVGDocument->setMarkupUnsafe(decoder->decodeAndFlush(m_data->makeContiguous()->span()), { ParserContentPolicy::AllowDeclarativeShadowRoots });
             sawError = decoder->sawError();
             m_externalSVGDocument = WTFMove(externalSVGDocument);
         }

--- a/Source/WebCore/loader/cache/CachedScript.cpp
+++ b/Source/WebCore/loader/cache/CachedScript.cpp
@@ -82,16 +82,17 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
     }
 
     if (m_decodingState == DataAndDecodedStringHaveSameBytes)
-        return { contiguousData->data(), static_cast<unsigned>(contiguousData->size()) };
+        return { contiguousData->span() };
 
     bool shouldForceRedecoding = m_wasForceDecodedAsUTF8 != (shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes);
     if (!m_script || shouldForceRedecoding) {
+        ASSERT(contiguousData->span().size() == encodedSize());
         if (shouldDecodeAsUTF8Only == ShouldDecodeAsUTF8Only::Yes) {
             Ref forceUTF8Decoder = TextResourceDecoder::create("text/javascript"_s, PAL::UTF8Encoding());
             forceUTF8Decoder->setAlwaysUseUTF8();
-            m_script = forceUTF8Decoder->decodeAndFlush(contiguousData->data(), encodedSize());
+            m_script = forceUTF8Decoder->decodeAndFlush(contiguousData->span());
         } else
-            m_script = m_decoder->decodeAndFlush(contiguousData->data(), encodedSize());
+            m_script = m_decoder->decodeAndFlush(contiguousData->span());
         if (m_decodingState == NeverDecoded || shouldForceRedecoding)
             m_scriptHash = m_script.hash();
         ASSERT(!m_scriptHash || m_scriptHash == m_script.hash());

--- a/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
+++ b/Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp
@@ -71,7 +71,7 @@ void CachedXSLStyleSheet::finishLoading(const FragmentedSharedBuffer* data, cons
     if (data) {
         Ref contiguousData = data->makeContiguous();
         setEncodedSize(data->size());
-        m_sheet = protectedDecoder()->decodeAndFlush(contiguousData->data(), encodedSize());
+        m_sheet = protectedDecoder()->decodeAndFlush(contiguousData->span());
         m_data = WTFMove(contiguousData);
     } else {
         m_data = nullptr;

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -225,7 +225,7 @@ void EventSource::didReceiveData(const SharedBuffer& buffer)
     ASSERT(m_requestInFlight);
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!m_isSuspendedForBackForwardCache);
 
-    append(m_receiveBuffer, m_decoder->decode(buffer.data(), buffer.size()));
+    append(m_receiveBuffer, m_decoder->decode(buffer.span()));
     parseEventStream();
 }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2426,7 +2426,7 @@ const String& Page::userStyleSheet() const
     if (!data)
         return m_userStyleSheet;
 
-    m_userStyleSheet = TextResourceDecoder::create(cssContentTypeAtom())->decodeAndFlush(data->data(), data->size());
+    m_userStyleSheet = TextResourceDecoder::create(cssContentTypeAtom())->decodeAndFlush(data->span());
 
     return m_userStyleSheet;
 }

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -416,6 +416,7 @@ public:
     size_t size() const { return m_size; }
     const uint8_t* data() const { return m_segment->data() + m_positionWithinSegment; }
     const char* dataAsCharPtr() const { return reinterpret_cast<const char*>(data()); }
+    std::span<const uint8_t> span() const { return { data(), size() }; }
 
     WEBCORE_EXPORT Ref<SharedBuffer> createSharedBuffer() const;
 #if USE(FOUNDATION)

--- a/Source/WebCore/platform/graphics/InbandTextTrackPrivateClient.h
+++ b/Source/WebCore/platform/graphics/InbandTextTrackPrivateClient.h
@@ -61,7 +61,7 @@ public:
     virtual void removeGenericCue(InbandGenericCue&) = 0;
 
     virtual void parseWebVTTFileHeader(String&&) { ASSERT_NOT_REACHED(); }
-    virtual void parseWebVTTCueData(const uint8_t* data, unsigned length) = 0;
+    virtual void parseWebVTTCueData(std::span<const uint8_t>) = 0;
     virtual void parseWebVTTCueData(ISOWebVTTCue&&) = 0;
 };
 

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
@@ -123,7 +123,7 @@ void InbandTextTrackPrivateGStreamer::notifyTrackOfSample()
         ASSERT(isMainThread());
         ASSERT(!hasClients() || hasOneClient());
         notifyMainThreadClient([&](auto& client) {
-            downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(mappedBuffer.data(), mappedBuffer.size());
+            downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(std::span { mappedBuffer.data(), mappedBuffer.size() });
         });
     }
 }

--- a/Source/WebCore/workers/WorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/WorkerScriptLoader.cpp
@@ -289,7 +289,7 @@ void WorkerScriptLoader::didReceiveData(const SharedBuffer& buffer)
     if (buffer.isEmpty())
         return;
 
-    m_script.append(m_decoder->decode(buffer.data(), buffer.size()));
+    m_script.append(m_decoder->decode(buffer.span()));
 }
 
 void WorkerScriptLoader::didFinishLoading(ResourceLoaderIdentifier identifier, const NetworkLoadMetrics&)

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -1074,7 +1074,7 @@ void XMLHttpRequest::didReceiveData(const SharedBuffer& buffer)
         return;
 
     if (useDecoder)
-        m_responseBuilder.append(m_decoder->decode(buffer.data(), buffer.size()));
+        m_responseBuilder.append(m_decoder->decode(buffer.span()));
     else {
         // Buffer binary data.
         m_binaryResponseBuilder.append(buffer);

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp
@@ -177,12 +177,12 @@ void RemoteTextTrackProxy::parseWebVTTFileHeader(String&& header)
     connection->connection().send(Messages::MediaPlayerPrivateRemote::ParseWebVTTFileHeader(m_trackPrivate->id(), header), m_mediaPlayerIdentifier);
 }
 
-void RemoteTextTrackProxy::parseWebVTTCueData(const uint8_t* data, unsigned length)
+void RemoteTextTrackProxy::parseWebVTTCueData(std::span<const uint8_t> data)
 {
     auto connection = m_connectionToWebProcess.get();
     if (!connection)
         return;
-    connection->connection().send(Messages::MediaPlayerPrivateRemote::ParseWebVTTCueData(m_trackPrivate->id(), std::span(data, length)), m_mediaPlayerIdentifier);
+    connection->connection().send(Messages::MediaPlayerPrivateRemote::ParseWebVTTCueData(m_trackPrivate->id(), data), m_mediaPlayerIdentifier);
 }
 
 void RemoteTextTrackProxy::parseWebVTTCueData(ISOWebVTTCue&& cueData)

--- a/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h
@@ -78,7 +78,7 @@ private:
     virtual void removeGenericCue(WebCore::InbandGenericCue&);
 
     virtual void parseWebVTTFileHeader(String&&);
-    virtual void parseWebVTTCueData(const uint8_t* data, unsigned length);
+    virtual void parseWebVTTCueData(std::span<const uint8_t>);
     virtual void parseWebVTTCueData(WebCore::ISOWebVTTCue&&);
 
     // TrackPrivateBaseClient

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
@@ -184,7 +184,7 @@ void ServiceWorkerSoftUpdateLoader::didReceiveBuffer(const WebCore::FragmentedSh
 
     buffer.forEachSegment([&](auto segment) {
         if (segment.size())
-            m_script.append(m_decoder->decode(segment.data(), segment.size()));
+            m_script.append(m_decoder->decode(segment));
     });
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp
@@ -137,7 +137,7 @@ void TextTrackPrivateRemote::parseWebVTTCueData(std::span<const uint8_t> data)
 {
     ASSERT(hasOneClient());
     notifyMainThreadClient([&](auto& client) {
-        downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(data.data(), data.size());
+        downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(data);
     });
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -3252,7 +3252,7 @@ IGNORE_WARNINGS_END
 + (NSString *)_decodeData:(NSData *)data
 {
     WebCore::HTMLNames::init(); // this method is used for importing bookmarks at startup, so HTMLNames are likely to be uninitialized yet
-    return WebCore::TextResourceDecoder::create("text/html"_s)->decodeAndFlush(static_cast<const char*>([data bytes]), [data length]); // bookmark files are HTML
+    return WebCore::TextResourceDecoder::create("text/html"_s)->decodeAndFlush(span(data)); // bookmark files are HTML
 }
 
 - (void)_pushPerformingProgrammaticFocus


### PR DESCRIPTION
#### 6b5f672f73a323a6d23ee262f46f1673e20a2d76
<pre>
Drop TextResourceDecoder member functions taking in raw pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=271448">https://bugs.webkit.org/show_bug.cgi?id=271448</a>

Reviewed by Darin Adler.

Drop TextResourceDecoder member functions taking in raw pointers,
leaving only the overloads taking in a span.

* Source/WebCore/fileapi/FileReaderLoader.cpp:
(WebCore::FileReaderLoader::convertToText):
* Source/WebCore/html/track/InbandTextTrack.h:
* Source/WebCore/html/track/InbandWebVTTTextTrack.cpp:
(WebCore::InbandWebVTTTextTrack::parseWebVTTCueData):
* Source/WebCore/html/track/InbandWebVTTTextTrack.h:
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::parseBytes):
(WebCore::WebVTTParser::fileFinished):
* Source/WebCore/html/track/WebVTTParser.h:
* Source/WebCore/inspector/NetworkResourcesData.cpp:
(WebCore::NetworkResourcesData::ResourceData::decodeDataToContent):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::cachedResourceContent):
* Source/WebCore/loader/TextResourceDecoder.cpp:
(WebCore::TextResourceDecoder::textFromUTF8):
* Source/WebCore/loader/TextResourceDecoder.h:
(WebCore::TextResourceDecoder::decode): Deleted.
(WebCore::TextResourceDecoder::decodeAndFlush): Deleted.
* Source/WebCore/loader/TextTrackLoader.cpp:
(WebCore::TextTrackLoader::processNewCueData):
* Source/WebCore/loader/appcache/ApplicationCacheGroup.cpp:
(WebCore::ApplicationCacheGroup::didFinishLoadingManifest):
* Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp:
(WebCore::parseApplicationCacheManifest):
* Source/WebCore/loader/appcache/ApplicationCacheManifestParser.h:
* Source/WebCore/loader/cache/CachedApplicationManifest.cpp:
(WebCore::CachedApplicationManifest::finishLoading):
* Source/WebCore/loader/cache/CachedCSSStyleSheet.cpp:
(WebCore::CachedCSSStyleSheet::sheetText const):
(WebCore::CachedCSSStyleSheet::finishLoading):
* Source/WebCore/loader/cache/CachedSVGDocument.cpp:
(WebCore::CachedSVGDocument::finishLoading):
* Source/WebCore/loader/cache/CachedSVGFont.cpp:
(WebCore::CachedSVGFont::ensureCustomFontData):
* Source/WebCore/loader/cache/CachedScript.cpp:
(WebCore::CachedScript::script):
* Source/WebCore/loader/cache/CachedXSLStyleSheet.cpp:
(WebCore::CachedXSLStyleSheet::finishLoading):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::didReceiveData):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::userStyleSheet const):
* Source/WebCore/platform/SharedBuffer.h:
(WebCore::SharedBufferDataView::span const):
* Source/WebCore/platform/graphics/InbandTextTrackPrivateClient.h:
* Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp:
(WebCore::InbandTextTrackPrivateGStreamer::notifyTrackOfSample):
* Source/WebCore/workers/WorkerScriptLoader.cpp:
(WebCore::WorkerScriptLoader::didReceiveData):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::didReceiveData):
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.cpp:
(WebKit::RemoteTextTrackProxy::parseWebVTTCueData):
* Source/WebKit/GPUProcess/media/RemoteTextTrackProxy.h:
* Source/WebKit/WebProcess/GPU/media/TextTrackPrivateRemote.cpp:
(WebKit::TextTrackPrivateRemote::parseWebVTTCueData):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(+[WebView _decodeData:]):

Canonical link: <a href="https://commits.webkit.org/276558@main">https://commits.webkit.org/276558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9766342b4dd0dc119cf6da3635c8cf76678d1da2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47617 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40966 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21466 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21128 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38718 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17995 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39850 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3007 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49289 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43908 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21247 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42689 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21592 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6254 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->