### PR TITLE
[GTK] Creates a lot of MPRIS notifications with no reason

### DIFF
--- a/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
+++ b/Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h
@@ -51,7 +51,9 @@ public:
     void dispatch(PlatformMediaSession::RemoteControlCommandType, PlatformMediaSession::RemoteCommandArgument);
 
     const GRefPtr<GDBusNodeInfo>& mprisInterface() const { return m_mprisInterface; }
-    PlatformMediaSession* nowPlayingEligibleSession();
+    void setPrimarySessionIfNeeded(PlatformMediaSession&);
+    void unregisterAllOtherSessions(PlatformMediaSession&);
+    WeakPtr<PlatformMediaSession> nowPlayingEligibleSession();
 
     void setDBusNotificationsEnabled(bool dbusNotificationsEnabled) { m_dbusNotificationsEnabled = dbusNotificationsEnabled; }
     bool areDBusNotificationsEnabled() const { return m_dbusNotificationsEnabled; }


### PR DESCRIPTION
#### 5e2b534ceb82cab15eac4b487e09c592bd06fec6
<pre>
[GTK] Creates a lot of MPRIS notifications with no reason
<a href="https://bugs.webkit.org/show_bug.cgi?id=247527">https://bugs.webkit.org/show_bug.cgi?id=247527</a>

Reviewed by Philippe Normand.

At any given time, there should be only one active MPRIS session.
MediaSessionManagerGLib would not unregister inactive MPRIS sessions
once a new one became the current session. This patch ensures that
once a new current session is set, all others both unregistered and
marked as ineligible for future registration on status changes.

* Source/WebCore/platform/audio/glib/MediaSessionGLib.cpp:
(WebCore::MediaSessionGLib::~MediaSessionGLib):
(WebCore::MediaSessionGLib::ensureMprisSessionRegistered):
(WebCore::MediaSessionGLib::unregisterMprisSession):
(WebCore::MediaSessionGLib::emitPositionChanged):
(WebCore::MediaSessionGLib::getPlaybackStatusAsGVariant):
(WebCore::MediaSessionGLib::emitPropertiesChanged):
* Source/WebCore/platform/audio/glib/MediaSessionGLib.h:
(WebCore::MediaSessionGLib::setMprisRegistrationEligibility):
(WebCore::MediaSessionGLib::mprisRegistrationEligibility const):
(WTF::LogArgument&lt;WebCore::MediaSessionGLib::MprisRegistrationEligiblilty&gt;::toString):
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.cpp:
(WebCore::MediaSessionManagerGLib::setPrimarySessionIfNeeded):
(WebCore::MediaSessionManagerGLib::unregisterAllOtherSessions):
(WebCore::MediaSessionManagerGLib::nowPlayingEligibleSession): Modified to reflect the Cocoa implementation
(WebCore::MediaSessionManagerGLib::updateNowPlayingInfo):
(WebCore::MediaSessionManagerGLib::setCurrentSession):
* Source/WebCore/platform/audio/glib/MediaSessionManagerGLib.h:

Canonical link: <a href="https://commits.webkit.org/276591@main">https://commits.webkit.org/276591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c3daf8aea8fc8d4ca738760752809ae5a2a4849

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41099 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/36996 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18677 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39965 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3138 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49438 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16597 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21379 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42796 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10027 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21729 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->