### PR TITLE
Make WKWebViewConfiguration a wrapper around API::PageConfiguration

### DIFF
--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -65,6 +65,7 @@
 #import "WKWebProcessPlugInNodeHandleInternal.h"
 #import "WKWebProcessPlugInRangeHandleInternal.h"
 #import "WKWebProcessPlugInScriptWorldInternal.h"
+#import "WKWebViewConfigurationInternal.h"
 #import "WKWebpagePreferencesInternal.h"
 #import "WKWebsiteDataRecordInternal.h"
 #import "WKWebsiteDataStoreInternal.h"
@@ -226,6 +227,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     case Type::ProcessPoolConfiguration:
         wrapper = [_WKProcessPoolConfiguration alloc];
+        break;
+
+    case Type::PageConfiguration:
+        wrapper = [WKWebViewConfiguration alloc];
         break;
 
     case Type::Data:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -353,10 +353,8 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
 
     WebKit::WebProcessPool& processPool = *[_configuration processPool]->_processPool;
 
-    auto pageConfiguration = [configuration copyPageConfiguration];
-
-    pageConfiguration->setProcessPool(&processPool);
-    
+    // FIXME: This copy is probably not necessary.
+    Ref pageConfiguration = _configuration->_pageConfiguration->copy();
     [self _setupPageConfiguration:pageConfiguration];
 
     _usePlatformFindUI = YES;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
@@ -24,17 +24,24 @@
  */
 
 #import "APIPageConfiguration.h"
+#import "WKObject.h"
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <wtf/Ref.h>
 
-@class WKWebView;
-@class WKWebViewContentProviderRegistry;
+namespace WebKit {
 
-@interface WKWebViewConfiguration ()
+template<> struct WrapperTraits<API::PageConfiguration> {
+    using WrapperClass = WKWebViewConfiguration;
+};
+
+}
+
+@interface WKWebViewConfiguration () <WKObject> {
+@package
+    API::ObjectStorage<API::PageConfiguration> _pageConfiguration;
+}
 
 @property (nonatomic, readonly) NSString *_applicationNameForDesktopUserAgent;
-
-- (Ref<API::PageConfiguration>)copyPageConfiguration;
 
 @end
 


### PR DESCRIPTION
#### a66494cd648255f4674c3aa5a133e81259a8db0b
<pre>
Make WKWebViewConfiguration a wrapper around API::PageConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=271471">https://bugs.webkit.org/show_bug.cgi?id=271471</a>
<a href="https://rdar.apple.com/125240015">rdar://125240015</a>

Reviewed by Tim Horton.

* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration init]):
(-[WKWebViewConfiguration copyWithZone:]):
(-[WKWebViewConfiguration _apiObject]):
(-[WKWebViewConfiguration copyPageConfiguration]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h:

Canonical link: <a href="https://commits.webkit.org/276566@main">https://commits.webkit.org/276566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfc6ceca44347a2da9fcc75292225edc95d50c93

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47639 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40988 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21488 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38733 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18009 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18569 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3029 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41251 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49333 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/19954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16499 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21269 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6258 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20948 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->