### PR TITLE
Use std::span more with SharedBuffer

### DIFF
--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -168,9 +168,9 @@ WTF_EXPORT_PRIVATE long long seekFile(PlatformFileHandle, long long offset, File
 WTF_EXPORT_PRIVATE bool truncateFile(PlatformFileHandle, long long offset);
 WTF_EXPORT_PRIVATE bool flushFile(PlatformFileHandle);
 // Returns number of bytes actually read if successful, -1 otherwise.
-WTF_EXPORT_PRIVATE int writeToFile(PlatformFileHandle, const void* data, int length);
+WTF_EXPORT_PRIVATE int64_t writeToFile(PlatformFileHandle, const void* data, size_t length);
 // Returns number of bytes actually written if successful, -1 otherwise.
-WTF_EXPORT_PRIVATE int readFromFile(PlatformFileHandle, void* data, int length);
+WTF_EXPORT_PRIVATE int64_t readFromFile(PlatformFileHandle, void* data, size_t length);
 
 WTF_EXPORT_PRIVATE PlatformFileHandle openAndLockFile(const String&, FileOpenMode, OptionSet<FileLockMode> = FileLockMode::Exclusive);
 WTF_EXPORT_PRIVATE void unlockAndCloseFile(PlatformFileHandle);

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -800,6 +800,7 @@ public:
     size_t capacity() const { return Base::capacity(); }
     bool isEmpty() const { return !size(); }
     std::span<const T> span() const { return { data(), size() }; }
+    std::span<T> mutableSpan() { return { data(), size() }; }
 
     Vector<T> subvector(size_t offset, size_t length = std::dynamic_extent) const
     {

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -134,20 +134,20 @@ bool flushFile(PlatformFileHandle handle)
     return !fsync(handle);
 }
 
-int writeToFile(PlatformFileHandle handle, const void* data, int length)
+int64_t writeToFile(PlatformFileHandle handle, const void* data, size_t length)
 {
     do {
-        int bytesWritten = write(handle, data, static_cast<size_t>(length));
+        auto bytesWritten = write(handle, data, length);
         if (bytesWritten >= 0)
             return bytesWritten;
     } while (errno == EINTR);
     return -1;
 }
 
-int readFromFile(PlatformFileHandle handle, void* data, int length)
+int64_t readFromFile(PlatformFileHandle handle, void* data, size_t length)
 {
     do {
-        int bytesRead = read(handle, data, static_cast<size_t>(length));
+        auto bytesRead = read(handle, data, length);
         if (bytesRead >= 0)
             return bytesRead;
     } while (errno == EINTR);

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -63,7 +63,7 @@ public:
     ALWAYS_INLINE static Ref<AtomStringImpl> add(ASCIILiteral literal) { return addLiteral(literal.characters(), literal.length()); }
 
     // Not using the add() naming to encourage developers to call add(ASCIILiteral) when they have a string literal.
-    ALWAYS_INLINE static RefPtr<AtomStringImpl> addCString(const char* s) { return s ? add(std::span { s, strlen(s) }) : nullptr; }
+    ALWAYS_INLINE static RefPtr<AtomStringImpl> addCString(const char* s) { return s ? add(WTF::span8(s)) : nullptr; }
 
     // Returns null if the input data contains an invalid UTF-8 sequence.
     static RefPtr<AtomStringImpl> addUTF8(const char* start, const char* end);

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -1153,9 +1153,20 @@ inline std::span<const UChar> span(const UChar& character)
     return { &character, 1 };
 }
 
+inline std::span<const LChar> span8(const char* string)
+{
+    return { reinterpret_cast<const LChar*>(string), string ? strlen(string) : 0 };
+}
+
+inline std::span<const char> span(const char* string)
+{
+    return { string, string ? strlen(string) : 0 };
+}
+
 }
 
 using WTF::equalIgnoringASCIICase;
 using WTF::equalLettersIgnoringASCIICase;
 using WTF::isLatin1;
 using WTF::span;
+using WTF::span8;

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -253,7 +253,7 @@ public:
     template<size_t inlineCapacity> static Ref<StringImpl> create8BitIfPossible(const Vector<UChar, inlineCapacity>&);
 
     // Not using create() naming to encourage developers to call create(ASCIILiteral) when they have a string literal.
-    ALWAYS_INLINE static Ref<StringImpl> createFromCString(const char* characters) { return create(std::span { characters, strlen(characters) }); }
+    ALWAYS_INLINE static Ref<StringImpl> createFromCString(const char* characters) { return create(WTF::span8(characters)); }
 
     static Ref<StringImpl> createSubstringSharingImpl(StringImpl&, unsigned offset, unsigned length);
 

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -408,7 +408,7 @@ inline StringView::StringView(std::span<const UChar> characters)
 
 inline StringView::StringView(const char* characters)
 {
-    initialize(std::span { reinterpret_cast<const LChar*>(characters), characters ? strlen(characters) : 0 });
+    initialize(WTF::span8(characters));
 }
 
 inline StringView::StringView(std::span<const char> characters)

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -275,7 +275,7 @@ bool flushFile(PlatformFileHandle)
     return false;
 }
 
-int writeToFile(PlatformFileHandle handle, const void* data, int length)
+int64_t writeToFile(PlatformFileHandle handle, const void* data, size_t length)
 {
     if (!isHandleValid(handle))
         return -1;
@@ -285,10 +285,10 @@ int writeToFile(PlatformFileHandle handle, const void* data, int length)
 
     if (!success)
         return -1;
-    return static_cast<int>(bytesWritten);
+    return static_cast<int64_t>(bytesWritten);
 }
 
-int readFromFile(PlatformFileHandle handle, void* data, int length)
+int64_t readFromFile(PlatformFileHandle handle, void* data, size_t length)
 {
     if (!isHandleValid(handle))
         return -1;
@@ -298,7 +298,7 @@ int readFromFile(PlatformFileHandle handle, void* data, int length)
 
     if (!success)
         return -1;
-    return static_cast<int>(bytesRead);
+    return static_cast<int64_t>(bytesRead);
 }
 
 String localUserSpecificStorageDirectory()

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -260,7 +260,7 @@ void ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::didFinishLoading(
     if (!stringResult.isNull())
         m_data = { stringResult };
     else if (auto arrayBuffer = m_blobLoader->arrayBufferResult())
-        m_data = { SharedBuffer::create(static_cast<const char*>(arrayBuffer->data()), arrayBuffer->byteLength()) };
+        m_data = { SharedBuffer::create(arrayBuffer->span()) };
     m_blobLoader = nullptr;
     invokeCompletionHandler();
 }

--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -416,7 +416,7 @@ void DOMCache::put(RequestInfo&& info, Ref<FetchResponse>&& response, DOMPromise
             }
 
             if (auto* chunk = result.returnValue())
-                data.append(chunk->data(), chunk->size());
+                data.append(*chunk);
             else
                 this->putWithResponseData(WTFMove(promise), WTFMove(request), WTFMove(response), RefPtr<SharedBuffer> { data.takeAsContiguous() });
         });

--- a/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/InitDataRegistry.cpp
@@ -116,8 +116,7 @@ static RefPtr<SharedBuffer> sanitizeKeyids(const SharedBuffer& buffer)
         kidsArray->pushString(base64URLEncodeToString(buffer->data(), buffer->size()));
     object->setArray("kids"_s, WTFMove(kidsArray));
 
-    CString jsonData = object->toJSONString().utf8();
-    return SharedBuffer::create(jsonData.data(), jsonData.length());
+    return SharedBuffer::create(object->toJSONString().utf8().span());
 }
 
 std::optional<Vector<std::unique_ptr<ISOProtectionSystemSpecificHeaderBox>>> InitDataRegistry::extractPsshBoxesFromCenc(const SharedBuffer& buffer)
@@ -179,7 +178,7 @@ std::optional<Vector<Ref<SharedBuffer>>> InitDataRegistry::extractKeyIDsCenc(con
             if (CDMPrivateFairPlayStreaming::validFairPlayStreamingSchemes().contains(scheme)) {
                 for (const auto& request : fpsPssh->initDataBox().requests()) {
                     auto& keyID = request.requestInfo().keyID();
-                    keyIDs.append(SharedBuffer::create(keyID.data(), keyID.size()));
+                    keyIDs.append(SharedBuffer::create(keyID.span()));
                 }
             }
         }

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -175,7 +175,7 @@ void MediaKeySession::generateRequest(const AtomString& initDataType, const Buff
     // 8. Let session type be this object's session type.
     // 9. Let promise be a new promise.
     // 10. Run the following steps in parallel:
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, weakThis = WeakPtr { *this }, initData = SharedBuffer::create(initData.data(), initData.length()), initDataType, promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, weakThis = WeakPtr { *this }, initData = SharedBuffer::create(initData.span()), initDataType, promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
         // 10.1. If the init data is not valid for initDataType, reject promise with a newly created TypeError.
         // 10.2. Let sanitized init data be a validated and sanitized version of init data.
         RefPtr<SharedBuffer> sanitizedInitData = m_implementation->sanitizeInitData(initDataType, initData);
@@ -422,7 +422,7 @@ void MediaKeySession::update(const BufferSource& response, Ref<DeferredPromise>&
     // 4. Let response copy be a copy of the contents of the response parameter.
     // 5. Let promise be a new promise.
     // 6. Run the following steps in parallel:
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, weakThis = WeakPtr { *this }, response = SharedBuffer::create(response.data(), response.length()), promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, weakThis = WeakPtr { *this }, response = SharedBuffer::create(response.span()), promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
         // 6.1. Let sanitized response be a validated and/or sanitized version of response copy.
         RefPtr<SharedBuffer> sanitizedResponse = m_implementation->sanitizeResponse(response);
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeys.cpp
@@ -128,7 +128,7 @@ void MediaKeys::setServerCertificate(const BufferSource& serverCertificate, Ref<
     }
 
     // 3. Let certificate be a copy of the contents of the serverCertificate parameter.
-    auto certificate = SharedBuffer::create(serverCertificate.data(), serverCertificate.length());
+    auto certificate = SharedBuffer::create(serverCertificate.span());
 
     // 4. Let promise be a new promise.
     // 5. Run the following steps in parallel:

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -351,7 +351,7 @@ void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& co
                 return;
             }
 
-            data.append(chunk->data(), chunk->size());
+            data.append(*chunk);
         });
         m_sink->pipeFrom(*stream);
         return;

