### PR TITLE
Drop StringView constructors taking in raw pointers

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -418,7 +418,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncToString, (JSGlobalObject* globalObject, 
 
         bool sawHoles = false;
         bool genericCase = false;
-        JSValue result = fastJoin(globalObject, thisArray, { &comma, 1 }, length, sawHoles, genericCase);
+        JSValue result = fastJoin(globalObject, thisArray, span(comma), length, sawHoles, genericCase);
         RETURN_IF_EXCEPTION(scope, { });
 
         if (!sawHoles && !genericCase && result && isJSString(result) && isCoW) {
@@ -627,7 +627,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncJoin, (JSGlobalObject* globalObject, Call
         unsigned unsignedLength = static_cast<unsigned>(length);
         ASSERT(static_cast<double>(unsignedLength) == length);
 
-        RELEASE_AND_RETURN(scope, JSValue::encode(fastJoin(globalObject, thisObject, { &comma, 1 }, unsignedLength)));
+        RELEASE_AND_RETURN(scope, JSValue::encode(fastJoin(globalObject, thisObject, span(comma), unsignedLength)));
     }
 
     // 4. Let sep be ? ToString(separator).

--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -168,11 +168,7 @@ String notAFunctionSourceAppender(const String& originalMessage, StringView sour
     ASSERT(occurrence == ErrorInstance::FoundExactSource);
     auto notAFunctionIndex = originalMessage.reverseFind("is not a function"_s);
     RELEASE_ASSERT(notAFunctionIndex != notFound);
-    StringView displayValue;
-    if (originalMessage.is8Bit()) 
-        displayValue = StringView(originalMessage.characters8(), notAFunctionIndex - 1);
-    else
-        displayValue = StringView(originalMessage.characters16(), notAFunctionIndex - 1);
+    auto displayValue = StringView { originalMessage }.left(notAFunctionIndex - 1);
 
     StringView base = functionCallBase(sourceText);
     if (!base)

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -141,7 +141,7 @@ static std::optional<Duration> parseDuration(StringParsingBuffer<CharacterType>&
         while (digits < buffer.lengthRemaining() && isASCIIDigit(buffer[digits]))
             digits++;
 
-        double integer = factor * parseInt({ buffer.position(), digits }, 10);
+        double integer = factor * parseInt(buffer.span().first(digits), 10);
         buffer.advanceBy(digits);
         if (buffer.atEnd())
             return std::nullopt;
@@ -186,7 +186,7 @@ static std::optional<Duration> parseDuration(StringParsingBuffer<CharacterType>&
         while (digits < buffer.lengthRemaining() && isASCIIDigit(buffer[digits]))
             digits++;
 
-        double integer = factor * parseInt({ buffer.position(), digits }, 10);
+        double integer = factor * parseInt(buffer.span().first(digits), 10);
         buffer.advanceBy(digits);
         if (buffer.atEnd())
             return std::nullopt;
@@ -200,7 +200,7 @@ static std::optional<Duration> parseDuration(StringParsingBuffer<CharacterType>&
             if (!digits || digits > 9)
                 return std::nullopt;
 
-            fractionalPart = { buffer.position(), digits };
+            fractionalPart = buffer.span().first(digits);
             buffer.advanceBy(digits);
             if (buffer.atEnd())
                 return std::nullopt;

--- a/Source/JavaScriptCore/runtime/IntlCollator.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCollator.cpp
@@ -448,7 +448,7 @@ void IntlCollator::checkICULocaleInvariants(const LocaleSet& locales)
                         ASSERT(U_SUCCESS(status));
                         auto resultJSC = compareASCIIWithUCADUCET(xstring, 1, ystring, 1);
                         if (resultJSC && resultICU != resultJSC.value()) {
-                            dataLogLn("BAD ", locale, " ", makeString(hex(x)), "(", StringView(xstring, 1), ") <=> ", makeString(hex(y)), "(", StringView(ystring, 1), ") ICU:(", static_cast<int32_t>(resultICU), "),JSC:(", static_cast<int32_t>(resultJSC.value()), ")");
+                            dataLogLn("BAD ", locale, " ", makeString(hex(x)), "(", StringView { span(*xstring) }, ") <=> ", makeString(hex(y)), "(", StringView { span(*ystring) }, ") ICU:(", static_cast<int32_t>(resultICU), "),JSC:(", static_cast<int32_t>(resultJSC.value()), ")");
                             allAreGood = false;
                         }
                     }
@@ -498,7 +498,7 @@ void IntlCollator::checkICULocaleInvariants(const LocaleSet& locales)
                         CRASH();
                     }
                 } else {
-                    if (StringView(buffer.data(), buffer.size()).containsOnlyASCII()) {
+                    if (charactersAreAllASCII(buffer.span())) {
                         dataLogLn("BAD ", locale, " ", String(buffer.data(), buffer.size()), " including ASCII tailored characters");
                         CRASH();
                     }

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -123,7 +123,7 @@ static String canonicalizeTimeZoneName(const String& timeZoneName)
         if (!ianaTimeZone)
             break;
 
-        StringView ianaTimeZoneView(ianaTimeZone, ianaTimeZoneLength);
+        StringView ianaTimeZoneView(std::span(ianaTimeZone, ianaTimeZoneLength));
         if (!equalIgnoringASCIICase(timeZoneName, ianaTimeZoneView))
             continue;
 
@@ -888,7 +888,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
                     return;
                 }
                 replaceHourCycleInSkeleton(skeleton, specifiedHour12);
-                dataLogLnIf(IntlDateTimeFormatInternal::verbose, "replaced:(", StringView(skeleton.data(), skeleton.size()), ")");
+                dataLogLnIf(IntlDateTimeFormatInternal::verbose, "replaced:(", StringView { skeleton.span() }, ")");
 
                 patternBuffer = vm.intlCache().getBestDateTimePattern(dataLocaleWithExtensions, skeleton.data(), skeleton.size(), status);
                 if (U_FAILURE(status)) {
@@ -940,7 +940,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
     if (hourCycle != HourCycle::None)
         replaceHourCycleInPattern(patternBuffer, hourCycle);
 
-    StringView pattern(patternBuffer.data(), patternBuffer.size());
+    StringView pattern(patternBuffer.span());
     setFormatsFromPattern(pattern);
 
     dataLogLnIf(IntlDateTimeFormatInternal::verbose, "locale:(", m_locale, "),dataLocale:(", dataLocaleWithExtensions, "),pattern:(", pattern, ")");
@@ -1356,7 +1356,7 @@ JSValue IntlDateTimeFormat::formatToParts(JSGlobalObject* globalObject, double v
     if (!parts)
         return throwOutOfMemoryError(globalObject, scope);
 
-    StringView resultStringView(result.data(), result.size());
+    StringView resultStringView(result.span());
     auto literalString = jsNontrivialString(vm, "literal"_s);
 
     int32_t resultLength = result.size();
@@ -1697,7 +1697,7 @@ JSValue IntlDateTimeFormat::formatRangeToParts(JSGlobalObject* globalObject, dou
     Vector<UChar, 32> buffer(std::span<const UChar> { formattedStringPointer, static_cast<size_t>(formattedStringLength) });
     replaceNarrowNoBreakSpaceOrThinSpaceWithNormalSpace(buffer);
 
-    StringView resultStringView(buffer.data(), buffer.size());
+    StringView resultStringView(buffer.span());
 
     // We care multiple categories (UFIELD_CATEGORY_DATE and UFIELD_CATEGORY_DATE_INTERVAL_SPAN).
     // So we do not constraint iterator.

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -609,7 +609,7 @@ JSValue IntlDurationFormat::formatToParts(JSGlobalObject* globalObject, ISO8601:
     const UChar* formattedStringPointer = ufmtval_getString(formattedValue, &formattedStringLength, &status);
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to format list of strings"_s);
-    StringView resultStringView(formattedStringPointer, formattedStringLength);
+    StringView resultStringView(std::span(formattedStringPointer, formattedStringLength));
 
     auto iterator = std::unique_ptr<UConstrainedFieldPosition, ICUDeleter<ucfpos_close>>(ucfpos_open(&status));
     if (U_FAILURE(status))

--- a/Source/JavaScriptCore/runtime/IntlListFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlListFormat.cpp
@@ -230,7 +230,7 @@ JSValue IntlListFormat::formatToParts(JSGlobalObject* globalObject, JSValue list
     const UChar* formattedStringPointer = ufmtval_getString(formattedValue, &formattedStringLength, &status);
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to format list of strings"_s);
-    StringView resultStringView(formattedStringPointer, formattedStringLength);
+    StringView resultStringView(std::span(formattedStringPointer, formattedStringLength));
 
     auto iterator = std::unique_ptr<UConstrainedFieldPosition, ICUDeleter<ucfpos_close>>(ucfpos_open(&status));
     if (U_FAILURE(status))

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -643,7 +643,7 @@ JSArray* IntlLocale::hourCycles(JSGlobalObject* globalObject)
         return nullptr;
     }
 
-    dataLogLnIf(IntlLocaleInternal::verbose, "pattern:(", StringView(pattern.data(), pattern.size()), ")");
+    dataLogLnIf(IntlLocaleInternal::verbose, "pattern:(", StringView { pattern.span() }, ")");
 
     switch (IntlDateTimeFormat::hourCycleFromPattern(pattern)) {
     case IntlDateTimeFormat::HourCycle::None:

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -947,7 +947,7 @@ void IntlNumberFormat::formatRangeToPartsInternal(JSGlobalObject* globalObject, 
         throwTypeError(globalObject, scope, "Failed to format number range"_s);
         return;
     }
-    StringView resultStringView(formattedStringPointer, formattedStringLength);
+    StringView resultStringView(std::span(formattedStringPointer, formattedStringLength));
 
     // We care multiple categories (UFIELD_CATEGORY_DATE and UFIELD_CATEGORY_DATE_INTERVAL_SPAN).
     // So we do not constraint iterator.

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -1097,12 +1097,8 @@ ALWAYS_INLINE StringView JSRopeString::unsafeView(JSGlobalObject* globalObject) 
 {
     if constexpr (validateDFGDoesGC)
         vm().verifyCanGC();
-    if (isSubstring()) {
-        auto& base = substringBase()->valueInternal();
-        if (base.is8Bit())
-            return StringView(base.characters8() + substringOffset(), length());
-        return StringView(base.characters16() + substringOffset(), length());
-    }
+    if (isSubstring())
+        return StringView { substringBase()->valueInternal() }.substring(substringOffset(), length());
     return resolveRope(globalObject);
 }
 
@@ -1112,9 +1108,7 @@ ALWAYS_INLINE StringViewWithUnderlyingString JSRopeString::viewWithUnderlyingStr
         vm().verifyCanGC();
     if (isSubstring()) {
         auto& base = substringBase()->valueInternal();
-        if (base.is8Bit())
-            return { { base.characters8() + substringOffset(), length() }, base };
-        return { { base.characters16() + substringOffset(), length() }, base };
+        return { StringView { base }.substring(substringOffset(), length()), base };
     }
     auto& string = resolveRope(globalObject);
     return { string, string };

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -769,7 +769,7 @@ ALWAYS_INLINE TokenType LiteralParser<CharType>::Lexer::lex(LiteralParserToken<C
             return tokenType;
         }
     }
-    m_lexErrorMessage = makeString("Unrecognized token '"_s, StringView { m_ptr, 1 }, '\'');
+    m_lexErrorMessage = makeString("Unrecognized token '"_s, span(*m_ptr), '\'');
     return TokError;
 }
 
@@ -952,7 +952,7 @@ slowPathBegin:
                     } // uNNNN == 5 characters
                     for (int i = 1; i < 5; i++) {
                         if (!isASCIIHexDigit(m_ptr[i])) {
-                            m_lexErrorMessage = makeString("\"\\"_s, StringView { m_ptr, 5 }, "\" is not a valid unicode escape"_s);
+                            m_lexErrorMessage = makeString("\"\\"_s, std::span { m_ptr, 5 }, "\" is not a valid unicode escape"_s);
                             return TokError;
                         }
                     }
@@ -966,7 +966,7 @@ slowPathBegin:
                         m_ptr++;
                         break;
                     }
-                    m_lexErrorMessage = makeString("Invalid escape character "_s, StringView { m_ptr, 1 });
+                    m_lexErrorMessage = makeString("Invalid escape character "_s, span(*m_ptr));
                     return TokError;
             }
         }
@@ -1144,7 +1144,7 @@ ALWAYS_INLINE JSValue LiteralParser<CharType>::parsePrimitiveValue(VM& vm)
 
         auto tryMakeErrorString = [&] (unsigned length) -> String {
             bool addEllipsis = length != token->stringOrIdentifierLength;
-            return tryMakeString("Unexpected identifier \""_s, StringView { token->identifierStart, length }, addEllipsis ? "..."_s : ""_s, '"');
+            return tryMakeString("Unexpected identifier \""_s, std::span { token->identifierStart, length }, addEllipsis ? "..."_s : ""_s, '"');
         };
 
         constexpr unsigned maxLength = 200;

--- a/Source/JavaScriptCore/wasm/WasmIndexOrName.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIndexOrName.cpp
@@ -59,7 +59,7 @@ String makeString(const IndexOrName& ion)
     const String moduleName = ion.nameSection()->moduleName.size() ? String(ion.nameSection()->moduleName.data(), ion.nameSection()->moduleName.size()) : String(ion.nameSection()->moduleHash.data(), ion.nameSection()->moduleHash.size());
     if (ion.isIndex())
         return makeString(moduleName, ".wasm-function["_s, ion.index(), ']');
-    return makeString(moduleName, ".wasm-function["_s, StringView(ion.name()->data(), ion.name()->size()), ']');
+    return makeString(moduleName, ".wasm-function["_s, ion.name()->span(), ']');
 }
 
 } } // namespace JSC::Wasm

