### PR TITLE
WebXR waits on the finished sync fence on Cocoa

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -223,9 +223,10 @@ void WebXROpaqueFramebuffer::endFrame()
     if (m_completionSyncEvent) {
         auto completionSync = gl->createExternalSync(std::tuple(m_completionSyncEvent, m_renderingFrameIndex));
         ASSERT(completionSync);
-        constexpr uint64_t kTimeout = 1'000'000'000; // 1 second
-        gl->clientWaitExternalSyncWithFlush(completionSync, kTimeout);
-        gl->deleteExternalSync(completionSync);
+        if (completionSync) {
+            gl->flush();
+            gl->deleteExternalSync(completionSync);
+        }
     } else
         gl->finish();
 

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1531,7 +1531,6 @@ public:
     using ExternalSyncSource = GraphicsContextGLExternalSyncSource;
     virtual GCGLExternalSync createExternalSync(ExternalSyncSource&&) = 0;
     virtual void deleteExternalSync(GCGLExternalSync) = 0;
-    virtual bool clientWaitExternalSyncWithFlush(GCGLExternalSync, uint64_t timeout) = 0;
 
     // ========== Extension related entry points.
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -2906,22 +2906,6 @@ void GraphicsContextGLANGLE::deleteExternalSync(GCGLExternalSync sync)
         addError(GCGLErrorCode::InvalidOperation);
 }
 
-bool GraphicsContextGLANGLE::clientWaitExternalSyncWithFlush(GCGLExternalSync sync, uint64_t timeout)
-{
-    EGLSync eglSync = m_eglSyncs.get(sync);
-    if (UNLIKELY(!eglSync)) {
-        addError(GCGLErrorCode::InvalidOperation);
-        return false;
-    }
-    auto ret = EGL_ClientWaitSync(platformDisplay(), eglSync, EGL_SYNC_FLUSH_COMMANDS_BIT, timeout);
-    if (ret == EGL_FALSE) {
-        ASSERT_NOT_REACHED();
-        addError(GCGLErrorCode::InvalidOperation);
-        return false;
-    }
-    return ret == EGL_CONDITION_SATISFIED;
-}
-
 void GraphicsContextGLANGLE::multiDrawArraysANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLint, const GCGLsizei> firstsAndCounts)
 {
     if (!makeContextCurrent())

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -294,7 +294,6 @@ public:
     void bindExternalImage(GCGLenum target, GCGLExternalImage) override;
     GCGLExternalSync createExternalSync(ExternalSyncSource&&) override;
     void deleteExternalSync(GCGLExternalSync) final;
-    bool clientWaitExternalSyncWithFlush(GCGLExternalSync, uint64_t) final;
     void multiDrawArraysANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLint, const GCGLsizei> firstsAndCounts) final;
     void multiDrawArraysInstancedANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLint, const GCGLsizei, const GCGLsizei> firstsCountsAndInstanceCounts) final;
     void multiDrawElementsANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLsizei, const GCGLsizei> countsAndOffsets, GCGLenum type) final;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -328,7 +328,6 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void BindExternalImage(uint32_t target, uint32_t arg1)
     void CreateExternalSync(uint32_t externalSync, WebCore::GraphicsContextGL::ExternalSyncSource arg0) NotStreamEncodable
     void DeleteExternalSync(uint32_t arg0)
-    void ClientWaitExternalSyncWithFlush(uint32_t arg0, uint64_t timeout) -> (bool returnValue) Synchronous
     [EnabledIf='webXREnabled()'] void EnableRequiredWebXRExtensions() -> (bool returnValue) Synchronous
     [EnabledIf='webXREnabled()'] void AddFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const float> horizontalSamplesLeft, std::span<const float> verticalSamples, std::span<const float> horizontalSamplesRight) -> (bool returnValue) Synchronous
     [EnabledIf='webXREnabled()'] void EnableFoveation(uint32_t arg0)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -1694,15 +1694,6 @@
         arg0 = m_objectNames.take(arg0);
         m_context->deleteExternalSync(arg0);
     }
-    void clientWaitExternalSyncWithFlush(uint32_t arg0, uint64_t timeout, CompletionHandler<void(bool)>&& completionHandler)
-    {
-        assertIsCurrent(workQueue());
-        bool returnValue = { };
-        if (arg0)
-            arg0 = m_objectNames.get(arg0);
-        returnValue = m_context->clientWaitExternalSyncWithFlush(arg0, timeout);
-        completionHandler(returnValue);
-    }
     void enableRequiredWebXRExtensions(CompletionHandler<void(bool)>&& completionHandler)
     {
         assertIsCurrent(workQueue());

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -370,7 +370,6 @@ public:
     void bindExternalImage(GCGLenum target, GCGLExternalImage) final;
     GCGLExternalSync createExternalSync(WebCore::GraphicsContextGL::ExternalSyncSource&&) final;
     void deleteExternalSync(GCGLExternalSync) final;
-    bool clientWaitExternalSyncWithFlush(GCGLExternalSync, uint64_t timeout) final;
 
     bool enableRequiredWebXRExtensions() IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
     bool addFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const GCGLfloat> horizontalSamplesLeft, std::span<const GCGLfloat> verticalSamples, std::span<const GCGLfloat> horizontalSamplesRight) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -3143,19 +3143,6 @@ void RemoteGraphicsContextGLProxy::deleteExternalSync(GCGLExternalSync arg0)
     }
 }
 
-bool RemoteGraphicsContextGLProxy::clientWaitExternalSyncWithFlush(GCGLExternalSync arg0, uint64_t timeout)
-{
-    if (isContextLost())
-        return { };
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::ClientWaitExternalSyncWithFlush(arg0, timeout));
-    if (!sendResult.succeeded()) {
-        markContextLost();
-        return { };
-    }
-    auto& [returnValue] = sendResult.reply();
-    return returnValue;
-}
-
 bool RemoteGraphicsContextGLProxy::enableRequiredWebXRExtensions()
 {
     if (isContextLost())


### PR DESCRIPTION
#### 878556947ba9df79afb77f6b8c35aef99ee9ce07
<pre>
WebXR waits on the finished sync fence on Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=271649">https://bugs.webkit.org/show_bug.cgi?id=271649</a>
<a href="https://rdar.apple.com/125355156">rdar://125355156</a>

Reviewed by Dan Glastonbury.

Remove the wait. The idea is that the compositor waits on the event.
When the wait is removed, ensure that the underlying Metal event is
encoded by flushing GL commands.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::endFrame):
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::clientWaitExternalSyncWithFlush): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::withBufferAsNativeImage):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(deleteExternalSync):
(clientWaitExternalSyncWithFlush): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::clientWaitExternalSyncWithFlush): Deleted.

Canonical link: <a href="https://commits.webkit.org/277430@main">https://commits.webkit.org/277430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37bf74e1199868a08410d337b4ff6686ef5e6874

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50136 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38630 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19953 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42065 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5496 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52013 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22487 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18813 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45933 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23759 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44972 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10503 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24549 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->