--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -482,7 +482,7 @@ void FetchResponse::setBodyData(ResponseData&& data, uint64_t bodySizeWithPaddin
 
 void FetchResponse::consumeChunk(Ref<JSC::Uint8Array>&& chunk)
 {
-    body().consumer().append(SharedBuffer::create(chunk->data(), chunk->byteLength()));
+    body().consumer().append(SharedBuffer::create(chunk->span()));
 }
 
 void FetchResponse::consumeBodyAsStream()

--- a/Source/WebCore/Modules/highlight/AppHighlightRangeData.cpp
+++ b/Source/WebCore/Modules/highlight/AppHighlightRangeData.cpp
@@ -56,7 +56,7 @@ Ref<FragmentedSharedBuffer> AppHighlightRangeData::toSharedBuffer() const
 {
     WTF::Persistence::Encoder encoder;
     encoder << *this;
-    return SharedBuffer::create(encoder.buffer(), encoder.bufferSize());
+    return SharedBuffer::create(encoder.span());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -307,7 +307,7 @@ ExceptionOr<void> SourceBuffer::setAppendWindowEnd(double newValue)
 
 ExceptionOr<void> SourceBuffer::appendBuffer(const BufferSource& data)
 {
-    return appendBufferInternal(static_cast<const unsigned char*>(data.data()), data.length());
+    return appendBufferInternal(data.span());
 }
 
 void SourceBuffer::resetParserState()
@@ -582,7 +582,7 @@ void SourceBuffer::scheduleEvent(const AtomString& eventName)
     queueTaskToDispatchEvent(*this, TaskSource::MediaElement, Event::create(eventName, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
-ExceptionOr<void> SourceBuffer::appendBufferInternal(const unsigned char* data, unsigned size)
+ExceptionOr<void> SourceBuffer::appendBufferInternal(std::span<const uint8_t> data)
 {
     // Section 3.2 appendBuffer()
     // https://dvcs.w3.org/hg/html-media/raw-file/default/media-source/media-source.html#widl-SourceBuffer-appendBuffer-void-ArrayBufferView-data
@@ -597,7 +597,7 @@ ExceptionOr<void> SourceBuffer::appendBufferInternal(const unsigned char* data, 
     if (isRemoved() || m_updating)
         return Exception { ExceptionCode::InvalidStateError };
 
-    ALWAYS_LOG(LOGIDENTIFIER, "size = ", size, "maximumBufferSize = ", maximumBufferSize(), "buffered = ", m_buffered->ranges(), " streaming = ", m_source->streaming());
+    ALWAYS_LOG(LOGIDENTIFIER, "size = ", data.size(), "maximumBufferSize = ", maximumBufferSize(), "buffered = ", m_buffered->ranges(), " streaming = ", m_source->streaming());
 
     // 3. If the readyState attribute of the parent media source is in the "ended" state then run the following steps:
     // 3.1. Set the readyState attribute of the parent media source to "open"
@@ -605,7 +605,7 @@ ExceptionOr<void> SourceBuffer::appendBufferInternal(const unsigned char* data, 
     m_source->openIfInEndedState();
 
     // 4. Run the coded frame eviction algorithm.
-    bool bufferFull = m_private->evictCodedFrames(size, m_source->currentTime());
+    bool bufferFull = m_private->evictCodedFrames(data.size(), m_source->currentTime());
 
     // 5. If the buffer full flag equals true, then throw a QuotaExceededError exception and abort these step.
     if (bufferFull) {
@@ -616,7 +616,7 @@ ExceptionOr<void> SourceBuffer::appendBufferInternal(const unsigned char* data, 
     // NOTE: Return to 3.2 appendBuffer()
     // 3. Add data to the end of the input buffer.
     ASSERT(!m_pendingAppendData);
-    m_pendingAppendData = SharedBuffer::create(data, size);
+    m_pendingAppendData = SharedBuffer::create(data);
 
     // 4. Set the updating attribute to true.
     m_updating = true;

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -193,7 +193,7 @@ private:
     bool isRemoved() const;
     void scheduleEvent(const AtomString& eventName);
 
-    ExceptionOr<void> appendBufferInternal(const unsigned char*, unsigned);
+    ExceptionOr<void> appendBufferInternal(std::span<const uint8_t>);
     void sourceBufferPrivateAppendComplete(MediaPromise::Result&&);
     void resetParserState();
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
@@ -185,7 +185,7 @@ void LibWebRTCDataChannelHandler::OnMessage(const webrtc::DataBuffer& buffer)
     if (!m_hasClient) {
         auto* data = buffer.data.data<uint8_t>();
         if (buffer.binary)
-            m_bufferedMessages.append(SharedBuffer::create(data, buffer.size()));
+            m_bufferedMessages.append(SharedBuffer::create(std::span { data, buffer.size() }));
         else
             m_bufferedMessages.append(String::fromUTF8(data, buffer.size()));
         return;

--- a/Source/WebCore/css/CSSFontFaceSource.cpp
+++ b/Source/WebCore/css/CSSFontFaceSource.cpp
@@ -176,7 +176,7 @@ void CSSFontFaceSource::load(Document* document)
         } else if (m_immediateSource) {
             ASSERT(!m_immediateFontCustomPlatformData);
             bool wrapping;
-            auto buffer = SharedBuffer::create(static_cast<const char*>(m_immediateSource->baseAddress()), m_immediateSource->byteLength());
+            auto buffer = SharedBuffer::create(m_immediateSource->span());
             m_immediateFontCustomPlatformData = CachedFont::createCustomFontData(buffer.get(), String(), wrapping);
             success = static_cast<bool>(m_immediateFontCustomPlatformData);
         } else {

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -822,7 +822,7 @@ void ImageBitmap::createFromBuffer(ScriptExecutionContext& scriptExecutionContex
         return;
     }
 
-    auto sharedBuffer = SharedBuffer::create(static_cast<const char*>(arrayBuffer->data()), arrayBuffer->byteLength());
+    auto sharedBuffer = SharedBuffer::create(arrayBuffer->span());
     auto observer = ImageBitmapImageObserver::create(mimeType, expectedContentLength, sourceURL);
     auto image = BitmapImage::create(observer.ptr());
     auto result = image->setData(sharedBuffer.copyRef(), true);

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -1296,10 +1296,8 @@ Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptWithRes
             return makeUnexpected("Unable to decode given content"_s);
 
         overrideData = SharedBuffer::create(WTFMove(*buffer));
-    } else {
-        auto utf8Content = content.utf8();
-        overrideData = SharedBuffer::create(utf8Content.data(), utf8Content.length());
-    }
+    } else
+        overrideData = SharedBuffer::create(content.utf8().span());
 
     pendingInterceptResponse->respond(overrideResponse, overrideData);
 
@@ -1324,10 +1322,8 @@ Inspector::Protocol::ErrorStringOr<void> InspectorNetworkAgent::interceptRequest
             return makeUnexpected("Unable to decode given content"_s);
 
         data = SharedBuffer::create(WTFMove(*buffer));
-    } else {
-        auto utf8Content = content.utf8();
-        data = SharedBuffer::create(utf8Content.data(), utf8Content.length());
-    }
+    } else
+        data = SharedBuffer::create(content.utf8().span());
 
     // Mimic data URL load behavior - report didReceiveResponse & didFinishLoading.
     ResourceResponse response(pendingRequest->m_loader->url(), mimeType, data->size(), String());

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1639,7 +1639,7 @@ SubstituteData FrameLoader::defaultSubstituteDataForURL(const URL& url)
     CString encodedSrcdoc = srcdoc.string().utf8();
 
     ResourceResponse response(URL(), textHTMLContentTypeAtom(), encodedSrcdoc.length(), "UTF-8"_s);
-    return SubstituteData(SharedBuffer::create(encodedSrcdoc.data(), encodedSrcdoc.length()), URL(), response, SubstituteData::SessionHistoryVisibility::Hidden);
+    return SubstituteData(SharedBuffer::create(encodedSrcdoc.span()), URL(), response, SubstituteData::SessionHistoryVisibility::Hidden);
 }
 
 void FrameLoader::load(FrameLoadRequest&& request)

--- a/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
@@ -168,7 +168,7 @@ Ref<FragmentedSharedBuffer> MHTMLArchive::generateMHTMLData(Page* page)
     ASSERT(stringBuilder.toString().containsOnlyASCII());
     CString asciiString = stringBuilder.toString().utf8();
     SharedBufferBuilder mhtmlData;
-    mhtmlData.append(asciiString.data(), asciiString.length());
+    mhtmlData.append(asciiString.span());
 
     for (auto& resource : resources) {
         stringBuilder.clear();
@@ -183,15 +183,15 @@ Ref<FragmentedSharedBuffer> MHTMLArchive::generateMHTMLData(Page* page)
         stringBuilder.append("\r\nContent-Transfer-Encoding: ", contentEncoding, "\r\nContent-Location: ", resource.url.string(), "\r\n\r\n");
 
         asciiString = stringBuilder.toString().utf8();
-        mhtmlData.append(asciiString.data(), asciiString.length());
+        mhtmlData.append(asciiString.span());
 
         // FIXME: ideally we would encode the content as a stream without having to fetch it all.
         auto* data = resource.data->data();
         size_t dataLength = resource.data->size();
         if (!strcmp(contentEncoding, quotedPrintable)) {
             auto encodedData = quotedPrintableEncode(data, dataLength);
-            mhtmlData.append(encodedData.data(), encodedData.size());
-            mhtmlData.append("\r\n", 2);
+            mhtmlData.append(encodedData.span());
+            mhtmlData.append("\r\n"_span);
         } else {
             ASSERT(!strcmp(contentEncoding, base64));
             // We are not specifying insertLFs = true below as it would cut the lines with LFs and MHTML requires CRLFs.
@@ -201,15 +201,15 @@ Ref<FragmentedSharedBuffer> MHTMLArchive::generateMHTMLData(Page* page)
             size_t encodedDataLength = encodedData.size();
             do {
                 size_t lineLength = std::min(encodedDataLength - index, maximumLineLength);
-                mhtmlData.append(encodedData.data() + index, lineLength);
-                mhtmlData.append("\r\n", 2);
+                mhtmlData.append(encodedData.subspan(index, lineLength));
+                mhtmlData.append("\r\n"_span);
                 index += maximumLineLength;
             } while (index < encodedDataLength);
         }
     }
 
     asciiString = makeString("--", boundary, "--\r\n").utf8();
-    mhtmlData.append(asciiString.data(), asciiString.length());
+    mhtmlData.append(asciiString.span());
 
     return mhtmlData.take();
 }

--- a/Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp
@@ -181,10 +181,10 @@ RefPtr<ArchiveResource> MHTMLParser::parseNextPart(const MIMEHeader& mimeHeader,
                 break;
             }
             // Note that we use line.utf8() and not line.ascii() as ascii turns special characters (such as tab, line-feed...) into '?'.
-            content.append(line.utf8().data(), line.length());
+            content.append(line.utf8().span());
             if (mimeHeader.contentTransferEncoding() == MIMEHeader::QuotedPrintable) {
                 // The line reader removes the \r\n, but we need them for the content in this case as the QuotedPrintable decoder expects CR-LF terminated lines.
-                content.append("\r\n", 2);
+                content.append("\r\n"_span);
             }
         }
     }

--- a/Source/WebCore/page/ShareDataReader.cpp
+++ b/Source/WebCore/page/ShareDataReader.cpp
@@ -80,7 +80,7 @@ void ShareDataReader::didFinishLoading(int loadIndex, const String& fileName)
 
     RawFile file;
     file.fileName = fileName;
-    file.fileData = SharedBuffer::create(static_cast<const unsigned char*>(arrayBuffer->data()), arrayBuffer->byteLength());
+    file.fileData = SharedBuffer::create(arrayBuffer->span());
     m_shareData.files.append(WTFMove(file));
     m_filesReadSoFar++;
 

--- a/Source/WebCore/platform/Decimal.cpp
+++ b/Source/WebCore/platform/Decimal.cpp
@@ -542,7 +542,7 @@ Decimal Decimal::fromDouble(double doubleValue)
     if (std::isfinite(doubleValue)) {
         NumberToStringBuffer buffer;
         auto* result = numberToString(doubleValue, buffer);
-        return fromString(std::span { result, strlen(result) });
+        return fromString(span8(result));
     }
 
     if (std::isinf(doubleValue))

--- a/Source/WebCore/platform/PasteboardCustomData.cpp
+++ b/Source/WebCore/platform/PasteboardCustomData.cpp
@@ -96,7 +96,7 @@ Ref<SharedBuffer> PasteboardCustomData::createSharedBuffer() const
     encoder << m_origin;
     encoder << sameOriginCustomStringData();
     encoder << orderedTypes();
-    return SharedBuffer::create(encoder.buffer(), encoder.bufferSize());
+    return SharedBuffer::create(encoder.span());
 }
 
 PasteboardCustomData PasteboardCustomData::fromPersistenceDecoder(WTF::Persistence::Decoder&& decoder)

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -50,9 +50,9 @@ Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create()
     return adoptRef(*new FragmentedSharedBuffer);
 }
 
-Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(const uint8_t* data, size_t size)
+Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(std::span<const uint8_t> data)
 {
-    return adoptRef(*new FragmentedSharedBuffer(data, size));
+    return adoptRef(*new FragmentedSharedBuffer(data));
 }
 
 Ref<FragmentedSharedBuffer> FragmentedSharedBuffer::create(FileSystem::MappedFileData&& mappedFileData)
@@ -103,7 +103,7 @@ std::optional<Ref<FragmentedSharedBuffer>> FragmentedSharedBuffer::fromIPCData(I
         RefPtr sharedMemoryBuffer = SharedMemory::map(WTFMove(handle.value()), SharedMemory::Protection::ReadOnly);
         if (!sharedMemoryBuffer)
             return std::nullopt;
-        return SharedBuffer::create(static_cast<unsigned char*>(sharedMemoryBuffer->data()), sharedMemoryBuffer->size());
+        return SharedBuffer::create(sharedMemoryBuffer->span());
     });
 }
 

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -163,8 +163,7 @@ public:
     using IPCData = std::variant<std::optional<WebCore::SharedMemoryHandle>, Vector<std::span<const uint8_t>>>;
 
     WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create();
-    WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create(const uint8_t*, size_t);
-    static Ref<FragmentedSharedBuffer> create(const char* data, size_t size) { return create(reinterpret_cast<const uint8_t*>(data), size); }
+    WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create(std::span<const uint8_t>);
     WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create(FileSystem::MappedFileData&&);
     WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create(Ref<SharedBuffer>&&);
     WEBCORE_EXPORT static Ref<FragmentedSharedBuffer> create(Vector<uint8_t>&&);
@@ -243,8 +242,7 @@ protected:
     bool m_contiguous { false };
 
     WEBCORE_EXPORT FragmentedSharedBuffer();
-    explicit FragmentedSharedBuffer(const uint8_t* data, size_t size) { append(data, size); }
-    explicit FragmentedSharedBuffer(const char* data, size_t size) { append(data, size); }
+    explicit FragmentedSharedBuffer(std::span<const uint8_t> data) { append(data); }
     explicit FragmentedSharedBuffer(Vector<uint8_t>&& data) { append(WTFMove(data)); }
     WEBCORE_EXPORT explicit FragmentedSharedBuffer(FileSystem::MappedFileData&&);
     WEBCORE_EXPORT explicit FragmentedSharedBuffer(DataSegment::Provider&&);
@@ -267,8 +265,6 @@ private:
     friend class SharedBufferBuilder;
     WEBCORE_EXPORT void append(const FragmentedSharedBuffer&);
     WEBCORE_EXPORT void append(std::span<const uint8_t>);
-    void append(const uint8_t* data, size_t length) { append(std::span { data, length }); } // FIXME: Call sites should pass in a span.
-    void append(const char* data, size_t length) { append(reinterpret_cast<const uint8_t*>(data), length); }
     WEBCORE_EXPORT void append(Vector<uint8_t>&&);
 #if USE(FOUNDATION)
     WEBCORE_EXPORT void append(NSData *);

--- a/Source/WebCore/platform/SharedBufferChunkReader.cpp
+++ b/Source/WebCore/platform/SharedBufferChunkReader.cpp
@@ -60,7 +60,7 @@ void SharedBufferChunkReader::setSeparator(const Vector<char>& separator)
 void SharedBufferChunkReader::setSeparator(const char* separator)
 {
     m_separator.clear();
-    m_separator.append(std::span { separator, strlen(separator) });
+    m_separator.append(span(separator));
 }
 
 bool SharedBufferChunkReader::nextChunk(Vector<uint8_t>& chunk, bool includeSeparator)

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -113,7 +113,7 @@ public:
         return m_data;
     }
 
-    std::span<const uint8_t> bytes() const { return { static_cast<const uint8_t*>(m_data), m_size }; }
+    std::span<const uint8_t> span() const { return { static_cast<const uint8_t*>(m_data), m_size }; }
 
 #if OS(WINDOWS)
     HANDLE handle() const { return m_handle.get(); }

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -149,7 +149,7 @@ AudioFileReader::AudioFileReader(const void* data, size_t dataSize)
 {
 #if ENABLE(MEDIA_SOURCE)
     if (isMaybeWebM(static_cast<const uint8_t*>(data), dataSize)) {
-        m_webmData = demuxWebMData(static_cast<const uint8_t*>(data), dataSize);
+        m_webmData = demuxWebMData(std::span { static_cast<const uint8_t*>(data), dataSize });
         if (m_webmData)
             return;
     }
@@ -181,12 +181,12 @@ bool AudioFileReader::isMaybeWebM(const uint8_t* data, size_t dataSize) const
     return dataSize >= 4 && data[0] == 0x1A && data[1] == 0x45 && data[2] == 0xDF && data[3] == 0xA3;
 }
 
