### PR TITLE
Use std::span more in WebSocketHandshake

### DIFF
--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -83,11 +83,11 @@ static String hostName(const URL& url, bool secure)
 }
 
 static constexpr size_t maxInputSampleSize = 128;
-static String trimInputSample(const uint8_t* p, size_t length)
+static String trimInputSample(std::span<const uint8_t> input)
 {
-    if (length <= maxInputSampleSize)
-        return String(p, length);
-    return makeString(std::span { p, length }.first(maxInputSampleSize), horizontalEllipsis);
+    if (input.size() <= maxInputSampleSize)
+        return input;
+    return makeString(input.first(maxInputSampleSize), horizontalEllipsis);
 }
 
 static String generateSecWebSocketKey()
@@ -216,17 +216,18 @@ void WebSocketHandshake::reset()
     m_extensionDispatcher.reset();
 }
 
-int WebSocketHandshake::readServerHandshake(const uint8_t* header, size_t len)
+int WebSocketHandshake::readServerHandshake(std::span<const uint8_t> header)
 {
+    ASSERT(header.size() <= static_cast<size_t>(std::numeric_limits<int>::max()));
     m_mode = Incomplete;
     int statusCode;
     String statusText;
-    int lineLength = readStatusLine(header, len, statusCode, statusText);
+    int lineLength = readStatusLine(header, statusCode, statusText);
     if (lineLength == -1)
         return -1;
     if (statusCode == -1) {
         m_mode = Failed; // m_failureReason is set inside readStatusLine().
-        return len;
+        return header.size();
     }
     LOG(Network, "WebSocketHandshake %p readServerHandshake() Status code is %d", this, statusCode);
 
@@ -237,28 +238,28 @@ int WebSocketHandshake::readServerHandshake(const uint8_t* header, size_t len)
     if (statusCode != 101) {
         m_mode = Failed;
         m_failureReason = makeString("Unexpected response code: ", statusCode);
-        return len;
+        return header.size();
     }
     m_mode = Normal;
-    if (!memmem(header, len, "\r\n\r\n", 4)) {
+    if (!memmem(header.data(), header.size(), "\r\n\r\n", 4)) {
         // Just hasn't been received fully yet.
         m_mode = Incomplete;
         return -1;
     }
-    auto p = readHTTPHeaders(header + lineLength, header + len);
-    if (!p) {
+    auto p = readHTTPHeaders(header.subspan(lineLength));
+    if (!p.data()) {
         LOG(Network, "WebSocketHandshake %p readServerHandshake() readHTTPHeaders() failed", this);
         m_mode = Failed; // m_failureReason is set inside readHTTPHeaders().
-        return len;
+        return header.size();
     }
     if (!checkResponseHeaders()) {
         LOG(Network, "WebSocketHandshake %p readServerHandshake() checkResponseHeaders() failed", this);
         m_mode = Failed;
-        return p - header;
+        return p.data() - header.data();
     }
 
     m_mode = Connected;
-    return p - header;
+    return p.data() - header.data();
 }
 
 WebSocketHandshake::Mode WebSocketHandshake::mode() const
@@ -356,7 +357,7 @@ static inline bool headerHasValidHTTPVersion(StringView httpStatusLine)
 // Returns the header length (including "\r\n"), or -1 if we have not received enough data yet.
 // If the line is malformed or the status code is not a 3-digit number,
 // statusCode and statusText will be set to -1 and a null string, respectively.
-int WebSocketHandshake::readStatusLine(const uint8_t* header, size_t headerLength, int& statusCode, String& statusText)
+int WebSocketHandshake::readStatusLine(std::span<const uint8_t> header, int& statusCode, String& statusText)
 {
     // Arbitrary size limit to prevent the server from sending an unbounded
     // amount of data with no newlines and forcing us to buffer it all.
@@ -365,57 +366,55 @@ int WebSocketHandshake::readStatusLine(const uint8_t* header, size_t headerLengt
     statusCode = -1;
     statusText = nullAtom();
 
-    const uint8_t* space1 = nullptr;
-    const uint8_t* space2 = nullptr;
-    const uint8_t* p;
-    size_t consumedLength;
+    std::optional<size_t> firstSpaceIndex;
+    std::optional<size_t> secondSpaceIndex;
 
-    for (p = header, consumedLength = 0; consumedLength < headerLength; p++, consumedLength++) {
-        if (*p == ' ') {
-            if (!space1)
-                space1 = p;
-            else if (!space2)
-                space2 = p;
-        } else if (*p == '\0') {
+    size_t index = 0;
+    for (; index < header.size(); ++index) {
+        if (header[index] == ' ') {
+            if (!firstSpaceIndex)
+                firstSpaceIndex = index;
+            else if (!secondSpaceIndex)
+                secondSpaceIndex = index;
+        } else if (header[index] == '\0') {
             // The caller isn't prepared to deal with null bytes in status
             // line. WebSockets specification doesn't prohibit this, but HTTP
             // does, so we'll just treat this as an error.
             m_failureReason = "Status line contains embedded null"_s;
-            return p + 1 - header;
-        } else if (!isASCII(*p)) {
+            return index + 1;
+        } else if (!isASCII(header[index])) {
             m_failureReason = "Status line contains non-ASCII character"_s;
-            return p + 1 - header;
-        } else if (*p == '\n')
+            return index + 1;
+        } else if (header[index] == '\n')
             break;
     }
-    if (consumedLength == headerLength)
+    if (index == header.size())
         return -1; // We have not received '\n' yet.
 
-    auto end = p + 1;
-    int lineLength = end - header;
+    int lineLength = index + 1;
     if (lineLength > maximumLength) {
         m_failureReason = "Status line is too long"_s;
         return maximumLength;
     }
 
     // The line must end with "\r\n".
-    if (lineLength < 2 || *(end - 2) != '\r') {
+    if (lineLength < 2 || header[index - 1] != '\r') {
         m_failureReason = "Status line does not end with CRLF"_s;
         return lineLength;
     }
 
-    if (!space1 || !space2) {
-        m_failureReason = makeString("No response code found: ", trimInputSample(header, lineLength - 2));
+    if (!firstSpaceIndex || !secondSpaceIndex) {
+        m_failureReason = makeString("No response code found: ", trimInputSample(header.first(lineLength - 2)));
         return lineLength;
     }
 
-    StringView httpStatusLine(std::span(header, space1 - header));
+    StringView httpStatusLine(header.first(*firstSpaceIndex));
     if (!headerHasValidHTTPVersion(httpStatusLine)) {
         m_failureReason = makeString("Invalid HTTP version string: ", httpStatusLine);
         return lineLength;
     }
 
-    StringView statusCodeString(std::span(space1 + 1, space2 - space1 - 1));
+    StringView statusCodeString(header.subspan(*firstSpaceIndex + 1, *secondSpaceIndex - *firstSpaceIndex - 1));
     if (statusCodeString.length() != 3) // Status code must consist of three digits.
         return lineLength;
     for (int i = 0; i < 3; ++i) {
@@ -426,23 +425,22 @@ int WebSocketHandshake::readStatusLine(const uint8_t* header, size_t headerLengt
     }
 
     statusCode = parseInteger<int>(statusCodeString).value();
-    statusText = String(space2 + 1, end - space2 - 3); // Exclude "\r\n".
+    statusText = String(header.subspan(*secondSpaceIndex + 1, index - *secondSpaceIndex - 3)); // Exclude "\r\n".
     return lineLength;
 }
 
-const uint8_t* WebSocketHandshake::readHTTPHeaders(const uint8_t* start, const uint8_t* end)
+std::span<const uint8_t> WebSocketHandshake::readHTTPHeaders(std::span<const uint8_t> data)
 {
     StringView name;
     String value;
     bool sawSecWebSocketExtensionsHeaderField = false;
     bool sawSecWebSocketAcceptHeaderField = false;
     bool sawSecWebSocketProtocolHeaderField = false;
-    auto p = start;
-    for (; p < end; p++) {
-        size_t consumedLength = parseHTTPHeader(std::span(p, end - p), m_failureReason, name, value);
+    for (; !data.empty(); data = data.subspan(1)) {
+        size_t consumedLength = parseHTTPHeader(data, m_failureReason, name, value);
         if (!consumedLength)
-            return nullptr;
-        p += consumedLength;
+            return { };
+        data = data.subspan(consumedLength);
 
         // Stop once we consumed an empty line.
         if (name.isEmpty())
@@ -462,30 +460,30 @@ const uint8_t* WebSocketHandshake::readHTTPHeaders(const uint8_t* start, const u
             || headerName == HTTPHeaderName::SecWebSocketProtocol)
             && !value.containsOnlyASCII()) {
             m_failureReason = makeString(name, " header value should only contain ASCII characters");
-            return nullptr;
+            return { };
         }
         
         if (headerName == HTTPHeaderName::SecWebSocketExtensions) {
             if (sawSecWebSocketExtensionsHeaderField) {
                 m_failureReason = "The Sec-WebSocket-Extensions header must not appear more than once in an HTTP response"_s;
-                return nullptr;
+                return { };
             }
             if (!m_extensionDispatcher.processHeaderValue(value)) {
                 m_failureReason = m_extensionDispatcher.failureReason();
-                return nullptr;
+                return { };
             }
             sawSecWebSocketExtensionsHeaderField = true;
         } else {
             if (headerName == HTTPHeaderName::SecWebSocketAccept) {
                 if (sawSecWebSocketAcceptHeaderField) {
                     m_failureReason = "The Sec-WebSocket-Accept header must not appear more than once in an HTTP response"_s;
-                    return nullptr;
+                    return { };
                 }
                 sawSecWebSocketAcceptHeaderField = true;
             } else if (headerName == HTTPHeaderName::SecWebSocketProtocol) {
                 if (sawSecWebSocketProtocolHeaderField) {
                     m_failureReason = "The Sec-WebSocket-Protocol header must not appear more than once in an HTTP response"_s;
-                    return nullptr;
+                    return { };
                 }
                 sawSecWebSocketProtocolHeaderField = true;
             }
@@ -493,7 +491,7 @@ const uint8_t* WebSocketHandshake::readHTTPHeaders(const uint8_t* start, const u
             m_serverHandshakeResponse.addHTTPHeaderField(headerName, value);
         }
     }
-    return p;
+    return data;
 }
 
 bool WebSocketHandshake::checkResponseHeaders()

--- a/Source/WebCore/Modules/websockets/WebSocketHandshake.h
+++ b/Source/WebCore/Modules/websockets/WebSocketHandshake.h
@@ -69,7 +69,7 @@ public:
 
     WEBCORE_EXPORT void reset();
 
-    WEBCORE_EXPORT int readServerHandshake(const uint8_t* header, size_t len);
+    WEBCORE_EXPORT int readServerHandshake(std::span<const uint8_t> header);
     WEBCORE_EXPORT Mode mode() const;
     WEBCORE_EXPORT String failureReason() const; // Returns a string indicating the reason of failure if mode() == Failed.
 
@@ -88,10 +88,10 @@ public:
 
 private:
 
-    int readStatusLine(const uint8_t* header, size_t headerLength, int& statusCode, String& statusText);
+    int readStatusLine(std::span<const uint8_t> header, int& statusCode, String& statusText);
 
     // Reads all headers except for the two predefined ones.
-    const uint8_t* readHTTPHeaders(const uint8_t* start, const uint8_t* end);
+    std::span<const uint8_t> readHTTPHeaders(std::span<const uint8_t>);
     void processHeaders();
     bool checkResponseHeaders();
 

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -289,7 +289,7 @@ Expected<bool, String> WebSocketTask::validateOpeningHandshake()
         return makeUnexpected("Unexpected handshakeing condition"_s);
     }
 
-    auto headerLength = m_handshake->readServerHandshake(m_receiveBuffer.data(), m_receiveBuffer.size());
+    auto headerLength = m_handshake->readServerHandshake(m_receiveBuffer.span());
     if (headerLength <= 0)
         return false;
 

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -458,7 +458,7 @@ bool WebSocketChannel::processBuffer()
     Ref<WebSocketChannel> protectedThis(*this); // The client can close the channel, potentially removing the last reference.
 
     if (m_handshake->mode() == WebSocketHandshake::Incomplete) {
-        int headerLength = m_handshake->readServerHandshake(m_buffer.data(), m_buffer.size());
+        int headerLength = m_handshake->readServerHandshake(m_buffer.span());
         if (headerLength <= 0)
             return false;
         if (m_handshake->mode() == WebSocketHandshake::Connected) {


### PR DESCRIPTION
#### 0827d780deda55ea3c0ea1079a09814fdcd14617
<pre>
Use std::span more in WebSocketHandshake
<a href="https://bugs.webkit.org/show_bug.cgi?id=271650">https://bugs.webkit.org/show_bug.cgi?id=271650</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/websockets/WebSocketHandshake.cpp:
(WebCore::trimInputSample):
(WebCore::WebSocketHandshake::readServerHandshake):
(WebCore::WebSocketHandshake::readStatusLine):
(WebCore::WebSocketHandshake::readHTTPHeaders):
* Source/WebCore/Modules/websockets/WebSocketHandshake.h:
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::validateOpeningHandshake):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp:
(WebCore::WebSocketChannel::processBuffer):

Canonical link: <a href="https://commits.webkit.org/276696@main">https://commits.webkit.org/276696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/994ded41b3a699431aa1ab9fb754830f7e0fad23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48035 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21888 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37208 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39147 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18310 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40227 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3418 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41664 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49755 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16879 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44255 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21661 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43069 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10094 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22022 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21349 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->