### PR TITLE
Select element Interaction Regions don't align with other inputs in including their padding

### DIFF
--- a/LayoutTests/interaction-region/button-in-link-expected.txt
+++ b/LayoutTests/interaction-region/button-in-link-expected.txt
@@ -1,4 +1,4 @@
-Some text but also a button
+Some text but also a button and another that overflows
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -13,8 +13,11 @@ Some text but also a button
 
       (interaction regions [
         (interaction (20,20) width=442 height=67),
-        (interaction (270,41) width=171 height=23)
-        (cornerRadius 6.00)])
+        (interaction (265,46) width=171 height=23)
+        (cornerRadius 6.00),
+        (guard (156,37) width=98 height=38),
+        (interaction (156,47) width=98 height=18)
+        (cornerRadius 10.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/button-in-link.html
+++ b/LayoutTests/interaction-region/button-in-link.html
@@ -9,19 +9,28 @@
         padding: 20px;
         line-height: 25px;
     }
-    a button {
+    .styled {
         float: right;
         appearance: none;
         background: gray;
         border-radius: 6px;
         border: none;
         font-size: 18px;
+        margin: 5px;
+    }
+    .styled-native {
+        width: 100px;
+        text-wrap: nowrap;
+        overflow: hidden;
+        margin: 5px;
+        float: right;
     }
 </style>
 <body>
 <a href="#">
     Some text
-    <button>but also a button</button>
+    <button class="styled">but also a button</button>
+    <button class="styled-native">and another that overflows</button>
 </a>
 
 <pre id="results"></pre>

--- a/LayoutTests/interaction-region/input-type-file-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-file-region-expected.txt
@@ -12,8 +12,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (guard (1,-8) width=84 height=38),
-        (interaction (1,2) width=84 height=18)
+        (interaction (0,1) width=85.50 height=20)
         (cornerRadius 10.00)])
       )
     )

--- a/LayoutTests/interaction-region/select-element-expected.txt
+++ b/LayoutTests/interaction-region/select-element-expected.txt
@@ -1,0 +1,27 @@
+
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction (8,33) width=111 height=20)
+        (cornerRadius 10.00),
+        (interaction (123,33) width=100 height=20)
+        (cornerRadius 10.00),
+        (interaction (227,8) width=139 height=70)
+        (cornerRadius 20.00),
+        (interaction (370,8) width=100 height=70)
+        (cornerRadius 20.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/select-element.html
+++ b/LayoutTests/interaction-region/select-element.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 20; }
+    .styled {
+        padding: 20px;
+        height: 70px;
+        background-color: aqua;
+        border-radius: 20px;
+    }
+</style>
+<body>
+<select>
+    <option>This is an option</option>
+</select>
+<select style="width: 100px;">
+    <option>This is an option that should overflow and clip</option>
+</select>
+<select class="styled">
+    <option>This is a styled option</option>
+</select>
+<select class="styled" style="width: 100px;">
+    <option>This is a styled option that should overflow and clip</option>
+</select>
+
+
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/text-controls-expected.txt
+++ b/LayoutTests/interaction-region/text-controls-expected.txt
@@ -14,7 +14,9 @@
       (interaction regions [
         (interaction (9,9) width=211 height=204)
         (cornerRadius 5.00),
-        (interaction (226,178) width=330 height=55)
+        (interaction (225,177) width=332 height=57)
+        (cornerRadius 5.00),
+        (interaction (8,234) width=350 height=75)
         (cornerRadius 5.00)])
       )
     )

--- a/LayoutTests/interaction-region/text-controls.html
+++ b/LayoutTests/interaction-region/text-controls.html
@@ -16,6 +16,7 @@
 <body>
 <textarea></textarea>
 <input type="text"></input>
+<input type="text" style="border: 10px solid gray"></input>
 <pre id="results"></pre>
 <script>
 if (window.testRunner)

--- a/LayoutTests/interaction-region/text-input-expected.txt
+++ b/LayoutTests/interaction-region/text-input-expected.txt
@@ -1,26 +1,29 @@
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 800.00 644.00)
+  (bounds 800.00 940.00)
   (children 1
     (GraphicsLayer
-      (bounds 800.00 644.00)
+      (bounds 800.00 940.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=800 height=644)
+        (rect (0,0) width=800 height=940)
 
       (interaction regions [
-        (interaction (161,126) width=98 height=38)
+        (interaction (160,125) width=100 height=40)
         (cornerRadius 5.00),
         (interaction (344,120) width=110 height=50)
         (cornerRadius 5.00),
         (interaction (160,250) width=110 height=50)
         (cornerRadius 5.00),
-        (interaction (161,381) width=98 height=38),
-        (interaction (161,461) width=110 height=50),
-        (interaction (161,553) width=110 height=50)])
+        (interaction (160,380) width=100 height=40),
+        (interaction (160,460) width=100 height=40),
+        (interaction (160,540) width=120 height=60),
+        (interaction (160,640) width=120 height=60),
+        (interaction (160,740) width=120 height=60),
+        (interaction (160,840) width=120 height=60)])
       )
     )
   )

--- a/LayoutTests/interaction-region/text-input.html
+++ b/LayoutTests/interaction-region/text-input.html
@@ -12,7 +12,7 @@
     .styled {
         display: block;
         border-radius: 0;
-        border: 1px gray solid;
+        border: 5px gray solid;
     }
 </style>
 <script src="../resources/ui-helper.js"></script>
