### PR TITLE
GPUP WebGL resource creation functions are slow

### DIFF
--- a/LayoutTests/inspector/canvas/recording-offscreen-webgl-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-offscreen-webgl-full-expected.txt
@@ -21,7 +21,7 @@ frames:
         3: performActions
         4: Global Code
   1: (duration)
-    0: attachShader(1, 4)
+    0: attachShader(1, 7)
       swizzleTypes: [WebGLProgram, WebGLShader]
       trace:
         0: attachShader
@@ -35,28 +35,28 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   3: (duration)
-    0: bindBuffer(1, 1)
+    0: bindBuffer(1, 4)
       swizzleTypes: [Number, WebGLBuffer]
       trace:
         0: bindBuffer
         1: (anonymous function)
         2: executeFrameFunction
   4: (duration)
-    0: bindFramebuffer(1, 3)
+    0: bindFramebuffer(1, 5)
       swizzleTypes: [Number, WebGLFramebuffer]
       trace:
         0: bindFramebuffer
         1: (anonymous function)
         2: executeFrameFunction
   5: (duration)
-    0: bindRenderbuffer(1, 3)
+    0: bindRenderbuffer(1, 6)
       swizzleTypes: [Number, WebGLRenderbuffer]
       trace:
         0: bindRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   6: (duration)
-    0: bindTexture(1, 2)
+    0: bindTexture(1, 8)
       swizzleTypes: [Number, WebGLTexture]
       trace:
         0: bindTexture
@@ -161,7 +161,7 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   20: (duration)
-    0: compileShader(4)
+    0: compileShader(7)
       swizzleTypes: [WebGLShader]
       trace:
         0: compileShader
@@ -240,14 +240,14 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   32: (duration)
-    0: deleteBuffer(1)
+    0: deleteBuffer(4)
       swizzleTypes: [WebGLBuffer]
       trace:
         0: deleteBuffer
         1: (anonymous function)
         2: executeFrameFunction
   33: (duration)
-    0: deleteFramebuffer(3)
+    0: deleteFramebuffer(5)
       swizzleTypes: [WebGLFramebuffer]
       trace:
         0: deleteFramebuffer
@@ -261,21 +261,21 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   35: (duration)
-    0: deleteRenderbuffer(3)
+    0: deleteRenderbuffer(6)
       swizzleTypes: [WebGLRenderbuffer]
       trace:
         0: deleteRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   36: (duration)
-    0: deleteShader(4)
+    0: deleteShader(7)
       swizzleTypes: [WebGLShader]
       trace:
         0: deleteShader
         1: (anonymous function)
         2: executeFrameFunction
   37: (duration)
-    0: deleteTexture(2)
+    0: deleteTexture(8)
       swizzleTypes: [WebGLTexture]
       trace:
         0: deleteTexture

--- a/LayoutTests/platform/mac-monterey-wk2/inspector/canvas/recording-offscreen-webgl-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2/inspector/canvas/recording-offscreen-webgl-expected.txt
@@ -1,8 +1,8 @@
-Test that CanvasManager is able to record actions made to WebGL canvas contexts.
+Test that CanvasManager is able to record actions made to offscreen WebGL canvas contexts.
 
 
-== Running test suite: Canvas.recordingWebGL
--- Running test case: Canvas.recordingWebGL.multipleFrames
+== Running test suite: Canvas.recordingOffscreenWebGL
+-- Running test case: Canvas.recordingOffscreenWebGL.multipleFrames
 initialState:
   attributes:
     width: 2
@@ -21,7 +21,7 @@ frames:
         3: performActions
         4: Global Code
   1: (duration)
-    0: attachShader(1, 7)
+    0: attachShader(1, 4)
       swizzleTypes: [WebGLProgram, WebGLShader]
       trace:
         0: attachShader
@@ -35,28 +35,28 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   3: (duration)
-    0: bindBuffer(1, 4)
+    0: bindBuffer(1, 1)
       swizzleTypes: [Number, WebGLBuffer]
       trace:
         0: bindBuffer
         1: (anonymous function)
         2: executeFrameFunction
   4: (duration)
-    0: bindFramebuffer(1, 5)
+    0: bindFramebuffer(1, 3)
       swizzleTypes: [Number, WebGLFramebuffer]
       trace:
         0: bindFramebuffer
         1: (anonymous function)
         2: executeFrameFunction
   5: (duration)
-    0: bindRenderbuffer(1, 6)
+    0: bindRenderbuffer(1, 3)
       swizzleTypes: [Number, WebGLRenderbuffer]
       trace:
         0: bindRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   6: (duration)
-    0: bindTexture(1, 8)
+    0: bindTexture(1, 2)
       swizzleTypes: [Number, WebGLTexture]
       trace:
         0: bindTexture
@@ -161,7 +161,7 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   20: (duration)
-    0: compileShader(7)
+    0: compileShader(4)
       swizzleTypes: [WebGLShader]
       trace:
         0: compileShader
@@ -240,14 +240,14 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   32: (duration)
-    0: deleteBuffer(4)
+    0: deleteBuffer(1)
       swizzleTypes: [WebGLBuffer]
       trace:
         0: deleteBuffer
         1: (anonymous function)
         2: executeFrameFunction
   33: (duration)
-    0: deleteFramebuffer(5)
+    0: deleteFramebuffer(3)
       swizzleTypes: [WebGLFramebuffer]
       trace:
         0: deleteFramebuffer
@@ -261,21 +261,21 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   35: (duration)
-    0: deleteRenderbuffer(6)
+    0: deleteRenderbuffer(3)
       swizzleTypes: [WebGLRenderbuffer]
       trace:
         0: deleteRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   36: (duration)
-    0: deleteShader(7)
+    0: deleteShader(4)
       swizzleTypes: [WebGLShader]
       trace:
         0: deleteShader
         1: (anonymous function)
         2: executeFrameFunction
   37: (duration)
-    0: deleteTexture(8)
+    0: deleteTexture(2)
       swizzleTypes: [WebGLTexture]
       trace:
         0: deleteTexture

--- a/LayoutTests/platform/mac-monterey-wk2/inspector/canvas/recording-offscreen-webgl-full-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2/inspector/canvas/recording-offscreen-webgl-full-expected.txt
@@ -1,8 +1,8 @@
-Test that CanvasManager is able to record actions made to WebGL canvas contexts.
+Test that CanvasManager is able to record actions made to offscreen WebGL canvas contexts.
 
 
-== Running test suite: Canvas.recordingWebGL
--- Running test case: Canvas.recordingWebGL.multipleFrames
+== Running test suite: Canvas.recordingOffscreenWebGL
+-- Running test case: Canvas.recordingOffscreenWebGL.multipleFrames
 initialState:
   attributes:
     width: 2
@@ -21,7 +21,7 @@ frames:
         3: performActions
         4: Global Code
   1: (duration)
-    0: attachShader(1, 7)
+    0: attachShader(1, 4)
       swizzleTypes: [WebGLProgram, WebGLShader]
       trace:
         0: attachShader
@@ -35,28 +35,28 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   3: (duration)
-    0: bindBuffer(1, 4)
+    0: bindBuffer(1, 1)
       swizzleTypes: [Number, WebGLBuffer]
       trace:
         0: bindBuffer
         1: (anonymous function)
         2: executeFrameFunction
   4: (duration)
-    0: bindFramebuffer(1, 5)
+    0: bindFramebuffer(1, 3)
       swizzleTypes: [Number, WebGLFramebuffer]
       trace:
         0: bindFramebuffer
         1: (anonymous function)
         2: executeFrameFunction
   5: (duration)
-    0: bindRenderbuffer(1, 6)
+    0: bindRenderbuffer(1, 3)
       swizzleTypes: [Number, WebGLRenderbuffer]
       trace:
         0: bindRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   6: (duration)
-    0: bindTexture(1, 8)
+    0: bindTexture(1, 2)
       swizzleTypes: [Number, WebGLTexture]
       trace:
         0: bindTexture
@@ -161,7 +161,7 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   20: (duration)
-    0: compileShader(7)
+    0: compileShader(4)
       swizzleTypes: [WebGLShader]
       trace:
         0: compileShader
@@ -240,14 +240,14 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   32: (duration)
-    0: deleteBuffer(4)
+    0: deleteBuffer(1)
       swizzleTypes: [WebGLBuffer]
       trace:
         0: deleteBuffer
         1: (anonymous function)
         2: executeFrameFunction
   33: (duration)
-    0: deleteFramebuffer(5)
+    0: deleteFramebuffer(3)
       swizzleTypes: [WebGLFramebuffer]
       trace:
         0: deleteFramebuffer
@@ -261,21 +261,21 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   35: (duration)
-    0: deleteRenderbuffer(6)
+    0: deleteRenderbuffer(3)
       swizzleTypes: [WebGLRenderbuffer]
       trace:
         0: deleteRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   36: (duration)
-    0: deleteShader(7)
+    0: deleteShader(4)
       swizzleTypes: [WebGLShader]
       trace:
         0: deleteShader
         1: (anonymous function)
         2: executeFrameFunction
   37: (duration)
-    0: deleteTexture(8)
+    0: deleteTexture(2)
       swizzleTypes: [WebGLTexture]
       trace:
         0: deleteTexture

--- a/LayoutTests/platform/mac-monterey-wk2/inspector/canvas/recording-webgl-full-expected.txt
+++ b/LayoutTests/platform/mac-monterey-wk2/inspector/canvas/recording-webgl-full-expected.txt
@@ -21,7 +21,7 @@ frames:
         3: performActions
         4: Global Code
   1: (duration)
-    0: attachShader(1, 7)
+    0: attachShader(1, 4)
       swizzleTypes: [WebGLProgram, WebGLShader]
       trace:
         0: attachShader
@@ -35,28 +35,28 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   3: (duration)
-    0: bindBuffer(1, 4)
+    0: bindBuffer(1, 1)
       swizzleTypes: [Number, WebGLBuffer]
       trace:
         0: bindBuffer
         1: (anonymous function)
         2: executeFrameFunction
   4: (duration)
-    0: bindFramebuffer(1, 5)
+    0: bindFramebuffer(1, 3)
       swizzleTypes: [Number, WebGLFramebuffer]
       trace:
         0: bindFramebuffer
         1: (anonymous function)
         2: executeFrameFunction
   5: (duration)
-    0: bindRenderbuffer(1, 6)
+    0: bindRenderbuffer(1, 3)
       swizzleTypes: [Number, WebGLRenderbuffer]
       trace:
         0: bindRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   6: (duration)
-    0: bindTexture(1, 8)
+    0: bindTexture(1, 2)
       swizzleTypes: [Number, WebGLTexture]
       trace:
         0: bindTexture
@@ -161,7 +161,7 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   20: (duration)
-    0: compileShader(7)
+    0: compileShader(4)
       swizzleTypes: [WebGLShader]
       trace:
         0: compileShader
@@ -240,14 +240,14 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   32: (duration)
-    0: deleteBuffer(4)
+    0: deleteBuffer(1)
       swizzleTypes: [WebGLBuffer]
       trace:
         0: deleteBuffer
         1: (anonymous function)
         2: executeFrameFunction
   33: (duration)
-    0: deleteFramebuffer(5)
+    0: deleteFramebuffer(3)
       swizzleTypes: [WebGLFramebuffer]
       trace:
         0: deleteFramebuffer
@@ -261,21 +261,21 @@ frames:
         1: (anonymous function)
         2: executeFrameFunction
   35: (duration)
