### PR TITLE
[GTK] Build broken with USE_GBM=OFF

### DIFF
--- a/Source/WebCore/PlatformGTK.cmake
+++ b/Source/WebCore/PlatformGTK.cmake
@@ -193,11 +193,7 @@ if (USE_ATSPI)
 endif ()
 
 if (USE_GBM)
-    list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
-        ${LIBDRM_INCLUDE_DIR}
-    )
-    list(APPEND WebCore_LIBRARIES
-        GBM::GBM
-        ${LIBDRM_LIBRARIES}
-    )
+    list(APPEND WebCore_LIBRARIES GBM::GBM)
+elseif (USE_LIBDRM)
+    list(APPEND WebCore_LIBRARIES LibDRM::LibDRM)
 endif ()

--- a/Source/WebCore/PlatformWPE.cmake
+++ b/Source/WebCore/PlatformWPE.cmake
@@ -128,13 +128,9 @@ if (USE_ATSPI)
 endif ()
 
 if (USE_GBM)
-    list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
-        ${LIBDRM_INCLUDE_DIR}
-    )
-    list(APPEND WebCore_LIBRARIES
-        GBM::GBM
-        ${LIBDRM_LIBRARIES}
-    )
+    list(APPEND WebCore_LIBRARIES GBM::GBM)
+elseif (USE_LIBDRM)
+    list(APPEND WebCore_LIBRARIES LibDRM::LibDRM)
 endif ()
 
 if (ENABLE_GAMEPAD)

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -338,15 +338,6 @@ list(APPEND GPUProcess_SOURCES
     GPUProcess/EntryPoint/unix/GPUProcessMain.cpp
 )
 
-if (USE_LIBDRM)
-    list(APPEND WebKit_SYSTEM_INCLUDE_DIRECTORIES
-        ${LIBDRM_INCLUDE_DIR}
-    )
-    list(APPEND WebKit_LIBRARIES
-        ${LIBDRM_LIBRARIES}
-    )
-endif ()
-
 if (GTK_UNIX_PRINT_FOUND)
     list(APPEND WebKit_LIBRARIES GTK::UnixPrint)
 endif ()

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -477,15 +477,6 @@ else ()
     )
 endif ()
 
-if (USE_LIBDRM)
-    list(APPEND WebKit_SYSTEM_INCLUDE_DIRECTORIES
-        ${LIBDRM_INCLUDE_DIR}
-    )
-    list(APPEND WebKit_LIBRARIES
-        ${LIBDRM_LIBRARIES}
-    )
-endif ()
-
 if (ENABLE_WPE_PLATFORM)
     list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
         "${WPEPlatform_DERIVED_SOURCES_DIR}"

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -90,13 +90,9 @@ set(WPEPlatform_LIBRARIES
 )
 
 if (USE_GBM)
-    list(APPEND WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES
-        ${LIBDRM_INCLUDE_DIR}
-    )
-    list(APPEND WPEPlatform_LIBRARIES
-        GBM::GBM
-        ${LIBDRM_LIBRARIES}
-    )
+    list(APPEND WPEPlatform_LIBRARIES GBM::GBM)
+elseif (USE_LIBDRM)
+    list(APPEND WPEPlatform_LIBRARIES LibDRM::LibDRM)
 endif ()
 
 if (NOT USE_SYSTEM_MALLOC)
@@ -152,7 +148,6 @@ if (ENABLE_WPE_PLATFORM_DRM)
         OPTIONS
             -I${WEBKIT_DIR}/WPEPlatform
             -I${WPEPlatform_DERIVED_SOURCES_DIR}
-            -I${LIBDRM_INCLUDE_DIR}
         SOURCES
             ${WPEPlatformDRM_SOURCES_FOR_INTROSPECTION}
         NO_IMPLICIT_SOURCES

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -545,8 +545,10 @@ bool AcceleratedSurfaceDMABuf::backgroundColorDidChange()
     if (!AcceleratedSurface::backgroundColorDidChange())
         return false;
 