--- a/Source/WTF/wtf/HexNumber.cpp
+++ b/Source/WTF/wtf/HexNumber.cpp
@@ -48,7 +48,7 @@ std::pair<LChar*, unsigned> appendHex(LChar* buffer, unsigned bufferSize, std::u
 
 void printInternal(PrintStream& out, HexNumberBuffer buffer)
 {
-    out.print(StringView(buffer.characters(), buffer.length));
+    out.print(StringView(buffer.span()));
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/HexNumber.h
+++ b/Source/WTF/wtf/HexNumber.h
@@ -54,6 +54,7 @@ struct HexNumberBuffer {
     unsigned length;
 
     const LChar* characters() const { return &*(buffer.end() - length); }
+    std::span<const LChar> span() const { return { characters(), length }; }
 };
 
 template<typename NumberType> HexNumberBuffer hex(NumberType number, unsigned minimumDigits = 0, HexConversionMode mode = Uppercase)

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -497,7 +497,7 @@ void URL::setHost(StringView newHost)
     parse(makeString(
         StringView(m_string).left(hostStart()),
         slashSlashNeeded ? "//"_s : ""_s,
-        hasSpecialScheme() ? StringView(encodedHostName.data(), encodedHostName.size()) : newHost,
+        hasSpecialScheme() ? StringView(encodedHostName.span()) : newHost,
         StringView(m_string).substring(m_hostEnd)
     ));
 }
@@ -550,7 +550,7 @@ void URL::setHostAndPort(StringView hostAndPort)
     parse(makeString(
         StringView(m_string).left(hostStart()),
         slashSlashNeeded ? "//"_s : ""_s,
-        hasSpecialScheme() ? StringView(encodedHostName.data(), encodedHostName.size()) : hostName,
+        hasSpecialScheme() ? StringView(encodedHostName.span()) : hostName,
         portString.isEmpty() ? ""_s : ":"_s,
         portString,
         StringView(m_string).substring(pathStart())

--- a/Source/WTF/wtf/cf/CFURLExtras.cpp
+++ b/Source/WTF/wtf/cf/CFURLExtras.cpp
@@ -85,7 +85,7 @@ bool isSameOrigin(CFURLRef a, const URL& b)
     auto aBytes = bytesAsVector(a);
     RELEASE_ASSERT(aBytes.size() <= String::MaxLength);
 
-    StringView aString { aBytes.data(), static_cast<unsigned>(aBytes.size()) };
+    StringView aString { aBytes.span() };
     StringView bString { b.string() };
 
     if (!b.hasPath())

--- a/Source/WTF/wtf/text/NullTextBreakIterator.h
+++ b/Source/WTF/wtf/text/NullTextBreakIterator.h
@@ -51,7 +51,7 @@ public:
         return false;
     }
 
-    void setText(StringView, const UChar*, unsigned)
+    void setText(StringView, std::span<const UChar>)
     {
         ASSERT_NOT_REACHED();
     }

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -152,8 +152,8 @@ inline void StringBuilder::swap(StringBuilder& other)
 inline StringBuilder::operator StringView() const
 {
     if (is8Bit())
-        return { characters<LChar>(), length() };
-    return { characters<UChar>(), length() };
+        return span<LChar>();
+    return span<UChar>();
 }
 
 inline void StringBuilder::append(UChar character)
@@ -320,7 +320,7 @@ template<typename... StringTypes> void StringBuilder::append(StringTypes... stri
 
 template<typename CharacterType> bool equal(const StringBuilder& builder, const CharacterType* buffer, unsigned length)
 {
-    return builder == StringView { buffer, length };
+    return builder == StringView { std::span { buffer, length } };
 }
 
 template<> struct IntegerToStringConversionTrait<StringBuilder> {

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -1143,8 +1143,19 @@ inline void copyElements(LChar* __restrict destination, const UChar* __restrict 
     copyElements(bitwise_cast<uint8_t*>(destination), bitwise_cast<const uint16_t*>(source), length);
 }
 
+inline std::span<const LChar> span(const LChar& character)
+{
+    return { &character, 1 };
+}
+
+inline std::span<const UChar> span(const UChar& character)
+{
+    return { &character, 1 };
+}
+
 }
 
 using WTF::equalIgnoringASCIICase;
 using WTF::equalLettersIgnoringASCIICase;
 using WTF::isLatin1;
+using WTF::span;

--- a/Source/WTF/wtf/text/StringParsingBuffer.h
+++ b/Source/WTF/wtf/text/StringParsingBuffer.h
@@ -67,7 +67,7 @@ public:
         m_position = position;
     }
 
-    StringView stringViewOfCharactersRemaining() const { return { m_position, lengthRemaining() }; }
+    StringView stringViewOfCharactersRemaining() const { return span(); }
 
     CharacterType consume()
     {
@@ -76,6 +76,8 @@ public:
         ++m_position;
         return character;
     }
+
+    std::span<const CharacterType> span() const { return { m_position, lengthRemaining() }; }
 
     std::span<const CharacterType> consume(size_t count)
     {

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -209,9 +209,7 @@ public:
 
     StringView operator*() const
     {
-        if (m_stringView.is8Bit())
-            return StringView(m_stringView.characters8() + m_index, m_indexEnd - m_index);
-        return StringView(m_stringView.characters16() + m_index, m_indexEnd - m_index);
+        return m_stringView.substring(m_index, m_indexEnd - m_index);
     }
 
     bool operator==(const Impl& other) const
@@ -301,7 +299,7 @@ static AtomString convertASCIILowercaseAtom(const CharacterType* input, unsigned
 {
     for (unsigned i = 0; i < length; ++i) {
         if (UNLIKELY(isASCIIUpper(input[i])))
-            return makeAtomString(asASCIILowercase(StringView { input, length }));
+            return makeAtomString(asASCIILowercase(std::span { input, length }));
     }
     // Fast path when the StringView is already all lowercase.
     return AtomString(input, length);

--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCF.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCF.h
@@ -49,10 +49,10 @@ public:
     TextBreakIteratorCF& operator=(const TextBreakIteratorCF&) = delete;
     TextBreakIteratorCF& operator=(TextBreakIteratorCF&&) = default;
 
-    void setText(StringView string, const UChar* priorContext, unsigned priorContextLength)
+    void setText(StringView string, std::span<const UChar> priorContext)
     {
         return switchOn(m_backing, [&](auto& iterator) {
-            return iterator.setText(string, { priorContext, priorContextLength });
+            return iterator.setText(string, priorContext);
         });
     }
 

--- a/Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp
+++ b/Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp
@@ -31,23 +31,23 @@ namespace WTF {
 // Buffer sized to hold ASCII locale ID strings up to 32 characters long.
 using LocaleIDBuffer = std::array<char, 33>;
 
-TextBreakIterator::Backing TextBreakIterator::mapModeToBackingIterator(StringView string, const UChar* priorContext, unsigned priorContextLength, Mode mode, ContentAnalysis contentAnalysis, const AtomString& locale)
+TextBreakIterator::Backing TextBreakIterator::mapModeToBackingIterator(StringView string, std::span<const UChar> priorContext, Mode mode, ContentAnalysis contentAnalysis, const AtomString& locale)
 {
-    return switchOn(mode, [string, priorContext, priorContextLength, contentAnalysis, &locale](TextBreakIterator::LineMode lineMode) -> TextBreakIterator::Backing {
+    return switchOn(mode, [string, priorContext, contentAnalysis, &locale](TextBreakIterator::LineMode lineMode) -> TextBreakIterator::Backing {
         if (contentAnalysis == ContentAnalysis::Linguistic && lineMode.behavior == LineMode::Behavior::Default)
-            return TextBreakIteratorCF(string, { priorContext, priorContextLength }, TextBreakIteratorCF::Mode::LineBreak, locale);
-        return TextBreakIteratorICU(string, priorContext, priorContextLength, TextBreakIteratorICU::LineMode { lineMode.behavior }, locale);
-    }, [string, priorContext, priorContextLength, &locale](TextBreakIterator::CaretMode) -> TextBreakIterator::Backing {
-        return TextBreakIteratorCF(string, { priorContext, priorContextLength }, TextBreakIteratorCF::Mode::ComposedCharacter, locale);
-    }, [string, priorContext, priorContextLength, &locale](TextBreakIterator::DeleteMode) -> TextBreakIterator::Backing {
-        return TextBreakIteratorCF(string, { priorContext, priorContextLength }, TextBreakIteratorCF::Mode::BackwardDeletion, locale);
-    }, [string, priorContext, priorContextLength, &locale](TextBreakIterator::CharacterMode) -> TextBreakIterator::Backing {
-        return TextBreakIteratorCF(string, { priorContext, priorContextLength }, TextBreakIteratorCF::Mode::ComposedCharacter, locale);
+            return TextBreakIteratorCF(string, priorContext, TextBreakIteratorCF::Mode::LineBreak, locale);
+        return TextBreakIteratorICU(string, priorContext, TextBreakIteratorICU::LineMode { lineMode.behavior }, locale);
+    }, [string, priorContext, &locale](TextBreakIterator::CaretMode) -> TextBreakIterator::Backing {
+        return TextBreakIteratorCF(string, priorContext, TextBreakIteratorCF::Mode::ComposedCharacter, locale);
+    }, [string, priorContext, &locale](TextBreakIterator::DeleteMode) -> TextBreakIterator::Backing {
+        return TextBreakIteratorCF(string, priorContext, TextBreakIteratorCF::Mode::BackwardDeletion, locale);
+    }, [string, priorContext, &locale](TextBreakIterator::CharacterMode) -> TextBreakIterator::Backing {
+        return TextBreakIteratorCF(string, priorContext, TextBreakIteratorCF::Mode::ComposedCharacter, locale);
     });
 }
 
-TextBreakIterator::TextBreakIterator(StringView string, const UChar* priorContext, unsigned priorContextLength, Mode mode, ContentAnalysis contentAnalysis, const AtomString& locale)
-    : m_backing(mapModeToBackingIterator(string, priorContext, priorContextLength, mode, contentAnalysis, locale))
+TextBreakIterator::TextBreakIterator(StringView string, std::span<const UChar> priorContext, Mode mode, ContentAnalysis contentAnalysis, const AtomString& locale)
+    : m_backing(mapModeToBackingIterator(string, priorContext, mode, contentAnalysis, locale))
     , m_mode(mode)
     , m_locale(locale)
 {

--- a/Source/WTF/wtf/text/icu/UTextProvider.h
+++ b/Source/WTF/wtf/text/icu/UTextProvider.h
@@ -44,15 +44,15 @@ inline UTextProviderContext uTextProviderContext(const UText* text, int64_t nati
     return UTextProviderContext::PriorContext;
 }
 
-inline void initializeContextAwareUTextProvider(UText* text, const UTextFuncs* funcs, const void* string, unsigned length, const UChar* priorContext, int priorContextLength)
+inline void initializeContextAwareUTextProvider(UText* text, const UTextFuncs* funcs, const void* string, unsigned length, std::span<const UChar> priorContext)
 {
     text->pFuncs = funcs;
     text->providerProperties = 1 << UTEXT_PROVIDER_STABLE_CHUNKS;
     text->context = string;
     text->p = string;
     text->a = length;
-    text->q = priorContext;
-    text->b = priorContextLength;
+    text->q = priorContext.data();
+    text->b = priorContext.size();
 }
 
 // Shared implementation for the UTextClone function on UTextFuncs.

--- a/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
@@ -211,11 +211,11 @@ static void uTextLatin1Close(UText* uText)
     uText->context = nullptr;
 }
 
-UText* openLatin1UTextProvider(UTextWithBuffer* utWithBuffer, const LChar* string, unsigned length, UErrorCode* status)
+UText* openLatin1UTextProvider(UTextWithBuffer* utWithBuffer, std::span<const LChar> string, UErrorCode* status)
 {
     if (U_FAILURE(*status))
         return nullptr;
-    if (!string || length > static_cast<unsigned>(std::numeric_limits<int32_t>::max())) {
+    if (!string.data() || string.size() > static_cast<unsigned>(std::numeric_limits<int32_t>::max())) {
         *status = U_ILLEGAL_ARGUMENT_ERROR;
         return nullptr;
     }
@@ -225,8 +225,8 @@ UText* openLatin1UTextProvider(UTextWithBuffer* utWithBuffer, const LChar* strin
         return nullptr;
     }
 
-    text->context = string;
-    text->a = length;
+    text->context = string.data();
+    text->a = string.size();
     text->pFuncs = &uTextLatin1Funcs;
     text->chunkContents = static_cast<UChar*>(text->pExtra);
     memset(const_cast<UChar*>(text->chunkContents), 0, sizeof(UChar) * UTextWithBufferInlineCapacity);
@@ -373,7 +373,7 @@ static void uTextLatin1ContextAwareClose(UText* text)
     text->context = nullptr;
 }
 
-UText* openLatin1ContextAwareUTextProvider(UTextWithBuffer* utWithBuffer, const LChar* string, unsigned length, const UChar* priorContext, int priorContextLength, UErrorCode* status)
+UText* openLatin1ContextAwareUTextProvider(UTextWithBuffer* utWithBuffer, const LChar* string, unsigned length, std::span<const UChar> priorContext, UErrorCode* status)
 {
     if (U_FAILURE(*status))
         return nullptr;
@@ -387,7 +387,7 @@ UText* openLatin1ContextAwareUTextProvider(UTextWithBuffer* utWithBuffer, const 
         return nullptr;
     }
 
-    initializeContextAwareUTextProvider(text, &textLatin1ContextAwareFuncs, string, length, priorContext, priorContextLength);
+    initializeContextAwareUTextProvider(text, &textLatin1ContextAwareFuncs, string, length, priorContext);
     return text;
 }
 

--- a/Source/WTF/wtf/text/icu/UTextProviderLatin1.h
+++ b/Source/WTF/wtf/text/icu/UTextProviderLatin1.h
@@ -38,7 +38,7 @@ struct UTextWithBuffer {
     UChar buffer[UTextWithBufferInlineCapacity];
 };
 
-UText* openLatin1UTextProvider(UTextWithBuffer* utWithBuffer, const LChar* string, unsigned length, UErrorCode* status);
-WTF_EXPORT_PRIVATE UText* openLatin1ContextAwareUTextProvider(UTextWithBuffer* utWithBuffer, const LChar* string, unsigned length, const UChar* priorContext, int priorContextLength, UErrorCode* status);
+UText* openLatin1UTextProvider(UTextWithBuffer* utWithBuffer, std::span<const LChar> string, UErrorCode* status);
+WTF_EXPORT_PRIVATE UText* openLatin1ContextAwareUTextProvider(UTextWithBuffer* utWithBuffer, const LChar* string, unsigned length, std::span<const UChar> priorContext, UErrorCode* status);
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/icu/UTextProviderUTF16.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProviderUTF16.cpp
@@ -162,7 +162,7 @@ static void uTextUTF16ContextAwareClose(UText* text)
     text->context = nullptr;
 }
 
-UText* openUTF16ContextAwareUTextProvider(UText* text, const UChar* string, unsigned length, const UChar* priorContext, int priorContextLength, UErrorCode* status)
+UText* openUTF16ContextAwareUTextProvider(UText* text, const UChar* string, unsigned length, std::span<const UChar> priorContext, UErrorCode* status)
 {
     if (U_FAILURE(*status))
         return nullptr;
@@ -176,7 +176,7 @@ UText* openUTF16ContextAwareUTextProvider(UText* text, const UChar* string, unsi
         return nullptr;
     }
 
-    initializeContextAwareUTextProvider(text, &textUTF16ContextAwareFuncs, string, length, priorContext, priorContextLength);
+    initializeContextAwareUTextProvider(text, &textUTF16ContextAwareFuncs, string, length, priorContext);
     return text;
 }
 

--- a/Source/WTF/wtf/text/icu/UTextProviderUTF16.h
+++ b/Source/WTF/wtf/text/icu/UTextProviderUTF16.h
@@ -29,6 +29,6 @@
 
 namespace WTF {
 
-WTF_EXPORT_PRIVATE UText* openUTF16ContextAwareUTextProvider(UText*, const UChar*, unsigned length, const UChar* priorContext, int priorContextLength, UErrorCode*);
+WTF_EXPORT_PRIVATE UText* openUTF16ContextAwareUTextProvider(UText*, const UChar*, unsigned length, std::span<const UChar> priorContext, UErrorCode*);
 
 } // namespace WTF

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.cpp
@@ -65,7 +65,7 @@ public:
             auto stats = certificate->GetSSLCertificate().GetStats();
             auto* info = stats.get();
             while (info) {
-                StringView fingerprint { reinterpret_cast<const unsigned char*>(info->fingerprint.data()), static_cast<unsigned>(info->fingerprint.length()) };
+                StringView fingerprint { std::span { info->fingerprint } };
                 fingerprints.append({ fromStdString(info->fingerprint_algorithm), fingerprint.convertToASCIILowercase() });
                 info = info->issuer.get();
             };

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -87,7 +87,7 @@ static String trimInputSample(const uint8_t* p, size_t length)
 {
     if (length <= maxInputSampleSize)
         return String(p, length);
-    return makeString(StringView(p, length).left(maxInputSampleSize), horizontalEllipsis);
+    return makeString(std::span { p, length }.first(maxInputSampleSize), horizontalEllipsis);
 }
 
 static String generateSecWebSocketKey()
@@ -409,13 +409,13 @@ int WebSocketHandshake::readStatusLine(const uint8_t* header, size_t headerLengt
         return lineLength;
     }
 
-    StringView httpStatusLine(header, space1 - header);
+    StringView httpStatusLine(std::span(header, space1 - header));
     if (!headerHasValidHTTPVersion(httpStatusLine)) {
         m_failureReason = makeString("Invalid HTTP version string: ", httpStatusLine);
         return lineLength;
     }
 
-    StringView statusCodeString(space1 + 1, space2 - space1 - 1);
+    StringView statusCodeString(std::span(space1 + 1, space2 - space1 - 1));
     if (statusCodeString.length() != 3) // Status code must consist of three digits.
         return lineLength;
     for (int i = 0; i < 3; ++i) {
@@ -439,7 +439,7 @@ const uint8_t* WebSocketHandshake::readHTTPHeaders(const uint8_t* start, const u
     bool sawSecWebSocketProtocolHeaderField = false;
     auto p = start;
     for (; p < end; p++) {
-        size_t consumedLength = parseHTTPHeader(std::span { p, static_cast<size_t>(end - p) }, m_failureReason, name, value);
+        size_t consumedLength = parseHTTPHeader(std::span(p, end - p), m_failureReason, name, value);
         if (!consumedLength)
             return nullptr;
         p += consumedLength;

--- a/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
+++ b/Source/WebCore/bindings/js/ScriptBufferSourceProvider.h
@@ -67,7 +67,7 @@ public:
                 m_scriptHash = StringHasher::computeHashAndMaskTop8Bits(m_contiguousBuffer->span());
         }
         if (*m_containsOnlyASCII)
-            return { m_contiguousBuffer->data(), static_cast<unsigned>(m_contiguousBuffer->size()) };
+            return m_contiguousBuffer->span();
 
         if (!m_cachedScriptString) {
             m_cachedScriptString = m_scriptBuffer.toString();

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
@@ -50,7 +50,7 @@ auto CSSCustomPropertySyntax::parseComponent(StringParsingBuffer<CharacterType> 
         if (buffer.position() == begin)
             return { };
 
-        auto dataTypeName = StringView(begin, buffer.position() - begin);
+        auto dataTypeName = StringView(std::span(begin, buffer.position() - begin));
         if (!skipExactly(buffer, '>'))
             return { };
 
@@ -75,7 +75,7 @@ auto CSSCustomPropertySyntax::parseComponent(StringParsingBuffer<CharacterType> 
         ++buffer;
 
     auto ident = [&] {
-        auto tokenizer = CSSTokenizer::tryCreate(StringView(begin, buffer.position() - begin).toStringWithoutCopying());
+        auto tokenizer = CSSTokenizer::tryCreate(StringView(std::span(begin, buffer.position() - begin)).toStringWithoutCopying());
         if (!tokenizer)
             return nullAtom();
 

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -406,11 +406,11 @@ static StringView mergeIfAdjacent(StringView a, StringView b)
     if (a.is8Bit() && b.is8Bit()) {
         auto characters = a.characters8();
         if (characters + a.length() == b.characters8())
-            return { characters, a.length() + b.length() };
+            return std::span { characters, a.length() + b.length() };
     } else if (!a.is8Bit() && !b.is8Bit()) {
         auto characters = a.characters16();
         if (characters + a.length() == b.characters16())
-            return { characters, a.length() + b.length() };
+            return std::span { characters, a.length() + b.length() };
     }
     return { };
 }

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1627,7 +1627,7 @@ void WordAwareIterator::advance()
 StringView WordAwareIterator::text() const
 {
     if (!m_buffer.isEmpty())
-        return StringView(m_buffer.data(), m_buffer.size());
+        return m_buffer.span();
     if (m_previousText.text().length())
         return m_previousText.text();
     return m_underlyingIterator.text();
@@ -2186,7 +2186,7 @@ inline bool SearchBuffer::isWordEndMatch(size_t start, size_t length) const
 
     // Start searching at the end of matched search, so that multiple word matches succeed.
     int endWord;
-    findEndWordBoundary(StringView(m_buffer.data(), m_buffer.size()), start + length - 1, &endWord);
+    findEndWordBoundary(m_buffer.span(), start + length - 1, &endWord);
     return static_cast<size_t>(endWord) == start + length;
 }
 
@@ -2241,7 +2241,7 @@ inline bool SearchBuffer::isWordStartMatch(size_t start, size_t length) const
 
     size_t wordBreakSearchStart = start + length;
     while (wordBreakSearchStart > start)
-        wordBreakSearchStart = findNextWordFromIndex(StringView(m_buffer.data(), m_buffer.size()), wordBreakSearchStart, false /* backwards */);
+        wordBreakSearchStart = findNextWordFromIndex(m_buffer.span(), wordBreakSearchStart, false /* backwards */);
     return wordBreakSearchStart == start;
 }
 
@@ -2284,7 +2284,7 @@ nextMatch:
             // determining if it is at a word boundary.
             unsigned wordBoundaryContextStart = matchStart;
             U16_BACK_1(m_buffer.data(), 0, wordBoundaryContextStart);
-            wordBoundaryContextStart = startOfLastWordBoundaryContext(StringView(m_buffer.data(), wordBoundaryContextStart));
+            wordBoundaryContextStart = startOfLastWordBoundaryContext(m_buffer.subspan(0, wordBoundaryContextStart));
             overlap = std::min(size - 1, std::max(overlap, size - wordBoundaryContextStart));
         }
         memcpy(m_buffer.data(), m_buffer.data() + size - overlap, overlap * sizeof(UChar));

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -73,7 +73,7 @@ private:
 
 class TextIteratorCopyableText {
 public:
-    StringView text() const { return m_singleCharacter ? StringView(&m_singleCharacter, 1) : StringView(m_string).substring(m_offset, m_length); }
+    StringView text() const { return m_singleCharacter ? StringView(span(m_singleCharacter)) : StringView(m_string).substring(m_offset, m_length); }
     void appendToStringBuilder(StringBuilder&) const;
 
     void reset();

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -265,7 +265,7 @@ static UBreakIterator* wordBreakIteratorForMinOffsetBoundary(const VisiblePositi
     }
     append(string, textBox->originalText());
 
-    return wordBreakIterator(StringView(string.data(), string.size()));
+    return WTF::wordBreakIterator(string.span());
 }
 
 static UBreakIterator* wordBreakIteratorForMaxOffsetBoundary(const VisiblePosition& visiblePosition, InlineIterator::TextBoxIterator textBox,
@@ -289,7 +289,7 @@ static UBreakIterator* wordBreakIteratorForMaxOffsetBoundary(const VisiblePositi
         append(string, nextTextBox->originalText());
     }
 
-    return wordBreakIterator(StringView(string.data(), string.size()));
+    return WTF::wordBreakIterator(string.span());
 }
 
 static bool isLogicalStartOfWord(UBreakIterator* iter, int position, bool hardLineBreak)
@@ -491,7 +491,7 @@ unsigned backwardSearchForBoundaryWithTextIterator(SimplifiedBackwardsTextIterat
             prependRepeatedCharacter(string, 'x', it.text().length());
         }
         if (string.size() > suffixLength) {
-            next = searchFunction(StringView(string.data(), string.size()), string.size() - suffixLength, MayHaveMoreContext, needMoreContext);
+            next = searchFunction(string.span(), string.size() - suffixLength, MayHaveMoreContext, needMoreContext);
             if (next > 1) // FIXME: This is a work around for https://webkit.org/b/115070. We need to provide more contexts in general case.
                 break;
         }
@@ -500,7 +500,7 @@ unsigned backwardSearchForBoundaryWithTextIterator(SimplifiedBackwardsTextIterat
     if (needMoreContext && string.size() > suffixLength) {
         // The last search returned the beginning of the buffer and asked for more context,
         // but there is no earlier text. Force a search with what's available.
-        next = searchFunction(StringView(string.data(), string.size()), string.size() - suffixLength, DontHaveMoreContext, needMoreContext);
+        next = searchFunction(string.span(), string.size() - suffixLength, DontHaveMoreContext, needMoreContext);
         ASSERT(!needMoreContext);
     }
     
@@ -522,7 +522,7 @@ unsigned forwardSearchForBoundaryWithTextIterator(TextIterator& it, Vector<UChar
             appendRepeatedCharacter(string, 'x', it.text().length());
         }
         if (string.size() > prefixLength) {
-            next = searchFunction(StringView(string.data(), string.size()), prefixLength, MayHaveMoreContext, needMoreContext);
+            next = searchFunction(string.span(), prefixLength, MayHaveMoreContext, needMoreContext);
             if (next != string.size())
                 break;
         }
@@ -531,7 +531,7 @@ unsigned forwardSearchForBoundaryWithTextIterator(TextIterator& it, Vector<UChar
     if (needMoreContext && string.size() > prefixLength) {
         // The last search returned the end of the buffer and asked for more context,
         // but there is no further text. Force a search with what's available.
-        next = searchFunction(StringView(string.data(), string.size()), prefixLength, DontHaveMoreContext, needMoreContext);
+        next = searchFunction(string.span(), prefixLength, DontHaveMoreContext, needMoreContext);
         ASSERT(!needMoreContext);
     }
     

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -392,7 +392,7 @@ void FTPDirectoryDocumentParser::append(RefPtr<StringImpl>&& inputSource)
 
     while (cursor < m_dest) {
         if (*cursor == '\n') {
-            m_carryOver.append(StringView(start, cursor - start));
+            m_carryOver.append(StringView(std::span(start, cursor - start)));
             LOG(FTP, "%s", m_carryOver.toString().ascii().data());
             parseAndAppendOneLine(m_carryOver.toString());
             m_carryOver.clear();
@@ -404,7 +404,7 @@ void FTPDirectoryDocumentParser::append(RefPtr<StringImpl>&& inputSource)
 
     // Copy the partial line we have left to the carryover buffer
     if (cursor - start > 1)
-        m_carryOver.append(StringView(start, cursor - start - 1));
+        m_carryOver.append(StringView(std::span(start, cursor - start - 1)));
 }
 
 void FTPDirectoryDocumentParser::finish()

--- a/Source/WebCore/html/MediaFragmentURIParser.cpp
+++ b/Source/WebCore/html/MediaFragmentURIParser.cpp
@@ -65,7 +65,7 @@ static StringView collectFraction(const LChar* input, unsigned length, unsigned&
     unsigned start = position++;
     while (position < length && isASCIIDigit(input[position]))
         ++position;
-    return StringView { input + start, position - start };
+    return std::span(input + start, position - start);
 }
 
 MediaFragmentURIParser::MediaFragmentURIParser(const URL& url)

--- a/Source/WebCore/html/parser/CSSPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.cpp
@@ -236,10 +236,10 @@ static bool hasValidImportConditions(StringView conditions)
 
 void CSSPreloadScanner::emitRule()
 {
-    StringView rule(m_rule.data(), m_rule.size());
+    StringView rule(m_rule.span());
     if (equalLettersIgnoringASCIICase(rule, "import"_s)) {
         String url = parseCSSStringOrURL(m_ruleValue.data(), m_ruleValue.size());
-        StringView conditions(m_ruleConditions.data(), m_ruleConditions.size());
+        StringView conditions(m_ruleConditions.span());
         if (!url.isEmpty() && hasValidImportConditions(conditions)) {
             URL baseElementURL; // FIXME: This should be passed in from the HTMLPreloadScanner via scan(): without it we will get relative URLs wrong.
             // FIXME: Should this be including the charset in the preload request?

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -656,7 +656,7 @@ static NEVER_INLINE unsigned findBreakIndexSlow(const String& string, unsigned c
     // see <https://bugs.webkit.org/show_bug.cgi?id=29092>.
     // We need at least two characters look-ahead to account for UTF-16 surrogates.
     unsigned breakSearchLength = std::min(proposedBreakIndex - currentPosition + 2, stringLength - currentPosition);
-    NonSharedCharacterBreakIterator it(StringView(string.characters16(), stringLength).substring(currentPosition, breakSearchLength));
+    NonSharedCharacterBreakIterator it(StringView(string).substring(currentPosition, breakSearchLength));
 
     unsigned stringLengthLimit = proposedBreakIndex - currentPosition;
     if (ubrk_isBoundary(it, stringLengthLimit))

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
@@ -85,7 +85,7 @@ static StringView extractCharset(StringView value)
 bool HTMLMetaCharsetParser::processMeta(HTMLToken& token)
 {
     auto attributes = token.attributes().map([](auto& attribute) {
-        return std::pair { StringView { attribute.name.data(), static_cast<unsigned>(attribute.name.size()) }, StringView { attribute.value.data(), static_cast<unsigned>(attribute.value.size()) } };
+        return std::pair { StringView { attribute.name.span() }, StringView { attribute.value.span() } };
     });
     m_encoding = encodingFromMetaAttributes(attributes);
     return m_encoding.isValid();

--- a/Source/WebCore/html/parser/HTMLParserIdioms.cpp
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.cpp
@@ -342,7 +342,7 @@ static bool parseHTTPRefreshInternal(const CharacterType* position, const Charac
     while (position < end && isASCIIDigit(*position))
         ++position;
 
-    StringView timeString(numberStart, position - numberStart);
+    StringView timeString(std::span(numberStart, position - numberStart));
     if (timeString.isEmpty()) {
         if (position >= end || *position != '.')
             return false;
@@ -379,7 +379,7 @@ static bool parseHTTPRefreshInternal(const CharacterType* position, const Charac
         return true;
 
     if (*position == 'U' || *position == 'u') {
-        StringView url(position, end - position);
+        StringView url(std::span(position, end - position));
 
         ++position;
 
@@ -418,7 +418,7 @@ static bool parseHTTPRefreshInternal(const CharacterType* position, const Charac
     } else
         quote = '\0';
 
-    StringView url(position, end - position);
+    StringView url(std::span(position, end - position));
 
     if (quote != '\0') {
         size_t index = url.find(quote);

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -120,8 +120,7 @@ public:
         Ref document = protectedDocument();
         for (auto& attribute : attributes) {
             auto knownAttributeName = AtomString::lookUp(attribute.name.data(), attribute.name.size());
-            StringView attributeValue { attribute.value.data(), static_cast<unsigned>(attribute.value.size()) };
-            processAttribute(knownAttributeName, attributeValue, pictureState);
+            processAttribute(knownAttributeName, attribute.value.span(), pictureState);
         }
 
         if (m_tagId == TagId::Source && !pictureState.isEmpty() && !pictureState.last() && m_mediaMatched && m_typeMatched && !m_srcSetAttribute.isEmpty()) {

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -56,7 +56,7 @@ template<typename CharType>
 static void appendDescriptorAndReset(const CharType*& descriptorStart, const CharType* position, Vector<StringView>& descriptors)
 {
     if (position > descriptorStart)
-        descriptors.append(StringView(descriptorStart, position - descriptorStart));
+        descriptors.append(StringView { std::span(descriptorStart, position - descriptorStart) });
     descriptorStart = nullptr;
 }
 
@@ -208,7 +208,7 @@ static Vector<ImageCandidate> parseImageCandidatesFromSrcsetAttribute(const Char
 
         ASSERT(imageURLEnd > imageURLStart);
         unsigned imageURLLength = imageURLEnd - imageURLStart;
-        imageCandidates.append(ImageCandidate(StringViewWithUnderlyingString(StringView(imageURLStart, imageURLLength), String()), result, ImageCandidate::SrcsetOrigin));
+        imageCandidates.append(ImageCandidate(StringViewWithUnderlyingString(std::span(imageURLStart, imageURLLength), String()), result, ImageCandidate::SrcsetOrigin));
         // 11. Return to the step labeled splitting loop.
     }
     return imageCandidates;

--- a/Source/WebCore/html/track/VTTScanner.cpp
+++ b/Source/WebCore/html/track/VTTScanner.cpp
@@ -129,9 +129,9 @@ unsigned VTTScanner::scanDigits(unsigned& number)
     StringView string;
     unsigned numDigits = runOfDigits.length();
     if (m_is8Bit)
-        string = { m_data.characters8, numDigits };
+        string = std::span { m_data.characters8, numDigits };
     else
-        string = { m_data.characters16, numDigits };
+        string = std::span { m_data.characters16, numDigits };
 
     // Since these are ASCII digits, the only failure mode is overflow, so use the maximum unsigned value.
     number = parseInteger<unsigned>(string).value_or(std::numeric_limits<unsigned>::max());

--- a/Source/WebCore/loader/LinkHeader.cpp
+++ b/Source/WebCore/loader/LinkHeader.cpp
@@ -179,7 +179,7 @@ template<typename CharacterType> static std::optional<LinkHeader::LinkParameterN
     skipWhile<isTabOrSpace>(buffer);
     bool hasEqual = skipExactly(buffer, '=');
     skipWhile<isTabOrSpace>(buffer);
-    auto name = parameterNameFromString(StringView { nameStart, static_cast<unsigned>(nameEnd - nameStart) });
+    auto name = parameterNameFromString(std::span { nameStart, static_cast<size_t>(nameEnd - nameStart) });
     if (hasEqual)
         return name;
     bool validParameterValueEnd = buffer.atEnd() || isParameterValueEnd(*buffer);

--- a/Source/WebCore/loader/ResourceCryptographicDigest.cpp
+++ b/Source/WebCore/loader/ResourceCryptographicDigest.cpp
@@ -69,7 +69,7 @@ template<typename CharacterType> static std::optional<ResourceCryptographicDiges
     if (buffer.position() == beginHashValue)
         return std::nullopt;
 
-    StringView hashValue(beginHashValue, buffer.position() - beginHashValue);
+    StringView hashValue(std::span(beginHashValue, buffer.position() - beginHashValue));
 
     if (auto digest = base64Decode(hashValue))
         return ResourceCryptographicDigest { *algorithm, WTFMove(*digest) };

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -363,7 +363,7 @@ void EventSource::parseEventStreamLine(unsigned position, std::optional<unsigned
     if (fieldLength && !fieldLength.value())
         return;
 
-    StringView field { &m_receiveBuffer[position], fieldLength ? fieldLength.value() : lineLength };
+    StringView field { m_receiveBuffer.subspan(position, fieldLength ? fieldLength.value() : lineLength) };
 
     unsigned step;
     if (!fieldLength)
@@ -381,7 +381,7 @@ void EventSource::parseEventStreamLine(unsigned position, std::optional<unsigned
     } else if (field == "event"_s)
         m_eventName = { &m_receiveBuffer[position], valueLength };
     else if (field == "id"_s) {
-        StringView parsedEventId = { &m_receiveBuffer[position], valueLength };
+        StringView parsedEventId = m_receiveBuffer.subspan(position, valueLength);
         constexpr UChar nullCharacter = '\0';
         if (!parsedEventId.contains(nullCharacter))
             m_currentlyParsedEventId = parsedEventId.toString();
@@ -389,7 +389,7 @@ void EventSource::parseEventStreamLine(unsigned position, std::optional<unsigned
         if (!valueLength)
             m_reconnectDelay = defaultReconnectDelay;
         else {
-            if (auto reconnectDelay = parseInteger<uint64_t>({ &m_receiveBuffer[position], valueLength }))
+            if (auto reconnectDelay = parseInteger<uint64_t>(m_receiveBuffer.subspan(position, valueLength)))
                 m_reconnectDelay = *reconnectDelay;
         }
     }

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -464,7 +464,7 @@ template<typename CharacterType> StringView ContentSecurityPolicySourceList::par
     if (!buffer.atEnd())
         return { };
 
-    return StringView(begin, buffer.position() - begin);
+    return std::span(begin, buffer.position() - begin);
 }
 
 // host              = [ "*." ] 1*host-char *( "." 1*host-char )
@@ -503,7 +503,7 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
     }
 
     ASSERT(buffer.atEnd());
-    host.value = StringView(hostBegin, buffer.position() - hostBegin);
+    host.value = std::span(hostBegin, buffer.position() - hostBegin);
     return host;
 }
 
@@ -521,7 +521,7 @@ template<typename CharacterType> String ContentSecurityPolicySourceList::parsePa
     ASSERT(buffer.position() <= buffer.end());
     ASSERT(buffer.atEnd() || (*buffer == '#' || *buffer == '?'));
 
-    return PAL::decodeURLEscapeSequences(StringView(begin, buffer.position() - begin));
+    return PAL::decodeURLEscapeSequences(std::span(begin, buffer.position() - begin));
 }
 
 // port              = ":" ( 1*DIGIT / "*" )
@@ -549,7 +549,7 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
         return std::nullopt;
 
     unsigned length = buffer.position() - begin;
-    auto portInteger = parseInteger<uint16_t>({ begin, length }).value_or(0);
+    auto portInteger = parseInteger<uint16_t>(std::span { begin, length }).value_or(0);
     if (!portInteger)
         return std::nullopt;
 

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -71,7 +71,7 @@ static Length parseLength(const UChar* data, unsigned length)
             return Length(r, LengthType::Percent);
         return Length(1, LengthType::Relative);
     }
-    auto r = parseInteger<int>({ data, intLength });
+    auto r = parseInteger<int>(std::span { data, intLength });
     if (next == '*')
         return Length(r.value_or(1), LengthType::Relative);
     if (r)

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -211,7 +211,7 @@ unsigned ComplexTextController::offsetForPosition(float h, bool includePartialGl
                 }
 
                 unsigned stringLength = complexTextRun.stringLength();
-                CachedTextBreakIterator cursorPositionIterator(StringView(complexTextRun.characters(), stringLength), nullptr, 0, TextBreakIterator::CaretMode { }, nullAtom());
+                CachedTextBreakIterator cursorPositionIterator(complexTextRun.span(), { }, TextBreakIterator::CaretMode { }, nullAtom());
                 unsigned clusterStart;
                 if (cursorPositionIterator.isBoundary(hitIndex))
                     clusterStart = hitIndex;
@@ -328,7 +328,7 @@ void ComplexTextController::collectComplexTextRuns()
     const Font* synthesizedFont = nullptr;
     const Font* smallSynthesizedFont = nullptr;
 
-    CachedTextBreakIterator graphemeClusterIterator(m_run.text(), nullptr, 0, TextBreakIterator::CharacterMode { }, m_font.fontDescription().computedLocale());
+    CachedTextBreakIterator graphemeClusterIterator(m_run.text(), { }, TextBreakIterator::CharacterMode { }, m_font.fontDescription().computedLocale());
 
     unsigned markCount;
     char32_t baseCharacter;
@@ -338,7 +338,7 @@ void ComplexTextController::collectComplexTextRuns()
     // We don't perform font fallback on the capitalized characters when small caps is synthesized.
     // We may want to change this code to do so in the future; if we do, then the logic in initiateFontLoadingByAccessingGlyphDataIfApplicable()
     // would need to be updated accordingly too.
-    nextFont = m_font.fontForCombiningCharacterSequence({ baseOfString, currentIndex });
+    nextFont = m_font.fontForCombiningCharacterSequence(std::span { baseOfString, currentIndex });
 
     bool isSmallCaps = false;
     bool nextIsSmallCaps = false;
@@ -379,7 +379,7 @@ void ComplexTextController::collectComplexTextRuns()
             }
         }
 
-        nextFont = m_font.fontForCombiningCharacterSequence({ baseOfString + previousIndex, currentIndex - previousIndex });
+        nextFont = m_font.fontForCombiningCharacterSequence(std::span { baseOfString + previousIndex, currentIndex - previousIndex });
 
         capitalizedBase = capitalized(baseCharacter);
         if (!synthesizedFont && shouldSynthesizeSmallCaps(dontSynthesizeSmallCaps, nextFont, baseCharacter, capitalizedBase, fontVariantCaps, engageAllSmallCapsProcessing)) {

--- a/Source/WebCore/platform/graphics/ComplexTextController.h
+++ b/Source/WebCore/platform/graphics/ComplexTextController.h
@@ -102,6 +102,7 @@ public:
         unsigned glyphCount() const { return m_glyphCount; }
         const Font& font() const { return m_font; }
         const UChar* characters() const { return m_characters; }
+        std::span<const UChar> span() const { return { m_characters, stringLength() }; }
         unsigned stringLocation() const { return m_stringLocation; }
         unsigned stringLength() const { return m_stringLength; }
         ALWAYS_INLINE unsigned indexAt(unsigned) const;

--- a/Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h
+++ b/Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h
@@ -33,10 +33,9 @@ namespace WebCore {
 class ComposedCharacterClusterTextIterator {
 public:
     // The passed in UChar pointer starts at 'currentIndex'. The iterator operates on the range [currentIndex, lastIndex].
-    // 'endIndex' denotes the maximum length of the UChar array, which might exceed 'lastIndex'.
-    ComposedCharacterClusterTextIterator(const UChar* characters, unsigned currentIndex, unsigned lastIndex, unsigned endIndex)
-        : m_iterator(StringView(characters, endIndex - currentIndex), nullptr, 0, TextBreakIterator::CaretMode { }, nullAtom())
-        , m_characters(characters)
+    ComposedCharacterClusterTextIterator(std::span<const UChar> characters, unsigned currentIndex, unsigned lastIndex)
+        : m_iterator(characters, { }, TextBreakIterator::CaretMode { }, nullAtom())
+        , m_characters(characters.data())
         , m_originalIndex(currentIndex)
         , m_currentIndex(currentIndex)
         , m_lastIndex(lastIndex)

--- a/Source/WebCore/platform/graphics/StringTruncator.cpp
+++ b/Source/WebCore/platform/graphics/StringTruncator.cpp
@@ -195,7 +195,7 @@ static unsigned leftTruncateToBuffer(const String& string, unsigned length, unsi
 
 static float stringWidth(const FontCascade& renderer, const UChar* characters, unsigned length)
 {
-    TextRun run(StringView(characters, length));
+    TextRun run(StringView { std::span { characters, length } });
     return renderer.width(run);
 }
 

--- a/Source/WebCore/platform/graphics/TextRun.h
+++ b/Source/WebCore/platform/graphics/TextRun.h
@@ -118,6 +118,8 @@ public:
     UChar operator[](unsigned i) const { RELEASE_ASSERT(i < m_text.length()); return m_text[i]; }
     const LChar* data8(unsigned i) const { ASSERT_WITH_SECURITY_IMPLICATION(i < m_text.length()); ASSERT(is8Bit()); return &m_text.characters8()[i]; }
     const UChar* data16(unsigned i) const { ASSERT_WITH_SECURITY_IMPLICATION(i < m_text.length()); ASSERT(!is8Bit()); return &m_text.characters16()[i]; }
+    std::span<const LChar> span8(unsigned i) { ASSERT(is8Bit()); return m_text.span8().subspan(i); }
+    std::span<const UChar> span16(unsigned i) { ASSERT(!is8Bit()); return m_text.span16().subspan(i); }
 
     const LChar* characters8() const { ASSERT(is8Bit()); return m_text.characters8(); }
     const UChar* characters16() const { ASSERT(!is8Bit()); return m_text.characters16(); }
@@ -125,8 +127,8 @@ public:
     bool is8Bit() const { return m_text.is8Bit(); }
     unsigned length() const { return m_text.length(); }
 
-    void setText(const LChar* text, unsigned length) { setText({ text, length }); }
-    void setText(const UChar* text, unsigned length) { setText({ text, length }); }
+    void setText(const LChar* text, unsigned length) { setText(std::span { text, length }); }
+    void setText(const UChar* text, unsigned length) { setText(std::span { text, length }); }
     void setText(StringView text) { ASSERT(!text.isNull()); m_text = text.toStringWithoutCopying(); }
 
     float horizontalGlyphStretch() const { return m_horizontalGlyphStretch; }

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -808,7 +808,7 @@ void WidthIterator::advance(unsigned offset, GlyphBuffer& glyphBuffer)
         advanceInternal(textIterator, glyphBuffer);
     } else {
 #if USE(CLUSTER_AWARE_WIDTH_ITERATOR)
-        ComposedCharacterClusterTextIterator textIterator(m_run->data16(m_currentCharacterIndex), m_currentCharacterIndex, offset, length);
+        ComposedCharacterClusterTextIterator textIterator(m_run->span16(m_currentCharacterIndex), m_currentCharacterIndex, offset);
 #else
         SurrogatePairAwareTextIterator textIterator(m_run->data16(m_currentCharacterIndex), m_currentCharacterIndex, offset, length);
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
@@ -556,7 +556,7 @@ void InbandTextTrackPrivateAVF::processNativeSamples(CFArrayRef nativeSamples, c
 
                 // A WebVTT header is terminated by "One or more WebVTT line terminators" so append two line feeds to make sure the parser
                 // reccognized this string as a full header.
-                auto header = makeString(StringView { CFDataGetBytePtr(webvttHeaderData), length }, "\n\n");
+                auto header = makeString(std::span { CFDataGetBytePtr(webvttHeaderData), length }, "\n\n");
 
                 INFO_LOG(LOGIDENTIFIER, "VTT header ", header);
                 notifyMainThreadClient([&](auto& client) {

--- a/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
+++ b/Source/WebCore/platform/graphics/cairo/FontCairoHarfbuzzNG.cpp
@@ -144,7 +144,7 @@ const Font* FontCascade::fontForCombiningCharacterSequence(StringView stringView
             return systemFallback.get();
 
         // In case of emoji, if fallback font is colored try again without the variation selector character.
-        if (isEmoji && characters[length - 1] == 0xFE0F && systemFallback->platformData().isColorBitmapFont() && systemFallback->canRenderCombiningCharacterSequence({ characters, length - 1 }))
+        if (isEmoji && characters[length - 1] == 0xFE0F && systemFallback->platformData().isColorBitmapFont() && systemFallback->canRenderCombiningCharacterSequence(std::span { characters, length - 1 }))
             return systemFallback.get();
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -326,9 +326,8 @@ public:
         unsigned offset = 0u;
         if (buffer->size() >= 7) {
             auto data = buffer->read(0, 7);
-            StringView dataString(reinterpret_cast<const LChar*>(data.data()), data.size());
-            static NeverDestroyed<StringView> type(reinterpret_cast<const LChar*>(":Type:"), 6);
-            if (dataString.endsWith(type)) {
+            StringView dataString(data.span());
+            if (dataString.endsWith(":Type:"_s)) {
                 m_type.emplace(static_cast<WebCore::MediaKeyMessageType>(dataString.characterAt(0) - '0'));
                 offset = 7;
             }
@@ -624,7 +623,7 @@ void CDMInstanceSessionThunder::loadSession(LicenseType, const String& sessionID
                 callback(std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed, sessionLoadFailureFromThunder({ }));
             else {
                 auto responseData = responseMessage->extractData();
-                StringView response(reinterpret_cast<const LChar*>(responseData.data()), responseData.size());
+                StringView response(responseData.span());
                 GST_DEBUG("Error message: %s", response.utf8().data());
                 callback(std::nullopt, std::nullopt, std::nullopt, SuccessValue::Failed, sessionLoadFailureFromThunder(response));
             }

--- a/Source/WebCore/platform/graphics/skia/GlyphPageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GlyphPageSkia.cpp
@@ -41,7 +41,7 @@ bool GlyphPage::fill(UChar* buffer, unsigned bufferLength)
     if (!skiaHarfBuzzFont)
         return false;
 
-    StringView stringView(buffer, bufferLength);
+    StringView stringView(std::span { buffer, bufferLength });
     auto codePoints = stringView.codePoints();
     auto codePointsIterator = codePoints.begin();
 

--- a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
+++ b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
@@ -265,7 +265,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(const UChar* cp,
             origins.append({ offsetX, offsetY });
         }
         bool ltr = !item.a.fRTL;
-        auto stringIndices = stringIndicesFromClusters(clusters, StringView(str, length), item.iCharPos, glyphs.size(), ltr);
+        auto stringIndices = stringIndicesFromClusters(clusters, std::span(str, length), item.iCharPos, glyphs.size(), ltr);
         FloatSize initialAdvance = toFloatSize(origins[0]);
         m_complexTextRuns.append(ComplexTextRun::create(baseAdvances, origins, glyphs, stringIndices, initialAdvance, *font, cp, stringLocation, stringLength, item.iCharPos, items[i+1].iCharPos, ltr));
     }

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -318,7 +318,7 @@ static String trimInputSample(CharType* p, size_t length)
 {
     if (length <= maxInputSampleSize)
         return String(p, length);
-    return makeString(StringView(p, length).left(maxInputSampleSize), horizontalEllipsis);
+    return makeString(std::span { p, length }.first(maxInputSampleSize), horizontalEllipsis);
 }
 
 std::optional<WallTime> parseHTTPDate(const String& value)
@@ -756,7 +756,7 @@ size_t parseHTTPHeader(std::span<const uint8_t> data, String& failureReason, Str
     }
 
     nameSize = name.size();
-    nameStr = StringView(namePtr, nameSize);
+    nameStr = std::span { namePtr, nameSize };
 
     for (; p < end && *p == 0x20; p++) { }
 

--- a/Source/WebCore/platform/network/RFC8941.cpp
+++ b/Source/WebCore/platform/network/RFC8941.cpp
@@ -55,7 +55,7 @@ template<typename CharType> static StringView parseKey(StringParsingBuffer<CharT
     auto keyStart = buffer.position();
     ++buffer;
     skipUntil<isEndOfKey>(buffer);
-    return StringView(keyStart, buffer.position() - keyStart);
+    return std::span(keyStart, buffer.position() - keyStart);
 }
 
 // Parsing a String (https://datatracker.ietf.org/doc/html/rfc8941#section-4.2.5).

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3155,12 +3155,12 @@ TextRun RenderBlock::constructTextRun(const RenderText& text, unsigned offset, u
 
 TextRun RenderBlock::constructTextRun(const LChar* characters, unsigned length, const RenderStyle& style, ExpansionBehavior expansion)
 {
-    return constructTextRun(StringView(characters, length), style, expansion);
+    return constructTextRun(StringView { std::span { characters, length } }, style, expansion);
 }
 
 TextRun RenderBlock::constructTextRun(const UChar* characters, unsigned length, const RenderStyle& style, ExpansionBehavior expansion)
 {
-    return constructTextRun(StringView(characters, length), style, expansion);
+    return constructTextRun(StringView { std::span { characters, length } }, style, expansion);
 }
 
 #if ASSERT_ENABLED

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -177,7 +177,7 @@ String capitalize(const String& string, UChar previousCharacter)
     for (unsigned i = 1; i < length + 1; i++)
         stringWithPrevious[i] = convertNoBreakSpaceToSpace(stringImpl[i - 1]);
 
-    auto* breakIterator = wordBreakIterator(StringView { stringWithPrevious.data(), length + 1 });
+    auto* breakIterator = WTF::wordBreakIterator(stringWithPrevious.span().first(length + 1));
     if (!breakIterator)
         return string;
 
@@ -2009,13 +2009,13 @@ int RenderText::previousOffset(int current) const
     if (m_containsOnlyASCII || text().is8Bit())
         return current - 1;
 
-    CachedTextBreakIterator iterator(text(), nullptr, 0, TextBreakIterator::CaretMode { }, nullAtom());
+    CachedTextBreakIterator iterator(text(), { }, TextBreakIterator::CaretMode { }, nullAtom());
     return iterator.preceding(current).value_or(current - 1);
 }
 
 int RenderText::previousOffsetForBackwardDeletion(int current) const
 {
-    CachedTextBreakIterator iterator(text(), nullptr, 0, TextBreakIterator::DeleteMode { }, nullAtom());
+    CachedTextBreakIterator iterator(text(), { }, TextBreakIterator::DeleteMode { }, nullAtom());
     return iterator.preceding(current).value_or(0);
 }
 
@@ -2024,7 +2024,7 @@ int RenderText::nextOffset(int current) const
     if (m_containsOnlyASCII || text().is8Bit())
         return current + 1;
 
-    CachedTextBreakIterator iterator(text(), nullptr, 0, TextBreakIterator::CaretMode { }, nullAtom());
+    CachedTextBreakIterator iterator(text(), { }, TextBreakIterator::CaretMode { }, nullAtom());
     return iterator.following(current).value_or(current + 1);
 }
 
@@ -2051,9 +2051,7 @@ StringView RenderText::stringView(unsigned start, std::optional<unsigned> stop) 
     ASSERT(start <= length());
     ASSERT(destination <= length());
     ASSERT(start <= destination);
-    if (text().is8Bit())
-        return { text().characters8() + start, destination - start };
-    return { text().characters16() + start, destination - start };
+    return StringView { text() }.substring(start, destination - start);
 }
 
 RenderInline* RenderText::inlineWrapperForDisplayContents()

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -194,7 +194,7 @@ void TextPainter::paintTextAndEmphasisMarksIfNeeded(const TextRun& textRun, cons
 
     FloatPoint boxOrigin = boxRect.location();
     updateGraphicsContext(m_context, paintStyle, UseEmphasisMarkColor);
-    static NeverDestroyed<TextRun> objectReplacementCharacterTextRun(StringView(&objectReplacementCharacter, 1));
+    static NeverDestroyed<TextRun> objectReplacementCharacterTextRun(StringView { span(objectReplacementCharacter) });
     const TextRun& emphasisMarkTextRun = m_combinedText ? objectReplacementCharacterTextRun.get() : textRun;
     FloatPoint emphasisMarkTextOrigin = m_combinedText ? FloatPoint(boxOrigin.x() + boxRect.width() / 2, boxOrigin.y() + m_font.metricsOfPrimaryFont().intAscent()) : textOrigin;
     if (m_combinedText)

--- a/Source/WebCore/svg/SVGLengthList.cpp
+++ b/Source/WebCore/svg/SVGLengthList.cpp
@@ -47,7 +47,7 @@ bool SVGLengthList::parse(StringView value)
             if (buffer.position() == start)
                 break;
 
-            auto value = SVGLengthValue::construct(m_lengthMode, StringView(start, buffer.position() - start));
+            auto value = SVGLengthValue::construct(m_lengthMode, std::span(start, buffer.position() - start));
             if (!value)
                 break;
 

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -282,9 +282,8 @@ void MockCDMInstance::initializeWithConfiguration(const MediaKeySystemConfigurat
 
 void MockCDMInstance::setServerCertificate(Ref<SharedBuffer>&& certificate, SuccessCallback&& callback)
 {
-    StringView certificateStringView(certificate->makeContiguous()->data(), certificate->size());
-
-    callback(equalLettersIgnoringASCIICase(certificateStringView, "valid"_s) ? Succeeded : Failed);
+    Ref contiguousData = certificate->makeContiguous();
+    callback(equalLettersIgnoringASCIICase(StringView { contiguousData->span() }, "valid"_s) ? Succeeded : Failed);
 }
 
 void MockCDMInstance::setStorageDirectory(const String&)

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp
@@ -134,7 +134,7 @@ static std::optional<uint64_t> readSizeFile(const String& sizeDirectoryPath)
     if (!buffer)
         return std::nullopt;
 
-    return parseInteger<uint64_t>({ buffer->data(), static_cast<unsigned>(buffer->size()) });
+    return parseInteger<uint64_t>(buffer->span());
 }
 
 static bool writeSizeFile(const String& sizeDirectoryPath, uint64_t size)

--- a/Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm
+++ b/Source/WebKitLegacy/ios/Misc/WebUIKitSupport.mm
@@ -90,7 +90,7 @@ int WebKitGetLastLineBreakInBuffer(UChar *characters, int position, int length)
 {
     unsigned lastBreakPos = position;
     unsigned breakPos = 0;
-    CachedLineBreakIteratorFactory lineBreakIteratorFactory(StringView(characters, length));
+    CachedLineBreakIteratorFactory lineBreakIteratorFactory(StringView { std::span(characters, length) });
     while (static_cast<int>(breakPos = nextBreakablePosition(lineBreakIteratorFactory, breakPos)) < position)
         lastBreakPos = breakPos++;
     return static_cast<int>(lastBreakPos) < position ? lastBreakPos : INT_MAX;

--- a/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
@@ -69,7 +69,7 @@ static bool canUseFastRenderer(const UniChar* buffer, unsigned length)
 
     if (canUseFastRenderer(buffer.data(), length)) {
         FontCascade webCoreFont(FontPlatformData((__bridge CTFontRef)font, [font pointSize]));
-        TextRun run(StringView(reinterpret_cast<const UChar*>(buffer.data()), length));
+        TextRun run(StringView(std::span { reinterpret_cast<const UChar*>(buffer.data()), length }));
 
         // The following is a half-assed attempt to match AppKit's rounding rules for drawAtPoint.
         // If you change it, be sure to test all the text drawn this way in Safari, including
@@ -109,7 +109,7 @@ static bool canUseFastRenderer(const UniChar* buffer, unsigned length)
 
     if (canUseFastRenderer(buffer.data(), length)) {
         FontCascade webCoreFont(FontPlatformData((__bridge CTFontRef)font, [font pointSize]));
-        TextRun run(StringView(reinterpret_cast<const UChar*>(buffer.data()), length));
+        TextRun run(StringView(std::span { reinterpret_cast<const UChar*>(buffer.data()), length }));
         return webCoreFont.width(run);
     }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -167,10 +167,10 @@ TEST(WTF, StringViewIterators)
     EXPECT_TRUE(compareLoopIterations(heloView.codePoints(), {'h', 'e', 'l', 'o'}));
     EXPECT_TRUE(compareLoopIterations(heloView.codeUnits(), {'h', 'e', 'l', 'o'}));
     EXPECT_TRUE(compareLoopIterations(heloView.graphemeClusters(), {
-        StringView(heloView.characters8(), 1),
-        StringView(heloView.characters8() + 1, 1),
-        StringView(heloView.characters8() + 2, 1),
-        StringView(heloView.characters8() + 3, 1)}));
+        StringView(heloView.span8().subspan(0, 1)),
+        StringView(heloView.span8().subspan(1, 1)),
+        StringView(heloView.span8().subspan(2, 1)),
+        StringView(heloView.span8().subspan(3, 1)) }));
 
     StringBuilder b;
     build(b, {0xD800, 0xDD55}); // Surrogates for unicode code point U+10155
@@ -186,33 +186,33 @@ TEST(WTF, StringViewIterators)
     build(b, {0xD800, 0xD801}); // Two leading surrogates
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {0xD800, 0xD801}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codeUnits(), {0xD800, 0xD801}));
-    EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), {StringView(b.characters16(), 1), StringView(b.characters16() + 1, 1)}));
+    EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), { StringView(b.span<UChar>().subspan(0, 1)), StringView(b.span<UChar>().subspan(1, 1)) }));
 
     build(b, {0xDD55}); // Trailing surrogate only
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {0xDD55}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codeUnits(), {0xDD55}));
-    EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), {StringView(b.toString())}));
+    EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), { StringView(b.toString()) }));
 
     build(b, {0xD800, 'h'}); // Leading surrogate followed by non-surrogate
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {0xD800, 'h'}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codeUnits(), {0xD800, 'h'}));
-    EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), {StringView(b.characters16(), 1), StringView(b.characters16() + 1, 1)}));
+    EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), { StringView(b.span<UChar>().subspan(0, 1)), StringView(b.span<UChar>().subspan(1, 1)) }));
 
     build(b, {0x0306}); // "COMBINING BREVE"
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {0x0306}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codeUnits(), {0x0306}));
-    EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), {StringView(b.toString())}));
+    EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), { StringView(b.toString()) }));
 
     build(b, {0x0306, 0xD800, 0xDD55, 'h', 'e', 'l', 'o'}); // Mix of single code unit and multi code unit code points
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {0x0306, 0x10155, 'h', 'e', 'l', 'o'}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codeUnits(), {0x0306, 0xD800, 0xDD55, 'h', 'e', 'l', 'o'}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), {
-        StringView(b.characters16(), 1),
-        StringView(b.characters16() + 1, 2),
-        StringView(b.characters16() + 3, 1),
-        StringView(b.characters16() + 4, 1),
-        StringView(b.characters16() + 5, 1),
-        StringView(b.characters16() + 6, 1)}));
+        StringView(b.span<UChar>().subspan(0, 1)),
+        StringView(b.span<UChar>().subspan(1, 2)),
+        StringView(b.span<UChar>().subspan(3, 1)),
+        StringView(b.span<UChar>().subspan(4, 1)),
+        StringView(b.span<UChar>().subspan(5, 1)),
+        StringView(b.span<UChar>().subspan(6, 1)) }));
 
     build(b, {'e', 0x0301}); // "COMBINING ACUTE"
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {'e', 0x0301}));
@@ -223,16 +223,16 @@ TEST(WTF, StringViewIterators)
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {'e', 0x0301, 0x0306, 'a'}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codeUnits(), {'e', 0x0301, 0x0306, 'a'}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), {
-        StringView(b.characters16(), 3),
-        StringView(b.characters16() + 3, 1),
+        StringView(b.span<UChar>().subspan(0, 3)),
+        StringView(b.span<UChar>().subspan(3, 1)),
         }));
 
     build(b, {0x1112, 0x116f, 0x11b6, 0x1107, 0x1161, 0x11B8}); // Korean combining Jamo
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codePoints(), {0x1112, 0x116f, 0x11b6, 0x1107, 0x1161, 0x11B8}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).codeUnits(), {0x1112, 0x116f, 0x11b6, 0x1107, 0x1161, 0x11B8}));
     EXPECT_TRUE(compareLoopIterations(StringView(b.toString()).graphemeClusters(), {
-        StringView(b.characters16(), 3),
-        StringView(b.characters16() + 3, 3)}));
+        StringView(b.span<UChar>().subspan(0, 3)),
+        StringView(b.span<UChar>().subspan(3, 3)) }));
 }
 
 static Vector<String> vectorFromSplitResult(const StringView::SplitResult& substrings)
