### PR TITLE
Move remaining ivars from WKWebViewConfiguration to API::PageConfiguration

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/WKDataDetectorTypesInternal.h
+++ b/Source/WebKit/Shared/API/Cocoa/WKDataDetectorTypesInternal.h
@@ -25,7 +25,7 @@
 
 #import "WKDataDetectorTypes.h"
 
-#if PLATFORM(IOS_FAMILY)
+#if PLATFORM(IOS_FAMILY) && ENABLE(DATA_DETECTION)
 
 #import <WebCore/DataDetectorType.h>
 
@@ -49,5 +49,27 @@ static inline OptionSet<WebCore::DataDetectorType> fromWKDataDetectorTypes(WKDat
 
     return result;
 }
+
+static inline WKDataDetectorTypes toWKDataDetectorTypes(OptionSet<WebCore::DataDetectorType> types)
+{
+    WKDataDetectorTypes result { WKDataDetectorTypeNone };
+    if (types.contains(WebCore::DataDetectorType::PhoneNumber))
+        result = result | WKDataDetectorTypePhoneNumber;
+    if (types.contains(WebCore::DataDetectorType::Link))
+        result = result | WKDataDetectorTypeLink;
+    if (types.contains(WebCore::DataDetectorType::Address))
+        result = result | WKDataDetectorTypeAddress;
+    if (types.contains(WebCore::DataDetectorType::CalendarEvent))
+        result = result | WKDataDetectorTypeCalendarEvent;
+    if (types.contains(WebCore::DataDetectorType::TrackingNumber))
+        result = result | WKDataDetectorTypeTrackingNumber;
+    if (types.contains(WebCore::DataDetectorType::FlightNumber))
+        result = result | WKDataDetectorTypeFlightNumber;
+    if (types.contains(WebCore::DataDetectorType::LookupSuggestion))
+        result = result | WKDataDetectorTypeLookupSuggestion;
+
+    return result;
+}
+
 
 #endif

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -177,7 +177,7 @@ WebPageProxy* PageConfiguration::relatedPage() const
     return m_data.relatedPage.get();
 }
 
-void PageConfiguration::setRelatedPage(RefPtr<WebPageProxy>&& relatedPage)
+void PageConfiguration::setRelatedPage(WeakPtr<WebPageProxy>&& relatedPage)
 {
     m_data.relatedPage = WTFMove(relatedPage);
 }
@@ -187,9 +187,19 @@ WebPageProxy* PageConfiguration::pageToCloneSessionStorageFrom() const
     return m_data.pageToCloneSessionStorageFrom.get();
 }
 
-void PageConfiguration::setPageToCloneSessionStorageFrom(WebPageProxy* pageToCloneSessionStorageFrom)
+void PageConfiguration::setPageToCloneSessionStorageFrom(WeakPtr<WebPageProxy>&& pageToCloneSessionStorageFrom)
 {
-    m_data.pageToCloneSessionStorageFrom = pageToCloneSessionStorageFrom;
+    m_data.pageToCloneSessionStorageFrom = WTFMove(pageToCloneSessionStorageFrom);
+}
+
+WebPageProxy* PageConfiguration::alternateWebViewForNavigationGestures() const
+{
+    return m_data.alternateWebViewForNavigationGestures.get();
+}
+
+void PageConfiguration::setAlternateWebViewForNavigationGestures(WeakPtr<WebPageProxy>&& alternateWebViewForNavigationGestures)
+{
+    m_data.alternateWebViewForNavigationGestures = WTFMove(alternateWebViewForNavigationGestures);
 }
 
 WebKit::VisitedLinkStore& PageConfiguration::visitedLinkStore() const

--- a/Source/WebKit/UIProcess/API/Cocoa/APIPageConfigurationCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIPageConfigurationCocoa.mm
@@ -48,4 +48,17 @@ WebKit::DragLiftDelay PageConfiguration::Data::defaultDragLiftDelay()
 }
 #endif
 
+NSUInteger PageConfiguration::Data::defaultMediaTypesRequiringUserActionForPlayback()
+{
+#if PLATFORM(IOS_FAMILY)
+#if !PLATFORM(WATCHOS)
+    if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::MediaTypesRequiringUserActionForPlayback))
+        return WKAudiovisualMediaTypeAudio;
+#endif // !PLATFORM(WATCHOS)
+    return WKAudiovisualMediaTypeAll;
+#else // PLATFORM(IOS_FAMILY)
+    return WKAudiovisualMediaTypeNone;
+#endif // PLATFORM(IOS_FAMILY)
+}
+
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -64,6 +64,7 @@
 #import "WKBackForwardListItemInternal.h"
 #import "WKBrowsingContextHandleInternal.h"
 #import "WKContentWorldInternal.h"
+#import "WKDataDetectorTypesInternal.h"
 #import "WKDownloadInternal.h"
 #import "WKErrorInternal.h"
 #import "WKFindConfiguration.h"
@@ -174,10 +175,6 @@
 
 #if ENABLE(APPLICATION_MANIFEST)
 #import "_WKApplicationManifestInternal.h"
-#endif
-
-#if ENABLE(DATA_DETECTION)
-#import "WKDataDetectorTypesInternal.h"
 #endif
 
 #if ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -45,6 +45,7 @@
 #import "VisibleContentRectUpdateInfo.h"
 #import "WKBackForwardListItemInternal.h"
 #import "WKContentViewInteraction.h"
