### PR TITLE
Some AVSampleBufferDisplayLayer methods are deprecated

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -196,8 +196,10 @@ LocalSampleBufferDisplayLayer::~LocalSampleBufferDisplayLayer()
 
     m_pendingVideoFrameQueue.clear();
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [m_sampleBufferDisplayLayer stopRequestingMediaData];
     [m_sampleBufferDisplayLayer flush];
+ALLOW_DEPRECATED_DECLARATIONS_END
     m_sampleBufferDisplayLayer = nullptr;
 
     m_rootLayer = nullptr;
@@ -219,7 +221,9 @@ void LocalSampleBufferDisplayLayer::setShouldMaintainAspectRatio(bool shouldMain
 void LocalSampleBufferDisplayLayer::layerStatusDidChange()
 {
     ASSERT(isMainThread());
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (m_client && m_sampleBufferDisplayLayer.get().status == AVQueuedSampleBufferRenderingStatusFailed) {
+ALLOW_DEPRECATED_DECLARATIONS_END
         RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::layerStatusDidChange going to failed status (%{public}s) ", m_logIdentifier.utf8().data());
         if (!m_didFail) {
             m_didFail = true;
@@ -250,7 +254,9 @@ PlatformLayer* LocalSampleBufferDisplayLayer::rootLayer()
 
 bool LocalSampleBufferDisplayLayer::didFail() const
 {
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     return m_didFail || [m_sampleBufferDisplayLayer status] == AVQueuedSampleBufferRenderingStatusFailed;
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 void LocalSampleBufferDisplayLayer::updateDisplayMode(bool hideDisplayLayer, bool hideRootLayer)
@@ -308,7 +314,9 @@ void LocalSampleBufferDisplayLayer::flush()
         if (!protectedThis)
             return;
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         [m_sampleBufferDisplayLayer flush];
+ALLOW_DEPRECATED_DECLARATIONS_END
     });
 }
 
@@ -320,7 +328,9 @@ void LocalSampleBufferDisplayLayer::flushAndRemoveImage()
             return;
 
         @try {
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             [m_sampleBufferDisplayLayer flushAndRemoveImage];
+ALLOW_DEPRECATED_DECLARATIONS_END
         } @catch(id exception) {
             RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::flushAndRemoveImage failed");
             layerErrorDidChange();
@@ -389,7 +399,9 @@ void LocalSampleBufferDisplayLayer::enqueueBufferInternal(CVPixelBufferRef pixel
     if (m_renderPolicy == RenderPolicy::Immediately || now >= presentationTime)
         setSampleBufferAsDisplayImmediately(sampleBuffer.get());
 
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [m_sampleBufferDisplayLayer enqueueSampleBuffer:sampleBuffer.get()];
+ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if !RELEASE_LOG_DISABLED
     constexpr size_t frameCountPerLog = 1800; // log every minute at 30 fps
@@ -463,6 +475,7 @@ void LocalSampleBufferDisplayLayer::requestNotificationWhenReadyForVideoData()
     assertIsCurrent(workQueue());
 
     ThreadSafeWeakPtr weakThis { *this };
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     [m_sampleBufferDisplayLayer requestMediaDataWhenReadyOnQueue:dispatch_get_main_queue() usingBlock:^{
         auto protectedThis = weakThis.get();
         if (!protectedThis)
@@ -485,6 +498,7 @@ void LocalSampleBufferDisplayLayer::requestNotificationWhenReadyForVideoData()
             }
         });
     }];
+ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 }


### PR DESCRIPTION
#### 533a598f6d616ddd5075ca57cbbf06029803d428
<pre>
Some AVSampleBufferDisplayLayer methods are deprecated
<a href="https://rdar.apple.com/125340931">rdar://125340931</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=271633">https://bugs.webkit.org/show_bug.cgi?id=271633</a>

Reviewed by Jonathan Bedard.

Add deprecation blocks to AVSampleBufferDisplayLayer flush, flushAndRemoveImage, isReadyForMoreMediaData, requestMediaDataWhenReadyOnQueue, stopRequestingMediaData and status.

* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(WebCore::LocalSampleBufferDisplayLayer::~LocalSampleBufferDisplayLayer):
(WebCore::LocalSampleBufferDisplayLayer::didFail const):
(WebCore::LocalSampleBufferDisplayLayer::flush):
(WebCore::LocalSampleBufferDisplayLayer::flushAndRemoveImage):
(WebCore::LocalSampleBufferDisplayLayer::requestNotificationWhenReadyForVideoData):

Canonical link: <a href="https://commits.webkit.org/276628@main">https://commits.webkit.org/276628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb06437e519ea97b735d8670a1860f6beba3168f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41229 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47528 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21736 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37088 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/38997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40081 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3268 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49589 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44123 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21509 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42918 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10045 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21865 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21197 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->