### PR TITLE
WebXR should not work from an iFrame unless it is allowed to use the xr-spatial-tracking permissions policy

### DIFF
--- a/LayoutTests/http/tests/webxr/resources/resources/test-only-api.js
+++ b/LayoutTests/http/tests/webxr/resources/resources/test-only-api.js
@@ -1,0 +1,1 @@
+../../../../wpt/webxr/resources/test-only-api.js

--- a/LayoutTests/http/tests/webxr/resources/resources/webxr_test_constants_single_view.js
+++ b/LayoutTests/http/tests/webxr/resources/resources/webxr_test_constants_single_view.js
@@ -1,0 +1,1 @@
+../../../../wpt/webxr/resources/webxr_test_constants_single_view.js

--- a/LayoutTests/http/tests/webxr/resources/resources/webxr_util.js
+++ b/LayoutTests/http/tests/webxr/resources/resources/webxr_util.js
@@ -1,0 +1,1 @@
+../../../../wpt/webxr/resources/webxr_util.js

--- a/LayoutTests/http/tests/webxr/resources/webxr-issessionsupported-test.html
+++ b/LayoutTests/http/tests/webxr/resources/webxr-issessionsupported-test.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script src=/resources/testharness.js></script>
+    <script src=/resources/testharnessreport.js></script>
+    <script src="resources/webxr_util.js"></script>
+    <script src="resources/webxr_test_constants_single_view.js"></script>
+    <script>
+        xr_promise_test(
+          "Tests isSessionSupported with immersive device connected",
+          async (t) => {
+            await navigator.xr.test.simulateDeviceConnection(TRACKED_IMMERSIVE_DEVICE);
+            try {
+              const supported = await navigator.xr.isSessionSupported('immersive-vr');
+              top.postMessage({'isSessionSupported': supported}, '*');
+            } catch (e) {
+              top.postMessage({'isSessionSupported': e.name}, '*');
+            }
+          }
+        );
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/resources/webxr-makexrcompatible-test.html
+++ b/LayoutTests/http/tests/webxr/resources/webxr-makexrcompatible-test.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script src=/resources/testharness.js></script>
+    <script src=/resources/testharnessreport.js></script>
+    <script src="resources/webxr_util.js"></script>
+    <script src="resources/webxr_test_constants_single_view.js"></script>
+    <script>
+        async function testMakeXRCompatible(t, gl) {
+          await navigator.xr.test.simulateDeviceConnection(TRACKED_IMMERSIVE_DEVICE);
+          await gl.makeXRCompatible();
+          top.postMessage({'makeXRCompatible': gl.getContextAttributes().xrCompatible}, '*');
+        }
+
+        xr_promise_test(
+          "Tests makeXRCompatible with immersive device connected",
+          testMakeXRCompatible,
+          null,
+          'webgl'
+        );
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/resources/webxr-requestsession-test.html
+++ b/LayoutTests/http/tests/webxr/resources/webxr-requestsession-test.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script src=/resources/testharness.js></script>
+    <script src=/resources/testharnessreport.js></script>
+    <script src="resources/webxr_util.js"></script>
+    <script src="resources/webxr_test_constants_single_view.js"></script>
+    <script>
+        xr_promise_test(
+          "Tests requestSession when connected to immersive device",
+          async (t) => {
+            await navigator.xr.test.simulateDeviceConnection(TRACKED_IMMERSIVE_DEVICE);
+            navigator.xr.test.simulateUserActivation(async () => {
+              window.focus();
+              try {
+                const session = await navigator.xr.requestSession('immersive-vr');
+                top.postMessage({'requestSession': session != null}, '*');
+              } catch (e) {
+                top.postMessage({'requestSession': e.name}, '*');
+              }
+            });
+          }
+        );
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-allowed-by-feature-policy-expected.txt
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-allowed-by-feature-policy-expected.txt
@@ -1,0 +1,10 @@
+Tests that third-party iframes will be allowed webxr session support with xr-spatial-tracking feature policy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS e.data.isSessionSupported is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-allowed-by-feature-policy.html
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-allowed-by-feature-policy.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that third-party iframes will be allowed webxr session support with xr-spatial-tracking feature policy.");
+jsTestIsAsync = true;
+
+onmessage = (_e) => {
+    e = _e;
+    if (e.data.isSessionSupported != undefined) {
+        shouldBeTrue("e.data.isSessionSupported");
+        finishJSTest();
+    }
+};
+</script>
+<iframe src="http://localhost:8000/webxr/resources/webxr-issessionsupported-test.html" allow="xr-spatial-tracking"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-denied-by-insufficient-feature-policy-expected.txt
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-denied-by-insufficient-feature-policy-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Feature policy 'XRSpatialTracking' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
+Tests that third-party iframes will be denied webxr session support without xr-spatial-tracking feature policy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS e.data.isSessionSupported is "SecurityError"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-denied-by-insufficient-feature-policy.html
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-denied-by-insufficient-feature-policy.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that third-party iframes will be denied webxr session support without xr-spatial-tracking feature policy.");
+jsTestIsAsync = true;
+
+onmessage = (_e) => {
+    e = _e;
+    if (e.data.isSessionSupported != undefined) {
+        shouldBeEqualToString("e.data.isSessionSupported", "SecurityError");
+        finishJSTest();
+    }
+};
+</script>
+<iframe src="http://localhost:8000/webxr/resources/webxr-issessionsupported-test.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy-expected.txt
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy-expected.txt
@@ -1,0 +1,10 @@
+Tests that third-party iframes will be allowed to call makeXRCompatible() with xr-spatial-tracking feature policy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS e.data.makeXRCompatible is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy.html
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that third-party iframes will be allowed to call makeXRCompatible() with xr-spatial-tracking feature policy.");
+jsTestIsAsync = true;
+
+onmessage = (_e) => {
+    e = _e;
+    if (e.data.makeXRCompatible != undefined) {
+        shouldBeTrue("e.data.makeXRCompatible");
+        finishJSTest();
+    }
+};
+</script>
+<iframe src="http://localhost:8000/webxr/resources/webxr-makexrcompatible-test.html" allow="xr-spatial-tracking"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-denied-by-insufficient-feature-policy-expected.txt
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-denied-by-insufficient-feature-policy-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Feature policy 'XRSpatialTracking' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
+Tests that third-party iframes will be denied from calling makeXRCompatible() without xr-spatial-tracking feature policy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS e.data.makeXRCompatible is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-denied-by-insufficient-feature-policy.html
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-denied-by-insufficient-feature-policy.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that third-party iframes will be denied from calling makeXRCompatible() without xr-spatial-tracking feature policy.");
+jsTestIsAsync = true;
+
+onmessage = (_e) => {
+    e = _e;
+    if (e.data.makeXRCompatible != undefined) {
+        shouldBeFalse("e.data.makeXRCompatible");
+        finishJSTest();
+    }
+};
+</script>
+<iframe src="http://localhost:8000/webxr/resources/webxr-makexrcompatible-test.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-allowed-by-feature-policy-expected.txt
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-allowed-by-feature-policy-expected.txt
@@ -1,0 +1,10 @@
+Tests that third-party iframes will be allowed to request webxr session with xr-spatial-tracking feature policy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS e.data.requestSession is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-allowed-by-feature-policy.html
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-allowed-by-feature-policy.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that third-party iframes will be allowed to request webxr session with xr-spatial-tracking feature policy.");
+jsTestIsAsync = true;
+
+onmessage = (_e) => {
+    e = _e;
+    if (e.data.requestSession != undefined) {
+        shouldBeTrue("e.data.requestSession");
+        finishJSTest();
+    }
+};
+</script>
+<iframe src="http://localhost:8000/webxr/resources/webxr-requestsession-test.html" allow="xr-spatial-tracking"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy-expected.txt
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy-expected.txt
@@ -1,0 +1,11 @@
+CONSOLE MESSAGE: Feature policy 'XRSpatialTracking' check failed for element with origin 'http://localhost:8000' and allow attribute ''.
+Tests that third-party iframes will be denied from requesting webxr session without xr-spatial-tracking feature policy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS e.data.requestSession is "NotSupportedError"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy.html
+++ b/LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that third-party iframes will be denied from requesting webxr session without xr-spatial-tracking feature policy.");
+jsTestIsAsync = true;
+
+onmessage = (_e) => {
+    e = _e;
+    if (e.data.requestSession != undefined) {
+        shouldBeEqualToString("e.data.requestSession", "NotSupportedError");
+        finishJSTest();
+    }
+};
+</script>
+<iframe src="http://localhost:8000/webxr/resources/webxr-requestSession-test.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -225,6 +225,7 @@ webkit.org/b/254733 inspector/canvas/shaderProgram-add-remove-webgl.html [ Failu
 webkit.org/b/254733 inspector/canvas/shaderProgram-add-remove-webgl2.html [ Failure ]
 
 # WebXR is not yet supported in GTK
