### PR TITLE
Refactor mach exception sandboxing rules for mac

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1813,28 +1813,19 @@
     io_registry_entry_get_name_in_plane
     io_registry_entry_get_properties_bin_buf
     io_registry_get_root_entry
-    io_service_close))
-
-(define (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry) (kernel-mig-routine
+    io_service_close
     thread_info
-#if !ENABLE(BLOCK_SET_EXCEPTION_PORTS)
-    thread_set_exception_ports
-#endif
 ))
-
-(define (allow-thread-adopt-exception-handler)
-    (when (defined? 'thread_adopt_exception_handler)
-        (allow mach-message-send (kernel-mig-routine thread_adopt_exception_handler))
-    )
-)
 
 (define (allow-mach-exceptions)
 #if HAVE(HARDENED_MACH_EXCEPTIONS)
-(if (equal? (param "CPU") "arm64")
-    (when (defined? 'task_register_hardened_exception_handler)
-        (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler))
+    (when (equal? (param "CPU") "arm64")
+        (with-filter (require-not (webcontent-process-launched))
+            (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler))
+        )
+        (allow mach-message-send (kernel-mig-routine thread_adopt_exception_handler))
     )
-    ; else
+    (when (not (equal? (param "CPU") "arm64"))
         (allow mach-message-send (kernel-mig-routine thread_set_exception_ports))
     )
 #else
@@ -1848,23 +1839,15 @@
             (deny mach-message-send)
 #if ENABLE(LOCKDOWN_MODE_TELEMETRY)
             (with-filter (require-not (lockdown-mode))
-                (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode))
-                (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry))
-                (allow-thread-adopt-exception-handler))
+                (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode)))
             (with-filter (lockdown-mode)
-                (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode))
-                (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry)))
+                (deny mach-message-send (with telemetry) (kernel-mig-routines-blocked-in-lockdown-mode)))
 #else
             (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode))
-            (allow mach-message-send (kernel-mig-routines-blocked-in-lockdown-mode-avoid-telemetry))
-            (allow-thread-adopt-exception-handler)
 #endif
-#if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
-            (with-filter (require-not (webcontent-process-launched))
-                (allow-mach-exceptions))
-#else
-            (allow-mach-exceptions)
-#endif
+            (with-filter (require-not (lockdown-mode))
+                (allow-mach-exceptions)
+            )
 
             (allow mach-message-send (kernel-mig-routines-in-use))
 #if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED <= 140000


### PR DESCRIPTION
#### 851d99c108a97eaddb3789b0bfb99f32870b5b13
<pre>
Refactor mach exception sandboxing rules for mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=271530">https://bugs.webkit.org/show_bug.cgi?id=271530</a>
<a href="https://rdar.apple.com/125301161">rdar://125301161</a>

Reviewed by Per Arne Vollan.

This fixes a bug where we weren&apos;t allowing thread_set_exception_ports after webcontent-process-launched (after the first content was loaded).
Also, I think it makes the logic flow a bit clearer.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/276605@main">https://commits.webkit.org/276605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9da58b55f0664eb25c049886c27e4e1a62993cdd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47778 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41124 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21627 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38872 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18111 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18689 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3163 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40289 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49463 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20090 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16621 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44027 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21404 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42814 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10032 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21756 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->