### PR TITLE
Use std::span and char8_t for UTF-8

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRef.cpp
+++ b/Source/JavaScriptCore/API/JSStringRef.cpp
@@ -48,10 +48,9 @@ JSStringRef JSStringCreateWithUTF8CString(const char* string)
         Vector<UChar, 1024> buffer(length);
         UChar* p = buffer.data();
         bool sourceContainsOnlyASCII;
-        const LChar* stringStart = reinterpret_cast<const LChar*>(string);
-        if (convertUTF8ToUTF16(string, string + length, &p, p + length, &sourceContainsOnlyASCII)) {
+        if (convertUTF8ToUTF16(std::span { reinterpret_cast<const char8_t*>(string), length }, &p, p + length, &sourceContainsOnlyASCII)) {
             if (sourceContainsOnlyASCII)
-                return &OpaqueJSString::create(stringStart, length).leakRef();
+                return &OpaqueJSString::create(reinterpret_cast<const LChar*>(string), length).leakRef();
             return &OpaqueJSString::create(buffer.data(), p - buffer.data()).leakRef();
         }
     }

--- a/Source/JavaScriptCore/wasm/WasmFormat.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFormat.cpp
@@ -58,9 +58,7 @@ void Segment::destroy(Segment *segment)
 
 String makeString(const Name& characters)
 {
-    String result = String::fromUTF8(characters);
-    ASSERT(result);
-    return result;
+    return WTF::makeString(characters);
 }
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmName.h
+++ b/Source/JavaScriptCore/wasm/WasmName.h
@@ -25,13 +25,12 @@
 
 #pragma once
 
