### PR TITLE
Implement URL.parse()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any-expected.txt
@@ -1,0 +1,10 @@
+
+PASS URL.parse(undefined, undefined)
+PASS URL.parse(aaa:b, undefined)
+PASS URL.parse(undefined, aaa:b)
+PASS URL.parse(aaa:/b, undefined)
+PASS URL.parse(undefined, aaa:/b)
+PASS URL.parse(https://test:test, undefined)
+PASS URL.parse(a, https://b/)
+PASS URL.parse() should return a unique object
+

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any.js
@@ -1,0 +1,50 @@
+// This intentionally does not use resources/urltestdata.json to preserve resources.
+[
+  {
+    "url": undefined,
+    "base": undefined,
+    "expected": false
+  },
+  {
+    "url": "aaa:b",
+    "base": undefined,
+    "expected": true
+  },
+  {
+    "url": undefined,
+    "base": "aaa:b",
+    "expected": false
+  },
+  {
+    "url": "aaa:/b",
+    "base": undefined,
+    "expected": true
+  },
+  {
+    "url": undefined,
+    "base": "aaa:/b",
+    "expected": true
+  },
+  {
+    "url": "https://test:test",
+    "base": undefined,
+    "expected": false
+  },
+  {
+    "url": "a",
+    "base": "https://b/",
+    "expected": true
+  }
+].forEach(({ url, base, expected }) => {
+  test(() => {
+    if (expected == false) {
+      assert_equals(URL.parse(url, base), null);
+    } else {
+      assert_equals(URL.parse(url, base).href, new URL(url, base).href);
+    }
+  }, `URL.parse(${url}, ${base})`);
+});
+
+test(() => {
+  assert_not_equals(URL.parse("https://example/"), URL.parse("https://example/"));
+}, `URL.parse() should return a unique object`);

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any.worker-expected.txt
@@ -1,0 +1,10 @@
+
+PASS URL.parse(undefined, undefined)
+PASS URL.parse(aaa:b, undefined)
+PASS URL.parse(undefined, aaa:b)
+PASS URL.parse(aaa:/b, undefined)
+PASS URL.parse(undefined, aaa:/b)
+PASS URL.parse(https://test:test, undefined)
+PASS URL.parse(a, https://b/)
+PASS URL.parse() should return a unique object
+

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/url/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/w3c-import.log
@@ -36,6 +36,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/url/url-setters-stripping.any.js
 /LayoutTests/imported/w3c/web-platform-tests/url/url-setters.any.js
 /LayoutTests/imported/w3c/web-platform-tests/url/url-statics-canparse.any.js
+/LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any.js
 /LayoutTests/imported/w3c/web-platform-tests/url/url-tojson.any.js
 /LayoutTests/imported/w3c/web-platform-tests/url/urlencoded-parser.any.js
 /LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-append.any.js

--- a/Source/WebCore/html/DOMURL.h
+++ b/Source/WebCore/html/DOMURL.h
@@ -43,6 +43,7 @@ public:
     static ExceptionOr<Ref<DOMURL>> create(const String& url, const String& base);
     WEBCORE_EXPORT ~DOMURL();
 
+    static RefPtr<DOMURL> parse(const String& url, const String& base);
     static bool canParse(const String& url, const String& base);
 
     const URL& href() const { return m_url; }
@@ -59,12 +60,11 @@ public:
 
 private:
     static ExceptionOr<Ref<DOMURL>> create(const String& url, const URL& base);
-    DOMURL(URL&& completeURL, const URL& baseURL);
+    DOMURL(URL&& completeURL);
 
     URL fullURL() const final { return m_url; }
     void setFullURL(const URL& fullURL) final { setHref(fullURL.string()); }
 
-    URL m_baseURL;
     URL m_url;
     RefPtr<URLSearchParams> m_searchParams;
 };

--- a/Source/WebCore/html/DOMURL.idl
+++ b/Source/WebCore/html/DOMURL.idl
@@ -34,6 +34,7 @@
 ] interface DOMURL {
     constructor(USVString url, optional USVString base);
 
+    static DOMURL? parse(USVString url, optional USVString base);
     static boolean canParse(USVString url, optional USVString base);
 
     [URL] stringifier attribute USVString href;


### PR DESCRIPTION
#### e1614bd8c992e7e6e162fff5143f3a4932226ae5
<pre>
Implement URL.parse()
<a href="https://bugs.webkit.org/show_bug.cgi?id=271636">https://bugs.webkit.org/show_bug.cgi?id=271636</a>

Reviewed by Alex Christensen.

This was standardized in <a href="https://github.com/whatwg/url/pull/825">https://github.com/whatwg/url/pull/825</a> and test
coverage was added here:
<a href="https://github.com/web-platform-tests/wpt/pull/45248">https://github.com/web-platform-tests/wpt/pull/45248</a>

As a drive-by fix we remove m_baseURL from DOMURL as it does not need it.

* LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any.js: Added.
(forEach):
(test):
* LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/url/url-statics-parse.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/url/w3c-import.log:
* Source/WebCore/html/DOMURL.cpp:
(WebCore::DOMURL::DOMURL):
(WebCore::DOMURL::create):
(WebCore::parseInternal):
(WebCore::DOMURL::parse):
(WebCore::DOMURL::canParse):
* Source/WebCore/html/DOMURL.h:
* Source/WebCore/html/DOMURL.idl:

Canonical link: <a href="https://commits.webkit.org/276656@main">https://commits.webkit.org/276656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d52cd678b3570e1310b3958c90bfaa54d946525

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47910 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41255 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37113 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18211 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18827 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40107 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3294 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49615 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44146 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42949 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10065 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->