### PR TITLE
Use std::span more for KeyedCoding

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBKeyData.cpp
@@ -155,7 +155,7 @@ void IDBKeyData::encode(KeyedEncoder& encoder) const
         auto* data = std::get<ThreadSafeDataBuffer>(m_value).data();
         encoder.encodeBool("hasBinary"_s, !!data);
         if (data)
-            encoder.encodeBytes("binary"_s, data->data(), data->size());
+            encoder.encodeBytes("binary"_s, data->span());
         return;
     }
     case IndexedDB::KeyType::String:

--- a/Source/WebCore/platform/KeyedCoding.h
+++ b/Source/WebCore/platform/KeyedCoding.h
@@ -40,7 +40,7 @@ public:
 
     virtual ~KeyedDecoder() = default;
 
-    virtual WARN_UNUSED_RETURN bool decodeBytes(const String& key, const uint8_t*&, size_t&) = 0;
+    virtual WARN_UNUSED_RETURN bool decodeBytes(const String& key, std::span<const uint8_t>&) = 0;
     virtual WARN_UNUSED_RETURN bool decodeBool(const String& key, bool&) = 0;
     virtual WARN_UNUSED_RETURN bool decodeUInt32(const String& key, uint32_t&) = 0;
     virtual WARN_UNUSED_RETURN bool decodeUInt64(const String& key, uint64_t&) = 0;
@@ -55,13 +55,11 @@ public:
     {
         static_assert(sizeof(T) == 1);
 
-        size_t size;
-        const uint8_t* bytes;
-        if (!decodeBytes(key, bytes, size))
+        std::span<const uint8_t> bytes;
+        if (!decodeBytes(key, bytes))
             return false;
 
-        vector.resize(size);
-        std::copy_n(bytes, size, vector.data());
+        vector = bytes;
         return true;
     }
 
@@ -150,7 +148,7 @@ public:
 
     virtual ~KeyedEncoder() = default;
 
-    virtual void encodeBytes(const String& key, const uint8_t*, size_t) = 0;
+    virtual void encodeBytes(const String& key, std::span<const uint8_t>) = 0;
     virtual void encodeBool(const String& key, bool) = 0;
     virtual void encodeUInt32(const String& key, uint32_t) = 0;
     virtual void encodeUInt64(const String& key, uint64_t) = 0;

--- a/Source/WebCore/platform/cf/KeyedDecoderCF.cpp
+++ b/Source/WebCore/platform/cf/KeyedDecoderCF.cpp
@@ -56,14 +56,13 @@ KeyedDecoderCF::~KeyedDecoderCF()
     ASSERT(m_arrayIndexStack.isEmpty());
 }
 
-bool KeyedDecoderCF::decodeBytes(const String& key, const uint8_t*& bytes, size_t& size)
+bool KeyedDecoderCF::decodeBytes(const String& key, std::span<const uint8_t>& bytes)
 {
     auto data = dynamic_cf_cast<CFDataRef>(CFDictionaryGetValue(m_dictionaryStack.last(), key.createCFString().get()));
     if (!data)
         return false;
 
-    bytes = CFDataGetBytePtr(data);
-    size = CFDataGetLength(data);
+    bytes = { CFDataGetBytePtr(data), static_cast<size_t>(CFDataGetLength(data)) };
     return true;
 }
 

--- a/Source/WebCore/platform/cf/KeyedDecoderCF.h
+++ b/Source/WebCore/platform/cf/KeyedDecoderCF.h
@@ -38,7 +38,7 @@ public:
     ~KeyedDecoderCF() override;
 
 private:
-    WARN_UNUSED_RETURN bool decodeBytes(const String& key, const uint8_t*&, size_t&) override;
+    WARN_UNUSED_RETURN bool decodeBytes(const String& key, std::span<const uint8_t>&) override;
     WARN_UNUSED_RETURN bool decodeBool(const String& key, bool&) override;
     WARN_UNUSED_RETURN bool decodeUInt32(const String& key, uint32_t&) override;
     WARN_UNUSED_RETURN bool decodeUInt64(const String& key, uint64_t&) override;

--- a/Source/WebCore/platform/cf/KeyedEncoderCF.cpp
+++ b/Source/WebCore/platform/cf/KeyedEncoderCF.cpp
@@ -55,9 +55,9 @@ KeyedEncoderCF::~KeyedEncoderCF()
     ASSERT(m_arrayStack.isEmpty());
 }
 
