### PR TITLE
Syscalls related to exceptions should not be allowed in Lockdown Mode

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1800,6 +1800,7 @@
 
 (define (kernel-mig-routines-blocked-in-lockdown-mode) (kernel-mig-routine
     task_threads_from_user
+    thread_info
     thread_policy
     thread_policy_set))
 
@@ -1815,32 +1816,20 @@
     io_registry_get_root_entry
     io_service_close))
 
-(define (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry) (kernel-mig-routine
-    thread_info
-#if !ENABLE(BLOCK_SET_EXCEPTION_PORTS)
-    thread_set_exception_ports
-#endif
-))
-
 (define (allow-thread-adopt-exception-handler)
     (when (defined? 'thread_adopt_exception_handler)
-        (allow mach-message-send (kernel-mig-routine thread_adopt_exception_handler))
-    )
-)
+        (allow mach-message-send (kernel-mig-routine thread_adopt_exception_handler))))
 
 (define (allow-mach-exceptions)
 #if HAVE(HARDENED_MACH_EXCEPTIONS)
-(if (equal? (param "CPU") "arm64")
-    (when (defined? 'task_register_hardened_exception_handler)
-        (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler))
-    )
+    (if (equal? (param "CPU") "arm64")
+        (when (defined? 'task_register_hardened_exception_handler)
+            (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler)))
     ; else
-        (allow mach-message-send (kernel-mig-routine thread_set_exception_ports))
-    )
+        (allow mach-message-send (kernel-mig-routine thread_set_exception_ports))))
 #else
-    (allow mach-message-send (kernel-mig-routine thread_set_exception_ports))
+    (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
 #endif
-)
 
 (if (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'mach-kernel-endpoint))
     (allow mach-kernel-endpoint
@@ -1849,21 +1838,19 @@
 #if ENABLE(LOCKDOWN_MODE_TELEMETRY)
             (with-filter (require-not (lockdown-mode))
                 (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode))
-                (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry))
                 (allow-thread-adopt-exception-handler))
             (with-filter (lockdown-mode)
-                (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode))
-                (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry)))
+                (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode)))
 #else
             (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode))
-            (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry))
             (allow-thread-adopt-exception-handler)
 #endif
+            (with-filter (require-not (lockdown-mode))
 #if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
-            (with-filter (require-not (webcontent-process-launched))
-                (allow-mach-exceptions))
+                (with-filter (require-any (require-not (webcontent-process-launched)) (equal? (param "CPU") "x86_64"))
+                    (allow-mach-exceptions)))
 #else
-            (allow-mach-exceptions)
+                (allow-mach-exceptions))
 #endif
 
             (allow mach-message-send (kernel-mig-routines-in-use))


### PR DESCRIPTION
#### b83dcbd66285d49e65455cdc57e43dede12772aa
<pre>
Syscalls related to exceptions should not be allowed in Lockdown Mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=271523">https://bugs.webkit.org/show_bug.cgi?id=271523</a>
<a href="https://rdar.apple.com/125293241">rdar://125293241</a>

Reviewed by Chris Dumez.

Syscalls related to exceptions should not be allowed in Lockdown Mode. This is a sandbox follow-up after
&lt;<a href="https://commits.webkit.org/276579@main">https://commits.webkit.org/276579@main</a>&gt;.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/276603@main">https://commits.webkit.org/276603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/250fd0eddb3bc1d6ad946c0ec4dc3beaf37cf9ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47764 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41110 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/28327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21611 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45680 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/28327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/18104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/28327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3149 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/28327 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/40278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49449 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16607 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21390 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21740 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6279 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->