@@ -323,7 +323,7 @@ TEST(WTF, StringViewEqualBasic)
     EXPECT_FALSE(a == "Hello World!!"_s);
 
     auto test = "Hell\0";
-    a = StringView { (const LChar*)test, 5 };
+    a = StringView { std::span { (const LChar*)test, 5 } };
     EXPECT_FALSE(a == "Hell\0"_s);
     EXPECT_FALSE(a == "Hell"_s);
 
@@ -895,13 +895,13 @@ TEST(WTF, StringView8Bit)
     EXPECT_TRUE(StringView().is8Bit());
     EXPECT_TRUE(emptyStringView().is8Bit());
 
-    LChar* lcharPtr = nullptr;
-    UChar* ucharPtr = nullptr;
-    EXPECT_TRUE(StringView(lcharPtr, 0).is8Bit());
-    EXPECT_FALSE(StringView(ucharPtr, 0).is8Bit());
+    std::span<const LChar> lcharSpan;
+    std::span<const UChar> ucharSpan;
+    EXPECT_TRUE(StringView(lcharSpan).is8Bit());
+    EXPECT_FALSE(StringView(ucharSpan).is8Bit());
 
-    EXPECT_TRUE(StringView(String(lcharPtr, 0)).is8Bit());
-    EXPECT_TRUE(StringView(String(ucharPtr, 0)).is8Bit());
+    EXPECT_TRUE(StringView(String(lcharSpan)).is8Bit());
+    EXPECT_TRUE(StringView(String(ucharSpan)).is8Bit());
 
     EXPECT_TRUE(StringView(String().impl()).is8Bit());
     EXPECT_TRUE(StringView(emptyString().impl()).is8Bit());

