### PR TITLE
[Legacy line layout removal] Remove incremental layout support

### DIFF
--- a/Source/WebCore/rendering/LegacyInlineBox.h
+++ b/Source/WebCore/rendering/LegacyInlineBox.h
@@ -271,7 +271,6 @@ private:
             , m_extracted(extracted)
             , m_hasVirtualLogicalHeight(false)
             , m_isHorizontal(isHorizontal)
-            , m_endsWithBreak(false)
             , m_knownToHaveNoOverflow(true)
             , m_determinedIfNextOnLineExists(false)
             , m_nextOnLineExists(false)

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -145,8 +145,6 @@ void LegacyInlineFlowBox::removeChild(LegacyInlineBox* child)
     if (!isDirty())
         dirtyLineBoxes();
 
-    root().childRemoved(child);
-
     if (child == m_firstChild)
         m_firstChild = child->nextOnLine();
     if (child == m_lastChild)

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -171,12 +171,12 @@ LegacyInlineBox* LegacyLineLayout::createInlineBoxForRenderer(RenderObject* rend
     return nullptr;
 }
 
-static inline void dirtyLineBoxesForRenderer(RenderObject& renderer, bool fullLayout)
+static inline void dirtyLineBoxesForRenderer(RenderObject& renderer)
 {
     if (CheckedPtr renderText = dynamicDowncast<RenderText>(renderer))
-        renderText->dirtyLineBoxes(fullLayout);
+        renderText->dirtyLineBoxes(true);
     else if (CheckedPtr renderInline = dynamicDowncast<RenderInline>(renderer))
-        renderInline->dirtyLineBoxes(fullLayout);
+        renderInline->dirtyLineBoxes(true);
 }
 
 static bool parentIsConstructedOrHaveNext(LegacyInlineFlowBox* parentBox)
@@ -434,81 +434,6 @@ void LegacyLineLayout::removeEmptyTextBoxesAndUpdateVisualReordering(LegacyRootI
     }
 }
 