-void KeyedEncoderCF::encodeBytes(const String& key, const uint8_t* bytes, size_t size)
+void KeyedEncoderCF::encodeBytes(const String& key, std::span<const uint8_t> bytes)
 {
-    auto data = adoptCF(CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, bytes, size, kCFAllocatorNull));
+    RetainPtr data = adoptCF(CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, bytes.data(), bytes.size(), kCFAllocatorNull));
     CFDictionarySetValue(m_dictionaryStack.last(), key.createCFString().get(), data.get());
 }
 

--- a/Source/WebCore/platform/cf/KeyedEncoderCF.h
+++ b/Source/WebCore/platform/cf/KeyedEncoderCF.h
@@ -39,7 +39,7 @@ public:
 private:
     RefPtr<WebCore::SharedBuffer> finishEncoding() final;
 
-    void encodeBytes(const String& key, const uint8_t*, size_t) final;
+    void encodeBytes(const String& key, std::span<const uint8_t>) final;
     void encodeBool(const String& key, bool) final;
     void encodeUInt32(const String& key, uint32_t) final;
     void encodeUInt64(const String& key, uint64_t) final;

--- a/Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp
+++ b/Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp
@@ -239,14 +239,13 @@ bool KeyedDecoderGeneric::decodeSimpleValue(const String& key, T& result)
     return true;
 }
 
-bool KeyedDecoderGeneric::decodeBytes(const String& key, const uint8_t*& data, size_t& size)
+bool KeyedDecoderGeneric::decodeBytes(const String& key, std::span<const uint8_t>& data)
 {
     auto value = getPointerFromDictionaryStack<Vector<uint8_t>>(key);
     if (!value)
         return false;
 
-    data = value->data();
-    size = value->size();
+    data = value->span();
     return true;
 }
 

--- a/Source/WebCore/platform/generic/KeyedDecoderGeneric.h
+++ b/Source/WebCore/platform/generic/KeyedDecoderGeneric.h
@@ -37,7 +37,7 @@ public:
     using Array = Vector<std::unique_ptr<Dictionary>>;
 
 private:
-    WARN_UNUSED_RETURN bool decodeBytes(const String& key, const uint8_t*&, size_t&) override;
+    WARN_UNUSED_RETURN bool decodeBytes(const String& key, std::span<const uint8_t>&) override;
     WARN_UNUSED_RETURN bool decodeBool(const String& key, bool&) override;
     WARN_UNUSED_RETURN bool decodeUInt32(const String& key, uint32_t&) override;
     WARN_UNUSED_RETURN bool decodeUInt64(const String& key, uint64_t&) override;

--- a/Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp
+++ b/Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp
@@ -47,12 +47,12 @@ void KeyedEncoderGeneric::encodeString(const String& key)
     RELEASE_ASSERT(result);
 }
 
-void KeyedEncoderGeneric::encodeBytes(const String& key, const uint8_t* bytes, size_t size)
+void KeyedEncoderGeneric::encodeBytes(const String& key, std::span<const uint8_t> bytes)
 {
     m_encoder << Type::Bytes;
     encodeString(key);
-    m_encoder << size;
-    m_encoder.encodeFixedLengthData({ bytes, size });
+    m_encoder << bytes.size();
+    m_encoder.encodeFixedLengthData(bytes);
 }
 
 void KeyedEncoderGeneric::encodeBool(const String& key, bool value)

--- a/Source/WebCore/platform/generic/KeyedEncoderGeneric.h
+++ b/Source/WebCore/platform/generic/KeyedEncoderGeneric.h
@@ -59,7 +59,7 @@ public:
 private:
     RefPtr<SharedBuffer> finishEncoding() override;
 
-    void encodeBytes(const String& key, const uint8_t*, size_t) override;
+    void encodeBytes(const String& key, std::span<const uint8_t>) override;
     void encodeBool(const String& key, bool) override;
     void encodeUInt32(const String& key, uint32_t) override;
     void encodeUInt64(const String& key, uint64_t) override;

--- a/Source/WebCore/platform/glib/KeyedDecoderGlib.cpp
+++ b/Source/WebCore/platform/glib/KeyedDecoderGlib.cpp
@@ -63,14 +63,13 @@ HashMap<String, GRefPtr<GVariant>> KeyedDecoderGlib::dictionaryFromGVariant(GVar
     return dictionary;
 }
 
-bool KeyedDecoderGlib::decodeBytes(const String& key, const uint8_t*& bytes, size_t& size)
+bool KeyedDecoderGlib::decodeBytes(const String& key, std::span<const uint8_t>& bytes)
 {
     GRefPtr<GVariant> value = m_dictionaryStack.last().get(key);
     if (!value)
         return false;
 
-    size = g_variant_get_size(value.get());
-    bytes = static_cast<const uint8_t*>(g_variant_get_data(value.get()));
+    bytes = { static_cast<const uint8_t*>(g_variant_get_data(value.get())), g_variant_get_size(value.get()) };
     return true;
 }
 