-    0: deleteRenderbuffer(6)
+    0: deleteRenderbuffer(3)
       swizzleTypes: [WebGLRenderbuffer]
       trace:
         0: deleteRenderbuffer
         1: (anonymous function)
         2: executeFrameFunction
   36: (duration)
-    0: deleteShader(7)
+    0: deleteShader(4)
       swizzleTypes: [WebGLShader]
       trace:
         0: deleteShader
         1: (anonymous function)
         2: executeFrameFunction
   37: (duration)
-    0: deleteTexture(8)
+    0: deleteTexture(2)
       swizzleTypes: [WebGLTexture]
       trace:
         0: deleteTexture

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1497,7 +1497,7 @@ public:
     virtual String getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex) = 0;
     virtual void uniformBlockBinding(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLuint uniformBlockBinding) = 0;
 
-    virtual void getActiveUniformBlockiv(GCGLuint program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params) = 0;
+    virtual void getActiveUniformBlockiv(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params) = 0;
 
     // ========== EGL related entry points.
 
@@ -1595,7 +1595,7 @@ public:
     GCGLboolean getBoolean(GCGLenum pname);
     GCGLint getInteger(GCGLenum pname);
     GCGLint getIntegeri(GCGLenum pname, GCGLuint index);
-    GCGLint getActiveUniformBlocki(GCGLuint program, GCGLuint uniformBlockIndex, GCGLenum pname);
+    GCGLint getActiveUniformBlocki(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLenum pname);
     GCGLint getInternalformati(GCGLenum target, GCGLenum internalformat, GCGLenum pname);
 
     GraphicsContextGLAttributes contextAttributes() const { return m_attrs; }

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -2852,7 +2852,7 @@ Vector<GCGLuint> GraphicsContextGLANGLE::getUniformIndices(PlatformGLObject prog
     return result;
 }
 
-void GraphicsContextGLANGLE::getActiveUniformBlockiv(GCGLuint program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params)
+void GraphicsContextGLANGLE::getActiveUniformBlockiv(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params)
 {
     if (!makeContextCurrent())
         return;

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -288,7 +288,7 @@ public:
     GCGLuint getUniformBlockIndex(PlatformGLObject program, const String& uniformBlockName) final;
     String getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex) final;
     void uniformBlockBinding(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLuint uniformBlockBinding) final;
-    void getActiveUniformBlockiv(GCGLuint program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params) final;
+    void getActiveUniformBlockiv(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params) final;
     GCEGLImage createAndBindEGLImage(GCGLenum, EGLImageSource, GCGLint) override;
     void destroyEGLImage(GCEGLImage) final;
     GCEGLSync createEGLSync(ExternalEGLSyncEvent) override;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -126,7 +126,7 @@ protected:
     void surfaceBufferToVideoFrame(WebCore::GraphicsContextGL::SurfaceBuffer, CompletionHandler<void(std::optional<WebKit::RemoteVideoFrameProxy::Properties>&&)>&&);
 #endif
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
-    void copyTextureFromVideoFrame(SharedVideoFrame&&, uint32_t texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY, CompletionHandler<void(bool)>&&);
+    void copyTextureFromVideoFrame(SharedVideoFrame&&, PlatformGLObject texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY, CompletionHandler<void(bool)>&&);
     void setSharedVideoFrameSemaphore(IPC::Semaphore&&);
     void setSharedVideoFrameMemory(WebCore::SharedMemory::Handle&&);
 #endif
@@ -171,6 +171,7 @@ protected:
     ScopedWebGLRenderingResourcesRequest m_renderingResourcesRequest;
     WebCore::ProcessIdentifier m_webProcessIdentifier;
     const WebCore::ProcessIdentity m_resourceOwner;
+    HashMap<uint32_t, PlatformGLObject, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_objectNames;
 };
 
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -45,7 +45,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void SurfaceBufferToVideoFrame(enum:bool WebCore::GraphicsContextGLSurfaceBuffer buffer) -> (std::optional<WebKit::RemoteVideoFrameProxyProperties> properties) Synchronous
 #endif
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
-    void CopyTextureFromVideoFrame(struct WebKit::SharedVideoFrame frame, uint32_t texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY) -> (bool success) Synchronous NotStreamEncodable
+    void CopyTextureFromVideoFrame(struct WebKit::SharedVideoFrame frame, PlatformGLObject texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY) -> (bool success) Synchronous NotStreamEncodable
     void SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore) NotStreamEncodable
     void SetSharedVideoFrameMemory(WebCore::SharedMemory::Handle storageHandle) NotStreamEncodable
 #endif
@@ -84,12 +84,12 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void CompileShader(uint32_t arg0)
     void CopyTexImage2D(uint32_t target, int32_t level, uint32_t internalformat, int32_t x, int32_t y, int32_t width, int32_t height, int32_t border)
     void CopyTexSubImage2D(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t x, int32_t y, int32_t width, int32_t height)
-    void CreateBuffer() -> (uint32_t returnValue) Synchronous
-    void CreateFramebuffer() -> (uint32_t returnValue) Synchronous
-    void CreateProgram() -> (uint32_t returnValue) Synchronous
-    void CreateRenderbuffer() -> (uint32_t returnValue) Synchronous
-    void CreateShader(uint32_t arg0) -> (uint32_t returnValue) Synchronous
-    void CreateTexture() -> (uint32_t returnValue) Synchronous
+    void CreateBuffer(uint32_t buffer)
+    void CreateFramebuffer(uint32_t framebuffer)
+    void CreateProgram(uint32_t program)
+    void CreateRenderbuffer(uint32_t renderbuffer)
+    void CreateShader(uint32_t shader, uint32_t arg0)
+    void CreateTexture(uint32_t texture)
     void CullFace(uint32_t mode)
     void DeleteBuffer(uint32_t arg0)
     void DeleteFramebuffer(uint32_t arg0)
@@ -210,7 +210,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void DrawArraysInstanced(uint32_t mode, int32_t first, int32_t count, int32_t primcount)
     void DrawElementsInstanced(uint32_t mode, int32_t count, uint32_t type, uint64_t offset, int32_t primcount)
     void VertexAttribDivisor(uint32_t index, uint32_t divisor)
-    void CreateVertexArray() -> (uint32_t returnValue) Synchronous
+    void CreateVertexArray(uint32_t vertexArray)
     void DeleteVertexArray(uint32_t arg0)
     void IsVertexArray(uint32_t arg0) -> (bool returnValue) Synchronous
     void BindVertexArray(uint32_t arg0)
@@ -259,14 +259,14 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void ClearBufferuiv(uint32_t buffer, int32_t drawbuffer, std::span<const uint32_t> values)
     void ClearBufferfv(uint32_t buffer, int32_t drawbuffer, std::span<const float> values)
     void ClearBufferfi(uint32_t buffer, int32_t drawbuffer, float depth, int32_t stencil)
-    void CreateQuery() -> (uint32_t returnValue) Synchronous
+    void CreateQuery(uint32_t query)
     void DeleteQuery(uint32_t query)
     void IsQuery(uint32_t query) -> (bool returnValue) Synchronous
     void BeginQuery(uint32_t target, uint32_t query)
     void EndQuery(uint32_t target)
     void GetQuery(uint32_t target, uint32_t pname) -> (int32_t returnValue) Synchronous
     void GetQueryObjectui(uint32_t query, uint32_t pname) -> (uint32_t returnValue) Synchronous
-    void CreateSampler() -> (uint32_t returnValue) Synchronous
+    void CreateSampler(uint32_t sampler)
     void DeleteSampler(uint32_t sampler)
     void IsSampler(uint32_t sampler) -> (bool returnValue) Synchronous
     void BindSampler(uint32_t unit, uint32_t sampler)
@@ -280,7 +280,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void ClientWaitSync(uint64_t arg0, uint32_t flags, uint64_t timeout) -> (uint32_t returnValue) Synchronous
     void WaitSync(uint64_t arg0, uint32_t flags, int64_t timeout)
     void GetSynci(uint64_t arg0, uint32_t pname) -> (int32_t returnValue) Synchronous
-    void CreateTransformFeedback() -> (uint32_t returnValue) Synchronous
+    void CreateTransformFeedback(uint32_t transformFeedback)
     void DeleteTransformFeedback(uint32_t id)
     void IsTransformFeedback(uint32_t id) -> (bool returnValue) Synchronous
     void BindTransformFeedback(uint32_t target, uint32_t id)
@@ -300,7 +300,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void GetActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, size_t paramsSize) -> (std::span<const int32_t> params) Synchronous
     void GetTranslatedShaderSourceANGLE(uint32_t arg0) -> (String returnValue) Synchronous
     void DrawBuffersEXT(std::span<const uint32_t> bufs)
-    void CreateQueryEXT() -> (uint32_t returnValue) Synchronous
+    void CreateQueryEXT(uint32_t queryEXT)
     void DeleteQueryEXT(uint32_t query)
     void IsQueryEXT(uint32_t query) -> (bool returnValue) Synchronous
     void BeginQueryEXT(uint32_t target, uint32_t query)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
@@ -43,7 +43,7 @@
 namespace WebKit {
 
 #if ENABLE(VIDEO)
-void RemoteGraphicsContextGL::copyTextureFromVideoFrame(WebKit::SharedVideoFrame&& frame, uint32_t texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY, CompletionHandler<void(bool)>&& completionHandler)
+void RemoteGraphicsContextGL::copyTextureFromVideoFrame(WebKit::SharedVideoFrame&& frame, PlatformGLObject texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY, CompletionHandler<void(bool)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
     UNUSED_VARIABLE(premultiplyAlpha);
@@ -69,7 +69,7 @@ void RemoteGraphicsContextGL::copyTextureFromVideoFrame(WebKit::SharedVideoFrame
         completionHandler(false);
         return;
     }
-
+    texture = m_objectNames.get(texture);
     completionHandler(contextCV->copyVideoSampleToTexture(*videoFrameCV, texture, level, internalFormat, format, type, WebCore::GraphicsContextGL::FlipY(flipY)));
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -33,31 +33,38 @@
     void attachShader(uint32_t program, uint32_t shader)
     {
         assertIsCurrent(workQueue());
+        program = m_objectNames.get(program);
+        shader = m_objectNames.get(shader);
         m_context->attachShader(program, shader);
     }
     void bindAttribLocation(uint32_t arg0, uint32_t index, String&& name)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.get(arg0);
         m_context->bindAttribLocation(arg0, index, name);
     }
     void bindBuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
+        arg1 = m_objectNames.get(arg1);
         m_context->bindBuffer(target, arg1);
     }
     void bindFramebuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
+        arg1 = m_objectNames.get(arg1);
         m_context->bindFramebuffer(target, arg1);
     }
     void bindRenderbuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
+        arg1 = m_objectNames.get(arg1);
         m_context->bindRenderbuffer(target, arg1);
     }
     void bindTexture(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
+        arg1 = m_objectNames.get(arg1);
         m_context->bindTexture(target, arg1);
     }
     void blendColor(float red, float green, float blue, float alpha)
@@ -87,8 +94,8 @@
     }
     void checkFramebufferStatus(uint32_t target, CompletionHandler<void(uint32_t)>&& completionHandler)
     {
-        GCGLenum returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLenum returnValue = { };
         returnValue = m_context->checkFramebufferStatus(target);
         completionHandler(returnValue);
     }
@@ -120,6 +127,7 @@
     void compileShader(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.get(arg0);
         m_context->compileShader(arg0);
     }
     void copyTexImage2D(uint32_t target, int32_t level, uint32_t internalformat, int32_t x, int32_t y, int32_t width, int32_t height, int32_t border)
