### PR TITLE
Potential crash when updating Interaction Regions layers

### DIFF
--- a/LayoutTests/interaction-region/layer-tree.html
+++ b/LayoutTests/interaction-region/layer-tree.html
@@ -107,13 +107,16 @@ window.onload = async function () {
     if (!window.internals)
         return;
 
+    // Resizing - reuses the layer while maintaining its position in the sublayers array.
+    await UIHelper.animationFrame();
+    document.getElementById("resized").style.width = "200px";
+
+    // Adding - appends a new layer.
     await UIHelper.animationFrame();
     document.querySelector("iframe").srcdoc = "<div style='cursor:pointer;width:100%;height:200px'; onclick='click()'>tappable</div>";
     document.getElementById("resized").style.backgroundColor = "blue";
 
-    await UIHelper.animationFrame();
-    document.getElementById("resized").style.width = "200px";
-
+    // Removing - moves layers arround.
     await UIHelper.animationFrame();
     document.getElementById("to-hide").style.display = "none";
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -314,7 +314,10 @@ void updateLayersForInteractionRegions(RemoteLayerTreeNode& node)
         if (applyBackgroundColorForDebugging)
             applyBackgroundColorForDebuggingToLayer(regionLayer.get(), region);
 
-        if ([container.sublayers objectAtIndex:insertionPoint] != regionLayer) {
+        // Since we insert new layers as we go, insertionPoint is always <= container.sublayers.count.
+        ASSERT(insertionPoint <= container.sublayers.count);
+        bool shouldAppendLayer = insertionPoint == container.sublayers.count;
+        if (shouldAppendLayer || [container.sublayers objectAtIndex:insertionPoint] != regionLayer) {
             [regionLayer removeFromSuperlayer];
             [container insertSublayer:regionLayer.get() atIndex:insertionPoint];
         }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -188,11 +188,13 @@ void RemoteLayerTreeNode::repositionInteractionRegionsContainerIfNeeded()
         insertionPoint++;
     }
 
-    if ([layer().sublayers objectAtIndex:insertionPoint] == m_interactionRegionsContainer)
-        return;
-
-    [m_interactionRegionsContainer removeFromSuperlayer];
-    [layer() insertSublayer:m_interactionRegionsContainer.get() atIndex:insertionPoint];
+    // We searched through the sublayers, so insertionPoint is always <= sublayers.count.
+    ASSERT(insertionPoint <= layer().sublayers.count);
+    bool shouldAppendLayer = insertionPoint == layer().sublayers.count;
+    if (shouldAppendLayer || [layer().sublayers objectAtIndex:insertionPoint] != m_interactionRegionsContainer) {
+        [m_interactionRegionsContainer removeFromSuperlayer];
+        [layer() insertSublayer:m_interactionRegionsContainer.get() atIndex:insertionPoint];
+    }
 }
 
 void RemoteLayerTreeNode::propagateInteractionRegionsChangeInHierarchy(InteractionRegionsInSubtree interactionRegionsInSubtree)


### PR DESCRIPTION
#### cbebffce13f3d12fb005b445138c9f312d886ecc
<pre>
Potential crash when updating Interaction Regions layers
&lt;<a href="https://rdar.apple.com/117358144">rdar://117358144</a>&gt;

Reviewed by David Kilzer.

When appending at the end of a sublayers array, we shouldn&apos;t look up
the `objectAtIndex` at this (out of bounds) position.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(WebKit::updateLayersForInteractionRegions):
Add a comment and an assertion about the `insertionPoint` range.
Check for the appending case and skip the objectAtIndex lookup.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::repositionInteractionRegionsContainerIfNeeded):
Add a comment and an assertion about the `insertionPoint` range.
Check for the appending case and skip the objectAtIndex lookup.

* LayoutTests/interaction-region/layer-tree.html:
Make the test a bit more readable and make sure we exercise the layer
reuse, layer move and layer append code paths.
No expectations change needed.

Originally-landed-as: 272448.238@safari-7618-branch (a2d409b8eee9). <a href="https://rdar.apple.com/124556170">rdar://124556170</a>
Canonical link: <a href="https://commits.webkit.org/276602@main">https://commits.webkit.org/276602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66e21f9228c96dece66b9342fd18cca2f7060a40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47543 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47698 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41049 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36952 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18057 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39914 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49376 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43957 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21329 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42731 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10031 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21675 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21008 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->