--- a/Source/WebCore/platform/glib/KeyedDecoderGlib.h
+++ b/Source/WebCore/platform/glib/KeyedDecoderGlib.h
@@ -41,7 +41,7 @@ public:
     ~KeyedDecoderGlib() override;
 
 private:
-    WARN_UNUSED_RETURN bool decodeBytes(const String& key, const uint8_t*&, size_t&) override;
+    WARN_UNUSED_RETURN bool decodeBytes(const String& key, std::span<const uint8_t>&) override;
     WARN_UNUSED_RETURN bool decodeBool(const String& key, bool&) override;
     WARN_UNUSED_RETURN bool decodeUInt32(const String& key, uint32_t&) override;
     WARN_UNUSED_RETURN bool decodeUInt64(const String& key, uint64_t&) override;

--- a/Source/WebCore/platform/glib/KeyedEncoderGlib.cpp
+++ b/Source/WebCore/platform/glib/KeyedEncoderGlib.cpp
@@ -50,9 +50,9 @@ KeyedEncoderGlib::~KeyedEncoderGlib()
     ASSERT(m_objectStack.isEmpty());
 }
 
-void KeyedEncoderGlib::encodeBytes(const String& key, const uint8_t* bytes, size_t size)
+void KeyedEncoderGlib::encodeBytes(const String& key, std::span<const uint8_t> bytes)
 {
-    GRefPtr<GBytes> gBytes = adoptGRef(g_bytes_new_static(bytes, size));
+    GRefPtr<GBytes> gBytes = adoptGRef(g_bytes_new_static(bytes.data(), bytes.size()));
     g_variant_builder_add(m_variantBuilderStack.last(), "{sv}", key.utf8().data(), g_variant_new_from_bytes(G_VARIANT_TYPE("ay"), gBytes.get(), TRUE));
 }
 

--- a/Source/WebCore/platform/glib/KeyedEncoderGlib.h
+++ b/Source/WebCore/platform/glib/KeyedEncoderGlib.h
@@ -41,7 +41,7 @@ public:
 private:
     RefPtr<WebCore::SharedBuffer> finishEncoding() final;
 
-    void encodeBytes(const String& key, const uint8_t*, size_t) final;
+    void encodeBytes(const String& key, std::span<const uint8_t>) final;
     void encodeBool(const String& key, bool) final;
     void encodeUInt32(const String& key, uint32_t) final;
     void encodeUInt64(const String& key, uint64_t) final;


### PR DESCRIPTION
#### d3c216cd1186dcd7d55e986b0e0f962a04ed6782
<pre>
Use std::span more for KeyedCoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=271511">https://bugs.webkit.org/show_bug.cgi?id=271511</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/indexeddb/IDBKeyData.cpp:
(WebCore::IDBKeyData::encode const):
* Source/WebCore/platform/KeyedCoding.h:
(WebCore::KeyedDecoder::decodeBytes):
* Source/WebCore/platform/cf/KeyedDecoderCF.cpp:
(WebCore::KeyedDecoderCF::decodeBytes):
* Source/WebCore/platform/cf/KeyedDecoderCF.h:
* Source/WebCore/platform/cf/KeyedEncoderCF.cpp:
(WebCore::KeyedEncoderCF::encodeBytes):
* Source/WebCore/platform/cf/KeyedEncoderCF.h:
* Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp:
(WebCore::KeyedDecoderGeneric::decodeBytes):
* Source/WebCore/platform/generic/KeyedDecoderGeneric.h:
* Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp:
(WebCore::KeyedEncoderGeneric::encodeBytes):
* Source/WebCore/platform/generic/KeyedEncoderGeneric.h:
* Source/WebCore/platform/glib/KeyedDecoderGlib.cpp:
(WebCore::KeyedDecoderGlib::decodeBytes):
* Source/WebCore/platform/glib/KeyedDecoderGlib.h:
* Source/WebCore/platform/glib/KeyedEncoderGlib.cpp:
(WebCore::KeyedEncoderGlib::encodeBytes):
* Source/WebCore/platform/glib/KeyedEncoderGlib.h:
* Tools/TestWebKitAPI/Tests/WebCore/KeyedCoding.cpp:
(TestWebKitAPI::checkDecodedBytes):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/276593@main">https://commits.webkit.org/276593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cb35948c35806a8e8e2bf903a754994ddae35e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47726 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41075 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36973 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18071 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39942 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3114 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49408 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43983 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21355 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42764 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21702 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6273 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->