### PR TITLE
[macOS] Menu and MenuText system colors are incorrect

### DIFF
--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-color/system-color-compute-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-color/system-color-compute-expected.txt
@@ -2,31 +2,31 @@ Parent
 Specified Child
 Inherit Child
 
-FAIL color-scheme property affects Menu system color keyword assert_not_equals: got disallowed value "rgb(246, 246, 246)"
-FAIL System color doesn't compute to itself on color assert_not_equals: got disallowed value "rgb(246, 246, 246)"
+PASS color-scheme property affects Menu system color keyword
+PASS System color doesn't compute to itself on color
 PASS Inherited system color keyword is observable on color
-FAIL System color doesn't compute to itself on background-color assert_not_equals: got disallowed value "rgb(246, 246, 246)"
+PASS System color doesn't compute to itself on background-color
 PASS Inherited system color keyword is observable on background-color
-FAIL System color doesn't compute to itself on box-shadow assert_not_equals: got disallowed value "rgb(246, 246, 246) 2px 2px 0px 0px"
+PASS System color doesn't compute to itself on box-shadow
 PASS Inherited system color keyword is observable on box-shadow
-FAIL System color doesn't compute to itself on text-shadow assert_not_equals: got disallowed value "rgb(246, 246, 246) 2px 2px 0px"
+PASS System color doesn't compute to itself on text-shadow
 PASS Inherited system color keyword is observable on text-shadow
-FAIL System color doesn't compute to itself on border-left-color assert_not_equals: got disallowed value "rgb(246, 246, 246)"
+PASS System color doesn't compute to itself on border-left-color
 PASS Inherited system color keyword is observable on border-left-color
-FAIL System color doesn't compute to itself on border-top-color assert_not_equals: got disallowed value "rgb(246, 246, 246)"
+PASS System color doesn't compute to itself on border-top-color
 PASS Inherited system color keyword is observable on border-top-color
-FAIL System color doesn't compute to itself on border-right-color assert_not_equals: got disallowed value "rgb(246, 246, 246)"
+PASS System color doesn't compute to itself on border-right-color
 PASS Inherited system color keyword is observable on border-right-color
-FAIL System color doesn't compute to itself on border-bottom-color assert_not_equals: got disallowed value "rgb(246, 246, 246)"
+PASS System color doesn't compute to itself on border-bottom-color
 PASS Inherited system color keyword is observable on border-bottom-color
-FAIL System color doesn't compute to itself on column-rule-color assert_not_equals: got disallowed value "rgb(246, 246, 246)"
+PASS System color doesn't compute to itself on column-rule-color
 PASS Inherited system color keyword is observable on column-rule-color
-FAIL System color doesn't compute to itself on outline-color assert_not_equals: got disallowed value "rgb(246, 246, 246)"
+PASS System color doesn't compute to itself on outline-color
 PASS Inherited system color keyword is observable on outline-color
-FAIL System color doesn't compute to itself on caret-color assert_not_equals: got disallowed value "rgb(246, 246, 246)"
+PASS System color doesn't compute to itself on caret-color
 PASS Inherited system color keyword is observable on caret-color
-FAIL System color doesn't compute to itself on fill assert_not_equals: got disallowed value "rgb(246, 246, 246)"
+PASS System color doesn't compute to itself on fill
 PASS Inherited system color keyword is observable on fill
-FAIL System color doesn't compute to itself on stroke assert_not_equals: got disallowed value "rgb(246, 246, 246)"
+PASS System color doesn't compute to itself on stroke
 PASS Inherited system color keyword is observable on stroke
 

--- a/Source/WebCore/PAL/pal/spi/mac/NSGraphicsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSGraphicsSPI.h
@@ -46,6 +46,12 @@
 }
 @end
 
+typedef NS_OPTIONS(NSUInteger, NSMenuBackgroundFlags) {
+    NSMenuBackgroundPopupMenu = 0x200
+};
+
+APPKIT_EXTERN void NSDrawMenuBackground(NSRect bounds, NSRect clipRect, NSMenuBackgroundFlags);
+
 #endif
 
 WTF_EXTERN_C_BEGIN


### PR DESCRIPTION
#### 80d6b8db8ff38513395c9ed7c404f22874c94c09
<pre>
[macOS] Menu and MenuText system colors are incorrect
<a href="https://bugs.webkit.org/show_bug.cgi?id=271506">https://bugs.webkit.org/show_bug.cgi?id=271506</a>
<a href="https://rdar.apple.com/125270664">rdar://125270664</a>

Reviewed by Wenson Hsieh.

There are two issues:

1. `MenuText` is using `+[NSColor selectedMenuItemTextColor]`. The system color
   is not about selected items.

2. `Menu` does not adapt to dark mode.

* LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-color/system-color-compute-expected.txt:
* Source/WebCore/PAL/pal/spi/mac/NSGraphicsSPI.h:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::menuBackgroundColor):

Adopt `NSDrawMenuBackground` for dark mode support. While this method is
deprecated, the only alternative is to use a custom material, which is not
viable at this time.

(WebCore::RenderThemeMac::systemColor const):

Use `+[NSColor labelColor]` for `MenuText`, which matches the system.

Canonical link: <a href="https://commits.webkit.org/276597@main">https://commits.webkit.org/276597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4599f2590e823411a805fa023b5f913e99ff6ea5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45077 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47742 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41085 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36986 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18086 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39948 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3124 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41344 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49422 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43996 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21365 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42777 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10028 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21712 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21044 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->