+#if USE(GBM)
     if (m_swapChain.type() == SwapChain::Type::EGLImage)
         m_swapChain.setupBufferFormat(m_webPage.preferredBufferFormats(), m_isOpaque);
+#endif
 
     return true;
 }

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -162,7 +162,14 @@ private:
         explicit SwapChain(uint64_t);
         ~SwapChain() = default;
 
-        enum class Type { Invalid, EGLImage, SharedMemory, Texture };
+        enum class Type {
+            Invalid,
+#if USE(GBM)
+            EGLImage,
+#endif
+            SharedMemory,
+            Texture
+        };
 
         Type type() const { return m_type; }
         void resize(const WebCore::IntSize&);

--- a/Source/cmake/FindGBM.cmake
+++ b/Source/cmake/FindGBM.cmake
@@ -82,6 +82,8 @@ if (GBM_LIBRARY AND NOT TARGET GBM::GBM)
         INTERFACE_COMPILE_OPTIONS "${GBM_COMPILE_OPTIONS}"
         INTERFACE_INCLUDE_DIRECTORIES "${GBM_INCLUDE_DIR}"
     )
+    find_package(LibDRM REQUIRED)
+    target_link_libraries(GBM::GBM INTERFACE LibDRM::LibDRM)
 endif ()
 
 mark_as_advanced(

--- a/Source/cmake/FindLibDRM.cmake
+++ b/Source/cmake/FindLibDRM.cmake
@@ -1,30 +1,97 @@
-# - Find libdrm
-# This module looks for libdrm. This module defines the
-# following variables:
-#  LIBDRM_FOUND - system has libdrm
-#  LIBDRM_INCLUDE_DIRS - the libdrm include directories
-#  LIBDRM_LIBRARIES - link these to use libdrm
+# Copyright (C) 2024 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindLibDRM
+----------
+
+Find libdrm headers and libraries.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+``LibDRM::LibDRM``
+  The libdrm library, if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables in your project:
+
+``LibDRM_FOUND``
+  true if (the requested version of) libdrm is available.
+``LibDRM_VERSION``
+  the libdrm version.
+``LibDRM_LIBRARIES``
+  the libraries to link against to use libdrm.
+``LibDRM_INCLUDE_DIRS``
+  where to find the libdrm headers.
+``LibDRM_COMPILE_OPTIONS``
+  this should be passed to target_compile_options(), if the
+  target is not used for linking
+
+#]=======================================================================]
 
 find_package(PkgConfig QUIET)
 pkg_check_modules(PC_LIBDRM QUIET libdrm)
+set(LibDRM_COMPILE_OPTIONS ${PC_LIBDRM_COMPILE_OPTIONS})
+set(LibDRM_VERSION ${PC_LIBDRM_VERSION})
 
-find_library(LIBDRM_LIBRARIES
-    NAMES drm
-    HINTS ${PC_LIBDRM_LIBDIR}
-          ${PC_LIBDRM_LIBRARY_DIRS}
-)
-
-find_path(LIBDRM_INCLUDE_DIR
+find_path(LibDRM_INCLUDE_DIR
     NAMES drm.h
     HINTS ${PC_LIBDRM_INCLUDEDIR}
           ${PC_LIBDRM_INCLUDE_DIRS}
     PATH_SUFFIXES libdrm
 )
 
+find_library(LibDRM_LIBRARY
+    NAMES drm
+    HINTS ${PC_LIBDRM_LIBDIR}
+          ${PC_LIBDRM_LIBRARY_DIRS}
+)
+
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibDRM DEFAULT_MSG LIBDRM_LIBRARIES LIBDRM_INCLUDE_DIR)
+find_package_handle_standard_args(LibDRM
+    FOUND_VAR LibDRM_FOUND
+    REQUIRED_VARS LibDRM_INCLUDE_DIR LibDRM_LIBRARY
+    VERSION_VAR LibDRM_VERSION
+)
+
+if (LibDRM_LIBRARY AND NOT TARGET LibDRM::LibDRM)
+    add_library(LibDRM::LibDRM UNKNOWN IMPORTED GLOBAL)
+    set_target_properties(LibDRM::LibDRM PROPERTIES
+        IMPORTED_LOCATION "${LibDRM_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${LibDRM_COMPILE_OPTIONS}"
+        INTERFACE_INCLUDE_DIRECTORIES "${LibDRM_INCLUDE_DIR}"
+    )
+endif ()
 
 mark_as_advanced(
-  LIBDRM_INCLUDE_DIR
-  LIBDRM_LIBRARIES
+    LibDRM_INCLUDE_DIR
+    LibDRM_LIBRARY
 )
+
+if (LibDRM_FOUND)
+    set(LibDRM_LIBRARIES ${LibDRM_LIBRARY})
+    set(LibDRM_INCLUDE_DIRS ${LibDRM_INCLUDE_DIR})
+endif ()

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -321,7 +321,7 @@ endif ()
 
 if (USE_LIBDRM)
     find_package(LibDRM)
-    if (NOT LIBDRM_FOUND)
+    if (NOT LibDRM_FOUND)
         message(FATAL_ERROR "libdrm is required for USE_LIBDRM")
     endif ()
 endif ()

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -376,7 +376,7 @@ SET_AND_EXPOSE_TO_BUILD(HAVE_OS_DARK_MODE_SUPPORT 1)
 
 if (USE_LIBDRM)
     find_package(LibDRM)
-    if (NOT LIBDRM_FOUND)
+    if (NOT LibDRM_FOUND)
         message(FATAL_ERROR "libdrm is required for USE_LIBDRM")
     endif ()
 endif ()


### PR DESCRIPTION
#### 6af38ff932848db2eb8f1ad168c9ce9cfdc5cb96
<pre>
[GTK] Build broken with USE_GBM=OFF
<a href="https://bugs.webkit.org/show_bug.cgi?id=271525">https://bugs.webkit.org/show_bug.cgi?id=271525</a>

Reviewed by Michael Catanzaro.

Add missing USE(GBM) guards, arrange to link against libdrm with
USE_GBM=OFF and USE_LIBDRM=ON, and while at it convert the the libdrm
CMake find-module to use imported targets.

* Source/WebCore/PlatformGTK.cmake: Link libgbm or libdrm as appropriate.
* Source/WebCore/PlatformWPE.cmake: Ditto.
* Source/WebKit/PlatformGTK.cmake: Remove explicit libdrm linking, now
using an imported target it gets pulled transitively due to WebKit
linking against the WebCore target.
* Source/WebKit/PlatformWPE.cmake: Ditto.
* Source/WebKit/WPEPlatform/CMakeLists.txt: Link libgbm of libdrm as
appropriate, remove specifying the libdrm include directory for
GObject-Introspection as it gets pulled from transitively from the
imported target.
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::backgroundColorDidChange): Add
missing USE(GBM) guard on usage of SwapChain::Type::EGLImage.
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:
Only define SwapChain::Type::EGLImage with USE(GBM).
* Source/cmake/FindGBM.cmake: Make the GBM::GBM target INTERFACE-depend
on the LibDRM::LibDRM target, because headers from the former include
headers from the latter.
* Source/cmake/FindLibDRM.cmake: Convert to use imported targets, this
is needed to make GBM::GBM depend on it, and simplifies CMake build
files all around.
* Source/cmake/OptionsGTK.cmake: Use LibDRM_FOUND instead of LIBDRM_FOUND.
* Source/cmake/OptionsWPE.cmake: Ditto.

Canonical link: <a href="https://commits.webkit.org/276612@main">https://commits.webkit.org/276612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a6e96689180859d7b4009db35b83d6ddd340694

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47773 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41119 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21623 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37007 "Failure limit exceed. At least found 2 new test failures: http/tests/websocket/tests/hybi/multiple-connections-limit.html, imported/w3c/web-platform-tests/fetch/private-network-access/worker-fetch.https.window.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45689 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21278 "Found 1 new test failure: fast/forms/ios/autocapitalize-words.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18107 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/39977 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3158 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38317 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49458 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44573 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44024 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21399 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42811 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21751 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51738 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6282 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21078 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10525 "Passed tests") | 
<!--EWS-Status-Bubble-End-->