### PR TITLE
[Remote Inspection] _WKTargetedElementInfo should expose a method to get contained subframes

### DIFF
--- a/Source/WebCore/page/ElementTargeting.cpp
+++ b/Source/WebCore/page/ElementTargeting.cpp
@@ -186,6 +186,16 @@ static inline RectEdges<bool> computeOffsetEdges(const RenderStyle& style)
     };
 }
 
+static inline Vector<FrameIdentifier> collectChildFrameIdentifiers(Element& element)
+{
+    Vector<FrameIdentifier> identifiers;
+    for (auto& owner : descendantsOfType<HTMLFrameOwnerElement>(element)) {
+        if (RefPtr frame = owner.protectedContentFrame())
+            identifiers.append(frame->frameID());
+    }
+    return identifiers;
+}
+
 static TargetedElementInfo targetedElementInfo(Element& element)
 {
     CheckedPtr renderer = element.renderer();
@@ -196,7 +206,8 @@ static TargetedElementInfo targetedElementInfo(Element& element)
         .renderedText = TextExtraction::extractRenderedText(element),
         .selectors = selectorsForTarget(element),
         .boundsInRootView = element.boundingBoxInRootViewCoordinates(),
-        .positionType = renderer->style().position()
+        .positionType = renderer->style().position(),
+        .childFrameIdentifiers = collectChildFrameIdentifiers(element),
     };
 }
 

--- a/Source/WebCore/page/ElementTargetingTypes.h
+++ b/Source/WebCore/page/ElementTargetingTypes.h
@@ -28,6 +28,7 @@
 #include "ElementIdentifier.h"
 #include "FloatPoint.h"
 #include "FloatRect.h"
+#include "FrameIdentifier.h"
 #include "RectEdges.h"
 #include "RenderStyleConstants.h"
 #include "ScriptExecutionContextIdentifier.h"
@@ -48,6 +49,7 @@ struct TargetedElementInfo {
     Vector<String> selectors;
     FloatRect boundsInRootView;
     PositionType positionType { PositionType::Static };
+    Vector<FrameIdentifier> childFrameIdentifiers;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -302,7 +302,7 @@ inline API::Object* Object::unwrap(void* object)
 }
 #endif
 
-} // namespace Object
+} // namespace API
 
 #undef DELEGATE_REF_COUNTING_TO_COCOA
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -897,6 +897,7 @@ header: <WebCore/ElementTargetingTypes.h>
     Vector<String> selectors
     WebCore::FloatRect boundsInRootView
     WebCore::PositionType positionType
+    Vector<WebCore::FrameIdentifier> childFrameIdentifiers
 };
 
 header: <WebCore/RenderStyleConstants.h>

--- a/Source/WebKit/UIProcess/API/APIFrameInfo.cpp
+++ b/Source/WebKit/UIProcess/API/APIFrameInfo.cpp
@@ -57,4 +57,15 @@ RefPtr<FrameHandle> FrameInfo::parentFrameHandle() const
     return FrameHandle::create(*m_data.parentFrameID);
 }
 
+WTF::String FrameInfo::title() const
+{
+    if (!m_page)
+        return { };
+
+    if (RefPtr frame = WebKit::WebFrameProxy::webFrame(m_data.frameID); frame && frame->page() == m_page)
+        return frame->title();
+
+    return { };
+}
+
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIFrameInfo.h
+++ b/Source/WebKit/UIProcess/API/APIFrameInfo.h
@@ -59,6 +59,7 @@ public:
     ProcessID processID() const { return m_data.processID; }
     bool isFocused() const { return m_data.isFocused; }
     bool errorOccurred() const { return m_data.errorOccurred; }
+    WTF::String title() const;
 
 private:
     FrameInfo(WebKit::FrameInfoData&&, RefPtr<WebKit::WebPageProxy>&&);

--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
@@ -27,6 +27,7 @@
 
 #include "APIObject.h"
 #include <WebCore/ElementTargetingTypes.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
 