+webkit.org/b/208988 http/tests/webxr [ Skip ]
 webkit.org/b/208988 http/wpt/webxr [ Skip ]
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr [ Skip ]
 webkit.org/b/208988 webxr [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4463,6 +4463,7 @@ http/tests/misc/heic-accept-header.html [ Pass ]
 
 webkit.org/b/254044 webxr [ Skip ]
 webkit.org/b/254044 imported/w3c/web-platform-tests/webxr [ Skip ]
+webkit.org/b/254044 http/tests/webxr [ Skip ]
 webkit.org/b/254044 http/wpt/webxr [ Skip ]
 webkit.org/b/254044 imported/w3c/web-platform-tests/feature-policy/reporting/xr-reporting.https.html [ Skip ]
 

--- a/LayoutTests/platform/mac-gpup/TestExpectations
+++ b/LayoutTests/platform/mac-gpup/TestExpectations
@@ -5,6 +5,7 @@ compositing/images/direct-image-object-fit.html [ Skip ]
 compositing/reflections/direct-image-object-fit-reflected.html [ Skip ]
 
 # rdar://102067140 WebXR tests crash
+http/tests/webxr [ Skip ]
 http/wpt/webxr [ Skip ]
 imported/w3c/web-platform-tests/webxr [ Skip ]
 webxr [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2274,6 +2274,7 @@ http/tests/misc/heic-accept-header.html [ Pass ]
 
 webkit.org/b/254044 webxr [ Skip ]
 webkit.org/b/254044 imported/w3c/web-platform-tests/webxr [ Skip ]
+webkit.org/b/254044 http/tests/webxr [ Skip ]
 webkit.org/b/254044 http/wpt/webxr [ Skip ]
 webkit.org/b/254044 imported/w3c/web-platform-tests/feature-policy/reporting/xr-reporting.https.html [ Skip ]
 

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -913,6 +913,8 @@ http/tests/websocket/tests/hybi/send-object-tostring-check.html [ Pass Failure ]
 http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-ws-redirect.html [ Failure ]
 http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party.html [ Failure ]
 
+http/tests/webxr [ Skip ]
+
 # Needs curl download support
 http/tests/workers/service/service-worker-download-async-delegates.https.html [ Failure ]
 http/tests/workers/service/service-worker-download.https.html [ Failure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1758,3 +1758,5 @@ fast/text/whitespace/pre-wrap-015.html [ Timeout ]
 webkit.org/b/272224 imported/w3c/web-platform-tests/selection/textcontrols/selectionchange.html [ Failure ]
 
 webkit.org/b/272225 media/media-source/media-managedmse-resume-after-stall.html [ Failure ]
+
+webkit.org/b/272426 http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy.html [ Crash Pass ]

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -105,6 +105,7 @@ private:
     bool immersiveSessionRequestIsAllowedForGlobalObject(LocalDOMWindow&, Document&) const;
     bool inlineSessionRequestIsAllowedForGlobalObject(LocalDOMWindow&, Document&, const XRSessionInit&) const;
 
+    bool isFeaturePermitted(PlatformXR::SessionFeature) const;
     bool isFeatureSupported(PlatformXR::SessionFeature, XRSessionMode, const PlatformXR::Device&) const;
     struct ResolvedRequestedFeatures;
     std::optional<ResolvedRequestedFeatures> resolveRequestedFeatures(XRSessionMode, const XRSessionInit&, RefPtr<PlatformXR::Device>, JSC::JSGlobalObject&) const;

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -92,6 +92,7 @@
 #include "OESTextureHalfFloatLinear.h"
 #include "OESVertexArrayObject.h"
 #include "Page.h"
+#include "PermissionsPolicy.h"
 #include "RenderBox.h"
 #include "Settings.h"
 #include "WebCodecsVideoFrame.h"
@@ -2854,9 +2855,16 @@ void WebGLRenderingContextBase::makeXRCompatible(MakeXRCompatiblePromise&& promi
         return;
     }
 
-    // 1. Let promise be a new Promise.
-    // 2. Let context be the target WebGLRenderingContextBase object.
-    // 3. Ensure an immersive XR device is selected.
+    // 1. If the requesting document’s origin is not allowed to use the "xr-spatial-tracking"
+    // permissions policy, resolve promise and return it.
+    if (!isPermissionsPolicyAllowedByDocumentAndAllOwners(PermissionsPolicy::Type::XRSpatialTracking, canvas->document(), LogPermissionsPolicyFailure::Yes)) {
+        promise.resolve();
+        return;
+    }
+
+    // 2. Let promise be a new Promise.
+    // 3. Let context be the target WebGLRenderingContextBase object.
+    // 4. Ensure an immersive XR device is selected.
     auto& xrSystem = NavigatorWebXR::xr(window->navigator());
     xrSystem.ensureImmersiveXRDeviceIsSelected([this, protectedThis = Ref { *this }, promise = WTFMove(promise), protectedXrSystem = Ref { xrSystem }]() mutable {
         auto rejectPromiseWithInvalidStateError = makeScopeExit([&]() {


### PR DESCRIPTION
#### 7b007a862a8738cd222cb669afbdef82e07d8422
<pre>
WebXR should not work from an iFrame unless it is allowed to use the xr-spatial-tracking permissions policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=271363">https://bugs.webkit.org/show_bug.cgi?id=271363</a>
<a href="https://rdar.apple.com/122963817">rdar://122963817</a>

Reviewed by Mike Wyrzykowski.

Follow the latest WebXR spec and check whether &apos;xr-spatial-tracking&apos; is enabled for
the requesting document&apos;s origin in WebGLRenderingContextBase::makeXRCompatible and
WebXRSystem::resolveRequestedFeatures.

Added layout tests to verify &apos;xr-spatial-tracking&apos; permissions policy is checked
properly for xr.isSessionSupported, xr.requestSession, and WebGLRenderingContextBase::makeXRCompatible.
Set up symbolic links to the webxr related scripts from http/wpt/webxr folder so the
pages embedded in the iframes can reference them.

* LayoutTests/http/tests/webxr/resources/resources/test-only-api.js: Added.
* LayoutTests/http/tests/webxr/resources/resources/webxr_test_constants_single_view.js: Added.
* LayoutTests/http/tests/webxr/resources/resources/webxr_util.js: Added.
* LayoutTests/http/tests/webxr/resources/webxr-issessionsupported-test.html: Added.
* LayoutTests/http/tests/webxr/resources/webxr-makexrcompatible-test.html: Added.
* LayoutTests/http/tests/webxr/resources/webxr-requestsession-test.html: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-allowed-by-feature-policy-expected.txt: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-allowed-by-feature-policy.html: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-denied-by-insufficient-feature-policy-expected.txt: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-issessionsupported-denied-by-insufficient-feature-policy.html: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy-expected.txt: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-allowed-by-feature-policy.html: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-denied-by-insufficient-feature-policy-expected.txt: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-makexrcompatible-denied-by-insufficient-feature-policy.html: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-allowed-by-feature-policy-expected.txt: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-allowed-by-feature-policy.html: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy-expected.txt: Added.
* LayoutTests/http/tests/webxr/webxr-third-party-iframe-requestsession-denied-by-insufficient-feature-policy.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-gpup/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
Skip http/tests/webxr tests in the same places where we&apos;ve skipped other webxr layout tests.
* LayoutTests/platform/wpe/TestExpectations:
Filed a new bug on a crash found when calling WebXRSession destructor.
* LayoutTests/platform/wincairo/TestExpectations:
Skip http/tests/webxr tests in the same places where we&apos;ve skipped other webxr layout tests.
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
(WebCore::WebXRSystem::isFeaturePermitted const):
(WebCore::WebXRSystem::resolveRequestedFeatures const):
* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::makeXRCompatible):

Canonical link: <a href="https://commits.webkit.org/277301@main">https://commits.webkit.org/277301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2559ec2f901b7c62b307ef588fc6dab62d2f1cbc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49893 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43259 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38452 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23879 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19765 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41849 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5254 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51769 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18610 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45748 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44757 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10421 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23230 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->