@@ -132,47 +140,41 @@
         assertIsCurrent(workQueue());
         m_context->copyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height);
     }
-    void createBuffer(CompletionHandler<void(uint32_t)>&& completionHandler)
+    void createBuffer(uint32_t name)
     {
-        PlatformGLObject returnValue = { };
         assertIsCurrent(workQueue());
-        returnValue = m_context->createBuffer();
-        completionHandler(returnValue);
+        auto result = m_context->createBuffer();
+        m_objectNames.add(name, result);
     }
-    void createFramebuffer(CompletionHandler<void(uint32_t)>&& completionHandler)
+    void createFramebuffer(uint32_t name)
     {
-        PlatformGLObject returnValue = { };
         assertIsCurrent(workQueue());
-        returnValue = m_context->createFramebuffer();
-        completionHandler(returnValue);
+        auto result = m_context->createFramebuffer();
+        m_objectNames.add(name, result);
     }
-    void createProgram(CompletionHandler<void(uint32_t)>&& completionHandler)
+    void createProgram(uint32_t name)
     {
-        PlatformGLObject returnValue = { };
         assertIsCurrent(workQueue());
-        returnValue = m_context->createProgram();
-        completionHandler(returnValue);
+        auto result = m_context->createProgram();
+        m_objectNames.add(name, result);
     }
-    void createRenderbuffer(CompletionHandler<void(uint32_t)>&& completionHandler)
+    void createRenderbuffer(uint32_t name)
     {
-        PlatformGLObject returnValue = { };
         assertIsCurrent(workQueue());
-        returnValue = m_context->createRenderbuffer();
-        completionHandler(returnValue);
+        auto result = m_context->createRenderbuffer();
+        m_objectNames.add(name, result);
     }
-    void createShader(uint32_t arg0, CompletionHandler<void(uint32_t)>&& completionHandler)
+    void createShader(uint32_t name, uint32_t arg0)
     {
-        PlatformGLObject returnValue = { };
         assertIsCurrent(workQueue());
-        returnValue = m_context->createShader(arg0);
-        completionHandler(returnValue);
+        auto result = m_context->createShader(arg0);
+        m_objectNames.add(name, result);
     }
-    void createTexture(CompletionHandler<void(uint32_t)>&& completionHandler)
+    void createTexture(uint32_t name)
     {
-        PlatformGLObject returnValue = { };
         assertIsCurrent(workQueue());
-        returnValue = m_context->createTexture();
-        completionHandler(returnValue);
+        auto result = m_context->createTexture();
+        m_objectNames.add(name, result);
     }
     void cullFace(uint32_t mode)
     {
@@ -182,31 +184,37 @@
     void deleteBuffer(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.take(arg0);
         m_context->deleteBuffer(arg0);
     }
     void deleteFramebuffer(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.take(arg0);
         m_context->deleteFramebuffer(arg0);
     }
     void deleteProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.take(arg0);
         m_context->deleteProgram(arg0);
     }
     void deleteRenderbuffer(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.take(arg0);
         m_context->deleteRenderbuffer(arg0);
     }
     void deleteShader(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.take(arg0);
         m_context->deleteShader(arg0);
     }
     void deleteTexture(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.take(arg0);
         m_context->deleteTexture(arg0);
     }
     void depthFunc(uint32_t func)
@@ -232,6 +240,8 @@
     void detachShader(uint32_t arg0, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.get(arg0);
+        arg1 = m_objectNames.get(arg1);
         m_context->detachShader(arg0, arg1);
     }
     void disable(uint32_t cap)
@@ -277,11 +287,13 @@
     void framebufferRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
     {
         assertIsCurrent(workQueue());
+        arg3 = m_objectNames.get(arg3);
         m_context->framebufferRenderbuffer(target, attachment, renderbuffertarget, arg3);
     }
     void framebufferTexture2D(uint32_t target, uint32_t attachment, uint32_t textarget, uint32_t arg3, int32_t level)
     {
         assertIsCurrent(workQueue());
+        arg3 = m_objectNames.get(arg3);
         m_context->framebufferTexture2D(target, attachment, textarget, arg3, level);
     }
     void frontFace(uint32_t mode)
@@ -296,186 +308,198 @@
     }
     void getActiveAttrib(uint32_t program, uint32_t index, CompletionHandler<void(bool, struct WebCore::GraphicsContextGLActiveInfo&&)>&& completionHandler)
     {
-        bool returnValue = { };
-        struct WebCore::GraphicsContextGLActiveInfo arg2 { };
         assertIsCurrent(workQueue());
+        bool returnValue = { };
+        program = m_objectNames.get(program);
+        struct WebCore::GraphicsContextGLActiveInfo arg2 { };
         returnValue = m_context->getActiveAttrib(program, index, arg2);
         completionHandler(returnValue, WTFMove(arg2));
     }
     void getActiveUniform(uint32_t program, uint32_t index, CompletionHandler<void(bool, struct WebCore::GraphicsContextGLActiveInfo&&)>&& completionHandler)
     {
-        bool returnValue = { };
-        struct WebCore::GraphicsContextGLActiveInfo arg2 { };
         assertIsCurrent(workQueue());
+        bool returnValue = { };
+        program = m_objectNames.get(program);
+        struct WebCore::GraphicsContextGLActiveInfo arg2 { };
         returnValue = m_context->getActiveUniform(program, index, arg2);
         completionHandler(returnValue, WTFMove(arg2));
     }
     void getAttribLocation(uint32_t arg0, String&& name, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getAttribLocation(arg0, name);
         completionHandler(returnValue);
     }
     void getBufferParameteri(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
         returnValue = m_context->getBufferParameteri(target, pname);
         completionHandler(returnValue);
     }
     void getString(uint32_t name, CompletionHandler<void(String&&)>&& completionHandler)
     {
-        String returnValue = { };
         assertIsCurrent(workQueue());
+        String returnValue = { };
         returnValue = m_context->getString(name);
         completionHandler(WTFMove(returnValue));
     }
     void getFloatv(uint32_t pname, size_t valueSize, CompletionHandler<void(std::span<const float>)>&& completionHandler)
     {
-        Vector<GCGLfloat, 16> value(valueSize, 0);
         assertIsCurrent(workQueue());
+        Vector<GCGLfloat, 16> value(valueSize, 0);
         m_context->getFloatv(pname, value);
         completionHandler(std::span<const float>(reinterpret_cast<const float*>(value.data()), value.size()));
     }
     void getIntegerv(uint32_t pname, size_t valueSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
-        Vector<GCGLint, 4> value(valueSize, 0);
         assertIsCurrent(workQueue());
+        Vector<GCGLint, 4> value(valueSize, 0);
         m_context->getIntegerv(pname, value);
         completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(value.data()), value.size()));
     }
     void getIntegeri_v(uint32_t pname, uint32_t index, CompletionHandler<void(std::span<const int32_t, 4>)>&& completionHandler) // NOLINT
     {
-        std::array<GCGLint, 4> value { };
         assertIsCurrent(workQueue());
+        std::array<GCGLint, 4> value { };
         m_context->getIntegeri_v(pname, index, value);
         completionHandler(std::span<const int32_t, 4>(reinterpret_cast<const int32_t*>(value.data()), value.size()));
     }
     void getInteger64(uint32_t pname, CompletionHandler<void(int64_t)>&& completionHandler)
     {
-        GCGLint64 returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint64 returnValue = { };
         returnValue = m_context->getInteger64(pname);
         completionHandler(static_cast<int64_t>(returnValue));
     }
     void getInteger64i(uint32_t pname, uint32_t index, CompletionHandler<void(int64_t)>&& completionHandler)
     {
-        GCGLint64 returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint64 returnValue = { };
         returnValue = m_context->getInteger64i(pname, index);
         completionHandler(static_cast<int64_t>(returnValue));
     }
     void getProgrami(uint32_t program, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
+        program = m_objectNames.get(program);
         returnValue = m_context->getProgrami(program, pname);
         completionHandler(returnValue);
     }
     void getBooleanv(uint32_t pname, size_t valueSize, CompletionHandler<void(std::span<const bool>)>&& completionHandler)
     {
-        Vector<GCGLboolean, 4> value(valueSize, 0);
         assertIsCurrent(workQueue());
+        Vector<GCGLboolean, 4> value(valueSize, 0);
         m_context->getBooleanv(pname, value);
         completionHandler(std::span<const bool>(reinterpret_cast<const bool*>(value.data()), value.size()));
     }
     void getFramebufferAttachmentParameteri(uint32_t target, uint32_t attachment, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
         returnValue = m_context->getFramebufferAttachmentParameteri(target, attachment, pname);
         completionHandler(returnValue);
     }
     void getProgramInfoLog(uint32_t arg0, CompletionHandler<void(String&&)>&& completionHandler)
     {
-        String returnValue = { };
         assertIsCurrent(workQueue());
+        String returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getProgramInfoLog(arg0);
         completionHandler(WTFMove(returnValue));
     }
     void getRenderbufferParameteri(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
         returnValue = m_context->getRenderbufferParameteri(target, pname);
         completionHandler(returnValue);
     }
     void getShaderi(uint32_t arg0, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getShaderi(arg0, pname);
         completionHandler(returnValue);
     }
     void getShaderInfoLog(uint32_t arg0, CompletionHandler<void(String&&)>&& completionHandler)
     {
-        String returnValue = { };
         assertIsCurrent(workQueue());
+        String returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getShaderInfoLog(arg0);
         completionHandler(WTFMove(returnValue));
     }
     void getShaderPrecisionFormat(uint32_t shaderType, uint32_t precisionType, CompletionHandler<void(std::span<const int32_t, 2>, int32_t)>&& completionHandler)
     {
+        assertIsCurrent(workQueue());
         std::array<GCGLint, 2> range { };
         GCGLint precision = { };
-        assertIsCurrent(workQueue());
         m_context->getShaderPrecisionFormat(shaderType, precisionType, range, &precision);
         completionHandler(std::span<const int32_t, 2>(reinterpret_cast<const int32_t*>(range.data()), range.size()), precision);
     }
     void getShaderSource(uint32_t arg0, CompletionHandler<void(String&&)>&& completionHandler)
     {
-        String returnValue = { };
         assertIsCurrent(workQueue());
+        String returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getShaderSource(arg0);
         completionHandler(WTFMove(returnValue));
     }
     void getTexParameterf(uint32_t target, uint32_t pname, CompletionHandler<void(float)>&& completionHandler)
     {
-        GCGLfloat returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLfloat returnValue = { };
         returnValue = m_context->getTexParameterf(target, pname);
         completionHandler(returnValue);
     }
     void getTexParameteri(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
         returnValue = m_context->getTexParameteri(target, pname);
         completionHandler(returnValue);
     }
     void getUniformfv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const float>)>&& completionHandler)
     {
-        Vector<GCGLfloat, 16> value(valueSize, 0);
         assertIsCurrent(workQueue());
+        program = m_objectNames.get(program);
+        Vector<GCGLfloat, 16> value(valueSize, 0);
         m_context->getUniformfv(program, location, value);
         completionHandler(std::span<const float>(reinterpret_cast<const float*>(value.data()), value.size()));
     }
     void getUniformiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
-        Vector<GCGLint, 4> value(valueSize, 0);
         assertIsCurrent(workQueue());
