### PR TITLE
shorthand value for CSS gap is not kept as-is in serialized and computed values.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/gaps/gap-animation-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/gaps/gap-animation-001-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL gap is interpolable assert_equals: expected "50px" but got "50px 50px"
+PASS gap is interpolable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/gaps/gap-animation-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/gaps/gap-animation-002-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL gap: normal is not interpolable assert_equals: expected "100px" but got "100px 100px"
+PASS gap: normal is not interpolable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/gaps/gap-animation-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/gaps/gap-animation-003-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Default gap is not interpolable assert_equals: expected "100px" but got "100px 100px"
+PASS Default gap is not interpolable
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/gaps/gap-parsing-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/gaps/gap-parsing-002-expected.txt
@@ -7,12 +7,12 @@ PASS e.style['column-gap'] = "normal" should set the property value
 PASS e.style['column-gap'] = "10px" should set the property value
 PASS e.style['row-gap'] = "normal" should set the property value
 PASS e.style['row-gap'] = "10px" should set the property value
-FAIL 'row-gap: normal; column-gap: normal;' is serialized to 'gap: normal;' assert_equals: expected "gap: normal;" but got "row-gap: normal; column-gap: normal;"
+PASS 'row-gap: normal; column-gap: normal;' is serialized to 'gap: normal;'
 PASS getPropertyValue for 'row-gap: normal; column-gap: normal;' returns 'normal'
-FAIL 'row-gap: 10px; column-gap: 10px;' is serialized to 'gap: 10px;' assert_equals: expected "gap: 10px;" but got "row-gap: 10px; column-gap: 10px;"
+PASS 'row-gap: 10px; column-gap: 10px;' is serialized to 'gap: 10px;'
 PASS getPropertyValue for 'row-gap: 10px; column-gap: 10px;' returns '10px'
-FAIL 'row-gap: 10px; column-gap: normal;' is serialized to 'gap: 10px normal;' assert_equals: expected "gap: 10px normal;" but got "row-gap: 10px; column-gap: normal;"
+PASS 'row-gap: 10px; column-gap: normal;' is serialized to 'gap: 10px normal;'
 PASS getPropertyValue for 'row-gap: 10px; column-gap: normal;' returns '10px normal'
-FAIL 'column-gap: normal; row-gap: 10px;' is serialized to 'gap: 10px normal;' assert_equals: expected "gap: 10px normal;" but got "column-gap: normal; row-gap: 10px;"
+PASS 'column-gap: normal; row-gap: 10px;' is serialized to 'gap: 10px normal;'
 PASS getPropertyValue for 'column-gap: normal; row-gap: 10px;' returns '10px normal'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/parsing/gap-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/parsing/gap-computed-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL Property gap value 'normal' assert_equals: expected "normal" but got "normal normal"
-FAIL Property gap value '10px' assert_equals: expected "10px" but got "10px 10px"
-FAIL Property gap value '20%' assert_equals: expected "20%" but got "20% 20%"
-FAIL Property gap value 'calc(20% + 10px)' assert_equals: expected "calc(20% + 10px)" but got "calc(20% + 10px) calc(20% + 10px)"
-FAIL Property gap value 'calc(-0.5em + 10px)' assert_equals: expected "0px" but got "0px 0px"
-FAIL Property gap value 'calc(0.5em + 10px)' assert_equals: expected "30px" but got "30px 30px"
+PASS Property gap value 'normal'
+PASS Property gap value '10px'
+PASS Property gap value '20%'
+PASS Property gap value 'calc(20% + 10px)'
+PASS Property gap value 'calc(-0.5em + 10px)'
+PASS Property gap value 'calc(0.5em + 10px)'
 PASS Property gap value 'normal 10px'
 PASS Property gap value '10px 20%'
 PASS Property gap value '20% calc(20% + 10px)'

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.cpp
@@ -130,6 +130,7 @@ String CSSComputedStyleDeclaration::getPropertyValue(CSSPropertyID propertyID) c
 
     auto canUseShorthandSerializerForPropertyValue = [&]() {
         switch (propertyID) {
+        case CSSPropertyGap:
         case CSSPropertyGridArea:
         case CSSPropertyGridColumn:
         case CSSPropertyGridRow:

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -250,7 +250,6 @@ static constexpr bool canUseShorthandForLonghand(CSSPropertyID shorthandID, CSSP
     case CSSPropertyColumns:
     case CSSPropertyContainer:
     case CSSPropertyFontSynthesis:
-    case CSSPropertyGap:
     case CSSPropertyGridArea:
     case CSSPropertyGridColumn:
     case CSSPropertyGridRow:


### PR DESCRIPTION
#### ab28ade5ffd5e80451a6a8fc8b0cff43c722ad64
<pre>
shorthand value for CSS gap is not kept as-is in serialized and computed values.
<a href="https://bugs.webkit.org/show_bug.cgi?id=271627">https://bugs.webkit.org/show_bug.cgi?id=271627</a>
<a href="https://rdar.apple.com/125335787">rdar://125335787</a>

Reviewed by Tim Nguyen.

When the shorthand CSS property gap is used, the cssText and computed
declaration can stay in the short form when the values for column and
row are identical.

* LayoutTests/imported/w3c/web-platform-tests/css/css-align/gaps/gap-animation-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/gaps/gap-animation-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/gaps/gap-animation-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/gaps/gap-parsing-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/parsing/gap-computed-expected.txt:
* Source/WebCore/css/CSSComputedStyleDeclaration.cpp:
(WebCore::CSSComputedStyleDeclaration::getPropertyValue const):
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::canUseShorthandForLonghand):

Canonical link: <a href="https://commits.webkit.org/276794@main">https://commits.webkit.org/276794@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d47112f46daed78ea2383a518d022ff437f59fa4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48353 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41719 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37406 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18555 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19294 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40493 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3728 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50102 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44510 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21978 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43354 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10151 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21667 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->