### PR TITLE
Fix "use-after-free" warning in WebCore/page/Navigation.cpp with GCC 12

### DIFF
--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(NavigateEvent);
 
-NavigateEvent::NavigateEvent(const AtomString& type, const NavigateEvent::Init& init, RefPtr<AbortController> abortController)
+NavigateEvent::NavigateEvent(const AtomString& type, const NavigateEvent::Init& init, AbortController* abortController)
     : Event(EventInterfaceType::NavigateEvent, type, init, Event::IsTrusted::Yes)
     , m_navigationType(init.navigationType)
     , m_destination(init.destination)
@@ -50,7 +50,7 @@ NavigateEvent::NavigateEvent(const AtomString& type, const NavigateEvent::Init& 
 {
 }
 
-Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, const NavigateEvent::Init& init, RefPtr<AbortController> abortController)
+Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, const NavigateEvent::Init& init, AbortController* abortController)
 {
     return adoptRef(*new NavigateEvent(type, init, abortController));
 }

--- a/Source/WebCore/page/NavigateEvent.h
+++ b/Source/WebCore/page/NavigateEvent.h
@@ -77,7 +77,7 @@ public:
     };
 
     static Ref<NavigateEvent> create(const AtomString& type, const Init&);
-    static Ref<NavigateEvent> create(const AtomString& type, const Init&, RefPtr<AbortController>);
+    static Ref<NavigateEvent> create(const AtomString& type, const Init&, AbortController*);
 
     NavigationNavigationType navigationType() const { return m_navigationType; };
     bool canIntercept() const { return m_canIntercept; };
@@ -102,7 +102,7 @@ public:
     Vector<RefPtr<NavigationInterceptHandler>> handlers() { return m_handlers; };
 
 private:
-    NavigateEvent(const AtomString& type, const Init&, RefPtr<AbortController>);
+    NavigateEvent(const AtomString& type, const Init&, AbortController*);
 
     ExceptionOr<void> sharedChecks();
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -433,7 +433,7 @@ bool Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationT
     if (apiMethodTracker)
         apiMethodTracker->info = JSC::jsUndefined();
 
-    Ref event = NavigateEvent::create(eventNames().navigateEvent, init, abortController);
+    Ref event = NavigateEvent::create(eventNames().navigateEvent, init, abortController.get());
     m_ongoingNavigateEvent = event.ptr();
     m_focusChangedDuringOnoingNavigation = false;
     m_suppressNormalScrollRestorationDuringOngoingNavigation = false;


### PR DESCRIPTION
#### 508e1805310e8f0136a08d4449bc3b23720a6ecc
<pre>
Fix &quot;use-after-free&quot; warning in WebCore/page/Navigation.cpp with GCC 12
<a href="https://bugs.webkit.org/show_bug.cgi?id=271648">https://bugs.webkit.org/show_bug.cgi?id=271648</a>

Reviewed by Michael Catanzaro.

GCC hits a bug with copying this RefPtr by value for some reason.

This should never have been passed by value anyway and since it
doesn&apos;t take ownership should have been passed by a raw pointer.

* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::NavigateEvent):
(WebCore::NavigateEvent::create):
* Source/WebCore/page/NavigateEvent.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/276662@main">https://commits.webkit.org/276662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef1a4d0071159fad974e3cb7510b26c0b38d138e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47768 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47911 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41256 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37111 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18209 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18829 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40108 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3295 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49616 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44143 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21536 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42944 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10070 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21898 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->