### PR TITLE
[@starting-style] Contents of popover is not rendered when opened a 2nd time

### DIFF
--- a/LayoutTests/fast/animation/starting-style-repeat-expected.html
+++ b/LayoutTests/fast/animation/starting-style-repeat-expected.html
@@ -1,0 +1,4 @@
+<style>
+div { color: green; }
+</style>
+<div>This should be green.</div>

--- a/LayoutTests/fast/animation/starting-style-repeat.html
+++ b/LayoutTests/fast/animation/starting-style-repeat.html
@@ -1,0 +1,16 @@
+<style>
+div { transition: color 10s step-end; display: none; color: red; }
+.show { display: block; }
+@starting-style {
+    div { color: green; }
+}
+</style>
+<div id=t>This should be green.</div>
+<script>
+t.offsetHeight;
+t.classList.add("show");
+t.offsetHeight;
+t.classList.remove("show");
+t.offsetHeight;
+t.classList.add("show");
+</script>


### PR DESCRIPTION
#### 353c94ffa3f78de045388574a4cae299d124998e
<pre>
[@starting-style] Contents of popover is not rendered when opened a 2nd time
<a href="https://bugs.webkit.org/show_bug.cgi?id=271307">https://bugs.webkit.org/show_bug.cgi?id=271307</a>
<a href="https://rdar.apple.com/125085007">rdar://125085007</a>

Reviewed by Antoine Quint.

Repeatedly applying @starting-style may fail because we compute the style diff
against wrong style and may conclude that there is no change and fail to
update the subtree. First time round the renderer is marked invalid so we avoid
this problem.

* LayoutTests/fast/animation/starting-style-repeat-expected.html: Added.
* LayoutTests/fast/animation/starting-style-repeat.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

Take care to diff with the current style.

Canonical link: <a href="https://commits.webkit.org/276546@main">https://commits.webkit.org/276546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4d43ae5fa6d7ce996abf707aaadbce31cd1ea9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47592 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40941 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21440 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36891 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17976 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18526 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39834 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2983 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49264 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19908 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/16464 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43886 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21225 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42657 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10005 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21565 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->