### PR TITLE
[WGSL] Validate functions missing a return statement

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -37,6 +37,7 @@
 #include "Types.h"
 #include "WGSLShaderModule.h"
 #include <wtf/DataLog.h>
+#include <wtf/OptionSet.h>
 #include <wtf/SetForScope.h>
 #include <wtf/SortedArrayMap.h>
 
@@ -68,6 +69,14 @@ struct Binding {
     Evaluation evaluation;
     std::optional<ConstantValue> constantValue;
 };
+
+enum class Behavior : uint8_t {
+    Return = 1 << 0,
+    Break = 1 << 1,
+    Continue = 1 << 2,
+    Next = 1 << 3,
+};
+using Behaviors = OptionSet<Behavior>;
 
 static ASCIILiteral bindingKindToString(Binding::Kind kind)
 {
@@ -210,6 +219,15 @@ private:
 
     template<typename Node>
     void setConstantValue(Node&, const Type*, const ConstantValue&);
+
+    Behaviors analyze(AST::Statement&);
+    Behaviors analyze(AST::CompoundStatement&);
+    Behaviors analyze(AST::ForStatement&);
+    Behaviors analyze(AST::IfStatement&);
+    Behaviors analyze(AST::LoopStatement&);
+    Behaviors analyze(AST::SwitchStatement&);
+    Behaviors analyze(AST::WhileStatement&);
+    Behaviors analyzeStatements(AST::Statement::List&);
 
     ShaderModule& m_shaderModule;
     const Type* m_inferredType { nullptr };
@@ -693,6 +711,10 @@ void TypeChecker::visit(AST::Function& function)
         for (unsigned i = 0; i < parameters.size(); ++i)
             introduceValue(function.parameters()[i].name(), parameters[i]);
         Base::visit(function.body());
+
+        auto behaviours = analyze(function.body());
+        if (!behaviours.contains(Behavior::Return) && function.maybeReturnType())
+            typeError(InferBottom::No, function.span(), "missing return at end of function");
     }
 
     const Type* functionType = m_types.functionType(WTFMove(parameters), m_returnType, mustUse);