@@ -35,6 +36,8 @@ class WebPageProxy;
 }
 
 namespace API {
+
+class FrameTreeNode;
 
 class TargetedElementInfo final : public ObjectImpl<Object::Type::TargetedElementInfo> {
 public:
@@ -52,6 +55,8 @@ public:
     WebCore::PositionType positionType() const { return m_info.positionType; }
     WebCore::FloatRect boundsInRootView() const { return m_info.boundsInRootView; }
     WebCore::FloatRect boundsInWebView() const;
+
+    void childFrames(CompletionHandler<void(Vector<Ref<FrameTreeNode>>&&)>&&) const;
 
     bool isSameElement(const TargetedElementInfo&) const;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -119,4 +119,9 @@
     return _frameInfo->errorOccurred();
 }
 
+- (NSString *)_title
+{
+    return _frameInfo->title();
+}
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h
@@ -35,5 +35,6 @@
 @property (nonatomic, readonly) BOOL _isLocalFrame WK_API_AVAILABLE(macos(14.0), ios(17.0));
 @property (nonatomic, readonly) BOOL _isFocused WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, readonly) BOOL _errorOccurred WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, readonly, copy, nullable) NSString *_title WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
@@ -35,6 +35,8 @@ typedef NS_ENUM(NSInteger, _WKTargetedElementPosition) {
     _WKTargetedElementPositionFixed
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+@class _WKFrameTreeNode;
+
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @interface _WKTargetedElementInfo : NSObject
 
@@ -46,6 +48,8 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @property (nonatomic, readonly) _WKRectEdge offsetEdges;
 
 - (BOOL)isSameElement:(_WKTargetedElementInfo *)other;
+
+- (void)getChildFrames:(void(^)(NSArray<_WKFrameTreeNode *> *))completionHandler;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -26,8 +26,13 @@
 #import "config.h"
 #import "_WKTargetedElementInfo.h"
 
+#import "APIFrameTreeNode.h"
+#import "WKObject.h"
+#import "WebPageProxy.h"
+#import "_WKFrameTreeNodeInternal.h"
 #import "_WKTargetedElementInfoInternal.h"
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/BlockPtr.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 @implementation _WKTargetedElementInfo
@@ -89,6 +94,15 @@
     if (coreEdges.right())
         edges |= _WKRectEdgeRight;
     return edges;
+}
+
+- (void)getChildFrames:(void(^)(NSArray<_WKFrameTreeNode *> *))completion
+{
+    return _info->childFrames([completion = makeBlockPtr(completion)](auto&& nodes) {
+        completion(createNSArray(WTFMove(nodes), [](API::FrameTreeNode& node) {
+            return wrapper(node);
+        }).autorelease());
+    });
 }
 
 - (BOOL)isSameElement:(_WKTargetedElementInfo *)other

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1183,6 +1183,7 @@
 		F4512E131F60C44600BB369E /* DataTransferItem-getAsEntry.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4512E121F60C43400BB369E /* DataTransferItem-getAsEntry.html */; };
 		F4517B672054C49500C26721 /* TestWKWebViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4517B662054C49500C26721 /* TestWKWebViewController.mm */; };
 		F4538EF71E8473E600B5C953 /* large-red-square.png in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4538EF01E846B4100B5C953 /* large-red-square.png */; };
+		F455DB952BAE45B600732E1B /* nested-frames.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F455DB8C2BAE37C100732E1B /* nested-frames.html */; };
 		F456AB1C213EDBA300CB2CEF /* FontManagerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F456AB1B213EDBA300CB2CEF /* FontManagerTests.mm */; };
 		F457275E25578D06007ACA34 /* DisplayListTestsCG.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F457275D25578D06007ACA34 /* DisplayListTestsCG.cpp */; };
 		F457A9D6202D68AF00F7E9D5 /* DataTransfer.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F457A9B3202D535300F7E9D5 /* DataTransfer.html */; };
@@ -1810,6 +1811,7 @@
 				9BF356CD202D458500F71160 /* mso-list.html in Copy Resources */,
 				F42F081227449892007E0D90 /* multiple-images.html in Copy Resources */,
 				5797FE331EB15AB100B2F4A0 /* navigation-client-default-crypto.html in Copy Resources */,