+        program = m_objectNames.get(program);
+        Vector<GCGLint, 4> value(valueSize, 0);
         m_context->getUniformiv(program, location, value);
         completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(value.data()), value.size()));
     }
     void getUniformuiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const uint32_t>)>&& completionHandler)
     {
-        Vector<GCGLuint, 4> value(valueSize, 0);
         assertIsCurrent(workQueue());
+        program = m_objectNames.get(program);
+        Vector<GCGLuint, 4> value(valueSize, 0);
         m_context->getUniformuiv(program, location, value);
         completionHandler(std::span<const uint32_t>(reinterpret_cast<const uint32_t*>(value.data()), value.size()));
     }
     void getUniformLocation(uint32_t arg0, String&& name, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getUniformLocation(arg0, name);
         completionHandler(returnValue);
     }
     void getVertexAttribOffset(uint32_t index, uint32_t pname, CompletionHandler<void(uint64_t)>&& completionHandler)
     {
-        GCGLsizeiptr returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLsizeiptr returnValue = { };
         returnValue = m_context->getVertexAttribOffset(index, pname);
         completionHandler(static_cast<uint64_t>(returnValue));
     }
@@ -486,50 +510,56 @@
     }
     void isBuffer(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
     {
-        GCGLboolean returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLboolean returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isBuffer(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void isEnabled(uint32_t cap, CompletionHandler<void(bool)>&& completionHandler)
     {
-        GCGLboolean returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLboolean returnValue = { };
         returnValue = m_context->isEnabled(cap);
         completionHandler(static_cast<bool>(returnValue));
     }
     void isFramebuffer(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
     {
-        GCGLboolean returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLboolean returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isFramebuffer(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void isProgram(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
     {
-        GCGLboolean returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLboolean returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isProgram(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void isRenderbuffer(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
     {
-        GCGLboolean returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLboolean returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isRenderbuffer(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void isShader(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
     {
-        GCGLboolean returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLboolean returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isShader(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void isTexture(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
     {
-        GCGLboolean returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLboolean returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isTexture(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
@@ -541,6 +571,7 @@
     void linkProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.get(arg0);
         m_context->linkProgram(arg0);
     }
     void pixelStorei(uint32_t pname, int32_t param)
@@ -571,6 +602,7 @@
     void shaderSource(uint32_t arg0, String&& arg1)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.get(arg0);
         m_context->shaderSource(arg0, arg1);
     }
     void stencilFunc(uint32_t func, int32_t ref, uint32_t mask)
@@ -711,11 +743,13 @@
     void useProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.get(arg0);
         m_context->useProgram(arg0);
     }
     void validateProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.get(arg0);
         m_context->validateProgram(arg0);
     }
     void vertexAttrib1f(uint32_t index, float x)
@@ -843,28 +877,30 @@
         assertIsCurrent(workQueue());
         m_context->vertexAttribDivisor(index, divisor);
     }
-    void createVertexArray(CompletionHandler<void(uint32_t)>&& completionHandler)
+    void createVertexArray(uint32_t name)
     {
-        PlatformGLObject returnValue = { };
         assertIsCurrent(workQueue());
-        returnValue = m_context->createVertexArray();
-        completionHandler(returnValue);
+        auto result = m_context->createVertexArray();
+        m_objectNames.add(name, result);
     }
     void deleteVertexArray(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.take(arg0);
         m_context->deleteVertexArray(arg0);
     }
     void isVertexArray(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
     {
-        GCGLboolean returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLboolean returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isVertexArray(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void bindVertexArray(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        arg0 = m_objectNames.get(arg0);
         m_context->bindVertexArray(arg0);
     }
     void copyBufferSubData(uint32_t readTarget, uint32_t writeTarget, uint64_t readOffset, uint64_t writeOffset, uint64_t arg4)
@@ -874,8 +910,8 @@
     }
     void getBufferSubData(uint32_t target, uint64_t offset, size_t dataSize, CompletionHandler<void(std::span<const uint8_t>)>&& completionHandler)
     {
-        Vector<uint8_t, 4> data(dataSize, 0);
         assertIsCurrent(workQueue());
+        Vector<uint8_t, 4> data(dataSize, 0);
         m_context->getBufferSubData(target, static_cast<GCGLintptr>(offset), data);
         completionHandler(std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size()));
     }
@@ -887,6 +923,7 @@
     void framebufferTextureLayer(uint32_t target, uint32_t attachment, uint32_t texture, int32_t level, int32_t layer)
     {
         assertIsCurrent(workQueue());
+        texture = m_objectNames.get(texture);
         m_context->framebufferTextureLayer(target, attachment, texture, level, layer);
     }
     void invalidateFramebuffer(uint32_t target, std::span<const uint32_t>&& attachments)
@@ -966,8 +1003,9 @@
     }
     void getFragDataLocation(uint32_t program, String&& name, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
+        program = m_objectNames.get(program);
         returnValue = m_context->getFragDataLocation(program, name);
         completionHandler(returnValue);
     }
@@ -1096,28 +1134,30 @@
         assertIsCurrent(workQueue());
         m_context->clearBufferfi(buffer, drawbuffer, depth, stencil);
     }
-    void createQuery(CompletionHandler<void(uint32_t)>&& completionHandler)
+    void createQuery(uint32_t name)
     {
-        PlatformGLObject returnValue = { };
         assertIsCurrent(workQueue());
-        returnValue = m_context->createQuery();
-        completionHandler(returnValue);
+        auto result = m_context->createQuery();
+        m_objectNames.add(name, result);
     }
     void deleteQuery(uint32_t query)
     {
         assertIsCurrent(workQueue());
+        query = m_objectNames.take(query);
         m_context->deleteQuery(query);
     }
     void isQuery(uint32_t query, CompletionHandler<void(bool)>&& completionHandler)
     {
-        GCGLboolean returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLboolean returnValue = { };
+        query = m_objectNames.get(query);
         returnValue = m_context->isQuery(query);
         completionHandler(static_cast<bool>(returnValue));
     }
     void beginQuery(uint32_t target, uint32_t query)
     {
         assertIsCurrent(workQueue());
+        query = m_objectNames.get(query);
         m_context->beginQuery(target, query);
     }
     void endQuery(uint32_t target)
@@ -1127,77 +1167,84 @@
     }
     void getQuery(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
         returnValue = m_context->getQuery(target, pname);
         completionHandler(returnValue);
     }
     void getQueryObjectui(uint32_t query, uint32_t pname, CompletionHandler<void(uint32_t)>&& completionHandler)
     {
-        GCGLuint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLuint returnValue = { };
+        query = m_objectNames.get(query);
         returnValue = m_context->getQueryObjectui(query, pname);
         completionHandler(returnValue);
     }
-    void createSampler(CompletionHandler<void(uint32_t)>&& completionHandler)
+    void createSampler(uint32_t name)
     {
-        PlatformGLObject returnValue = { };
         assertIsCurrent(workQueue());
-        returnValue = m_context->createSampler();
-        completionHandler(returnValue);
+        auto result = m_context->createSampler();
+        m_objectNames.add(name, result);
     }
     void deleteSampler(uint32_t sampler)
     {
         assertIsCurrent(workQueue());
+        sampler = m_objectNames.take(sampler);
         m_context->deleteSampler(sampler);
     }
     void isSampler(uint32_t sampler, CompletionHandler<void(bool)>&& completionHandler)
     {
-        GCGLboolean returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLboolean returnValue = { };
+        sampler = m_objectNames.get(sampler);
         returnValue = m_context->isSampler(sampler);
         completionHandler(static_cast<bool>(returnValue));
     }
     void bindSampler(uint32_t unit, uint32_t sampler)
     {
         assertIsCurrent(workQueue());
+        sampler = m_objectNames.get(sampler);
         m_context->bindSampler(unit, sampler);
     }
     void samplerParameteri(uint32_t sampler, uint32_t pname, int32_t param)
     {
         assertIsCurrent(workQueue());
+        sampler = m_objectNames.get(sampler);
         m_context->samplerParameteri(sampler, pname, param);
     }
     void samplerParameterf(uint32_t sampler, uint32_t pname, float param)
     {
         assertIsCurrent(workQueue());
+        sampler = m_objectNames.get(sampler);
         m_context->samplerParameterf(sampler, pname, param);
     }
     void getSamplerParameterf(uint32_t sampler, uint32_t pname, CompletionHandler<void(float)>&& completionHandler)
     {
-        GCGLfloat returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLfloat returnValue = { };
+        sampler = m_objectNames.get(sampler);
         returnValue = m_context->getSamplerParameterf(sampler, pname);
         completionHandler(returnValue);
     }
     void getSamplerParameteri(uint32_t sampler, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
+        sampler = m_objectNames.get(sampler);
         returnValue = m_context->getSamplerParameteri(sampler, pname);
         completionHandler(returnValue);
     }
     void fenceSync(uint32_t condition, uint32_t flags, CompletionHandler<void(uint64_t)>&& completionHandler)
     {
-        GCGLsync returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLsync returnValue = { };
         returnValue = m_context->fenceSync(condition, flags);
         completionHandler(static_cast<uint64_t>(reinterpret_cast<intptr_t>(returnValue)));
     }
     void isSync(uint64_t arg0, CompletionHandler<void(bool)>&& completionHandler)
     {
-        GCGLboolean returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLboolean returnValue = { };
         returnValue = m_context->isSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)));
         completionHandler(static_cast<bool>(returnValue));
     }
@@ -1208,8 +1255,8 @@
     }
     void clientWaitSync(uint64_t arg0, uint32_t flags, uint64_t timeout, CompletionHandler<void(uint32_t)>&& completionHandler)
     {
-        GCGLenum returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLenum returnValue = { };
         returnValue = m_context->clientWaitSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), flags, static_cast<GCGLuint64>(timeout));
         completionHandler(returnValue);
     }
@@ -1220,33 +1267,35 @@
     }
     void getSynci(uint64_t arg0, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
         returnValue = m_context->getSynci(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), pname);
         completionHandler(returnValue);
     }
-    void createTransformFeedback(CompletionHandler<void(uint32_t)>&& completionHandler)
+    void createTransformFeedback(uint32_t name)
     {
-        PlatformGLObject returnValue = { };
         assertIsCurrent(workQueue());
-        returnValue = m_context->createTransformFeedback();
-        completionHandler(returnValue);
+        auto result = m_context->createTransformFeedback();
+        m_objectNames.add(name, result);
     }
     void deleteTransformFeedback(uint32_t id)
     {
         assertIsCurrent(workQueue());
+        id = m_objectNames.take(id);
         m_context->deleteTransformFeedback(id);
     }
     void isTransformFeedback(uint32_t id, CompletionHandler<void(bool)>&& completionHandler)
     {
-        GCGLboolean returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLboolean returnValue = { };
+        id = m_objectNames.get(id);
         returnValue = m_context->isTransformFeedback(id);
         completionHandler(static_cast<bool>(returnValue));
     }
     void bindTransformFeedback(uint32_t target, uint32_t id)
     {
         assertIsCurrent(workQueue());
+        id = m_objectNames.get(id);
         m_context->bindTransformFeedback(target, id);
     }
     void beginTransformFeedback(uint32_t primitiveMode)
@@ -1262,12 +1311,14 @@
     void transformFeedbackVaryings(uint32_t program, Vector<String>&& varyings, uint32_t bufferMode)
     {
         assertIsCurrent(workQueue());
+        program = m_objectNames.get(program);
         m_context->transformFeedbackVaryings(program, varyings, bufferMode);
     }
     void getTransformFeedbackVarying(uint32_t program, uint32_t index, CompletionHandler<void(struct WebCore::GraphicsContextGLActiveInfo&&)>&& completionHandler)
     {
-        struct WebCore::GraphicsContextGLActiveInfo arg2 { };
         assertIsCurrent(workQueue());
+        program = m_objectNames.get(program);
+        struct WebCore::GraphicsContextGLActiveInfo arg2 { };
         m_context->getTransformFeedbackVarying(program, index, arg2);
         completionHandler(WTFMove(arg2));
     }
@@ -1284,57 +1335,66 @@
     void bindBufferBase(uint32_t target, uint32_t index, uint32_t buffer)
     {
         assertIsCurrent(workQueue());
+        buffer = m_objectNames.get(buffer);
         m_context->bindBufferBase(target, index, buffer);
     }
     void bindBufferRange(uint32_t target, uint32_t index, uint32_t buffer, uint64_t offset, uint64_t arg4)
     {
         assertIsCurrent(workQueue());
+        buffer = m_objectNames.get(buffer);
         m_context->bindBufferRange(target, index, buffer, static_cast<GCGLintptr>(offset), static_cast<GCGLsizeiptr>(arg4));
     }
     void getUniformIndices(uint32_t program, Vector<String>&& uniformNames, CompletionHandler<void(Vector<uint32_t>&&)>&& completionHandler)
     {
-        Vector<GCGLuint> returnValue = { };
         assertIsCurrent(workQueue());
+        Vector<GCGLuint> returnValue = { };
+        program = m_objectNames.get(program);
         returnValue = m_context->getUniformIndices(program, uniformNames);
         completionHandler(WTFMove(returnValue));
     }
     void getActiveUniforms(uint32_t program, Vector<uint32_t>&& uniformIndices, uint32_t pname, CompletionHandler<void(Vector<int32_t>&&)>&& completionHandler)
     {
-        Vector<GCGLint> returnValue = { };
         assertIsCurrent(workQueue());
+        Vector<GCGLint> returnValue = { };
+        program = m_objectNames.get(program);
         returnValue = m_context->getActiveUniforms(program, uniformIndices, pname);
         completionHandler(WTFMove(returnValue));
     }
     void getUniformBlockIndex(uint32_t program, String&& uniformBlockName, CompletionHandler<void(uint32_t)>&& completionHandler)
     {
-        GCGLuint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLuint returnValue = { };
+        program = m_objectNames.get(program);
         returnValue = m_context->getUniformBlockIndex(program, uniformBlockName);
         completionHandler(returnValue);
     }
     void getActiveUniformBlockName(uint32_t program, uint32_t uniformBlockIndex, CompletionHandler<void(String&&)>&& completionHandler)
     {
-        String returnValue = { };
         assertIsCurrent(workQueue());
+        String returnValue = { };
+        program = m_objectNames.get(program);
         returnValue = m_context->getActiveUniformBlockName(program, uniformBlockIndex);
         completionHandler(WTFMove(returnValue));
     }
     void uniformBlockBinding(uint32_t program, uint32_t uniformBlockIndex, uint32_t uniformBlockBinding)
     {
         assertIsCurrent(workQueue());
+        program = m_objectNames.get(program);
         m_context->uniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
     }
     void getActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, size_t paramsSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
-        Vector<GCGLint, 4> params(paramsSize, 0);
         assertIsCurrent(workQueue());
+        program = m_objectNames.get(program);
+        Vector<GCGLint, 4> params(paramsSize, 0);
         m_context->getActiveUniformBlockiv(program, uniformBlockIndex, pname, params);
         completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(params.data()), params.size()));
     }
     void getTranslatedShaderSourceANGLE(uint32_t arg0, CompletionHandler<void(String&&)>&& completionHandler)
     {
-        String returnValue = { };
         assertIsCurrent(workQueue());
+        String returnValue = { };
+        arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getTranslatedShaderSourceANGLE(arg0);
         completionHandler(WTFMove(returnValue));
     }
