### PR TITLE
[JSC] Update RegExp tracing code

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4215,6 +4215,14 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
                 fprintf(stderr, "could not save profiler output.\n");
         }
 
+
+#if ENABLE(REGEXP_TRACING)
+        {
+            JSLockHolder locker(vm);
+            vm.dumpRegExpTrace();
+        }
+#endif
+
 #if ENABLE(JIT)
         {
             JSLockHolder locker(vm);

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -142,6 +142,8 @@ public:
     void deleteCode();
 
 #if ENABLE(REGEXP_TRACING)
+    constexpr static unsigned SameLineFormatedRegExpnWidth = 74;
+    static void printTraceHeader();
     void printTraceData();
 #endif
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1176,15 +1176,15 @@ void VM::addRegExpToTrace(RegExp* regExp)
 
 void VM::dumpRegExpTrace()
 {
+    if (m_rtTraceList.size() <= 1)
+        return;
+
     // The first RegExp object is ignored. It is created by the RegExpPrototype ctor and not used.
     RTTraceList::iterator iter = ++m_rtTraceList.begin();
     
     if (iter != m_rtTraceList.end()) {
-        dataLogF("\nRegExp Tracing\n");
-        dataLogF("Regular Expression                              8 Bit          16 Bit        match()    Matches    Average\n");
-        dataLogF(" <Match only / Match>                         JIT Addr      JIT Address       calls      found   String len\n");
-        dataLogF("----------------------------------------+----------------+----------------+----------+----------+-----------\n");
-    
+        RegExp::printTraceHeader();
+
         unsigned reCount = 0;
     
         for (; iter != m_rtTraceList.end(); ++iter, ++reCount) {

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -860,7 +860,8 @@ public:
     JS_EXPORT_PRIVATE void invalidateStructureChainIntegrity(StructureChainIntegrityEvent);
 
 #if ENABLE(REGEXP_TRACING)
-    ListHashSet<RegExp*> m_rtTraceList;
+    using RTTraceList = ListHashSet<RegExp*>;
+    RTTraceList m_rtTraceList;
     void addRegExpToTrace(RegExp*);
     JS_EXPORT_PRIVATE void dumpRegExpTrace();
 #endif


### PR DESCRIPTION
#### 6299ee9f0fddf6a9e9d12b0b59ee9ba5abb531f3
<pre>
[JSC] Update RegExp tracing code
<a href="https://bugs.webkit.org/show_bug.cgi?id=271625">https://bugs.webkit.org/show_bug.cgi?id=271625</a>
<a href="https://rdar.apple.com/125334427">rdar://125334427</a>

Reviewed by Yusuke Suzuki.

Moved the tracing output header generation from VM.cpp to RegExp.cpp to is same place as where the code to format the trace entries.
Parameterized the formatting code to use a width value.  Fixed the dumping of trace data to work in the jsc shell when
processing modules.  Eliminated use of snprintf() in favor of makeString() calls.  Some other minor changes made as well.

This code is build time enabled through ENABLE_REGEXP_TRACING, which is by default turned off.

* Source/JavaScriptCore/jsc.cpp:
(runJSC):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::printTraceHeader):
(JSC::RegExp::printTraceData):
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::dumpRegExpTrace):
* Source/JavaScriptCore/runtime/VM.h:

Canonical link: <a href="https://commits.webkit.org/276730@main">https://commits.webkit.org/276730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f285a0c53b440283bcf00b71ad97146d1dcd0723

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48162 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41484 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37288 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46054 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18412 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19084 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40328 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3522 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38704 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/simple-inline-stacktrace-with-catch.js.wasm-eager (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41781 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49871 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44944 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44346 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21769 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43175 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10117 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22128 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52103 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21456 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10642 "Passed tests") | 
<!--EWS-Status-Bubble-End-->