+				F455DB952BAE45B600732E1B /* nested-frames.html in Copy Resources */,
 				2E4838472169DF30002F4531 /* nested-lists.html in Copy Resources */,
 				C99B675F1E39736F00FC6C80 /* no-autoplay-with-controls.html in Copy Resources */,
 				466C3843210637DE006A88DE /* notify-resourceLoadObserver.html in Copy Resources */,
@@ -3548,6 +3550,7 @@
 		F4517B652054C49500C26721 /* TestWKWebViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestWKWebViewController.h; sourceTree = "<group>"; };
 		F4517B662054C49500C26721 /* TestWKWebViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TestWKWebViewController.mm; sourceTree = "<group>"; };
 		F4538EF01E846B4100B5C953 /* large-red-square.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "large-red-square.png"; sourceTree = "<group>"; };
+		F455DB8C2BAE37C100732E1B /* nested-frames.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "nested-frames.html"; sourceTree = "<group>"; };
 		F456AB1B213EDBA300CB2CEF /* FontManagerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FontManagerTests.mm; sourceTree = "<group>"; };
 		F457275D25578D06007ACA34 /* DisplayListTestsCG.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DisplayListTestsCG.cpp; path = cg/DisplayListTestsCG.cpp; sourceTree = "<group>"; };
 		F457A9B3202D535300F7E9D5 /* DataTransfer.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = DataTransfer.html; sourceTree = "<group>"; };
@@ -4941,6 +4944,7 @@
 				9BCD4119206D5ED7001D71BE /* mso-list-on-h4.html */,
 				9BF356CC202D44F200F71160 /* mso-list.html */,
 				F42F0811274497C8007E0D90 /* multiple-images.html */,