-std::unique_ptr<AudioFileReaderWebMData> AudioFileReader::demuxWebMData(const uint8_t* data, size_t dataSize) const
+std::unique_ptr<AudioFileReaderWebMData> AudioFileReader::demuxWebMData(std::span<const uint8_t> data) const
 {
     auto parser = SourceBufferParserWebM::create();
     if (!parser)
         return nullptr;
-    auto buffer = SharedBuffer::create(data, dataSize);
+    auto buffer = SharedBuffer::create(data);
 
     std::optional<uint64_t> audioTrackId;
     MediaTime duration;

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
@@ -72,7 +72,7 @@ public:
 private:
 #if ENABLE(MEDIA_SOURCE)
     bool isMaybeWebM(const uint8_t* data, size_t dataSize) const;
-    std::unique_ptr<AudioFileReaderWebMData> demuxWebMData(const uint8_t* data, size_t dataSize) const;
+    std::unique_ptr<AudioFileReaderWebMData> demuxWebMData(std::span<const uint8_t>) const;
     Vector<AudioStreamPacketDescription> getPacketDescriptions(CMSampleBufferRef) const;
     std::optional<size_t> decodeWebMData(AudioBufferList&, size_t numberOfFrames, const AudioStreamBasicDescription& inFormat, const AudioStreamBasicDescription& outFormat) const;
 #endif

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.h
@@ -62,7 +62,7 @@ public:
     {
         return adoptRef(*new KeyHandle(status, WTFMove(keyID), WTFMove(keyHandleValue)));
     }
-    Ref<SharedBuffer> idAsSharedBuffer() const { return SharedBuffer::create(m_id.data(), m_id.size()); }
+    Ref<SharedBuffer> idAsSharedBuffer() const { return SharedBuffer::create(m_id.span()); }
 
     bool takeValueIfDifferent(KeyHandleValueVariant&&);
 

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -221,7 +221,7 @@ static Ref<SharedBuffer> extractKeyidsFromCencInitData(const SharedBuffer& initD
 
     object->setArray("kids"_s, WTFMove(keyIdsArray));
     CString jsonData = object->toJSONString().utf8();
-    return SharedBuffer::create(jsonData.data(), jsonData.length());
+    return SharedBuffer::create(jsonData.span());
 }
 
 static Ref<SharedBuffer> extractKeyIdFromWebMInitData(const SharedBuffer& initData)
@@ -242,8 +242,7 @@ static Ref<SharedBuffer> extractKeyIdFromWebMInitData(const SharedBuffer& initDa
     keyIdsArray->pushString(base64URLEncodeToString(initData.data(), initData.size()));
 
     object->setArray("kids"_s, WTFMove(keyIdsArray));
-    CString jsonData = object->toJSONString().utf8();
-    return SharedBuffer::create(jsonData.data(), jsonData.length());
+    return SharedBuffer::create(object->toJSONString().utf8().span());
 }
 
 CDMFactoryClearKey& CDMFactoryClearKey::singleton()
@@ -576,8 +575,7 @@ void CDMInstanceSessionClearKey::removeSessionData(const String& sessionId, Lice
 
         // Copy the JSON data into a SharedBuffer object.
         String messageString = rootObject->toJSONString();
-        CString messageCString = messageString.utf8();
-        message = SharedBuffer::create(messageCString.data(), messageCString.length());
+        message = SharedBuffer::create(messageString.utf8().span());
     }
 
     m_keyStore.unrefAllKeys();

--- a/Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp
+++ b/Source/WebCore/platform/generic/KeyedEncoderGeneric.cpp
@@ -145,7 +145,7 @@ void KeyedEncoderGeneric::endArray()
 
 RefPtr<SharedBuffer> KeyedEncoderGeneric::finishEncoding()
 {
-    return SharedBuffer::create(m_encoder.buffer(), m_encoder.bufferSize());
+    return SharedBuffer::create(m_encoder.span());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/glib/KeyedEncoderGlib.cpp
+++ b/Source/WebCore/platform/glib/KeyedEncoderGlib.cpp
@@ -137,7 +137,7 @@ RefPtr<SharedBuffer> KeyedEncoderGlib::finishEncoding()
     g_assert(m_variantBuilderStack.last() == &m_variantBuilder);
     GRefPtr<GVariant> variant = g_variant_builder_end(&m_variantBuilder);
     GRefPtr<GBytes> data = adoptGRef(g_variant_get_data_as_bytes(variant.get()));
-    return SharedBuffer::create(static_cast<const unsigned char*>(g_bytes_get_data(data.get(), nullptr)), static_cast<unsigned>(g_bytes_get_size(data.get())));
+    return SharedBuffer::create(std::span { static_cast<const unsigned char*>(g_bytes_get_data(data.get(), nullptr)), static_cast<unsigned>(g_bytes_get_size(data.get())) });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -248,9 +248,7 @@ RefPtr<SharedBuffer> CDMPrivateFairPlayStreaming::sanitizeMpts(const SharedBuffe
 
 const Vector<Ref<SharedBuffer>>& CDMPrivateFairPlayStreaming::mptsKeyIDs() {
     static NeverDestroyed<Vector<Ref<SharedBuffer>>> mptsKeyID = [] {
-        ASCIILiteral keyID = "TransportStreamIdentifier"_s;
-        Ref keyBuffer = SharedBuffer::create(keyID.characters(), keyID.length());
-        return Vector { 1, WTFMove(keyBuffer) };
+        return Vector { 1, SharedBuffer::create("TransportStreamIdentifier"_span) };
     }();
     return mptsKeyID;
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -168,7 +168,7 @@ RefPtr<Uint8Array> CDMSessionAVContentKeySession::generateKeyRequest(const Strin
     if (m_cdmVersion == 2)
         m_identifier = initData;
     else
-        m_initData = SharedBuffer::create(initData->data(), initData->length());
+        m_initData = SharedBuffer::create(initData->span());
 
     ASSERT(!m_certificate);
     String certificateString("certificate"_s);

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -858,7 +858,7 @@ Status WebMParser::OnTrackEntry(const ElementMetadata&, const TrackEntry& trackE
                 continue;
 
             auto& keyId = keyIdElement.value();
-            m_keyIds.append(std::make_pair(trackEntry.track_uid.value(), SharedBuffer::create(keyId.data(), keyId.size())));
+            m_keyIds.append(std::make_pair(trackEntry.track_uid.value(), SharedBuffer::create(std::span { keyId })));
         }
     }
 
@@ -1226,7 +1226,7 @@ webm::Status WebMParser::AudioTrackData::consumeFrameData(webm::Reader& reader, 
                 return Skip(&reader, bytesRemaining);
             }
             OpusCookieContents cookieContents;
-            if (!parseOpusPrivateData(privateData.size(), privateData.data(), *contiguousBuffer, cookieContents)) {
+            if (!parseOpusPrivateData(std::span { privateData }, *contiguousBuffer, cookieContents)) {
                 PARSER_LOG_ERROR_IF_POSSIBLE("Failed to parse Opus private data");
                 return Skip(&reader, bytesRemaining);
             }
@@ -1265,7 +1265,7 @@ webm::Status WebMParser::AudioTrackData::consumeFrameData(webm::Reader& reader, 
             PARSER_LOG_ERROR_IF_POSSIBLE("AudioTrackData::consumeFrameData: unable to create contiguous data block");
             return Skip(&reader, bytesRemaining);
         }
-        if (!parseOpusPrivateData(privateData.size(), privateData.data(), *contiguousBuffer, cookieContents)
+        if (!parseOpusPrivateData(std::span { privateData }, *contiguousBuffer, cookieContents)
             || cookieContents.framesPerPacket != m_framesPerPacket
             || cookieContents.frameDuration != m_frameDuration) {
             PARSER_LOG_ERROR_IF_POSSIBLE("Opus frames-per-packet changed within a track; error");

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -603,7 +603,7 @@ static Ref<VideoInfo> createVideoInfoFromVPCodecConfigurationRecord(const VPCode
     view->set(8, record.transferCharacteristics, false);
     view->set(9, record.matrixCoefficients, false);
     view->set(10, codecIntializationDataSize, false);
-    videoInfo->atomData = SharedBuffer::create(static_cast<uint8_t*>(view->data()), view->byteLength());
+    videoInfo->atomData = SharedBuffer::create(view->span());
     videoInfo->colorSpace.fullRange = record.videoFullRangeFlag == VPConfigurationRange::FullRange;
     videoInfo->colorSpace.primaries = convertToPlatformVideoColorPrimaries(record.colorPrimaries);
     videoInfo->colorSpace.transfer = convertToPlatformVideoTransferCharacteristics(record.transferCharacteristics);

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h
@@ -63,7 +63,7 @@ WEBCORE_EXPORT bool isOpusDecoderAvailable();
 WEBCORE_EXPORT bool registerOpusDecoderIfNeeded();
 static constexpr size_t kOpusHeaderSize = 19;
 static constexpr size_t kOpusMinimumFrameDataSize = 2;
-bool parseOpusPrivateData(size_t privateDataSize, const uint8_t* privateData, SharedBuffer& frameData, OpusCookieContents&);
+bool parseOpusPrivateData(std::span<const uint8_t> privateData, SharedBuffer& frameData, OpusCookieContents&);
 bool parseOpusTOCData(const SharedBuffer& frameData, OpusCookieContents&);
 RefPtr<AudioInfo> createOpusAudioInfo(const OpusCookieContents&);
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -271,8 +271,8 @@ CDMInstanceSessionThunder::CDMInstanceSessionThunder(CDMInstanceThunder& instanc
         const uint16_t challengeLength) {
         GST_DEBUG("Got 'challenge' OCDM notification with length %hu", challengeLength);
         ASSERT(challengeLength > 0);
-        callOnMainThread([session = WeakPtr { static_cast<CDMInstanceSessionThunder*>(userData) }, buffer = WebCore::SharedBuffer::create(challenge,
-            challengeLength)]() mutable {
+        callOnMainThread([session = WeakPtr { static_cast<CDMInstanceSessionThunder*>(userData) }, buffer = WebCore::SharedBuffer::create(std::span { challenge,
+            challengeLength })]() mutable {
             if (!session)
                 return;
             session->challengeGeneratedCallback(WTFMove(buffer));
@@ -298,8 +298,7 @@ CDMInstanceSessionThunder::CDMInstanceSessionThunder(CDMInstanceThunder& instanc
     };
     m_thunderSessionCallbacks.error_message_callback = [](OpenCDMSession*, void* userData, const char message[]) {
         GST_ERROR("Got 'error' OCDM notification: %s", message);
-        callOnMainThread([session = WeakPtr { static_cast<CDMInstanceSessionThunder*>(userData) }, buffer = WebCore::SharedBuffer::create(message,
-            strlen(message))]() mutable {
+        callOnMainThread([session = WeakPtr { static_cast<CDMInstanceSessionThunder*>(userData) }, buffer = WebCore::SharedBuffer::create(span(message))]() mutable {
             if (!session)
                 return;
             session->errorCallback(WTFMove(buffer));

--- a/Source/WebCore/platform/graphics/gtk/ImageAdapterGtk.cpp
+++ b/Source/WebCore/platform/graphics/gtk/ImageAdapterGtk.cpp
@@ -42,7 +42,7 @@ static Ref<Image> loadImageFromGResource(const char* iconName)
     GUniquePtr<char> path(g_strdup_printf("/org/webkitgtk/resources/images/%s", iconName));
     GRefPtr<GBytes> data = adoptGRef(g_resources_lookup_data(path.get(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
     ASSERT(data);
-    icon->setData(SharedBuffer::create(static_cast<const unsigned char*>(g_bytes_get_data(data.get(), nullptr)), g_bytes_get_size(data.get())), true);
+    icon->setData(SharedBuffer::create(std::span { static_cast<const uint8_t*>(g_bytes_get_data(data.get(), nullptr)), g_bytes_get_size(data.get()) }), true);
     return icon;
 }
 

--- a/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/ico/ICOImageDecoder.cpp
@@ -144,7 +144,7 @@ void ICOImageDecoder::setDataForPNGDecoderAtIndex(size_t index)
     // Copy out PNG data to a separate vector and send to the PNG decoder.
     // FIXME: Save this copy by making the PNG decoder able to take an
     // optional offset.
-    auto pngData = SharedBuffer::create(&m_data->data()[dirEntry.m_imageOffset], m_data->size() - dirEntry.m_imageOffset);
+    auto pngData = SharedBuffer::create(std::span { &m_data->data()[dirEntry.m_imageOffset], m_data->size() - dirEntry.m_imageOffset });
     m_pngDecoders[index]->setData(pngData.get(), isAllDataReceived());
 }
 

--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
@@ -233,7 +233,7 @@ static RefPtr<SharedBuffer> readICCProfile(jpeg_decompress_struct* info)
             return nullptr;
 
         unsigned markerSize = marker->data_length - iccHeaderSize;
-        buffer.append(reinterpret_cast<const uint8_t*>(marker->data + iccHeaderSize), markerSize);
+        buffer.append(std::span { reinterpret_cast<const uint8_t*>(marker->data + iccHeaderSize), markerSize });
     }
 
     if (buffer.isEmpty())

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.cpp
@@ -406,7 +406,7 @@ void MediaRecorderPrivateBackend::processSample(GRefPtr<GstSample>&& sample)
     Locker locker { m_dataLock };
 
     GST_LOG_OBJECT(m_transcoder.get(), "Queueing %zu bytes of encoded data, caps: %" GST_PTR_FORMAT, buffer.size(), gst_sample_get_caps(sample.get()));
-    m_data.append(buffer.data(), buffer.size());
+    m_data.append(std::span<const uint8_t> { buffer.data(), buffer.size() });
 }
 
 void MediaRecorderPrivateBackend::notifyEOS()

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -117,7 +117,7 @@ void BlobResourceSynchronousLoader::didReceiveResponseAsync(ResourceHandle* hand
 
     // Read all the data.
     m_data.resize(static_cast<size_t>(response.expectedContentLength()));
-    static_cast<BlobResourceHandle*>(handle)->readSync(m_data.data(), static_cast<int>(m_data.size()));
+    static_cast<BlobResourceHandle*>(handle)->readSync(m_data.mutableSpan());
     completionHandler();
 }
 
@@ -321,7 +321,7 @@ auto BlobResourceHandle::seek() -> std::optional<Error>
     return std::nullopt;
 }
 
-int BlobResourceHandle::readSync(uint8_t* buf, int length)
+int BlobResourceHandle::readSync(std::span<uint8_t> buffer)
 {
     ASSERT(isMainThread());
 
@@ -329,7 +329,7 @@ int BlobResourceHandle::readSync(uint8_t* buf, int length)
     Ref<BlobResourceHandle> protectedThis(*this);
 
     int offset = 0;
-    int remaining = length;
+    size_t remaining = buffer.size();
     while (remaining) {
         // Do not continue if the request is aborted or an error occurs.
         if (erroredOrAborted())
@@ -342,9 +342,9 @@ int BlobResourceHandle::readSync(uint8_t* buf, int length)
         const BlobDataItem& item = m_blobData->items().at(m_readItemCount);
         int bytesRead = 0;
         if (item.type() == BlobDataItem::Type::Data)
-            bytesRead = readDataSync(item, buf + offset, remaining);
+            bytesRead = readDataSync(item, buffer.subspan(offset));
         else if (item.type() == BlobDataItem::Type::File)
-            bytesRead = readFileSync(item, buf + offset, remaining);
+            bytesRead = readFileSync(item, buffer.subspan(offset));
         else
             ASSERT_NOT_REACHED();
 
@@ -358,10 +358,10 @@ int BlobResourceHandle::readSync(uint8_t* buf, int length)
     if (erroredOrAborted())
         result = -1;
     else
-        result = length - remaining;
+        result = buffer.size() - remaining;
 
     if (result > 0)
-        notifyReceiveData(buf, result);
+        notifyReceiveData(buffer);
 
     if (!result)
         notifyFinish();
@@ -369,17 +369,15 @@ int BlobResourceHandle::readSync(uint8_t* buf, int length)
     return result;
 }
 
-int BlobResourceHandle::readDataSync(const BlobDataItem& item, void* buf, int length)
+int BlobResourceHandle::readDataSync(const BlobDataItem& item, std::span<uint8_t> buffer)
 {
     ASSERT(isMainThread());
 
     ASSERT(!m_async);
 
     long long remaining = item.length() - m_currentItemReadSize;
-    int bytesToRead = (length > remaining) ? static_cast<int>(remaining) : length;
-    if (bytesToRead > m_totalRemainingSize)
-        bytesToRead = static_cast<int>(m_totalRemainingSize);
-    memcpy(buf, item.data()->data() + item.offset() + m_currentItemReadSize, bytesToRead);
+    long long bytesToRead = std::min(std::min<long long>(remaining, buffer.size()), m_totalRemainingSize);
+    memcpy(buffer.data(), item.data()->data() + item.offset() + m_currentItemReadSize, bytesToRead);
     m_totalRemainingSize -= bytesToRead;
 
     m_currentItemReadSize += bytesToRead;
@@ -391,7 +389,7 @@ int BlobResourceHandle::readDataSync(const BlobDataItem& item, void* buf, int le
     return bytesToRead;
 }
 
-int BlobResourceHandle::readFileSync(const BlobDataItem& item, void* buf, int length)
+int BlobResourceHandle::readFileSync(const BlobDataItem& item, std::span<uint8_t> buffer)
 {
     ASSERT(isMainThread());
 
@@ -411,7 +409,7 @@ int BlobResourceHandle::readFileSync(const BlobDataItem& item, void* buf, int le
         m_fileOpened = true;
     }
 
-    int bytesRead = m_stream->read(buf, length);
+    int bytesRead = m_stream->read(buffer.data(), buffer.size());
     if (bytesRead < 0) {
         m_errorCode = Error::NotReadableError;
         return 0;
@@ -461,10 +459,10 @@ void BlobResourceHandle::readDataAsync(const BlobDataItem& item)
     if (bytesToRead > m_totalRemainingSize)
         bytesToRead = m_totalRemainingSize;
 
-    auto* data = item.data()->data() + item.offset() + m_currentItemReadSize;
+    auto data = item.data()->span().subspan(item.offset() + m_currentItemReadSize, bytesToRead);
     m_currentItemReadSize = 0;
 
-    consumeData(data, static_cast<int>(bytesToRead));
+    consumeData(data);
 }
 
 void BlobResourceHandle::readFileAsync(const BlobDataItem& item)
@@ -504,23 +502,23 @@ void BlobResourceHandle::didRead(int bytesRead)
         return;
     }
 
-    consumeData(m_buffer.data(), bytesRead);
+    consumeData(m_buffer.subspan(0, bytesRead));
 }
 
-void BlobResourceHandle::consumeData(const uint8_t* data, int bytesRead)
+void BlobResourceHandle::consumeData(std::span<const uint8_t> data)
 {
     ASSERT(m_async);
     Ref<BlobResourceHandle> protectedThis(*this);
 
-    m_totalRemainingSize -= bytesRead;
+    m_totalRemainingSize -= data.size();
 
     // Notify the client.
-    if (bytesRead)
-        notifyReceiveData(data, bytesRead);
+    if (!data.empty())
+        notifyReceiveData(data);
 
     if (m_fileOpened) {
         // When the current item is a file item, the reading is completed only if bytesRead is 0.
-        if (!bytesRead) {
+        if (data.empty()) {
             // Close the file.
             m_fileOpened = false;
             m_asyncStream->close();
@@ -591,10 +589,10 @@ void BlobResourceHandle::notifyResponseOnSuccess()
     });
 }
 
-void BlobResourceHandle::notifyReceiveData(const uint8_t* data, int bytesRead)
+void BlobResourceHandle::notifyReceiveData(std::span<const uint8_t> data)
 {
     if (client())
-        client()->didReceiveBuffer(this, SharedBuffer::create(data, bytesRead), bytesRead);
+        client()->didReceiveBuffer(this, SharedBuffer::create(data), data.size());
 }
 
 void BlobResourceHandle::notifyFail(Error errorCode)

--- a/Source/WebCore/platform/network/BlobResourceHandle.h
+++ b/Source/WebCore/platform/network/BlobResourceHandle.h
@@ -51,7 +51,7 @@ public:
     static void loadResourceSynchronously(BlobData*, const ResourceRequest&, ResourceError&, ResourceResponse&, Vector<uint8_t>& data);
 
     void start();
-    int readSync(uint8_t*, int);
+    int readSync(std::span<uint8_t>);
 
     bool aborted() const { return m_aborted; }
 
@@ -79,20 +79,20 @@ private:
     void doStart();
     void getSizeForNext();
     std::optional<Error> seek();
-    void consumeData(const uint8_t* data, int bytesRead);
+    void consumeData(std::span<const uint8_t>);
     void failed(Error);
 
     void readAsync();
     void readDataAsync(const BlobDataItem&);
     void readFileAsync(const BlobDataItem&);
 
-    int readDataSync(const BlobDataItem&, void*, int);
-    int readFileSync(const BlobDataItem&, void*, int);
+    int readDataSync(const BlobDataItem&, std::span<uint8_t>);
+    int readFileSync(const BlobDataItem&, std::span<uint8_t>);
 
     void notifyResponse();
     void notifyResponseOnSuccess();
     void notifyResponseOnError();
-    void notifyReceiveData(const uint8_t*, int);
+    void notifyReceiveData(std::span<const uint8_t>);
     void notifyFail(Error);
     void notifyFinish();
 

--- a/Source/WebCore/platform/network/FormDataBuilder.cpp
+++ b/Source/WebCore/platform/network/FormDataBuilder.cpp
@@ -50,7 +50,7 @@ static inline void append(Vector<uint8_t>& buffer, std::span<const uint8_t> byte
 
 static inline void append(Vector<uint8_t>& buffer, const char* string)
 {
-    buffer.append(std::span { string, strlen(string) });
+    buffer.append(span8(string));
 }
 
 static inline void append(Vector<uint8_t>& buffer, const CString& string)

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -213,7 +213,7 @@ static String getFullCFHTML(IDataObject* data)
 
 static void append(Vector<char>& vector, const char* string)
 {
-    vector.append(std::span { string, strlen(string) });
+    vector.append(span(string));
 }
 
 static void append(Vector<char>& vector, const CString& string)

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -330,7 +330,7 @@ void MockCDMInstanceSession::requestLicense(LicenseType licenseType, KeyGrouping
     factory->addKeysToSessionWithID(sessionID, WTFMove(keyIDs.value()));
 
     CString license { "license" };
-    callback(SharedBuffer::create(license.data(), license.length()), sessionID, false, SuccessValue::Succeeded);
+    callback(SharedBuffer::create(license.span()), sessionID, false, SuccessValue::Succeeded);
 }
 
 void MockCDMInstanceSession::updateLicense(const String& sessionID, LicenseType, Ref<SharedBuffer>&& response, LicenseUpdateCallback&& callback)
@@ -375,7 +375,7 @@ void MockCDMInstanceSession::loadSession(LicenseType, const String&, const Strin
     // FIXME: Key status and expiration handling should be implemented once the relevant algorithms are supported.
 
     CString messageData { "session loaded" };
-    Message message { MessageType::LicenseRenewal, SharedBuffer::create(messageData.data(), messageData.length()) };
+    Message message { MessageType::LicenseRenewal, SharedBuffer::create(messageData.span()) };
 
     callback(std::nullopt, std::nullopt, WTFMove(message), SuccessValue::Succeeded, SessionLoadFailure::None);
 }
@@ -406,7 +406,7 @@ void MockCDMInstanceSession::removeSessionData(const String& id, LicenseType, Re
     });
 
     CString message { "remove-message" };
-    callback(WTFMove(keyStatusVector), SharedBuffer::create(message.data(), message.length()), SuccessValue::Succeeded);
+    callback(WTFMove(keyStatusVector), SharedBuffer::create(message.span()), SuccessValue::Succeeded);
 }
 
 void MockCDMInstanceSession::storeRecordOfKeyUsage(const String&)

--- a/Source/WebCore/testing/MockContentFilter.cpp
+++ b/Source/WebCore/testing/MockContentFilter.cpp
@@ -114,7 +114,7 @@ void MockContentFilter::finishedAddingData()
 Ref<FragmentedSharedBuffer> MockContentFilter::replacementData() const
 {
     ASSERT(didBlockData());
-    return SharedBuffer::create(m_replacementData.data(), m_replacementData.size());
+    return SharedBuffer::create(m_replacementData.span());
 }
 
 ContentFilterUnblockHandler MockContentFilter::unblockHandler() const

--- a/Source/WebCore/workers/ScriptBuffer.cpp
+++ b/Source/WebCore/workers/ScriptBuffer.cpp
@@ -86,7 +86,7 @@ void ScriptBuffer::append(const String& string)
     if (string.isEmpty())
         return;
     auto result = string.tryGetUTF8([&](std::span<const char> span) -> bool {
-        m_buffer.append(span.data(), span.size());
+        m_buffer.append(spanReinterpretCast<const uint8_t>(span));
         return true;
     });
     RELEASE_ASSERT(result);

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp
@@ -377,7 +377,7 @@ void BackgroundFetch::Record::didReceiveResponseBodyChunk(const SharedBuffer& da
         m_fetch->storeResponseBodyChunk(m_index, data);
 
     if (!m_responseBodyCallbacks.isEmpty()) {
-        RefPtr buffer = SharedBuffer::create(data.data(), data.size());
+        RefPtr buffer = SharedBuffer::create(data.span());
         for (auto& callback : m_responseBodyCallbacks)
             callback(buffer.copyRef());
     }

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -140,7 +140,7 @@ static void processResponse(Ref<Client>&& client, Expected<Ref<FetchResponse>, s
             }
 
             if (auto* chunk = result.returnValue())
-                client->didReceiveData(SharedBuffer::create(chunk->data(), chunk->size()));
+                client->didReceiveData(SharedBuffer::create(*chunk));
             else
                 client->didFinish(response ? response->networkLoadMetrics() : NetworkLoadMetrics { });
         });

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.cpp
@@ -78,7 +78,7 @@ static RefPtr<WebCore::SharedBuffer> convertToOptionalSharedBuffer(T array)
 {
     if (!array)
         return nullptr;
-    return SharedBuffer::create((const char*)array->data(), array->byteLength());
+    return SharedBuffer::create(array->span());
 }
 
 void RemoteLegacyCDMSessionProxy::generateKeyRequest(const String& mimeType, RefPtr<SharedBuffer>&& initData, GenerateKeyCallback&& completion)

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.h
@@ -84,12 +84,12 @@ private:
     void getSizeForNext();
     void dispatchDidReceiveResponse();
     std::optional<Error> seek();
-    void consumeData(const uint8_t* data, int bytesRead);
+    void consumeData(std::span<const uint8_t>);
     void read();
     void readData(const WebCore::BlobDataItem&);
     void readFile(const WebCore::BlobDataItem&);
     void download();
-    bool writeDownload(const uint8_t* data, int bytesRead);
+    bool writeDownload(std::span<const uint8_t>);
     void cleanDownloadFiles();
     void didFailDownload(const WebCore::ResourceError&);
     void didFinishDownload();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
@@ -187,7 +187,7 @@ void Entry::initializeBufferFromStorageRecord() const
             return;
     }
 #endif
-    m_buffer = WebCore::SharedBuffer::create(m_sourceStorageRecord.body.data(), m_sourceStorageRecord.body.size());
+    m_buffer = WebCore::SharedBuffer::create(m_sourceStorageRecord.body.span());
 }
 
 WebCore::FragmentedSharedBuffer* Entry::buffer() const

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -313,13 +313,13 @@ std::optional<CacheStorageRecord> CacheStorageDiskStore::readRecordFromFileData(
         if (bodyOffset + bodySize != buffer.size())
             return std::nullopt;
 
-        auto bodyData = std::span(buffer.data() + bodyOffset, bodySize);
+        auto bodyData = buffer.subspan(bodyOffset, bodySize);
         if (storedInfo->metaData.bodyHash != computeSHA1(bodyData, m_salt))
             return std::nullopt;
 
         // FIXME: avoid copying inline body data here, perhaps by adding offset support to
         // MappedFileData, or by taking a read-only virtual copy of bodyData.
-        responseBody = WebCore::SharedBuffer::create(bodyData.data(), bodyData.size());
+        responseBody = WebCore::SharedBuffer::create(bodyData);
     } else {
         if (!blobBuffer)
             return std::nullopt;

--- a/Source/WebKit/Shared/WebCompiledContentRuleList.cpp
+++ b/Source/WebKit/Shared/WebCompiledContentRuleList.cpp
@@ -69,7 +69,7 @@ std::span<const uint8_t> WebCompiledContentRuleList::serializedActions() const
 std::span<const uint8_t> WebCompiledContentRuleList::spanWithOffsetAndLength(size_t offset, size_t length) const
 {
     RELEASE_ASSERT(offset + length <= m_data.data->size());
-    return m_data.data->bytes().subspan(offset, length);
+    return m_data.data->span().subspan(offset, length);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitURISchemeRequest.cpp
@@ -268,7 +268,7 @@ static void webkitURISchemeRequestReadCallback(GInputStream* inputStream, GAsync
         return;
     }
 
-    priv->task->didReceiveData(SharedBuffer::create(priv->readBuffer, bytesRead));
+    priv->task->didReceiveData(SharedBuffer::create(std::span(priv->readBuffer, bytesRead)));
     priv->bytesRead += bytesRead;
     g_input_stream_read_async(inputStream, priv->readBuffer, gReadBufferSize, RunLoopSourcePriority::AsyncIONetwork, priv->cancellable.get(),
         reinterpret_cast<GAsyncReadyCallback>(webkitURISchemeRequestReadCallback), g_object_ref(request.get()));

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -3345,7 +3345,7 @@ void webkit_web_view_load_plain_text(WebKitWebView* webView, const gchar* plainT
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
     g_return_if_fail(plainText);
 
-    getPage(webView).loadData({ reinterpret_cast<const uint8_t*>(plainText), plainText ? strlen(plainText) : 0 }, "text/plain"_s, "UTF-8"_s, aboutBlankURL().string());
+    getPage(webView).loadData(span8(plainText), "text/plain"_s, "UTF-8"_s, aboutBlankURL().string());
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp
@@ -212,7 +212,7 @@ void DropTarget::dataReceived(IntPoint&& position, GtkSelectionData* data, unsig
         int length;
         const auto* customData = gtk_selection_data_get_data_with_length(data, &length);
         if (length > 0)
-            m_selectionData->setCustomData(SharedBuffer::create(customData, static_cast<size_t>(length)));
+            m_selectionData->setCustomData(SharedBuffer::create(std::span { customData, static_cast<size_t>(length) }));
         break;
     }
     }

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -75,7 +75,7 @@ void SubFrameSOAuthorizationSession::fallBackToWebPathInternal()
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("fallBackToWebPathInternal: navigationAction=%p", navigationAction());
     ASSERT(navigationAction());
-    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(std::span { soAuthorizationPostDidCancelMessageToParent, strlen(soAuthorizationPostDidCancelMessageToParent) }));
+    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(span8(soAuthorizationPostDidCancelMessageToParent)));
     appendRequestToLoad(URL(navigationAction()->request().url()), String(navigationAction()->request().httpReferrer()));
 }
 
@@ -101,7 +101,7 @@ void SubFrameSOAuthorizationSession::beforeStart()
     // Cancelled the current load before loading the data to post SOAuthorizationDidStart to the parent frame.
     invokeCallback(true);
     ASSERT(navigationAction());
-    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(std::span { soAuthorizationPostDidStartMessageToParent, strlen(soAuthorizationPostDidStartMessageToParent) }));
+    appendRequestToLoad(URL(navigationAction()->request().url()), Vector<uint8_t>(span8(soAuthorizationPostDidStartMessageToParent)));
 }
 
 void SubFrameSOAuthorizationSession::didFinishLoad()

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
@@ -227,7 +227,7 @@ void RemoteInspectorProtocolHandler::platformStartTask(WebPageProxy& pageProxy, 
     htmlBuilder.append("</html>");
 
     auto html = htmlBuilder.toString().utf8();
-    auto data = SharedBuffer::create(html.data(), html.length());
+    auto data = SharedBuffer::create(html.span());
     ResourceResponse response(requestURL, "text/html"_s, html.length(), "UTF-8"_s);
     task.didReceiveResponse(response);
     task.didReceiveData(WTFMove(data));

--- a/Source/WebKit/UIProcess/Inspector/win/InspectorResourceURLSchemeHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/InspectorResourceURLSchemeHandler.cpp
@@ -58,7 +58,7 @@ void InspectorResourceURLSchemeHandler::platformStartTask(WebPageProxy&, WebURLS
     if (contentType.isEmpty())
         contentType = "application/octet-stream"_s;
     WebCore::ResourceResponse response(requestURL, contentType, file.size(), "UTF-8"_s);
-    auto data = WebCore::SharedBuffer::create(static_cast<const char*>(file.data()), file.size());
+    auto data = WebCore::SharedBuffer::create(file.span());
 
     task.didReceiveResponse(response);
     task.didReceiveData(WTFMove(data));

--- a/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
+++ b/Source/WebKit/UIProcess/gtk/ClipboardGtk3.cpp
@@ -168,7 +168,7 @@ void Clipboard::readBuffer(const char* format, CompletionHandler<void(Ref<WebCor
         std::unique_ptr<ReadBufferAsyncData> data(static_cast<ReadBufferAsyncData*>(userData));
         int contentsLength;
         const auto* contents = gtk_selection_data_get_data_with_length(selection, &contentsLength);
-        data->completionHandler(WebCore::SharedBuffer::create(contents, contentsLength > 0 ? static_cast<size_t>(contentsLength) : 0));
+        data->completionHandler(WebCore::SharedBuffer::create(std::span { contents, static_cast<size_t>(std::max(0, contentsLength)) }));
     }, new ReadBufferAsyncData(WTFMove(completionHandler)));
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMSession.cpp
@@ -62,7 +62,7 @@ static RefPtr<SharedBuffer> convertToSharedBuffer(T array)
 {
     if (!array)
         return nullptr;
-    return SharedBuffer::create(array->data(), array->byteLength());
+    return SharedBuffer::create(array->span());
 }
 
 std::unique_ptr<RemoteLegacyCDMSession> RemoteLegacyCDMSession::create(WeakPtr<RemoteLegacyCDMFactory> factory, RemoteLegacyCDMSessionIdentifier&& identifier, LegacyCDMSessionClient& client)

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.cpp
@@ -177,7 +177,7 @@ void MediaRecorderPrivate::fetchData(CompletionHandler<void(RefPtr<WebCore::Frag
         // FIXME: If completion handler is called following a GPUProcess connection being closed, we should fail the MediaRecorder.
         RefPtr<FragmentedSharedBuffer> buffer;
         if (data.size())
-            buffer = SharedBuffer::create(data.data(), data.size());
+            buffer = SharedBuffer::create(data);
         completionHandler(WTFMove(buffer), mimeType, timeCode);
     }, identifier());
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1978,7 +1978,7 @@ void WebPage::loadDataInFrame(std::span<const uint8_t> data, String&& type, Stri
         return;
     ASSERT(&mainWebFrame() != frame);
 
-    auto sharedBuffer = SharedBuffer::create(data.data(), data.size());
+    Ref sharedBuffer = SharedBuffer::create(data);
     ResourceResponse response(baseURL, type, sharedBuffer->size(), encodingName);
     SubstituteData substituteData(WTFMove(sharedBuffer), baseURL, WTFMove(response), SubstituteData::SessionHistoryVisibility::Hidden);
     frame->coreLocalFrame()->loader().load(FrameLoadRequest(*frame->coreLocalFrame(), ResourceRequest(baseURL), WTFMove(substituteData)));
@@ -2101,7 +2101,7 @@ void WebPage::loadData(LoadParameters&& loadParameters)
 
     platformDidReceiveLoadParameters(loadParameters);
 
-    auto sharedBuffer = SharedBuffer::create(loadParameters.data.data(), loadParameters.data.size());
+    Ref sharedBuffer = SharedBuffer::create(loadParameters.data);
 
     URL baseURL;
     if (loadParameters.baseURLString.isEmpty())
@@ -2126,7 +2126,7 @@ void WebPage::loadAlternateHTML(LoadParameters&& loadParameters)
     URL baseURL = loadParameters.baseURLString.isEmpty() ? aboutBlankURL() : URL { loadParameters.baseURLString };
     URL unreachableURL = loadParameters.unreachableURLString.isEmpty() ? URL() : URL { loadParameters.unreachableURLString };
     URL provisionalLoadErrorURL = loadParameters.provisionalLoadErrorURLString.isEmpty() ? URL() : URL { loadParameters.provisionalLoadErrorURLString };
-    auto sharedBuffer = SharedBuffer::create(loadParameters.data.data(), loadParameters.data.size());
+    auto sharedBuffer = SharedBuffer::create(loadParameters.data);
     m_mainFrame->coreLocalFrame()->loader().setProvisionalLoadErrorBeingHandledURL(provisionalLoadErrorURL);
 
     WebProcess::singleton().addAllowedFirstPartyForCookies(WebCore::RegistrableDomain { baseURL });
@@ -2139,7 +2139,7 @@ void WebPage::loadAlternateHTML(LoadParameters&& loadParameters)
 void WebPage::loadSimulatedRequestAndResponse(LoadParameters&& loadParameters, ResourceResponse&& simulatedResponse)
 {
     setLastNavigationWasAppInitiated(loadParameters.request.isAppInitiated());
-    auto sharedBuffer = SharedBuffer::create(loadParameters.data.data(), loadParameters.data.size());
+    auto sharedBuffer = SharedBuffer::create(loadParameters.data);
     loadDataImpl(loadParameters.navigationID, loadParameters.shouldTreatAsContinuingLoad, WTFMove(loadParameters.websitePolicies), WTFMove(sharedBuffer), WTFMove(loadParameters.request), WTFMove(simulatedResponse), URL(), loadParameters.userData, loadParameters.isNavigatingToAppBoundDomain, SubstituteData::SessionHistoryVisibility::Visible);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPrintOperationGtk.cpp
@@ -212,7 +212,7 @@ void WebPrintOperationGtk::startPrint(WebCore::PrintContext* printContext, Compl
 
     auto writeCairoStream = [](void* userData, const unsigned char* data, unsigned length) -> cairo_status_t {
         auto& printOperation = *static_cast<WebPrintOperationGtk*>(userData);
-        printOperation.m_buffer.append(data, length);
+        printOperation.m_buffer.append(std::span { data, length });
         return CAIRO_STATUS_SUCCESS;
     };
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SharedBuffer.cpp
@@ -36,6 +36,7 @@
 #endif
 #include <wtf/MainThread.h>
 #include <wtf/StringExtras.h>
+#include <wtf/text/StringCommon.h>
 
 using namespace WebCore;
 
@@ -80,7 +81,7 @@ TEST_F(FragmentedSharedBufferTest, appendBufferCreatedWithContentsOfExistingFile
     ASSERT_NOT_NULL(buffer);
     SharedBufferBuilder builder;
     builder.append(*buffer);
-    builder.append("a", 1);
+    builder.append("a"_span);
     EXPECT_TRUE(builder.size() == (strlen(FragmentedSharedBufferTest::testData()) + 1));
     EXPECT_TRUE(!memcmp(builder.get()->makeContiguous()->data(), FragmentedSharedBufferTest::testData(), strlen(FragmentedSharedBufferTest::testData())));
     EXPECT_EQ('a', builder.get()->makeContiguous()->data()[strlen(FragmentedSharedBufferTest::testData())]);
@@ -88,12 +89,9 @@ TEST_F(FragmentedSharedBufferTest, appendBufferCreatedWithContentsOfExistingFile
 
 TEST_F(FragmentedSharedBufferTest, tryCreateArrayBuffer)
 {
-    char testData0[] = "Hello";
-    char testData1[] = "World";
-    char testData2[] = "Goodbye";
-    SharedBufferBuilder builder(std::in_place, testData0, strlen(testData0));
-    builder.append(testData1, strlen(testData1));
-    builder.append(testData2, strlen(testData2));
+    SharedBufferBuilder builder(std::in_place, "Hello"_span);
+    builder.append("World"_span);
+    builder.append("Goodbye"_span);
     RefPtr<ArrayBuffer> arrayBuffer = builder.get()->tryCreateArrayBuffer();
     char expectedConcatenation[] = "HelloWorldGoodbye";
     ASSERT_EQ(strlen(expectedConcatenation), arrayBuffer->byteLength());
@@ -128,7 +126,7 @@ TEST_F(FragmentedSharedBufferTest, tryCreateArrayBufferLargeSegments)
 
 TEST_F(FragmentedSharedBufferTest, copy)
 {
-    char testData[] = "Habitasse integer eros tincidunt a scelerisque! Enim elit? Scelerisque magnis,"
+    const auto testData = "Habitasse integer eros tincidunt a scelerisque! Enim elit? Scelerisque magnis,"
     "et montes ultrices tristique a! Pid. Velit turpis, dapibus integer rhoncus sociis amet facilisis,"
     "adipiscing pulvinar nascetur magnis tempor sit pulvinar, massa urna enim porttitor sociis sociis proin enim?"
     "Lectus, platea dolor, integer a. A habitasse hac nunc, nunc, nec placerat vut in sit nunc nec, sed. Sociis,"
@@ -144,12 +142,12 @@ TEST_F(FragmentedSharedBufferTest, copy)
     "sagittis sed, tortor auctor nascetur rhoncus nec, rhoncus, magna integer. Sit eu massa vut?"
     "Porta augue porttitor elementum, enim, rhoncus pulvinar duis integer scelerisque rhoncus natoque,"
     "mattis dignissim massa ac pulvinar urna, nunc ut. Sagittis, aliquet penatibus proin lorem, pulvinar lectus,"
-    "augue proin! Ac, arcu quis. Placerat habitasse, ridiculus ridiculus.";
-    unsigned length = strlen(testData);
-    SharedBufferBuilder builder1(std::in_place, testData, length);
-    builder1.append(testData, length);
-    builder1.append(testData, length);
-    builder1.append(testData, length);
+    "augue proin! Ac, arcu quis. Placerat habitasse, ridiculus ridiculus."_span;
+    unsigned length = testData.size();
+    SharedBufferBuilder builder1(std::in_place, testData);
+    builder1.append(testData);
+    builder1.append(testData);
+    builder1.append(testData);
     // sharedBuffer must contain data more than segmentSize (= 0x1000) to check copy().
     EXPECT_EQ(length * 4, builder1.size());
     RefPtr<FragmentedSharedBuffer> clone = builder1.copy();
@@ -158,7 +156,7 @@ TEST_F(FragmentedSharedBufferTest, copy)
 
     SharedBufferBuilder builder2;
     builder2.append(*clone);
-    builder2.append(testData, length);
+    builder2.append(testData);
     EXPECT_EQ(length * 5, builder2.size());
     auto buffer = builder2.take();
     EXPECT_EQ(length * 5, buffer->size());
@@ -170,8 +168,8 @@ TEST_F(FragmentedSharedBufferTest, copy)
 
 TEST_F(FragmentedSharedBufferTest, builder)
 {
-    char testData0[] = "Hello";
-    SharedBufferBuilder builder1(std::in_place, testData0, strlen(testData0));
+    const auto testData0 = "Hello"_span;
+    SharedBufferBuilder builder1(std::in_place, testData0);
     EXPECT_FALSE(builder1.isNull());
     EXPECT_FALSE(builder1.isEmpty());
     auto copy = builder1.copy();
@@ -184,7 +182,7 @@ TEST_F(FragmentedSharedBufferTest, builder)
     SharedBufferBuilder builder2;
     EXPECT_TRUE(builder2.isNull());
     EXPECT_TRUE(builder2.isEmpty());
-    builder2.append(testData0, strlen(testData0));
+    builder2.append(testData0);
     EXPECT_FALSE(builder2.isNull());
     EXPECT_FALSE(builder2.isEmpty());
     builder2.reset();
@@ -315,7 +313,7 @@ TEST_F(FragmentedSharedBufferTest, toHexString)
 
 TEST_F(FragmentedSharedBufferTest, read)
 {
-    const char* const simpleText = "This is a simple test.";
+    const auto simpleText = "This is a simple test."_span;
 
     auto check = [](FragmentedSharedBuffer& sharedBuffer) {
         Vector<uint8_t> data = sharedBuffer.read(4, 3);
@@ -327,26 +325,26 @@ TEST_F(FragmentedSharedBufferTest, read)
 
         EXPECT_EQ(StringView(data.subspan(0, 18)), " is a simple test."_s);
     };
-    auto sharedBuffer = SharedBuffer::create(simpleText, strlen(simpleText));
+    auto sharedBuffer = SharedBuffer::create(simpleText);
     check(sharedBuffer);
 
     SharedBufferBuilder builder;
-    for (size_t i = 0; i < strlen(simpleText); i++)
-        builder.append(&simpleText[i], 1);
+    for (size_t i = 0; i < simpleText.size(); ++i)
+        builder.append(simpleText.subspan(i, 1));
     check(builder.take());
     EXPECT_TRUE(builder.isNull() && !builder);
     EXPECT_EQ(builder.size(), 0u);
 
-    for (size_t i = 0; i < strlen(simpleText); i += 2)
-        builder.append(&simpleText[i], 2);
-    EXPECT_EQ(builder.size(), strlen(simpleText));
+    for (size_t i = 0; i < simpleText.size(); i += 2)
+        builder.append(simpleText.subspan(i, 2));
+    EXPECT_EQ(builder.size(), simpleText.size());
     check(builder.take());
 }
 
 TEST_F(FragmentedSharedBufferTest, extractData)
 {
-    const char* const simpleText = "This is a simple test.";
-    auto original = SharedBuffer::create(simpleText, strlen(simpleText));
+    const auto simpleText = "This is a simple test."_span;
+    auto original = SharedBuffer::create(simpleText);
     auto copy = original->copy();
     auto vector = copy->extractData();
     EXPECT_TRUE(copy->isEmpty());
@@ -359,9 +357,9 @@ TEST_F(FragmentedSharedBufferTest, copyIsContiguous)
 {
     EXPECT_TRUE(SharedBuffer::create()->copy()->isContiguous());
     EXPECT_FALSE(FragmentedSharedBuffer::create()->copy()->isContiguous());
-    const char* const simpleText = "This is a simple test.";
-    EXPECT_TRUE(SharedBuffer::create(simpleText, strlen(simpleText))->copy()->isContiguous());
-    EXPECT_FALSE(FragmentedSharedBuffer::create(simpleText, strlen(simpleText))->copy()->isContiguous());
+    const auto simpleText = "This is a simple test."_span;
+    EXPECT_TRUE(SharedBuffer::create(simpleText)->copy()->isContiguous());
+    EXPECT_FALSE(FragmentedSharedBuffer::create(simpleText)->copy()->isContiguous());
 }
 
 #if ENABLE(MHTML)
@@ -413,25 +411,25 @@ TEST_F(SharedBufferChunkReaderTest, includeSeparator)
 
         EXPECT_FALSE(chunkReader.nextChunk(out));
     };
-    uint8_t data[256];
+    std::array<uint8_t, 256> data { };
     for (size_t i = 0; i < 256; ++i)
         data[i] = i;
-    auto sharedBuffer = SharedBuffer::create(data, 256);
+    auto sharedBuffer = SharedBuffer::create(std::span<const uint8_t> { data });
     check(sharedBuffer);
 
-    SharedBufferBuilder builder(std::in_place, data, 256);
+    SharedBufferBuilder builder(std::in_place, std::span<const uint8_t> { data });
     check(builder.take());
 
     for (size_t i = 0; i < 256; ++i) {
-        char c = i;
-        builder.append(&c, 1);
+        LChar c = i;
+        builder.append(std::span<const uint8_t> { &c, 1 });
     }
     check(builder.take());
 }
 
 TEST_F(SharedBufferChunkReaderTest, peekData)
 {
-    const char* const simpleText = "This is a simple test.";
+    const auto simpleText = "This is a simple test."_span;
 
     auto check = [](FragmentedSharedBuffer& sharedBuffer) {
         SharedBufferChunkReader chunkReader(&sharedBuffer, "is");
@@ -460,25 +458,25 @@ TEST_F(SharedBufferChunkReaderTest, peekData)
         chunk = chunkReader.nextChunkAsUTF8StringWithLatin1Fallback();
         EXPECT_TRUE(chunk.isNull());
     };
-    auto sharedBuffer = SharedBuffer::create(simpleText, strlen(simpleText));
+    auto sharedBuffer = SharedBuffer::create(simpleText);
     check(sharedBuffer);
 
-    SharedBufferBuilder builder(std::in_place, simpleText, strlen(simpleText));
+    SharedBufferBuilder builder(std::in_place, simpleText);
     check(builder.take());
 
-    for (size_t i = 0; i < strlen(simpleText); i++)
-        builder.append(&simpleText[i], 1);
+    for (size_t i = 0; i < simpleText.size(); i++)
+        builder.append(simpleText.subspan(i, 1));
     check(builder.take());
 
-    for (size_t i = 0; i < strlen(simpleText); i += 2)
-        builder.append(&simpleText[i], 2);
-    EXPECT_EQ(builder.size(), strlen(simpleText));
+    for (size_t i = 0; i < simpleText.size(); i += 2)
+        builder.append(simpleText.subspan(i, 2));
+    EXPECT_EQ(builder.size(), simpleText.size());
     check(builder.take());
 }
 
 TEST_F(SharedBufferChunkReaderTest, readAllChunksInMultiSegment)
 {
-    const char* const simpleText = "This is the most ridiculous history there is.";
+    const auto simpleText = "This is the most ridiculous history there is."_span;
     auto check = [](FragmentedSharedBuffer& sharedBuffer) {
         std::vector<String> chunks;
         const char* const expectedChunks1WithoutSeparator[] = { "Th", "s ", "s the most r", "d", "culous h", "story there ", "s." };
@@ -510,28 +508,28 @@ TEST_F(SharedBufferChunkReaderTest, readAllChunksInMultiSegment)
         readAllChunks(&chunks, sharedBuffer, "ist"_s, true);
         EXPECT_TRUE(checkChunks(chunks, expectedChunks3WithSeparator, arraysize(expectedChunks3WithSeparator)));
     };
-    auto sharedBuffer = SharedBuffer::create(simpleText, strlen(simpleText));
+    auto sharedBuffer = SharedBuffer::create(simpleText);
     check(sharedBuffer);
 
-    SharedBufferBuilder builder(std::in_place, simpleText, strlen(simpleText));
+    SharedBufferBuilder builder(std::in_place, simpleText);
     check(builder.take());
 
-    for (size_t i = 0; i < strlen(simpleText); i++)
-        builder.append(&simpleText[i], 1);
-    EXPECT_EQ(builder.size(), strlen(simpleText));
+    for (size_t i = 0; i < simpleText.size(); i++)
+        builder.append(simpleText.subspan(i, 1));
+    EXPECT_EQ(builder.size(), simpleText.size());
     check(builder.take());
 
-    for (size_t i = 0; i < strlen(simpleText); i += 5)
-        builder.append(&simpleText[i], 5);
-    EXPECT_EQ(builder.size(), strlen(simpleText));
+    for (size_t i = 0; i < simpleText.size(); i += 5)
+        builder.append(simpleText.subspan(i, 5));
+    EXPECT_EQ(builder.size(), simpleText.size());
     check(builder.take());
 }
 
 TEST_F(SharedBufferChunkReaderTest, changingIterator)
 {
     {
-        const char* const simpleText = "This is the most ridiculous history there is.";
-        auto sharedBuffer = SharedBuffer::create(simpleText, strlen(simpleText));
+        const auto simpleText = "This is the most ridiculous history there is."_span;
+        auto sharedBuffer = SharedBuffer::create(simpleText);
         SharedBufferChunkReader chunkReader(sharedBuffer.ptr(), "is");
         String chunk = chunkReader.nextChunkAsUTF8StringWithLatin1Fallback();
         EXPECT_EQ(chunk, "Th"_s);
@@ -558,8 +556,8 @@ TEST_F(SharedBufferChunkReaderTest, changingIterator)
     }
 
     {
-        const char* const simpleText = "dog";
-        auto sharedBuffer = SharedBuffer::create(simpleText, strlen(simpleText));
+        const auto simpleText = "dog"_span;
+        auto sharedBuffer = SharedBuffer::create(simpleText);
         const char* const expectedChunksWithoutSeparator[] = { "" };
         std::vector<String> chunks;
         readAllChunks(&chunks, sharedBuffer, "dog"_s);
@@ -573,8 +571,8 @@ TEST_F(SharedBufferChunkReaderTest, changingIterator)
 
     // Ends with repeated separators.
     {
-        const char* const simpleText = "Beaucoup de chats catcatcatcatcat";
-        auto sharedBuffer = SharedBuffer::create(simpleText, strlen(simpleText));
+        const auto simpleText = "Beaucoup de chats catcatcatcatcat"_span;
+        auto sharedBuffer = SharedBuffer::create(simpleText);
         const char* const expectedChunksWithoutSeparator[] = { "Beaucoup de chats ", "", "", "", "" };
         std::vector<String> chunks;
         readAllChunks(&chunks, sharedBuffer, "cat"_s);
@@ -586,18 +584,18 @@ TEST_F(SharedBufferChunkReaderTest, changingIterator)
         EXPECT_TRUE(checkChunks(chunks, expectedChunksWithSeparator, arraysize(expectedChunksWithSeparator)));
     }
     {
-        const char* const simpleText = "This is a simple test.\r\nNothing special.\r\n";
+        const auto simpleText = "This is a simple test.\r\nNothing special.\r\n"_span;
         const char* const expectedChunks[] = { "This is a simple test.", "Nothing special." };
-        auto sharedBuffer = SharedBuffer::create(simpleText, strlen(simpleText));
+        auto sharedBuffer = SharedBuffer::create(simpleText);
         std::vector<String> chunks;
         readAllChunks(&chunks, sharedBuffer);
         EXPECT_TRUE(checkChunks(chunks, expectedChunks, arraysize(expectedChunks)));
     }
 
     {
-        const char* const simpleText = "This is a simple test.\r\nNothing special.";
+        const auto simpleText = "This is a simple test.\r\nNothing special."_span;
         const char* const expectedChunks[] = { "This is a simple test.", "Nothing special." };
-        auto sharedBuffer = SharedBuffer::create(simpleText, strlen(simpleText));
+        auto sharedBuffer = SharedBuffer::create(simpleText);
 
         std::vector<String> chunks;
         readAllChunks(&chunks, sharedBuffer);
@@ -605,9 +603,9 @@ TEST_F(SharedBufferChunkReaderTest, changingIterator)
     }
 
     {
-        const char* const simpleText = "Simple line with no EOL.";
+        const auto simpleText = "Simple line with no EOL."_span;
         const char* const expectedChunks[] = { "Simple line with no EOL." };
-        auto sharedBuffer = SharedBuffer::create(simpleText, strlen(simpleText));
+        auto sharedBuffer = SharedBuffer::create(simpleText);
 
         std::vector<String> chunks;
         readAllChunks(&chunks, sharedBuffer);
@@ -615,9 +613,9 @@ TEST_F(SharedBufferChunkReaderTest, changingIterator)
     }
 
     {
-        const char* const simpleText = "Line that has a EOL\r\nand then ends with a CR\r";
+        const auto simpleText = "Line that has a EOL\r\nand then ends with a CR\r"_span;
         const char* const expectedChunks[] = { "Line that has a EOL", "and then ends with a CR\r" };
-        auto sharedBuffer = SharedBuffer::create(simpleText, strlen(simpleText));
+        auto sharedBuffer = SharedBuffer::create(simpleText);
 
         std::vector<String> chunks;
         readAllChunks(&chunks, sharedBuffer);
@@ -625,18 +623,18 @@ TEST_F(SharedBufferChunkReaderTest, changingIterator)
     }
 
     {
-        const char* const simpleText = "Repeated CRs should not cause probems\r\r\r\nShouln't they?";
+        const auto simpleText = "Repeated CRs should not cause probems\r\r\r\nShouln't they?"_span;
         const char* const expectedChunks[] = { "Repeated CRs should not cause probems\r\r", "Shouln't they?" };
-        auto sharedBuffer = SharedBuffer::create(simpleText, strlen(simpleText));
+        auto sharedBuffer = SharedBuffer::create(simpleText);
 
         std::vector<String> chunks;
         readAllChunks(&chunks, sharedBuffer);
         EXPECT_TRUE(checkChunks(chunks, expectedChunks, arraysize(expectedChunks)));
     }
     {
-        const char* const simpleText = "EOL\r\n betwe\r\nen segments";
+        const auto simpleText = "EOL\r\n betwe\r\nen segments"_span;
         const char* const expectedChunks[] = { "EOL", " betwe", "en segments" };
-        auto sharedBuffer = SharedBuffer::create(simpleText, strlen(simpleText));
+        auto sharedBuffer = SharedBuffer::create(simpleText);
 
         std::vector<String> chunks;
         readAllChunks(&chunks, sharedBuffer);

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/SharedBuffer.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/SharedBuffer.mm
@@ -28,6 +28,7 @@
 #import "SharedBufferTest.h"
 #import "Utilities.h"
 #import <WebCore/SharedBuffer.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 using namespace WebCore;
 
@@ -53,7 +54,7 @@ TEST_F(FragmentedSharedBufferTest, createNSDataArray)
         expectDataArraysEqual(nil, builder.get()->createNSDataArray().get());
 
         NSData *helloData = [NSData dataWithBytes:"hello" length:5];
-        builder.append((const char*)helloData.bytes, helloData.length);
+        builder.append(span(helloData));
         expectDataArraysEqual(@[ helloData ], builder.get()->createNSDataArray().get());
 
         NSData *worldData = [NSData dataWithBytes:"world" length:5];
@@ -73,7 +74,7 @@ TEST_F(FragmentedSharedBufferTest, createNSDataForDataSegment)
         SharedBufferBuilder builder;
 
         NSData *helloData = [NSData dataWithBytes:"hello" length:5];
-        builder.append((const char*)helloData.bytes, helloData.length);
+        builder.append(span(helloData));
 
         NSData *worldData = [NSData dataWithBytes:"world" length:5];
         builder.append((__bridge CFDataRef)worldData);


### PR DESCRIPTION
#### 20f975626f24cd2a36d74011d4c6f70a3895feb2
<pre>
Use std::span more with SharedBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=271534">https://bugs.webkit.org/show_bug.cgi?id=271534</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/Vector.h:
(WTF::Vector::mutableSpan):
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::didFinishLoading):
* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::put):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::resolve):
* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::consumeChunk):
* Source/WebCore/Modules/highlight/AppHighlightRangeData.cpp:
(WebCore::AppHighlightRangeData::toSharedBuffer const):
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::appendBuffer):
(WebCore::SourceBuffer::appendBufferInternal):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp:
(WebCore::LibWebRTCDataChannelHandler::OnMessage):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::FragmentedSharedBuffer::create):
* Source/WebCore/platform/SharedBuffer.h:
(WebCore::FragmentedSharedBuffer::FragmentedSharedBuffer):
(WebCore::FragmentedSharedBuffer::create): Deleted.
(WebCore::FragmentedSharedBuffer::append): Deleted.
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::AudioFileReader::demuxWebMData const):
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h:
* Source/WebCore/platform/encryptedmedia/CDMProxy.h:
(WebCore::KeyHandle::idAsSharedBuffer const):
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
(WebCore::extractKeyidsFromCencInitData):
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::CDMPrivateFairPlayStreaming::mptsKeyIDs):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::OnTrackEntry):
(WebCore::WebMParser::AudioTrackData::consumeFrameData):
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
(WebCore::createVideoInfoFromVPCodecConfigurationRecord):
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::parseOpusPrivateData):
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::readSync):
(WebCore::BlobResourceHandle::readDataSync):
(WebCore::BlobResourceHandle::readFileSync):
(WebCore::BlobResourceHandle::readDataAsync):
(WebCore::BlobResourceHandle::didRead):
(WebCore::BlobResourceHandle::consumeData):
(WebCore::BlobResourceHandle::notifyReceiveData):
* Source/WebCore/platform/network/BlobResourceHandle.h:
* Source/WebCore/workers/ScriptBuffer.cpp:
(WebCore::ScriptBuffer::append):
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.cpp:
(WebCore::BackgroundFetch::Record::didReceiveResponseBodyChunk):
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::processResponse):

Canonical link: <a href="https://commits.webkit.org/276672@main">https://commits.webkit.org/276672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbbc54c402026e885f60a33f6efa7ee3c0ae32a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47985 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41329 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28648 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21838 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45899 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/21498 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/39093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18268 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40178 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3368 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/38541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41590 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49696 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/44790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/20304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16831 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44203 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/45362 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43011 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51949 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6308 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21299 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->