### PR TITLE
Fixes after 276579@main: New exception handler adoption with fallback.

### DIFF
--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -70,6 +70,8 @@ extern "C" {
 
 namespace WTF {
 
+Atomic<bool> fallbackToOldExceptions { false };
+
 void SignalHandlers::add(Signal signal, SignalHandler&& handler)
 {
     Config::AssertNotFrozenScope assertScope;
@@ -158,8 +160,7 @@ void initMachExceptionHandlerThread(bool enable, uint32_t signingKey, exception_
         if (ret == 1) {
             fallbackToOldExceptions.store(true);
         } else if (!ret) {
-            kr = task_register_hardened_exception_handler(current_task(),
-                signingKey, exceptionsAllowed | toMachMask(Signal::FloatingPoint),
+            kr = task_register_hardened_exception_handler(current_task(), signingKey, exceptionsAllowed,
                 behaviorsAllowed, flavorsAllowed, handlers.exceptionPort);
             if (kr != KERN_SUCCESS)
                 fallbackToOldExceptions.store(true);

--- a/Source/WTF/wtf/threads/Signals.h
+++ b/Source/WTF/wtf/threads/Signals.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,7 +81,7 @@ struct SigInfo {
 using SignalHandler = Function<SignalAction(Signal, SigInfo&, PlatformRegisters&)>;
 using SignalHandlerMemory = std::aligned_storage<sizeof(SignalHandler), std::alignment_of<SignalHandler>::value>::type;
 
-static Atomic<bool> fallbackToOldExceptions { false };
+extern Atomic<bool> fallbackToOldExceptions;
 struct SignalHandlers {
     static void initialize();
 


### PR DESCRIPTION
#### 123b9c7ce25c62b320e8e8df56c5863b2aa97834
<pre>
Fixes after 276579@main: New exception handler adoption with fallback.
<a href="https://bugs.webkit.org/show_bug.cgi?id=271507">https://bugs.webkit.org/show_bug.cgi?id=271507</a>
<a href="https://rdar.apple.com/125270901">rdar://125270901</a>

Reviewed by Keith Miller.

1. fallbackToOldExceptions should not be a static variable since it&apos;s used in more than one
   compilation unit.  Make it a global.
2. initMachExceptionHandlerThread() should add Signal::FloatingPoint to its exceptionsAllowed
   mask.  This is just debugging code that was accidentally left in.  Remove it.

* Source/WTF/wtf/threads/Signals.cpp:
(WTF::initMachExceptionHandlerThread):
* Source/WTF/wtf/threads/Signals.h:

Canonical link: <a href="https://commits.webkit.org/276601@main">https://commits.webkit.org/276601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/361541f269decb10fa606d7acb40f543fcf6700e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47718 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41068 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36971 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45637 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18067 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18633 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39932 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3107 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38264 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41329 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49397 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44521 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43976 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21348 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42753 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21695 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51687 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6278 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21027 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->