### PR TITLE
Update generate-gpup-webgl to match 2024-03-22 trunk

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -621,7 +621,7 @@
     void uniform1fv(int32_t location, std::span<const float>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform1fv(location, std::span(reinterpret_cast<const GCGLfloat*>(v.data()), v.size()));
+        m_context->uniform1fv(location, v);
     }
     void uniform1i(int32_t location, int32_t x)
     {
@@ -631,7 +631,7 @@
     void uniform1iv(int32_t location, std::span<const int32_t>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform1iv(location, std::span(reinterpret_cast<const GCGLint*>(v.data()), v.size()));
+        m_context->uniform1iv(location, v);
     }
     void uniform2f(int32_t location, float x, float y)
     {
@@ -641,7 +641,7 @@
     void uniform2fv(int32_t location, std::span<const float>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform2fv(location, std::span(reinterpret_cast<const GCGLfloat*>(v.data()), v.size()));
+        m_context->uniform2fv(location, v);
     }
     void uniform2i(int32_t location, int32_t x, int32_t y)
     {
@@ -651,7 +651,7 @@
     void uniform2iv(int32_t location, std::span<const int32_t>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform2iv(location, std::span(reinterpret_cast<const GCGLint*>(v.data()), v.size()));
+        m_context->uniform2iv(location, v);
     }
     void uniform3f(int32_t location, float x, float y, float z)
     {
@@ -661,7 +661,7 @@
     void uniform3fv(int32_t location, std::span<const float>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform3fv(location, std::span(reinterpret_cast<const GCGLfloat*>(v.data()), v.size()));
+        m_context->uniform3fv(location, v);
     }
     void uniform3i(int32_t location, int32_t x, int32_t y, int32_t z)
     {
@@ -671,7 +671,7 @@
     void uniform3iv(int32_t location, std::span<const int32_t>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform3iv(location, std::span(reinterpret_cast<const GCGLint*>(v.data()), v.size()));
+        m_context->uniform3iv(location, v);
     }
     void uniform4f(int32_t location, float x, float y, float z, float w)
     {
@@ -681,7 +681,7 @@
     void uniform4fv(int32_t location, std::span<const float>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform4fv(location, std::span(reinterpret_cast<const GCGLfloat*>(v.data()), v.size()));
+        m_context->uniform4fv(location, v);
     }
     void uniform4i(int32_t location, int32_t x, int32_t y, int32_t z, int32_t w)
     {
@@ -691,22 +691,22 @@
     void uniform4iv(int32_t location, std::span<const int32_t>&& v)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform4iv(location, std::span(reinterpret_cast<const GCGLint*>(v.data()), v.size()));
+        m_context->uniform4iv(location, v);
     }
     void uniformMatrix2fv(int32_t location, bool transpose, std::span<const float>&& value)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix2fv(location, static_cast<GCGLboolean>(transpose), std::span(reinterpret_cast<const GCGLfloat*>(value.data()), value.size()));
+        m_context->uniformMatrix2fv(location, static_cast<GCGLboolean>(transpose), value);
     }
     void uniformMatrix3fv(int32_t location, bool transpose, std::span<const float>&& value)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix3fv(location, static_cast<GCGLboolean>(transpose), std::span(reinterpret_cast<const GCGLfloat*>(value.data()), value.size()));
+        m_context->uniformMatrix3fv(location, static_cast<GCGLboolean>(transpose), value);
     }
     void uniformMatrix4fv(int32_t location, bool transpose, std::span<const float>&& value)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix4fv(location, static_cast<GCGLboolean>(transpose), std::span(reinterpret_cast<const GCGLfloat*>(value.data()), value.size()));
+        m_context->uniformMatrix4fv(location, static_cast<GCGLboolean>(transpose), value);
     }
     void useProgram(uint32_t arg0)
     {
@@ -726,7 +726,7 @@
     void vertexAttrib1fv(uint32_t index, std::span<const float, 1>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttrib1fv(index, std::span<const GCGLfloat, 1> { reinterpret_cast<const GCGLfloat*>(values.data()), 1 });
+        m_context->vertexAttrib1fv(index, values);
     }
     void vertexAttrib2f(uint32_t index, float x, float y)
     {
@@ -736,7 +736,7 @@
     void vertexAttrib2fv(uint32_t index, std::span<const float, 2>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttrib2fv(index, std::span<const GCGLfloat, 2> { reinterpret_cast<const GCGLfloat*>(values.data()), 2 });
+        m_context->vertexAttrib2fv(index, values);
     }
     void vertexAttrib3f(uint32_t index, float x, float y, float z)
     {
@@ -746,7 +746,7 @@
     void vertexAttrib3fv(uint32_t index, std::span<const float, 3>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttrib3fv(index, std::span<const GCGLfloat, 3> { reinterpret_cast<const GCGLfloat*>(values.data()), 3 });
+        m_context->vertexAttrib3fv(index, values);
     }
     void vertexAttrib4f(uint32_t index, float x, float y, float z, float w)
     {
@@ -756,7 +756,7 @@
     void vertexAttrib4fv(uint32_t index, std::span<const float, 4>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttrib4fv(index, std::span<const GCGLfloat, 4> { reinterpret_cast<const GCGLfloat*>(values.data()), 4 });
+        m_context->vertexAttrib4fv(index, values);
     }
     void vertexAttribPointer(uint32_t index, int32_t size, uint32_t type, bool normalized, int32_t stride, uint64_t offset)
     {
@@ -776,12 +776,12 @@
     void bufferData1(uint32_t target, std::span<const uint8_t>&& data, uint32_t usage)
     {
         assertIsCurrent(workQueue());
-        m_context->bufferData(target, std::span(reinterpret_cast<const uint8_t*>(data.data()), data.size()), usage);
+        m_context->bufferData(target, data, usage);
     }
     void bufferSubData(uint32_t target, uint64_t offset, std::span<const uint8_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->bufferSubData(target, static_cast<GCGLintptr>(offset), std::span(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
+        m_context->bufferSubData(target, static_cast<GCGLintptr>(offset), data);
     }
     void readPixelsBufferObject(WebCore::IntRect&& arg0, uint32_t format, uint32_t type, uint64_t offset, int32_t alignment, int32_t rowLength)
     {
@@ -791,7 +791,7 @@
     void texImage2D0(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t border, uint32_t format, uint32_t type, std::span<const uint8_t>&& pixels)
     {
         assertIsCurrent(workQueue());
-        m_context->texImage2D(target, level, internalformat, width, height, border, format, type, std::span(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size()));
+        m_context->texImage2D(target, level, internalformat, width, height, border, format, type, pixels);
     }
     void texImage2D1(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t border, uint32_t format, uint32_t type, uint64_t offset)
     {
@@ -801,7 +801,7 @@
     void texSubImage2D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t width, int32_t height, uint32_t format, uint32_t type, std::span<const uint8_t>&& pixels)
     {
         assertIsCurrent(workQueue());
-        m_context->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, std::span(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size()));
+        m_context->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
     }
     void texSubImage2D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t width, int32_t height, uint32_t format, uint32_t type, uint64_t offset)
     {
@@ -811,7 +811,7 @@
     void compressedTexImage2D0(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t border, int32_t imageSize, std::span<const uint8_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, std::span(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
+        m_context->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, data);
     }
     void compressedTexImage2D1(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t border, int32_t imageSize, uint64_t offset)
     {
@@ -821,7 +821,7 @@
     void compressedTexSubImage2D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t width, int32_t height, uint32_t format, int32_t imageSize, std::span<const uint8_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, std::span(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
+        m_context->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, data);
     }
     void compressedTexSubImage2D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t width, int32_t height, uint32_t format, int32_t imageSize, uint64_t offset)
     {
@@ -892,12 +892,12 @@
     void invalidateFramebuffer(uint32_t target, std::span<const uint32_t>&& attachments)
     {
         assertIsCurrent(workQueue());
-        m_context->invalidateFramebuffer(target, std::span(reinterpret_cast<const GCGLenum*>(attachments.data()), attachments.size()));
+        m_context->invalidateFramebuffer(target, attachments);
     }
     void invalidateSubFramebuffer(uint32_t target, std::span<const uint32_t>&& attachments, int32_t x, int32_t y, int32_t width, int32_t height)
     {
         assertIsCurrent(workQueue());
-        m_context->invalidateSubFramebuffer(target, std::span(reinterpret_cast<const GCGLenum*>(attachments.data()), attachments.size()), x, y, width, height);
+        m_context->invalidateSubFramebuffer(target, attachments, x, y, width, height);
     }
     void readBuffer(uint32_t src)
     {
@@ -922,7 +922,7 @@
     void texImage3D0(uint32_t target, int32_t level, int32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, uint32_t format, uint32_t type, std::span<const uint8_t>&& pixels)
     {
         assertIsCurrent(workQueue());
-        m_context->texImage3D(target, level, internalformat, width, height, depth, border, format, type, std::span(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size()));
+        m_context->texImage3D(target, level, internalformat, width, height, depth, border, format, type, pixels);
     }
     void texImage3D1(uint32_t target, int32_t level, int32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, uint32_t format, uint32_t type, uint64_t offset)
     {
@@ -932,7 +932,7 @@
     void texSubImage3D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, uint32_t type, std::span<const uint8_t>&& pixels)
     {
         assertIsCurrent(workQueue());
-        m_context->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, std::span(reinterpret_cast<const uint8_t*>(pixels.data()), pixels.size()));
+        m_context->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
     }
     void texSubImage3D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, uint32_t type, uint64_t offset)
     {
@@ -947,7 +947,7 @@
     void compressedTexImage3D0(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, int32_t imageSize, std::span<const uint8_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, std::span(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
+        m_context->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, data);
     }
     void compressedTexImage3D1(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, int32_t imageSize, uint64_t offset)
     {
@@ -957,7 +957,7 @@
     void compressedTexSubImage3D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, int32_t imageSize, std::span<const uint8_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, std::span(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
+        m_context->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
     }
     void compressedTexSubImage3D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, int32_t imageSize, uint64_t offset)
     {
@@ -994,52 +994,52 @@
     void uniform1uiv(int32_t location, std::span<const uint32_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform1uiv(location, std::span(reinterpret_cast<const GCGLuint*>(data.data()), data.size()));
+        m_context->uniform1uiv(location, data);
     }
     void uniform2uiv(int32_t location, std::span<const uint32_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform2uiv(location, std::span(reinterpret_cast<const GCGLuint*>(data.data()), data.size()));
+        m_context->uniform2uiv(location, data);
     }
     void uniform3uiv(int32_t location, std::span<const uint32_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform3uiv(location, std::span(reinterpret_cast<const GCGLuint*>(data.data()), data.size()));
+        m_context->uniform3uiv(location, data);
     }
     void uniform4uiv(int32_t location, std::span<const uint32_t>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniform4uiv(location, std::span(reinterpret_cast<const GCGLuint*>(data.data()), data.size()));
+        m_context->uniform4uiv(location, data);
     }
     void uniformMatrix2x3fv(int32_t location, bool transpose, std::span<const float>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix2x3fv(location, static_cast<GCGLboolean>(transpose), std::span(reinterpret_cast<const GCGLfloat*>(data.data()), data.size()));
+        m_context->uniformMatrix2x3fv(location, static_cast<GCGLboolean>(transpose), data);
     }
     void uniformMatrix3x2fv(int32_t location, bool transpose, std::span<const float>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix3x2fv(location, static_cast<GCGLboolean>(transpose), std::span(reinterpret_cast<const GCGLfloat*>(data.data()), data.size()));
+        m_context->uniformMatrix3x2fv(location, static_cast<GCGLboolean>(transpose), data);
     }
     void uniformMatrix2x4fv(int32_t location, bool transpose, std::span<const float>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix2x4fv(location, static_cast<GCGLboolean>(transpose), std::span(reinterpret_cast<const GCGLfloat*>(data.data()), data.size()));
+        m_context->uniformMatrix2x4fv(location, static_cast<GCGLboolean>(transpose), data);
     }
     void uniformMatrix4x2fv(int32_t location, bool transpose, std::span<const float>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix4x2fv(location, static_cast<GCGLboolean>(transpose), std::span(reinterpret_cast<const GCGLfloat*>(data.data()), data.size()));
+        m_context->uniformMatrix4x2fv(location, static_cast<GCGLboolean>(transpose), data);
     }
     void uniformMatrix3x4fv(int32_t location, bool transpose, std::span<const float>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix3x4fv(location, static_cast<GCGLboolean>(transpose), std::span(reinterpret_cast<const GCGLfloat*>(data.data()), data.size()));
+        m_context->uniformMatrix3x4fv(location, static_cast<GCGLboolean>(transpose), data);
     }
     void uniformMatrix4x3fv(int32_t location, bool transpose, std::span<const float>&& data)
     {
         assertIsCurrent(workQueue());
-        m_context->uniformMatrix4x3fv(location, static_cast<GCGLboolean>(transpose), std::span(reinterpret_cast<const GCGLfloat*>(data.data()), data.size()));
+        m_context->uniformMatrix4x3fv(location, static_cast<GCGLboolean>(transpose), data);
     }
     void vertexAttribI4i(uint32_t index, int32_t x, int32_t y, int32_t z, int32_t w)
     {
@@ -1049,7 +1049,7 @@
     void vertexAttribI4iv(uint32_t index, std::span<const int32_t, 4>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttribI4iv(index, std::span<const GCGLint, 4> { reinterpret_cast<const GCGLint*>(values.data()), 4 });
+        m_context->vertexAttribI4iv(index, values);
     }
     void vertexAttribI4ui(uint32_t index, uint32_t x, uint32_t y, uint32_t z, uint32_t w)
     {
@@ -1059,7 +1059,7 @@
     void vertexAttribI4uiv(uint32_t index, std::span<const uint32_t, 4>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->vertexAttribI4uiv(index, std::span<const GCGLuint, 4> { reinterpret_cast<const GCGLuint*>(values.data()), 4 });
+        m_context->vertexAttribI4uiv(index, values);
     }
     void vertexAttribIPointer(uint32_t index, int32_t size, uint32_t type, int32_t stride, uint64_t offset)
     {
@@ -1074,22 +1074,22 @@
     void drawBuffers(std::span<const uint32_t>&& bufs)
     {
         assertIsCurrent(workQueue());
-        m_context->drawBuffers(std::span(reinterpret_cast<const GCGLenum*>(bufs.data()), bufs.size()));
+        m_context->drawBuffers(bufs);
     }
     void clearBufferiv(uint32_t buffer, int32_t drawbuffer, std::span<const int32_t>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->clearBufferiv(buffer, drawbuffer, std::span(reinterpret_cast<const GCGLint*>(values.data()), values.size()));
+        m_context->clearBufferiv(buffer, drawbuffer, values);
     }
     void clearBufferuiv(uint32_t buffer, int32_t drawbuffer, std::span<const uint32_t>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->clearBufferuiv(buffer, drawbuffer, std::span(reinterpret_cast<const GCGLuint*>(values.data()), values.size()));
+        m_context->clearBufferuiv(buffer, drawbuffer, values);
     }
     void clearBufferfv(uint32_t buffer, int32_t drawbuffer, std::span<const float>&& values)
     {
         assertIsCurrent(workQueue());
-        m_context->clearBufferfv(buffer, drawbuffer, std::span(reinterpret_cast<const GCGLfloat*>(values.data()), values.size()));
+        m_context->clearBufferfv(buffer, drawbuffer, values);
     }
     void clearBufferfi(uint32_t buffer, int32_t drawbuffer, float depth, int32_t stencil)
     {
@@ -1341,7 +1341,7 @@
     void drawBuffersEXT(std::span<const uint32_t>&& bufs)
     {
         assertIsCurrent(workQueue());
-        m_context->drawBuffersEXT(std::span(reinterpret_cast<const GCGLenum*>(bufs.data()), bufs.size()));
+        m_context->drawBuffersEXT(bufs);
     }
     void createQueryEXT(CompletionHandler<void(uint32_t)>&& completionHandler)
     {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -1240,7 +1240,7 @@ void RemoteGraphicsContextGLProxy::uniform1fv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1fv(location, std::span<const float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1fv(location, v));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1262,7 +1262,7 @@ void RemoteGraphicsContextGLProxy::uniform1iv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1iv(location, std::span<const int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1iv(location, v));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1284,7 +1284,7 @@ void RemoteGraphicsContextGLProxy::uniform2fv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2fv(location, std::span<const float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2fv(location, v));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1306,7 +1306,7 @@ void RemoteGraphicsContextGLProxy::uniform2iv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2iv(location, std::span<const int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2iv(location, v));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1328,7 +1328,7 @@ void RemoteGraphicsContextGLProxy::uniform3fv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3fv(location, std::span<const float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3fv(location, v));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1350,7 +1350,7 @@ void RemoteGraphicsContextGLProxy::uniform3iv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3iv(location, std::span<const int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3iv(location, v));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1372,7 +1372,7 @@ void RemoteGraphicsContextGLProxy::uniform4fv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4fv(location, std::span<const float>(reinterpret_cast<const float*>(v.data()), v.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4fv(location, v));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1394,7 +1394,7 @@ void RemoteGraphicsContextGLProxy::uniform4iv(GCGLint location, std::span<const 
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4iv(location, std::span<const int32_t>(reinterpret_cast<const int32_t*>(v.data()), v.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4iv(location, v));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1405,7 +1405,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2fv(GCGLint location, GCGLboolea
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2fv(location, static_cast<bool>(transpose), std::span<const float>(reinterpret_cast<const float*>(value.data()), value.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2fv(location, static_cast<bool>(transpose), value));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1416,7 +1416,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3fv(GCGLint location, GCGLboolea
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3fv(location, static_cast<bool>(transpose), std::span<const float>(reinterpret_cast<const float*>(value.data()), value.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3fv(location, static_cast<bool>(transpose), value));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1427,7 +1427,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix4fv(GCGLint location, GCGLboolea
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4fv(location, static_cast<bool>(transpose), std::span<const float>(reinterpret_cast<const float*>(value.data()), value.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4fv(location, static_cast<bool>(transpose), value));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1471,7 +1471,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib1fv(GCGLuint index, std::span<con
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1fv(index, std::span<const float, 1>(reinterpret_cast<const float*>(values.data()), values.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib1fv(index, values));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1493,7 +1493,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib2fv(GCGLuint index, std::span<con
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2fv(index, std::span<const float, 2>(reinterpret_cast<const float*>(values.data()), values.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib2fv(index, values));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1515,7 +1515,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib3fv(GCGLuint index, std::span<con
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3fv(index, std::span<const float, 3>(reinterpret_cast<const float*>(values.data()), values.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib3fv(index, values));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1537,7 +1537,7 @@ void RemoteGraphicsContextGLProxy::vertexAttrib4fv(GCGLuint index, std::span<con
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4fv(index, std::span<const float, 4>(reinterpret_cast<const float*>(values.data()), values.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttrib4fv(index, values));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1829,7 +1829,7 @@ void RemoteGraphicsContextGLProxy::invalidateFramebuffer(GCGLenum target, std::s
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateFramebuffer(target, std::span<const uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateFramebuffer(target, attachments));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -1840,7 +1840,7 @@ void RemoteGraphicsContextGLProxy::invalidateSubFramebuffer(GCGLenum target, std
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateSubFramebuffer(target, std::span<const uint32_t>(reinterpret_cast<const uint32_t*>(attachments.data()), attachments.size()), x, y, width, height));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::InvalidateSubFramebuffer(target, attachments, x, y, width, height));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2051,7 +2051,7 @@ void RemoteGraphicsContextGLProxy::uniform1uiv(GCGLint location, std::span<const
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1uiv(location, std::span<const uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform1uiv(location, data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2062,7 +2062,7 @@ void RemoteGraphicsContextGLProxy::uniform2uiv(GCGLint location, std::span<const
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2uiv(location, std::span<const uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform2uiv(location, data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2073,7 +2073,7 @@ void RemoteGraphicsContextGLProxy::uniform3uiv(GCGLint location, std::span<const
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3uiv(location, std::span<const uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform3uiv(location, data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2084,7 +2084,7 @@ void RemoteGraphicsContextGLProxy::uniform4uiv(GCGLint location, std::span<const
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4uiv(location, std::span<const uint32_t>(reinterpret_cast<const uint32_t*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::Uniform4uiv(location, data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2095,7 +2095,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2x3fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x3fv(location, static_cast<bool>(transpose), std::span<const float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x3fv(location, static_cast<bool>(transpose), data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2106,7 +2106,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3x2fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x2fv(location, static_cast<bool>(transpose), std::span<const float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x2fv(location, static_cast<bool>(transpose), data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2117,7 +2117,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix2x4fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x4fv(location, static_cast<bool>(transpose), std::span<const float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix2x4fv(location, static_cast<bool>(transpose), data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2128,7 +2128,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix4x2fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x2fv(location, static_cast<bool>(transpose), std::span<const float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x2fv(location, static_cast<bool>(transpose), data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2139,7 +2139,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix3x4fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x4fv(location, static_cast<bool>(transpose), std::span<const float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix3x4fv(location, static_cast<bool>(transpose), data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2150,7 +2150,7 @@ void RemoteGraphicsContextGLProxy::uniformMatrix4x3fv(GCGLint location, GCGLbool
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x3fv(location, static_cast<bool>(transpose), std::span<const float>(reinterpret_cast<const float*>(data.data()), data.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::UniformMatrix4x3fv(location, static_cast<bool>(transpose), data));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2172,7 +2172,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4iv(GCGLuint index, std::span<co
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4iv(index, std::span<const int32_t, 4>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4iv(index, values));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2194,7 +2194,7 @@ void RemoteGraphicsContextGLProxy::vertexAttribI4uiv(GCGLuint index, std::span<c
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4uiv(index, std::span<const uint32_t, 4>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::VertexAttribI4uiv(index, values));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2227,7 +2227,7 @@ void RemoteGraphicsContextGLProxy::drawBuffers(std::span<const GCGLenum> bufs)
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffers(std::span<const uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffers(bufs));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2238,7 +2238,7 @@ void RemoteGraphicsContextGLProxy::clearBufferiv(GCGLenum buffer, GCGLint drawbu
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferiv(buffer, drawbuffer, std::span<const int32_t>(reinterpret_cast<const int32_t*>(values.data()), values.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferiv(buffer, drawbuffer, values));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2249,7 +2249,7 @@ void RemoteGraphicsContextGLProxy::clearBufferuiv(GCGLenum buffer, GCGLint drawb
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferuiv(buffer, drawbuffer, std::span<const uint32_t>(reinterpret_cast<const uint32_t*>(values.data()), values.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferuiv(buffer, drawbuffer, values));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2260,7 +2260,7 @@ void RemoteGraphicsContextGLProxy::clearBufferfv(GCGLenum buffer, GCGLint drawbu
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfv(buffer, drawbuffer, std::span<const float>(reinterpret_cast<const float*>(values.data()), values.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::ClearBufferfv(buffer, drawbuffer, values));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;
@@ -2764,7 +2764,7 @@ void RemoteGraphicsContextGLProxy::drawBuffersEXT(std::span<const GCGLenum> bufs
 {
     if (isContextLost())
         return;
-    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffersEXT(std::span<const uint32_t>(reinterpret_cast<const uint32_t*>(bufs.data()), bufs.size())));
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::DrawBuffersEXT(bufs));
     if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return;

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -106,7 +106,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {{
     void GetErrors() -> (GCGLErrorCodeSet returnValue) Synchronous
     void DrawSurfaceBufferToImageBuffer(WebCore::GraphicsContextGL::SurfaceBuffer buffer, WebCore::RenderingResourceIdentifier imageBuffer) -> () Synchronous
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
-    void SurfaceBufferToVideoFrame(WebCore::GraphicsContextGL::SurfaceBuffer buffer) -> (std::optional<WebKit::RemoteVideoFrameProxy::Properties> properties) Synchronous
+    void SurfaceBufferToVideoFrame(WebCore::GraphicsContextGL::SurfaceBuffer buffer) -> (std::optional<WebKit::RemoteVideoFrameProxyProperties> properties) Synchronous
 #endif
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
     void CopyTextureFromVideoFrame(struct WebKit::SharedVideoFrame frame, uint32_t texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY) -> (bool success) Synchronous NotStreamEncodable
@@ -123,7 +123,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {{
     void MultiDrawArraysInstancedBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, uint32_t> firstsCountsInstanceCountsAndBaseInstances)
     void MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, int32_t, uint32_t> countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, uint32_t type)
 #if PLATFORM(COCOA)
-    void CreateAndBindEGLImage(GCGLenum target, WebCore::GraphicsContextGL::EGLImageSource source) -> (uint64_t handle, WebCore::IntSize size) Synchronous NotStreamEncodable NotStreamEncodableReply
+    void CreateAndBindEGLImage(GCGLenum target, WebCore::GraphicsContextGL::EGLImageSource source, GCGLint layer) -> (uint64_t handle) Synchronous NotStreamEncodable NotStreamEncodableReply
     void CreateEGLSync(MachSendRight syncEvent, uint64_t signalValue) -> (uint64_t sync) Synchronous NotStreamEncodable NotStreamEncodableReply
 #endif
 {}
@@ -361,9 +361,6 @@ def cpp_array_reinterpret_cast_conversion(expr: cpp_expr, type: cpp_type_contain
     element_pointer_type = type.get_contained_type().get_pointer_type()
     return cpp_expr(type, f"{str(type)}(reinterpret_cast<{element_pointer_type}>({str(expr)}.data()), {str(expr)}.size())")
 
-def webkit_ipc_span_transfer_type_reinterpret_cast_conversion(expr: cpp_expr, type: cpp_type_container) -> cpp_expr:
-    element_pointer_type = type.get_contained_type().get_pointer_type()
-    return cpp_expr(type, f"{str(type)}(reinterpret_cast<{element_pointer_type}>({str(expr)}.data()), {str(expr)}.size())")
 
 def cpp_move_expr(expr: cpp_expr) -> cpp_expr:
     return cpp_expr(expr.type.get_rvalue_type(), f"WTFMove({str(expr)})")
@@ -524,14 +521,6 @@ def webkit_ipc_get_span_store_type(type: cpp_type_container) -> cpp_type:
         return get_cpp_type(f"Vector<{str(element_type)}, {str(inline_capacity)}>")
     return get_cpp_type(f"std::array<{str(element_type)}, {str(type.get_arity())}>")
 
-def webkit_ipc_make_gcglspan_conversion(expr : cpp_expr, type : cpp_type_container) -> cpp_expr:
-    pointer_cast_type = type.get_contained_type().get_pointer_type()
-    element_type = type.get_contained_type()
-    if type.is_dynamic_span():
-        return cpp_expr(type, f"std::span(reinterpret_cast<{str(pointer_cast_type)}>({str(expr)}.data()), {str(expr)}.size())")
-
-    assert(type.is_span())
-    return cpp_expr(type, f"std::span<{element_type}, {str(type.get_arity())}> {{ reinterpret_cast<{str(pointer_cast_type)}>({str(expr)}.data()), {str(type.get_arity())} }}")
 
 # See messages.py function_parameter_type
 webkit_ipc_builtin_types = set(
@@ -1020,12 +1009,8 @@ def main():
         if cpp_type.is_dynamic_span() or cpp_type.is_span():
             transfer_type = webkit_ipc_get_span_transfer_type(cpp_type)
             webkit_ipc_types[cpp_type] = transfer_type.get_value_type()
-            if cpp_type.get_contained_type().is_const():
-                webkit_ipc_types_converters[(cpp_type, transfer_type)] = webkit_ipc_span_transfer_type_reinterpret_cast_conversion
-                webkit_ipc_types_converters[(transfer_type, cpp_type)] = webkit_ipc_make_gcglspan_conversion
-            else:
-                store_type = webkit_ipc_get_span_store_type(cpp_type)
-                webkit_ipc_types_converters[(store_type, transfer_type)] = cpp_array_reinterpret_cast_conversion
+            store_type = webkit_ipc_get_span_store_type(cpp_type)
+            webkit_ipc_types_converters[(store_type, transfer_type)] = cpp_array_reinterpret_cast_conversion
         elif cpp_type.is_reference() or cpp_type.is_const_reference() or cpp_type.is_container():
             value_type = cpp_type.get_value_type() if not cpp_type.is_container() else cpp_type
             if value_type.is_container():


### PR DESCRIPTION
#### edd186761aa1653c0dde50e549e291d39b0a60fa
<pre>
Update generate-gpup-webgl to match 2024-03-22 trunk
<a href="https://bugs.webkit.org/show_bug.cgi?id=271453">https://bugs.webkit.org/show_bug.cgi?id=271453</a>
<a href="https://rdar.apple.com/125219873">rdar://125219873</a>

Unreviewed build fix.

Fix the generator to match the refactorings that were done to the
generated files manually.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(uniform1fv):
(uniform1iv):
(uniform2fv):
(uniform2iv):
(uniform3fv):
(uniform3iv):
(uniform4fv):
(uniform4iv):
(uniformMatrix2fv):
(uniformMatrix3fv):
(uniformMatrix4fv):
(vertexAttrib1fv):
(vertexAttrib2fv):
(vertexAttrib3fv):
(vertexAttrib4fv):
(bufferData1):
(bufferSubData):
(texImage2D0):
(texSubImage2D0):
(compressedTexImage2D0):
(compressedTexSubImage2D0):
(invalidateFramebuffer):
(invalidateSubFramebuffer):
(texImage3D0):
(texSubImage3D0):
(compressedTexImage3D0):
(compressedTexSubImage3D0):
(uniform1uiv):
(uniform2uiv):
(uniform3uiv):
(uniform4uiv):
(uniformMatrix2x3fv):
(uniformMatrix3x2fv):
(uniformMatrix2x4fv):
(uniformMatrix4x2fv):
(uniformMatrix3x4fv):
(uniformMatrix4x3fv):
(vertexAttribI4iv):
(vertexAttribI4uiv):
(drawBuffers):
(clearBufferiv):
(clearBufferuiv):
(clearBufferfv):
(drawBuffersEXT):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::uniform1fv):
(WebKit::RemoteGraphicsContextGLProxy::uniform1iv):
(WebKit::RemoteGraphicsContextGLProxy::uniform2fv):
(WebKit::RemoteGraphicsContextGLProxy::uniform2iv):
(WebKit::RemoteGraphicsContextGLProxy::uniform3fv):
(WebKit::RemoteGraphicsContextGLProxy::uniform3iv):
(WebKit::RemoteGraphicsContextGLProxy::uniform4fv):
(WebKit::RemoteGraphicsContextGLProxy::uniform4iv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix2fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix3fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix4fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib1fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib2fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib3fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttrib4fv):
(WebKit::RemoteGraphicsContextGLProxy::invalidateFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::invalidateSubFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::uniform1uiv):
(WebKit::RemoteGraphicsContextGLProxy::uniform2uiv):
(WebKit::RemoteGraphicsContextGLProxy::uniform3uiv):
(WebKit::RemoteGraphicsContextGLProxy::uniform4uiv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix2x3fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix3x2fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix2x4fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix4x2fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix3x4fv):
(WebKit::RemoteGraphicsContextGLProxy::uniformMatrix4x3fv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribI4iv):
(WebKit::RemoteGraphicsContextGLProxy::vertexAttribI4uiv):
(WebKit::RemoteGraphicsContextGLProxy::drawBuffers):
(WebKit::RemoteGraphicsContextGLProxy::clearBufferiv):
(WebKit::RemoteGraphicsContextGLProxy::clearBufferuiv):
(WebKit::RemoteGraphicsContextGLProxy::clearBufferfv):
(WebKit::RemoteGraphicsContextGLProxy::drawBuffersEXT):
* Tools/Scripts/generate-gpup-webgl:

Canonical link: <a href="https://commits.webkit.org/276540@main">https://commits.webkit.org/276540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c40cd3e20bc831b6e7472274bb87eb83b6dbf8b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47590 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40939 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36885 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21105 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38694 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17975 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39832 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2981 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49262 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19906 "Built successfully") | [💥 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16457 "An unexpected error occured. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Running apply-patch; Checked out pull request") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43885 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21223 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42656 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10001 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20898 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->