### PR TITLE
REGRESSION (276119@main): [ macOS iOS ] http/tests/navigation/page-cache-getUserMedia-pending-promise.html is a flaky timeout

### DIFF
--- a/LayoutTests/http/tests/navigation/page-cache-getUserMedia-pending-promise-expected.txt
+++ b/LayoutTests/http/tests/navigation/page-cache-getUserMedia-pending-promise-expected.txt
@@ -7,8 +7,8 @@ pageshow - not from cache
 pagehide - entering cache
 pageshow - from cache
 PASS Page was restored from Page Cache
-PASS Promised was resolved
 PASS restoredFromPageCache is true
+PASS getUserMediaRejected is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/navigation/page-cache-getUserMedia-pending-promise.html
+++ b/LayoutTests/http/tests/navigation/page-cache-getUserMedia-pending-promise.html
@@ -9,34 +9,43 @@
 description('Tests that a page with a pending getUserMedia request is able to go into the back/forward cache.');
 jsTestIsAsync = true;
 let restoredFromPageCache = false;
+let getUserMediaRejected = false;
 
 if (window.testRunner)
     testRunner.setUserMediaPermission(true);
 
-window.addEventListener("pageshow", function(event) {
-    debug("pageshow - " + (event.persisted ? "" : "not ") + "from cache");
-    if (event.persisted) {
-        testPassed("Page was restored from Page Cache");
-        restoredFromPageCache = true;
-    }
-});
+function getUserMediaCompleted() {
+    // Avoid invoking getUserMedia again.
+    window.removeEventListener("pagehide", onPageHide);
+    shouldBeTrue("restoredFromPageCache");
+    // Pending request gets denied on navigation.
+    shouldBeTrue("getUserMediaRejected");
+    finishJSTest();
+}
 
-window.addEventListener("pagehide", function(event) {
+function onPageHide(event) {
     debug("pagehide - " + (event.persisted ? "" : "not ") + "entering cache");
     if (!event.persisted) {
         testFailed("Page failed to enter the Page Cache");
         finishJSTest();
     }
 
-    navigator.mediaDevices.getUserMedia({ audio: true }).then(() => {
-        testPassed("Promised was resolved");
-        shouldBeTrue("restoredFromPageCache");
-        finishJSTest();
-    }, () => {
-        testFailed("Promise was rejected");
-        finishJSTest();
+    navigator.mediaDevices.getUserMedia({ audio: true }).then(getUserMediaCompleted, () => {
+        getUserMediaRejected = true;
+        getUserMediaCompleted();
     });
-});
+}
+
+function onPageShow(event) {
+    debug("pageshow - " + (event.persisted ? "" : "not ") + "from cache");
+    if (event.persisted) {
+        testPassed("Page was restored from Page Cache");
+        restoredFromPageCache = true;
+    }
+}
+
+window.addEventListener("pageshow", onPageShow);
+window.addEventListener("pagehide", onPageHide);
 
 onload = () => {
     setTimeout(() => {

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -344,8 +344,10 @@ void UserMediaPermissionRequestManagerProxy::resetAccess(std::optional<FrameIden
     ALWAYS_LOG(LOGIDENTIFIER, frameID ? frameID->object().toUInt64() : 0);
 
     if (RefPtr currentUserMediaRequest = m_currentUserMediaRequest; currentUserMediaRequest && (!frameID || m_currentUserMediaRequest->frameID() == *frameID)) {
-        currentUserMediaRequest->invalidate();
-        m_currentUserMediaRequest = nullptr;
+        // Avoid starting pending requests after denying current request.
+        auto pendingUserMediaRequests = std::exchange(m_pendingUserMediaRequests, { });
+        currentUserMediaRequest->deny(UserMediaPermissionRequestProxy::UserMediaAccessDenialReason::OtherFailure);
+        m_pendingUserMediaRequests = std::exchange(pendingUserMediaRequests, { });
     }
 
     if (frameID) {


### PR DESCRIPTION
#### a2555ef76ee7191c3726a000a635c285704e355a
<pre>
REGRESSION (276119@main): [ macOS iOS ] http/tests/navigation/page-cache-getUserMedia-pending-promise.html is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=271063">https://bugs.webkit.org/show_bug.cgi?id=271063</a>
<a href="https://rdar.apple.com/problem/124698382">rdar://problem/124698382</a>

Reviewed by Chris Dumez.

In existing implementation, when main document of page changes (e.g. due to reload or navigation), we invalidate all
existing media permission requests and clear cache (UserMediaPermissionRequestManagerProxy::resetAccess). However, the
invalidation (UserMediaPermissionRequestProxy::invalidate) does not include sending backing request result to web
process, so the Promise of getUserMedia() may never finish (since web process finishes it when receiving result from
UI process).

This causes trouble to the failed test, as it invokes getUserMedia(), immediately navigates away to a new link (main
document changes), then navigates back to the previous page (page restored from page cache) and waits for the Promise
returned by getUserMedia() to finish. To fix this issue, now UserMediaPermissionRequestManagerProxy::resetAccess calls
UserMediaPermissionRequestProxy::deny instead of UserMediaPermissionRequestProxy::invalidate.

* LayoutTests/http/tests/navigation/page-cache-getUserMedia-pending-promise-expected.txt:
* LayoutTests/http/tests/navigation/page-cache-getUserMedia-pending-promise.html:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::resetAccess):

Canonical link: <a href="https://commits.webkit.org/276618@main">https://commits.webkit.org/276618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee0eab1f83432148f176d193158d942209bca553

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47821 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41167 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37042 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18140 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40027 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3206 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41421 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49518 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16665 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44070 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42859 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10038 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21802 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21129 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->