### PR TITLE
Use std::span in ASCIIFastPath

### DIFF
--- a/Source/JavaScriptCore/API/JSScript.mm
+++ b/Source/JavaScriptCore/API/JSScript.mm
@@ -138,7 +138,7 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
     if (!success)
         return createError([NSString stringWithFormat:@"File at path %@ could not be mapped.", static_cast<NSString *>(systemPath)], error);
 
-    if (!charactersAreAllASCII(reinterpret_cast<const LChar*>(fileData.data()), fileData.size()))
+    if (!charactersAreAllASCII(fileData.span()))
         return createError([NSString stringWithFormat:@"Not all characters in file at %@ are ASCII.", static_cast<NSString *>(systemPath)], error);
 
     auto result = adoptNS([[JSScript alloc] init]);

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1909,7 +1909,7 @@ static JSValue normalize(JSGlobalObject* globalObject, JSString* string, Normali
     // Latin-1 characters (U+0000..U+00FF) are left unaffected by NFC.
     // ASCII characters (U+0000..U+007F) are left unaffected by all of the Normalization Forms
     // https://unicode.org/reports/tr15/#Description_Norm
-    if (view.is8Bit() && (form == NormalizationForm::NFC || charactersAreAllASCII(view.characters8(), view.length())))
+    if (view.is8Bit() && (form == NormalizationForm::NFC || view.containsOnlyASCII()))
         RELEASE_AND_RETURN(scope, string);
 
     const UNormalizer2* normalizer = JSC::normalizer(form);

--- a/Source/JavaScriptCore/wasm/WasmParser.h
+++ b/Source/JavaScriptCore/wasm/WasmParser.h
@@ -177,10 +177,10 @@ ALWAYS_INLINE bool Parser<SuccessType>::consumeUTF8String(Name& result, size_t s
     if (!result.tryReserveCapacity(stringLength))
         return false;
 
-    const uint8_t* stringStart = source() + m_offset;
+    auto* stringStart = source() + m_offset;
 
     // We don't cache the UTF-16 characters since it seems likely the string is ASCII.
-    if (UNLIKELY(!charactersAreAllASCII(stringStart, stringLength))) {
+    if (UNLIKELY(!charactersAreAllASCII(std::span { stringStart, stringLength }))) {
         Vector<UChar, 1024> buffer(stringLength);
         UChar* bufferStart = buffer.data();
 

--- a/Source/WTF/wtf/text/ASCIIFastPath.h
+++ b/Source/WTF/wtf/text/ASCIIFastPath.h
@@ -84,10 +84,11 @@ inline bool containsOnlyASCII(MachineWord word)
 // Note: This function assume the input is likely all ASCII, and
 // does not leave early if it is not the case.
 template<typename CharacterType>
-inline bool charactersAreAllASCII(const CharacterType* characters, size_t length)
+inline bool charactersAreAllASCII(std::span<const CharacterType> span)
 {
     MachineWord allCharBits = 0;
-    const CharacterType* end = characters + length;
+    auto* characters = span.data();
+    auto* end = characters + span.size();
 
     // Prologue: align the input.
     while (!isAlignedToMachineWord(characters) && characters != end) {
@@ -116,13 +117,14 @@ inline bool charactersAreAllASCII(const CharacterType* characters, size_t length
 // Note: This function assume the input is likely all Latin1, and
 // does not leave early if it is not the case.
 template<typename CharacterType>
-inline bool charactersAreAllLatin1(const CharacterType* characters, size_t length)
+inline bool charactersAreAllLatin1(std::span<const CharacterType> span)
 {
     if constexpr (sizeof(CharacterType) == 1)
         return true;
     else {
         MachineWord allCharBits = 0;
-        const CharacterType* end = characters + length;
+        auto* characters = span.data();
+        auto* end = characters + span.size();
 
         // Prologue: align the input.
         while (!isAlignedToMachineWord(characters) && characters != end) {

--- a/Source/WTF/wtf/text/AdaptiveStringSearcher.h
+++ b/Source/WTF/wtf/text/AdaptiveStringSearcher.h
@@ -135,7 +135,7 @@ public:
         , m_start(std::max<int>(0, pattern.size() - bmMaxShift))
     {
         if (sizeof(PatternChar) > sizeof(SubjectChar)) {
-            if (!charactersAreAllLatin1(m_pattern.data(), m_pattern.size())) {
+            if (!charactersAreAllLatin1(m_pattern)) {
                 m_strategy = &failSearch;
                 return;
             }

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -275,7 +275,7 @@ public:
 
     static Ref<StringImpl> createStaticStringImpl(const char* characters, unsigned length)
     {
-        ASSERT(charactersAreAllASCII(bitwise_cast<const LChar*>(characters), length));
+        ASSERT(charactersAreAllASCII(std::span { bitwise_cast<const LChar*>(characters), static_cast<size_t>(length) }));
         return createStaticStringImpl(bitwise_cast<const LChar*>(characters), length);
     }
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createStaticStringImpl(const LChar*, unsigned length);
@@ -874,8 +874,8 @@ inline Ref<StringImpl> StringImpl::isolatedCopy() const
 inline bool StringImpl::containsOnlyASCII() const
 {
     if (is8Bit())
-        return charactersAreAllASCII(characters8(), length());
-    return charactersAreAllASCII(characters16(), length());
+        return charactersAreAllASCII(span8());
+    return charactersAreAllASCII(span16());
 }
 
 inline bool StringImpl::containsOnlyLatin1() const

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -511,8 +511,8 @@ template<> ALWAYS_INLINE const UChar* StringView::characters<UChar>() const
 inline bool StringView::containsOnlyASCII() const
 {
     if (is8Bit())
-        return charactersAreAllASCII(characters8(), length());
-    return charactersAreAllASCII(characters16(), length());
+        return charactersAreAllASCII(span8());
+    return charactersAreAllASCII(span16());
 }
 
 template<size_t N>

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -487,7 +487,7 @@ String fromUTF8Impl(const LChar* stringStart, size_t length)
     if (!length)
         return emptyString();
 
-    if (charactersAreAllASCII(stringStart, length))
+    if (charactersAreAllASCII(std::span { stringStart, length }))
         return StringImpl::create(std::span { stringStart, length });
 
     Vector<UChar, 1024> buffer(length);

--- a/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
@@ -62,7 +62,7 @@ public:
         if (!m_contiguousBuffer && (!m_containsOnlyASCII || *m_containsOnlyASCII))
             m_contiguousBuffer = m_scriptBuffer.buffer()->makeContiguous();
         if (!m_containsOnlyASCII) {
-            m_containsOnlyASCII = charactersAreAllASCII(m_contiguousBuffer->data(), m_contiguousBuffer->size());
+            m_containsOnlyASCII = charactersAreAllASCII(m_contiguousBuffer->span());
             if (*m_containsOnlyASCII)
                 m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(m_contiguousBuffer->span());
         }

--- a/Source/WebCore/loader/cache/CachedScript.cpp
+++ b/Source/WebCore/loader/cache/CachedScript.cpp
@@ -70,7 +70,7 @@ StringView CachedScript::script(ShouldDecodeAsUTF8Only shouldDecodeAsUTF8Only)
     if (m_decodingState == NeverDecoded
         && PAL::TextEncoding(encoding()).isByteBasedEncoding()
         && contiguousData->size()
-        && charactersAreAllASCII(contiguousData->data(), contiguousData->size())) {
+        && charactersAreAllASCII(contiguousData->span())) {
 
         m_decodingState = DataAndDecodedStringHaveSameBytes;
 

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -223,16 +223,16 @@ bool MockCDM::supportsInitData(const AtomString& initDataType, const SharedBuffe
 
 RefPtr<SharedBuffer> MockCDM::sanitizeResponse(const SharedBuffer& response) const
 {
-    auto buffer = response.makeContiguous();
-    if (!charactersAreAllASCII(buffer->data(), response.size()))
+    auto contiguousResponse = response.makeContiguous();
+    if (!charactersAreAllASCII(contiguousResponse->span()))
         return nullptr;
 
-    Vector<String> responseArray = String(buffer->data(), response.size()).split(' ');
+    for (auto word : StringView(contiguousResponse->span()).split(' ')) {
+        if (word == "valid-response"_s)
+            return contiguousResponse;
+    }
 
-    if (!responseArray.contains(String("valid-response"_s)))
-        return nullptr;
-
-    return response.makeContiguous();
+    return nullptr;
 }
 
 std::optional<String> MockCDM::sanitizeSessionId(const String& sessionId) const


### PR DESCRIPTION
#### 4caac858f636ac96404ec53cda91b6804704702c
<pre>
Use std::span in ASCIIFastPath
<a href="https://bugs.webkit.org/show_bug.cgi?id=271509">https://bugs.webkit.org/show_bug.cgi?id=271509</a>
<a href="https://rdar.apple.com/125271340">rdar://125271340</a>

Reviewed by Chris Dumez.

* Source/JavaScriptCore/API/JSScript.mm:
(+[JSScript scriptOfType:memoryMappedFromASCIIFile:withSourceURL:andBytecodeCache:inVirtualMachine:error:]):
Use span.

* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::normalize): Use StringView::containsOnlyASCII.

* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::Parser&lt;SuccessType&gt;::consumeUTF8String): Use span.

* Source/WTF/wtf/text/ASCIIFastPath.h:
(WTF::charactersAreAllASCII): Take span.
(WTF::charactersAreAllLatin1): Ditto.

* Source/WTF/wtf/text/AdaptiveStringSearcher.h:
(WTF::AdaptiveStringSearcher::AdaptiveStringSearcher): Use span.
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::createStaticStringImpl): Use span.
(WTF::StringImpl::containsOnlyASCII const): Ditto.
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::containsOnlyASCII const): Ditto.
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::fromUTF8Impl): Ditto.
* Source/WebCore/bindings/js/ScriptBufferSourceProvider.h: Ditto.
* Source/WebCore/loader/cache/CachedScript.cpp:
(WebCore::CachedScript::script): Ditto.

* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDM::sanitizeResponse const): Use span and StringView::split.

Canonical link: <a href="https://commits.webkit.org/276587@main">https://commits.webkit.org/276587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3963752512658e53350b57b7c5d47ce2f33c211a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47717 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41067 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21567 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36970 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45636 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18065 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39933 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3106 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/38263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49396 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44520 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43973 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21347 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42749 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10023 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21694 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51686 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21026 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->