-static inline bool isCollapsibleSpace(UChar character, const RenderText& renderer)
-{
-    if (character == ' ' || character == '\t' || character == softHyphen)
-        return true;
-    if (character == '\n')
-        return !renderer.style().preserveNewline();
-    if (character == noBreakSpace)
-        return renderer.style().nbspMode() == NBSPMode::Space;
-    return false;
-}
-
-template <typename CharacterType>
-static inline unsigned findFirstTrailingSpace(const RenderText& lastText, const CharacterType* characters, unsigned start, unsigned stop)
-{
-    unsigned firstSpace = stop;
-    while (firstSpace > start) {
-        UChar current = characters[firstSpace - 1];
-        if (!isCollapsibleSpace(current, lastText))
-            break;
-        firstSpace--;
-    }
-
-    return firstSpace;
-}
-
-inline BidiRun* LegacyLineLayout::handleTrailingSpaces(BidiRunList<BidiRun>& bidiRuns, BidiContext* currentContext)
-{
-    if (!bidiRuns.runCount()
-        || !bidiRuns.logicallyLastRun()->renderer().style().breakOnlyAfterWhiteSpace()
-        || !bidiRuns.logicallyLastRun()->renderer().style().autoWrap())
-        return nullptr;
-
-    BidiRun* trailingSpaceRun = bidiRuns.logicallyLastRun();
-    CheckedPtr lastText = dynamicDowncast<RenderText>(trailingSpaceRun->renderer());
-    if (!lastText)
-        return nullptr;
-
-    unsigned firstSpace;
-    if (lastText->text().is8Bit())
-        firstSpace = findFirstTrailingSpace(*lastText, lastText->text().characters8(), trailingSpaceRun->start(), trailingSpaceRun->stop());
-    else
-        firstSpace = findFirstTrailingSpace(*lastText, lastText->text().characters16(), trailingSpaceRun->start(), trailingSpaceRun->stop());
-
-    if (firstSpace == trailingSpaceRun->stop())
-        return nullptr;
-
-    TextDirection direction = style().direction();
-    bool shouldReorder = trailingSpaceRun != (direction == TextDirection::LTR ? bidiRuns.lastRun() : bidiRuns.firstRun());
-    if (firstSpace != trailingSpaceRun->start()) {
-        BidiContext* baseContext = currentContext;
-        while (BidiContext* parent = baseContext->parent())
-            baseContext = parent;
-
-        std::unique_ptr<BidiRun> newTrailingRun = makeUnique<BidiRun>(firstSpace, trailingSpaceRun->m_stop, trailingSpaceRun->renderer(), baseContext, U_OTHER_NEUTRAL);
-        trailingSpaceRun->m_stop = firstSpace;
-        trailingSpaceRun = newTrailingRun.get();
-        if (direction == TextDirection::LTR)
-            bidiRuns.appendRun(WTFMove(newTrailingRun));
-        else
-            bidiRuns.prependRun(WTFMove(newTrailingRun));
-        return trailingSpaceRun;
-    }
-    if (!shouldReorder)
-        return trailingSpaceRun;
-
-    if (direction == TextDirection::LTR) {
-        bidiRuns.moveRunToEnd(trailingSpaceRun);
-        trailingSpaceRun->m_level = 0;
-    } else {
-        bidiRuns.moveRunToBeginning(trailingSpaceRun);
-        trailingSpaceRun->m_level = 1;
-    }
-    return trailingSpaceRun;
-}
-
 static inline void notifyResolverToResumeInIsolate(InlineBidiResolver& resolver, RenderObject* root, RenderObject* startObject)
 {
     if (root != startObject) {
@@ -529,13 +454,13 @@ static inline void setUpResolverToResumeInIsolate(InlineBidiResolver& resolver, 
 }
 
 // FIXME: BidiResolver should have this logic.
-static inline void constructBidiRunsForSegment(InlineBidiResolver& topResolver, BidiRunList<BidiRun>& bidiRuns, const LegacyInlineIterator& endOfRuns, VisualDirectionOverride override, bool previousLineBrokeCleanly)
+static inline void constructBidiRunsForSegment(InlineBidiResolver& topResolver, BidiRunList<BidiRun>& bidiRuns, const LegacyInlineIterator& endOfRuns, VisualDirectionOverride override)
 {
     // FIXME: We should pass a BidiRunList into createBidiRunsForLine instead
     // of the resolver owning the runs.
     ASSERT(&topResolver.runs() == &bidiRuns);
     ASSERT(topResolver.position() != endOfRuns);
-    topResolver.createBidiRunsForLine(endOfRuns, override, previousLineBrokeCleanly);
+    topResolver.createBidiRunsForLine(endOfRuns, override);
 
     while (!topResolver.isolatedRuns().isEmpty()) {
         // It does not matter which order we resolve the runs as long as we resolve them all.
@@ -572,9 +497,7 @@ static inline void constructBidiRunsForSegment(InlineBidiResolver& topResolver, 
         isolatedResolver.setPositionIgnoringNestedIsolates(iter);
 
         // We stop at the next end of line; we may re-enter this isolate in the next call to constructBidiRuns().
-        // FIXME: What should end and previousLineBrokeCleanly be?
-        // rniwa says previousLineBrokeCleanly is just a WinIE hack and could always be false here?
-        isolatedResolver.createBidiRunsForLine(endOfRuns, NoVisualOverride, previousLineBrokeCleanly);
+        isolatedResolver.createBidiRunsForLine(endOfRuns, NoVisualOverride);
         // Note that we do not delete the runs from the resolver.
         // We're not guaranteed to get any BidiRuns in the previous step. If we don't, we allow the placeholder
         // itself to be turned into an InlineBox. We can't remove it here without potentially losing track of
@@ -607,8 +530,7 @@ LegacyRootInlineBox* LegacyLineLayout::createLineBoxesFromBidiRuns(unsigned bidi
         return nullptr;
 
     lineBox->setBidiLevel(bidiLevel);
-    lineBox->setEndsWithBreak(lineInfo.previousLineBrokeCleanly());
-    
+
     bool isSVGRootInlineBox = is<SVGRootInlineBox>(*lineBox);
     ASSERT(isSVGRootInlineBox);
 
@@ -634,19 +556,6 @@ LegacyRootInlineBox* LegacyLineLayout::createLineBoxesFromBidiRuns(unsigned bidi
     return lineBox;
 }
 
-static void deleteLineRange(LineLayoutState& layoutState, LegacyRootInlineBox* startLine, LegacyRootInlineBox* stopLine = 0)
-{
-    LegacyRootInlineBox* boxToDelete = startLine;
-    while (boxToDelete && boxToDelete != stopLine) {
-        layoutState.updateRepaintRangeFromBox(boxToDelete);
-        // Note: deleteLineRange(firstRootBox()) is not identical to deleteLineBoxTree().
-        // deleteLineBoxTree uses nextLineBox() instead of nextRootBox() when traversing.
-        LegacyRootInlineBox* next = boxToDelete->nextRootBox();
-        boxToDelete->deleteLine();
-        boxToDelete = next;
-    }
-}
-
 static void repaintSelfPaintInlineBoxes(const LegacyRootInlineBox& firstRootInlineBox, const LegacyRootInlineBox& lastRootInlineBox)
 {
     for (auto* rootInlineBox = &firstRootInlineBox; rootInlineBox; rootInlineBox = rootInlineBox->nextRootBox()) {
@@ -663,14 +572,20 @@ static void repaintSelfPaintInlineBoxes(const LegacyRootInlineBox& firstRootInli
 
 void LegacyLineLayout::layoutRunsAndFloats(LineLayoutState& layoutState, bool hasInlineChild)
 {
-    // We want to skip ahead to the first dirty line
-    InlineBidiResolver resolver;
-    LegacyRootInlineBox* startLine = determineStartPosition(layoutState, resolver);
+    m_lineBoxes.deleteLineBoxTree();
 
-    // FIXME: This would make more sense outside of this function, but since
-    // determineStartPosition can change the fullLayout flag we have to do this here. Failure to call
-    // determineStartPosition first will break fast/repaint/line-flow-with-floats-9.html.
-    if (layoutState.isFullLayout() && hasInlineChild && !m_flow.selfNeedsLayout()) {
+    layoutState.lineInfo().setFirstLine(true);
+
+    TextDirection direction = style().direction();
+    if (style().unicodeBidi() == UnicodeBidi::Plaintext)
+        determineDirectionality(direction, LegacyInlineIterator(&m_flow, firstInlineRendererSkippingEmpty(m_flow), 0));
+
+    InlineBidiResolver resolver;
+    resolver.setStatus(BidiStatus(direction, isOverride(style().unicodeBidi())));
+    LegacyInlineIterator iter = LegacyInlineIterator(&m_flow, firstInlineRendererSkippingEmpty(m_flow, &resolver), 0);
+    resolver.setPosition(iter, numberOfIsolateAncestors(iter));
+
+    if (hasInlineChild && !m_flow.selfNeedsLayout()) {
         m_flow.setNeedsLayout(MarkOnlyThis); // Mark as needing a full layout to force us to repaint.
         if (!layoutContext().needsFullRepaint() && m_flow.cachedLayerClippedOverflowRect()) {
             // Because we waited until we were already inside layout to discover
@@ -681,51 +596,25 @@ void LegacyLineLayout::layoutRunsAndFloats(LineLayoutState& layoutState, bool ha
         }
     }
 
-    // We also find the first clean line and extract these lines. We will add them back
-    // if we determine that we're able to synchronize after handling all our dirty lines.
-    LegacyInlineIterator cleanLineStart;
-    if (!layoutState.isFullLayout() && startLine)
-        determineEndPosition(layoutState, startLine, cleanLineStart);
-
-    if (startLine) {
-        if (!layoutState.usesRepaintBounds())
-            layoutState.setRepaintRange(m_flow.logicalHeight());
-        deleteLineRange(layoutState, startLine);
-    }
-
-    layoutRunsAndFloatsInRange(layoutState, resolver, cleanLineStart);
-    linkToEndLineIfNeeded(layoutState);
+    layoutRunsAndFloatsInRange(layoutState, resolver);
     if (firstRootBox())
-        repaintSelfPaintInlineBoxes(*firstRootBox(), layoutState.endLine() ? *layoutState.endLine() : *lastRootBox());
+        repaintSelfPaintInlineBoxes(*firstRootBox(), *lastRootBox());
 }
 
-void LegacyLineLayout::layoutRunsAndFloatsInRange(LineLayoutState& layoutState, InlineBidiResolver& resolver, const LegacyInlineIterator& cleanLineStart)
+void LegacyLineLayout::layoutRunsAndFloatsInRange(LineLayoutState& layoutState, InlineBidiResolver& resolver)
 {
     const RenderStyle& styleToUse = style();
     LineWhitespaceCollapsingState& lineWhitespaceCollapsingState = resolver.whitespaceCollapsingState();
     LegacyInlineIterator end = resolver.position();
-    bool checkForEndLineMatch = layoutState.endLine();
     RenderTextInfo renderTextInfo;
 
     LineBreaker lineBreaker(m_flow);
 
     while (!end.atEnd()) {
-        // FIXME: Is this check necessary before the first iteration or can it be moved to the end?
-        if (checkForEndLineMatch) {
-            layoutState.setEndLineMatched(matchedEndLine(layoutState, resolver, cleanLineStart));
-            if (layoutState.endLineMatched()) {
-                resolver.setPosition(LegacyInlineIterator(resolver.position().root(), 0, 0), 0);
-                layoutState.marginInfo().clearMargin();
-                break;
-            }
-        }
-
         lineWhitespaceCollapsingState.reset();
 
         layoutState.lineInfo().setEmpty(true);
         layoutState.lineInfo().resetRunsFromLeadingWhitespace();
-
-        bool isNewUBAParagraph = layoutState.lineInfo().previousLineBrokeCleanly();
 
         WordMeasurements wordMeasurements;
         end = lineBreaker.nextLineBreak(resolver, layoutState.lineInfo(), renderTextInfo, wordMeasurements);
@@ -742,25 +631,18 @@ void LegacyLineLayout::layoutRunsAndFloatsInRange(LineLayoutState& layoutState, 
 
         ASSERT(end != resolver.position());
 
-        // This is a short-cut for empty lines.
-        if (layoutState.lineInfo().isEmpty()) {
-            if (lastRootBox())
-                lastRootBox()->setLineBreakInfo(end.renderer(), end.offset(), resolver.status());
-        } else {
+        if (!layoutState.lineInfo().isEmpty()) {
             VisualDirectionOverride override = (styleToUse.rtlOrdering() == Order::Visual ? (styleToUse.direction() == TextDirection::LTR ? VisualLeftToRightOverride : VisualRightToLeftOverride) : NoVisualOverride);
 
-            if (isNewUBAParagraph && styleToUse.unicodeBidi() == UnicodeBidi::Plaintext && !resolver.context()->parent()) {
+            if (styleToUse.unicodeBidi() == UnicodeBidi::Plaintext && !resolver.context()->parent()) {
                 TextDirection direction = styleToUse.direction();
                 determineDirectionality(direction, resolver.position());
                 resolver.setStatus(BidiStatus(direction, isOverride(styleToUse.unicodeBidi())));
             }
             // FIXME: This ownership is reversed. We should own the BidiRunList and pass it to createBidiRunsForLine.
             BidiRunList<BidiRun>& bidiRuns = resolver.runs();
-            constructBidiRunsForSegment(resolver, bidiRuns, end, override, layoutState.lineInfo().previousLineBrokeCleanly());
+            constructBidiRunsForSegment(resolver, bidiRuns, end, override);
             ASSERT(resolver.position() == end);
-
-            if (!layoutState.lineInfo().previousLineBrokeCleanly())
-                handleTrailingSpaces(bidiRuns, resolver.context());
 
             // Now that the runs have been ordered, we create the line boxes.
             // At the same time we figure out where border/padding/margin should be applied for
@@ -771,13 +653,8 @@ void LegacyLineLayout::layoutRunsAndFloatsInRange(LineLayoutState& layoutState, 
             bidiRuns.clear();
             resolver.markCurrentRunEmpty(); // FIXME: This can probably be replaced by an ASSERT (or just removed).
 
-            if (lineBox) {
-                lineBox->setLineBreakInfo(end.renderer(), end.offset(), resolver.status());
-                if (layoutState.usesRepaintBounds())
-                    layoutState.updateRepaintRangeFromBox(lineBox);
-
+            if (lineBox)
                 layoutState.marginInfo().setAtBeforeSideOfBlock(false);
-            }
         }
 
         if (!layoutState.lineInfo().isEmpty())
@@ -788,39 +665,13 @@ void LegacyLineLayout::layoutRunsAndFloatsInRange(LineLayoutState& layoutState, 
     }
 }
 
-void LegacyLineLayout::linkToEndLineIfNeeded(LineLayoutState& layoutState)
-{
-    auto* firstCleanLine = layoutState.endLine();
-    if (firstCleanLine) {
-        if (layoutState.endLineMatched()) {
-            // Attach all the remaining lines, and then adjust their y-positions as needed.
-            LayoutUnit delta = m_flow.logicalHeight() - layoutState.endLineLogicalTop();
-            for (auto* line = firstCleanLine; line; line = line->nextRootBox()) {
-                line->attachLine();
-                if (delta) {
-                    layoutState.updateRepaintRangeFromBox(line, delta);
-                    line->adjustBlockDirectionPosition(delta);
-                }
-            }
-            m_flow.setLogicalHeight(lastRootBox()->lineBoxBottom());
-        } else {
-            // Delete all the remaining lines.
-            deleteLineRange(layoutState, layoutState.endLine());
-        }
-    }
-}
-
-void LegacyLineLayout::layoutLineBoxes(bool relayoutChildren, LayoutUnit& repaintLogicalTop, LayoutUnit& repaintLogicalBottom)
+void LegacyLineLayout::layoutLineBoxes()
 {
     m_flow.setLogicalHeight(m_flow.borderAndPaddingBefore());
 
-    // Figure out if we should clear out our line boxes.
-    // FIXME: Handle resize eventually!
-    bool isFullLayout = !firstRootBox() || m_flow.selfNeedsLayout() || relayoutChildren;
-    LineLayoutState layoutState(m_flow, isFullLayout, repaintLogicalTop, repaintLogicalBottom);
+    LineLayoutState layoutState(m_flow);
 
-    if (isFullLayout)
-        lineBoxes().deleteLineBoxes();
+    lineBoxes().deleteLineBoxes();
 
     if (m_flow.firstChild()) {
         // In full layout mode, clear the line boxes of children upfront. Otherwise,
@@ -829,34 +680,15 @@ void LegacyLineLayout::layoutLineBoxes(bool relayoutChildren, LayoutUnit& repain
         // deleted and only dirtied. In that case, we can layout the replaced
         // elements at the same time.
         bool hasInlineChild = false;
-        auto hasDirtyRenderCounterWithInlineBoxParent = false;
-        Vector<RenderBox*> replacedChildren;
         for (InlineWalker walker(m_flow); !walker.atEnd(); walker.advance()) {
             RenderObject& o = *walker.current();
 
             if (!hasInlineChild && o.isInline())
                 hasInlineChild = true;
 
-            if (layoutState.isFullLayout() || o.selfNeedsLayout()) {
-                dirtyLineBoxesForRenderer(o, layoutState.isFullLayout());
-                hasDirtyRenderCounterWithInlineBoxParent = hasDirtyRenderCounterWithInlineBoxParent || (is<RenderCounter>(o) && is<RenderInline>(o.parent()));
-            }
+            dirtyLineBoxesForRenderer(o);
             o.clearNeedsLayout();
         }
-
-        for (size_t i = 0; i < replacedChildren.size(); i++)
-            replacedChildren[i]->layoutIfNeeded();
-
-        auto clearNeedsLayoutIfNeeded = [&] {
-            if (!hasDirtyRenderCounterWithInlineBoxParent)
-                return;
-            for (InlineWalker walker(m_flow); !walker.atEnd(); walker.advance()) {
-                auto& renderer = *walker.current();
-                if (is<RenderCounter>(renderer) || is<RenderInline>(renderer))
-                    renderer.clearNeedsLayout();
-            }
-        };
-        clearNeedsLayoutIfNeeded();
 
         layoutRunsAndFloats(layoutState, hasInlineChild);
     }
@@ -870,113 +702,6 @@ void LegacyLineLayout::layoutLineBoxes(bool relayoutChildren, LayoutUnit& repain
 
     if (!firstRootBox() && m_flow.hasLineIfEmpty())
         m_flow.setLogicalHeight(m_flow.logicalHeight() + m_flow.lineHeight(true, m_flow.isHorizontalWritingMode() ? HorizontalLine : VerticalLine, PositionOfInteriorLineBoxes));
-}
-
-LegacyRootInlineBox* LegacyLineLayout::determineStartPosition(LineLayoutState& layoutState, InlineBidiResolver& resolver)
-{
-    LegacyRootInlineBox* currentLine = nullptr;
-    LegacyRootInlineBox* lastLine = nullptr;
-
-    if (layoutState.isFullLayout()) {
-        m_lineBoxes.deleteLineBoxTree();
-        ASSERT(!firstRootBox() && !lastRootBox());
-    } else {
-        for (currentLine = firstRootBox(); currentLine && !currentLine->isDirty(); currentLine = currentLine->nextRootBox()) { }
-        if (currentLine) {
-            // We have a dirty line.
-            if (LegacyRootInlineBox* prevRootBox = currentLine->prevRootBox()) {
-                // We have a previous line.
-                if (!prevRootBox->endsWithBreak()
-                    || !prevRootBox->lineBreakObj()
-                    || (is<RenderText>(*prevRootBox->lineBreakObj())
-                    && prevRootBox->lineBreakPos() >= downcast<RenderText>(*prevRootBox->lineBreakObj()).text().length())) {
-                    // The previous line didn't break cleanly or broke at a newline
-                    // that has been deleted, so treat it as dirty too.
-                    currentLine = prevRootBox;
-                }
-            }
-        }
-        // If we have no dirty lines, then last is just the last root box.
-        lastLine = currentLine ? currentLine->prevRootBox() : lastRootBox();
-    }
-
-    layoutState.lineInfo().setFirstLine(!lastLine);
-    layoutState.lineInfo().setPreviousLineBrokeCleanly(!lastLine || lastLine->endsWithBreak());
-
-    if (lastLine) {
-        m_flow.setLogicalHeight(lastLine->lineBoxBottom());
-        LegacyInlineIterator iter = LegacyInlineIterator(&m_flow, lastLine->lineBreakObj(), lastLine->lineBreakPos());
-        resolver.setPosition(iter, numberOfIsolateAncestors(iter));
-        resolver.setStatus(lastLine->lineBreakBidiStatus());
-    } else {
-        TextDirection direction = style().direction();
-        if (style().unicodeBidi() == UnicodeBidi::Plaintext)
-            determineDirectionality(direction, LegacyInlineIterator(&m_flow, firstInlineRendererSkippingEmpty(m_flow), 0));
-        resolver.setStatus(BidiStatus(direction, isOverride(style().unicodeBidi())));
-        LegacyInlineIterator iter = LegacyInlineIterator(&m_flow, firstInlineRendererSkippingEmpty(m_flow, &resolver), 0);
-        resolver.setPosition(iter, numberOfIsolateAncestors(iter));
-    }
-    return currentLine;
-}
-
-void LegacyLineLayout::determineEndPosition(LineLayoutState& layoutState, LegacyRootInlineBox* startLine, LegacyInlineIterator& cleanLineStart)
-{
-    ASSERT(!layoutState.endLine());
-    LegacyRootInlineBox* lastLine = nullptr;
-    for (auto* currentLine = startLine->nextRootBox(); currentLine; currentLine = currentLine->nextRootBox()) {
-        if (currentLine->isDirty())
-            lastLine = nullptr;
-        else if (!lastLine)
-            lastLine = currentLine;
-    }
-
-    if (!lastLine)
-        return;
-
-    // At this point, |last| is the first line in a run of clean lines that ends with the last line
-    // in the block.
-    LegacyRootInlineBox* previousLine = lastLine->prevRootBox();
-    cleanLineStart = LegacyInlineIterator(&m_flow, previousLine->lineBreakObj(), previousLine->lineBreakPos());
-    layoutState.setEndLineLogicalTop(previousLine->lineBoxBottom());
-
-    for (auto* line = lastLine; line; line = line->nextRootBox()) {
-        // Disconnect all line boxes from their render objects while preserving their connections to one another.
-        line->extractLine();
-    }
-    layoutState.setEndLine(lastLine);
-}
-
-bool LegacyLineLayout::matchedEndLine(LineLayoutState& layoutState, const InlineBidiResolver& resolver, const LegacyInlineIterator& endLineStart)
-{
-    if (resolver.position() == endLineStart)
-        return false;
-
-    // The first clean line doesn't match, but we can check a handful of following lines to try
-    // to match back up.
-    static const int numLines = 8; // The # of lines we're willing to match against.
-    LegacyRootInlineBox* originalEndLine = layoutState.endLine();
-    LegacyRootInlineBox* line = originalEndLine;
-    for (int i = 0; i < numLines && line; i++, line = line->nextRootBox()) {
-        if (line->lineBreakObj() == resolver.position().renderer() && line->lineBreakPos() == resolver.position().offset()) {
-            // We have a match.
-            if (line->lineBreakBidiStatus() != resolver.status())
-                return false; // ...but the bidi state doesn't match.
-            
-            bool matched = false;
-            LegacyRootInlineBox* result = line->nextRootBox();
-            layoutState.setEndLine(result);
-            if (result) {
-                layoutState.setEndLineLogicalTop(line->lineBoxBottom());
-                matched = true;
-            }
-
-            // Now delete the lines that we failed to sync.
-            deleteLineRange(layoutState, originalEndLine, result);
-            return matched;
-        }
-    }
-
-    return false;
 }
 
 void LegacyLineLayout::addOverflowFromInlineChildren()
@@ -1001,18 +726,6 @@ size_t LegacyLineLayout::lineCount() const
     size_t count = 0;
     for (auto* box = firstRootBox(); box; box = box->nextRootBox())
         ++count;
-
-    return count;
-}
-
-size_t LegacyLineLayout::lineCountUntil(const LegacyRootInlineBox* stopRootInlineBox) const
-{
-    size_t count = 0;
-    for (auto* box = firstRootBox(); box; box = box->nextRootBox()) {
-        ++count;
-        if (box == stopRootInlineBox)
-            break;
-    }
 
     return count;
 }

--- a/Source/WebCore/rendering/LegacyLineLayout.h
+++ b/Source/WebCore/rendering/LegacyLineLayout.h
@@ -62,13 +62,12 @@ public:
     LegacyRootInlineBox* firstRootBox() const { return downcast<LegacyRootInlineBox>(m_lineBoxes.firstLineBox()); }
     LegacyRootInlineBox* lastRootBox() const { return downcast<LegacyRootInlineBox>(m_lineBoxes.lastLineBox()); }
 
-    void layoutLineBoxes(bool relayoutChildren, LayoutUnit& repaintLogicalTop, LayoutUnit& repaintLogicalBottom);
+    void layoutLineBoxes();
 
     LegacyRootInlineBox* constructLine(BidiRunList<BidiRun>&, const LineInfo&);
     void addOverflowFromInlineChildren();
 
     size_t lineCount() const;
-    size_t lineCountUntil(const LegacyRootInlineBox*) const;
 
     static void appendRunsForObject(BidiRunList<BidiRun>*, int start, int end, RenderObject&, InlineBidiResolver&);
     static void updateLogicalWidthForAlignment(RenderBlockFlow&, const TextAlignMode&, const LegacyRootInlineBox*, BidiRun* trailingSpaceRun, float& logicalLeft, float& totalLogicalWidth, float& availableLogicalWidth, int expansionOpportunityCount);
@@ -83,11 +82,7 @@ private:
     inline BidiRun* handleTrailingSpaces(BidiRunList<BidiRun>& bidiRuns, BidiContext* currentContext);
     LegacyRootInlineBox* createLineBoxesFromBidiRuns(unsigned bidiLevel, BidiRunList<BidiRun>& bidiRuns, const LegacyInlineIterator& end, LineInfo&);
     void layoutRunsAndFloats(LineLayoutState&, bool hasInlineChild);
-    void layoutRunsAndFloatsInRange(LineLayoutState&, InlineBidiResolver&, const LegacyInlineIterator& cleanLineStart);
-    void linkToEndLineIfNeeded(LineLayoutState&);
-    LegacyRootInlineBox* determineStartPosition(LineLayoutState&, InlineBidiResolver&);
-    void determineEndPosition(LineLayoutState&, LegacyRootInlineBox* startLine, LegacyInlineIterator& cleanLineStart);
-    bool matchedEndLine(LineLayoutState&, const InlineBidiResolver&, const LegacyInlineIterator& endLineStart);
+    void layoutRunsAndFloatsInRange(LineLayoutState&, InlineBidiResolver&);
 
     const RenderStyle& style() const;
     const LocalFrameViewLayoutContext& layoutContext() const;

--- a/Source/WebCore/rendering/LegacyRootInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.cpp
@@ -43,9 +43,6 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRootInlineBox);
 
 struct SameSizeAsLegacyRootInlineBox : LegacyInlineFlowBox, CanMakeWeakPtr<LegacyRootInlineBox>, CanMakeCheckedPtr {
-    unsigned lineBreakPos;
-    SingleThreadWeakPtr<RenderObject> lineBreakObj;
-    void* lineBreakContext;
     int layoutUnits[4];
 };
 
@@ -82,17 +79,6 @@ void LegacyRootInlineBox::adjustPosition(float dx, float dy)
     m_lineBottom += blockDirectionDelta;
     m_lineBoxTop += blockDirectionDelta;
     m_lineBoxBottom += blockDirectionDelta;
-}
-
-void LegacyRootInlineBox::childRemoved(LegacyInlineBox* box)
-{
-    if (&box->renderer() == m_lineBreakObj)
-        setLineBreakInfo(nullptr, 0, BidiStatus());
-
-    for (auto* prev = prevRootBox(); prev && prev->lineBreakObj() == &box->renderer(); prev = prev->prevRootBox()) {
-        prev->setLineBreakInfo(nullptr, 0, BidiStatus());
-        prev->markDirty();
-    }
 }
 
 RenderObject::HighlightState LegacyRootInlineBox::selectionState() const
@@ -170,21 +156,6 @@ LayoutUnit LegacyRootInlineBox::selectionBottom() const
 RenderBlockFlow& LegacyRootInlineBox::blockFlow() const
 {
     return downcast<RenderBlockFlow>(renderer());
-}
-
-BidiStatus LegacyRootInlineBox::lineBreakBidiStatus() const
-{ 
-    return { static_cast<UCharDirection>(m_lineBreakBidiStatusEor), static_cast<UCharDirection>(m_lineBreakBidiStatusLastStrong), static_cast<UCharDirection>(m_lineBreakBidiStatusLast), m_lineBreakContext.copyRef() };
-}
-
-void LegacyRootInlineBox::setLineBreakInfo(RenderObject* object, unsigned breakPosition, const BidiStatus& status)
-{
-    m_lineBreakObj = object;
-    m_lineBreakPos = breakPosition;
-    m_lineBreakBidiStatusEor = status.eor;
-    m_lineBreakBidiStatusLastStrong = status.lastStrong;
-    m_lineBreakBidiStatusLast = status.last;
-    m_lineBreakContext = status.context;
 }
 
 void LegacyRootInlineBox::removeLineBoxFromRenderObject()

--- a/Source/WebCore/rendering/LegacyRootInlineBox.h
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.h
@@ -70,18 +70,6 @@ public:
         m_lineBoxBottom = lineBoxBottom;
     }
 
-    RenderObject* lineBreakObj() const { return m_lineBreakObj.get(); }
-    BidiStatus lineBreakBidiStatus() const;
-    void setLineBreakInfo(RenderObject*, unsigned breakPos, const BidiStatus&);
-
-    unsigned lineBreakPos() const { return m_lineBreakPos; }
-    void setLineBreakPos(unsigned p) { m_lineBreakPos = p; }
-
-    using LegacyInlineBox::endsWithBreak;
-    using LegacyInlineBox::setEndsWithBreak;
-
-    void childRemoved(LegacyInlineBox*);
-
     LayoutUnit baselinePosition(FontBaseline baselineType) const final;
     LayoutUnit lineHeight() const final;
 
@@ -122,13 +110,6 @@ private:
     bool isRootInlineBox() const final { return true; }
 
     LayoutUnit lineSnapAdjustment(LayoutUnit delta = 0_lu) const;
-
-    unsigned m_lineBreakPos { 0 };
-
-    // Where this line ended. The exact object and the position within that object are stored so that
-    // we can create an LegacyInlineIterator beginning just after the end of this line.
-    SingleThreadWeakPtr<RenderObject> m_lineBreakObj;
-    RefPtr<BidiContext> m_lineBreakContext;
 
     LayoutUnit m_lineTop;
     LayoutUnit m_lineBottom;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1043,7 +1043,7 @@ void RenderBlockFlow::layoutInlineChildren(bool relayoutChildren, LayoutUnit& re
     if (!legacyLineLayout())
         m_lineLayout = makeUnique<LegacyLineLayout>(*this);
 
-    legacyLineLayout()->layoutLineBoxes(relayoutChildren, repaintLogicalTop, repaintLogicalBottom);
+    legacyLineLayout()->layoutLineBoxes();
     m_previousModernLineLayoutContentBoxLogicalHeight = { };
 }
 

--- a/Source/WebCore/rendering/RenderCombineText.cpp
+++ b/Source/WebCore/rendering/RenderCombineText.cpp
@@ -191,7 +191,6 @@ void RenderCombineText::combineTextIfNeeded()
         m_combinedTextWidth = combinedTextWidth;
         m_combinedTextAscent = glyphOverflow.top;
         m_combinedTextDescent = glyphOverflow.bottom;
-        m_lineBoxes.dirtyRange(*this, 0, originalText().length(), originalText().length());
         setNeedsLayout();
     }
 }

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1724,15 +1724,14 @@ void RenderText::setText(const String& newContent, bool force)
     invalidateLineLayoutPathOnContentChangeIfNeeded(*this, 0, text().length());
 }
 
-void RenderText::setTextWithOffset(const String& newText, unsigned offset, unsigned length, bool force)
+void RenderText::setTextWithOffset(const String& newText, unsigned offset, unsigned, bool force)
 {
     if (!force && text() == newText)
         return;
 
     int delta = newText.length() - text().length();
-    unsigned end = offset + length;
 
-    m_linesDirty = m_lineBoxes.dirtyRange(*this, offset, end, delta);
+    m_linesDirty = m_lineBoxes.dirtyForTextChange(*this);
 
     setTextInternal(newText, force || m_linesDirty);
     invalidateLineLayoutPathOnContentChangeIfNeeded(*this, offset, delta);

--- a/Source/WebCore/rendering/RenderTextLineBoxes.h
+++ b/Source/WebCore/rendering/RenderTextLineBoxes.h
@@ -52,7 +52,7 @@ public:
     void deleteAll();
 
     void dirtyAll();
-    bool dirtyRange(RenderText&, unsigned start, unsigned end, int lengthDelta);
+    bool dirtyForTextChange(RenderText&);
 
     LegacyInlineTextBox* findNext(int offset, int& position) const;
 

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -94,13 +94,11 @@ public:
         , m_autoWrapWasEverTrueOnLine(false)
         , m_floatsFitOnLine(true)
         , m_collapseWhiteSpace(false)
-        , m_startingNewParagraph(m_lineInfo.previousLineBrokeCleanly())
         , m_allowImagesToBreak(!block.document().inQuirksMode() || !block.isRenderTableCell() || !m_blockStyle.logicalWidth().isIntrinsicOrAuto())
         , m_atEnd(false)
         , m_hadUncommittedWidthBeforeCurrent(false)
         , m_lineWhitespaceCollapsingState(resolver.whitespaceCollapsingState())
     {
-        m_lineInfo.setPreviousLineBrokeCleanly(false);
     }
 
     RenderObject* currentObject() { return m_current.renderer(); }
@@ -193,7 +191,6 @@ private:
     bool m_autoWrapWasEverTrueOnLine;
     bool m_floatsFitOnLine;
     bool m_collapseWhiteSpace;
-    bool m_startingNewParagraph;
     bool m_allowImagesToBreak;
     bool m_atEnd;
     bool m_hadUncommittedWidthBeforeCurrent;
@@ -328,7 +325,7 @@ inline void BreakingContext::handleEmptyInline()
         // An empty inline that only has line-height, vertical-align or font-metrics will only get a
         // line box to affect the height of the line if the rest of the line is not empty.
         if (requiresLineBox)
-            m_lineInfo.setEmpty(false, &m_block, &m_width);
+            m_lineInfo.setEmpty(false);
         if (m_ignoringSpaces) {
             m_trailingObjects.clear();
             m_lineWhitespaceCollapsingState.ensureLineBoxInsideIgnoredSpaces(*m_current.renderer());
@@ -506,7 +503,7 @@ inline bool BreakingContext::handleText(WordMeasurements& wordMeasurements)
         }
 
         if (!m_collapseWhiteSpace || !m_currentCharacterIsSpace)
-            m_lineInfo.setEmpty(false, &m_block, &m_width);
+            m_lineInfo.setEmpty(false);
 
         bool applyWordSpacing = false;
 
@@ -610,7 +607,6 @@ inline bool BreakingContext::handleText(WordMeasurements& wordMeasurements)
                         if (!stoppedIgnoringSpaces && m_current.offset() > 0)
                             ensureCharacterGetsLineBox(m_lineWhitespaceCollapsingState, m_current);
                         m_lineBreak.increment();
-                        m_lineInfo.setPreviousLineBrokeCleanly(true);
                         wordMeasurement.endOffset = m_lineBreak.offset();
                     }
                     if (m_lineBreak.offset() && m_lineBreak.offset() != (unsigned)wordMeasurement.endOffset && !wordMeasurement.width) {
@@ -635,7 +631,6 @@ inline bool BreakingContext::handleText(WordMeasurements& wordMeasurements)
                     ensureCharacterGetsLineBox(m_lineWhitespaceCollapsingState, m_current);
                 commitLineBreakAtCurrentWidth(renderer, m_current.offset(), m_current.nextBreakablePosition());
                 m_lineBreak.increment();
-                m_lineInfo.setPreviousLineBrokeCleanly(true);
                 return true;
             }
 

--- a/Source/WebCore/rendering/line/LineBreaker.cpp
+++ b/Source/WebCore/rendering/line/LineBreaker.cpp
@@ -49,7 +49,7 @@ LegacyInlineIterator LineBreaker::nextLineBreak(InlineBidiResolver& resolver, Li
 
     bool appliedStartWidth = resolver.position().offset();
 
-    LineWidth width(m_block, lineInfo.isFirstLine(), requiresIndent(lineInfo.isFirstLine(), lineInfo.previousLineBrokeCleanly(), m_block.style()));
+    LineWidth width(m_block, lineInfo.isFirstLine(), requiresIndent(lineInfo.isFirstLine(), true, m_block.style()));
 
     skipLeadingWhitespace(resolver, lineInfo);
 

--- a/Source/WebCore/rendering/line/LineInfo.cpp
+++ b/Source/WebCore/rendering/line/LineInfo.cpp
@@ -35,16 +35,9 @@
 
 namespace WebCore {
 
-void LineInfo::setEmpty(bool empty, RenderBlock* block, LineWidth* lineWidth)
+void LineInfo::setEmpty(bool empty)
 {
-    if (m_isEmpty == empty)
-        return;
     m_isEmpty = empty;
-    if (!empty && block && floatPaginationStrut()) {
-        block->setLogicalHeight(block->logicalHeight() + floatPaginationStrut());
-        setFloatPaginationStrut(0);
-        lineWidth->updateAvailableWidth();
-    }
 }
 
 }

--- a/Source/WebCore/rendering/line/LineInfo.h
+++ b/Source/WebCore/rendering/line/LineInfo.h
@@ -41,32 +41,24 @@ public:
         : m_isFirstLine(true)
         , m_isLastLine(false)
         , m_isEmpty(true)
-        , m_previousLineBrokeCleanly(true)
-        , m_floatPaginationStrut(0)
         , m_runsFromLeadingWhitespace(0)
     { }
 
     bool isFirstLine() const { return m_isFirstLine; }
     bool isLastLine() const { return m_isLastLine; }
     bool isEmpty() const { return m_isEmpty; }
-    bool previousLineBrokeCleanly() const { return m_previousLineBrokeCleanly; }
-    LayoutUnit floatPaginationStrut() const { return m_floatPaginationStrut; }
     unsigned runsFromLeadingWhitespace() const { return m_runsFromLeadingWhitespace; }
     void resetRunsFromLeadingWhitespace() { m_runsFromLeadingWhitespace = 0; }
     void incrementRunsFromLeadingWhitespace() { m_runsFromLeadingWhitespace++; }
 
     void setFirstLine(bool firstLine) { m_isFirstLine = firstLine; }
     void setLastLine(bool lastLine) { m_isLastLine = lastLine; }
-    void setEmpty(bool empty, RenderBlock* block = 0, LineWidth* lineWidth = 0);
-    void setPreviousLineBrokeCleanly(bool previousLineBrokeCleanly) { m_previousLineBrokeCleanly = previousLineBrokeCleanly; }
-    void setFloatPaginationStrut(LayoutUnit strut) { m_floatPaginationStrut = strut; }
+    void setEmpty(bool);
 
 private:
     bool m_isFirstLine;
     bool m_isLastLine;
     bool m_isEmpty;
-    bool m_previousLineBrokeCleanly;
-    LayoutUnit m_floatPaginationStrut;
     unsigned m_runsFromLeadingWhitespace;
 };
 

--- a/Source/WebCore/rendering/line/LineInlineHeaders.h
+++ b/Source/WebCore/rendering/line/LineInlineHeaders.h
@@ -71,7 +71,7 @@ inline bool shouldCollapseWhiteSpace(const RenderStyle* style, const LineInfo& l
     // If a space (U+0020) at the end of a line has 'white-space' set to 'normal', 'nowrap', or 'pre-line', it is also removed.
     // If spaces (U+0020) or tabs (U+0009) at the end of a line have 'white-space' set to 'pre-wrap', UAs may visually collapse them.
     return style->collapseWhiteSpace()
-        || (whitespacePosition == TrailingWhitespace && style->whiteSpace() == WhiteSpace::PreWrap && (!lineInfo.isEmpty() || !lineInfo.previousLineBrokeCleanly()));
+        || (whitespacePosition == TrailingWhitespace && style->whiteSpace() == WhiteSpace::PreWrap && !lineInfo.isEmpty());
 }
 
 inline bool skipNonBreakingSpace(const LegacyInlineIterator& it, const LineInfo& lineInfo)
@@ -84,7 +84,7 @@ inline bool skipNonBreakingSpace(const LegacyInlineIterator& it, const LineInfo&
     // Do not skip a non-breaking space if it is the first character
     // on a line after a clean line break (or on the first line, since previousLineBrokeCleanly starts off
     // |true|).
-    if (lineInfo.isEmpty() && lineInfo.previousLineBrokeCleanly())
+    if (lineInfo.isEmpty())
         return false;
 
     return true;

--- a/Source/WebCore/rendering/line/LineLayoutState.h
+++ b/Source/WebCore/rendering/line/LineLayoutState.h
@@ -43,67 +43,20 @@ namespace WebCore {
 // during an entire linebox tree layout pass (aka layoutInlineChildren).
 class LineLayoutState {
 public:
-    LineLayoutState(const RenderBlockFlow& blockFlow, bool fullLayout, LayoutUnit& repaintLogicalTop, LayoutUnit& repaintLogicalBottom)
-        : m_repaintLogicalTop(repaintLogicalTop)
-        , m_repaintLogicalBottom(repaintLogicalBottom)
-        , m_marginInfo(blockFlow, blockFlow.borderAndPaddingBefore(), blockFlow.borderAndPaddingAfter() + blockFlow.scrollbarLogicalHeight())
-        , m_endLineMatched(false)
-        , m_isFullLayout(fullLayout)
-        , m_usesRepaintBounds(false)
+    LineLayoutState(const RenderBlockFlow& blockFlow)
+        : m_marginInfo(blockFlow, blockFlow.borderAndPaddingBefore(), blockFlow.borderAndPaddingAfter() + blockFlow.scrollbarLogicalHeight())
     {
     }
 
     LineInfo& lineInfo() { return m_lineInfo; }
     const LineInfo& lineInfo() const { return m_lineInfo; }
 
-    LayoutUnit endLineLogicalTop() const { return m_endLineLogicalTop; }
-    void setEndLineLogicalTop(LayoutUnit logicalTop) { m_endLineLogicalTop = logicalTop; }
-
-    LegacyRootInlineBox* endLine() const { return m_endLine.get(); }
-    void setEndLine(LegacyRootInlineBox* line) { m_endLine = line; }
-
-    LayoutUnit adjustedLogicalLineTop() const { return m_adjustedLogicalLineTop; }
-    void setAdjustedLogicalLineTop(LayoutUnit value) { m_adjustedLogicalLineTop = value; }
-
-    bool endLineMatched() const { return m_endLineMatched; }
-    void setEndLineMatched(bool endLineMatched) { m_endLineMatched = endLineMatched; }
-
-    void markForFullLayout() { m_isFullLayout = true; }
-    bool isFullLayout() const { return m_isFullLayout; }
-
-    bool usesRepaintBounds() const { return m_usesRepaintBounds; }
-
-    void setRepaintRange(LayoutUnit logicalHeight)
-    {
-        m_usesRepaintBounds = true;
-        m_repaintLogicalTop = m_repaintLogicalBottom = logicalHeight;
-    }
-
-    void updateRepaintRangeFromBox(LegacyRootInlineBox* box, LayoutUnit paginationDelta = 0_lu)
-    {
-        m_usesRepaintBounds = true;
-        m_repaintLogicalTop = std::min(m_repaintLogicalTop, box->logicalTopVisualOverflow() + std::min<LayoutUnit>(paginationDelta, 0));
-        m_repaintLogicalBottom = std::max(m_repaintLogicalBottom, box->logicalBottomVisualOverflow() + std::max<LayoutUnit>(paginationDelta, 0));
-    }
-
     RenderBlockFlow::MarginInfo& marginInfo() { return m_marginInfo; }
 
 private:
     LineInfo m_lineInfo;
-    LayoutUnit m_endLineLogicalTop;
-    WeakPtr<LegacyRootInlineBox> m_endLine;
-
-    LayoutUnit m_adjustedLogicalLineTop;
-
-    // FIXME: Should this be a range object instead of two ints?
-    LayoutUnit& m_repaintLogicalTop;
-    LayoutUnit& m_repaintLogicalBottom;
 
     RenderBlockFlow::MarginInfo m_marginInfo;
-
-    bool m_endLineMatched : 1;
-    bool m_isFullLayout : 1;
-    bool m_usesRepaintBounds : 1;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### e6adb32149c044cff114910e85d078c5fa8add7e
<pre>
[Legacy line layout removal] Remove incremental layout support
<a href="https://bugs.webkit.org/show_bug.cgi?id=271635">https://bugs.webkit.org/show_bug.cgi?id=271635</a>
<a href="https://rdar.apple.com/125343719">rdar://125343719</a>

Reviewed by Alan Baradlay.

We only use this code for SVG now. SVG line layout is never incremental as
there is never more than one line.

* Source/WebCore/rendering/LegacyInlineBox.h:
(WebCore::LegacyInlineBox::InlineBoxBitfields::InlineBoxBitfields):
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::LegacyInlineFlowBox::removeChild):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::dirtyLineBoxesForRenderer):
(WebCore::constructBidiRunsForSegment):
(WebCore::LegacyLineLayout::createLineBoxesFromBidiRuns):
(WebCore::LegacyLineLayout::layoutRunsAndFloats):
(WebCore::LegacyLineLayout::layoutRunsAndFloatsInRange):
(WebCore::LegacyLineLayout::layoutLineBoxes):
(WebCore::isCollapsibleSpace): Deleted.
(WebCore::findFirstTrailingSpace): Deleted.
(WebCore::LegacyLineLayout::handleTrailingSpaces): Deleted.
(WebCore::deleteLineRange): Deleted.
(WebCore::LegacyLineLayout::linkToEndLineIfNeeded): Deleted.
(WebCore::LegacyLineLayout::determineStartPosition): Deleted.
(WebCore::LegacyLineLayout::determineEndPosition): Deleted.
(WebCore::LegacyLineLayout::matchedEndLine): Deleted.
* Source/WebCore/rendering/LegacyLineLayout.h:
* Source/WebCore/rendering/LegacyRootInlineBox.cpp:
(WebCore::LegacyRootInlineBox::childRemoved): Deleted.
(WebCore::LegacyRootInlineBox::lineBreakBidiStatus const): Deleted.
(WebCore::LegacyRootInlineBox::setLineBreakInfo): Deleted.
* Source/WebCore/rendering/LegacyRootInlineBox.h:
(WebCore::LegacyRootInlineBox::lineBreakObj const): Deleted.
(WebCore::LegacyRootInlineBox::lineBreakPos const): Deleted.
(WebCore::LegacyRootInlineBox::setLineBreakPos): Deleted.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutInlineChildren):
* Source/WebCore/rendering/RenderCombineText.cpp:
(WebCore::RenderCombineText::combineTextIfNeeded):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::setTextWithOffset):
* Source/WebCore/rendering/RenderTextLineBoxes.cpp:
(WebCore::RenderTextLineBoxes::dirtyAll):
(WebCore::RenderTextLineBoxes::dirtyRange): Deleted.
* Source/WebCore/rendering/RenderTextLineBoxes.h:
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::BreakingContext):
(WebCore::BreakingContext::handleEmptyInline):
(WebCore::BreakingContext::handleText):
* Source/WebCore/rendering/line/LineBreaker.cpp:
(WebCore::LineBreaker::nextLineBreak):
* Source/WebCore/rendering/line/LineInfo.cpp:
(WebCore::LineInfo::setEmpty):
* Source/WebCore/rendering/line/LineInfo.h:
(WebCore::LineInfo::LineInfo):
(WebCore::LineInfo::isEmpty const):
(WebCore::LineInfo::previousLineBrokeCleanly const): Deleted.
(WebCore::LineInfo::floatPaginationStrut const): Deleted.
(WebCore::LineInfo::setPreviousLineBrokeCleanly): Deleted.
(WebCore::LineInfo::setFloatPaginationStrut): Deleted.
* Source/WebCore/rendering/line/LineInlineHeaders.h:
(WebCore::shouldCollapseWhiteSpace):
(WebCore::skipNonBreakingSpace):
* Source/WebCore/rendering/line/LineLayoutState.h:
(WebCore::LineLayoutState::LineLayoutState):
(WebCore::LineLayoutState::endLineLogicalTop const): Deleted.
(WebCore::LineLayoutState::setEndLineLogicalTop): Deleted.
(WebCore::LineLayoutState::endLine const): Deleted.
(WebCore::LineLayoutState::setEndLine): Deleted.
(WebCore::LineLayoutState::adjustedLogicalLineTop const): Deleted.
(WebCore::LineLayoutState::setAdjustedLogicalLineTop): Deleted.
(WebCore::LineLayoutState::endLineMatched const): Deleted.
(WebCore::LineLayoutState::setEndLineMatched): Deleted.
(WebCore::LineLayoutState::markForFullLayout): Deleted.
(WebCore::LineLayoutState::isFullLayout const): Deleted.
(WebCore::LineLayoutState::usesRepaintBounds const): Deleted.
(WebCore::LineLayoutState::setRepaintRange): Deleted.

Also repaint code can go, SVG issues its own repaints.

(WebCore::LineLayoutState::updateRepaintRangeFromBox): Deleted.

Canonical link: <a href="https://commits.webkit.org/276624@main">https://commits.webkit.org/276624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9400e7f2185e1df1a50d8c2c655820df2851dd85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47872 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41218 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21724 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18177 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40072 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3257 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41475 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49578 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16726 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44116 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21498 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42911 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10043 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21854 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->