--- a/Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp
@@ -152,17 +152,17 @@ TEST(WTF_TextBreakIterator, Behaviors)
     {
         auto string = u"ぁぁ"_str;
         auto locale = AtomString("ja"_str);
-        CachedTextBreakIterator strictIterator({ string }, nullptr, 0, TextBreakIterator::LineMode { TextBreakIterator::LineMode::Behavior::Strict }, locale);
+        CachedTextBreakIterator strictIterator({ string }, { }, TextBreakIterator::LineMode { TextBreakIterator::LineMode::Behavior::Strict }, locale);
         EXPECT_EQ(strictIterator.following(0), 2);
-        CachedTextBreakIterator looseIterator({ string }, nullptr, 0, TextBreakIterator::LineMode { TextBreakIterator::LineMode::Behavior::Loose }, locale);
+        CachedTextBreakIterator looseIterator({ string }, { }, TextBreakIterator::LineMode { TextBreakIterator::LineMode::Behavior::Loose }, locale);
         EXPECT_EQ(looseIterator.following(0), 1);
     }
     {
         auto string = u"中〜"_str;
         auto locale = AtomString("zh-Hans"_str);
-        CachedTextBreakIterator strictIterator({ string }, nullptr, 0, TextBreakIterator::LineMode { TextBreakIterator::LineMode::Behavior::Strict }, locale);
+        CachedTextBreakIterator strictIterator({ string }, { }, TextBreakIterator::LineMode { TextBreakIterator::LineMode::Behavior::Strict }, locale);
         EXPECT_EQ(strictIterator.following(0), 2);
-        CachedTextBreakIterator looseIterator({ string }, nullptr, 0, TextBreakIterator::LineMode { TextBreakIterator::LineMode::Behavior::Loose }, locale);
+        CachedTextBreakIterator looseIterator({ string }, { }, TextBreakIterator::LineMode { TextBreakIterator::LineMode::Behavior::Loose }, locale);
         EXPECT_EQ(looseIterator.following(0), 1);
     }
 }