@@ -1343,28 +1403,30 @@
         assertIsCurrent(workQueue());
         m_context->drawBuffersEXT(bufs);
     }
-    void createQueryEXT(CompletionHandler<void(uint32_t)>&& completionHandler)
+    void createQueryEXT(uint32_t name)
     {
-        PlatformGLObject returnValue = { };
         assertIsCurrent(workQueue());
-        returnValue = m_context->createQueryEXT();
-        completionHandler(returnValue);
+        auto result = m_context->createQueryEXT();
+        m_objectNames.add(name, result);
     }
     void deleteQueryEXT(uint32_t query)
     {
         assertIsCurrent(workQueue());
+        query = m_objectNames.take(query);
         m_context->deleteQueryEXT(query);
     }
     void isQueryEXT(uint32_t query, CompletionHandler<void(bool)>&& completionHandler)
     {
-        GCGLboolean returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLboolean returnValue = { };
+        query = m_objectNames.get(query);
         returnValue = m_context->isQueryEXT(query);
         completionHandler(static_cast<bool>(returnValue));
     }
     void beginQueryEXT(uint32_t target, uint32_t query)
     {
         assertIsCurrent(workQueue());
+        query = m_objectNames.get(query);
         m_context->beginQueryEXT(target, query);
     }
     void endQueryEXT(uint32_t target)
@@ -1375,33 +1437,36 @@
     void queryCounterEXT(uint32_t query, uint32_t target)
     {
         assertIsCurrent(workQueue());
+        query = m_objectNames.get(query);
         m_context->queryCounterEXT(query, target);
     }
     void getQueryiEXT(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
         returnValue = m_context->getQueryiEXT(target, pname);
         completionHandler(returnValue);
     }
     void getQueryObjectiEXT(uint32_t query, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
     {
-        GCGLint returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint returnValue = { };
+        query = m_objectNames.get(query);
         returnValue = m_context->getQueryObjectiEXT(query, pname);
         completionHandler(returnValue);
     }
     void getQueryObjectui64EXT(uint32_t query, uint32_t pname, CompletionHandler<void(uint64_t)>&& completionHandler)
     {
-        GCGLuint64 returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLuint64 returnValue = { };
+        query = m_objectNames.get(query);
         returnValue = m_context->getQueryObjectui64EXT(query, pname);
         completionHandler(static_cast<uint64_t>(returnValue));
     }
     void getInteger64EXT(uint32_t pname, CompletionHandler<void(int64_t)>&& completionHandler)
     {
-        GCGLint64 returnValue = { };
         assertIsCurrent(workQueue());
+        GCGLint64 returnValue = { };
         returnValue = m_context->getInteger64EXT(pname);
         completionHandler(static_cast<int64_t>(returnValue));
     }
@@ -1482,8 +1547,8 @@
     }
     void getInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, size_t paramsSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
-        Vector<GCGLint, 4> params(paramsSize, 0);
         assertIsCurrent(workQueue());
+        Vector<GCGLint, 4> params(paramsSize, 0);
         m_context->getInternalformativ(target, internalformat, pname, params);
         completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(params.data()), params.size()));
     }
@@ -1494,8 +1559,8 @@
     }
     void drawingBufferToPixelBuffer(WebCore::GraphicsContextGL::FlipY&& arg0, CompletionHandler<void(RefPtr<WebCore::PixelBuffer>&&)>&& completionHandler)
     {
-        RefPtr<WebCore::PixelBuffer> returnValue = { };
         assertIsCurrent(workQueue());
+        RefPtr<WebCore::PixelBuffer> returnValue = { };
         returnValue = m_context->drawingBufferToPixelBuffer(arg0);
         completionHandler(WTFMove(returnValue));
     }
@@ -1511,8 +1576,8 @@
     }
     void enableRequiredWebXRExtensions(CompletionHandler<void(bool)>&& completionHandler)
     {
-        bool returnValue = { };
         assertIsCurrent(workQueue());
+        bool returnValue = { };
         returnValue = m_context->enableRequiredWebXRExtensions();
         completionHandler(returnValue);
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -510,6 +510,11 @@ void RemoteGraphicsContextGLProxy::disconnectGpuProcessIfNeeded()
     ASSERT(isContextLost());
 }
 
+uint32_t RemoteGraphicsContextGLProxy::createObjectName()
+{
+    return ++m_nextObjectName;
+}
+
 } // namespace WebKit
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -334,7 +334,7 @@ public:
     GCGLuint getUniformBlockIndex(PlatformGLObject program, const String& uniformBlockName) final;
     String getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex) final;
     void uniformBlockBinding(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLuint uniformBlockBinding) final;
-    void getActiveUniformBlockiv(GCGLuint program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params) final;
+    void getActiveUniformBlockiv(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params) final;
     String getTranslatedShaderSourceANGLE(PlatformGLObject arg0) final;
     void drawBuffersEXT(std::span<const GCGLenum> bufs) final;
     PlatformGLObject createQueryEXT() final;
@@ -413,6 +413,7 @@ private:
     void waitUntilInitialized();
     void disconnectGpuProcessIfNeeded();
     void abandonGpuProcess();
+    uint32_t createObjectName();
 
     RefPtr<IPC::Connection> m_connection;
     bool m_didInitialize { false };
@@ -430,6 +431,7 @@ private:
 #endif
     GCGLenum m_externalImageTarget { 0 };
     GCGLenum m_externalImageBindingQuery { 0 };
+    uint32_t m_nextObjectName { 0 };
 };
 
 // The GCGL types map to following WebKit IPC types. The list is used by generate-gpup-webgl script.

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -267,78 +267,78 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createBuffer()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateBuffer());
-    if (!sendResult.succeeded()) {
+    auto name = createObjectName();
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CreateBuffer(name));
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return { };
     }
-    auto& [returnValue] = sendResult.reply();
-    return returnValue;
+    return name;
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createFramebuffer()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateFramebuffer());
-    if (!sendResult.succeeded()) {
+    auto name = createObjectName();
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CreateFramebuffer(name));
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return { };
     }
-    auto& [returnValue] = sendResult.reply();
-    return returnValue;
+    return name;
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createProgram()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateProgram());
-    if (!sendResult.succeeded()) {
+    auto name = createObjectName();
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CreateProgram(name));
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return { };
     }
-    auto& [returnValue] = sendResult.reply();
-    return returnValue;
+    return name;
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createRenderbuffer()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateRenderbuffer());
-    if (!sendResult.succeeded()) {
+    auto name = createObjectName();
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CreateRenderbuffer(name));
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return { };
     }
-    auto& [returnValue] = sendResult.reply();
-    return returnValue;
+    return name;
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createShader(GCGLenum arg0)
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateShader(arg0));
-    if (!sendResult.succeeded()) {
+    auto name = createObjectName();
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CreateShader(name, arg0));
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return { };
     }
-    auto& [returnValue] = sendResult.reply();
-    return returnValue;
+    return name;
 }
 
 PlatformGLObject RemoteGraphicsContextGLProxy::createTexture()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateTexture());
-    if (!sendResult.succeeded()) {
+    auto name = createObjectName();
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CreateTexture(name));
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return { };
     }
-    auto& [returnValue] = sendResult.reply();
-    return returnValue;
+    return name;
 }
 
 void RemoteGraphicsContextGLProxy::cullFace(GCGLenum mode)
@@ -1735,13 +1735,13 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createVertexArray()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateVertexArray());
-    if (!sendResult.succeeded()) {
+    auto name = createObjectName();
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CreateVertexArray(name));
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return { };
     }
