### PR TITLE
Web Inspector: Timelines: DataGrid header layout issues in some locales

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
@@ -29,6 +29,7 @@
 
     --data-grid-header-horizontal-padding: 6px;
     --data-grid-header-height: 22px;
+    --data-grid-header-border-size: 1px;
     --data-grid-sorting-indicator-height: 8px;
 }
 
@@ -49,7 +50,7 @@
 
 .data-grid .data-container {
     position: absolute;
-    top: 23px;
+    top: calc(var(--data-grid-header-height) + var(--data-grid-header-border-size));
     bottom: 0;
     left: 0;
     right: 0;
@@ -63,11 +64,13 @@
 }
 
 .data-grid.inline {
-    border: 1px solid var(--border-color);
+    border: var(--data-grid-header-border-size) solid var(--border-color);
 }
 
 .data-grid > .header-wrapper {
-    border-bottom: 1px solid var(--border-color);
+    position: absolute;
+    z-index: var(--z-index-header);
+    border-bottom: var(--data-grid-header-border-size) solid var(--border-color);
 }
 
 .data-grid.no-header > .header-wrapper {
@@ -92,6 +95,7 @@
 .data-grid th > .header-cell-content {
     margin: 3px 0;
     padding: 0 var(--data-grid-header-horizontal-padding);
+    line-height: 1.5;
 }
 
 .data-grid th:not(:last-child) > .header-cell-content {


### PR DESCRIPTION
#### 2bc4a0fc65fa6c4f784474127b2900454f93a2c7
<pre>
Web Inspector: Timelines: DataGrid header layout issues in some locales
<a href="https://bugs.webkit.org/show_bug.cgi?id=271481">https://bugs.webkit.org/show_bug.cgi?id=271481</a>
<a href="https://rdar.apple.com/124993083">rdar://124993083</a>

Reviewed by NOBODY (OOPS!).

The line box of text is defined by the font used to render glyphs.

- When using `overflow: hidden`, the clipping region is given by the height of the line box,
not the glyphs in it. With an insufficient line height, text can get clipped.

Fixed by defining a line-height value.

- When the line box is taller, it increases the dimensions of the element.
The DataGrid header was positioned in the document flow.
The DataGrid content is absolutely positioned (out-of-flow) and offset vertically by an amount
equal to the height of the the header. When the header grows, it goes underneath the content.

Fixed by placing the DataGrid header on top of the content.
Overlap might still occur in some scenarios, but it will obscure a top portion
of the first row of content instead of hiding the header underneath it.

Ideally the layout of DataGrid would not be based on absolute positioning
and fixed dimensions, but that refactoring is beyond the scope of this patch.

* Source/WebInspectorUI/UserInterface/Views/DataGrid.css:
(.data-grid):
(.data-grid .data-container):
(.data-grid.inline):
(.data-grid &gt; .header-wrapper):
(.data-grid th &gt; .header-cell-content):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bc4a0fc65fa6c4f784474127b2900454f93a2c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/44994 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41001 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36927 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38754 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18015 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39880 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3042 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40183 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49326 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/19967 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43931 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21282 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42721 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/20961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->