### PR TITLE
[JSC] `Object.groupBy` and `Map.groupBy` should allow iterable `items` that are not objects

### DIFF
--- a/JSTests/stress/map-groupBy.js
+++ b/JSTests/stress/map-groupBy.js
@@ -116,13 +116,49 @@ shouldBeObject(Map.groupBy([0, 1, 2, 3], (x) => objectWithValueOfThatThrows).get
 shouldBeObject(Map.groupBy([0, 1, 2, 3], (x) => symbol).get(symbol), [0, 1, 2, 3]);
 
 
+// String
+
+shouldBeMap(Map.groupBy("", (x) => x === "" ? "a" : "b"), []);
+shouldBeMap(Map.groupBy("", (x) => x === ""), []);
+
+shouldBeMap(Map.groupBy("wxyz", (x) => x < "y" ? "a" : "b"), [["a", ["w", "x"]], ["b", ["y", "z"]]]);
+shouldBeMap(Map.groupBy("wxyz", (x) => x < "y"), [[true, ["w", "x"]], [false, ["y", "z"]]]);
+
+shouldBeMap(Map.groupBy(String("wxyz"), (x) => x < "y" ? "a" : "b"), [["a", ["w", "x"]], ["b", ["y", "z"]]]);
+shouldBeMap(Map.groupBy(String("wxyz"), (x) => x < "y"), [[true, ["w", "x"]], [false, ["y", "z"]]]);
+
+shouldBeMap(Map.groupBy(new String("wxyz"), (x) => x < "y" ? "a" : "b"), [["a", ["w", "x"]], ["b", ["y", "z"]]]);
+shouldBeMap(Map.groupBy(new String("wxyz"), (x) => x < "y"), [[true, ["w", "x"]], [false, ["y", "z"]]]);
+
+
 // Invalid parameters
 
 try {
     shouldBeMap(Map.groupBy(null, () => {}), []);
     notReached();
 } catch (e) {
-    shouldBe(String(e), "TypeError: Map.groupBy requires that the first argument must be an object");
+    shouldBe(String(e), "TypeError: Map.groupBy requires that the first argument not be null or undefined");
+}
+
+try {
+    shouldBeMap(Map.groupBy(undefined, () => {}), []);
+    notReached();
+} catch (e) {
+    shouldBe(String(e), "TypeError: Map.groupBy requires that the first argument not be null or undefined");
+}
+
+try {
+    shouldBeMap(Map.groupBy({}, () => {}), []);
+    notReached();
+} catch (e) {
+    shouldBe(String(e), "TypeError: Map.groupBy requires that the property of the first argument, items[Symbol.iterator] be a function");
+}
+
+try {
+    shouldBeMap(Map.groupBy(0, () => {}), []);
+    notReached();
+} catch (e) {
+    shouldBe(String(e), "TypeError: Map.groupBy requires that the property of the first argument, items[Symbol.iterator] be a function");
 }
 
 try {

--- a/JSTests/stress/object-groupBy.js
+++ b/JSTests/stress/object-groupBy.js
@@ -116,6 +116,20 @@ shouldBeObject(Object.groupBy([0, 1, 2, 3], (x) => objectWithValueOfThatThrows)[
 
 shouldBeObject(Object.groupBy([0, 1, 2, 3], (x) => symbol)[symbol], [0, 1, 2, 3]);
 
+// String
+
+shouldBeObject(Object.groupBy("", (x) => x === "" ? "a" : "b"), {});
+shouldBeObject(Object.groupBy("", (x) => x === ""), {});
+
+shouldBeObject(Object.groupBy("wxyz", (x) => x < "y" ? "a" : "b"), {"a": ["w", "x"], "b": ["y", "z"]});
+shouldBeObject(Object.groupBy("wxyz", (x) => x < "y"), {"true": ["w", "x"], "false": ["y", "z"]});
+
+shouldBeObject(Object.groupBy(String("wxyz"), (x) => x < "y" ? "a" : "b"), {"a": ["w", "x"], "b": ["y", "z"]});
+shouldBeObject(Object.groupBy(String("wxyz"), (x) => x < "y"), {"true": ["w", "x"], "false": ["y", "z"]});
+
+shouldBeObject(Object.groupBy(new String("wxyz"), (x) => x < "y" ? "a" : "b"), {"a": ["w", "x"], "b": ["y", "z"]});
+shouldBeObject(Object.groupBy(new String("wxyz"), (x) => x < "y"), {"true": ["w", "x"], "false": ["y", "z"]});
+
 
 // Invalid parameters
 
@@ -123,7 +137,28 @@ try {
     shouldBeObject(Object.groupBy(null, () => {}), {});
     notReached();
 } catch (e) {
-    shouldBe(String(e), "TypeError: Object.groupBy requires that the first argument must be an object");
+    shouldBe(String(e), "TypeError: Object.groupBy requires that the first argument not be null or undefined");
+}
+
+try {
+    shouldBeObject(Object.groupBy(undefined, () => {}), {});
+    notReached();
+} catch (e) {
+    shouldBe(String(e), "TypeError: Object.groupBy requires that the first argument not be null or undefined");
+}
+
+try {
+    shouldBeObject(Object.groupBy({}, () => {}), {});
+    notReached();
+} catch (e) {
+    shouldBe(String(e), "TypeError: Object.groupBy requires that the property of the first argument, items[Symbol.iterator] be a function");
+}
+
+try {
+    shouldBeObject(Object.groupBy(0, () => {}), {});
+    notReached();
+} catch (e) {
+    shouldBe(String(e), "TypeError: Object.groupBy requires that the property of the first argument, items[Symbol.iterator] be a function");
 }
 
 try {

--- a/Source/JavaScriptCore/builtins/ObjectConstructor.js
+++ b/Source/JavaScriptCore/builtins/ObjectConstructor.js
@@ -47,15 +47,27 @@ function groupBy(items, callback)
 {
     "use strict";
 
-    if (!@isObject(items))
-        @throwTypeError("Object.groupBy requires that the first argument must be an object");
+    if (@isUndefinedOrNull(items))
+        @throwTypeError("Object.groupBy requires that the first argument not be null or undefined");
 
     if (!@isCallable(callback))
         @throwTypeError("Object.groupBy requires that the second argument must be a function");
 
+    var iteratorMethod = items.@@iterator;
+    if (!@isCallable(iteratorMethod))
+        @throwTypeError("Object.groupBy requires that the property of the first argument, items[Symbol.iterator] be a function");
+
     var groups = @Object.@create(null);
     var k = 0;
-    for (var item of items) {
+
+    var iterator = iteratorMethod.@call(items);
+    // Since for-of loop once more looks up the @@iterator property of a given iterable,
+    // it could be observable if the user defines a getter for @@iterator.
+    // To avoid this situation, we define a wrapper object that @@iterator just returns a given iterator.
+    var wrapper = {
+        @@iterator: function () { return iterator; }
+    };
+    for (var item of wrapper) {
         var key = @toPropertyKey(callback.@call(@undefined, item, k));
         var group = groups[key];
         if (!group) {


### PR DESCRIPTION
#### 5209f3cb6908f44c6035c69004bd7c8dc1044f7f
<pre>
[JSC] `Object.groupBy` and `Map.groupBy` should allow iterable `items` that are not objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=271524">https://bugs.webkit.org/show_bug.cgi?id=271524</a>

Reviewed by Keith Miller.

Before this change, Object.groupBy and Map.groupBy would throw a TypeError if items were not objects.
Therefore, they would throw a TypeError even when passed primitive values with @@iterator, such as strings. This is incorrect behavior.
In this patch, following the specification[1], Object.groupBy and Map.groupBy are changed to throw a TypeError only when the first argument, items, is null or undefined.
Even after this change, according to the specification[2], they will throw a TypeError for primitives like Number or Symbol that do not have @@iterator.

[1]: <a href="https://tc39.es/ecma262/#sec-groupby">https://tc39.es/ecma262/#sec-groupby</a>
[2]: <a href="https://tc39.es/ecma262/#sec-getiterator">https://tc39.es/ecma262/#sec-getiterator</a>

* JSTests/stress/map-groupBy.js:
(catch):
* JSTests/stress/object-groupBy.js:
(catch):
* Source/JavaScriptCore/builtins/MapConstructor.js:
(wrapper.iterator):
(groupBy):
* Source/JavaScriptCore/builtins/ObjectConstructor.js:
(wrapper.iterator):
(groupBy):

Canonical link: <a href="https://commits.webkit.org/276736@main">https://commits.webkit.org/276736@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27516df734388cad76bf4055128e99ac21dfe67d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41172 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37043 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18141 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40036 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3211 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38385 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49528 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44630 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44076 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21452 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42864 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10122 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21807 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51791 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21134 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10548 "Passed tests") | 
<!--EWS-Status-Bubble-End-->