### PR TITLE
Update Modules/mediastream to use std::span more

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp
@@ -43,11 +43,11 @@ static inline void writeUInt64(uint8_t* data, uint64_t value, uint8_t valueLengt
         *data++ = (value >> ((valueLength - 1 - i) * 8)) & 0xff;
 }
 
-static inline uint64_t readUInt64(const uint8_t* data, size_t size)
+static inline uint64_t readUInt64(std::span<const uint8_t> data)
 {
     uint64_t value = 0;
-    while (size--)
-        value = (value << 8) | *data++;
+    for (auto byte : data)
+        value = (value << 8) | byte;
     return value;
 }
 
@@ -106,14 +106,15 @@ struct SFrameHeaderInfo {
     uint64_t keyId;
     uint64_t counter;
 };
-static inline std::optional<SFrameHeaderInfo> parseSFrameHeader(const uint8_t* data, size_t size)
+static inline std::optional<SFrameHeaderInfo> parseSFrameHeader(std::span<const uint8_t> data)
 {
-    auto* start = data;
+    auto* start = data.data();
 
     uint64_t keyId = 0;
     uint64_t counter = 0;
 
-    auto firstByte = *data++;
+    auto firstByte = data.front();
+    data = data.subspan(1);
 
     // Signature bit.
     if (hasSignature(firstByte))
@@ -121,25 +122,25 @@ static inline std::optional<SFrameHeaderInfo> parseSFrameHeader(const uint8_t* d
 
     size_t counterLength = ((firstByte >> 4) & 0x07) + 1;
 
-    if (size < counterLength + 1)
+    if (data.size() < counterLength + 1)
         return { };
 
     if (hasLongKeyLength(firstByte)) {
         size_t keyLength = (firstByte & 0x07) + 1;
-        if (size < counterLength + keyLength + 1)
+        if (data.size() < counterLength + keyLength + 1)
             return { };
 
-        keyId = readUInt64(data, keyLength);
-        data += keyLength;
+        keyId = readUInt64(data.first(keyLength));
+        data = data.subspan(keyLength);
 
-        counter = readUInt64(data, counterLength);
-        data += counterLength;
+        counter = readUInt64(data.first(counterLength));
+        data = data.subspan(counterLength);
     } else {
         keyId = firstByte & 0x07;
-        counter = readUInt64(data, counterLength);
-        data += counterLength;
+        counter = readUInt64(data.first(counterLength));
+        data = data.subspan(counterLength);
     }
-    uint8_t headerSize = data - start;
+    uint8_t headerSize = data.data() - start;
     return SFrameHeaderInfo { headerSize, keyId, counter };
 }
 
@@ -208,26 +209,20 @@ ExceptionOr<void> RTCRtpSFrameTransformer::updateEncryptionKey(const Vector<uint
 
 RTCRtpSFrameTransformer::TransformResult RTCRtpSFrameTransformer::decryptFrame(std::span<const uint8_t> data)
 {
-    auto* frameData = data.data();
-    auto frameSize = data.size();
-
     Vector<uint8_t> buffer;
     switch (m_compatibilityMode) {
     case CompatibilityMode::H264: {
-        auto offset = computeH264PrefixOffset(frameData, frameSize);
-        frameData += offset;
-        frameSize -= offset;
-        if (needsRbspUnescaping(frameData, frameSize)) {
-            buffer = fromRbsp(frameData, frameSize);
-            frameData = buffer.data();
-            frameSize = buffer.size();
+        auto offset = computeH264PrefixOffset(data);
+        data = data.subspan(offset);
+        if (needsRbspUnescaping(data)) {
+            buffer = fromRbsp(data);
+            data = buffer.span();
         }
         break;
     }
     case CompatibilityMode::VP8: {
-        auto offset = computeVP8PrefixOffset(frameData, frameSize);
-        frameData += offset;
-        frameSize -= offset;
+        auto offset = computeVP8PrefixOffset(data);
+        data = data.subspan(offset);
         break;
     }
     case CompatibilityMode::None:
@@ -236,7 +231,7 @@ RTCRtpSFrameTransformer::TransformResult RTCRtpSFrameTransformer::decryptFrame(s
 
     Locker locker { m_keyLock };
 
-    auto header = parseSFrameHeader(frameData, frameSize);
+    auto header = parseSFrameHeader(data);
 
     if (!header)
         return makeUnexpected(ErrorInformation {Error::Syntax, "Invalid header"_s, 0 });
@@ -254,14 +249,14 @@ RTCRtpSFrameTransformer::TransformResult RTCRtpSFrameTransformer::decryptFrame(s
             return makeUnexpected(ErrorInformation {Error::Other, result.exception().message(), 0 });
     }
 
-    if (frameSize < (header->size + m_authenticationSize))
+    if (data.size() < (header->size + m_authenticationSize))
         return makeUnexpected(ErrorInformation { Error::Syntax, "Chunk is too small for authentication size"_s, 0 });
 
     auto iv = computeIV(m_counter, m_saltKey);
 
     // Compute signature
-    auto* transmittedSignature = frameData + frameSize - m_authenticationSize;
-    auto signature = computeEncryptedDataSignature(iv, frameData, header->size, frameData + header->size, frameSize  - m_authenticationSize - header->size, m_authenticationKey);
+    auto transmittedSignature = data.last(m_authenticationSize);
+    auto signature = computeEncryptedDataSignature(iv, data.first(header->size), data.subspan(header->size, data.size() - m_authenticationSize - header->size), m_authenticationKey);
     for (size_t cptr = 0; cptr < m_authenticationSize; ++cptr) {
         if (signature[cptr] != transmittedSignature[cptr]) {
             // FIXME: We should try ratcheting.
@@ -270,8 +265,8 @@ RTCRtpSFrameTransformer::TransformResult RTCRtpSFrameTransformer::decryptFrame(s
     }
 
     // Decrypt data
-    auto dataSize = frameSize - header->size - m_authenticationSize;
-    auto result = decryptData(frameData + header->size, dataSize, iv, m_encryptionKey);
+    auto dataSize = data.size() - header->size - m_authenticationSize;
+    auto result = decryptData(data.subspan(header->size, dataSize), iv, m_encryptionKey);
 
     if (result.hasException())
         return makeUnexpected(ErrorInformation { Error::Other, result.exception().message(), 0 });
@@ -281,18 +276,15 @@ RTCRtpSFrameTransformer::TransformResult RTCRtpSFrameTransformer::decryptFrame(s
 
 RTCRtpSFrameTransformer::TransformResult RTCRtpSFrameTransformer::encryptFrame(std::span<const uint8_t> data)
 {
-    auto* frameData = data.data();
-    auto frameSize = data.size();
-
     static const unsigned MaxHeaderSize = 17;
 
     SFrameCompatibilityPrefixBuffer prefixBuffer;
     switch (m_compatibilityMode) {
     case CompatibilityMode::H264:
-        prefixBuffer = computeH264PrefixBuffer(frameData, frameSize);
+        prefixBuffer = computeH264PrefixBuffer(data);
         break;
     case CompatibilityMode::VP8:
-        prefixBuffer = computeVP8PrefixBuffer(frameData, frameSize);
+        prefixBuffer = computeVP8PrefixBuffer(data);
         break;
     case CompatibilityMode::None:
         break;
@@ -302,7 +294,7 @@ RTCRtpSFrameTransformer::TransformResult RTCRtpSFrameTransformer::encryptFrame(s
 
     auto iv = computeIV(m_counter, m_saltKey);
 
-    Vector<uint8_t> transformedData(prefixBuffer.size + frameSize + MaxHeaderSize + m_authenticationSize);
+    Vector<uint8_t> transformedData(prefixBuffer.size + data.size() + MaxHeaderSize + m_authenticationSize);
 
     if (prefixBuffer.data)
         std::memcpy(transformedData.data(), prefixBuffer.data, prefixBuffer.size);
@@ -324,16 +316,16 @@ RTCRtpSFrameTransformer::TransformResult RTCRtpSFrameTransformer::encryptFrame(s
     transformedData.shrink(transformedData.size() - (MaxHeaderSize - headerSize));
 
     // Fill encrypted data
-    auto encryptedData = encryptData(frameData, frameSize, iv, m_encryptionKey);
+    auto encryptedData = encryptData(data, iv, m_encryptionKey);
     ASSERT(!encryptedData.hasException());
     if (encryptedData.hasException())
         return makeUnexpected(ErrorInformation { Error::Other, encryptedData.exception().message(), 0 });
 
-    std::memcpy(newDataPointer + headerSize, encryptedData.returnValue().data(), frameSize);
+    std::memcpy(newDataPointer + headerSize, encryptedData.returnValue().data(), data.size());
 
     // Fill signature
-    auto signature = computeEncryptedDataSignature(iv, newDataPointer, headerSize, newDataPointer + headerSize, frameSize, m_authenticationKey);
-    std::memcpy(newDataPointer + frameSize + headerSize, signature.data(), m_authenticationSize);
+    auto signature = computeEncryptedDataSignature(iv, std::span { newDataPointer, headerSize }, std::span { newDataPointer + headerSize, data.size() }, m_authenticationKey);
+    std::memcpy(newDataPointer + data.size() + headerSize, signature.data(), m_authenticationSize);
 
     if (m_compatibilityMode == CompatibilityMode::H264)
         toRbsp(transformedData, prefixBuffer.size);
@@ -367,17 +359,17 @@ ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeEncryptionKey(const
     return Exception { ExceptionCode::NotSupportedError };
 }
 
-ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::decryptData(const uint8_t*, size_t, const Vector<uint8_t>&, const Vector<uint8_t>&)
+ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::decryptData(std::span<const uint8_t>, const Vector<uint8_t>&, const Vector<uint8_t>&)
 {
     return Exception { ExceptionCode::NotSupportedError };
 }
 
-ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::encryptData(const uint8_t*, size_t, const Vector<uint8_t>&, const Vector<uint8_t>&)
+ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::encryptData(std::span<const uint8_t>, const Vector<uint8_t>&, const Vector<uint8_t>&)
 {
     return Exception { ExceptionCode::NotSupportedError };
 }
 
-Vector<uint8_t> RTCRtpSFrameTransformer::computeEncryptedDataSignature(const Vector<uint8_t>&, const uint8_t*, size_t, const uint8_t*, size_t, const Vector<uint8_t>&)
+Vector<uint8_t> RTCRtpSFrameTransformer::computeEncryptedDataSignature(const Vector<uint8_t>&, std::span<const uint8_t>, std::span<const uint8_t>, const Vector<uint8_t>&)
 {
     return { };
 }

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h
@@ -81,9 +81,9 @@ private:
     ExceptionOr<Vector<uint8_t>> computeAuthenticationKey(const Vector<uint8_t>&);
     ExceptionOr<Vector<uint8_t>> computeEncryptionKey(const Vector<uint8_t>&);
 
-    ExceptionOr<Vector<uint8_t>> encryptData(const uint8_t*, size_t, const Vector<uint8_t>& iv, const Vector<uint8_t>& key);
-    ExceptionOr<Vector<uint8_t>> decryptData(const uint8_t*, size_t, const Vector<uint8_t>& iv, const Vector<uint8_t>& key);
-    Vector<uint8_t> computeEncryptedDataSignature(const Vector<uint8_t>& nonce, const uint8_t* header, size_t headerSize, const uint8_t* data, size_t dataSize, const Vector<uint8_t>& key);
+    ExceptionOr<Vector<uint8_t>> encryptData(std::span<const uint8_t>, const Vector<uint8_t>& iv, const Vector<uint8_t>& key);
+    ExceptionOr<Vector<uint8_t>> decryptData(std::span<const uint8_t>, const Vector<uint8_t>& iv, const Vector<uint8_t>& key);
+    Vector<uint8_t> computeEncryptedDataSignature(const Vector<uint8_t>& nonce, std::span<const uint8_t> header, std::span<const uint8_t> data, const Vector<uint8_t>& key);
     void updateAuthenticationSize();
 
     mutable Lock m_keyLock;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp
@@ -69,14 +69,14 @@ ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeEncryptionKey(const
     return deriveHDKFSHA256Bits(key.returnValue().data(), 16, usage, sizeof(usage) - 1, info, sizeof(info) - 1, 128);
 }
 
-ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::decryptData(const uint8_t* data, size_t size, const Vector<uint8_t>& iv, const Vector<uint8_t>& key)
+ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::decryptData(std::span<const uint8_t> data, const Vector<uint8_t>& iv, const Vector<uint8_t>& key)
 {
-    return transformAESCTR(kCCDecrypt, iv, iv.size(), key, data, size);
+    return transformAESCTR(kCCDecrypt, iv, iv.size(), key, data);
 }
 
-ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::encryptData(const uint8_t* data, size_t size, const Vector<uint8_t>& iv, const Vector<uint8_t>& key)
+ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::encryptData(std::span<const uint8_t> data, const Vector<uint8_t>& iv, const Vector<uint8_t>& key)
 {
-    return transformAESCTR(kCCEncrypt, iv, iv.size(), key, data, size);
+    return transformAESCTR(kCCEncrypt, iv, iv.size(), key, data);
 }
 
 static inline Vector<uint8_t, 8> encodeBigEndian(uint64_t value)
@@ -89,10 +89,10 @@ static inline Vector<uint8_t, 8> encodeBigEndian(uint64_t value)
     return result;
 }
 
-Vector<uint8_t> RTCRtpSFrameTransformer::computeEncryptedDataSignature(const Vector<uint8_t>& nonce, const uint8_t* header, size_t headerSize, const uint8_t* data, size_t dataSize, const Vector<uint8_t>& key)
+Vector<uint8_t> RTCRtpSFrameTransformer::computeEncryptedDataSignature(const Vector<uint8_t>& nonce, std::span<const uint8_t> header, std::span<const uint8_t> data, const Vector<uint8_t>& key)
 {
-    auto headerLength = encodeBigEndian(headerSize);
-    auto dataLength = encodeBigEndian(dataSize);
+    auto headerLength = encodeBigEndian(header.size());
+    auto dataLength = encodeBigEndian(data.size());
 
     Vector<uint8_t> result(CC_SHA256_DIGEST_LENGTH);
     CCHmacContext context;
@@ -100,8 +100,8 @@ Vector<uint8_t> RTCRtpSFrameTransformer::computeEncryptedDataSignature(const Vec
     CCHmacUpdate(&context, headerLength.data(), headerLength.size());
     CCHmacUpdate(&context, dataLength.data(), dataLength.size());
     CCHmacUpdate(&context, nonce.data(), 12);
-    CCHmacUpdate(&context, header, headerSize);
-    CCHmacUpdate(&context, data, dataSize);
+    CCHmacUpdate(&context, header.data(), header.size());
+    CCHmacUpdate(&context, data.data(), data.size());
     CCHmacFinal(&context, result.data());
 
     return result;

--- a/Source/WebCore/Modules/mediastream/SFrameUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/SFrameUtils.cpp
@@ -52,9 +52,9 @@ static inline bool isIDRNALU(uint8_t data)
     return (data & 0x1F) == 5;
 }
 
-static inline void findNalus(const uint8_t* frameData, size_t frameSize, size_t offset, const Function<bool(size_t)>& callback)
+static inline void findNalus(std::span<const uint8_t> frameData, size_t offset, const Function<bool(size_t)>& callback)
 {
-    for (size_t i = 4 + offset; i < frameSize; ++i) {
+    for (size_t i = 4 + offset; i < frameData.size(); ++i) {
         if (frameData[i - 4] == 0 && frameData[i - 3] == 0 && frameData[i - 2] == 0 && frameData[i - 1] == 1) {
             if (callback(i))
                 return;
@@ -62,10 +62,10 @@ static inline void findNalus(const uint8_t* frameData, size_t frameSize, size_t 
     }
 }
 
-size_t computeH264PrefixOffset(const uint8_t* frameData, size_t frameSize)
+size_t computeH264PrefixOffset(std::span<const uint8_t> frameData)
 {
     size_t offset = 0;
-    findNalus(frameData, frameSize, 0, [&offset, &frameData](auto position) {
+    findNalus(frameData, 0, [&offset, frameData](auto position) {
         if (isIDRNALU(frameData[position]) || isSliceNALU(frameData[position])) {
             // Skip 00 00 00 01, nalu type byte and the next byte.
             offset = position + 2;
@@ -76,22 +76,22 @@ size_t computeH264PrefixOffset(const uint8_t* frameData, size_t frameSize)
     return offset;
 }
 
-bool needsRbspUnescaping(const uint8_t* frameData, size_t frameSize)
+bool needsRbspUnescaping(std::span<const uint8_t> frameData)
 {
-    for (size_t i = 0; i < frameSize - 3; ++i) {
+    for (size_t i = 0; i < frameData.size() - 3; ++i) {
         if (frameData[i] == 0 && frameData[i + 1] == 0 && frameData[i + 2] == 3)
             return true;
     }
     return false;
 }
 
-Vector<uint8_t> fromRbsp(const uint8_t* frameData, size_t frameSize)
+Vector<uint8_t> fromRbsp(std::span<const uint8_t> frameData)
 {
     Vector<uint8_t> buffer;
-    buffer.reserveInitialCapacity(frameSize);
+    buffer.reserveInitialCapacity(frameData.size());
 
     size_t i;
-    for (i = 0; i < frameSize - 3; ++i) {
+    for (i = 0; i < frameData.size() - 3; ++i) {
         if (frameData[i] == 0 && frameData[i + 1] == 0 && frameData[i + 2] == 3) {
             buffer.append(frameData[i]);
             buffer.append(frameData[i + 1]);
@@ -100,18 +100,18 @@ Vector<uint8_t> fromRbsp(const uint8_t* frameData, size_t frameSize)
         } else
             buffer.append(frameData[i]);
     }
-    for (; i < frameSize; ++i)
+    for (; i < frameData.size(); ++i)
         buffer.append(frameData[i]);
 
     return buffer;
 }
 
-SFrameCompatibilityPrefixBuffer computeH264PrefixBuffer(const uint8_t* frameData, size_t frameSize)
+SFrameCompatibilityPrefixBuffer computeH264PrefixBuffer(std::span<const uint8_t> frameData)
 {
     // Delta and key prefixes assume SPS/PPS with IDs equal to 0 have been transmitted.
     static const uint8_t prefixDeltaFrame[6] = { 0x00, 0x00, 0x00, 0x01, 0x21, 0xe0 };
 
-    if (frameSize < 5)
+    if (frameData.size() < 5)
         return { };
 
     // We assume a key frame starts with SPS, then PPS. Otherwise we wrap it as a delta frame.
@@ -120,7 +120,7 @@ SFrameCompatibilityPrefixBuffer computeH264PrefixBuffer(const uint8_t* frameData
 
     // Search for PPS
     size_t spsPpsLength = 0;
-    findNalus(frameData, frameSize, 5, [frameData, &spsPpsLength](auto position) {
+    findNalus(frameData, 5, [frameData, &spsPpsLength](auto position) {
         if (isPPSNALU(frameData[position]))
             spsPpsLength = position;
         return true;
@@ -129,7 +129,7 @@ SFrameCompatibilityPrefixBuffer computeH264PrefixBuffer(const uint8_t* frameData
         return SFrameCompatibilityPrefixBuffer { prefixDeltaFrame, sizeof(prefixDeltaFrame), { } };
 
     // Search for next NALU to compute the real spsPpsLength, including the next 00 00 00 01.
-    findNalus(frameData, frameSize, spsPpsLength + 1, [&spsPpsLength](auto position) {
+    findNalus(frameData, spsPpsLength + 1, [&spsPpsLength](auto position) {
         spsPpsLength = position;
         return true;
     });
@@ -137,7 +137,7 @@ SFrameCompatibilityPrefixBuffer computeH264PrefixBuffer(const uint8_t* frameData
     Vector<uint8_t> buffer(spsPpsLength + 2);
 IGNORE_GCC_WARNINGS_BEGIN("restrict")
     // https://bugs.webkit.org/show_bug.cgi?id=246862
-    std::memcpy(buffer.data(), frameData, spsPpsLength);
+    std::memcpy(buffer.data(), frameData.data(), spsPpsLength);
 IGNORE_GCC_WARNINGS_END
     buffer[spsPpsLength] = 0x25;
     buffer[spsPpsLength + 1] = 0xb8;
@@ -185,21 +185,20 @@ void toRbsp(Vector<uint8_t>& frame, size_t offset)
     frame = WTFMove(newFrame);
 }
 
-static inline bool isVP8KeyFrame(const uint8_t* frame, size_t size)
+static inline bool isVP8KeyFrame(std::span<const uint8_t> frame)
 {
-    ASSERT_UNUSED(size, size);
-    return !(*frame & 0x01);
+    ASSERT(frame.size());
+    return !(frame.front() & 0x01);
 }
 
-size_t computeVP8PrefixOffset(const uint8_t* frame, size_t size)
+size_t computeVP8PrefixOffset(std::span<const uint8_t> frame)
 {
-    return isVP8KeyFrame(frame, size) ? 10 : 3;
+    return isVP8KeyFrame(frame) ? 10 : 3;
 }
 
-SFrameCompatibilityPrefixBuffer computeVP8PrefixBuffer(const uint8_t* frame, size_t size)
+SFrameCompatibilityPrefixBuffer computeVP8PrefixBuffer(std::span<const uint8_t> frame)
 {
-    Vector<uint8_t> prefix;
-    prefix.append(std::span(frame, isVP8KeyFrame(frame, size) ? 10 : 3));
+    Vector<uint8_t> prefix(frame.first(isVP8KeyFrame(frame) ? 10 : 3));
     return { prefix.data(), prefix.size(), WTFMove(prefix) };
 }
 

--- a/Source/WebCore/Modules/mediastream/SFrameUtils.h
+++ b/Source/WebCore/Modules/mediastream/SFrameUtils.h
@@ -37,15 +37,15 @@ struct SFrameCompatibilityPrefixBuffer {
     Vector<uint8_t> buffer;
 };
 
-size_t computeH264PrefixOffset(const uint8_t*, size_t);
-SFrameCompatibilityPrefixBuffer computeH264PrefixBuffer(const uint8_t*, size_t);
+size_t computeH264PrefixOffset(std::span<const uint8_t>);
+SFrameCompatibilityPrefixBuffer computeH264PrefixBuffer(std::span<const uint8_t>);
 
-WEBCORE_EXPORT bool needsRbspUnescaping(const uint8_t*, size_t);
-WEBCORE_EXPORT Vector<uint8_t> fromRbsp(const uint8_t*, size_t);
+WEBCORE_EXPORT bool needsRbspUnescaping(std::span<const uint8_t>);
+WEBCORE_EXPORT Vector<uint8_t> fromRbsp(std::span<const uint8_t>);
 WEBCORE_EXPORT void toRbsp(Vector<uint8_t>&, size_t);
 
-size_t computeVP8PrefixOffset(const uint8_t*, size_t);
-SFrameCompatibilityPrefixBuffer computeVP8PrefixBuffer(const uint8_t*, size_t);
+size_t computeVP8PrefixOffset(std::span<const uint8_t>);
+SFrameCompatibilityPrefixBuffer computeVP8PrefixBuffer(std::span<const uint8_t>);
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/mediastream/STUNMessageParsing.h
+++ b/Source/WebCore/Modules/mediastream/STUNMessageParsing.h
@@ -41,7 +41,7 @@ struct STUNMessageLengths {
 WEBCORE_EXPORT std::optional<STUNMessageLengths> getSTUNOrTURNMessageLengths(std::span<const uint8_t>);
 
 enum class MessageType { STUN, Data };
-WEBCORE_EXPORT Vector<uint8_t> extractMessages(Vector<uint8_t>&&, MessageType, const Function<void(const uint8_t* data, size_t size)>&);
+WEBCORE_EXPORT Vector<uint8_t> extractMessages(Vector<uint8_t>&&, MessageType, const Function<void(std::span<const uint8_t> data)>&);
 
 } // namespace WebRTC
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCTRMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCTRMac.cpp
@@ -36,13 +36,13 @@ namespace WebCore {
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESCTR::platformEncrypt(const CryptoAlgorithmAesCtrParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& plainText)
 {
     ASSERT(parameters.counterVector().size() == kCCBlockSizeAES128);
-    return transformAESCTR(kCCEncrypt, parameters.counterVector(), parameters.length, key.key(), plainText.data(), plainText.size());
+    return transformAESCTR(kCCEncrypt, parameters.counterVector(), parameters.length, key.key(), plainText.span());
 }
 
 ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESCTR::platformDecrypt(const CryptoAlgorithmAesCtrParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& cipherText)
 {
     ASSERT(parameters.counterVector().size() == kCCBlockSizeAES128);
-    return transformAESCTR(kCCDecrypt, parameters.counterVector(), parameters.length, key.key(), cipherText.data(), cipherText.size());
+    return transformAESCTR(kCCDecrypt, parameters.counterVector(), parameters.length, key.key(), cipherText.span());
 }
 
 

--- a/Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.cpp
@@ -31,14 +31,14 @@
 
 namespace WebCore {
 
-ExceptionOr<Vector<uint8_t>> transformAESCTR(CCOperation operation, const Vector<uint8_t>& counter, size_t counterLength, const Vector<uint8_t>& key, const uint8_t* data, size_t dataSize)
+ExceptionOr<Vector<uint8_t>> transformAESCTR(CCOperation operation, const Vector<uint8_t>& counter, size_t counterLength, const Vector<uint8_t>& key, std::span<const uint8_t> data)
 {
     // FIXME: We should remove the following hack once <rdar://problem/31361050> is fixed.
     // counter = nonce + counter
     // CommonCrypto currently can neither reset the counter nor detect overflow once the counter reaches its max value restricted
     // by the counterLength. It then increments the nonce which should stay same for the whole operation. To remedy this issue,
     // we detect the overflow ahead and divide the operation into two parts.
-    size_t numberOfBlocks = dataSize % kCCBlockSizeAES128 ? dataSize / kCCBlockSizeAES128 + 1 : dataSize / kCCBlockSizeAES128;
+    size_t numberOfBlocks = data.size() % kCCBlockSizeAES128 ? data.size() / kCCBlockSizeAES128 + 1 : data.size() / kCCBlockSizeAES128;
 
     // Detect loop
     if (counterLength < sizeof(size_t) * 8 && numberOfBlocks > (static_cast<size_t>(1) << counterLength))
@@ -49,7 +49,7 @@ ExceptionOr<Vector<uint8_t>> transformAESCTR(CCOperation operation, const Vector
     size_t capacity = counterBlockHelper.countToOverflowSaturating();
 
     // Divide data into two parts if necessary.
-    size_t headSize = dataSize;
+    size_t headSize = data.size();
     if (capacity < numberOfBlocks)
         headSize = capacity * kCCBlockSizeAES128;
 
@@ -62,7 +62,7 @@ ExceptionOr<Vector<uint8_t>> transformAESCTR(CCOperation operation, const Vector
     Vector<uint8_t> head(CCCryptorGetOutputLength(cryptor, headSize, true));
 
     size_t bytesWritten;
-    status = CCCryptorUpdate(cryptor, data, headSize, head.data(), head.size(), &bytesWritten);
+    status = CCCryptorUpdate(cryptor, data.data(), headSize, head.data(), head.size(), &bytesWritten);
     if (status)
         return Exception { ExceptionCode::OperationError };
 
@@ -87,10 +87,10 @@ ExceptionOr<Vector<uint8_t>> transformAESCTR(CCOperation operation, const Vector
     if (status)
         return Exception { ExceptionCode::OperationError };
 
-    size_t tailSize = dataSize - headSize;
+    size_t tailSize = data.size() - headSize;
     Vector<uint8_t> tail(CCCryptorGetOutputLength(cryptor, tailSize, true));
 
-    status = CCCryptorUpdate(cryptor, data + headSize, tailSize, tail.data(), tail.size(), &bytesWritten);
+    status = CCCryptorUpdate(cryptor, data.data() + headSize, tailSize, tail.data(), tail.size(), &bytesWritten);
     if (status)
         return Exception { ExceptionCode::OperationError };
 

--- a/Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.h
+++ b/Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.h
@@ -35,7 +35,7 @@ typedef uint32_t CCOperation;
 
 namespace WebCore {
 
-ExceptionOr<Vector<uint8_t>> transformAESCTR(CCOperation, const Vector<uint8_t>& counter, size_t counterLength, const Vector<uint8_t>& key, const uint8_t* data, size_t dataSize);
+ExceptionOr<Vector<uint8_t>> transformAESCTR(CCOperation, const Vector<uint8_t>& counter, size_t counterLength, const Vector<uint8_t>& key, std::span<const uint8_t> data);
 CCStatus keyDerivationHMAC(CCDigestAlgorithm, const void *, size_t, const void *, size_t, const void *, size_t, void *, size_t);
 ExceptionOr<Vector<uint8_t>> deriveHDKFBits(CCDigestAlgorithm, const uint8_t* key, size_t keySize, const uint8_t* salt, size_t saltSize, const uint8_t* info, size_t infoSize, size_t length);
 ExceptionOr<Vector<uint8_t>> deriveHDKFSHA256Bits(const uint8_t* key, size_t keySize, const uint8_t* salt, size_t saltSize, const uint8_t* info, size_t infoSize, size_t length);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm
@@ -128,8 +128,7 @@ NetworkRTCTCPSocketCocoa::NetworkRTCTCPSocketCocoa(LibWebRTCSocketIdentifier ide
     }).get());
 
     processIncomingData(m_nwConnection.get(), [identifier = m_identifier, connection = m_connection.copyRef(), ip = remoteAddress.ipaddr(), port = remoteAddress.port(), isSTUN = m_isSTUN](Vector<uint8_t>&& buffer) mutable {
-        return WebRTC::extractMessages(WTFMove(buffer), isSTUN ? WebRTC::MessageType::STUN : WebRTC::MessageType::Data, [&](auto* message, auto size) {
-            std::span data(message, size);
+        return WebRTC::extractMessages(WTFMove(buffer), isSTUN ? WebRTC::MessageType::STUN : WebRTC::MessageType::Data, [&](auto data) {
             connection->send(Messages::LibWebRTCNetwork::SignalReadPacket { identifier, data, RTCNetwork::IPAddress(ip), port, rtc::TimeMillis() * 1000 }, 0);
         });
     });

--- a/Tools/TestWebKitAPI/Tests/WebCore/RTCRtpSFrameTransformerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/RTCRtpSFrameTransformerTests.cpp
@@ -392,16 +392,16 @@ TEST(RTCRtpSFrameTransformer, TransformCounter65536)
 TEST(RTCRtpSFrameTransformer, RBSPEscaping)
 {
     uint8_t frame0[] = { 0, 33, 00, 24, 236, 156, 127, 8, 0, 0, 4 };
-    EXPECT_FALSE(WebCore::needsRbspUnescaping(frame0, sizeof(frame0)));
+    EXPECT_FALSE(WebCore::needsRbspUnescaping(frame0));
 
     uint8_t frame0b[] = { 0, 33, 00, 24, 236, 156, 127, 8, 0, 0, 3 };
-    EXPECT_FALSE(WebCore::needsRbspUnescaping(frame0b, sizeof(frame0b)));
+    EXPECT_FALSE(WebCore::needsRbspUnescaping(frame0b));
 
     uint8_t frame1[] = { 0, 33, 00, 24, 236, 156, 127, 8, 0, 0, 3, 1 };
     uint8_t frame1Unescaped[] = { 0, 33, 00, 24, 236, 156, 127, 8, 0, 0, 1 };
-    EXPECT_TRUE(WebCore::needsRbspUnescaping(frame1, sizeof(frame1)));
+    EXPECT_TRUE(WebCore::needsRbspUnescaping(frame1));
 
-    auto result = WebCore::fromRbsp(frame1, sizeof(frame1));
+    auto result = WebCore::fromRbsp(frame1);
 
     EXPECT_EQ(result.size(), sizeof(frame1Unescaped));
     for (size_t i = 0; i < sizeof(frame1Unescaped); ++i)
@@ -411,8 +411,8 @@ TEST(RTCRtpSFrameTransformer, RBSPEscaping)
     Vector<uint8_t> escaped { 0, 0, 0, 65, 0, 0, 1, 66, 0, 0, 2, 67, 0, 0, 3, 68, 0, 0, 4, 0, 0, 1 };
 
     WebCore::toRbsp(escaped, 0);
-    EXPECT_TRUE(WebCore::needsRbspUnescaping(escaped.data(), escaped.size()));
-    auto unescaped = WebCore::fromRbsp(escaped.data(), escaped.size());
+    EXPECT_TRUE(WebCore::needsRbspUnescaping(escaped.span()));
+    auto unescaped = WebCore::fromRbsp(escaped.span());
 
     EXPECT_EQ(unescaped.size(), frame2.size());
     for (size_t i = 0; i < frame2.size(); ++i)

--- a/Tools/TestWebKitAPI/Tests/WebCore/STUNMessageParsingTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/STUNMessageParsingTest.cpp
@@ -38,9 +38,9 @@ using namespace WebCore;
 TEST(STUNMessageParsing, MessageLength)
 {
     auto buffer = Vector<uint8_t>::from(0, 1, 3, 0, 2, 4);
-    buffer = WebRTC::extractMessages(WTFMove(buffer), WebRTC::MessageType::Data, [](const uint8_t* data, size_t size) {
-        EXPECT_EQ(size, 1u);
-        EXPECT_EQ(*data, 3u);
+    buffer = WebRTC::extractMessages(WTFMove(buffer), WebRTC::MessageType::Data, [](std::span<const uint8_t> data) {
+        EXPECT_EQ(data.size(), 1u);
+        EXPECT_EQ(data[0], 3u);
     });
     EXPECT_EQ(buffer.size(), 3u);
     EXPECT_EQ(buffer[0], 0u);


### PR DESCRIPTION
#### 76d4bdd76987f7f1c6b1d3ad1e88384b72c4d6b3
<pre>
Update Modules/mediastream to use std::span more
<a href="https://bugs.webkit.org/show_bug.cgi?id=271495">https://bugs.webkit.org/show_bug.cgi?id=271495</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.cpp:
(WebCore::readUInt64):
(WebCore::parseSFrameHeader):
(WebCore::RTCRtpSFrameTransformer::decryptFrame):
(WebCore::RTCRtpSFrameTransformer::encryptFrame):
(WebCore::RTCRtpSFrameTransformer::decryptData):
(WebCore::RTCRtpSFrameTransformer::encryptData):
(WebCore::RTCRtpSFrameTransformer::computeEncryptedDataSignature):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformer.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp:
(WebCore::RTCRtpSFrameTransformer::decryptData):
(WebCore::RTCRtpSFrameTransformer::encryptData):
(WebCore::RTCRtpSFrameTransformer::computeEncryptedDataSignature):
* Source/WebCore/Modules/mediastream/SFrameUtils.cpp:
(WebCore::findNalus):
(WebCore::computeH264PrefixOffset):
(WebCore::needsRbspUnescaping):
(WebCore::fromRbsp):
(WebCore::computeH264PrefixBuffer):
(WebCore::isVP8KeyFrame):
(WebCore::computeVP8PrefixOffset):
(WebCore::computeVP8PrefixBuffer):
* Source/WebCore/Modules/mediastream/SFrameUtils.h:
* Source/WebCore/Modules/mediastream/STUNMessageParsing.cpp:
(WebCore::WebRTC::extractSTUNOrTURNMessages):
(WebCore::WebRTC::extractDataMessages):
(WebCore::WebRTC::extractMessages):
* Source/WebCore/Modules/mediastream/STUNMessageParsing.h:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESCTRMac.cpp:
(WebCore::CryptoAlgorithmAESCTR::platformEncrypt):
(WebCore::CryptoAlgorithmAESCTR::platformDecrypt):
* Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.cpp:
(WebCore::transformAESCTR):
* Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.h:

Canonical link: <a href="https://commits.webkit.org/276611@main">https://commits.webkit.org/276611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ec50fc30222a74353f87179ee0ac54ca26710ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47779 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41125 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37014 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18113 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39988 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3164 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49471 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44031 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21405 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42819 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21757 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6281 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->