### PR TITLE
[iOS] fast/events/ios/rotation/basic-rotation.html is constantly failing.

### DIFF
--- a/LayoutTests/fast/events/ios/rotation/basic-rotation-expected.txt
+++ b/LayoutTests/fast/events/ios/rotation/basic-rotation-expected.txt
@@ -1,15 +1,15 @@
 Before rotation
-PASS window.innerWidth is 320
-PASS window.innerHeight is 548
-In orientationchange event handler:
-FAIL window.innerWidth should be 568. Was 320.
-FAIL window.innerHeight should be 320. Was 548.
-
+PASS window.innerWidth is 390
+PASS window.innerHeight is 797
 In resize event handler:
-PASS window.innerWidth is 568
-PASS window.innerHeight is 320
+PASS window.innerWidth is 844
+PASS window.innerHeight is 390
+
+In orientationchange event handler:
+PASS window.innerWidth is 844
+PASS window.innerHeight is 390
 
 After rotation
-PASS window.innerWidth is 568
-PASS window.innerHeight is 320
+PASS window.innerWidth is 844
+PASS window.innerHeight is 390
 Rotation test.

--- a/LayoutTests/fast/events/ios/rotation/basic-rotation.html
+++ b/LayoutTests/fast/events/ios/rotation/basic-rotation.html
@@ -21,15 +21,15 @@
         function doTest()
         {
             debug('Before rotation');
-            shouldBe("window.innerWidth", "320");
-            shouldBe("window.innerHeight", "548");
+            shouldBe("window.innerWidth", "390");
+            shouldBe("window.innerHeight", "797");
             if (!window.testRunner)
                 return;
 
             testRunner.runUIScript(getRotationUIScript(), function(result) {
                 debug('After rotation');
-                shouldBe("window.innerWidth", "568");
-                shouldBe("window.innerHeight", "320");
+                shouldBe("window.innerWidth", "844");
+                shouldBe("window.innerHeight", "390");
 
                 if (window.testRunner)
                     testRunner.notifyDone();
@@ -37,14 +37,14 @@
         }
         window.addEventListener('resize', function() {
             debug('In resize event handler:');
-            shouldBe("window.innerWidth", "568");
-            shouldBe("window.innerHeight", "320");
+            shouldBe("window.innerWidth", "844");
+            shouldBe("window.innerHeight", "390");
             debug('');
         }, false);
         window.addEventListener('orientationchange', function() {
             debug('In orientationchange event handler:');
-            shouldBe("window.innerWidth", "568");
-            shouldBe("window.innerHeight", "320");
+            shouldBe("window.innerWidth", "844");
+            shouldBe("window.innerHeight", "390");
             debug('');
         }, false);
 

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2767,6 +2767,4 @@ http/tests/security/clipboard/copy-paste-html-across-origin-sanitizes-html.html 
 http/tests/security/clipboard/copy-paste-html-across-origin-strips-mso-list.html [ Pass Failure ]
 imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-report-only-policy-works-with-external-hash-policy.html [ Pass Failure ]
 
-webkit.org/b/271442 fast/events/ios/rotation/basic-rotation.html [ Failure ]
-
 webkit.org/b/271445 fast/events/ios/rotation/resize-iframe-after-orientation-change.html [ Pass Failure ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4457,9 +4457,6 @@ imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-tex
 
 webkit.org/b/259228 [ Release ] fast/dom/lazy-image-loading-document-leak.html [ Pass Failure ]
 
-# rdar://102857582 (iOS17-iOS-Simulator queues timing out before finishing layout tests)
-fast/events/ios/rotation/ [ Skip ]
-
 # These tests require compile-time flags in WebKit that are only enabled in iOS17. They were marked as Skip in
 # https://bugs.webkit.org/show_bug.cgi?id=248545 — re-enable them here.
 fast/images/animations-resume-from-last-displayed-frame.html [ Pass ]


### PR DESCRIPTION
#### fec218f3209ad2b0883e2f0b2290a4f5f92e5001
<pre>
[iOS] fast/events/ios/rotation/basic-rotation.html is constantly failing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=271442">https://bugs.webkit.org/show_bug.cgi?id=271442</a>
<a href="https://rdar.apple.com/125210995">rdar://125210995</a>

Unreviewed test expectations adjustment.

The previous expectations were accurate for the iPhone SE (1st
generation), but we have defaulted to running layout tests on iPhone 12
(since 256495@main). As such, this patch updates the dimensions to match
the iPhone 12.

* LayoutTests/fast/events/ios/rotation/basic-rotation-expected.txt:
* LayoutTests/fast/events/ios/rotation/basic-rotation.html:
* LayoutTests/platform/ios-wk2/TestExpectations:

Remove the failing expectation.

* LayoutTests/platform/ios/TestExpectations:

Unskip fast/events/ios/rotation since the timeouts are no longer
reproducing.

Canonical link: <a href="https://commits.webkit.org/276589@main">https://commits.webkit.org/276589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01c937f4fe827253c3eb8488c0fe46547339ad56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47720 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41040 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36967 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45610 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21250 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18062 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18658 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39911 "Found 1 new test failure: imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3080 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41348 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49368 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20005 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43954 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42728 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10025 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21666 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21000 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->