### PR TITLE
[Skia] Fix support for custom cursors with GTK

### DIFF
--- a/Source/WebCore/platform/graphics/gtk/GdkSkiaUtilities.cpp
+++ b/Source/WebCore/platform/graphics/gtk/GdkSkiaUtilities.cpp
@@ -73,6 +73,23 @@ RefPtr<cairo_surface_t> skiaImageToCairoSurface(SkImage& image)
 }
 #endif
 
+GRefPtr<GdkPixbuf> skiaImageToGdkPixbuf(SkImage& image)
+{
+#if USE(GTK4)
+    auto texture = skiaImageToGdkTexture(image);
+    if (!texture)
+        return { };
+
+    return adoptGRef(gdk_pixbuf_get_from_texture(texture.get()));
+#else
+    RefPtr surface = skiaImageToCairoSurface(image);
+    if (!surface)
+        return { };
+
+    return adoptGRef(gdk_pixbuf_get_from_surface(surface.get(), 0, 0, cairo_image_surface_get_width(surface.get()), cairo_image_surface_get_height(surface.get())));
+#endif
+}
+
 } // namespace WebCore
 
 #endif // #if USE(SKIA)

--- a/Source/WebCore/platform/graphics/gtk/GdkSkiaUtilities.h
+++ b/Source/WebCore/platform/graphics/gtk/GdkSkiaUtilities.h
@@ -27,12 +27,11 @@
 
 #if USE(SKIA)
 
+#include <gdk/gdk.h>
 #include <skia/core/SkImage.h>
 #include <wtf/glib/GRefPtr.h>
 
-#if USE(GTK4)
-#include <gdk/gdk.h>
-#else
+#if !USE(GTK4)
 #include <cairo.h>
 #endif
 
@@ -43,6 +42,8 @@ GRefPtr<GdkTexture> skiaImageToGdkTexture(SkImage&);
 #else
 RefPtr<cairo_surface_t> skiaImageToCairoSurface(SkImage&);
 #endif
+
+GRefPtr<GdkPixbuf> skiaImageToGdkPixbuf(SkImage&);
 
 }
 

--- a/Source/WebCore/platform/graphics/gtk/ImageAdapterGtk.cpp
+++ b/Source/WebCore/platform/graphics/gtk/ImageAdapterGtk.cpp
@@ -28,7 +28,7 @@
 
 #include "BitmapImage.h"
 #include "GdkCairoUtilities.h"
-#include "NotImplemented.h"
+#include "GdkSkiaUtilities.h"
 #include "SharedBuffer.h"
 #include <cairo.h>
 #include <gdk/gdk.h>
@@ -61,12 +61,11 @@ GRefPtr<GdkPixbuf> ImageAdapter::gdkPixbuf()
     if (!nativeImage)
         return nullptr;
 
-#if USE(CAIRO)
     auto& surface = nativeImage->platformImage();
+#if USE(CAIRO)
     return cairoSurfaceToGdkPixbuf(surface.get());
 #elif USE(SKIA)
-    notImplemented();
-    return nullptr;
+    return skiaImageToGdkPixbuf(*surface.get());
 #endif
 }
 
@@ -77,12 +76,11 @@ GRefPtr<GdkTexture> ImageAdapter::gdkTexture()
     if (!nativeImage)
         return nullptr;
 
-#if USE(CAIRO)
     auto& surface = nativeImage->platformImage();
+#if USE(CAIRO)
     return cairoSurfaceToGdkTexture(surface.get());
 #elif USE(SKIA)
-    notImplemented();
-    return nullptr;
+    return skiaImageToGdkTexture(*surface.get());
 #endif
 }
 #endif

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -63,8 +63,11 @@ GraphicsContextSkia::GraphicsContextSkia(SkCanvas& canvas, RenderingMode renderi
 {
 }
 
-GraphicsContextSkia::~GraphicsContextSkia() = default;
-
+GraphicsContextSkia::~GraphicsContextSkia()
+{
+    if (m_destroyNotify)
+        m_destroyNotify();
+}
 
 bool GraphicsContextSkia::hasPlatformContext() const
 {

--- a/Source/WebCore/platform/gtk/CursorGtk.cpp
+++ b/Source/WebCore/platform/gtk/CursorGtk.cpp
@@ -64,19 +64,12 @@ static GRefPtr<GdkCursor> createCustomCursor(Image* image, const IntPoint& hotSp
     IntPoint effectiveHotSpot = determineHotSpot(image, hotSpot);
     return adoptGRef(gdk_cursor_new_from_texture(texture.get(), effectiveHotSpot.x(), effectiveHotSpot.y(), fallbackCursor().get()));
 #else
-    auto nativeImage = image->nativeImageForCurrentFrame();
-    if (!nativeImage)
+    auto pixbuf = image->adapter().gdkPixbuf();
+    if (!pixbuf)
         return nullptr;
 
-#if USE(CAIRO)
-    auto& surface = nativeImage->platformImage();
     IntPoint effectiveHotSpot = determineHotSpot(image, hotSpot);
-    return adoptGRef(gdk_cursor_new_from_surface(gdk_display_get_default(), surface.get(), effectiveHotSpot.x(), effectiveHotSpot.y()));
-#elif USE(SKIA)
-    UNUSED_PARAM(hotSpot);
-    notImplemented();
-    return nullptr;
-#endif
+    return adoptGRef(gdk_cursor_new_from_pixbuf(gdk_display_get_default(), pixbuf.get(), effectiveHotSpot.x(), effectiveHotSpot.y()));
 #endif // USE(GTK4)
 }
 


### PR DESCRIPTION
#### ee489d263ec64f9183dba00baba1b9feb9ec01a5
<pre>
[Skia] Fix support for custom cursors with GTK
<a href="https://bugs.webkit.org/show_bug.cgi?id=271613">https://bugs.webkit.org/show_bug.cgi?id=271613</a>

Reviewed by Adrian Perez de Castro.

* Source/WebCore/platform/graphics/gtk/GdkSkiaUtilities.cpp:
(WebCore::skiaImageToGdkPixbuf):
* Source/WebCore/platform/graphics/gtk/GdkSkiaUtilities.h:
* Source/WebCore/platform/graphics/gtk/ImageAdapterGtk.cpp:
(WebCore::ImageAdapter::gdkPixbuf):
(WebCore::ImageAdapter::gdkTexture):
* Source/WebCore/platform/gtk/CursorGtk.cpp:
(WebCore::createCustomCursor):

destroy notify was not being called.

* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::~GraphicsContextSkia):

Canonical link: <a href="https://commits.webkit.org/276737@main">https://commits.webkit.org/276737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ab2574d06e4b832e7bd7fb18c6cec6976b669d7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48055 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41399 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37227 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40243 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3438 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49775 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44272 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21683 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43090 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10123 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22042 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->