-#include <wtf/Vector.h>
-#include <wtf/text/LChar.h>
+#include <wtf/Forward.h>
 
 namespace JSC {
 
 namespace Wasm {
 
-using Name = Vector<LChar>;
+using Name = Vector<char8_t>;
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -463,9 +463,7 @@ auto SectionParser::parseExport() -> PartialResult
 
         WASM_PARSER_FAIL_IF(!parseVarUInt32(fieldLen), "can't get ", exportNumber, "th Export's field name length");
         WASM_PARSER_FAIL_IF(!consumeUTF8String(fieldString, fieldLen), "can't get ", exportNumber, "th Export's field name of length ", fieldLen);
-        String fieldName = String::fromUTF8(fieldString);
-        if (fieldName.isNull())
-            fieldName = emptyString();
+        String fieldName = WTF::makeString(fieldString);
         WASM_PARSER_FAIL_IF(exportNames.contains(fieldName), "duplicate export: '", fieldString, "'");
         exportNames.add(fieldName);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -188,17 +188,12 @@ JSWebAssemblyInstance* JSWebAssemblyInstance::tryCreate(VM& vm, JSGlobalObject* 
             return exception(createTypeError(globalObject, "can't make WebAssembly.Instance because there is no imports Object and the WebAssembly.Module requires imports"_s));
     }
 
-    auto stringFromUTF8 = [](auto& span) {
-        auto string = String::fromUTF8(span);
-        return string.isNull() ? emptyString() : string;
-    };
-
     // For each import i in module.imports:
     {
         IdentifierSet specifiers;
         for (auto& import : moduleInformation.imports) {
-            Identifier moduleName = Identifier::fromString(vm, stringFromUTF8(import.module));
-            Identifier fieldName = Identifier::fromString(vm, stringFromUTF8(import.field));
+            auto moduleName = Identifier::fromString(vm, makeAtomString(import.module));
+            auto fieldName = Identifier::fromString(vm, makeAtomString(import.field));
             auto result = specifiers.add(moduleName.impl());
             if (result.isNewEntry)
                 moduleRecord->appendRequestedModule(moduleName, nullptr);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
@@ -92,10 +92,7 @@ void JSWebAssemblyModule::finishCreation(VM& vm)
     }
     for (auto& exp : moduleInformation.exports) {
         auto offset = exportSymbolTable->takeNextScopeOffset(NoLockingNecessary);
-        String field = String::fromUTF8(exp.field);
-        if (field.isNull())
-            field = emptyString();
-        exportSymbolTable->set(NoLockingNecessary, AtomString(field).impl(), SymbolTableEntry(VarOffset(offset)));
+        exportSymbolTable->set(NoLockingNecessary, makeAtomString(exp.field).impl(), SymbolTableEntry(VarOffset(offset)));
     }
 
     m_exportSymbolTable.set(vm, this, exportSymbolTable);

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
@@ -85,7 +85,8 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyModuleCustomSections, (JSGlobalObject* globa
 
     const auto& customSections = module->moduleInformation().customSections;
     for (const Wasm::CustomSection& section : customSections) {
-        if (String::fromUTF8(section.name) == sectionNameString) {
+        // FIXME: Add a function that compares a String with a span<char8_t> so we don't need to make a string.
+        if (WTF::makeString(section.name) == sectionNameString) {
             auto buffer = ArrayBuffer::tryCreate(section.payload.data(), section.payload.size());
             if (!buffer)
                 return JSValue::encode(throwException(globalObject, throwScope, createOutOfMemoryError(globalObject)));
@@ -118,8 +119,8 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyModuleImports, (JSGlobalObject* globalObject
         for (const Wasm::Import& imp : imports) {
             JSObject* obj = constructEmptyObject(globalObject);
             RETURN_IF_EXCEPTION(throwScope, { });
-            obj->putDirect(vm, module, jsString(vm, String::fromUTF8(imp.module)));
-            obj->putDirect(vm, name, jsString(vm, String::fromUTF8(imp.field)));
+            obj->putDirect(vm, module, jsString(vm, WTF::makeString(imp.module)));
+            obj->putDirect(vm, name, jsString(vm, WTF::makeString(imp.field)));
             obj->putDirect(vm, kind, jsString(vm, String::fromLatin1(makeString(imp.kind))));
             result->push(globalObject, obj);
             RETURN_IF_EXCEPTION(throwScope, { });
@@ -148,7 +149,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyModuleExports, (JSGlobalObject* globalObject
         for (const Wasm::Export& exp : exports) {
             JSObject* obj = constructEmptyObject(globalObject);
             RETURN_IF_EXCEPTION(throwScope, { });
-            obj->putDirect(vm, name, jsString(vm, String::fromUTF8(exp.field)));
+            obj->putDirect(vm, name, jsString(vm, WTF::makeString(exp.field)));
             obj->putDirect(vm, kind, jsString(vm, String::fromLatin1(makeString(exp.kind))));
             result->push(globalObject, obj);
             RETURN_IF_EXCEPTION(throwScope, { });

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -75,9 +75,8 @@ void WebAssemblyModuleRecord::finishCreation(JSGlobalObject* globalObject, VM& v
 {
     Base::finishCreation(globalObject, vm);
     ASSERT(inherits(info()));
-    for (const auto& exp : moduleInformation.exports) {
-        auto fieldString = String::fromUTF8(exp.field);
-        Identifier field = Identifier::fromString(vm, fieldString.isNull() ? emptyString() : fieldString);
+    for (auto& exp : moduleInformation.exports) {
+        auto field = Identifier::fromString(vm, makeAtomString(exp.field));
         addExportEntry(ExportEntry::createLocal(field, field));
     }
 }
@@ -132,17 +131,12 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
     };
 
     auto importFailMessage = [&] (const Wasm::Import& import, const char* before, const char* after) {
-        return makeString(before, ' ', String::fromUTF8(import.module), ':', String::fromUTF8(import.field), ' ', after);
-    };
-
-    auto stringFromUTF8 = [](auto& span) {
-        auto string = String::fromUTF8(span);
-        return string.isNull() ? emptyString() : string;
+        return makeString(before, ' ', import.module, ':', import.field, ' ', after);
     };
 
     for (const auto& import : moduleInformation.imports) {
-        Identifier moduleName = Identifier::fromString(vm, stringFromUTF8(import.module));
-        Identifier fieldName = Identifier::fromString(vm, stringFromUTF8(import.field));
+        Identifier moduleName = Identifier::fromString(vm, makeAtomString(import.module));
+        Identifier fieldName = Identifier::fromString(vm, makeAtomString(import.field));
         JSValue value;
         if (creationMode == Wasm::CreationMode::FromJS) {
             // 1. Let o be the resultant value of performing Get(importObject, i.module_name).
@@ -734,8 +728,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
         }
         }
 
-        String fieldString = String::fromUTF8(exp.field);
-        Identifier propertyName = Identifier::fromString(vm, fieldString.isNull() ? emptyString() : fieldString);
+        auto propertyName = Identifier::fromString(vm, makeAtomString(exp.field));
 
         bool shouldThrowReadOnlyError = false;
         bool ignoreReadOnlyErrors = true;

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -165,8 +165,7 @@ struct HashAndUTF8CharactersTranslator {
         auto newString = StringImpl::createUninitialized(buffer.utf16Length, target);
 
         bool containsOnlyASCII;
-        const char* source = buffer.characters;
-        if (!convertUTF8ToUTF16(source, source + buffer.length, &target, target + buffer.utf16Length, &containsOnlyASCII))
+        if (!convertUTF8ToUTF16({ reinterpret_cast<const char8_t*>(buffer.characters), buffer.length }, &target, target + buffer.utf16Length, &containsOnlyASCII))
             RELEASE_ASSERT_NOT_REACHED();
 
         if (containsOnlyASCII)

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -480,9 +480,8 @@ String fromUTF8Impl(std::span<const LChar> string)
     UChar* bufferStart = buffer.data();
  
     UChar* bufferCurrent = bufferStart;
-    const char* stringCurrent = reinterpret_cast<const char*>(string.data());
     constexpr auto function = replaceInvalidSequences ? convertUTF8ToUTF16ReplacingInvalidSequences : convertUTF8ToUTF16;
-    if (!function(stringCurrent, reinterpret_cast<const char*>(string.data() + string.size()), &bufferCurrent, bufferCurrent + buffer.size(), nullptr))
+    if (!function(spanReinterpretCast<const char8_t>(string), &bufferCurrent, bufferCurrent + buffer.size(), nullptr))
         return String();
 
     size_t utf16Length = bufferCurrent - bufferStart;

--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -91,24 +91,24 @@ ConversionResult convertUTF16ToUTF8(const UChar** sourceStart, const UChar* sour
 }
 
 template<bool replaceInvalidSequences>
-bool convertUTF8ToUTF16Impl(const char* source, const char* sourceEnd, UChar** targetStart, const UChar* targetEnd, bool* sourceAllASCII)
+bool convertUTF8ToUTF16Impl(std::span<const char8_t> source, UChar** targetStart, const UChar* targetEnd, bool* sourceAllASCII)
 {
-    RELEASE_ASSERT(sourceEnd - source <= std::numeric_limits<int>::max());
+    RELEASE_ASSERT(source.size() <= std::numeric_limits<int>::max());
     UBool error = false;
     UChar* target = *targetStart;
-    RELEASE_ASSERT(targetEnd - target <= std::numeric_limits<int>::max());
+    size_t targetSize = targetEnd - target;
     char32_t orAllData = 0;
-    int targetOffset = 0;
-    for (int sourceOffset = 0; sourceOffset < sourceEnd - source; ) {
+    size_t targetOffset = 0;
+    for (size_t sourceOffset = 0; sourceOffset < source.size(); ) {
         char32_t character;
         if constexpr (replaceInvalidSequences) {
-            U8_NEXT_OR_FFFD(source, sourceOffset, sourceEnd - source, character);
+            U8_NEXT_OR_FFFD(source, sourceOffset, source.size(), character);
         } else {
-            U8_NEXT(source, sourceOffset, sourceEnd - source, character);
+            U8_NEXT(source, sourceOffset, source.size(), character);
             if (character == sentinelCodePoint)
                 return false;
         }
-        U16_APPEND(target, targetOffset, targetEnd - target, character, error);
+        U16_APPEND(target, targetOffset, targetSize, character, error);
         if (error)
             return false;
         orAllData |= character;
@@ -120,29 +120,28 @@ bool convertUTF8ToUTF16Impl(const char* source, const char* sourceEnd, UChar** t
     return true;
 }
 
-bool convertUTF8ToUTF16(const char* source, const char* sourceEnd, UChar** targetStart, const UChar* targetEnd, bool* sourceAllASCII)
+bool convertUTF8ToUTF16(std::span<const char8_t> source, UChar** targetStart, const UChar* targetEnd, bool* sourceAllASCII)
 {
-    return convertUTF8ToUTF16Impl<false>(source, sourceEnd, targetStart, targetEnd, sourceAllASCII);
+    return convertUTF8ToUTF16Impl<false>(source, targetStart, targetEnd, sourceAllASCII);
 }
 
-bool convertUTF8ToUTF16ReplacingInvalidSequences(const char* source, const char* sourceEnd, UChar** targetStart, const UChar* targetEnd, bool* sourceAllASCII)
+bool convertUTF8ToUTF16ReplacingInvalidSequences(std::span<const char8_t> source, UChar** targetStart, const UChar* targetEnd, bool* sourceAllASCII)
 {
-    return convertUTF8ToUTF16Impl<true>(source, sourceEnd, targetStart, targetEnd, sourceAllASCII);
+    return convertUTF8ToUTF16Impl<true>(source, targetStart, targetEnd, sourceAllASCII);
 }
 
-ComputeUTFLengthsResult computeUTFLengths(const char* sourceStart, const char* sourceEnd)
+ComputeUTFLengthsResult computeUTFLengths(std::span<const char8_t> source)
 {
-    size_t lengthUTF8 = sourceEnd - sourceStart;
     size_t lengthUTF16 = 0;
     char32_t orAllData = 0;
     ConversionResult result = ConversionResult::Success;
     size_t sourceOffset = 0;
-    while (sourceOffset < lengthUTF8) {
+    while (sourceOffset < source.size()) {
         char32_t character;
         size_t nextSourceOffset = sourceOffset;
-        U8_NEXT(sourceStart, nextSourceOffset, lengthUTF8, character);
+        U8_NEXT(source, nextSourceOffset, source.size(), character);
         if (character == sentinelCodePoint) {
-            result = nextSourceOffset == lengthUTF8 ? ConversionResult::SourceExhausted : ConversionResult::SourceIllegal;
+            result = nextSourceOffset == source.size() ? ConversionResult::SourceExhausted : ConversionResult::SourceIllegal;
             break;
         }
         sourceOffset = nextSourceOffset;

--- a/Source/WTF/wtf/unicode/UTF8Conversion.h
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.h
@@ -44,8 +44,8 @@ enum class ConversionResult : uint8_t {
 // converted to the replacement character, except for an unpaired lead surrogate
 // at the end of the source, which will instead cause a SourceExhausted error.
 
-WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16(const char* sourceStart, const char* sourceEnd, UChar** targetStart, const UChar* targetEnd, bool* isSourceAllASCII = nullptr);
-WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16ReplacingInvalidSequences(const char* sourceStart, const char* sourceEnd, UChar** targetStart, const UChar* targetEnd, bool* isSourceAllASCII = nullptr);
+WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16(std::span<const char8_t> source, UChar** targetStart, const UChar* targetEnd, bool* isSourceAllASCII = nullptr);
+WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16ReplacingInvalidSequences(std::span<const char8_t> source, UChar** targetStart, const UChar* targetEnd, bool* isSourceAllASCII = nullptr);
 WTF_EXPORT_PRIVATE bool convertLatin1ToUTF8(const LChar** sourceStart, const LChar* sourceEnd, char** targetStart, const char* targetEnd);
 WTF_EXPORT_PRIVATE ConversionResult convertUTF16ToUTF8(const UChar** sourceStart, const UChar* sourceEnd, char** targetStart, const char* targetEnd, bool strict = true);
 WTF_EXPORT_PRIVATE unsigned calculateStringHashAndLengthFromUTF8MaskingTop8Bits(std::span<const char> data, unsigned& dataLength, unsigned& utf16Length);
@@ -58,7 +58,7 @@ struct ComputeUTFLengthsResult {
     size_t lengthUTF16 { 0 };
     bool isAllASCII { false };
 };
-WTF_EXPORT_PRIVATE ComputeUTFLengthsResult computeUTFLengths(const char* sourceStart, const char* sourceEnd);
+WTF_EXPORT_PRIVATE ComputeUTFLengthsResult computeUTFLengths(std::span<const char8_t>);
 
 // Callers of these functions must check that the lengths are the same; accordingly we omit an end argument for UTF-16 and Latin-1.
 bool equalUTF16WithUTF8(const UChar* stringInUTF16, const char* stringInUTF8, const char* stringInUTF8End);

--- a/Source/WebCore/workers/ScriptBuffer.cpp
+++ b/Source/WebCore/workers/ScriptBuffer.cpp
@@ -71,7 +71,7 @@ String ScriptBuffer::toString() const
 
     StringBuilder builder;
     m_buffer.get()->forEachSegment([&](auto segment) {
-        builder.append(FromUTF8({ reinterpret_cast<const char*>(segment.data()), segment.size() }));
+        builder.append(spanReinterpretCast<const char8_t>(segment));
     });
     return builder.toString();
 }

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -163,7 +163,7 @@ static inline void setXSLTLoadCallBack(xsltDocLoaderFunc func, XSLTProcessor* pr
 static int writeToStringBuilder(void* context, const char* buffer, int length)
 {
     auto& builder = *static_cast<StringBuilder*>(context);
-    FromUTF8 adapter(buffer, length);
+    UTF8Adapter adapter({ reinterpret_cast<const char8_t*>(buffer), static_cast<size_t>(length) });
     ASSERT(!adapter.conversionFailed);
     if (adapter.conversionFailed)
         return -1;


### PR DESCRIPTION
#### 353a203b0b4c5c758073d49979f100c4f354ed53
<pre>
Use std::span and char8_t for UTF-8
<a href="https://bugs.webkit.org/show_bug.cgi?id=271527">https://bugs.webkit.org/show_bug.cgi?id=271527</a>
<a href="https://rdar.apple.com/problem/125298503">rdar://problem/125298503</a>

Reviewed by Chris Dumez.

An advantage of using char8_t is that it expresses the fact that
the characters are UTF-8, so we can just use std::span&lt;char8_t&gt;
instead of things like FromUTF8. Also, makeString never returns
a null string, which turns out to be what many of these callers
want, so we save code.

* Source/JavaScriptCore/API/JSStringRef.cpp:
(JSStringCreateWithUTF8CString): Cast to char8_t.

* Source/JavaScriptCore/wasm/WasmFormat.cpp:
(JSC::Wasm::makeString): Use makeString instead of String::fromUTF8.

* Source/JavaScriptCore/wasm/WasmName.h: Use char8_t.

* Source/JavaScriptCore/wasm/WasmParser.h:
(JSC::Wasm::Parser::fail const): Remove unneeded call to String::number.
(JSC::Wasm::Parser&lt;SuccessType&gt;::consumeUTF8String): Use span and
spanReinterpretCast&lt;const char8_t&gt;.

* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseExport): Use makeString instead of
String::fromUTF8.

* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::tryCreate): Use makeAtomString instead of
String::fromUTF8.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp:
(JSC::JSWebAssemblyModule::finishCreation): Ditto.

* Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp:
(JSC::webAssemblyModuleCustomSections): Use makeString instead of
String::fromUTF8.
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::finishCreation): Ditto.
(JSC::WebAssemblyModuleRecord::initializeImports): Take advantage of
the fact that makeString already handles this without calling
String::UTF8, and call makeAtomString instead of String::fromUTF8..
(JSC::WebAssemblyModuleRecord::initializeExports): Ditto.

* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::HashAndUTF8CharactersTranslator::translate): Cast to char8_t.

* Source/WTF/wtf/text/StringConcatenate.h: Renamed FromUTF8 to UTF8Adapter
since there is little need to use it directly any more. Use char8_t instead
of char. Added a specialization for span&lt;char8_t&gt; that uses the UTF8Adapter.

* Source/WTF/wtf/text/WTFString.cpp:
(WTF::fromUTF8Impl): Use spanReinterpretCast&lt;const char8_t&gt;.

* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::convertUTF8ToUTF16Impl): Use std::span&lt;const char8_t&gt;.
(WTF::Unicode::convertUTF8ToUTF16): Ditto.
(WTF::Unicode::convertUTF8ToUTF16ReplacingInvalidSequences): Ditto.
(WTF::Unicode::computeUTFLengths): Ditto.
* Source/WTF/wtf/unicode/UTF8Conversion.h: Ditto.

* Source/WebCore/workers/ScriptBuffer.cpp:
(WebCore::ScriptBuffer::toString const): Use
spanReinterpretCast&lt;const char8_t&gt;.

* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::writeToStringBuilder): Update to use UTF8Adapter.

Canonical link: <a href="https://commits.webkit.org/277249@main">https://commits.webkit.org/277249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/978b1961892229be057001e41cde3fb900226464

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49768 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49740 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43104 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31431 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38332 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23694 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19639 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21066 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5102 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40319 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43436 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51616 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46543 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Running jscore-test") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22079 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45624 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23359 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44630 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24138 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Running apply-patch; Checked out pull request; Running compile-webkit") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54047 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6619 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23076 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11090 "Passed tests") | 
<!--EWS-Status-Bubble-End-->