### PR TITLE
[Navigation] Process NavigateEvent earlier in FrameLoader::loadInSameDocument

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6895,6 +6895,9 @@ imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/same-do
 imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-away-and-back.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/cross-document-location-api.html [ Skip ]
 imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/location-reload.html [ Pass ]
+imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-fragment.html [ Pass ]
+imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-with-target.html [ Pass ]
+imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-fragment.html [ Pass ]
 
 # -- View Transitions -- #
 # Reftest failures:

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-fragment-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Fragment <a> click fires navigate event assert_true: expected true got false
+FAIL Fragment <a> click fires navigate event assert_equals: expected (object) Element node <a id="a" href="#1"></a> but got (undefined) undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-back-forward-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-back-forward-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigate event destination.getState() on back/forward navigation assert_equals: expected "traverse" but got "push"
+PASS navigate event destination.getState() on back/forward navigation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-fragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-fragment-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL <svg:a> click fires navigate event assert_true: expected true got false
+FAIL <svg:a> click fires navigate event assert_equals: expected (object) Element node <a id="a" href="#1"></a> but got (undefined) undefined
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1272,6 +1272,27 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
     RefPtr document = m_frame->document();
     // Update the data source's request with the new URL to fake the URL change
     URL oldURL = document->url();
+
+    if (document->settings().navigationAPIEnabled() && !url.isAboutBlank()) {
+        if (RefPtr domWindow = document->domWindow()) {
+            auto navigationType = determineNavigationType(policyChecker().loadType(), isNewNavigation);
+
+            // FIXME: This is likely not the ideal location for the navigate event and should happen earlier.
+            if (navigationType != NavigationNavigationType::Traverse) {
+                if (!domWindow->protectedNavigation()->dispatchPushReplaceReloadNavigateEvent(url, navigationType, equalIgnoringFragmentIdentifier(url, oldURL)))
+                    return;
+            }
+
+            if (RefPtr currentItem = checkedHistory()->currentItem()) {
+                // FIXME: Properly handle result of navigate event.
+                if (navigationType == NavigationNavigationType::Traverse)
+                    domWindow->protectedNavigation()->dispatchTraversalNavigateEvent(*currentItem);
+
+                domWindow->protectedNavigation()->updateForNavigation(*currentItem, navigationType);
+            }
+        }
+    }
+
     document->setURL(url);
     setOutgoingReferrer(url);
     protectedDocumentLoader()->replaceRequestURLForSameDocumentNavigation(url);
@@ -1298,24 +1319,6 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
     bool hashChange = equalIgnoringFragmentIdentifier(url, oldURL) && !equalRespectingNullity(url.fragmentIdentifier(), oldURL.fragmentIdentifier());
 
     checkedHistory()->updateForSameDocumentNavigation();
-
-    if (document->settings().navigationAPIEnabled() && !url.isAboutBlank()) {
-        if (RefPtr domWindow = document->domWindow()) {
-            auto navigationType = determineNavigationType(policyChecker().loadType(), isNewNavigation);
-
-            // FIXME: This is likely not the ideal location for the navigate event and should happen earlier.
-            if (navigationType != NavigationNavigationType::Traverse)
-                domWindow->protectedNavigation()->dispatchPushReplaceReloadNavigateEvent(url, navigationType, equalIgnoringFragmentIdentifier(url, oldURL));
-
-            if (RefPtr currentItem = checkedHistory()->currentItem()) {
-                // FIXME: Properly handle result of navigate event.
-                if (navigationType == NavigationNavigationType::Traverse)
-                    domWindow->protectedNavigation()->dispatchTraversalNavigateEvent(*currentItem);
-
-                domWindow->protectedNavigation()->updateForNavigation(*currentItem, navigationType);
-            }
-        }
-    }
 
     // If we were in the autoscroll/panScroll mode we want to stop it before following the link to the anchor
     if (hashChange)


### PR DESCRIPTION
#### 25694764feddef056fca34e4757708ef5cd45503
<pre>
[Navigation] Process NavigateEvent earlier in FrameLoader::loadInSameDocument
<a href="https://bugs.webkit.org/show_bug.cgi?id=271464">https://bugs.webkit.org/show_bug.cgi?id=271464</a>

Reviewed by Alex Christensen.

Process NavigateEvent earlier in FrameLoader::loadInSameDocument, this allows us to properly determine same document
and hashChange values, before updating the document url. Also now we react to preventDefault() calls by doing an early return.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-fragment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-getState-back-forward-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-svg-anchor-fragment-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadInSameDocument):

Canonical link: <a href="https://commits.webkit.org/277030@main">https://commits.webkit.org/277030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b5490abd90c1f2328df6332b2ede448ba69cbac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49125 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42490 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23068 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37906 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47027 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40053 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19152 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41160 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4494 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50959 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44099 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10280 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->