### PR TITLE
Inline box may not be present in the enclosing formatting context

### DIFF
--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -505,16 +505,12 @@ LayoutUnit RenderInline::innerPaddingBoxHeight() const
 
 IntRect RenderInline::linesBoundingBox() const
 {
-    IntRect result;
-
     if (auto* layout = LayoutIntegration::LineLayout::containing(*this)) {
-        if (!layout->contains(*this))
-            return result;
-
-        if (!layoutBox()) {
-            // Repaint may be issued on subtrees during content mutation with newly inserted renderers.
+        if (!layoutBox() || !layout->contains(*this)) {
+            // Repaint may be issued on subtrees during content mutation with newly inserted renderers
+            // (or we just forgot to initiate layout before querying geometry on stale content after moving inline boxes between blocks).
             ASSERT(needsLayout());
-            return result;
+            return { };
         }
         return enclosingIntRect(layout->enclosingBorderBoxRectFor(*this));
     }
@@ -523,6 +519,7 @@ IntRect RenderInline::linesBoundingBox() const
     // unable to reproduce this at all (and consequently unable to figure ot why this is happening).  The assert will hopefully catch the problem in debug
     // builds and help us someday figure out why.  We also put in a redundant check of lastLineBox() to avoid the crash for now.
     ASSERT(!firstLineBox() == !lastLineBox());  // Either both are null or both exist.
+    IntRect result;
     if (firstLineBox() && lastLineBox()) {
         // Return the width of the minimal left side and the maximal right side.
         float logicalLeftSide = 0;


### PR DESCRIPTION
#### fe11bcadadbf8b7ad5f95d337b6842b4b42982ec
<pre>
Inline box may not be present in the enclosing formatting context
<a href="https://bugs.webkit.org/show_bug.cgi?id=268525">https://bugs.webkit.org/show_bug.cgi?id=268525</a>
<a href="https://rdar.apple.com/119921061">rdar://119921061</a>

Reviewed by Antti Koivisto.

Speculative fix when the (potentially damaged) inline box is not present in the enclosing formatting context.
This may happen when RenderInline::linesBoundingBox is called on a dirty tree after moving an inline box (&lt;span&gt;)
from a block to an other (but before clearing the tree by running layout).

* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::linesBoundingBox const):

Originally-landed-as: 272448.456@safari-7618-branch (66b364de9dfc). <a href="https://rdar.apple.com/124553574">rdar://124553574</a>
Canonical link: <a href="https://commits.webkit.org/276674@main">https://commits.webkit.org/276674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b34337c6480bed1c26cbf30aaa63676a27d7dc81

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47894 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41239 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37098 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18194 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18893 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40092 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3278 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49599 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16744 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44132 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21519 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42947 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10074 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21875 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->