+#import "WKDataDetectorTypesInternal.h"
 #import "WKPasswordView.h"
 #import "WKProcessPoolPrivate.h"
 #import "WKSafeBrowsingWarning.h"
@@ -79,10 +80,6 @@
 #import <wtf/SystemTracing.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
-
-#if ENABLE(DATA_DETECTION)
-#import "WKDataDetectorTypesInternal.h"
-#endif
 
 #if ENABLE(LOCKDOWN_MODE_API)
 #import "_WKSystemPreferencesInternal.h"

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
@@ -27,14 +27,11 @@
 #import "WKWebProcessPlugInRangeHandleInternal.h"
 
 #import "InjectedBundleNodeHandle.h"
+#import "WKDataDetectorTypesInternal.h"
 #import "WKWebProcessPlugInFrameInternal.h"
 #import <WebCore/DataDetection.h>
 #import <WebCore/Range.h>
 #import <WebCore/WebCoreObjCExtras.h>
-
-#if ENABLE(DATA_DETECTION)
-#import "WKDataDetectorTypesInternal.h"
-#endif
 
 @implementation WKWebProcessPlugInRangeHandle {
     API::ObjectStorage<WebKit::InjectedBundleRangeHandle> _rangeHandle;


### PR DESCRIPTION
#### cf4a98a316fb56c1d99211c7d5542233c8784398
<pre>
Move remaining ivars from WKWebViewConfiguration to API::PageConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=271451">https://bugs.webkit.org/show_bug.cgi?id=271451</a>
<a href="https://rdar.apple.com/125216495">rdar://125216495</a>

Reviewed by Tim Horton.

* Source/WebKit/Shared/API/Cocoa/WKDataDetectorTypesInternal.h:
(toWKDataDetectorTypes):
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::setRelatedPage):
(API::PageConfiguration::setPageToCloneSessionStorageFrom):
(API::PageConfiguration::alternateWebViewForNavigationGestures const):
(API::PageConfiguration::setAlternateWebViewForNavigationGestures):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::dataDetectorTypes const):
(API::PageConfiguration::setDataDetectorTypes):
(API::PageConfiguration::selectionGranularity const):
(API::PageConfiguration::setSelectionGranularity):
(API::PageConfiguration::allowsPictureInPictureMediaPlayback const):
(API::PageConfiguration::setAllowsPictureInPictureMediaPlayback):
(API::PageConfiguration::mediaTypesRequiringUserActionForPlayback const):
(API::PageConfiguration::setMediaTypesRequiringUserActionForPlayback):
(API::PageConfiguration::suppressesIncrementalRendering const):
(API::PageConfiguration::setSuppressesIncrementalRendering):
(API::PageConfiguration::allowsAirPlayForMediaPlayback const):
(API::PageConfiguration::setAllowsAirPlayForMediaPlayback):
(API::PageConfiguration::ignoresViewportScaleLimits const):
(API::PageConfiguration::setIgnoresViewportScaleLimits):
(API::PageConfiguration::userInterfaceDirectionPolicy const):
(API::PageConfiguration::setUserInterfaceDirectionPolicy):
* Source/WebKit/UIProcess/API/Cocoa/APIPageConfigurationCocoa.mm:
(API::PageConfiguration::Data::defaultMediaTypesRequiringUserActionForPlayback):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration init]):
(-[WKWebViewConfiguration selectionGranularity]):
(-[WKWebViewConfiguration setSelectionGranularity:]):
(-[WKWebViewConfiguration setAllowsPictureInPictureMediaPlayback:]):
(-[WKWebViewConfiguration allowsPictureInPictureMediaPlayback]):
(-[WKWebViewConfiguration setIgnoresViewportScaleLimits:]):
(-[WKWebViewConfiguration ignoresViewportScaleLimits]):
(-[WKWebViewConfiguration setDataDetectorTypes:]):
(-[WKWebViewConfiguration dataDetectorTypes]):
(-[WKWebViewConfiguration userInterfaceDirectionPolicy]):
(-[WKWebViewConfiguration setUserInterfaceDirectionPolicy:]):
(-[WKWebViewConfiguration initWithCoder:]):
(-[WKWebViewConfiguration copyWithZone:]):
(-[WKWebViewConfiguration mediaTypesRequiringUserActionForPlayback]):
(-[WKWebViewConfiguration setMediaTypesRequiringUserActionForPlayback:]):
(-[WKWebViewConfiguration suppressesIncrementalRendering]):
(-[WKWebViewConfiguration setSuppressesIncrementalRendering:]):
(-[WKWebViewConfiguration setAllowsAirPlayForMediaPlayback:]):
(-[WKWebViewConfiguration allowsAirPlayForMediaPlayback]):
(-[WKWebViewConfiguration _relatedWebView]):
(-[WKWebViewConfiguration _setRelatedWebView:]):
(-[WKWebViewConfiguration _webViewToCloneSessionStorageFrom]):
(-[WKWebViewConfiguration _setWebViewToCloneSessionStorageFrom:]):
(-[WKWebViewConfiguration _alternateWebViewForNavigationGestures]):
(-[WKWebViewConfiguration _setAlternateWebViewForNavigationGestures:]):

Canonical link: <a href="https://commits.webkit.org/276554@main">https://commits.webkit.org/276554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/345c2c02046df9115d9f32fc5f4be7f9282151d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40964 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21464 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36905 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21125 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17991 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18549 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3005 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/40150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49287 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/19929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/16478 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21245 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42672 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6253 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20924 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->