-    auto& [returnValue] = sendResult.reply();
-    return returnValue;
+    return name;
 }
 
 void RemoteGraphicsContextGLProxy::deleteVertexArray(PlatformGLObject arg0)
@@ -2282,13 +2282,13 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createQuery()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateQuery());
-    if (!sendResult.succeeded()) {
+    auto name = createObjectName();
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CreateQuery(name));
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return { };
     }
-    auto& [returnValue] = sendResult.reply();
-    return returnValue;
+    return name;
 }
 
 void RemoteGraphicsContextGLProxy::deleteQuery(PlatformGLObject query)
@@ -2367,13 +2367,13 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createSampler()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateSampler());
-    if (!sendResult.succeeded()) {
+    auto name = createObjectName();
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CreateSampler(name));
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return { };
     }
-    auto& [returnValue] = sendResult.reply();
-    return returnValue;
+    return name;
 }
 
 void RemoteGraphicsContextGLProxy::deleteSampler(PlatformGLObject sampler)
@@ -2537,13 +2537,13 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createTransformFeedback()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateTransformFeedback());
-    if (!sendResult.succeeded()) {
+    auto name = createObjectName();
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CreateTransformFeedback(name));
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return { };
     }
-    auto& [returnValue] = sendResult.reply();
-    return returnValue;
+    return name;
 }
 
 void RemoteGraphicsContextGLProxy::deleteTransformFeedback(PlatformGLObject id)
@@ -2734,7 +2734,7 @@ void RemoteGraphicsContextGLProxy::uniformBlockBinding(PlatformGLObject program,
     }
 }
 