@@ -23,8 +23,11 @@
     <input type="text">
 
     <input class="styled" placeholder="Search" type="search">
+    <input class="styled" placeholder="Search" type="search" value="This is some overflowing text as a test of interaction region clipping">
     <input class="styled" placeholder="Password" type="password">
+    <input class="styled" placeholder="Password" type="password" value="This is some overflowing text as a test of interaction region clipping">
     <input class="styled" type="text">
+    <input class="styled" type="text" value="This is some overflowing text as a test of interaction region clipping">
 </form>
 <pre id="results"></pre>
 <script>

--- a/LayoutTests/platform/ios/editing/editable-region/overflow-scroll-text-field-and-contenteditable-expected.txt
+++ b/LayoutTests/platform/ios/editing/editable-region/overflow-scroll-text-field-and-contenteditable-expected.txt
@@ -11,7 +11,7 @@
       (event region
         (rect (0,0) width=800 height=600)
       (editable region
-        (rect (10,203) width=153 height=20)
+        (rect (9,202) width=155 height=22)
         (rect (19,448) width=275 height=38)
       )
       )

--- a/LayoutTests/platform/ios/editing/editable-region/search-field-basic-expected.txt
+++ b/LayoutTests/platform/ios/editing/editable-region/search-field-basic-expected.txt
@@ -11,7 +11,7 @@
       (event region
         (rect (0,0) width=800 height=600)
       (editable region
-        (rect (9,10) width=153 height=20)
+        (rect (8,9) width=155 height=22)
       )
       )
     )

--- a/LayoutTests/platform/ios/editing/editable-region/text-field-basic-expected.txt
+++ b/LayoutTests/platform/ios/editing/editable-region/text-field-basic-expected.txt
@@ -11,7 +11,7 @@
       (event region
         (rect (0,0) width=800 height=600)
       (editable region
-        (rect (9,10) width=153 height=20)
+        (rect (8,9) width=155 height=22)
       )
       )
     )

--- a/LayoutTests/platform/ios/editing/editable-region/text-field-inside-composited-negative-z-index-layer-expected.txt
+++ b/LayoutTests/platform/ios/editing/editable-region/text-field-inside-composited-negative-z-index-layer-expected.txt
@@ -29,7 +29,7 @@
               (event region
                 (rect (8,8) width=784 height=23)
               (editable region
-                (rect (9,10) width=153 height=20)
+                (rect (8,9) width=155 height=22)
               )
               )
             )

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -2162,7 +2162,7 @@ bool RenderBox::pushContentsClip(PaintInfo& paintInfo, const LayoutPoint& accumu
     if (paintInfo.phase == PaintPhase::BlockBackground || paintInfo.phase == PaintPhase::SelfOutline || paintInfo.phase == PaintPhase::Mask)
         return false;
 
-    bool isControlClip = hasControlClip();
+    bool isControlClip = paintInfo.phase != PaintPhase::EventRegion && hasControlClip();
     bool isOverflowClip = hasNonVisibleOverflow() && !layer()->isSelfPaintingLayer();
 
     if (!isControlClip && !isOverflowClip)


### PR DESCRIPTION
#### fea08da84e651a0fc6f1b4862f139fc2f0b0ee17
<pre>
Select element Interaction Regions don&apos;t align with other inputs in including their padding
<a href="https://bugs.webkit.org/show_bug.cgi?id=271499">https://bugs.webkit.org/show_bug.cgi?id=271499</a>
&lt;<a href="https://rdar.apple.com/114213996">rdar://114213996</a>&gt;

Reviewed by Tim Horton.

During the EventRegion paint phase, ignore control clipping to ensure
that Interaction Regions are properly sized.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::pushContentsClip):
Set `isControlClip` to false if we are in the EventRegion paint phase.

* LayoutTests/interaction-region/select-element-expected.txt: Added.
* LayoutTests/interaction-region/select-element.html: Added.
Add a test to cover `&lt;select&gt;` elements&apos; Interaction Regions.
* LayoutTests/interaction-region/text-controls-expected.txt:
* LayoutTests/interaction-region/text-controls.html:
* LayoutTests/interaction-region/text-input-expected.txt:
* LayoutTests/interaction-region/text-input.html:
* LayoutTests/interaction-region/button-in-link.html:
* LayoutTests/interaction-region/button-in-link-expected.txt:
Add test cases with increased borders and overflows to cover this change.
* LayoutTests/interaction-region/input-type-file-region-expected.txt:
Update test expectations to include 1px border on file inputs.
* LayoutTests/platform/ios/editing/editable-region/overflow-scroll-text-field-and-contenteditable-expected.txt:
* LayoutTests/platform/ios/editing/editable-region/search-field-basic-expected.txt:
* LayoutTests/platform/ios/editing/editable-region/text-field-basic-expected.txt:
* LayoutTests/platform/ios/editing/editable-region/text-field-inside-composited-negative-z-index-layer-expected.txt:
Re-baseline iOS Event Region tests.

Canonical link: <a href="https://commits.webkit.org/277387@main">https://commits.webkit.org/277387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23de2cfe8135049427ebcd46bc1cd4d4f8c8acc8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48841 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48477 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37726 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18932 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40906 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4214 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42469 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50651 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44910 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43819 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10473 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->