@@ -189,7 +189,7 @@ TEST(WTF_TextBreakIterator, ICULine)
     auto context = u"th"_str;
     auto string = u"is is some text"_str;
     ASSERT(!context.is8Bit());
-    WTF::TextBreakIteratorICU iterator(string, context.characters16(), context.length(), WTF::TextBreakIteratorICU::LineMode { WTF::TextBreakIteratorICU::LineMode::Behavior::Default }, AtomString("en_US"_str));
+    WTF::TextBreakIteratorICU iterator(string, context.span16(), WTF::TextBreakIteratorICU::LineMode { WTF::TextBreakIteratorICU::LineMode::Behavior::Default }, AtomString("en_US"_str));
 
     {
         unsigned wordBoundaries[] = { 3, 6, 11, 15 };
@@ -226,7 +226,7 @@ TEST(WTF_TextBreakIterator, ICULine)
         auto context = u"di"_str;
         auto string = u"ctionary order"_str;
         ASSERT(!context.is8Bit());
-        iterator.setText(string, context.characters16(), context.length());
+        iterator.setText(string, context.span16());
         auto result = iterator.following(1);
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(*result, 9U);
@@ -235,12 +235,12 @@ TEST(WTF_TextBreakIterator, ICULine)
         auto context = u"a "_str;
         auto string = u"word"_str;
         ASSERT(!context.is8Bit());
-        iterator.setText(string, context.characters16(), context.length());
+        iterator.setText(string, context.span16());
         ASSERT_TRUE(iterator.isBoundary(0));
     }
     {
         auto string = u"word"_str;
-        iterator.setText(string, nullptr, 0);
+        iterator.setText(string, { });
         ASSERT_TRUE(iterator.isBoundary(0));
     }
 }