-void RemoteGraphicsContextGLProxy::getActiveUniformBlockiv(GCGLuint program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params)
+void RemoteGraphicsContextGLProxy::getActiveUniformBlockiv(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params)
 {
     if (isContextLost())
         return;
@@ -2775,13 +2775,13 @@ PlatformGLObject RemoteGraphicsContextGLProxy::createQueryEXT()
 {
     if (isContextLost())
         return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::CreateQueryEXT());
-    if (!sendResult.succeeded()) {
+    auto name = createObjectName();
+    auto sendResult = send(Messages::RemoteGraphicsContextGL::CreateQueryEXT(name));
+    if (sendResult != IPC::Error::NoError) {
         markContextLost();
         return { };
     }
-    auto& [returnValue] = sendResult.reply();
-    return returnValue;
+    return name;
 }
 
 void RemoteGraphicsContextGLProxy::deleteQueryEXT(PlatformGLObject query)

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -42,9 +42,7 @@ from typing import List, Dict, Iterable, Callable, Tuple, Set, Optional, Generat
 
 root_dir = (pathlib.Path(__file__).parent / ".." / "..").resolve()
 
-functions_input_fns = [
-    root_dir / "Source" / "WebKit" / "WebProcess" / "GPU" / "graphics" / "RemoteGraphicsContextGLProxy.h"
-]
+functions_input_fns = [root_dir / "Source" / "WebKit" / "WebProcess" / "GPU" / "graphics" / "RemoteGraphicsContextGLProxy.h"]
 types_input_fn = root_dir / "Source" / "WebKit" / "WebProcess" / "GPU" / "graphics" / "RemoteGraphicsContextGLProxy.h"
 
 
@@ -109,7 +107,7 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {{
     void SurfaceBufferToVideoFrame(WebCore::GraphicsContextGL::SurfaceBuffer buffer) -> (std::optional<WebKit::RemoteVideoFrameProxyProperties> properties) Synchronous
 #endif
 #if ENABLE(VIDEO) && PLATFORM(COCOA)
-    void CopyTextureFromVideoFrame(struct WebKit::SharedVideoFrame frame, uint32_t texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY) -> (bool success) Synchronous NotStreamEncodable
+    void CopyTextureFromVideoFrame(struct WebKit::SharedVideoFrame frame, PlatformGLObject texture, uint32_t target, int32_t level, uint32_t internalFormat, uint32_t format, uint32_t type, bool premultiplyAlpha, bool flipY) -> (bool success) Synchronous NotStreamEncodable
     void SetSharedVideoFrameSemaphore(IPC::Semaphore semaphore) NotStreamEncodable
     void SetSharedVideoFrameMemory(WebCore::SharedMemory::Handle storageHandle) NotStreamEncodable
 #endif
@@ -163,10 +161,11 @@ def write_file(fn, new_contents):
     with open(fn, "w") as f:
         f.write(new_contents)
 
+
 class cpp_type(object):
     type_name: str
 
-    def __init__(self, type_name : str):
+    def __init__(self, type_name: str):
         self.type_name = type_name
 
     def __str__(self):
@@ -211,49 +210,58 @@ class cpp_type(object):
     def is_const_reference(self) -> bool:
         return False
 
-    def get_value_type(self) -> 'cpp_type':
+    def get_value_type(self) -> "cpp_type":
         return self
 
-    def get_decay_type(self) -> 'cpp_type':
+    def get_decay_type(self) -> "cpp_type":
         if self.is_const():
             return get_cpp_type(self.type_name[6:])
         return self
 
-    def get_rvalue_type(self) -> 'cpp_type':
+    def get_rvalue_type(self) -> "cpp_type":
         return get_cpp_type(self.type_name + "&&")
 
-    def get_pointer_type(self) -> 'cpp_type':
+    def get_pointer_type(self) -> "cpp_type":
         return get_cpp_type(self.type_name + "*")
 
+
 class cpp_type_container(cpp_type):
-    def __init__(self, type_name : str, container_name : str, contained_type : cpp_type, arity : Optional[int] = None):
+    def __init__(self, type_name: str, container_name: str, contained_type: cpp_type, arity: Optional[int] = None):
         cpp_type.__init__(self, type_name)
         self.container_name = container_name
         self.contained_type = contained_type
         self.arity = arity
+
     def is_container(self) -> bool:
         return True
+
     def is_span(self) -> bool:
         return self.container_name == "std::span"
+
     def is_dynamic_span(self) -> bool:
         return (self.container_name == "std::span" and self.arity is None) or self.container_name == "GCGLSpanTuple"
+
     def get_container_name(self):
         return self.container_name
+
     def get_arity(self) -> Optional[int]:
         return self.arity
+
     def get_contained_type(self) -> cpp_type:
         return self.contained_type
+
     def is_output_buffer_type(self) -> bool:
         return self.contained_type.is_const()
 
-def create_cpp_type_container(type_name : str) -> Optional[cpp_type_container]:
+
+def create_cpp_type_container(type_name: str) -> Optional[cpp_type_container]:
     # The logic to determine container is to just assume all templates are containers.
     m = re.match(r"([\w:]+)<(.+)>$", type_name)
     if not m:
         return None
     container_name = m[1]
     # All templates are containers except these below.
-    if container_name in ['RefPtr', 'Ref', 'RetainPtr', 'std::optional']:
+    if container_name in ["RefPtr", "Ref", "RetainPtr", "std::optional"]:
         return None
     templates = m[2]
     arity = None
@@ -263,64 +271,74 @@ def create_cpp_type_container(type_name : str) -> Optional[cpp_type_container]:
         arity = int(m[2])
     return cpp_type_container(type_name, container_name, get_cpp_type(templates), arity)
 
+
 class cpp_type_function(cpp_type):
-    def __init__(self, type_name : str, return_value_type : cpp_type, argument_types : List[cpp_type]):
+    def __init__(self, type_name: str, return_value_type: cpp_type, argument_types: List[cpp_type]):
         cpp_type.__init__(self, type_name)
-        self.return_value_type  = return_value_type
+        self.return_value_type = return_value_type
         self.argument_types = argument_types
 
-def cpp_split_args_specs(args_spec : str) -> Iterator[str]:
-     # https://stackoverflow.com/questions/33527245/python-split-by-comma-skipping-the-content-inside-parentheses
+
+def cpp_split_args_specs(args_spec: str) -> Iterator[str]:
+    # https://stackoverflow.com/questions/33527245/python-split-by-comma-skipping-the-content-inside-parentheses
     comma = r",(?!(?:[^<]*\<[^>]*\>)*[^<>]*\>)"
     return filter(None, [a.strip() for a in re.split(comma, args_spec.strip())])
 
-def create_cpp_type_function(type_name : str) -> Optional[cpp_type_function]:
-    m = re.match(r'(.*)\((.*)\)', type_name)
+
+def create_cpp_type_function(type_name: str) -> Optional[cpp_type_function]:
+    m = re.match(r"(.*)\((.*)\)", type_name)
     if not m:
         return None
     return_value_type = get_cpp_type(m[1])
     args_types = [get_cpp_type(a) for a in cpp_split_args_specs(m[2])]
     return cpp_type_function(type_name, return_value_type, args_types)
 
+
 # Pointer or refererence
 class cpp_type_indirect(cpp_type):
-    category : str
-    value_type : cpp_type
+    category: str
+    value_type: cpp_type
 
-    def __init__(self, type_name : str, category : str, value_type : cpp_type):
+    def __init__(self, type_name: str, category: str, value_type: cpp_type):
         cpp_type.__init__(self, type_name)
         self.category = category
         self.value_type = value_type
 
     def is_const_pointer(self):
-        return self.category == '*' and self.is_const()
+        return self.category == "*" and self.is_const()
+
     def is_pointer(self):
-        return self.category == '*' and not self.is_const()
+        return self.category == "*" and not self.is_const()
+
     def is_const_reference(self):
-        return self.category == '&' and self.is_const()
+        return self.category == "&" and self.is_const()
+
     def is_reference(self):
-        return self.category == '&' and not self.is_const()
+        return self.category == "&" and not self.is_const()
+
     def is_rvalue_reference(self):
-        return self.category == '&&'
+        return self.category == "&&"
+
     def get_value_type(self):
         return self.value_type
 
-def create_cpp_type_indirect(type_name : str) -> Optional[cpp_type_indirect]:
+
+def create_cpp_type_indirect(type_name: str) -> Optional[cpp_type_indirect]:
     m = re.match(r"const (.+)&&$", type_name)
     if not m:
         m = re.match(r"(.+)&&$", type_name)
     if m:
-        return cpp_type_indirect(type_name, '&&', get_cpp_type(m[1]))
+        return cpp_type_indirect(type_name, "&&", get_cpp_type(m[1]))
     m = re.match(r"const (.+)&$", type_name)
     if not m:
         m = re.match(r"(.+)&$", type_name)
     if m:
-        return cpp_type_indirect(type_name, '&', get_cpp_type(m[1]))
+        return cpp_type_indirect(type_name, "&", get_cpp_type(m[1]))
     m = re.match(r"const (.+)\*$", type_name)
     if not m:
         m = re.match(r"(.+)\*$", type_name)
     if m:
-        return cpp_type_indirect(type_name, '*', get_cpp_type(m[1]))
+        return cpp_type_indirect(type_name, "*", get_cpp_type(m[1]))
     return None
 
 
@@ -339,15 +357,19 @@ class cpp_expr(object):
 CppExprConverter = Callable[[cpp_expr, cpp_type], cpp_expr]
 
 
-def cpp_reinterpret_cast_from_pointer_through(cast_through_type : cpp_type) -> Callable[[cpp_expr, cpp_type], cpp_expr]:
+def cpp_reinterpret_cast_from_pointer_through(cast_through_type: cpp_type) -> Callable[[cpp_expr, cpp_type], cpp_expr]:
     def cpp_reinterpret_cast_from_pointer(expr: cpp_expr, type: cpp_type) -> cpp_expr:
         return cpp_expr(type, f"static_cast<{type.type_name}>(reinterpret_cast<{str(cast_through_type)}>({str(expr)}))")
+
     return cpp_reinterpret_cast_from_pointer
 
-def cpp_reinterpret_cast_to_pointer_through(cast_through_type : cpp_type) -> Callable[[cpp_expr, cpp_type], cpp_expr]:
+
+def cpp_reinterpret_cast_to_pointer_through(cast_through_type: cpp_type) -> Callable[[cpp_expr, cpp_type], cpp_expr]:
     def cpp_reinterpret_cast_to_pointer(expr: cpp_expr, type: cpp_type) -> cpp_expr:
         return cpp_expr(type, f"reinterpret_cast<{type.type_name}>(static_cast<{str(cast_through_type)}>({str(expr)}))")
+
     return cpp_reinterpret_cast_to_pointer
+
 
 def cpp_static_cast(expr: cpp_expr, type: cpp_type) -> cpp_expr:
     return cpp_expr(type, f"static_cast<{type.type_name}>({str(expr)})")
@@ -368,11 +390,8 @@ def cpp_move_expr(expr: cpp_expr) -> cpp_expr:
 
 cpp_types: Dict[str, cpp_type] = {}
 
-cpp_type_constructors : List[Callable[[str], Optional[cpp_type]]] = [
-    create_cpp_type_function,
-    create_cpp_type_container,
-    create_cpp_type_indirect
-]
+cpp_type_constructors: List[Callable[[str], Optional[cpp_type]]] = [create_cpp_type_function, create_cpp_type_container, create_cpp_type_indirect]
+
 
 def get_cpp_type(type_name: str):
     r = cpp_types.get(type_name, None)
@@ -453,7 +472,7 @@ class cpp_func(object):
         in_args = []
         out_args = []
         for a in self.args.args:
-            #fmt: off
+            # fmt: off
             if a.type.is_pointer() or \
                 a.type.is_reference():
                 out_args += [a]
@@ -461,7 +480,7 @@ class cpp_func(object):
                 out_args += [a]
             else:
                 in_args += [a]
-            #fmt: on
+            # fmt: on
         return in_args, out_args
 
     def is_implemented_type(self, type: cpp_type):
@@ -470,9 +489,9 @@ class cpp_func(object):
         return True
 
     def is_implemented(self):
-        #" in a.type.type_name for a in self.args.args):
+        # " in a.type.type_name for a in self.args.args):
         #    return False
-        #if "GCGLsync" in self.return_type.type_name:
+        # if "GCGLsync" in self.return_type.type_name:
         #    return False
         if any(a.name == "bufSize" for a in self.args.args):
             return False
@@ -493,7 +512,7 @@ webkit_ipc_types_converters: Dict[Tuple[cpp_type, cpp_type], CppExprConverter] =
 
 
 def webkit_ipc_convert_expr(expr: cpp_expr, type: cpp_type) -> cpp_expr:
-    """ Converts `expr` of type of `self` to `type` """
+    """Converts `expr` of type of `self` to `type`"""
     convert = webkit_ipc_types_converters.get((expr.type, type), None)
     if not convert:
         if expr.type == type:
@@ -502,20 +521,19 @@ def webkit_ipc_convert_expr(expr: cpp_expr, type: cpp_type) -> cpp_expr:
     return convert(expr, type)
 
 
-def webkit_ipc_get_span_transfer_type(type : cpp_type_container) -> cpp_type:
+def webkit_ipc_get_span_transfer_type(type: cpp_type_container) -> cpp_type:
     element_type = type.get_contained_type().get_decay_type()
     arity = type.get_arity()
-    webkit_ipc_element_type = webkit_ipc_types[element_type] if not element_type.is_void() else get_cpp_type('uint8_t')
+    webkit_ipc_element_type = webkit_ipc_types[element_type] if not element_type.is_void() else get_cpp_type("uint8_t")
     if arity is not None:
         return get_cpp_type(f"std::span<const {str(webkit_ipc_element_type)}, {arity}>")
     return get_cpp_type(f"std::span<const {str(webkit_ipc_element_type)}>")
 
 
-
 def webkit_ipc_get_span_store_type(type: cpp_type_container) -> cpp_type:
     element_type = type.get_contained_type().get_decay_type()
     if element_type.is_void():
-        element_type = get_cpp_type('GCGLchar')
+        element_type = get_cpp_type("GCGLchar")
     if type.is_dynamic_span():
         inline_capacity = 16 if "float" in element_type.type_name else 4
         return get_cpp_type(f"Vector<{str(element_type)}, {str(inline_capacity)}>")
@@ -544,6 +562,30 @@ def webkit_ipc_msg_name(func: cpp_func):
     return func.name[0].capitalize() + func.name[1:] + func.overload_suffix
 
 
+def to_variable_name(name: str) -> str:
+    return name[0].lower() + name[1:]
+
+
+def to_member_variable_name(name: str) -> str:
+    return f"m_{to_variable_name(name)}"
+
+
+def is_create_func(func: cpp_func) -> bool:
+    return func.name.startswith("create")
+
+
+def get_create_func_object_name(name: str) -> str:
+    return name[len("create") :]
+
+
+def is_delete_func(func: cpp_func) -> bool:
+    return func.name.startswith("delete")
+
+
+def get_delete_func_object_name(name: str) -> str:
+    return name[len("delete") :]
+
+
 class webkit_ipc_msg(object):
     name: str
     in_args: cpp_arg_list
@@ -554,7 +596,10 @@ class webkit_ipc_msg(object):
         in_args, out_args = func.get_args_categories()
         ipc_in_args = [cpp_arg(webkit_ipc_types[a.type], a.name) for a in in_args]
         ipc_out_args = []
-        if not func.return_type.is_void():
+        if is_create_func(func):
+            name = get_create_func_object_name(func.name)
+            ipc_in_args.insert(0, cpp_arg(webkit_ipc_types[func.return_type], to_variable_name(name)))
+        elif not func.return_type.is_void():
             ipc_out_args += [cpp_arg(webkit_ipc_types[func.return_type], "returnValue")]
         for a in out_args:
             ipc_out_args += [cpp_arg(webkit_ipc_types[a.type], a.name)]
@@ -571,6 +616,7 @@ class webkit_ipc_msg(object):
 
 class webkit_ipc_cpp_proxy_impl(object):
     name: str
+    is_create: bool
     msg_name: str
     return_type: cpp_type
     args: cpp_arg_list
@@ -584,6 +630,7 @@ class webkit_ipc_cpp_proxy_impl(object):
 
     def __init__(self, cpp_func: cpp_func):
         self.name = cpp_func.name
+        self.is_create = is_create_func(cpp_func)
         self.msg_name = webkit_ipc_msg_name(cpp_func)
         self.return_type = cpp_func.return_type
         self.args = cpp_func.args
@@ -602,12 +649,15 @@ class webkit_ipc_cpp_proxy_impl(object):
     def process_call(self):
         in_exprs = ", ".join([str(i) for i in self.in_exprs])
         out_exprs = ", ".join(str(o) for o in self.out_exprs)
-        is_async = self.return_type.is_void() and len(out_exprs) == 0
-        self.call_stmts += [ "if (isContextLost())" ]
+        is_async = (self.return_type.is_void() or self.is_create) and len(out_exprs) == 0
+        self.call_stmts += ["if (isContextLost())"]
         if self.return_type.is_void():
-            self.call_stmts += [ "    return;" ]
+            self.call_stmts += ["    return;"]
         else:
-            self.call_stmts += [ "    return { };"]
+            self.call_stmts += ["    return { };"]
+        if self.is_create:
+            
+            self.call_stmts += [f"auto name = createObjectName();"]
         if is_async:
             self.call_stmts += [
                 f"auto sendResult = send(Messages::RemoteGraphicsContextGL::{self.msg_name}({in_exprs}));",
@@ -631,8 +681,9 @@ class webkit_ipc_cpp_proxy_impl(object):
                 "}",
             ]
 
-
     def process_in_args(self, in_args: List[cpp_arg]):
+        if self.is_create:
+            self.in_exprs += [webkit_ipc_convert_expr(cpp_expr(self.return_type, "name"), webkit_ipc_types[self.return_type])]
         for i in in_args:
             if i.type.is_const_pointer():
                 assert False
@@ -648,10 +699,10 @@ class webkit_ipc_cpp_proxy_impl(object):
                 e = cpp_expr(v.type, v.name)
                 self.out_exprs += [e]
                 self.post_call_stmts += [
-                    #fmt: off
+                    # fmt: off
                     f"if ({o.name})",
                     f"    *{o.name} = {webkit_ipc_convert_expr(e, value_type)};"
-                    #fmt: on
+                    # fmt: on
                 ]
             elif o.type.is_reference():
                 value_type = o.type.get_value_type()
@@ -663,7 +714,7 @@ class webkit_ipc_cpp_proxy_impl(object):
                 ]
             elif o.type.is_span():
                 webkit_ipc_type = webkit_ipc_types[o.type]
-                assert(isinstance(webkit_ipc_type, cpp_type_container))
+                assert isinstance(webkit_ipc_type, cpp_type_container)
                 v = cpp_arg(webkit_ipc_type, o.name + "Reply")
                 self.out_exprs += [cpp_expr(v.type, v.name)]
                 if o.type.is_dynamic_span():
@@ -677,11 +728,14 @@ class webkit_ipc_cpp_proxy_impl(object):
         if self.out_exprs:
             out_exprs = ", ".join(str(o) for o in self.out_exprs)
             self.post_call_stmts = [
-                    f"auto& [{out_exprs}] = sendResult.reply();",
-                ] + self.post_call_stmts
+                f"auto& [{out_exprs}] = sendResult.reply();",
+            ] + self.post_call_stmts
 
     def process_return_value(self, return_type: cpp_type):
         if return_type.is_void():
+            return
+        if self.is_create:
+            self.return_stmts = [f"return name;"]
             return
         self.return_type = return_type
         ipc_return_type = webkit_ipc_types[return_type]
@@ -749,6 +803,8 @@ class webkit_ipc_cpp_impl(object):
 
     def __init__(self, cpp_func: cpp_func):
         self.name = cpp_func.name
+        self.is_create = is_create_func(cpp_func)
+        self.is_delete = is_delete_func(cpp_func)
         self.overload_suffix = cpp_func.overload_suffix
         self.args = cpp_arg_list([])
         self.pre_call_stmts = []
@@ -758,14 +814,13 @@ class webkit_ipc_cpp_impl(object):
         self.out_exprs = []
         self.return_value_expr = None
 
+        self.pre_call_stmts += ["assertIsCurrent(workQueue());"]
         self.process_return_value(cpp_func.return_type)
         in_args, out_args = cpp_func.get_args_categories()
         self.process_args(cpp_func.args.args, set(in_args), set(out_args))
         self.process_call()
 
     def process_call(self):
-        self.call_stmts += [ "assertIsCurrent(workQueue());" ]
-
         in_exprs = ", ".join(str(e) for e in self.in_exprs)
         is_async = len(self.out_exprs) == 0
 
@@ -793,6 +848,13 @@ class webkit_ipc_cpp_impl(object):
     def process_in_arg(self, a: cpp_arg):
         self.args.args += [cpp_arg(webkit_ipc_get_message_forwarder_type(webkit_ipc_types[a.type]), a.name)]
         self.in_exprs += [webkit_ipc_convert_expr(cpp_expr(webkit_ipc_types[a.type], a.name), a.type)]
+        if a.type.type_name == "PlatformGLObject":
+            if self.is_create:
+                self.pre_call_stmts += [f"if (UNLIKELY(!{a.name})) {{", f"    ASSERT_IS_TESTING_IPC();", f"    return;", f"}}"]
+            if self.is_delete:
+                self.pre_call_stmts += [f"{a.name} = m_objectNames.take({a.name});"]
+            else:
+                self.pre_call_stmts += [f"{a.name} = m_objectNames.get({a.name});"]
 
     def process_out_arg(self, a: cpp_arg):
         if a.type.is_pointer():
@@ -803,7 +865,7 @@ class webkit_ipc_cpp_impl(object):
             webkit_ipc_value_type = webkit_ipc_types[e.type]
             self.out_exprs += [webkit_ipc_convert_expr(e, webkit_ipc_value_type)]
         elif a.type.is_dynamic_span():
-            assert(isinstance(a.type, cpp_type_container))
+            assert isinstance(a.type, cpp_type_container)
             size_arg = cpp_arg(get_cpp_type("size_t"), f"{a.name}Size")
             self.args.args += [size_arg]
             store_arg = cpp_arg(webkit_ipc_get_span_store_type(a.type), a.name)
@@ -812,7 +874,7 @@ class webkit_ipc_cpp_impl(object):
             webkit_ipc_type = webkit_ipc_types[a.type]
             self.out_exprs += [webkit_ipc_convert_expr(cpp_expr(store_arg.type, store_arg.name), webkit_ipc_type)]
         elif a.type.is_span():
-            assert(isinstance(a.type, cpp_type_container))
+            assert isinstance(a.type, cpp_type_container)
             store_arg = cpp_arg(webkit_ipc_get_span_store_type(a.type), a.name)
             self.pre_call_stmts += [f"{str(store_arg.type)} {str(store_arg.name)} {{ }};"]
             self.in_exprs += [cpp_expr(store_arg.type, store_arg.name)]
@@ -828,6 +890,13 @@ class webkit_ipc_cpp_impl(object):
             self.out_exprs += [webkit_ipc_move_expr(webkit_ipc_convert_expr(e, webkit_ipc_type))]
 
     def process_return_value(self, return_type: cpp_type):
+        if self.is_create:
+            ipc_return_type = webkit_ipc_types[return_type]
+            self.args.args += [cpp_arg(webkit_ipc_get_message_forwarder_type(ipc_return_type), "name")]
+            return_value_expr = cpp_expr(return_type, f"auto result")
+            self.return_value_expr = return_value_expr
+            self.post_call_stmts += [f"m_objectNames.add(name, result);"]
+            return
         if return_type.is_void():
             return
         ipc_return_type = webkit_ipc_types[return_type]
@@ -849,9 +918,10 @@ class webkit_ipc_cpp_impl(object):
             return "WebCore::GraphicsContextGL::" + str(type)
         return str(type)
 
-def webkit_ipc_resolve_overload_suffix(funcs : Iterable[cpp_func]):
+
+def webkit_ipc_resolve_overload_suffix(funcs: Iterable[cpp_func]):
     counts = collections.Counter(f.name for f in funcs)
-    suffixes : Counter[str] = collections.Counter()
+    suffixes: Counter[str] = collections.Counter()
     for f in funcs:
         if counts[f.name] > 1:
             f.overload_suffix = str(suffixes[f.name])
@@ -910,11 +980,12 @@ def create_cpp_func(name: str, return_spec: str, args_specs: List[str]):
     return cpp_func(name=name, return_type=get_cpp_type(return_spec), args=create_cpp_arg_list(args_specs))
 
 
-def read_lines_until(lines : Iterable[str], match : str) -> Generator[str, None, None]:
+def read_lines_until(lines: Iterable[str], match: str) -> Generator[str, None, None]:
     for line in lines:
         if re.match(match, line.strip()):
             break
         yield line
+
 
 def main():
     parser = argparse.ArgumentParser("usage: %prog [options]")
@@ -945,9 +1016,13 @@ def main():
                     else:
                         unimplemented.append(func)
 
-
     webkit_ipc_resolve_overload_suffix(funcs)
     # Initialize WebKit IPC generation. Construct type mappings for the used C++ types -> IPC types.
+    # Populate types that are needed but not present in the interfaces.
+    for needed in ["unsigned"]:
+        cpp_type = get_cpp_type(needed)
+        webkit_ipc_types[cpp_type] = cpp_type
+
     # TODO: namespacing issues.
     ai_type = get_cpp_type("ActiveInfo&")
     ai_transfer_type = get_cpp_type("WebCore::GraphicsContextGL::ActiveInfo")
@@ -1000,7 +1075,7 @@ def main():
     # TODO: this is not driven by the typing.
     all_types = set()
     for func in funcs:
-       all_types.update(func.args.types() + [func.return_type])
+        all_types.update(func.args.types() + [func.return_type])
     # Sort by len so that template args come before templates.
     for cpp_type in sorted(all_types, key=lambda x: len(x.type_name)):
         if cpp_type in webkit_ipc_types:
@@ -1025,12 +1100,11 @@ def main():
                     # in the IPC definition. There is no sensible way to do this at the moment. We do not convert, rather
                     # expect that all the invocations are taken care of the fact that GCGLint is the same type as int32_t.
                     # This will not hold for all types such as GCGLboolean.
-                    #webkit_ipc_types_converters[(cpp_type, transfer_type)] = cpp_array_reinterpret_cast_conversion
+                    # webkit_ipc_types_converters[(cpp_type, transfer_type)] = cpp_array_reinterpret_cast_conversion
             else:
                 webkit_ipc_types[cpp_type] = value_type
         else:
             webkit_ipc_types[cpp_type] = cpp_type.get_value_type()
-
     # The input to the generators is list of functions to remote.
     # Run the various generators.
     generators = [


### PR DESCRIPTION
#### 3180ee0bf2d7f95d1d938b55546a3ef50eb2b9b6
<pre>
GPUP WebGL resource creation functions are slow
<a href="https://bugs.webkit.org/show_bug.cgi?id=271461">https://bugs.webkit.org/show_bug.cgi?id=271461</a>
<a href="https://rdar.apple.com/problem/125232933">rdar://problem/125232933</a>

Reviewed by Dan Glastonbury.

Make the WP side allocate the name directly and send it to GPUP side.
Build a mapping WP names -&gt; GL names in the RemoteGraphicsContextGL in
GPUP side.

Currently all object types share the namespace and all names are in the
same map.

Avoids blocking the WP for just creating WebGL objects like textures
or FBOs.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(attachShader):
(bindAttribLocation):
(bindBuffer):
(bindFramebuffer):
(bindRenderbuffer):
(bindTexture):
(checkFramebufferStatus):
(compileShader):
(createBuffer):
(createFramebuffer):
(createProgram):
(createRenderbuffer):
(createShader):
(createTexture):
(deleteBuffer):
(deleteFramebuffer):
(deleteProgram):
(deleteRenderbuffer):
(deleteShader):
(deleteTexture):
(detachShader):
(framebufferRenderbuffer):
(framebufferTexture2D):
(getActiveAttrib):
(getActiveUniform):
(getAttribLocation):
(getBufferParameteri):
(getString):
(getFloatv):
(getIntegerv):
(getIntegeri_v):
(getInteger64):
(getInteger64i):
(getProgrami):
(getBooleanv):
(getFramebufferAttachmentParameteri):
(getProgramInfoLog):
(getRenderbufferParameteri):
(getShaderi):
(getShaderInfoLog):
(getShaderPrecisionFormat):
(getShaderSource):
(getTexParameterf):
(getTexParameteri):
(getUniformfv):
(getUniformiv):
(getUniformuiv):
(getUniformLocation):
(getVertexAttribOffset):
(isBuffer):
(isEnabled):
(isFramebuffer):
(isProgram):
(isRenderbuffer):
(isShader):
(isTexture):
(linkProgram):
(shaderSource):
(useProgram):
(validateProgram):
(createVertexArray):
(deleteVertexArray):
(isVertexArray):
(bindVertexArray):
(getBufferSubData):
(framebufferTextureLayer):
(getFragDataLocation):
(createQuery):
(deleteQuery):
(isQuery):
(beginQuery):
(getQuery):
(getQueryObjectui):
(createSampler):
(deleteSampler):
(isSampler):
(bindSampler):
(samplerParameteri):
(samplerParameterf):
(getSamplerParameterf):
(getSamplerParameteri):
(fenceSync):
(isSync):
(clientWaitSync):
(getSynci):
(createTransformFeedback):
(deleteTransformFeedback):
(isTransformFeedback):
(bindTransformFeedback):
(transformFeedbackVaryings):
(getTransformFeedbackVarying):
(bindBufferBase):
(bindBufferRange):
(getUniformIndices):
(getActiveUniforms):
(getUniformBlockIndex):
(getActiveUniformBlockName):
(uniformBlockBinding):
(getActiveUniformBlockiv):
(getTranslatedShaderSourceANGLE):
(createQueryEXT):
(deleteQueryEXT):
(isQueryEXT):
(beginQueryEXT):
(queryCounterEXT):
(getQueryiEXT):
(getQueryObjectiEXT):
(getQueryObjectui64EXT):
(getInteger64EXT):
(getInternalformativ):
(drawingBufferToPixelBuffer):
(enableRequiredWebXRExtensions):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::createObjectName):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::createBuffer):
(WebKit::RemoteGraphicsContextGLProxy::createFramebuffer):
(WebKit::RemoteGraphicsContextGLProxy::createProgram):
(WebKit::RemoteGraphicsContextGLProxy::createRenderbuffer):
(WebKit::RemoteGraphicsContextGLProxy::createShader):
(WebKit::RemoteGraphicsContextGLProxy::createTexture):
(WebKit::RemoteGraphicsContextGLProxy::createVertexArray):
(WebKit::RemoteGraphicsContextGLProxy::createQuery):
(WebKit::RemoteGraphicsContextGLProxy::createSampler):
(WebKit::RemoteGraphicsContextGLProxy::createTransformFeedback):
(WebKit::RemoteGraphicsContextGLProxy::createQueryEXT):
* Tools/Scripts/generate-gpup-webgl:
(webkit_ipc_msg_name):
(to_variable_name):
(to_member_variable_name):
(is_create_func):
(get_create_func_object_name):
(is_delete_func):
(get_delete_func_object_name):
(webkit_ipc_msg.__init__):
(webkit_ipc_cpp_proxy_impl):
(webkit_ipc_cpp_proxy_impl.__init__):
(webkit_ipc_cpp_proxy_impl.process_call):
(webkit_ipc_cpp_proxy_impl.process_in_args):
(webkit_ipc_cpp_proxy_impl.process_return_value):
(webkit_ipc_cpp_impl.__init__):
(webkit_ipc_cpp_impl.process_args):
(process_in_arg):
(process_return_value):
(main):
(webkit_ipc_cpp_impl.process_in_arg): Deleted.
(webkit_ipc_cpp_impl.process_out_arg): Deleted.
(webkit_ipc_cpp_impl.process_return_value): Deleted.
(webkit_ipc_cpp_impl.__str__): Deleted.
(webkit_ipc_cpp_impl.ns): Deleted.

Canonical link: <a href="https://commits.webkit.org/276725@main">https://commits.webkit.org/276725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b46dcc68aecb126d48e24a759981b9f8287e4e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48014 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41358 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37188 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18291 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40205 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3397 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38570 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41636 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49731 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44819 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44234 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21640 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43045 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10113 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22000 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51978 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21328 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10615 "Passed tests") | 
<!--EWS-Status-Bubble-End-->