### PR TITLE
Add <template>'s shadowRootDelegatesFocus & shadowRootClonable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic-expected.txt
@@ -3,6 +3,10 @@ PASS Declarative Shadow DOM: Basic test
 PASS Declarative Shadow DOM: Feature detection
 PASS Shadowrootmode reflection
 PASS Shadowrootmode reflection, setter
+PASS Shadowrootdelegatesfocus reflection
+PASS Shadowrootdelegatesfocus reflection, setter
+PASS Shadowrootclonable reflection
+PASS Shadowrootclonable reflection, setter
 PASS Declarative Shadow DOM: Fragment parser basic test
 PASS Declarative Shadow DOM: Invalid shadow root attribute
 PASS Declarative Shadow DOM: Closed shadow root attribute

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic.html
@@ -55,6 +55,49 @@ test(() => {
 }, 'Shadowrootmode reflection, setter');
 
 test(() => {
+  const t = document.createElement('template');
+  t.setAttribute('shadowrootdelegatesfocus','');
+  assert_equals(t.shadowRootDelegatesFocus,true,'The shadowRootDelegatesFocus IDL should reflect the content attribute');
+  t.setAttribute('shadowrootdelegatesfocus','foobar');
+  assert_equals(t.shadowRootDelegatesFocus,true,'The value doesn\'t matter');
+  t.removeAttribute('shadowrootdelegatesfocus');
+  assert_equals(t.shadowRootDelegatesFocus,false,'No shadowRootDelegatesFocus attribute maps to false');
+}, 'Shadowrootdelegatesfocus reflection');
+
+test(() => {
+  const t = document.createElement('template');
+  assert_equals(t.getAttribute('shadowrootdelegatesfocus'), null);
+  t.shadowRootDelegatesFocus = true;
+  assert_equals(t.getAttribute('shadowrootdelegatesfocus'), '');
+  assert_equals(t.shadowRootDelegatesFocus, true);
+  t.shadowRootDelegatesFocus = false;
+  assert_equals(t.getAttribute('shadowrootdelegatesfocus'), null);
+  assert_equals(t.shadowRootDelegatesFocus, false);
+}, 'Shadowrootdelegatesfocus reflection, setter');
+
+
+test(() => {
+  const t = document.createElement('template');
+  t.setAttribute('shadowrootclonable','');
+  assert_equals(t.shadowRootClonable,true,'The shadowRootClonable IDL should reflect the content attribute');
+  t.setAttribute('shadowrootclonable','foobar');
+  assert_equals(t.shadowRootClonable,true,'The value doesn\'t matter');
+  t.removeAttribute('shadowrootclonable');
+  assert_equals(t.shadowRootClonable,false,'No shadowRootClonable attribute maps to false');
+}, 'Shadowrootclonable reflection');
+
+test(() => {
+  const t = document.createElement('template');
+  assert_equals(t.getAttribute('shadowrootclonable'), null);
+  t.shadowRootClonable = true;
+  assert_equals(t.getAttribute('shadowrootclonable'), '');
+  assert_equals(t.shadowRootClonable, true);
+  t.shadowRootClonable = false;
+  assert_equals(t.getAttribute('shadowrootclonable'), null);
+  assert_equals(t.shadowRootClonable, false);
+}, 'Shadowrootclonable reflection, setter');
+
+test(() => {
   const div = document.createElement('div');
   div.setHTMLUnsafe(`
     <div id="host">

--- a/Source/WebCore/html/HTMLTemplateElement.idl
+++ b/Source/WebCore/html/HTMLTemplateElement.idl
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012, Google Inc. All rights reserved.
+ * Copyright (c) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -34,4 +35,6 @@
 ] interface HTMLTemplateElement : HTMLElement {
     readonly attribute DocumentFragment content;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString shadowRootMode;
+    [CEReactions=NotNeeded, Reflect=shadowrootdelegatesfocus] attribute boolean shadowRootDelegatesFocus;
+    [CEReactions=NotNeeded, Reflect=shadowrootclonable] attribute boolean shadowRootClonable;
 };


### PR DESCRIPTION
#### db0669a6fa034ab98e120208f72fd232948b1fcc
<pre>
Add &lt;template&gt;&apos;s shadowRootDelegatesFocus &amp; shadowRootClonable
<a href="https://bugs.webkit.org/show_bug.cgi?id=271640">https://bugs.webkit.org/show_bug.cgi?id=271640</a>

Reviewed by Tim Nguyen.

These were missed in prior PRs that added support for the corresponding
content attributes.

Partially synchronize WPT up to the following commit to add missing
test coverage:
<a href="https://github.com/web-platform-tests/wpt/commit/2969dd3b1af9126ed769915ff852cb29eb615d52">https://github.com/web-platform-tests/wpt/commit/2969dd3b1af9126ed769915ff852cb29eb615d52</a>

* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/declarative/declarative-shadow-dom-basic.html:
* Source/WebCore/html/HTMLTemplateElement.idl:

Canonical link: <a href="https://commits.webkit.org/276631@main">https://commits.webkit.org/276631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57800ea27aa1f37bb575162bad11de9d5ab6f132

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47870 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41216 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21725 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37078 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38989 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18175 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40074 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3255 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41470 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49574 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16727 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44113 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42908 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10048 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21852 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->