### PR TITLE
visionOS: Compositing layers can end up getting shuffled out of order on layer tree mutation

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -68,6 +68,10 @@ static void configureSeparatedLayer(CALayer *) { }
     NSUInteger numOldSubviews = self.subviews.count;
     NSUInteger numNewSubviews = newSubviews.count;
 
+    // This method does not handle interleaved UIView and CALayer children of
+    // a UIView, so we must not have any non-UIView-backed CALayer children.
+    ASSERT(numOldSubviews == self.layer.sublayers.count);
+
     NSUInteger currIndex = 0;
     for (currIndex = 0; currIndex < numNewSubviews; ++currIndex) {
         UIView *currNewSubview = [newSubviews objectAtIndex:currIndex];
@@ -393,10 +397,6 @@ void RemoteLayerTreePropertyApplier::applyHierarchyUpdates(RemoteLayerTreeNode& 
 #endif
         return childNode->layer();
     }).get();
-
-#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    node.updateInteractionRegionAfterHierarchyChange();
-#endif
 
     END_BLOCK_OBJC_EXCEPTIONS
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm
@@ -210,7 +210,9 @@ static CACornerMask convertToCACornerMask(OptionSet<InteractionRegion::CornerMas
 
 void updateLayersForInteractionRegions(RemoteLayerTreeNode& node)
 {
-    if (node.eventRegion().interactionRegions().isEmpty()) {
+    ASSERT(node.uiView());
+
+    if (node.eventRegion().interactionRegions().isEmpty() || !node.uiView()) {
         node.removeInteractionRegionsContainer();
         return;
     }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -161,7 +161,7 @@ private:
     void setHasInteractionRegionsDescendant(bool value) { m_hasInteractionRegionsDescendant = value; }
 
     bool m_hasInteractionRegionsDescendant { false };
-    RetainPtr<CALayer> m_interactionRegionsContainer;
+    RetainPtr<UIView> m_interactionRegionsContainer;
 #endif
 #if PLATFORM(IOS_FAMILY)
     RetainPtr<UIView> m_uiView;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -120,17 +120,16 @@ void RemoteLayerTreeNode::initializeLayer()
 CALayer* RemoteLayerTreeNode::ensureInteractionRegionsContainer()
 {
     if (m_interactionRegionsContainer)
-        return m_interactionRegionsContainer.get();
+        return [m_interactionRegionsContainer layer];
 
-    m_interactionRegionsContainer = adoptNS([[CALayer alloc] init]);
-    [m_interactionRegionsContainer setName:@"InteractionRegions Container"];
-    [m_interactionRegionsContainer setValue:@(YES) forKey:WKInteractionRegionContainerKey];
-    [m_interactionRegionsContainer setDelegate:[WebActionDisablingCALayerDelegate shared]];
+    m_interactionRegionsContainer = adoptNS([[UIView alloc] init]);
+    [[m_interactionRegionsContainer layer] setName:@"InteractionRegions Container"];
+    [[m_interactionRegionsContainer layer] setValue:@YES forKey:WKInteractionRegionContainerKey];
 
     repositionInteractionRegionsContainerIfNeeded();
     propagateInteractionRegionsChangeInHierarchy(InteractionRegionsInSubtree::Yes);
 
-    return m_interactionRegionsContainer.get();
+    return [m_interactionRegionsContainer layer];
 }
 
 void RemoteLayerTreeNode::removeInteractionRegionsContainer()
@@ -138,7 +137,7 @@ void RemoteLayerTreeNode::removeInteractionRegionsContainer()
     if (!m_interactionRegionsContainer)
         return;
 
-    [m_interactionRegionsContainer removeFromSuperlayer];
+    [m_interactionRegionsContainer removeFromSuperview];
     m_interactionRegionsContainer = nullptr;
 
     propagateInteractionRegionsChangeInHierarchy(InteractionRegionsInSubtree::Unknown);
@@ -174,13 +173,14 @@ void RemoteLayerTreeNode::repositionInteractionRegionsContainerIfNeeded()
 {
     if (!m_interactionRegionsContainer)
         return;
+    ASSERT(uiView());
 
     NSUInteger insertionPoint = 0;
-    for (CALayer *sublayer in layer().sublayers) {
-        if ([sublayer valueForKey:WKInteractionRegionContainerKey])
+    for (UIView *subview in uiView().subviews) {
+        if ([subview.layer valueForKey:WKInteractionRegionContainerKey])
             continue;
 
-        if (auto *subnode = forCALayer(sublayer)) {
+        if (auto *subnode = forCALayer(subview.layer)) {
             if (subnode->hasInteractionRegions())
                 break;
         }
@@ -188,12 +188,12 @@ void RemoteLayerTreeNode::repositionInteractionRegionsContainerIfNeeded()
         insertionPoint++;
     }
 
-    // We searched through the sublayers, so insertionPoint is always <= sublayers.count.
-    ASSERT(insertionPoint <= layer().sublayers.count);
-    bool shouldAppendLayer = insertionPoint == layer().sublayers.count;
-    if (shouldAppendLayer || [layer().sublayers objectAtIndex:insertionPoint] != m_interactionRegionsContainer) {
-        [m_interactionRegionsContainer removeFromSuperlayer];
-        [layer() insertSublayer:m_interactionRegionsContainer.get() atIndex:insertionPoint];
+    // We searched through the subviews, so insertionPoint is always <= subviews.count.
+    ASSERT(insertionPoint <= uiView().subviews.count);
+    bool shouldAppendView = insertionPoint == uiView().subviews.count;
+    if (shouldAppendView || [uiView().subviews objectAtIndex:insertionPoint] != m_interactionRegionsContainer) {
+        [m_interactionRegionsContainer removeFromSuperview];
+        [uiView() insertSubview:m_interactionRegionsContainer.get() atIndex:insertionPoint];
     }
 }
 


### PR DESCRIPTION
#### d689b8edef147f0eab7c70fc6f0f3a1ad8db5e3b
<pre>
visionOS: Compositing layers can end up getting shuffled out of order on layer tree mutation
<a href="https://bugs.webkit.org/show_bug.cgi?id=268420">https://bugs.webkit.org/show_bug.cgi?id=268420</a>
&lt;<a href="https://rdar.apple.com/121612730">rdar://121612730</a>&gt;

Reviewed by Richard Robinson and Simon Fraser.

It turns out it is not advisable to have interleaved UIView and CALayer children
underneath a UIView. Avoid this by wrapping the interaction region root layer
in a UIView.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(-[UIView _web_setSubviews:]):
Add an assertion to avoid future re-debugging of this issue.

(WebKit::RemoteLayerTreePropertyApplier::applyHierarchyUpdates):
Don&apos;t bother moving the interaction region container around in the non-UIView
case; it never comes up, as on UIKit-having platforms we always make UIViews
for all but the tile contents layers, which never have interaction regions.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::ensureInteractionRegionsContainer):
(WebKit::RemoteLayerTreeNode::removeInteractionRegionsContainer):
(WebKit::RemoteLayerTreeNode::repositionInteractionRegionsContainerIfNeeded):
Swap the CALayer for a UIView. However, we&apos;ll continue using the layer
for maintaining state and our set of sublayers, since it has no view children.

Originally-landed-as: 272448.443@safari-7618-branch (1b8630ced33e). <a href="https://rdar.apple.com/124554005">rdar://124554005</a>
Canonical link: <a href="https://commits.webkit.org/276644@main">https://commits.webkit.org/276644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84940874049aa100e86ddd5b6d0927ec49de0089

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41236 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37094 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21393 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39005 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18191 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18807 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3275 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49596 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44127 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21516 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42923 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10056 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->