### PR TITLE
ASSERTION FAILED: watchpoints (./runtime/ScopedArgumentsTable.cpp(130))

### DIFF
--- a/JSTests/stress/arrow-function-captured-arguments-aliased.js
+++ b/JSTests/stress/arrow-function-captured-arguments-aliased.js
@@ -1,3 +1,6 @@
+//@ runDefault
+//@ runNoJIT
+
 function createOptAll(count) {
     count = 0;
 

--- a/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
+++ b/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
@@ -127,7 +127,9 @@ ScopedArgumentsTable* ScopedArgumentsTable::trySet(VM& vm, uint32_t i, ScopeOffs
 
 void ScopedArgumentsTable::trySetWatchpointSet(uint32_t i, WatchpointSet* watchpoints)
 {
-    ASSERT(watchpoints);
+    if (!watchpoints)
+        return;
+
     if (i >= m_watchpointSets.size())
         return;
 


### PR DESCRIPTION
#### ad8d3e19e21357cd9d1959b86e92dba341d0bcbe
<pre>
ASSERTION FAILED: watchpoints (./runtime/ScopedArgumentsTable.cpp(130))
<a href="https://rdar.apple.com/121446658">rdar://121446658</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=267946">https://bugs.webkit.org/show_bug.cgi?id=267946</a>

Reviewed by Alexey Shvayka.

Insatead of using an ASSERT that we have a valid WatchpointSet in ScopedArgumentsTable::trySetWatchpointSet(), we can just
exit early if the passed in WatchpointSet is null.  This can happen if the JIT is not enabled.

Updated the test to run both with and wothout the JIT.

* JSTests/stress/arrow-function-captured-arguments-aliased.js:
* Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp:
(JSC::ScopedArgumentsTable::trySetWatchpointSet):

Originally-landed-as: 272448.339@safari-7618-branch (66df5c618c1c). <a href="https://rdar.apple.com/124555300">rdar://124555300</a>
Canonical link: <a href="https://commits.webkit.org/276598@main">https://commits.webkit.org/276598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e31c7d9d5224c14cc47b2966d03efd11262c6d4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47545 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47700 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41051 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36953 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18047 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39921 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3090 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38247 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49411 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44504 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16544 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43989 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21331 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42770 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10030 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21677 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51670 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21010 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->