### PR TITLE
Remove `constructor` from `HighlightRegistry.idl`

### DIFF
--- a/LayoutTests/highlight/highlight-interfaces-expected.txt
+++ b/LayoutTests/highlight/highlight-interfaces-expected.txt
@@ -10,8 +10,6 @@ PASS new Highlight(new StaticRange({startContainer: document.body, startOffset: 
 PASS Highlight.prototype[Symbol.iterator] is Highlight.prototype.values
 PASS HighlightRegistry instanceof Function is true
 PASS typeof HighlightRegistry is "function"
-PASS new HighlightRegistry() instanceof HighlightRegistry is true
-PASS new HighlightRegistry().set("foo-styling",new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2}))) is defined.
 PASS CSS.highlights is defined.
 PASS CSS.highlights.set("foo-styling",new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2}))) is CSS.highlights
 PASS successfullyParsed is true

--- a/LayoutTests/highlight/highlight-interfaces.html
+++ b/LayoutTests/highlight/highlight-interfaces.html
@@ -13,8 +13,6 @@ shouldBeTrue("new Highlight(new StaticRange({startContainer: document.body, star
 shouldBe("Highlight.prototype[Symbol.iterator]", "Highlight.prototype.values");
 shouldBeTrue("HighlightRegistry instanceof Function");
 shouldBeEqualToString("typeof HighlightRegistry", "function");
-shouldBeTrue("new HighlightRegistry() instanceof HighlightRegistry");
-shouldBeDefined('new HighlightRegistry().set("foo-styling",new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2})))');
 shouldBeDefined('CSS.highlights');
 shouldBe('CSS.highlights.set("foo-styling",new Highlight(new StaticRange({startContainer: document.body, startOffset: 1, endContainer: document.body, endOffset: 2})))', 'CSS.highlights');
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-maplike-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-maplike-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL HighlightRegistry initializes as it should. assert_throws_js: HighlightRegistry constructor throws function "function () { var x = new HighlightRegistry(); }" did not throw
+PASS HighlightRegistry initializes as it should.
 PASS HighlightRegistry has a maplike interface.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-maplike-tampered-Map-prototype.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-maplike-tampered-Map-prototype.html
@@ -25,11 +25,39 @@ function tamperMapPrototype() {
   Object.freeze(Map.prototype);
 }
 
+function restoreMapPrototype(originalDescriptors) {
+  // Create a new object with the original descriptors
+  const newProto = Object.create(Object.prototype);
+  
+  for (const [key, descriptor] of Object.entries(originalDescriptors)) {
+    if (descriptor) {
+      Object.defineProperty(newProto, key, descriptor);
+    }
+  }
+  
+  // Replace the frozen prototype with the restored one
+  Object.setPrototypeOf(Map, newProto);
+}
+
 test(() => {
+  const originalDescriptors = {
+    size: Object.getOwnPropertyDescriptor(Map.prototype, 'size'),
+    entries: Object.getOwnPropertyDescriptor(Map.prototype, 'entries'),
+    forEach: Object.getOwnPropertyDescriptor(Map.prototype, 'forEach'),
+    get: Object.getOwnPropertyDescriptor(Map.prototype, 'get'),
+    has: Object.getOwnPropertyDescriptor(Map.prototype, 'has'),
+    keys: Object.getOwnPropertyDescriptor(Map.prototype, 'keys'),
+    values: Object.getOwnPropertyDescriptor(Map.prototype, 'values'),
+    [Symbol.iterator]: Object.getOwnPropertyDescriptor(Map.prototype, Symbol.iterator),
+    clear: Object.getOwnPropertyDescriptor(Map.prototype, 'clear'),
+    delete: Object.getOwnPropertyDescriptor(Map.prototype, 'delete'),
+    set: Object.getOwnPropertyDescriptor(Map.prototype, 'set')
+  };
+
   tamperMapPrototype();
 
   const highlight = new Highlight(new StaticRange({startContainer: document.body, endContainer: document.body, startOffset: 0, endOffset: 0}));
-  const highlightRegistry = new HighlightRegistry();
+  const highlightRegistry = CSS.highlights;
 
   assert_equals(highlightRegistry.size, 0);
   highlightRegistry.set("foo", highlight);
@@ -57,5 +85,8 @@ test(() => {
   let callbackCalled = false;
   highlightRegistry.forEach(() => { callbackCalled = true; });
   assert_true(callbackCalled);
+
+  highlightRegistry.clear();
+  restoreMapPrototype(originalDescriptors);
 }, "HighlightRegistry is a maplike interface that works as expected even if Map.prototype is tampered.");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt
@@ -18,9 +18,7 @@ PASS Highlight must be primary interface of new Highlight(new Range())
 PASS Stringification of new Highlight(new Range())
 PASS Highlight interface: new Highlight(new Range()) must inherit property "priority" with the proper type
 PASS Highlight interface: new Highlight(new Range()) must inherit property "type" with the proper type
-FAIL HighlightRegistry interface: existence and properties of interface object assert_throws_js: interface object didn't throw TypeError when called as a constructor function "function() {
-                new interface_object();
-            }" did not throw
+PASS HighlightRegistry interface: existence and properties of interface object
 PASS HighlightRegistry interface object length
 PASS HighlightRegistry interface object name
 PASS HighlightRegistry interface: existence and properties of interface prototype object

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.idl
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,10 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://drafts.csswg.org/css-highlight-api/#highlightregistry
+
 [
     Exposed=Window
 ] interface HighlightRegistry {
-    constructor();
-
     maplike<[AtomString] DOMString, Highlight>;
 };


### PR DESCRIPTION
#### 10396bf507cc815f725b7c17bad57e7b93b84e2b
<pre>
Remove `constructor` from `HighlightRegistry.idl`
<a href="https://bugs.webkit.org/show_bug.cgi?id=271360">https://bugs.webkit.org/show_bug.cgi?id=271360</a>
<a href="https://rdar.apple.com/problem/125529396">rdar://problem/125529396</a>

Reviewed by Brent Fulgham.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and
Web Specification [1]:

[1] <a href="https://drafts.csswg.org/css-highlight-api/#highlightregistry">https://drafts.csswg.org/css-highlight-api/#highlightregistry</a>

This removes `constructor` since it is not in web specification.

Additionally, this patch addresses two issues with the HighlightRegistry
tampered prototype test:

1. Removes reliance on the non-standard HighlightRegistry constructor and
   instead uses CSS.highlights to access the standard HighlightRegistry
   instance.

2. Properly restores Map.prototype to its original state after the test
   completes. Since Map.prototype is frozen during the test, restoration is
   done by creating a new prototype object with the saved descriptors and
   replacing Map&apos;s prototype, rather than attempting to modify the frozen
   object directly.

NOTE: Both of above changes were suggested by Alexey Shvaika (original
test author).

* LayoutTests/highlight/highlight-interfaces-expected.txt:
* LayoutTests/highlight/highlight-interfaces.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/idlharness.window-expected.txt:
* Source/WebCore/Modules/highlight/HighlightRegistry.idl:
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-maplike-tampered-Map-prototype.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-highlight-api/HighlightRegistry-maplike-expected.txt:

Canonical link: <a href="https://commits.webkit.org/303858@main">https://commits.webkit.org/303858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08fdc388c6c936fdc14fba7c5e9db1d73b50671f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140664 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85158 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/fed90578-7d87-4d64-ae6b-df1491c79d05) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101807 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/69185 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/31703ecf-2620-4236-8236-c6c4e6b623be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/4317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82604 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7c2045d3-37ad-4859-bac9-0084299864eb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4201 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1786 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143311 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5290 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110186 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110366 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/28131 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4083 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115557 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58952 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5345 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33911 "Found 1 new test failure: fast/mediastream/granted-denied-request-management1.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5188 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68797 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5434 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5301 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->