### PR TITLE
Add more smart pointers to RenderSearchField and SearchPopup

### DIFF
--- a/Source/WebCore/platform/SearchPopupMenu.h
+++ b/Source/WebCore/platform/SearchPopupMenu.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "PopupMenu.h"
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 #include <wtf/WallTime.h>
@@ -40,6 +41,7 @@ class SearchPopupMenu : public RefCounted<SearchPopupMenu> {
 public:
     virtual ~SearchPopupMenu() = default;
     virtual PopupMenu* popupMenu() = 0;
+    RefPtr<PopupMenu> protectedPopupMenu() { return popupMenu(); }
     virtual void saveRecentSearches(const AtomString& name, const Vector<RecentSearch>&) = 0;
     virtual void loadRecentSearches(const AtomString& name, Vector<RecentSearch>&) = 0;
     virtual bool enabled() = 0;

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -79,6 +79,7 @@ private:
     FontSelector* fontSelector() const override;
     HostWindow* hostWindow() const override;
     Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth) override;
+    RefPtr<SearchPopupMenu> protectedSearchPopup() const { return m_searchPopup; };
 
     HTMLElement* resultsButtonElement() const;
     HTMLElement* cancelButtonElement() const;

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -488,6 +488,11 @@ HTMLInputElement& RenderTextControlSingleLine::inputElement() const
     return downcast<HTMLInputElement>(RenderTextControl::textFormControlElement());
 }
 
+Ref<HTMLInputElement> RenderTextControlSingleLine::protectedInputElement() const
+{
+    return downcast<HTMLInputElement>(RenderTextControl::textFormControlElement());
+}
+
 RenderTextControlInnerBlock::RenderTextControlInnerBlock(Element& element, RenderStyle&& style)
     : RenderBlockFlow(Type::TextControlInnerBlock, element, WTFMove(style))
 {

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.h
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.h
@@ -37,6 +37,7 @@ protected:
     HTMLElement* containerElement() const;
     HTMLElement* innerBlockElement() const;
     HTMLInputElement& inputElement() const;
+    Ref<HTMLInputElement> protectedInputElement() const;
 
 private:
     void textFormControlElement() const = delete;


### PR DESCRIPTION
#### 2fa09212b231cb8c79895fcde70eebf92835601d
<pre>
Add more smart pointers to RenderSearchField and SearchPopup
<a href="https://bugs.webkit.org/show_bug.cgi?id=271504">https://bugs.webkit.org/show_bug.cgi?id=271504</a>
<a href="https://rdar.apple.com/125268281">rdar://125268281</a>

Reviewed by Ryosuke Niwa and Chris Dumez.

Add more smart pointers to RenderSearchField and modify supporting files and functions as needed

* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/platform/SearchPopupMenu.h:
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::willBeDestroyed):
(WebCore::RenderSearchField::resultsButtonElement const):
(WebCore::RenderSearchField::cancelButtonElement const):
(WebCore::RenderSearchField::addSearchResult):
(WebCore::RenderSearchField::showPopup):
(WebCore::RenderSearchField::hidePopup):
(WebCore::RenderSearchField::computeControlLogicalHeight const):
(WebCore::RenderSearchField::updateFromElement):
(WebCore::RenderSearchField::autosaveName const):
(WebCore::RenderSearchField::valueChanged):
(WebCore::RenderSearchField::clientPaddingLeft const):
(WebCore::RenderSearchField::clientPaddingRight const):
(WebCore::RenderSearchField::setTextFromItem):
(WebCore::RenderSearchField::createScrollbar):
* Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp:
(WebKit::WebSearchPopupMenu::protectedPopupMenu):
* Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.h:
* Source/WebKitLegacy/ios/WebCoreSupport/SearchPopupMenuIOS.cpp:
(SearchPopupMenuIOS::protectedPopupMenu):
* Source/WebKitLegacy/ios/WebCoreSupport/SearchPopupMenuIOS.h:
* Source/WebKitLegacy/mac/WebCoreSupport/SearchPopupMenuMac.h:
* Source/WebKitLegacy/mac/WebCoreSupport/SearchPopupMenuMac.mm:
(SearchPopupMenuMac::protectedPopupMenu):

Canonical link: <a href="https://commits.webkit.org/276849@main">https://commits.webkit.org/276849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/faa838a71003dc988f11703bc110002480bf5e34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48430 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41795 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37467 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46338 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39475 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18624 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40566 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3804 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50185 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44583 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22056 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43443 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10183 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->