### PR TITLE
[ews] Do not try to download build product from master

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5140,7 +5140,8 @@ class DownloadBuiltProduct(shell.ShellCommand):
     name = 'download-built-product'
     description = ['downloading built product']
     descriptionDone = ['Downloaded built product']
-    flunkOnFailure = False
+    haltOnFailure = True
+    flunkOnFailure = True
 
     def getResultSummary(self):
         if self.results not in [SUCCESS, SKIPPED]:


### PR DESCRIPTION
#### 74c76a11700d402f304b80e81e52fbf6e2b6ce5b
<pre>
[ews] Do not try to download build product from master
<a href="https://bugs.webkit.org/show_bug.cgi?id=271463">https://bugs.webkit.org/show_bug.cgi?id=271463</a>

Reviewed by Jonathan Bedard.

We stopped uploading archives to build master in 273509@main. So, while downloading
archives, when download from s3 fails, there is no point in trying to fallback to
download from build master.

* Tools/CISupport/ews-build/steps.py:
(DownloadBuiltProduct):

Canonical link: <a href="https://commits.webkit.org/276539@main">https://commits.webkit.org/276539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d012887501361d34825bc52a5efe4ba3563f35ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44939 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/24045 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/47432 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/47594 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47243 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/28116 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/21444 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/47594 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45516 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/28116 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/47432 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/47594 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/28116 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/47432 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/2985 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/28116 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/47432 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/49267 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19910 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/21444 "Build was cancelled. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/49267 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/44980 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21227 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/47432 "Build was cancelled. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/49267 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21567 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6235 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->