### PR TITLE
Drop `StringView(const char*, unsigned)` constructor

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -112,7 +112,7 @@ void LocaleIDBuilder::overrideLanguageScriptRegion(StringView language, StringVi
 {
     unsigned length = strlen(m_buffer.data());
 
-    StringView localeIDView { m_buffer.data(), length };
+    StringView localeIDView { m_buffer.subspan(0, length) };
 
     auto endOfLanguageScriptRegionVariant = localeIDView.find(ULOC_KEYWORD_SEPARATOR);
     if (endOfLanguageScriptRegionVariant == notFound)

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -333,7 +333,7 @@ Vector<char, 32> localeIDBufferForLanguageTagWithNullTerminator(const CString& t
 
 Vector<char, 32> canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization(Vector<char, 32>&& buffer)
 {
-    StringView locale(buffer.data(), buffer.size());
+    StringView locale(buffer.span());
     ASSERT(locale.is8Bit());
     size_t extensionIndex = locale.find("-u-"_s);
     if (extensionIndex == notFound)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -71,7 +71,6 @@ public:
     StringView(std::span<const LChar>);
     StringView(std::span<const UChar>);
     StringView(std::span<const char>); // FIXME: Consider dropping this overload. Callers should pass LChars/UChars instead.
-    StringView(const char*, unsigned length); // FIXME: Drop once all call sites pass a span.
     StringView(const void*, unsigned length, bool is8bit);
     StringView(ASCIILiteral);
 
@@ -279,7 +278,7 @@ WTF_EXPORT_PRIVATE StringViewWithUnderlyingString normalizedNFC(StringView);
 WTF_EXPORT_PRIVATE String normalizedNFC(const String&);
 
 inline StringView nullStringView() { return { }; }
-inline StringView emptyStringView() { return StringView("", 0); }
+inline StringView emptyStringView() { return ""_span; }
 
 } // namespace WTF
 
@@ -415,11 +414,6 @@ inline StringView::StringView(const char* characters)
 inline StringView::StringView(std::span<const char> characters)
 {
     initialize(std::span { reinterpret_cast<const LChar*>(characters.data()), characters.size() });
-}
-
-inline StringView::StringView(const char* characters, unsigned length)
-{
-    initialize(std::span { reinterpret_cast<const LChar*>(characters), length });
 }
 
 inline StringView::StringView(const void* characters, unsigned length, bool is8bit)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -64,6 +64,7 @@ public:
     WTF_EXPORT_PRIVATE String(const LChar* characters, unsigned length);
     WTF_EXPORT_PRIVATE String(const char* characters, unsigned length);
     ALWAYS_INLINE String(std::span<const LChar> characters) : String(characters.data(), characters.size()) { }
+    ALWAYS_INLINE String(std::span<const char> characters) : String(characters.data(), characters.size()) { }
     ALWAYS_INLINE static String fromLatin1(const char* characters) { return String { characters }; }
 
     // Construct a string referencing an existing StringImpl.

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -266,13 +266,13 @@ void FTPDirectoryDocumentParser::parseAndAppendOneLine(const String& inputLine)
 
     String filename;
     if (result.type == FTPDirectoryEntry) {
-        filename = makeString(StringView { result.filename, result.filenameLength }, '/');
+        filename = makeString(result.filenameSpan(), '/');
 
         // We have no interest in linking to "current directory"
         if (filename == "./"_s)
             return;
     } else
-        filename = String(result.filename, result.filenameLength);
+        filename = String(result.filenameSpan());
 
     LOG(FTP, "Appending entry - %s, %s", filename.ascii().data(), result.fileSize.ascii().data());
 

--- a/Source/WebCore/loader/FTPDirectoryParser.h
+++ b/Source/WebCore/loader/FTPDirectoryParser.h
@@ -134,14 +134,17 @@ struct ListResult
         caseSensitive = false;
         memset(&modifiedTime, 0, sizeof(FTPTime));
     }
+
+    std::span<const char> filenameSpan() const { return { filename, filenameLength }; }
+    std::span<const char> linknameSpan() const { return { linkname, linknameLength }; }
     
     bool valid;
     FTPEntryType type;        
     
-    const char* filename;
+    const char* filename; // FIXME: Should be stored as a std::span.
     uint32_t filenameLength;
     
-    const char* linkname;
+    const char* linkname; // FIXME: Should be stored as a std::span.
     uint32_t linknameLength;
     
     String fileSize;      

--- a/Source/WebCore/platform/Decimal.cpp
+++ b/Source/WebCore/platform/Decimal.cpp
@@ -542,7 +542,7 @@ Decimal Decimal::fromDouble(double doubleValue)
     if (std::isfinite(doubleValue)) {
         NumberToStringBuffer buffer;
         auto* result = numberToString(doubleValue, buffer);
-        return fromString(StringView(result, strlen(result)));
+        return fromString(std::span { result, strlen(result) });
     }
 
     if (std::isinf(doubleValue))

--- a/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/PlatformRawAudioDataGStreamer.cpp
@@ -221,7 +221,7 @@ void PlatformRawAudioData::copyTo(std::span<uint8_t> destination, AudioSampleFor
 
     GUniquePtr<GstAudioInfo> sourceInfo(gst_audio_info_copy(self.info()));
     GUniquePtr<char> key(gst_info_strdup_printf("%" GST_PTR_FORMAT ";%" GST_PTR_FORMAT, gst_sample_get_caps(self.sample()), outputCaps.get()));
-    auto converter = getAudioConvertedForFormat(StringView { key.get(), static_cast<unsigned>(strlen(key.get())) }, *sourceInfo.get(), destinationInfo);
+    auto converter = getAudioConvertedForFormat(StringView { std::span { key.get(), strlen(key.get()) } }, *sourceInfo.get(), destinationInfo);
 
     auto inFrames = gst_buffer_get_size(gst_sample_get_buffer(self.sample())) / GST_AUDIO_INFO_BPF(sourceInfo.get());
     auto outFrames = gst_audio_converter_get_out_frames(converter, inFrames);

--- a/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
@@ -113,7 +113,7 @@ String AudioTrackPrivateWebM::codec() const
     if (!m_track.codec_id.is_present())
         return emptyString();
 
-    StringView codecID { m_track.codec_id.value().data(), (unsigned)m_track.codec_id.value().length() };
+    StringView codecID { std::span { m_track.codec_id.value() } };
 
     if (codecID == "A_VORBIS"_s)
         return "vorbis"_s;

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -473,7 +473,7 @@ private:
 
         if (!track.codec_id.is_present())
             return emptyString();
-        StringView codecID { track.codec_id.value().data(), (unsigned)track.codec_id.value().length() };
+        StringView codecID { std::span { track.codec_id.value() } };
         if (!codecID.startsWith("V_"_s) && !codecID.startsWith("A_"_s) && !codecID.startsWith("S_"_s))
             return emptyString();
 
@@ -862,7 +862,7 @@ Status WebMParser::OnTrackEntry(const ElementMetadata&, const TrackEntry& trackE
         }
     }
 
-    StringView codecString { trackEntry.codec_id.value().data(), (unsigned)trackEntry.codec_id.value().length() };
+    StringView codecString { std::span { trackEntry.codec_id.value() } };
     auto track = [&]() -> UniqueRef<TrackData> {
 #if ENABLE(VP9)
         if (codecString == "V_VP9"_s && isVP9DecoderAvailable())

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
@@ -103,7 +103,7 @@ String VideoTrackPrivateWebM::codec() const
     if (!m_track.codec_id.is_present())
         return emptyString();
 
-    StringView codecID { m_track.codec_id.value().data(), (unsigned)m_track.codec_id.value().length() };
+    StringView codecID { std::span { m_track.codec_id.value() } };
 
     if (codecID == "V_VP9"_s)
         return "vp09"_s;

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -405,7 +405,7 @@ bool TrackPrivateBaseGStreamer::updateTrackIDFromTags(const GRefPtr<GstTagList>&
     if (!gst_tag_list_get_string(tags.get(), "container-specific-track-id", &trackIDString.outPtr()))
         return false;
 
-    auto trackID = WTF::parseInteger<TrackID>(StringView { trackIDString.get(), static_cast<unsigned>(strlen(trackIDString.get())) });
+    auto trackID = WTF::parseInteger<TrackID>(StringView { std::span { trackIDString.get(), strlen(trackIDString.get()) } });
     if (trackID && *trackID != m_trackID.value_or(0)) {
         m_trackID = *trackID;
         m_stringId = AtomString::number(static_cast<unsigned long long>(*m_trackID));

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -68,7 +68,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
     const char* quirksList = g_getenv("WEBKIT_GST_QUIRKS");
     GST_DEBUG("Attempting to parse requested quirks: %s", GST_STR_NULL(quirksList));
     if (quirksList) {
-        StringView quirks { quirksList, static_cast<unsigned>(strlen(quirksList)) };
+        StringView quirks { std::span { quirksList, strlen(quirksList) } };
         if (WTF::equalLettersIgnoringASCIICase(quirks, "help"_s)) {
             WTFLogAlways("Supported quirks for WEBKIT_GST_QUIRKS are: amlogic, broadcom, bcmnexus, realtek, westeros");
             return;
@@ -104,7 +104,7 @@ GStreamerQuirksManager::GStreamerQuirksManager(bool isForTesting, bool loadQuirk
     if (!holePunchQuirk)
         return;
 
-    StringView identifier { holePunchQuirk, static_cast<unsigned>(strlen(holePunchQuirk)) };
+    StringView identifier { std::span { holePunchQuirk, strlen(holePunchQuirk) } };
     if (WTF::equalLettersIgnoringASCIICase(identifier, "help"_s)) {
         WTFLogAlways("Supported quirks for WEBKIT_GST_HOLE_PUNCH_QUIRK are: fake, westeros, bcmnexus");
         return;

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -899,7 +899,7 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                         supports12BitsBigEndian = true;
                 }
 
-                StringView profile { profileString, static_cast<unsigned>(strlen(profileString)) };
+                StringView profile { std::span { profileString, strlen(profileString) } };
                 auto is12Bits = profile.findIgnoringASCIICase("-12"_s) != notFound;
                 auto is10Bits = profile.findIgnoringASCIICase("-10"_s) != notFound;
                 auto isY444 = profile.findIgnoringASCIICase("-444"_s) != notFound;

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp
@@ -442,7 +442,7 @@ static inline RTCRtpCapabilities toRTCRtpCapabilities(const webrtc::RtpCapabilit
         StringBuilder sdpFmtpLineBuilder;
         bool hasParameter = false;
         for (auto& parameter : codec.parameters) {
-            sdpFmtpLineBuilder.append(hasParameter ? ";" : "", StringView(parameter.first.data(), parameter.first.length()), '=', StringView(parameter.second.data(), parameter.second.length()));
+            sdpFmtpLineBuilder.append(hasParameter ? ";" : "", StringView(std::span(parameter.first)), '=', StringView(std::span(parameter.second)));
             hasParameter = true;
         }
         String sdpFmtpLine;

--- a/Source/WebCore/platform/network/HTTPHeaderMap.cpp
+++ b/Source/WebCore/platform/network/HTTPHeaderMap.cpp
@@ -89,7 +89,7 @@ void HTTPHeaderMap::set(CFStringRef name, const String& value)
     if (auto* nameCharacters = CFStringGetCStringPtr(name, kCFStringEncodingASCII)) {
         unsigned length = CFStringGetLength(name);
         HTTPHeaderName headerName;
-        if (findHTTPHeaderName(StringView(nameCharacters, length), headerName))
+        if (findHTTPHeaderName(StringView(std::span { nameCharacters, length }), headerName))
             set(headerName, value);
         else
             setUncommonHeader(String(nameCharacters, length), value);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -2044,7 +2044,7 @@ PrivateTokenTestSetupState setupWebViewForPrivateTokenTests(bool& didDecideServi
 "});"_s;
 
     auto headerFromRequest = [](const Vector<char>& request, const ASCIILiteral& headerPrefix) {
-        StringView requestView(request.data(), request.size());
+        StringView requestView(request.span());
         auto headerStart = requestView.find(headerPrefix);
         const auto headerLen = strlen(headerPrefix);
         if (headerStart == notFound)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -1981,7 +1981,7 @@ TEST(ResourceLoadStatistics, StorageAccessGrantMultipleSubFrameDomains)
     using namespace TestWebKitAPI;
 
     auto headerFromRequest = [](const Vector<char>& request, const ASCIILiteral& headerPrefix) {
-        StringView requestView(request.data(), request.size());
+        StringView requestView(request.span());
         auto headerStart = requestView.find(headerPrefix);
         const auto headerLen = strlen(headerPrefix);
         if (headerStart == notFound)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm
@@ -1059,7 +1059,7 @@ TEST(WKHTTPCookieStore, SameSiteWithPatternMatch)
                 co_await connection.awaitableSend(HTTPResponse({ { { "Set-Cookie"_s, "exists=1;samesite=strict"_s } }, "<body></body>"_s }).serialize());
                 continue;
             }
-            StringView requestView(request.data(), request.size());
+            StringView requestView(request.span());
             if (path == "http://site1.example/get-cookie"_s)
                 EXPECT_EQ(requestView.find("Cookie: exists=1"_s), notFound);
             else if (path == "http://site2.example/get-cookie"_s)


### PR DESCRIPTION
#### e7c31722d07633238c955129129f97d0739ae05b
<pre>
Drop `StringView(const char*, unsigned)` constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=271619">https://bugs.webkit.org/show_bug.cgi?id=271619</a>

Reviewed by Darin Adler and Brent Fulgham.

Drop `StringView(const char*, unsigned)` constructor, in favor of the one
taking in a span.

* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::LocaleIDBuilder::overrideLanguageScriptRegion):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization):
* Source/WTF/wtf/text/StringView.h:
(WTF::emptyStringView):
* Source/WebCore/html/FTPDirectoryDocument.cpp:
(WebCore::FTPDirectoryDocumentParser::parseAndAppendOneLine):
* Source/WebCore/platform/Decimal.cpp:
(WebCore::Decimal::fromDouble):
* Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp:
(WebCore::AudioTrackPrivateWebM::codec const):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::OnTrackEntry):
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp:
(WebCore::VideoTrackPrivateWebM::codec const):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.cpp:
(WebCore::toRTCRtpCapabilities):
* Source/WebCore/platform/network/HTTPHeaderMap.cpp:
(WebCore::HTTPHeaderMap::set):

Canonical link: <a href="https://commits.webkit.org/276664@main">https://commits.webkit.org/276664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7194ecd798a070f4608d15ce0251242723326b71

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47935 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41280 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47579 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37130 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18230 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40131 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3319 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38491 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41542 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40452 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49643 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44740 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44163 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21560 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42967 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51900 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6302 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21248 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10584 "Passed tests") | 
<!--EWS-Status-Bubble-End-->