@@ -1959,6 +1981,109 @@ const Type* TypeChecker::infer(AST::Expression& expression, Evaluation evaluatio
     m_inferredType = nullptr;
 
     return inferredType;
+}
+
+Behaviors TypeChecker::analyze(AST::Statement& statement)
+{
+    switch (statement.kind()) {
+    case AST::NodeKind::AssignmentStatement:
+    case AST::NodeKind::BreakStatement:
+    case AST::NodeKind::CallStatement:
+    case AST::NodeKind::CompoundAssignmentStatement:
+    case AST::NodeKind::ConstAssertStatement:
+    case AST::NodeKind::DecrementIncrementStatement:
+    case AST::NodeKind::DiscardStatement:
+    case AST::NodeKind::PhonyAssignmentStatement:
+    case AST::NodeKind::StaticAssertStatement:
+    case AST::NodeKind::VariableStatement:
+        return Behavior::Next;
+    case AST::NodeKind::ReturnStatement:
+        return Behavior::Return;
+    case AST::NodeKind::ContinueStatement:
+        return Behavior::Continue;
+    case AST::NodeKind::CompoundStatement:
+        return analyze(uncheckedDowncast<AST::CompoundStatement>(statement));
+    case AST::NodeKind::ForStatement:
+        return analyze(uncheckedDowncast<AST::ForStatement>(statement));
+    case AST::NodeKind::IfStatement:
+        return analyze(uncheckedDowncast<AST::IfStatement>(statement));
+    case AST::NodeKind::LoopStatement:
+        return analyze(uncheckedDowncast<AST::LoopStatement>(statement));
+    case AST::NodeKind::SwitchStatement:
+        return analyze(uncheckedDowncast<AST::SwitchStatement>(statement));
+    case AST::NodeKind::WhileStatement:
+        return analyze(uncheckedDowncast<AST::WhileStatement>(statement));
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+Behaviors TypeChecker::analyze(AST::CompoundStatement& statement)
+{
+    return analyzeStatements(statement.statements());
+}
+
+Behaviors TypeChecker::analyze(AST::ForStatement& statement)
+{
+    auto behaviors = Behaviors({ Behavior::Next, Behavior::Break, Behavior::Continue });
+    behaviors.add(analyze(statement.body()));
+    behaviors.remove({ Behavior::Break, Behavior::Continue });
+    return behaviors;
+}
+
+Behaviors TypeChecker::analyze(AST::IfStatement& statement)
+{
+    auto behaviors = analyze(statement.trueBody());
+    if (auto* elseBody = statement.maybeFalseBody())
+        behaviors.add(analyze(*elseBody));
+    return behaviors;
+}
+
+Behaviors TypeChecker::analyze(AST::LoopStatement& statement)
+{
+    auto behaviors = analyzeStatements(statement.body());
+    if (auto& continuing = statement.continuing()) {
+        behaviors.add(analyzeStatements(continuing->body));
+        if (auto* breakIf = continuing->breakIf)
+            behaviors.add({ Behavior::Break, Behavior:: Continue });
+    }
+    if (behaviors.contains(Behavior::Break))
+        behaviors.remove({ Behavior::Break, Behavior::Continue });
+    else
+        behaviors.remove({ Behavior::Next, Behavior::Continue });
+    return behaviors;
+}
+
+Behaviors TypeChecker::analyze(AST::SwitchStatement& statement)
+{
+    auto behaviors = analyze(statement.defaultClause().body);
+    for (auto& clause : statement.clauses())
+        behaviors.add(analyze(clause.body));
+    if (behaviors.contains(Behavior::Break)) {
+        behaviors.remove(Behavior::Break);
+        behaviors.add(Behavior::Break);
+    }
+    return behaviors;
+}
+
+Behaviors TypeChecker::analyze(AST::WhileStatement& statement)
+{
+    auto behaviors = Behaviors({ Behavior::Next, Behavior::Break });
+    behaviors.add(analyze(statement.body()));
+    behaviors.remove({ Behavior::Break, Behavior::Continue });
+    return behaviors;
+}
+
+Behaviors TypeChecker::analyzeStatements(AST::Statement::List& statements)
+{
+    auto behaviors = Behaviors(Behavior::Next);
+    for (auto& statement : statements) {
+        behaviors.remove(Behavior::Next);
+        behaviors.add(analyze(statement));
+        if (!behaviors.contains(Behavior::Next))
+            break;
+    }
+    return behaviors;
 }
 
 const Type* TypeChecker::check(AST::Expression& expression, Constraint constraint, Evaluation evaluation)

--- a/Source/WebGPU/WGSL/tests/invalid/function-call.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/function-call.wgsl
@@ -1,6 +1,8 @@
 // RUN: %not %wgslc | %check
 
-fn f1(x: f32) -> f32 { return x; }
+fn f1(x: f32) -> f32 {
+    // CHECK-L: missing return at end of function
+}
 
 fn f2() {
     // CHECK-L: unresolved call target 'f0'


### PR DESCRIPTION
#### 2fa5e500ae947d383e44891f61cd27213c0f622e
<pre>
[WGSL] Validate functions missing a return statement
<a href="https://bugs.webkit.org/show_bug.cgi?id=271482">https://bugs.webkit.org/show_bug.cgi?id=271482</a>
<a href="https://rdar.apple.com/124143123">rdar://124143123</a>

Reviewed by Mike Wyrzykowski.

Implement the behavior analysis from the spec[1] and check if functions with a
return type are missing a return statement.

[1]: <a href="https://www.w3.org/TR/WGSL/#behaviors">https://www.w3.org/TR/WGSL/#behaviors</a>

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::analyze):
(WGSL::TypeChecker::analyzeStatements):
* Source/WebGPU/WGSL/tests/invalid/function-call.wgsl:

Canonical link: <a href="https://commits.webkit.org/276630@main">https://commits.webkit.org/276630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/990be186d5a443947a4cd59440c47e9992bc85cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47883 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41219 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21726 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18186 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18791 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49577 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16728 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44115 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21499 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42907 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10046 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21855 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->