### PR TITLE
[MSE] video's currentTime can be further than the gap's start time

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-noresumeafterpause-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-noresumeafterpause-expected.txt
@@ -12,7 +12,7 @@ EVENT(update)
 RUN(video.play())
 EVENT(playing)
 EVENT(waiting)
-EXPECTED (video.currentTime >= '1') OK
+EXPECTED (video.currentTime == '1') OK
 RUN(video.pause())
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(1)))
 EXPECTED (video.currentTime == currentTimeWhenStalling == 'true') OK

--- a/LayoutTests/media/media-source/media-managedmse-noresumeafterpause.html
+++ b/LayoutTests/media/media-source/media-managedmse-noresumeafterpause.html
@@ -40,10 +40,10 @@
         run('video.play()');
         await waitFor(video, 'playing');
         await Promise.all([
-        testExpectedEventuallySilent('video.currentTime', 1, '>='),
+            testExpectedEventuallySilent('video.currentTime', 1, '>='),
             waitFor(video, 'waiting')
         ]);
-        testExpected('video.currentTime', 1, '>=');
+        testExpected('video.currentTime', 1, '==');
         currentTimeWhenStalling = video.currentTime;
 
         // Issue pause() command while playback has stalled.

--- a/LayoutTests/media/media-source/media-managedmse-resume-after-remove-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-resume-after-remove-expected.txt
@@ -1,0 +1,27 @@
+
+RUN(video.src = URL.createObjectURL(source))
+RUN(video.muted = true)
+RUN(video.playsInline = true)
+RUN(video.disableRemotePlayback = true)
+RUN(video.autoplay = true)
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(video.currentTime = 1)
+EVENT(seeked)
+EXPECTED (video.currentTime >= '1.5') OK
+RUN(sourceBuffer.remove(1, sourceBuffer.buffered.end(0)))
+EVENT(waiting)
+EXPECTED (video.currentTime >= '1.5') OK
+EXPECTED (video.readyState == '1') OK
+EXPECTED (video.currentTime == currentTime == 'true') OK
+EXPECTED (video.readyState == '1') OK
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+EXPECTED (video.currentTime >= '2') OK
+EXPECTED (video.readyState >= video.HAVE_CURRENT_DATA == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-resume-after-remove.html
+++ b/LayoutTests/media/media-source/media-managedmse-resume-after-remove.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>mediasource-resume-after-stall</title>
+    <title>mediasource-resume-after-remove</title>
     <script src="media-source-loader.js"></script>
     <script src="../video-test.js"></script>
     <script>
     var loader;
     var source;
     var sourceBuffer;
+    var currentTime;
 
     function loaderPromise(loader) {
         return new Promise((resolve, reject) => {
@@ -19,7 +20,7 @@
     window.addEventListener('load', async event => {
         findMediaElement();
 
-        loader = new MediaSourceLoader('content/test-fragmented-manifest.json');
+        loader = new MediaSourceLoader('content/test-vp9-profile0-manifest.json');
         await loaderPromise(loader);
 
         source = new ManagedMediaSource();
@@ -36,32 +37,27 @@
         run('sourceBuffer.appendBuffer(loader.initSegment())');
         await waitFor(sourceBuffer, 'update');
 
-        // Buffer a minimum of 3s to reach canPlayThrough and therefore autoplay.
         run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
         await waitFor(sourceBuffer, 'update');
-        run('sourceBuffer.appendBuffer(loader.mediaSegment(1))');
-        await waitFor(sourceBuffer, 'update');
-        run('sourceBuffer.appendBuffer(loader.mediaSegment(2))');
-        await waitFor(sourceBuffer, 'update');
-        testExpected('video.buffered.length', 1);
-        testExpected('video.buffered.end(0)', 3);
         await playingPromise;
+        run('video.currentTime = 1');
+        await Promise.all([ waitFor(video, 'seeked'), testExpectedEventually("video.currentTime", 1.5, ">=") ]);
 
-        await waitFor(video, 'waiting');
-        testExpected('video.currentTime', video.buffered.end(0));
+        run('sourceBuffer.remove(1, sourceBuffer.buffered.end(0))');
+        await Promise.all([ waitFor(video, 'waiting'), waitFor(sourceBuffer, 'update', true)]);
+        testExpected('video.currentTime', 1.5, ">=");
+        currentTime = video.currentTime;
+        testExpected('video.readyState', video.HAVE_METADATA);
 
-        sourceBuffer.timestampOffset = -0.5;
+        // make sure currentTime didn't progress.
+        await sleepFor(500);
+        testExpected('video.currentTime == currentTime',true);
+        testExpected('video.readyState', video.HAVE_METADATA);
 
-        // Again, buffer a minimum of 3s, see reasons above.
-        run('sourceBuffer.appendBuffer(loader.mediaSegment(3))');
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
         await waitFor(sourceBuffer, 'update');
-        run('sourceBuffer.appendBuffer(loader.mediaSegment(4))');
-        await waitFor(sourceBuffer, 'update');
-        run('sourceBuffer.appendBuffer(loader.mediaSegment(5))');
-        await waitFor(sourceBuffer, 'update');
-
-        // Marching beyond 3s (range buffered before the stall) is enough to prove that playback has continued.
-        await testExpectedEventually("video.currentTime", 3.5, ">=");
+        await testExpectedEventually("video.currentTime", 2, ">=");
+        testExpected('video.readyState >= video.HAVE_CURRENT_DATA', true);
 
         endTest();
     });

--- a/LayoutTests/media/media-source/media-managedmse-stall-endofstream-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-stall-endofstream-expected.txt
@@ -3,27 +3,25 @@ RUN(video.src = URL.createObjectURL(source))
 RUN(video.muted = true)
 RUN(video.playsInline = true)
 RUN(video.disableRemotePlayback = true)
-RUN(video.autoplay = true)
 EVENT(sourceopen)
 RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
 RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(loadedmetadata)
 EVENT(update)
+RUN(video.play())
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
 EVENT(update)
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(1)))
 EVENT(update)
-RUN(sourceBuffer.appendBuffer(loader.mediaSegment(2)))
-EVENT(update)
 EXPECTED (video.buffered.length == '1') OK
-EXPECTED (video.buffered.end(0) == '3') OK
+EXPECTED (video.buffered.end(0) == '2') OK
 EVENT(waiting)
-EXPECTED (video.currentTime == '3') OK
-RUN(sourceBuffer.appendBuffer(loader.mediaSegment(3)))
-EVENT(update)
-RUN(sourceBuffer.appendBuffer(loader.mediaSegment(4)))
-EVENT(update)
-RUN(sourceBuffer.appendBuffer(loader.mediaSegment(5)))
-EVENT(update)
-EXPECTED (video.currentTime >= '3.5') OK
+EXPECTED (video.currentTime == video.buffered.end(0) == 'true') OK
+RUN(source.endOfStream())
+EVENT(sourceended)
+EVENT(ended)
+EXPECTED (video.buffered.end(0) > endBuffered == 'true') OK
+EXPECTED (video.buffered.end(0) == video.duration == 'true') OK
+EXPECTED (video.currentTime == video.buffered.end(0) == 'true') OK
 END OF TEST
 

--- a/LayoutTests/media/media-source/media-managedmse-stall-endofstream.html
+++ b/LayoutTests/media/media-source/media-managedmse-stall-endofstream.html
@@ -8,6 +8,7 @@
     var loader;
     var source;
     var sourceBuffer;
+    var endBuffered;
 
     function loaderPromise(loader) {
         return new Promise((resolve, reject) => {
@@ -27,42 +28,33 @@
         run('video.muted = true');
         run('video.playsInline = true');
         run('video.disableRemotePlayback = true');
-        run('video.autoplay = true');
         await waitFor(source, 'sourceopen');
         waitFor(video, 'error').then(failTest);
         const playingPromise = waitFor(video, 'playing', true);
 
         run('sourceBuffer = source.addSourceBuffer(loader.type())');
         run('sourceBuffer.appendBuffer(loader.initSegment())');
-        await waitFor(sourceBuffer, 'update');
+        await Promise.all([ waitFor(video, 'loadedmetadata'), waitFor(sourceBuffer, 'update') ]);
+        run('video.play()');
 
-        // Buffer a minimum of 3s to reach canPlayThrough and therefore autoplay.
         run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
         await waitFor(sourceBuffer, 'update');
         run('sourceBuffer.appendBuffer(loader.mediaSegment(1))');
         await waitFor(sourceBuffer, 'update');
-        run('sourceBuffer.appendBuffer(loader.mediaSegment(2))');
-        await waitFor(sourceBuffer, 'update');
         testExpected('video.buffered.length', 1);
-        testExpected('video.buffered.end(0)', 3);
+        testExpected('video.buffered.end(0)', 2);
         await playingPromise;
-
-        await waitFor(video, 'waiting');
-        testExpected('video.currentTime', video.buffered.end(0));
-
-        sourceBuffer.timestampOffset = -0.5;
-
-        // Again, buffer a minimum of 3s, see reasons above.
-        run('sourceBuffer.appendBuffer(loader.mediaSegment(3))');
-        await waitFor(sourceBuffer, 'update');
-        run('sourceBuffer.appendBuffer(loader.mediaSegment(4))');
-        await waitFor(sourceBuffer, 'update');
-        run('sourceBuffer.appendBuffer(loader.mediaSegment(5))');
-        await waitFor(sourceBuffer, 'update');
-
-        // Marching beyond 3s (range buffered before the stall) is enough to prove that playback has continued.
-        await testExpectedEventually("video.currentTime", 3.5, ">=");
-
+        await Promise.all([ waitFor(video, 'waiting') ]);
+        testExpected('video.currentTime == video.buffered.end(0)', true);
+        const endedPromise = waitFor(video, 'ended');
+        endBuffered = video.buffered.end(0);
+        run('source.endOfStream()');
+        await Promise.all([ waitFor(source, 'sourceended'), endedPromise ]);
+        // Following call to endOfStream() buffered range was extended to the last
+        // known sample and playback resumed to the end.
+        testExpected('video.buffered.end(0) > endBuffered', true);
+        testExpected('video.buffered.end(0) == video.duration', true);
+        testExpected('video.currentTime == video.buffered.end(0)', true);
         endTest();
     });
     </script>

--- a/LayoutTests/media/media-source/media-source-fudge-factor-expected.txt
+++ b/LayoutTests/media/media-source/media-source-fudge-factor-expected.txt
@@ -3,12 +3,14 @@ RUN(video.src = URL.createObjectURL(source))
 EVENT(loadedmetadata)
 EVENT(update)
 Samples with presentation times after currentTime should not cause loadedData.
+EVENT(update)
 EXPECTED (video.readyState == '1') OK
 Samples with presentation times very close to currentTime should cause loadedData.
 EVENT(loadeddata)
 EVENT(update)
 EXPECTED (video.readyState == '2') OK
 Samples with presentation end times very close to currentTime should not cause canPlay.
+EVENT(update)
 EXPECTED (video.readyState == '2') OK
 Continuous samples with presentation end times after currentTime should cause canPlay.
 EVENT(canplay)

--- a/LayoutTests/media/media-source/media-source-fudge-factor.html
+++ b/LayoutTests/media/media-source/media-source-fudge-factor.html
@@ -8,10 +8,6 @@
     var source;
     var sourceBuffer;
 
-    var requestLength = 200000;
-    var nextRequest = 0;
-    var totalLength = 100;
-
     if (window.internals)
         internals.initializeMockMediaSource();
 
@@ -32,10 +28,7 @@
 
         consoleWrite('Samples with presentation times after currentTime should not cause loadedData.');
         sourceBuffer.appendBuffer(makeASample(500, 500, 500, 1000, 1, SAMPLE_FLAG.SYNC));
-        setTimeout(notLoadedData, 50);
-    }
-
-    async function notLoadedData() {
+        await waitFor(sourceBuffer, 'update');
         testExpected('video.readyState', HTMLMediaElement.HAVE_METADATA);
 
         consoleWrite('Samples with presentation times very close to currentTime should cause loadedData.');
@@ -46,19 +39,15 @@
 
         consoleWrite('Samples with presentation end times very close to currentTime should not cause canPlay.');
         sourceBuffer.appendBuffer(makeASample(20, 20, 10, 1000, 1, SAMPLE_FLAG.SYNC));
-        setTimeout(notCanPlay, 50);
-    }
+        await waitFor(sourceBuffer, 'update');
 
-    function notCanPlay() {
         testExpected('video.readyState', HTMLMediaElement.HAVE_CURRENT_DATA);
 
         consoleWrite('Continuous samples with presentation end times after currentTime should cause canPlay.');
         sourceBuffer.appendBuffer(makeASample(30, 30, 470, 1000, 1, SAMPLE_FLAG.SYNC));
-        waitForEvent('canplay', canPlay);
-    }
-
-    function canPlay() {
+        await waitFor(video, 'canplay');
         testExpected('video.readyState', HTMLMediaElement.HAVE_FUTURE_DATA, '>=');
+
         endTest();
     }
     </script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1073,6 +1073,7 @@ webkit.org/b/213699 http/wpt/mediarecorder/MediaRecorder-AV-audio-video-dataavai
 webkit.org/b/218317 media/media-source/media-source-trackid-change.html [ Failure ]
 webkit.org/b/238201 media/media-source/media-mp4-hevc-bframes.html [ Failure ]
 webkit.org/b/270622 media/media-source/media-managedmse-noresumeafterpause.html [ Timeout ]
+webkit.org/b/271631 media/media-source/media-managedmse-stall-endofstream.html [ Failure ]
 
 # GStreamer (< 1.24) doesn't set the track's id to the container's value.
 webkit.org/b/265919 media/track/media-audio-track.html [ Failure ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1069,6 +1069,8 @@ media/media-source/media-source-webm-configuration-vp9-header-color.html [ Failu
 # Managed MediaSource isn't enabled on WK1
 media/media-source/media-managedmse-multipletracks-bufferedchange.html [ Skip ]
 media/media-source/media-managedmse-poster.html [ Skip ]
+media/media-source/media-managedmse-stall-endofstream.html [ Skip ]
+media/media-source/media-managedmse-resume-after-remove.html [ Skip ]
 
 # CRABS WebM isn't supported in WK1
 media/media-webm-opus-buffered.html [ Failure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2448,7 +2448,6 @@ webkit.org/b/157589 fast/text-autosizing/ios/text-autosizing-after-back.html [ P
 
 # webkit.org/b/261304 Batch mark expectations for flaky media tests
 [ Monterey+ Debug ] media/modern-media-controls/airplay-support/airplay-support-disable-event-listeners-with-hidden-controls.html [ Pass Failure ]
-[ Monterey+ ] media/media-source/media-source-fudge-factor.html [ Pass Failure Timeout ]
 [ Monterey+ Debug ] media/remove-from-document.html [ Pass Failure ]
 [ Monterey+ Debug ] media/media-event-listeners.html [ Pass Failure ]
 [ Monterey+ x86_64 ] media/video-object-fit.html [ Pass ImageOnlyFailure ]

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -127,6 +127,10 @@ void ManagedMediaSource::monitorSourceBuffers()
         return;
     }
 
+    if (currentTime >= limitAhead(*m_highThreshold)) {
+        setStreaming(false);
+        return;
+    }
     PlatformTimeRanges neededBufferedRange { currentTime, limitAhead(*m_highThreshold) };
     if (isBuffered(neededBufferedRange))
         setStreaming(false);

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -497,7 +497,7 @@ bool MediaSource::hasFutureTime()
     if (isClosed())
         return false;
 
-    return m_private->hasFutureTime(currentTime());
+    return m_private->hasFutureTime(currentTime(), m_private->timeIsProgressing() ? MediaTime::zeroTime() : MediaSourcePrivate::futureDataThreshold());
 }
 
 bool MediaSource::isBuffered(const PlatformTimeRanges& ranges) const

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -174,9 +174,6 @@ public:
 protected:
     explicit MediaSource(ScriptExecutionContext&);
 
-    bool hasBufferedTime(const MediaTime&);
-    bool hasCurrentTime();
-    bool hasFutureTime();
     bool isBuffered(const PlatformTimeRanges&) const;
 
     void scheduleEvent(const AtomString& eventName);
@@ -218,6 +215,10 @@ private:
 
     void regenerateActiveSourceBuffers();
     void updateBufferedIfNeeded(bool forced = false);
+
+    bool hasBufferedTime(const MediaTime&);
+    bool hasCurrentTime();
+    bool hasFutureTime();
 
     void completeSeek();
 

--- a/Source/WebCore/platform/graphics/MediaSourcePrivate.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivate.h
@@ -80,6 +80,7 @@ public:
     virtual void notifyActiveSourceBuffersChanged() = 0;
     virtual void durationChanged(const MediaTime&); // Base class method must be called in overrides. Must be thread-safe
     virtual void bufferedChanged(const PlatformTimeRanges&); // Base class method must be called in overrides. Must be thread-safe.
+    virtual void trackBufferedChanged(SourceBufferPrivate&, Vector<PlatformTimeRanges>&&);
 
     virtual MediaPlayer::ReadyState mediaPlayerReadyState() const = 0;
     virtual void setMediaPlayerReadyState(MediaPlayer::ReadyState) = 0;
@@ -105,7 +106,11 @@ public:
     PlatformTimeRanges buffered() const;
     PlatformTimeRanges seekable() const;
 
+    bool hasBufferedData() const;
     bool hasFutureTime(const MediaTime& currentTime) const;
+    bool timeIsProgressing() const;
+    static constexpr MediaTime futureDataThreshold() { return MediaTime { 1001, 24000 }; }
+    bool hasFutureTime(const MediaTime& currentTime, const MediaTime& threshold) const;
     bool hasAudio() const;
     bool hasVideo() const;
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -137,6 +137,9 @@ Ref<MediaPromise> SourceBufferPrivate::updateBuffered()
 {
     assertIsCurrent(m_dispatcher);
 
+    if (RefPtr mediaSource = m_mediaSource.get())
+        mediaSource->trackBufferedChanged(*this, trackBuffersRanges());
+
     if (RefPtr client = this->client())
         return client->sourceBufferPrivateBufferedChanged(trackBuffersRanges());
     return MediaPromise::createAndReject(PlatformMediaError::BufferRemoved);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -304,7 +304,7 @@ private:
     void setResourceOwner(const ProcessIdentity& resourceOwner) final { m_resourceOwner = resourceOwner; }
 
     void checkNewVideoFrameMetadata(CMTime);
-    MediaTime clampTimeToLastSeekTime(const MediaTime&) const;
+    MediaTime clampTimeToSensicalValue(const MediaTime&) const;
 
     bool shouldEnsureLayer() const;
     bool shouldEnsureVideoRenderer() const;
@@ -320,6 +320,7 @@ private:
 #endif
 
     friend class MediaSourcePrivateAVFObjC;
+    void bufferedChanged();
 
     std::optional<SeekTarget> m_pendingSeek;
 
@@ -340,7 +341,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     mutable MediaPlayer::CurrentTimeDidChangeCallback m_currentTimeDidChangeCallback;
     RetainPtr<id> m_timeChangedObserver;
     RetainPtr<id> m_timeJumpedObserver;
-    RetainPtr<id> m_durationObserver;
+    RetainPtr<id> m_gapObserver;
     RetainPtr<id> m_performTaskObserver;
     RetainPtr<CVPixelBufferRef> m_lastPixelBuffer;
     RefPtr<NativeImage> m_lastImage;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
@@ -113,6 +113,8 @@ public:
     void setResourceOwner(const ProcessIdentity& resourceOwner) { m_resourceOwner = resourceOwner; }
 
 private:
+    friend class SourceBufferPrivateAVFObjC;
+
     MediaSourcePrivateAVFObjC(MediaPlayerPrivateMediaSourceAVFObjC&, MediaSourcePrivateClient&);
     MediaPlayerPrivateMediaSourceAVFObjC* platformPlayer() const { return m_player.get(); }
 
@@ -124,7 +126,8 @@ private:
 
     void setSourceBufferWithSelectedVideo(SourceBufferPrivateAVFObjC*);
 
-    friend class SourceBufferPrivateAVFObjC;
+    void bufferedChanged(const PlatformTimeRanges&) final;
+    void trackBufferedChanged(SourceBufferPrivate&, Vector<PlatformTimeRanges>&&) final;
 
     WeakPtr<MediaPlayerPrivateMediaSourceAVFObjC> m_player;
     Deque<SourceBufferPrivateAVFObjC*> m_sourceBuffersNeedingSessions;
@@ -138,6 +141,7 @@ private:
     uint64_t m_nextSourceBufferID { 0 };
 #endif
 
+    HashMap<SourceBufferPrivate*, Vector<PlatformTimeRanges>> m_bufferedRanges;
     ProcessIdentity m_resourceOwner;
 };
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -142,9 +142,14 @@ MediaTime MediaPlayerPrivateRemote::TimeProgressEstimator::cachedTime() const
     return m_cachedMediaTime;
 }
 
+MediaTime MediaPlayerPrivateRemote::TimeProgressEstimator::cachedTimeWithLockHeld() const
+{
+    assertIsHeld(m_lock);
+    return m_cachedMediaTime;
+}
+
 bool MediaPlayerPrivateRemote::TimeProgressEstimator::timeIsProgressing() const
 {
-    Locker locker { m_lock };
     return m_timeIsProgressing;
 }
 
@@ -344,7 +349,44 @@ MediaTime MediaPlayerPrivateRemote::duration() const
 
 MediaTime MediaPlayerPrivateRemote::currentTime() const
 {
-    return m_currentTimeEstimator.currentTime();
+    Locker locker { m_currentTimeEstimator.lock() };
+    return currentTimeWithLockHeld();
+}
+
+MediaTime MediaPlayerPrivateRemote::currentTimeWithLockHeld() const
+{
+#if ENABLE(MEDIA_SOURCE)
+    if (m_mediaSourcePrivate && timeIsProgressing()) {
+        if (!m_mediaSourcePrivate->hasBufferedData())
+            return m_currentTimeEstimator.cachedTimeWithLockHeld();
+        MediaTime currentTime = m_currentTimeEstimator.currentTimeWithLockHeld();
+        if (currentTime >= duration())
+            return duration();
+        auto ranges = m_mediaSourcePrivate->buffered();
+        // Handle the most common case.
+        MediaTime startGap;
+        if (ranges.start(ranges.length() - 1) <= currentTime) {
+            if (currentTime <= ranges.maximumBufferedTime())
+                return currentTime; // We are in the buffered range.
+            startGap = ranges.maximumBufferedTime();
+        } else {
+            unsigned i = 0;
+            for (; i < ranges.length(); i++) {
+                if (ranges.start(i) <= currentTime && currentTime <= ranges.end(i))
+                    return currentTime; // We are in the buffered range.
+                // We allow currentTime to be in a buffered gap smaller than the fudge factor.
+                if (i < ranges.length() - 1 && (ranges.start(i + 1) - ranges.end(i)) <= m_mediaSourcePrivate->timeFudgeFactor() && ranges.start(i + 1) >= currentTime)
+                    return currentTime;
+                if (ranges.start(i) > currentTime)
+                    break;
+            }
+            startGap = ranges.end(i - 1);
+        }
+        // The GPU's time is the reference time, it can't go backward.
+        return std::max(startGap, m_currentTimeEstimator.cachedTimeWithLockHeld());
+    }
+#endif
+    return m_currentTimeEstimator.currentTimeWithLockHeld();
 }
 
 bool MediaPlayerPrivateRemote::timeIsProgressing() const
@@ -371,7 +413,7 @@ MediaTime MediaPlayerPrivateRemote::currentOrPendingSeekTime() const
     auto pendingSeekTime = MediaPlayerPrivateInterface::pendingSeekTime();
     if (pendingSeekTime.isValid())
         return pendingSeekTime;
-    return m_currentTimeEstimator.currentTimeWithLockHeld();
+    return currentTimeWithLockHeld();
 }
 
 void MediaPlayerPrivateRemote::seekToTarget(const WebCore::SeekTarget& target)
@@ -427,6 +469,8 @@ void MediaPlayerPrivateRemote::setReadyState(MediaPlayer::ReadyState readyState)
     ensureOnMainRunLoop([protectedThis = Ref { *this }, this, readyState] {
         if (std::exchange(m_readyState, readyState) == readyState)
             return;
+        if (readyState > MediaPlayer::ReadyState::HaveCurrentData && m_readyState == MediaPlayer::ReadyState::HaveCurrentData)
+            ALWAYS_LOG(LOGIDENTIFIER, "stall detected");
         if (auto player = m_player.get())
             player->readyStateChanged();
     });

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -220,15 +220,18 @@ private:
         void setRate(double);
         Lock& lock() const { return m_lock; };
         MediaTime currentTimeWithLockHeld() const;
+        MediaTime cachedTimeWithLockHeld() const;
     private:
         mutable Lock m_lock;
-        bool m_timeIsProgressing WTF_GUARDED_BY_LOCK(m_lock) { false };
+        std::atomic<bool> m_timeIsProgressing { false };
         MediaTime m_cachedMediaTime WTF_GUARDED_BY_LOCK(m_lock);
         MonotonicTime m_cachedMediaTimeQueryTime WTF_GUARDED_BY_LOCK(m_lock);
         double m_rate WTF_GUARDED_BY_LOCK(m_lock) { 1.0 };
         const MediaPlayerPrivateRemote& m_parent;
     };
     TimeProgressEstimator m_currentTimeEstimator;
+
+    MediaTime currentTimeWithLockHeld() const;
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }

--- a/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
@@ -212,6 +212,13 @@ MediaPlayer::ReadyState MediaSourcePrivateRemote::mediaPlayerReadyState() const
 void MediaSourcePrivateRemote::setMediaPlayerReadyState(MediaPlayer::ReadyState readyState)
 {
     // Call from MediaSource's dispatcher.
+    if (m_mediaPlayerReadyState > MediaPlayer::ReadyState::HaveCurrentData && readyState == MediaPlayer::ReadyState::HaveCurrentData) {
+        RefPtr player = m_mediaPlayerPrivate.get();
+        auto currentTime = player->currentTime();
+        auto buffered = this->buffered();
+        auto duration = this->duration();
+        ALWAYS_LOG(LOGIDENTIFIER, "stall detected at:", currentTime, " duration:", duration, " buffered:", buffered);
+    }
     m_mediaPlayerReadyState = readyState;
     ensureOnDispatcher([protectedThis = Ref { *this }, this, readyState] {
         auto gpuProcessConnection = m_gpuProcessConnection.get();


### PR DESCRIPTION
#### e77ffd167967c24232e8dcbac584ac1809524c90
<pre>
[MSE] video&apos;s currentTime can be further than the gap&apos;s start time
<a href="https://bugs.webkit.org/show_bug.cgi?id=270618">https://bugs.webkit.org/show_bug.cgi?id=270618</a>
<a href="https://rdar.apple.com/124186726">rdar://124186726</a>

Reviewed by Jer Noble.

The AVFObjC MSE player relies on using AVSampleBufferRenderSynchronizer
which provides the base routines to handle A/V sync, seeking and determining
the playback current time.
The code used notification listeners such as AVSampleBufferRenderSynchronizerRateDidChangeNotification
to determine when the actual playback rate changed to 0.
But this notification will be received only if playback was paused through
external means such as on iOS &quot;by a phone call or another non-mixable app starting playback&quot;.
But actually AVSampleBufferRenderSynchronizer never stops otherwise, even
when it has run out of data to decode and play such as when there&apos;s a gap
in the buffered range or even if the currentTime has gone past the media&apos;s duration.
The MediaSource&apos;s monitorSourceBuffer would monitor the current time and
the buffered range and would pause the media element if it detected that
we no longer had anything to play. However this occurs in the content process
while decoding and playback occurs in the GPU process. The inherent latency
between the two processes means that the CP would set the readyState to
be HaveCurrentData which would make the MediaPlayerPrivateMediaSourceAVFObjC
pause playback, but by the time this was received the AVSampleBufferRenderSynchronizer&apos;s
timebase/clock would have already progressed further than it should have.
Worse, in combination with the time clock used by the MediaPlayerPrivateRemote
you would end up with nonsensical currentTime, positioned in the middle
of a media data gap, causing the readyState to move back to HaveMetadataData.
Similarly, you could end up with currentTime being significantly past
the media&apos;s duration. (When using a debugger, and blocking the GPU process
I saw currentTime being further than 90s past where it should have been).

To fix this issue, we adds two steps:
1- In the MediaPlayerPrivateRemote, when using MSE we ensure that the currentTime never
goes past the start of a gap greater than 2/24th of a second (the SourceBuffer&apos;s timeFuzzingFactor),
nor past the media&apos;s duration.
2- Add stall detections in the MediaPlayerPrivateMediaSourceAVFObjC by
using time observers with AVSampleBufferRenderSynchronizer that will
immediately pause playback once we reached the start of a gap.

To reduce the latency between data being added to the source buffer and the
GPU&apos;s MediaPlayer being notified that new data got added, we make the SourceBufferPrivate
immediately notifies its MediaSourcePrivate&apos;s parent that the buffered data
has changed.

Add tests to ensure that we always stall and fire the waiting event where
a gap starts.

* LayoutTests/media/media-source/media-managedmse-noresumeafterpause-expected.txt:
* LayoutTests/media/media-source/media-managedmse-noresumeafterpause.html:
* LayoutTests/media/media-source/media-managedmse-resume-after-remove-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-resume-after-remove.html: Copied from LayoutTests/media/media-source/media-managedmse-resume-after-stall.html.
* LayoutTests/media/media-source/media-managedmse-resume-after-stall-expected.txt:
* LayoutTests/media/media-source/media-managedmse-resume-after-stall.html:
* LayoutTests/media/media-source/media-managedmse-stall-endofstream-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-stall-endofstream.html: Copied from LayoutTests/media/media-source/media-managedmse-resume-after-stall.html.
* LayoutTests/media/media-source/media-source-fudge-factor-expected.txt:
* LayoutTests/media/media-source/media-source-fudge-factor.html: The test relied on timers to check
value which would cause intermittent failures. Test had been marked as expected to fail
on mac. Re-write the test using events instead of timers.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::monitorSourceBuffers):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::hasFutureTime):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/platform/graphics/MediaSourcePrivate.cpp:
(WebCore::MediaSourcePrivate::hasFutureTime const):
(WebCore::MediaSourcePrivate::trackBufferedChanged):
(WebCore::MediaSourcePrivate::hasBufferedData const):
(WebCore::MediaSourcePrivate::timeIsProgressing const):
* Source/WebCore/platform/graphics/MediaSourcePrivate.h:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::updateBuffered):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::currentTime const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::clampTimeToSensicalValue const):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setCurrentTimeDidChangeCallback):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::durationChanged): we no longer needs to
specifically add an observer for when currentTime reaches the end of the media. This is taken
care by the more generic gap detection.
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::setReadyState):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::clampTimeToLastSeekTime const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm:
(WebCore::MediaSourcePrivateAVFObjC::removeSourceBuffer):
(WebCore::MediaSourcePrivateAVFObjC::player const):
(WebCore::MediaSourcePrivateAVFObjC::bufferedChanged):
(WebCore::MediaSourcePrivateAVFObjC::trackBufferedChanged):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::TimeProgressEstimator::cachedTimeWithLockHeld const):
(WebKit::MediaPlayerPrivateRemote::TimeProgressEstimator::timeIsProgressing const):
(WebKit::MediaPlayerPrivateRemote::currentTime const):
(WebKit::MediaPlayerPrivateRemote::currentTimeWithLockHeld const):
(WebKit::MediaPlayerPrivateRemote::currentOrPendingSeekTime const):
(WebKit::MediaPlayerPrivateRemote::setReadyState):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/MediaSourcePrivateRemote.cpp:
(WebKit::MediaSourcePrivateRemote::setMediaPlayerReadyState):

Canonical link: <a href="https://commits.webkit.org/276761@main">https://commits.webkit.org/276761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd616170fd68f165bc724a74e5f922608f2ac212

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45333 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47997 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41341 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47640 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37175 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18278 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40190 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3380 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41609 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49714 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44220 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39267 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43030 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10129 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21983 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21311 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->