### PR TITLE
[Buildstream SDK] Bump to GStreamer 1.24.1 and rr ToT

### DIFF
--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -13,7 +13,7 @@ sources:
 - kind: patch
   path: patches/fdo-0004-gst-plugins-ugly-Enable-x264-encoder.patch
 - kind: patch
-  path: patches/fdo-0005-GStreamer-Bump-to-1.24.0.patch
+  path: patches/fdo-0005-GStreamer-Bump-to-1.24.1.patch
 - kind: patch
   path: patches/fdo-0006-gst-plugins-bad-Enable-soundtouch.patch
 - kind: patch

--- a/Tools/buildstream/elements/sdk/rr.bst
+++ b/Tools/buildstream/elements/sdk/rr.bst
@@ -13,8 +13,8 @@ variables:
     -DBUILD_TESTS=OFF
 sources:
 - kind: git_repo
-  url: github_com:rr-debugger/rr
-  track: 5.*
-  ref: 5.7.0-0-g7cf5a12dba5aaeea9efc5ad97176b07b5614e350
+  url: github_com:rr-debugger/rr.git
+  track: master
+  ref: 27d2cb542c8eeb6d9206d46bf93d661690681f46
 - kind: patch
   path: patches/rr/0001-cmake-Look-for-resources-in-cmake-s-install-lib-dir.patch

--- a/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.24.1.patch
+++ b/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.24.1.patch
@@ -1,7 +1,7 @@
 From db93844bb1f807d7acad0384e7804d6283079fdf Mon Sep 17 00:00:00 2001
 From: Philippe Normand <philn@igalia.com>
 Date: Wed, 6 Mar 2024 12:17:24 +0000
-Subject: [PATCH] Bump to GStreamer 1.24.0
+Subject: [PATCH] Bump to GStreamer 1.24.1
 
 ---
  elements/components/gstreamer-plugins-bad.bst |  1 +
@@ -89,7 +89,7 @@ index f36b91e..2d73091 100644
    url: freedesktop:gstreamer/gstreamer.git
    track: 1.*[02468].*
 -  ref: 1.22.5-0-gbf6ce1d64a0697e7910826147b48f8f658366a5a
-+  ref: 1.24.0-0-gb125253cade5432e535ef2ea848ac00d2fb5286d
++  ref: 1.24.1-0-g0d0a1d9d16d1eb0f5355202c9f8f3ae6df19cf3b
  - kind: patch_queue
    path: patches/gstreamer
 diff --git a/patches/gstreamer/graceful-error-noopenh264.patch b/patches/gstreamer/graceful-error-noopenh264.patch


### PR DESCRIPTION
#### c125db2d08b6d3ccd41638761132894c54718cc6
<pre>
[Buildstream SDK] Bump to GStreamer 1.24.1 and rr ToT
<a href="https://bugs.webkit.org/show_bug.cgi?id=271456">https://bugs.webkit.org/show_bug.cgi?id=271456</a>

Reviewed by Adrian Perez de Castro.

* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/elements/sdk/rr.bst:
* Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.24.1.patch: Renamed from Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.24.0.patch.

Canonical link: <a href="https://commits.webkit.org/276538@main">https://commits.webkit.org/276538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af7d11f908d351d7484994930b661577be6e851a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40932 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47230 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21424 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36879 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17969 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18511 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39827 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2974 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41184 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49255 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43878 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21214 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42649 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21553 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6234 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20889 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->