### PR TITLE
Unreviewed, fix the Mac Catalyst build after 276581@main

### DIFF
--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -59,8 +59,13 @@
 
 namespace WebCore {
 
+static UIPasteboard *generalUIPasteboard()
+{
+    return static_cast<UIPasteboard *>([PAL::getUIPasteboardClass() generalPasteboard]);
+}
+
 PlatformPasteboard::PlatformPasteboard()
-    : m_pasteboard([PAL::getUIPasteboardClass() generalPasteboard])
+    : m_pasteboard(generalUIPasteboard())
 {
 }
 
@@ -70,11 +75,11 @@ PlatformPasteboard::PlatformPasteboard(const String& name)
     if (name == Pasteboard::nameOfDragPasteboard())
         m_pasteboard = [WebItemProviderPasteboard sharedInstance];
     else
-        m_pasteboard = [PAL::getUIPasteboardClass() generalPasteboard];
+        m_pasteboard = generalUIPasteboard();
 }
 #else
 PlatformPasteboard::PlatformPasteboard(const String&)
-    : m_pasteboard([PAL::getUIPasteboardClass() generalPasteboard])
+    : m_pasteboard(generalUIPasteboard())
 {
 }
 #endif


### PR DESCRIPTION
#### 3a123fd1d8e2c2e22fc9fe77c724a650f2404d92
<pre>
Unreviewed, fix the Mac Catalyst build after 276581@main

Explicitly cast to `UIPasteboard`, so that the Catalyst WebCore build (that has declarations for
both `+[NSPasteboard generalPasteboard]` from AppKit as well as `+[UIPasteboard generalPasteboard]`
from UIKit) won&apos;t get confused.

* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::generalUIPasteboard):
(WebCore::PlatformPasteboard::PlatformPasteboard):

Canonical link: <a href="https://commits.webkit.org/276599@main">https://commits.webkit.org/276599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59a3ce16c2c4558e682a06d826fec1af875f30af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47761 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41107 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47405 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/28320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21608 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45677 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/28320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/38853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/18102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/28320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/39972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3146 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/28320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/40275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49446 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20072 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/16604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21387 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/42805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21737 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6277 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->