@@ -249,7 +249,7 @@ TEST(WTF_TextBreakIterator, ICUCharacter)
 {
     auto context = u"==>"_str;
     auto string = u" कि <=="_str;
-    WTF::TextBreakIteratorICU iterator(string, context.characters16(), context.length(), WTF::TextBreakIteratorICU::CharacterMode { }, AtomString("hi_IN"_str));
+    WTF::TextBreakIteratorICU iterator(string, context.span16(), WTF::TextBreakIteratorICU::CharacterMode { }, AtomString("hi_IN"_str));
 
     {
         unsigned wordBoundaries[] = { 1, 3, 4, 5, 6, 7 };
@@ -280,7 +280,7 @@ TEST(WTF_TextBreakIterator, Line)
     auto context = u"th"_str;
     auto string = u"is is some text"_str;
     ASSERT(!context.is8Bit());
-    WTF::CachedTextBreakIterator iterator(string, context.characters16(), context.length(), WTF::TextBreakIterator::LineMode { WTF::TextBreakIterator::LineMode::Behavior::Default }, AtomString("en_US"_str));
+    WTF::CachedTextBreakIterator iterator(string, context.span16(), WTF::TextBreakIterator::LineMode { WTF::TextBreakIterator::LineMode::Behavior::Default }, AtomString("en_US"_str));
 
     {
         unsigned wordBoundaries[] = { 3, 6, 11, 15 };
@@ -365,7 +365,7 @@ TEST(WTF_TextBreakIterator, CFWord)
     {
         auto context = u"di"_str;
         auto string = u"ctionary order"_str;
-        iterator.setText(string, context.characters16(), context.length());
+        iterator.setText(string, context.span16());
         auto result = iterator.following(1);
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(*result, 8U);
@@ -422,7 +422,7 @@ TEST(WTF_TextBreakIterator, CFLine)
     {
         auto context = u"di"_str;
         auto string = u"ctionary order"_str;
-        iterator.setText(string, context.characters16(), context.length());
+        iterator.setText(string, context.span16());
         auto result = iterator.following(1);
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(*result, 9U);
@@ -430,12 +430,12 @@ TEST(WTF_TextBreakIterator, CFLine)
     {
         auto context = u"a "_str;
         auto string = u"word"_str;
-        iterator.setText(string, context.characters16(), context.length());
+        iterator.setText(string, context.span16());
         ASSERT_TRUE(iterator.isBoundary(0));
     }
     {
         auto string = u"word"_str;
-        iterator.setText(string, nullptr, 0);
+        iterator.setText(string, { });
         ASSERT_TRUE(iterator.isBoundary(0));
     }
 }
@@ -480,7 +480,7 @@ TEST(WTF_TextBreakIterator, CFWordBoundary)
     {
         auto context = u"di"_str;
         auto string = u"ctionary order"_str;
-        iterator.setText(string, context.characters16(), context.length());
+        iterator.setText(string, context.span16());
         auto result = iterator.following(1);
         ASSERT_TRUE(result.has_value());
         EXPECT_EQ(*result, 8U);

--- a/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp
@@ -60,7 +60,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInRTL)
 
     UChar characters[] = { 0x644, 0x637, 0x641, 0x627, 0x64b, 0x20 };
     size_t charactersLength = std::size(characters);
-    TextRun textRun(StringView(characters, charactersLength));
+    TextRun textRun { StringView(characters) };
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(21.875, 0) }, { FloatPoint() }, { 5 }, { 5 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 5, 6, false);
     auto run2 = ComplexTextController::ComplexTextRun::create(advances, origins, { 193, 377, 447, 431, 458 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 0, 5, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
@@ -106,7 +106,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTL)
 
     UChar characters[] = { 0x644, 0x637, 0x641, 0x627, 0x64b };
     size_t charactersLength = std::size(characters);
-    TextRun textRun(StringView(characters, charactersLength));
+    TextRun textRun { StringView(characters) };
     auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 193, 377, 447, 431, 458 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 0, 5, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
     runs.append(WTFMove(run));
@@ -151,7 +151,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceWithLeftRunInLTR)
 
     UChar characters[] = { 0x20, 0x61, 0x20e3 };
     size_t charactersLength = std::size(characters);
-    TextRun textRun(StringView(characters, charactersLength));
+    TextRun textRun { StringView(characters) };
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(spaceWidth, 0) }, { FloatPoint() }, { 5 }, { 0 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 0, 1, true);
     auto run2 = ComplexTextController::ComplexTextRun::create(advances, origins, { 68, 1471 }, { 1, 2 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 1, 3, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
@@ -193,7 +193,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInLTR)
 
     UChar characters[] = { 0x61, 0x20e3 };
     size_t charactersLength = std::size(characters);
-    TextRun textRun(StringView(characters, charactersLength));
+    TextRun textRun { StringView(characters) };
     auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 68, 1471 }, { 0, 1 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 0, 2, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
     runs.append(WTFMove(run));
@@ -227,7 +227,7 @@ TEST_F(ComplexTextControllerTest, InitialAdvanceInRTLNoOrigins)
 
     UChar characters[] = { 0x633, 0x20, 0x627, 0x650 };
     size_t charactersLength = std::size(characters);
-    TextRun textRun(StringView(characters, charactersLength));
+    TextRun textRun { StringView(characters) };
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(-4.33996383363472, -12.368896925859), FloatSize(14.0397830018083, 0) }, { }, { 884, 240 }, { 3, 2 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 2, 4, false);
     auto run2 = ComplexTextController::ComplexTextRun::create({ FloatSize(12.0, 0) }, { }, { 3 }, { 1 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 1, 2, false);
     auto run3 = ComplexTextController::ComplexTextRun::create({ FloatSize(43.8119349005425, 0) }, { }, { 276 }, { 0 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 0, 1, false);
@@ -271,7 +271,7 @@ TEST_F(ComplexTextControllerTest, LeftExpansion)
 
     UChar characters[] = { 'a' };
     size_t charactersLength = std::size(characters);
-    TextRun textRun(StringView(characters, charactersLength), 0, 100, ExpansionBehavior::forceLeftOnly());
+    TextRun textRun(StringView(characters), 0, 100, ExpansionBehavior::forceLeftOnly());
     auto run = ComplexTextController::ComplexTextRun::create({ FloatSize(24, 0) }, { }, { 16 }, { 0 }, FloatSize(), font.primaryFont(), characters, 0, charactersLength, 0, 1, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
     runs.append(WTFMove(run));
@@ -301,7 +301,7 @@ TEST_F(ComplexTextControllerTest, VerticalAdvances)
 
     UChar characters[] = { 'a', 'b', 'c', 'd' };
     size_t charactersLength = std::size(characters);
-    TextRun textRun(StringView(characters, charactersLength));
+    TextRun textRun { StringView(characters) };
     auto run1 = ComplexTextController::ComplexTextRun::create({ FloatSize(0, 1), FloatSize(0, 2) }, { FloatPoint(0, 4), FloatPoint(0, 8) }, { 16, 17 }, { 0, 1 }, FloatSize(0, 16), font.primaryFont(), characters, 0, charactersLength, 0, 2, true);
     auto run2 = ComplexTextController::ComplexTextRun::create({ FloatSize(0, 32), FloatSize(0, 64) }, { FloatPoint(0, 128), FloatPoint(0, 256) }, { 18, 19 }, { 2, 3 }, FloatSize(0, 512), font.primaryFont(), characters, 0, charactersLength, 2, 4, true);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
@@ -350,7 +350,7 @@ TEST_F(ComplexTextControllerTest, TotalWidthWithJustification)
 
     UChar characters[] = { 0x644, ' ', 0x644, ' ', 0x644 };
     size_t charactersLength = std::size(characters);
-    TextRun textRun(StringView(characters, charactersLength), 0, 14, ExpansionBehavior::defaultBehavior(), TextDirection::RTL);
+    TextRun textRun(StringView(characters), 0, 14, ExpansionBehavior::defaultBehavior(), TextDirection::RTL);
     auto run = ComplexTextController::ComplexTextRun::create(advances, origins, { 5, 6, 7, 8, 9 }, { 4, 3, 2, 1, 0 }, initialAdvance, font.primaryFont(), characters, 0, charactersLength, 0, 5, false);
     Vector<Ref<ComplexTextController::ComplexTextRun>> runs;
     runs.append(WTFMove(run));

--- a/Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp
@@ -56,7 +56,7 @@ TEST(MonospaceFontsTest, EnsureMonospaceFontInvariants)
             if (fontCascade.canTakeFixedPitchFastContentMeasuring()) {
                 for (uint32_t character = 0; character <= UINT16_MAX; ++character) {
                     const char16_t ch = character;
-                    StringView content(&ch, 1);
+                    StringView content(span(ch));
                     if (fontCascade.codePath(TextRun(content)) == FontCascade::CodePath::Complex)
                         continue;
                     constexpr bool whitespaceIsCollapsed = false;
@@ -75,7 +75,7 @@ TEST(MonospaceFontsTest, EnsureMonospaceFontInvariants)
                     const char16_t characters[] {
                         ' ', ' ', 'a'
                     };
-                    StringView content(characters, 3);
+                    StringView content(characters);
                     constexpr bool whitespaceIsCollapsed = false;
                     fontCascade.fonts()->widthCache().clear();
                     float width = fontCascade.widthForSimpleTextWithFixedPitch(content, whitespaceIsCollapsed);

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
@@ -320,12 +320,12 @@ TEST_F(FragmentedSharedBufferTest, read)
     auto check = [](FragmentedSharedBuffer& sharedBuffer) {
         Vector<uint8_t> data = sharedBuffer.read(4, 3);
         EXPECT_EQ(data.size(), 3u);
-        EXPECT_EQ(StringView(data.data(), 3), " is"_s);
+        EXPECT_EQ(StringView(data.subspan(0, 3)), " is"_s);
 
         data = sharedBuffer.read(4, 1000);
         EXPECT_EQ(data.size(), 18u);
 
-        EXPECT_EQ(StringView(data.data(), 18), " is a simple test."_s);
+        EXPECT_EQ(StringView(data.subspan(0, 18)), " is a simple test."_s);
     };
     auto sharedBuffer = SharedBuffer::create(simpleText, strlen(simpleText));
     check(sharedBuffer);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -691,7 +691,7 @@ TEST(WebKit, DISABLED_AlternativeService)
 static void respondToRangeRequests(const TestWebKitAPI::Connection& connection, const RetainPtr<NSData>& data)
 {
     connection.receiveHTTPRequest([=] (Vector<char>&& bytes) {
-        StringView request(reinterpret_cast<const LChar*>(bytes.data()), bytes.size());
+        StringView request(bytes.span());
         auto rangeBytes = "Range: bytes="_s;
         auto begin = request.find(StringView(rangeBytes), 0);
         ASSERT(begin != notFound);


### PR DESCRIPTION
#### 8763b25f5d245877b35f4729bbea078d9d96b0d5
<pre>
Drop StringView constructors taking in raw pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=271512">https://bugs.webkit.org/show_bug.cgi?id=271512</a>

Reviewed by Darin Adler and Sihui Liu.

Drop StringView constructors taking in raw pointers, in favor of the ones taking in a std::span.

* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::notAFunctionSourceAppender):
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::parseDuration):
* Source/JavaScriptCore/runtime/IntlCollator.cpp:
(JSC::IntlCollator::checkICULocaleInvariants):
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::canonicalizeTimeZoneName):
(JSC::IntlDateTimeFormat::initializeDateTimeFormat):
(JSC::IntlDateTimeFormat::formatToParts const):
(JSC::IntlDateTimeFormat::formatRangeToParts):
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::IntlDurationFormat::formatToParts const):
* Source/JavaScriptCore/runtime/IntlListFormat.cpp:
(JSC::IntlListFormat::formatToParts const):
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::IntlLocale::hourCycles):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::formatRangeToPartsInternal):
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::JSRopeString::unsafeView const):
(JSC::JSRopeString::viewWithUnderlyingString const):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lex):
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lexStringSlow):
(JSC::LiteralParser&lt;CharType&gt;::parsePrimitiveValue):
* Source/JavaScriptCore/wasm/WasmIndexOrName.cpp:
(JSC::Wasm::makeString):
* Source/WTF/wtf/HexNumber.cpp:
(WTF::printInternal):
* Source/WTF/wtf/HexNumber.h:
(WTF::HexNumberBuffer::span const):
* Source/WTF/wtf/URL.cpp:
(WTF::URL::setHost):
(WTF::URL::setHostAndPort):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::encodeNonUTF8Query):
(WTF::URLParser::copyURLPartsUntil):
(WTF::URLParser::parsedDataView):
(WTF::URLParser::domainToASCII):
(WTF::URLParser::parseHostAndPort):
* Source/WTF/wtf/cf/CFURLExtras.cpp:
(WTF::isSameOrigin):
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::operator StringView const):
(WTF::equal):
* Source/WTF/wtf/text/StringCommon.h:
* Source/WTF/wtf/text/StringParsingBuffer.h:
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::GraphemeClusters::Iterator::Impl::operator* const):
(WTF::convertASCIILowercaseAtom):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::initialize):
(WTF::StringView::StringView):
(WTF::StringView::substring const):
(WTF::StringView::trim const):
* Source/WTF/wtf/text/TextBreakIterator.cpp:
(WTF::setTextForIterator):
* Source/WTF/wtf/text/TextBreakIterator.h:
(WTF::TextBreakIterator::setText):
(WTF::TextBreakIteratorCache::take):
(WTF::CachedTextBreakIterator::CachedTextBreakIterator):
(WTF::CachedLineBreakIteratorFactory::get):
* Source/WTF/wtf/text/cf/TextBreakIteratorCF.h:
(WTF::TextBreakIteratorCF::setText):
* Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp:
(WTF::TextBreakIterator::mapModeToBackingIterator):
(WTF::TextBreakIterator::TextBreakIterator):
* Source/WTF/wtf/text/icu/TextBreakIteratorICU.h:
(WTF::TextBreakIteratorICU::TextBreakIteratorICU):
(WTF::TextBreakIteratorICU::setText):
* Source/WTF/wtf/text/icu/UTextProvider.h:
(WTF::initializeContextAwareUTextProvider):
* Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp:
(WTF::openLatin1UTextProvider):
(WTF::openLatin1ContextAwareUTextProvider):
* Source/WTF/wtf/text/icu/UTextProviderLatin1.h:
* Source/WTF/wtf/text/icu/UTextProviderUTF16.cpp:
(WTF::openUTF16ContextAwareUTextProvider):
* Source/WTF/wtf/text/icu/UTextProviderUTF16.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCCertificateGenerator.cpp:
(WebCore::LibWebRTCCertificateGenerator::RTCCertificateGeneratorCallbackWrapper::process):
* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::trimInputSample):
(WebCore::WebSocketHandshake::readStatusLine):
(WebCore::WebSocketHandshake::readHTTPHeaders):
* Source/WebCore/bindings/js/ScriptBufferSourceProvider.h:
* Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp:
(WebCore::CSSCustomPropertySyntax::parseComponent):
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::mergeIfAdjacent):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::WordAwareIterator::text const):
(WebCore::SearchBuffer::isWordEndMatch const):
(WebCore::SearchBuffer::isWordStartMatch const):
(WebCore::SearchBuffer::search):
* Source/WebCore/editing/TextIterator.h:
(WebCore::TextIteratorCopyableText::text const):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::wordBreakIteratorForMinOffsetBoundary):
(WebCore::wordBreakIteratorForMaxOffsetBoundary):
(WebCore::backwardSearchForBoundaryWithTextIterator):
(WebCore::forwardSearchForBoundaryWithTextIterator):
* Source/WebCore/html/FTPDirectoryDocument.cpp:
(WebCore::FTPDirectoryDocumentParser::append):
* Source/WebCore/html/MediaFragmentURIParser.cpp:
(WebCore::collectFraction):
* Source/WebCore/html/parser/CSSPreloadScanner.cpp:
(WebCore::CSSPreloadScanner::emitRule):
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::findBreakIndexSlow):
* Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp:
(WebCore::HTMLMetaCharsetParser::processMeta):
* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(WebCore::parseHTTPRefreshInternal):
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processAttributes):
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
(WebCore::appendDescriptorAndReset):
(WebCore::parseImageCandidatesFromSrcsetAttribute):
* Source/WebCore/html/track/VTTScanner.cpp:
(WebCore::VTTScanner::scanDigits):
* Source/WebCore/loader/LinkHeader.cpp:
(WebCore::parseParameterName):
* Source/WebCore/loader/ResourceCryptographicDigest.cpp:
(WebCore::parseCryptographicDigestImpl):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::parseEventStreamLine):
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::ContentSecurityPolicySourceList::parseScheme):
(WebCore::ContentSecurityPolicySourceList::parseHost):
(WebCore::ContentSecurityPolicySourceList::parsePath):
(WebCore::ContentSecurityPolicySourceList::parsePort):
* Source/WebCore/platform/Length.cpp:
(WebCore::parseLength):
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::offsetForPosition):
(WebCore::ComplexTextController::collectComplexTextRuns):
* Source/WebCore/platform/graphics/ComplexTextController.h:
(WebCore::ComplexTextController::ComplexTextRun::span const):
* Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h:
(WebCore::ComposedCharacterClusterTextIterator::ComposedCharacterClusterTextIterator):
* Source/WebCore/platform/graphics/StringTruncator.cpp:
(WebCore::stringWidth):
* Source/WebCore/platform/graphics/TextRun.h:
(WebCore::TextRun::span8):
(WebCore::TextRun::span16):
(WebCore::TextRun::setText):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::advance):
* Source/WebCore/platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp:
(WebCore::InbandTextTrackPrivateAVF::processNativeSamples):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::trimInputSample):
(WebCore::parseHTTPHeader):
* Source/WebCore/platform/network/RFC8941.cpp:
(RFC8941::parseKey):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::constructTextRun):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::capitalize):
(WebCore::RenderText::previousOffset const):
(WebCore::RenderText::previousOffsetForBackwardDeletion const):
(WebCore::RenderText::nextOffset const):
(WebCore::RenderText::stringView const):
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::TextPainter::paintTextAndEmphasisMarksIfNeeded):
* Source/WebCore/svg/SVGLengthList.cpp:
(WebCore::SVGLengthList::parse):
* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDMInstance::setServerCertificate):
* Source/WebKit/NetworkProcess/storage/CacheStorageManager.cpp:
(WebKit::readSizeFile):
* Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm:
(-[NSString _web_drawAtPoint:font:textColor:]):
(-[NSString _web_widthWithFont:]):
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/ComplexTextController.cpp:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp:
(TestWebKitAPI::TEST_F):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(respondToRangeRequests):

Canonical link: <a href="https://commits.webkit.org/276616@main">https://commits.webkit.org/276616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19a176265fd7fdd66eaed8e0aeed831d4d977782

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47684 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47830 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41176 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37047 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38938 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18145 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18743 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40034 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3215 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38382 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49526 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44634 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20149 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16678 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21456 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42868 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21811 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51795 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6283 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21139 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10551 "Passed tests") | 
<!--EWS-Status-Bubble-End-->