### PR TITLE
Complete transition to std::span in CryptoDigest-related code

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlockHash.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlockHash.cpp
@@ -62,10 +62,10 @@ CodeBlockHash::CodeBlockHash(const SourceCode& sourceCode, CodeSpecializationKin
         unsigned length = str.length();
         unsigned step = (length >> 10) + 1;
 
-        sha1.addBytes(bitwise_cast<uint8_t*>(&length), sizeof(length));
+        sha1.addBytes(std::span { bitwise_cast<uint8_t*>(&length), sizeof(length) });
         do {
             UChar character = str[index];
-            sha1.addBytes(bitwise_cast<uint8_t*>(&character), sizeof(character));
+            sha1.addBytes(std::span { bitwise_cast<uint8_t*>(&character), sizeof(character) });
             oldIndex = index;
             index += step;
         } while (index > oldIndex && index < length);

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorUtils.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorUtils.cpp
@@ -74,7 +74,7 @@ const CString& backendCommandsHash()
         gconstpointer data = g_bytes_get_data(bytes.get(), &dataSize);
         ASSERT(dataSize);
         SHA1 sha1;
-        sha1.addBytes(static_cast<const uint8_t*>(data), dataSize);
+        sha1.addBytes(std::span { static_cast<const uint8_t*>(data), dataSize });
         hexDigest = sha1.computeHexDigest();
     }
     return hexDigest;

--- a/Source/JavaScriptCore/runtime/CachedBytecode.h
+++ b/Source/JavaScriptCore/runtime/CachedBytecode.h
@@ -64,6 +64,7 @@ public:
     using ForEachUpdateCallback = Function<void(off_t, const void*, size_t)>;
     JS_EXPORT_PRIVATE void commitUpdates(const ForEachUpdateCallback&) const;
 
+    std::span<const uint8_t> span() const { return { data(), size() }; }
     const uint8_t* data() const { return m_payload.data(); }
     size_t size() const { return m_payload.size(); }
     bool hasUpdates() const { return !m_updates.isEmpty(); }

--- a/Source/WTF/wtf/SHA1.h
+++ b/Source/WTF/wtf/SHA1.h
@@ -62,11 +62,6 @@ public:
         addBytes(input.span());
     }
 
-    void addBytes(const uint8_t* input, size_t length)
-    {
-        addBytes(std::span(input, length));
-    }
-
     // Size of the SHA1 hash
     WTF_EXPORT_PRIVATE static constexpr size_t hashSize = 20;
 

--- a/Source/WTF/wtf/persistence/PersistentEncoder.cpp
+++ b/Source/WTF/wtf/persistence/PersistentEncoder.cpp
@@ -44,7 +44,7 @@ uint8_t* Encoder::grow(size_t size)
 void Encoder::updateChecksumForData(SHA1& sha1, std::span<const uint8_t> span)
 {
     auto typeSalt = Salt<uint8_t*>::value;
-    sha1.addBytes(reinterpret_cast<uint8_t*>(&typeSalt), sizeof(typeSalt));
+    sha1.addBytes(std::span { reinterpret_cast<uint8_t*>(&typeSalt), sizeof(typeSalt) });
     sha1.addBytes(span);
 }
 

