### PR TITLE
Unreviewed, fix [ macOS ] Failed to download built product from build master

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1478,7 +1478,7 @@ class GenerateS3URL(master.MasterShellCommandNewStyle):
         self.minified = minified
         kwargs['command'] = [
             'python3', '../Shared/generate-s3-url',
-            '--revision', WithProperties('%(revision)s'),
+            '--revision', WithProperties('%(archive_revision)s'),
             '--identifier', self.identifier,
         ]
         if extension:
@@ -1509,7 +1509,7 @@ class GenerateS3URL(master.MasterShellCommandNewStyle):
             self.build.s3url = match.group('url')
             print(f'build: {build_url}, url for GenerateS3URL: {self.build.s3url}')
             bucket_url = S3_BUCKET_MINIFIED if self.minified else S3_BUCKET
-            self.build.s3_archives.append(S3URL + f"{bucket_url}/{self.identifier}/{self.getProperty('revision')}.{self.extension}")
+            self.build.s3_archives.append(S3URL + f"{bucket_url}/{self.identifier}/{self.getProperty('archive_revision')}.{self.extension}")
             defer.returnValue(rc)
         else:
             print(f'build: {build_url}, logs for GenerateS3URL:\n{log_text}')

--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -1695,7 +1695,7 @@ class TestGenerateS3URL(BuildStepMixinAdditions, unittest.TestCase):
 
     def configureStep(self, identifier='mac-highsierra-x86_64-release', extension='zip', content_type=None):
         self.setupStep(GenerateS3URL(identifier, extension=extension, content_type=content_type))
-        self.setProperty('revision', '1234')
+        self.setProperty('archive_revision', '1234')
 
     def disabled_test_success(self):
         # TODO: Figure out how to pass logs to unit-test for MasterShellCommand steps


### PR DESCRIPTION
#### a86cc8415fd8d40df5689acbdc7765edd9787f25
<pre>
Unreviewed, fix [ macOS ] Failed to download built product from build master
<a href="https://rdar.apple.com/125249462">rdar://125249462</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=271478">https://bugs.webkit.org/show_bug.cgi?id=271478</a>

Changes revision to match DownloadBuiltProductFromMaster step.

* Tools/CISupport/build-webkit-org/steps.py:
(GenerateS3URL.__init__):
(GenerateS3URL.run):
* Tools/CISupport/build-webkit-org/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/276560@main">https://commits.webkit.org/276560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/155cb9c0eca630483336ad4f7a912d4ec89acff0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47490 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/47649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/40998 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47297 "Failed to checkout and rebase branch from PR 26332") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21498 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/47649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45569 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/21160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/47649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/39878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/3039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/41265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/40181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49323 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/19964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/16513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/45033 "Failed to checkout and rebase branch from PR 26332") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6256 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->