### PR TITLE
(Unified)PDFPlugin: "Open" and "Save" write useless incomplete files when the document is not completely loaded

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -39,6 +39,7 @@
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/ScrollableArea.h>
 #include <WebCore/TextIndicator.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/Identified.h>
 #include <wtf/Lock.h>
 #include <wtf/Range.h>
@@ -391,6 +392,11 @@ protected:
 #endif
 
     RefPtr<WebCore::VoidCallback> m_pdfTestCallback;
+
+#if ENABLE(PDF_HUD)
+    CompletionHandler<void(const String&, const URL&, std::span<const uint8_t>)> m_pendingSaveCompletionHandler;
+    CompletionHandler<void(const String&, FrameInfoData&&, std::span<const uint8_t>, const String&)> m_pendingOpenCompletionHandler;
+#endif
 
     // Set overflow: hidden on the annotation container so <input> elements scrolled out of view don't show
     // scrollbars on the body. We can't add annotations directly to the body, because overflow: hidden on the body

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -136,6 +136,19 @@ void PDFPluginBase::teardown()
 
     destroyScrollbar(ScrollbarOrientation::Horizontal);
     destroyScrollbar(ScrollbarOrientation::Vertical);
+
+#if ENABLE(PDF_HUD)
+    if (auto existingCompletionHandler = std::exchange(m_pendingSaveCompletionHandler, { }))
+        existingCompletionHandler({ }, { }, { });
+
+    if (auto existingCompletionHandler = std::exchange(m_pendingOpenCompletionHandler, { })) {
+        // FrameInfo can't be default-constructed; the receiving process will ASSERT if it is.
+        FrameInfoData frameInfo;
+        if (m_frame)
+            frameInfo = m_frame->info();
+        existingCompletionHandler({ }, WTFMove(frameInfo), { }, { });
+    }
+#endif // ENABLE(PDF_HUD)
 }
 
 Page* PDFPluginBase::page() const
@@ -403,6 +416,14 @@ void PDFPluginBase::streamDidFinishLoading()
     }
 
     tryRunScriptsInPDFDocument();
+
+#if ENABLE(PDF_HUD)
+    if (auto existingCompletionHandler = std::exchange(m_pendingSaveCompletionHandler, { }))
+        save(WTFMove(existingCompletionHandler));
+
+    if (auto existingCompletionHandler = std::exchange(m_pendingOpenCompletionHandler, { }))
+        openWithPreview(WTFMove(existingCompletionHandler));
+#endif // ENABLE(PDF_HUD)
 }
 
 void PDFPluginBase::streamDidFail()
@@ -986,6 +1007,12 @@ bool PDFPluginBase::hudEnabled() const
 
 void PDFPluginBase::save(CompletionHandler<void(const String&, const URL&, std::span<const uint8_t>)>&& completionHandler)
 {
+    if (!m_documentFinishedLoading) {
+        if (auto existingCompletionHandler = std::exchange(m_pendingSaveCompletionHandler, WTFMove(completionHandler)))
+            existingCompletionHandler({ }, { }, { });
+        return;
+    }
+
     NSData *data = liveData();
     URL url;
     if (m_frame)
@@ -995,10 +1022,19 @@ void PDFPluginBase::save(CompletionHandler<void(const String&, const URL&, std::
 
 void PDFPluginBase::openWithPreview(CompletionHandler<void(const String&, FrameInfoData&&, std::span<const uint8_t>, const String&)>&& completionHandler)
 {
-    NSData *data = liveData();
     FrameInfoData frameInfo;
     if (m_frame)
         frameInfo = m_frame->info();
+
+    if (!m_documentFinishedLoading) {
+        if (auto existingCompletionHandler = std::exchange(m_pendingOpenCompletionHandler, WTFMove(completionHandler))) {
+            // FrameInfo can't be default-constructed; the receiving process will ASSERT if it is.
+            existingCompletionHandler({ }, WTFMove(frameInfo), { }, { });
+        }
+        return;
+    }
+
+    NSData *data = liveData();
     completionHandler(m_suggestedFilename, WTFMove(frameInfo), span(data), createVersion4UUIDString());
 }
 


### PR DESCRIPTION
#### bf47c375c189dccc7b88509bbb997e6e0363c18c
<pre>
(Unified)PDFPlugin: &quot;Open&quot; and &quot;Save&quot; write useless incomplete files when the document is not completely loaded
<a href="https://bugs.webkit.org/show_bug.cgi?id=271497">https://bugs.webkit.org/show_bug.cgi?id=271497</a>
&lt;<a href="https://rdar.apple.com/problem/117451408">rdar://problem/117451408</a>&gt;

Reviewed by Abrar Rahman Protyasha and Simon Fraser.

If Open or Save are clicked before the document is loaded, defer the action
until it is.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::teardown):
Call save/open with invalid data when tearing down the plugin.

(WebKit::PDFPluginBase::streamDidFinishLoading):
Call save/open once we&apos;re actually ready.

(WebKit::PDFPluginBase::save):
(WebKit::PDFPluginBase::openWithPreview):
If called multiple times, let go of the old completion handler by calling it
back with invalid data; only store the most recent one.

Canonical link: <a href="https://commits.webkit.org/276584@main">https://commits.webkit.org/276584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eabf12ead9c89a2bd676f0fe59fef0d3f0045fda

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47719 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41069 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21569 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/36966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21222 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18061 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18636 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3108 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49410 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/20034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16559 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/43985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21349 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42766 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10020 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->