--- a/Source/WTF/wtf/persistence/PersistentEncoder.h
+++ b/Source/WTF/wtf/persistence/PersistentEncoder.h
@@ -106,8 +106,8 @@ template <typename Type>
 void Encoder::updateChecksumForNumber(SHA1& sha1, Type value)
 {
     auto typeSalt = Salt<Type>::value;
-    sha1.addBytes(reinterpret_cast<uint8_t*>(&typeSalt), sizeof(typeSalt));
-    sha1.addBytes(reinterpret_cast<uint8_t*>(&value), sizeof(value));
+    sha1.addBytes(std::span { reinterpret_cast<uint8_t*>(&typeSalt), sizeof(typeSalt) });
+    sha1.addBytes(std::span { reinterpret_cast<uint8_t*>(&value), sizeof(value) });
 }
 
 }

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -186,7 +186,7 @@ Ref<ArrayBuffer> buildClientDataJson(ClientDataType type, const BufferSource& ch
 Vector<uint8_t> buildClientDataJsonHash(const ArrayBuffer& clientDataJson)
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    crypto->addBytes(clientDataJson.data(), clientDataJson.byteLength());
+    crypto->addBytes(clientDataJson.span());
     return crypto->computeHash();
 }
 

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -100,11 +100,11 @@ static String generateSecWebSocketKey()
 
 String WebSocketHandshake::getExpectedWebSocketAccept(const String& secWebSocketKey)
 {
-    constexpr uint8_t webSocketKeyGUID[] = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+    const auto webSocketKeyGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"_span;
     SHA1 sha1;
     CString keyData = secWebSocketKey.ascii();
     sha1.addBytes(keyData.span());
-    sha1.addBytes(webSocketKeyGUID, std::size(webSocketKeyGUID) - 1);
+    sha1.addBytes(webSocketKeyGUID);
     SHA1::Digest hash;
     sha1.computeHash(hash);
     return base64EncodeToString(hash.data(), SHA1::hashSize);

--- a/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
@@ -47,8 +47,7 @@ public:
     PAL_EXPORT static std::unique_ptr<CryptoDigest> create(Algorithm);
     PAL_EXPORT ~CryptoDigest();
 
-    void addBytes(std::span<const uint8_t>);
-    PAL_EXPORT void addBytes(const void* input, size_t length);
+    PAL_EXPORT void addBytes(std::span<const uint8_t>);
     PAL_EXPORT Vector<uint8_t> computeHash();
     PAL_EXPORT String toHexString();
     PAL_EXPORT static std::optional<Vector<uint8_t>> computeHash(Algorithm, const Vector<uint8_t>&, bool);
@@ -57,10 +56,5 @@ public:
 private:
     std::unique_ptr<CryptoDigestContext> m_context;
 };
-
-inline void CryptoDigest::addBytes(std::span<const uint8_t> input)
-{
-    return addBytes(input.data(), input.size());
-}
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.mm
+++ b/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.mm
@@ -119,25 +119,25 @@ std::unique_ptr<CryptoDigest> CryptoDigest::create(CryptoDigest::Algorithm algor
     return digest;
 }
 
-void CryptoDigest::addBytes(const void* input, size_t length)
+void CryptoDigest::addBytes(std::span<const uint8_t> input)
 {
     switch (m_context->algorithm) {
     case CryptoDigest::Algorithm::SHA_1:
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        CC_SHA1_Update(toSHA1Context(m_context.get()), input, length);
+        CC_SHA1_Update(toSHA1Context(m_context.get()), static_cast<const void*>(input.data()), input.size());
         ALLOW_DEPRECATED_DECLARATIONS_END
         return;
     case CryptoDigest::Algorithm::SHA_224:
-        CC_SHA224_Update(toSHA224Context(m_context.get()), input, length);
+        CC_SHA224_Update(toSHA224Context(m_context.get()), static_cast<const void*>(input.data()), input.size());
         return;
     case CryptoDigest::Algorithm::SHA_256:
-        CC_SHA256_Update(toSHA256Context(m_context.get()), input, length);
+        CC_SHA256_Update(toSHA256Context(m_context.get()), static_cast<const void*>(input.data()), input.size());
         return;
     case CryptoDigest::Algorithm::SHA_384:
-        CC_SHA384_Update(toSHA384Context(m_context.get()), input, length);
+        CC_SHA384_Update(toSHA384Context(m_context.get()), static_cast<const void*>(input.data()), input.size());
         return;
     case CryptoDigest::Algorithm::SHA_512:
-        CC_SHA512_Update(toSHA512Context(m_context.get()), input, length);
+        CC_SHA512_Update(toSHA512Context(m_context.get()), static_cast<const void*>(input.data()), input.size());
         return;
     }
 }

--- a/Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp
+++ b/Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp
@@ -78,9 +78,9 @@ std::unique_ptr<CryptoDigest> CryptoDigest::create(CryptoDigest::Algorithm algor
     return digest;
 }
 
