### PR TITLE
REGRESSION: JavaScriptCore: JSC::ScopedArguments::setIndexQuickly

### DIFF
--- a/Source/JavaScriptCore/runtime/ScopedArguments.h
+++ b/Source/JavaScriptCore/runtime/ScopedArguments.h
@@ -115,8 +115,12 @@ public:
             m_scope->variableAt(m_table->get(i)).set(vm, m_scope.get(), value);
 
             auto* watchpointSet = m_table->getWatchpointSet(i);
-            if (watchpointSet)
+            if (watchpointSet) {
+#if ASSERT_ENABLED
+                ASSERT(m_scope->symbolTable()->hasScopedWatchpointSet(watchpointSet));
+#endif
                 watchpointSet->touch(vm, "Write to ScopedArgument.");
+            }
         } else
             storage()[i - namedLength].set(vm, this, value);
     }

--- a/Source/JavaScriptCore/runtime/SymbolTable.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolTable.cpp
@@ -31,6 +31,7 @@
 
 #include "CodeBlock.h"
 #include "JSCJSValueInlines.h"
+#include "ResourceExhaustion.h"
 #include "TypeProfiler.h"
 
 #include <wtf/CommaPrinter.h>
@@ -145,19 +146,44 @@ SymbolTable* SymbolTable::cloneScopePart(VM& vm)
     result->m_nestedLexicalScope = m_nestedLexicalScope;
     result->m_scopeType = m_scopeType;
 
+    HashMap<VarOffset, uint32_t> varOffsetToArgIndexMap;
+
+    if (this->arguments()) {
+        // Copy the arguments, but not the WatchpointSets. We create new WatchpointSets as appropriate when we create the SymbolTableEntry
+        // copies below and propogate the new watchpointSets to the new ScopedArgumentsTable.
+        auto length = this->arguments()->length();
+        ScopedArgumentsTable* arguments = ScopedArgumentsTable::tryCreate(vm, length);
+        RELEASE_ASSERT_RESOURCE_AVAILABLE(arguments, MemoryExhaustion, "Crash intentionally because memory is exhausted.");
+
+        for (uint32_t index = 0; index < length; ++index) {
+            ScopeOffset offset = this->arguments()->get(index);
+
+            arguments->trySet(vm, index, offset);
+            if (this->arguments()->getWatchpointSet(index))
+                varOffsetToArgIndexMap.set(VarOffset(offset), index);
+        }
+
+        result->m_arguments.set(vm, result, arguments);
+    }
+
+    bool hasScopedArgumentWatchpoints = !varOffsetToArgIndexMap.isEmpty();
+
     for (auto iter = m_map.begin(), end = m_map.end(); iter != end; ++iter) {
         if (!iter->value.varOffset().isScope())
             continue;
-        result->m_map.add(
-            iter->key,
-            SymbolTableEntry(iter->value.varOffset(), iter->value.getAttributes()));
+        SymbolTableEntry entry(iter->value.varOffset(), iter->value.getAttributes());
+
+        if (hasScopedArgumentWatchpoints) {
+            auto findIter = varOffsetToArgIndexMap.find(iter->value.varOffset());
+            if (findIter != varOffsetToArgIndexMap.end())
+                result->prepareToWatchScopedArgument(entry, findIter->value);
+        }
+
+        result->m_map.add(iter->key, WTFMove(entry));
     }
-    
+
     result->m_maxScopeOffset = m_maxScopeOffset;
-    
-    if (ScopedArgumentsTable* arguments = this->arguments())
-        result->m_arguments.set(vm, result, arguments);
-    
+
     if (m_rareData) {
         result->ensureRareData();
 
@@ -277,6 +303,22 @@ RefPtr<TypeSet> SymbolTable::globalTypeSetForVariable(const ConcurrentJSLocker& 
 
     return iter->value;
 }
+
+#if ASSERT_ENABLED
+bool SymbolTable::hasScopedWatchpointSet(WatchpointSet* watchpointSet)
+{
+    for (auto iter = m_map.begin(), end = m_map.end(); iter != end; ++iter) {
+        if (!iter->value.varOffset().isScope())
+            continue;
+
+        auto* entryWatchpointSet = iter->value.watchpointSet();
+        if (entryWatchpointSet && entryWatchpointSet == watchpointSet)
+            return true;
+    }
+
+    return false;
+}
+#endif
 
 SymbolTable::SymbolTableRareData& SymbolTable::ensureRareDataSlow()
 {

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -758,6 +758,10 @@ public:
 
     DECLARE_EXPORT_INFO;
 
+#if ASSERT_ENABLED
+    bool hasScopedWatchpointSet(WatchpointSet*);
+#endif
+
     void finalizeUnconditionally(VM&, CollectionScope);
     void dump(PrintStream&) const;
 


### PR DESCRIPTION
#### 7bac523bd87dc3ce0c63e66ce5b279ec91e7b9dc
<pre>
REGRESSION: JavaScriptCore: JSC::ScopedArguments::setIndexQuickly
<a href="https://bugs.webkit.org/show_bug.cgi?id=268409">https://bugs.webkit.org/show_bug.cgi?id=268409</a>
<a href="https://rdar.apple.com/121748005">rdar://121748005</a>

Reviewed by Yusuke Suzuki.

A code inspection of the symbol table and scoped arguments code revealed that SymbolTable::cloneScopePart() doesn&apos;t
properly copy the ScopedArgumentsTable from the source.  Since ScopedArguments point to the WatchpointSets in the
related SymbolTable, we need to create new WatchpointSets in the cloned SymbolTable and have the ScopedArguments
point to the related new WatchpointSets.

This is a speculative fix.

* Source/JavaScriptCore/runtime/ScopedArguments.h:
* Source/JavaScriptCore/runtime/SymbolTable.cpp:
(JSC::SymbolTable::cloneScopePart):
(JSC::SymbolTable::hasScopedWatchpointSet):
* Source/JavaScriptCore/runtime/SymbolTable.h:

Originally-landed-as: 272448.422@safari-7618-branch (5bc92c9d5253). <a href="https://rdar.apple.com/124554329">rdar://124554329</a>
Canonical link: <a href="https://commits.webkit.org/276646@main">https://commits.webkit.org/276646@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c84a846e1be0ad3482f17d9e4a55a45f418dc7b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47889 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41234 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37096 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18192 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40087 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3273 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38444 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41488 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49594 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44694 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44134 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21514 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42931 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10058 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21870 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51854 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21202 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10571 "Passed tests") | 
<!--EWS-Status-Bubble-End-->