### PR TITLE
imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html is flaky

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html
@@ -12,15 +12,15 @@ const HELPER = '/webcodecs/videoFrame-serialization.crossAgentCluster.helper.htm
 const CROSSORIGIN_BASE = get_host_info().HTTPS_NOTSAMESITE_ORIGIN;
 const CROSSORIGIN_HELPER = CROSSORIGIN_BASE + HELPER;
 
-promise_test(async () => {
+promise_test(async (t) => {
   const target = (await appendIframe(CROSSORIGIN_HELPER)).contentWindow;
-  let frame = createVideoFrame(20);
+  let frame = createVideoFrame(t, 20);
   assert_false(await canSerializeVideoFrame(target, frame));
 }, 'Verify frames cannot be passed accross the different agent clusters');
 
-promise_test(async () => {
+promise_test(async (t) => {
   const target = (await appendIframe(CROSSORIGIN_HELPER)).contentWindow;
-  let frame = createVideoFrame(80);
+  let frame = createVideoFrame(t, 80);
   assert_false(await canTransferVideoFrame(target, frame));
 }, 'Verify frames cannot be transferred accross the different agent clusters');
 
@@ -31,17 +31,19 @@ function appendIframe(src) {
   return new Promise(resolve => frame.onload = () => resolve(frame));
 };
 
-function createVideoFrame(ts) {
+function createVideoFrame(test, timestamp) {
   let data = new Uint8Array([
     1, 2, 3, 4, 5, 6, 7, 8,
     9, 10, 11, 12, 13, 14, 15, 16,
   ]);
-  return new VideoFrame(data, {
-    timestamp: ts,
+  const frame = new VideoFrame(data, {
+    timestamp,
     codedWidth: 2,
     codedHeight: 2,
     format: 'RGBA',
   });
+  test.add_cleanup(() => frame.close());
+  return frame;
 }
 
 function canSerializeVideoFrame(target, vf) {

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1845,7 +1845,6 @@ webkit.org/b/263044 imported/w3c/web-platform-tests/webrtc-stats/supported-stats
 # webkit.org/b/261308 Batch mark expectations for flaky imported/w3c/web-platform-tests
 [ Monterey+ X86_64 ] imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html [ Pass Failure ]
 [ Ventura+ ] imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/navigation-reporting/reporting-coop-navigated-opener.https.html [ Pass Failure ]
-[ Monterey+ ] imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html [ Pass Failure ]
 
 
 webkit.org/b/261344 requestidlecallback/requestidlecallback-does-not-block-timer.html [ Pass Failure ]


### PR DESCRIPTION
#### 42bc00b84f3bf71daa1a91454460befba85d56d8
<pre>
imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=271460">https://bugs.webkit.org/show_bug.cgi?id=271460</a>
<a href="https://rdar.apple.com/125231124">rdar://125231124</a>

Reviewed by Eric Carlson.

Make sure to close VideoFrames explicitly to not trigger console warning messages about VideoFrames being GCed.

* LayoutTests/imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/276620@main">https://commits.webkit.org/276620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06dc4ad3ab723f768eea5691cb0e8dd3df8d8a24

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40937 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36882 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45510 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/17972 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39830 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2979 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41211 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49260 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16453 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43891 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21222 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/38933 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42654 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10040 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21558 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->