+				F455DB8C2BAE37C100732E1B /* nested-frames.html */,
 				2E4838462169DD42002F4531 /* nested-lists.html */,
 				466C3842210637CE006A88DE /* notify-resourceLoadObserver.html */,
 				CDB5DFFE21360ED800D3E189 /* now-playing.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-1.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-1.html
@@ -37,6 +37,12 @@ body, html {
     background: blueviolet;
 }
 
+iframe {
+    width: 200px;
+    height: 200px;
+    border: 1px solid black;
+}
+
 main {
     line-height: 200%;
 }
@@ -44,7 +50,7 @@ main {
 </head>
 <body>
     <div class="fixed container">
-        <p>The round pegs in the square holes. <a href="https://webkit.org">The ones who see things differently</a>.</p>
+        <iframe title="Outer Subframe"></iframe>
     </div>
     <div id="absolute" class="container">
         <p>Here’s to the crazy ones. <strong>The misfits.</strong> The rebels. The troublemakers.
@@ -56,5 +62,18 @@ main {
         <section><p>Sollicitudin aliquam ultrices sagittis orci a. Mattis pellentesque id nibh tortor id aliquet lectus proin nibh. Duis at consectetur lorem donec massa sapien faucibus. Massa tincidunt dui ut ornare lectus sit amet est placerat. In ante metus dictum at. Urna nec tincidunt praesent semper feugiat nibh sed. Tempus quam pellentesque nec nam. Sapien pellentesque habitant morbi tristique senectus et netus et malesuada. Orci sagittis eu volutpat odio facilisis. Morbi tristique senectus et netus et malesuada. Phasellus vestibulum lorem sed risus ultricies tristique nulla aliquet. Sem nulla pharetra diam sit. Rhoncus urna neque viverra justo nec. Ultrices vitae auctor eu augue ut lectus arcu bibendum at.</p></section>
         <section><p>Turpis egestas integer eget aliquet nibh praesent tristique. Diam volutpat commodo sed egestas egestas fringilla phasellus faucibus. Enim diam vulputate ut pharetra sit amet aliquam. Congue nisi vitae suscipit tellus mauris a diam. Placerat vestibulum lectus mauris ultrices eros in cursus turpis. Consequat mauris nunc congue nisi vitae suscipit. Est ullamcorper eget nulla facilisi etiam. Nisl nisi scelerisque eu ultrices. Ut tortor pretium viverra suspendisse potenti nullam ac. Sagittis eu volutpat odio facilisis mauris sit amet massa vitae. Aliquet nec ullamcorper sit amet risus. Pretium vulputate sapien nec sagittis. Vel facilisis volutpat est velit egestas dui. Id semper risus in hendrerit gravida rutrum quisque non tellus. Mauris ultrices eros in cursus turpis. Amet consectetur adipiscing elit ut aliquam.</p></section>
     </main>
+    <script>
+        subframeLoaded = false;
+        addEventListener("message", event => {
+            if (event.data !== "subframeLoaded")
+                return;
+            subframeLoaded = true;
+        });
+
+        addEventListener("load", () => {
+            const subframe = document.querySelector("iframe");
+            subframe.src = "nested-frames.html";
+        });
+    </script>
 </body>
 </html>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/nested-frames.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/nested-frames.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Outer Subframe</title>
+<style>
+iframe {
+    width: 100px;
+    height: 100px;
+    border: 1px solid black;
+}
+</style>
+</head>
+<body>
+    <p>The round pegs in the square holes.
+        <iframe title="Inner Subframe"></iframe>
+    </p>
+    <script>
+        addEventListener("load", () => {
+            const subframe = document.querySelector("iframe");
+            subframe.addEventListener("load", () => {
+                parent.postMessage("subframeLoaded", "*");
+            });
+            subframe.srcdoc = `
+                <head>
+                    <title>Inner Subframe</title>
+                </head>
+                <body>
+                    <a href='https://webkit.org'>The ones who see things differently.</a>
+                </body>`;
+        });
+    </script>
+</html>


### PR DESCRIPTION
#### c33f546359f3ccb08df0878d6957252f57f47047
<pre>
[Remote Inspection] _WKTargetedElementInfo should expose a method to get contained subframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=271510">https://bugs.webkit.org/show_bug.cgi?id=271510</a>

Reviewed by Megan Gardner.

Add a new method on `_WKTargetedElementInfo` to request `_WKFrameTreeNode`s that correspond to the
subframes underneath the targeted element. See below for more details.

* Source/WebCore/page/ElementTargeting.cpp:
(WebCore::collectChildFrameIdentifiers):
(WebCore::targetedElementInfo):

Plumb frame IDs for subframes underneath the targeted element from the web process to the UI
process.

* Source/WebCore/page/ElementTargetingTypes.h:
* Source/WebKit/Shared/API/APIObject.h:

Drive-by fix a typo in a comment: `namespace Object` should be `namespace API`.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APIFrameInfo.cpp:
(API::FrameInfo::title const):

Add a getter for `title` on `FrameInfo`, which calls into `WebFrameProxy`.

* Source/WebKit/UIProcess/API/APIFrameInfo.h:
* Source/WebKit/UIProcess/API/APITargetedElementInfo.cpp:
(API::TargetedElementInfo::isSameElement const):
(API::TargetedElementInfo::childFrames const):
* Source/WebKit/UIProcess/API/APITargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
(-[WKFrameInfo _title]):

Add a new SPI method on `WKFrameInfo`, which allows clients to read the last cached `title` for the
given frame.

* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo getChildFrames:]):

Implement the new API method. Using the list of subframe IDs from the targeting results, request
`FrameTreeNodeData` for each subframe and call the completion handler once all the async calls are
complete.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(-[_WKTargetedElementInfo childFrames]):
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-1.html:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/nested-frames.html: Added.

Augment an existing API test to cover this new method as well.

Canonical link: <a href="https://commits.webkit.org/276647@main">https://commits.webkit.org/276647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e4031b26ceb878c2541b1dd38ff2603ee1685f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41086 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36981 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45656 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38824 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18081 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18656 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39953 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3125 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49423 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16577 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/43997 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21366 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42778 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10059 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21045 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->