-void CryptoDigest::addBytes(const void* input, size_t length)
+void CryptoDigest::addBytes(std::span<const uint8_t> input)
 {
-    gcry_md_write(m_context->md, input, length);
+    gcry_md_write(m_context->md, static_cast<const void*>(input.data()), input.size());
 }
 
 Vector<uint8_t> CryptoDigest::computeHash()

--- a/Source/WebCore/PAL/pal/crypto/win/CryptoDigestWin.cpp
+++ b/Source/WebCore/PAL/pal/crypto/win/CryptoDigestWin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -80,11 +80,11 @@ std::unique_ptr<CryptoDigest> CryptoDigest::create(Algorithm algorithm)
     return nullptr;
 }
 
-void CryptoDigest::addBytes(const void* input, size_t length)
+void CryptoDigest::addBytes(std::span<const uint8_t> input)
 {
-    if (!input || !length)
+    if (input.empty())
         return;
-    RELEASE_ASSERT(CryptHashData(m_context->hHash, reinterpret_cast<const BYTE*>(input), length, 0));
+    RELEASE_ASSERT(CryptHashData(m_context->hHash, reinterpret_cast<const BYTE*>(input.data()), input.size(), 0));
 }
 
 Vector<uint8_t> CryptoDigest::computeHash()

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
@@ -73,7 +73,7 @@ static std::optional<Vector<uint8_t>> gcryptSign(gcry_sexp_t keySexp, const Vect
         if (!digest)
             return std::nullopt;
 
-        digest->addBytes(data.data(), data.size());
+        digest->addBytes(data);
         dataHash = digest->computeHash();
     }
 
@@ -133,7 +133,7 @@ static std::optional<bool> gcryptVerify(gcry_sexp_t keySexp, const Vector<uint8_
         if (!digest)
             return std::nullopt;
 
-        digest->addBytes(data.data(), data.size());
+        digest->addBytes(data);
         dataHash = digest->computeHash();
     }
 

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSASSA_PKCS1_v1_5GCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSASSA_PKCS1_v1_5GCrypt.cpp
@@ -46,7 +46,7 @@ static std::optional<Vector<uint8_t>> gcryptSign(gcry_sexp_t keySexp, const Vect
         if (!digest)
             return std::nullopt;
 
-        digest->addBytes(data.data(), data.size());
+        digest->addBytes(data);
         dataHash = digest->computeHash();
     }
 
@@ -97,7 +97,7 @@ static std::optional<bool> gcryptVerify(gcry_sexp_t keySexp, const Vector<uint8_
         if (!digest)
             return std::nullopt;
 
-        digest->addBytes(data.data(), data.size());
+        digest->addBytes(data);
         dataHash = digest->computeHash();
     }
 

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_PSSGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_PSSGCrypt.cpp
@@ -47,7 +47,7 @@ static std::optional<Vector<uint8_t>> gcryptSign(gcry_sexp_t keySexp, const Vect
         if (!digest)
             return std::nullopt;
 
-        digest->addBytes(data.data(), data.size());
+        digest->addBytes(data);
         dataHash = digest->computeHash();
     }
 
@@ -98,7 +98,7 @@ static std::optional<bool> gcryptVerify(gcry_sexp_t keySexp, const Vector<uint8_
         if (!digest)
             return std::nullopt;
 
-        digest->addBytes(data.data(), data.size());
+        digest->addBytes(data);
         dataHash = digest->computeHash();
     }
 

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -81,14 +81,14 @@ Ref<FontFace> FontFace::create(ScriptExecutionContext& context, const String& fa
             return { };
         },
         [&, fontTrustedTypes] (RefPtr<ArrayBufferView>& arrayBufferView) -> ExceptionOr<void> {
-            if (!arrayBufferView || fontBinaryParsingPolicy(arrayBufferView->data(), arrayBufferView->byteLength(), fontTrustedTypes) == FontParsingPolicy::Deny)
+            if (!arrayBufferView || fontBinaryParsingPolicy(arrayBufferView->span(), fontTrustedTypes) == FontParsingPolicy::Deny)
                 return { };
 
             dataRequiresAsynchronousLoading = populateFontFaceWithArrayBuffer(result->backing(), arrayBufferView.releaseNonNull());
             return { };
         },
         [&, fontTrustedTypes] (RefPtr<ArrayBuffer>& arrayBuffer) -> ExceptionOr<void> {
-            if (!arrayBuffer || fontBinaryParsingPolicy(arrayBuffer->data(), arrayBuffer->byteLength(), fontTrustedTypes) == FontParsingPolicy::Deny)
+            if (!arrayBuffer || fontBinaryParsingPolicy(arrayBuffer->span(), fontTrustedTypes) == FontParsingPolicy::Deny)
                 return { };
 
             unsigned byteLength = arrayBuffer->byteLength();

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1791,7 +1791,7 @@ void Node::setTextContent(String&& text)
 static SHA1::Digest hashPointer(const void* pointer)
 {
     SHA1 sha1;
-    sha1.addBytes(reinterpret_cast<const uint8_t*>(&pointer), sizeof(pointer));
+    sha1.addBytes(std::span { reinterpret_cast<const uint8_t*>(&pointer), sizeof(pointer) });
     SHA1::Digest digest;
     sha1.computeHash(digest);
     return digest;

--- a/Source/WebCore/inspector/DOMPatchSupport.cpp
+++ b/Source/WebCore/inspector/DOMPatchSupport.cpp
@@ -408,7 +408,7 @@ std::unique_ptr<DOMPatchSupport::Digest> DOMPatchSupport::createDigest(Node& nod
     SHA1 sha1;
 
     auto nodeType = node.nodeType();
-    sha1.addBytes(reinterpret_cast<const uint8_t*>(&nodeType), sizeof(nodeType));
+    sha1.addBytes(std::span { reinterpret_cast<const uint8_t*>(&nodeType), sizeof(nodeType) });
     addStringToSHA1(sha1, node.nodeName());
     addStringToSHA1(sha1, node.nodeValue());
 

--- a/Source/WebCore/loader/ResourceCryptographicDigest.cpp
+++ b/Source/WebCore/loader/ResourceCryptographicDigest.cpp
@@ -148,10 +148,10 @@ static PAL::CryptoDigest::Algorithm toCryptoDigestAlgorithm(ResourceCryptographi
     return PAL::CryptoDigest::Algorithm::SHA_512;
 }
 
-ResourceCryptographicDigest cryptographicDigestForBytes(ResourceCryptographicDigest::Algorithm algorithm, const void* bytes, size_t length)
+ResourceCryptographicDigest cryptographicDigestForBytes(ResourceCryptographicDigest::Algorithm algorithm, std::span<const uint8_t> bytes)
 {
     auto cryptoDigest = PAL::CryptoDigest::create(toCryptoDigestAlgorithm(algorithm));
-    cryptoDigest->addBytes(bytes, length);
+    cryptoDigest->addBytes(bytes);
     return { algorithm, cryptoDigest->computeHash() };
 }
 

--- a/Source/WebCore/loader/ResourceCryptographicDigest.h
+++ b/Source/WebCore/loader/ResourceCryptographicDigest.h
@@ -74,7 +74,7 @@ std::optional<EncodedResourceCryptographicDigest> parseEncodedCryptographicDiges
 std::optional<ResourceCryptographicDigest> decodeEncodedResourceCryptographicDigest(const EncodedResourceCryptographicDigest&);
 
 ResourceCryptographicDigest cryptographicDigestForSharedBuffer(ResourceCryptographicDigest::Algorithm, const FragmentedSharedBuffer*);
-ResourceCryptographicDigest cryptographicDigestForBytes(ResourceCryptographicDigest::Algorithm, const void* bytes, size_t length);
+ResourceCryptographicDigest cryptographicDigestForBytes(ResourceCryptographicDigest::Algorithm, std::span<const uint8_t> bytes);
 
 }
 

--- a/Source/WebCore/loader/cache/TrustedFonts.h
+++ b/Source/WebCore/loader/cache/TrustedFonts.h
@@ -55,6 +55,5 @@ enum class FontParsingPolicy : uint8_t {
 };
 
 FontParsingPolicy fontBinaryParsingPolicy(std::span<const uint8_t>, DownloadableBinaryFontTrustedTypes);
-FontParsingPolicy fontBinaryParsingPolicy(const void*, size_t, DownloadableBinaryFontTrustedTypes);
 
 } // namespace WebCore

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -395,7 +395,7 @@ static Vector<ContentSecurityPolicyHash> generateHashesForContent(const StringVi
     CString utf8Content = content.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
     Vector<ContentSecurityPolicyHash> hashes;
     for (auto algorithm : algorithms) {
-        auto hash = cryptographicDigestForBytes(algorithm, utf8Content.data(), utf8Content.length());
+        auto hash = cryptographicDigestForBytes(algorithm, utf8Content.span());
         hashes.append(hash);
     }
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -157,12 +157,11 @@ static void addStringToSHA1(SHA1& sha1, const String& string)
     if (string.is8Bit() && string.containsOnlyASCII()) {
         const uint8_t nullByte = 0;
         sha1.addBytes(string.span8());
-        sha1.addBytes(&nullByte, 1);
+        sha1.addBytes(std::span { &nullByte, 1 });
         return;
     }
 
-    auto utf8 = string.utf8();
-    sha1.addBytes(utf8.dataAsUInt8Ptr(), utf8.length() + 1); // Include terminating null byte.
+    sha1.addBytes(string.utf8().spanIncludingNullTerminator());
 }
 
 String RealtimeMediaSourceCenter::hashStringWithSalt(const String& id, const String& hashSalt)

--- a/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
+++ b/Source/WebCore/platform/network/soup/SoupNetworkSession.cpp
@@ -85,7 +85,7 @@ private:
             return String();
 
         auto digest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-        digest->addBytes(certificateData->data, certificateData->len);
+        digest->addBytes(std::span { certificateData->data, certificateData->len });
 
         auto hash = digest->computeHash();
         return base64EncodeToString(hash);

--- a/Source/WebCore/storage/StorageUtilities.cpp
+++ b/Source/WebCore/storage/StorageUtilities.cpp
@@ -93,7 +93,7 @@ String encodeSecurityOriginForFileName(FileSystem::Salt salt, const SecurityOrig
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto originString = origin.toString().utf8();
     crypto->addBytes(originString.span());
-    crypto->addBytes(salt.data(), salt.size());
+    crypto->addBytes(salt);
     auto hash = crypto->computeHash();
     return base64URLEncodeToString(hash.data(), hash.size());
 }

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -51,7 +51,7 @@ SWScriptStorage::SWScriptStorage(const String& directory)
 String SWScriptStorage::sha2Hash(const String& input) const
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    crypto->addBytes(m_salt.data(), m_salt.size());
+    crypto->addBytes(m_salt);
     auto inputUTF8 = input.utf8();
     crypto->addBytes(inputUTF8.span());
     auto hash = crypto->computeHash();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
@@ -82,7 +82,7 @@ Data adoptAndMapFile(FileSystem::PlatformFileHandle handle, size_t offset, size_
 SHA1::Digest computeSHA1(const Data& data, const Salt& salt)
 {
     SHA1 sha1;
-    sha1.addBytes(salt.data(), salt.size());
+    sha1.addBytes(salt);
     data.apply([&sha1](std::span<const uint8_t> span) {
         sha1.addBytes(span);
         return true;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -54,7 +54,7 @@ static bool shouldStoreBodyAsBlob(const Vector<uint8_t>& bodyData)
 static SHA1::Digest computeSHA1(std::span<const uint8_t> span, FileSystem::Salt salt)
 {
     SHA1 sha1;
-    sha1.addBytes(salt.data(), salt.size());
+    sha1.addBytes(salt);
     sha1.addBytes(span);
     SHA1::Digest digest;
     sha1.computeHash(digest);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -83,7 +83,7 @@ static String encode(const String& string, FileSystem::Salt salt)
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
     auto utf8String = string.utf8();
     crypto->addBytes(utf8String.span());
-    crypto->addBytes(salt.data(), salt.size());
+    crypto->addBytes(salt);
     auto hash = crypto->computeHash();
     return base64URLEncodeToString(hash.data(), hash.size());
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
@@ -105,7 +105,7 @@ static RetainPtr<NSData> produceClientDataJson(_WKWebAuthenticationType type, NS
 static Vector<uint8_t> produceClientDataJsonHash(NSData *clientDataJson)
 {
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
-    crypto->addBytes(clientDataJson.bytes, clientDataJson.length);
+    crypto->addBytes(span(clientDataJson));
     return crypto->computeHash();
 }
 
@@ -617,7 +617,7 @@ static void createNSErrorFromWKErrorIfNecessary(NSError **error, WKErrorCode err
 
     NSData *nsPublicKeyData = (NSData *)publicKeyDataRep.get();
     auto digest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_1);
-    digest->addBytes(nsPublicKeyData.bytes, nsPublicKeyData.length);
+    digest->addBytes(span(nsPublicKeyData));
     auto credentialId = digest->computeHash();
     auto nsCredentialId = adoptNS([[NSData alloc] initWithBytes:credentialId.data() length:credentialId.size()]);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -515,7 +515,7 @@ void LocalAuthenticator::continueMakeCredentialAfterUserVerification(SecAccessCo
     Vector<uint8_t> credentialId;
     {
         auto digest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_1);
-        digest->addBytes(nsPublicKeyData.bytes, nsPublicKeyData.length);
+        digest->addBytes(span(nsPublicKeyData));
         credentialId = digest->computeHash();
         m_provisionalCredentialId = toNSData(credentialId);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm
@@ -81,7 +81,7 @@ std::pair<Vector<uint8_t>, Vector<uint8_t>> credentialIdAndCosePubKeyForPrivateK
     Vector<uint8_t> credentialId;
     {
         auto digest = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_1);
-        digest->addBytes(nsPublicKeyData.bytes, nsPublicKeyData.length);
+        digest->addBytes(span(nsPublicKeyData));
         credentialId = digest->computeHash();
     }
 

--- a/Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp
+++ b/Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp
@@ -92,12 +92,12 @@ void computeSHA1HashStringForBitmapContext(BitmapContext* context, char hashStri
             uint32_t buffer[pixelsWide];
             for (unsigned column = 0; column < pixelsWide; column++)
                 buffer[column] = OSReadLittleInt32(bitmapData, 4 * column);
-            sha1.addBytes(reinterpret_cast<const uint8_t*>(buffer), 4 * pixelsWide);
+            sha1.addBytes(std::span { reinterpret_cast<const uint8_t*>(buffer), 4 * pixelsWide });
             bitmapData += bytesPerRow;
         }
     } else {
         for (unsigned row = 0; row < pixelsHigh; row++) {
-            sha1.addBytes(bitmapData, 4 * pixelsWide);
+            sha1.addBytes(std::span { bitmapData, 4 * pixelsWide });
             bitmapData += bytesPerRow;
         }
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/BloomFilter.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/BloomFilter.cpp
@@ -45,7 +45,7 @@ static Vector<SHA1::Digest> generateRandomDigests(size_t hashCount)
     SHA1 sha1;
     for (unsigned i = 0; i < hashCount; ++i) {
         double random = cryptographicallyRandomUnitInterval();
-        sha1.addBytes(reinterpret_cast<uint8_t*>(&random), sizeof(double));
+        sha1.addBytes(std::span { reinterpret_cast<uint8_t*>(&random), sizeof(double) });
         SHA1::Digest digest;
         sha1.computeHash(digest);
         hashes.append(digest);

--- a/Tools/TestWebKitAPI/Tests/WebCore/CryptoDigest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CryptoDigest.cpp
@@ -50,7 +50,7 @@ static void expect(PAL::CryptoDigest::Algorithm algorithm, const CString& input,
     auto cryptoDigest = PAL::CryptoDigest::create(algorithm);
 
     for (int i = 0; i < repeat; ++i)
-        cryptoDigest->addBytes(input.data(), input.length());
+        cryptoDigest->addBytes(input.span());
 
     CString actual = toHex(cryptoDigest->computeHash());
 

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -550,10 +550,10 @@ void Connection::webSocketHandshake(CompletionHandler<void()>&& connectionHandle
             const char* keyEnd = strnstr(keyBegin, "\r\n", request.size() + (keyBegin - request.data()));
             ASSERT(keyEnd);
 
-            constexpr auto* webSocketKeyGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+            const auto webSocketKeyGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"_span;
             SHA1 sha1;
-            sha1.addBytes(reinterpret_cast<const uint8_t*>(keyBegin), keyEnd - keyBegin);
-            sha1.addBytes(reinterpret_cast<const uint8_t*>(webSocketKeyGUID), strlen(webSocketKeyGUID));
+            sha1.addBytes(std::span { reinterpret_cast<const uint8_t*>(keyBegin), static_cast<size_t>(keyEnd - keyBegin) });
+            sha1.addBytes(webSocketKeyGUID);
             SHA1::Digest hash;
             sha1.computeHash(hash);
             return base64EncodeToString(hash.data(), SHA1::hashSize);

--- a/Tools/WebKitTestRunner/cairo/TestInvocationCairo.cpp
+++ b/Tools/WebKitTestRunner/cairo/TestInvocationCairo.cpp
@@ -54,7 +54,7 @@ static void computeSHA1HashStringForCairoSurface(cairo_surface_t* surface, char 
     SHA1 sha1;
     unsigned char* bitmapData = static_cast<unsigned char*>(cairo_image_surface_get_data(surface));
     for (size_t row = 0; row < pixelsHigh; ++row) {
-        sha1.addBytes(bitmapData, 4 * pixelsWide);
+        sha1.addBytes(std::span { bitmapData, 4 * pixelsWide });
         bitmapData += bytesPerRow;
     }
     SHA1::Digest hash;

--- a/Tools/WebKitTestRunner/cg/TestInvocationCG.cpp
+++ b/Tools/WebKitTestRunner/cg/TestInvocationCG.cpp
@@ -95,7 +95,7 @@ static std::optional<std::string> computeSHA1HashStringForContext(CGContextRef b
 #endif
     {
         for (unsigned row = 0; row < pixelsHigh; row++) {
-            sha1.addBytes(bitmapData, 4 * pixelsWide);
+            sha1.addBytes(std::span { bitmapData, 4 * pixelsWide });
             bitmapData += bytesPerRow;
         }
     }

--- a/Tools/WebKitTestRunner/skia/TestInvocationSkia.cpp
+++ b/Tools/WebKitTestRunner/skia/TestInvocationSkia.cpp
@@ -50,7 +50,7 @@ static std::string computeSHA1HashStringForPixmap(const SkPixmap& pixmap)
     SHA1 sha1;
     const auto* bitmapData = pixmap.addr8();
     for (size_t row = 0; row < pixelsHight; ++row) {
-        sha1.addBytes(bitmapData, 4 * pixelsWidth);
+        sha1.addBytes(std::span { bitmapData, 4 * pixelsWidth });
         bitmapData += bytesPerRow;
     }
     auto hexString = sha1.computeHexDigest();


### PR DESCRIPTION
#### 779251105768188876c269d293475f2a65f2152c
<pre>
Complete transition to std::span in CryptoDigest-related code
<a href="https://bugs.webkit.org/show_bug.cgi?id=271488">https://bugs.webkit.org/show_bug.cgi?id=271488</a>
&lt;<a href="https://rdar.apple.com/problem/125256518">rdar://problem/125256518</a>&gt;

Reviewed by Chris Dumez and Sihui Liu.

Following the changes in Bug 249414 and Bug 271383, complete the work of
moving to std::span in CryptoDigest-related code.

* Source/JavaScriptCore/API/JSScript.mm:
(-[JSScript readCache]):
(-[JSScript writeCache:]):
* Source/JavaScriptCore/bytecode/CodeBlockHash.cpp:
(JSC::CodeBlockHash::CodeBlockHash):
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorUtils.cpp:
(Inspector::backendCommandsHash):
* Source/JavaScriptCore/runtime/CachedBytecode.h:
(JSC::CachedBytecode::span const):
* Source/WTF/wtf/SHA1.h:
* Source/WTF/wtf/persistence/PersistentEncoder.cpp:
(WTF::Persistence::Encoder::updateChecksumForData):
* Source/WTF/wtf/persistence/PersistentEncoder.h:
(WTF::Persistence::Encoder::updateChecksumForNumber):
* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp:
(WebCore::buildClientDataJsonHash):
* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::WebSocketHandshake::getExpectedWebSocketAccept):
* Source/WebCore/PAL/pal/crypto/CryptoDigest.h:
(PAL::CryptoDigest::addBytes): Deleted.
* Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.mm:
(PAL::CryptoDigest::addBytes):
* Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp:
(PAL::CryptoDigest::addBytes):
* Source/WebCore/PAL/pal/crypto/openssl/CryptoDigestOpenSSL.cpp:
(PAL::CryptoDigest::addBytes):
* Source/WebCore/PAL/pal/crypto/win/CryptoDigestWin.cpp:
(PAL::CryptoDigest::addBytes):
* Source/WebCore/css/FontFace.cpp:
(WebCore::FontFace::create):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp:
(WebCore::gcryptSign):
(WebCore::gcryptVerify):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSASSA_PKCS1_v1_5GCrypt.cpp:
(WebCore::gcryptSign):
(WebCore::gcryptVerify):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmRSA_PSSGCrypt.cpp:
(WebCore::gcryptSign):
(WebCore::gcryptVerify):
* Source/WebCore/dom/Node.cpp:
(WebCore::hashPointer):
* Source/WebCore/inspector/DOMPatchSupport.cpp:
(WebCore::DOMPatchSupport::createDigest):
* Source/WebCore/loader/ResourceCryptographicDigest.cpp:
(WebCore::cryptographicDigestForBytes):
* Source/WebCore/loader/ResourceCryptographicDigest.h:
* Source/WebCore/loader/cache/TrustedFonts.cpp:
(WebCore::hashForFontData):
(WebCore::fontBinaryParsingPolicy):
* Source/WebCore/loader/cache/TrustedFonts.h:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::generateHashesForContent):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::addStringToSHA1):
* Source/WebCore/platform/network/soup/SoupNetworkSession.cpp:
(WebCore::HostTLSCertificateSet::computeCertificateHash):
* Source/WebCore/storage/StorageUtilities.cpp:
(WebCore::StorageUtilities::encodeSecurityOriginForFileName):
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::sha2Hash const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp:
(WebKit::NetworkCache::computeSHA1):
* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp:
(WebKit::NetworkCache::hashString):
(WebKit::NetworkCache::Key::computeHash const):
(WebKit::NetworkCache::Key::partitionToPartitionHash):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::computeSHA1):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::encode):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(produceClientDataJsonHash):
(+[_WKWebAuthenticationPanel importLocalAuthenticatorWithAccessGroup:credential:error:]):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::continueMakeCredentialAfterUserVerification):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorUtils.mm:
(WebKit::credentialIdAndCosePubKeyForPrivateKey):
* Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp:
(computeSHA1HashStringForBitmapContext):
* Tools/TestWebKitAPI/Tests/WTF/BloomFilter.cpp:
(TestWebKitAPI::generateRandomDigests):
* Tools/TestWebKitAPI/Tests/WebCore/CryptoDigest.cpp:
(TestWebKitAPI::expect):
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::Connection::webSocketHandshake):
* Tools/WebKitTestRunner/cairo/TestInvocationCairo.cpp:
(WTR::computeSHA1HashStringForCairoSurface):
* Tools/WebKitTestRunner/skia/TestInvocationSkia.cpp:
(WTR::computeSHA1HashStringForPixmap):

* Tools/WebKitTestRunner/cg/TestInvocationCG.cpp:
(WTR::computeSHA1HashStringForContext):

Canonical link: <a href="https://commits.webkit.org/276673@main">https://commits.webkit.org/276673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20298cb81fc60e10ed238cc6b153e265465dd983

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47941 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41286 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37133 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39053 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18233 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40138 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3325 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38498 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49650 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44747 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16793 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44168 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21567 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42981 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10075 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21928 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51906 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21254 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10590 "Passed tests") | 
<!--EWS-Status-Bubble-End-->