### PR TITLE
Rename topPrivatelyControlledDomain() to registrableDomain()

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4064,10 +4064,10 @@ const URL& Document::urlForBindings() const
         if (preNavigationURL.isEmpty() || RegistrableDomain { preNavigationURL }.matches(securityOrigin().data()))
             return false;
 
-        auto areSameSiteIgnoringPublicSuffix = [](StringView domain, StringView otherDomain) {
+        auto areSameSiteIgnoringPublicSuffix = [](const URL& url, const URL& otherURL) {
             auto& publicSuffixStore = PublicSuffixStore::singleton();
-            auto domainString = publicSuffixStore.topPrivatelyControlledDomain(domain.toStringWithoutCopying());
-            auto otherDomainString = publicSuffixStore.topPrivatelyControlledDomain(otherDomain.toStringWithoutCopying());
+            auto domainString = publicSuffixStore.registrableDomain(url);
+            auto otherDomainString = publicSuffixStore.registrableDomain(otherURL);
             auto substringToSeparator = [](const String& string) -> String {
                 auto indexOfFirstSeparator = string.find('.');
                 if (indexOfFirstSeparator == notFound)
@@ -4078,8 +4078,8 @@ const URL& Document::urlForBindings() const
             return !firstSubstring.isEmpty() && firstSubstring == substringToSeparator(otherDomainString);
         };
 
-        auto currentHost = securityOrigin().data().host();
-        if (areSameSiteIgnoringPublicSuffix(preNavigationURL.host(), currentHost))
+        auto currentURL = securityOrigin().toURL();
+        if (areSameSiteIgnoringPublicSuffix(preNavigationURL, currentURL))
             return false;
 
         if (!m_hasLoadedThirdPartyScript)
@@ -4089,7 +4089,7 @@ const URL& Document::urlForBindings() const
             if (RegistrableDomain { sourceURL }.matches(securityOrigin().data()))
                 return false;
 
-            if (areSameSiteIgnoringPublicSuffix(sourceURL.host(), currentHost))
+            if (areSameSiteIgnoringPublicSuffix(sourceURL, currentURL))
                 return false;
         }
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -100,8 +100,8 @@ static HashMap<RegistrableDomain, String>& updatableStorageAccessUserAgentString
 #if PLATFORM(IOS_FAMILY)
 static inline bool isYahooMail(Document& document)
 {
-    auto host = document.topDocument().url().host();
-    return host.startsWith("mail."_s) && PublicSuffixStore::singleton().topPrivatelyControlledDomain(host.toString()).startsWith("yahoo."_s);
+    auto url = document.topDocument().url();
+    return url.host().startsWith("mail."_s) && PublicSuffixStore::singleton().registrableDomain(url).startsWith("yahoo."_s);
 }
 #endif
 
@@ -263,7 +263,7 @@ bool Quirks::shouldHideSearchFieldResultsButton() const
     if (!needsQuirks())
         return false;
 
-    if (PublicSuffixStore::singleton().topPrivatelyControlledDomain(m_document->topDocument().url().host().toString()).startsWith("google."_s))
+    if (PublicSuffixStore::singleton().registrableDomain(m_document->topDocument().url()).startsWith("google."_s))
         return true;
 #endif
     return false;
@@ -454,13 +454,13 @@ bool Quirks::shouldDisableWritingSuggestionsByDefaultQuirk() const
 #if ENABLE(TOUCH_EVENTS)
 bool Quirks::isAmazon() const
 {
-    return PublicSuffixStore::singleton().topPrivatelyControlledDomain(m_document->topDocument().url().host().toString()).startsWith("amazon."_s);
+    return PublicSuffixStore::singleton().registrableDomain(m_document->topDocument().url()).startsWith("amazon."_s);
 }
 
 bool Quirks::isGoogleMaps() const
 {
     auto& url = m_document->topDocument().url();
-    return PublicSuffixStore::singleton().topPrivatelyControlledDomain(url.host().toString()).startsWith("google."_s) && startsWithLettersIgnoringASCIICase(url.path(), "/maps/"_s);
+    return PublicSuffixStore::singleton().registrableDomain(url).startsWith("google."_s) && startsWithLettersIgnoringASCIICase(url.path(), "/maps/"_s);
 }
 
 // rdar://49124313

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -417,17 +417,18 @@ bool SecurityOrigin::isSameSiteAs(const SecurityOrigin& other) const
     // https://html.spec.whatwg.org/#same-site
     if (isOpaque() != other.isOpaque())
         return false;
+
     if (!isOpaque() && protocol() != other.protocol())
         return false;
 
     if (isOpaque())
         return isSameOriginAs(other);
 
-    auto topDomain = PublicSuffixStore::singleton().topPrivatelyControlledDomain(domain());
+    auto topDomain = PublicSuffixStore::singleton().registrableDomain(toURL());
     if (topDomain.isEmpty())
         return host() == other.host();
 
-    return topDomain == PublicSuffixStore::singleton().topPrivatelyControlledDomain(other.domain());
+    return topDomain == PublicSuffixStore::singleton().registrableDomain(toURL());
 }
 
 bool SecurityOrigin::isMatchingRegistrableDomainSuffix(const String& domainSuffix, bool treatIPAddressAsDomain) const

--- a/Source/WebCore/platform/PublicSuffixStore.h
+++ b/Source/WebCore/platform/PublicSuffixStore.h
@@ -38,8 +38,8 @@ public:
 
     // https://url.spec.whatwg.org/#host-public-suffix
     WEBCORE_EXPORT bool isPublicSuffix(StringView domain) const;
-    WEBCORE_EXPORT String publicSuffix(const String& domain) const;
-    WEBCORE_EXPORT String topPrivatelyControlledDomain(const String& host) const;
+    WEBCORE_EXPORT String publicSuffix(const URL&) const;
+    WEBCORE_EXPORT String registrableDomain(const URL&) const;
     WEBCORE_EXPORT void clearHostTopPrivatelyControlledDomainCache();
 
 #if PLATFORM(COCOA)
@@ -52,10 +52,10 @@ private:
     PublicSuffixStore() = default;
 
     bool platformIsPublicSuffix(StringView domain) const;
-    String platformTopPrivatelyControlledDomain(const String& host) const;
+    String platformRegistrableDomain(const String& host) const;
 
-    mutable Lock m_HostTopPrivatelyControlledDomainCacheLock;
-    mutable HashMap<String, String, ASCIICaseInsensitiveHash> m_hostTopPrivatelyControlledDomainCache WTF_GUARDED_BY_LOCK(m_HostTopPrivatelyControlledDomainCacheLock);
+    mutable Lock m_hostRegistrableDomainCacheLock;
+    mutable HashMap<String, String, ASCIICaseInsensitiveHash> m_hostRegistrableDomainCache WTF_GUARDED_BY_LOCK(m_hostRegistrableDomainCacheLock);
 #if PLATFORM(COCOA)
     mutable Lock m_publicSuffixCacheLock;
     std::optional<HashSet<String, ASCIICaseInsensitiveHash>> m_publicSuffixCache WTF_GUARDED_BY_LOCK(m_publicSuffixCacheLock);

--- a/Source/WebCore/platform/RegistrableDomain.h
+++ b/Source/WebCore/platform/RegistrableDomain.h
@@ -40,12 +40,12 @@ public:
     RegistrableDomain() = default;
 
     explicit RegistrableDomain(const URL& url)
-        : RegistrableDomain(registrableDomainFromHost(url.host().toString()))
+        : RegistrableDomain(registrableDomainFromURL(url))
     {
     }
 
     explicit RegistrableDomain(const SecurityOriginData& origin)
-        : RegistrableDomain(registrableDomainFromHost(origin.host()))
+        : RegistrableDomain(registrableDomainFromURL(origin.toURL()))
     {
     }
 
@@ -91,7 +91,7 @@ public:
     
     static RegistrableDomain uncheckedCreateFromHost(const String& host)
     {
-        auto registrableDomain = PublicSuffixStore::singleton().topPrivatelyControlledDomain(host);
+        auto registrableDomain = PublicSuffixStore::singleton().registrableDomain(URL { host });
         if (registrableDomain.isEmpty())
             return uncheckedCreateFromRegistrableDomainString(host);
         return RegistrableDomain { WTFMove(registrableDomain) };
@@ -114,13 +114,15 @@ private:
         return host[host.length() - m_registrableDomain.length() - 1] == '.';
     }
 
-    static inline String registrableDomainFromHost(const String& host)
+    static inline String registrableDomainFromURL(const URL& url)
     {
-        auto domain = PublicSuffixStore::singleton().topPrivatelyControlledDomain(host);
-        if (host.isEmpty())
-            domain = "nullOrigin"_s;
-        else if (domain.isEmpty())
-            domain = host;
+        if (url.host().isEmpty())
+            return "nullOrigin"_s;
+
+        auto domain = PublicSuffixStore::singleton().registrableDomain(url);
+        if (domain.isEmpty())
+            return url.host().toString();
+
         return domain;
     }
 

--- a/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
@@ -49,7 +49,7 @@ bool PublicSuffixStore::platformIsPublicSuffix(StringView domain) const
     return isPublicSuffixCF(domainString);
 }
 
-String PublicSuffixStore::platformTopPrivatelyControlledDomain(const String& host) const
+String PublicSuffixStore::platformRegistrableDomain(const String& host) const
 {
     size_t separatorPosition;
     for (unsigned labelStart = 0; (separatorPosition = host.find('.', labelStart)) != notFound; labelStart = separatorPosition + 1) {

--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -168,7 +168,7 @@ UserAgentQuirks UserAgentQuirks::quirksForURL(const URL& url)
 
     String domain = url.host().toString();
     UserAgentQuirks quirks;
-    String baseDomain = PublicSuffixStore::singleton().topPrivatelyControlledDomain(domain);
+    String baseDomain = PublicSuffixStore::singleton().registrableDomain(domain);
 
     if (urlRequiresChromeBrowser(domain, baseDomain))
         quirks.add(UserAgentQuirks::NeedsChromeBrowser);

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -829,7 +829,7 @@ String ResourceRequestBase::partitionName(const String& domain)
 {
     if (domain.isNull())
         return emptyString();
-    auto highLevel = PublicSuffixStore::singleton().topPrivatelyControlledDomain(domain);
+    auto highLevel = PublicSuffixStore::singleton().registrableDomain(URL { domain });
     if (highLevel.isNull())
         return emptyString();
     return highLevel;

--- a/Source/WebCore/platform/network/curl/PublicSuffixStoreCurl.cpp
+++ b/Source/WebCore/platform/network/curl/PublicSuffixStoreCurl.cpp
@@ -50,7 +50,7 @@ static String topPrivatelyControlledDomainInternal(const psl_ctx_t* psl, const c
     return String();
 }
 
-String PublicSuffixStore::platformTopPrivatelyControlledDomain(const String& domain) const
+String PublicSuffixStore::platformRegistrableDomain(const String& domain) const
 {
     if (platformIsPublicSuffix(domain))
         return String();

--- a/Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp
+++ b/Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp
@@ -58,7 +58,7 @@ static String permissiveTopPrivateDomain(const String& domain)
     return foundDot ? domain : String();
 }
 
-String PublicSuffixStore::platformTopPrivatelyControlledDomain(const String& domain) const
+String PublicSuffixStore::platformRegistrableDomain(const String& domain) const
 {
     CString domainUTF8 = domain.utf8();
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -292,7 +292,7 @@ void ProvisionalPageProxy::goToBackForwardItem(API::Navigation& navigation, WebB
     URL itemURL { item.url() };
     m_page->maybeInitializeSandboxExtensionHandle(process(), itemURL, item.resourceDirectoryURL(), sandboxExtensionHandle);
 
-    auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(item.url()).host().toString());
+    auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(item.url()));
     GoToBackForwardItemParameters parameters { navigation.navigationID(), item.itemID(), *navigation.backForwardFrameLoadType(), shouldTreatAsContinuingLoad, WTFMove(websitePoliciesData), m_page->lastNavigationWasAppInitiated(), existingNetworkResourceLoadIdentifierToResume, WTFMove(publicSuffix), WTFMove(sandboxExtensionHandle) };
     if (!process().isLaunching() || !itemURL.protocolIsFile())
         send(Messages::WebPage::GoToBackForwardItem(WTFMove(parameters)));

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1199,7 +1199,7 @@ void WebProcessProxy::processDidTerminateOrFailedToLaunch(ProcessTerminationReas
     // FIXME: Perhaps this should consider ProcessTerminationReasons ExceededMemoryLimit, ExceededCPULimit, Unresponsive as well.
     if (pages.size() == 1 && reason == ProcessTerminationReason::Crash) {
         auto& page = pages[0];
-        auto domain = PublicSuffixStore::singleton().topPrivatelyControlledDomain(URL({ }, page->currentURL()).host().toString());
+        auto domain = PublicSuffixStore::singleton().registrableDomain(URL({ }, page->currentURL()));
         if (!domain.isEmpty())
             page->logDiagnosticMessageWithEnhancedPrivacy(WebCore::DiagnosticLoggingKeys::domainCausingCrashKey(), domain, WebCore::ShouldSample::No);
     }
@@ -2008,7 +2008,7 @@ void WebProcessProxy::didExceedMemoryFootprintThreshold(size_t footprint)
     bool hasAllowedToRunInTheBackgroundActivity = false;
 
     for (auto& page : this->pages()) {
-        auto pageDomain = PublicSuffixStore::singleton().topPrivatelyControlledDomain(URL({ }, page->currentURL()).host().toString());
+        auto pageDomain = PublicSuffixStore::singleton().registrableDomain(URL({ }, page->currentURL()));
         if (domain.isEmpty())
             domain = WTFMove(pageDomain);
         else if (domain != pageDomain)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataRecord.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataRecord.cpp
@@ -56,7 +56,7 @@ String WebsiteDataRecord::displayNameForCookieHostName(const String& hostName)
 
 String WebsiteDataRecord::displayNameForHostName(const String& hostName)
 {
-    return WebCore::PublicSuffixStore::singleton().topPrivatelyControlledDomain(hostName);
+    return WebCore::PublicSuffixStore::singleton().registrableDomain(URL { hostName });
 }
 
 String WebsiteDataRecord::displayNameForOrigin(const WebCore::SecurityOriginData& securityOrigin)
@@ -67,7 +67,7 @@ String WebsiteDataRecord::displayNameForOrigin(const WebCore::SecurityOriginData
         return displayNameForLocalFiles();
 
     if (protocol == "http"_s || protocol == "https"_s)
-        return WebCore::PublicSuffixStore::singleton().topPrivatelyControlledDomain(securityOrigin.host());
+        return WebCore::PublicSuffixStore::singleton().registrableDomain(securityOrigin.toURL());
 
     return String();
 }
@@ -140,10 +140,10 @@ String WebsiteDataRecord::topPrivatelyControlledDomain()
 {
     auto& publicSuffixStore = WebCore::PublicSuffixStore::singleton();
     if (!cookieHostNames.isEmpty())
-        return publicSuffixStore.topPrivatelyControlledDomain(cookieHostNames.takeAny());
+        return publicSuffixStore.registrableDomain(URL { cookieHostNames.takeAny() });
     
     if (!origins.isEmpty())
-        return publicSuffixStore.topPrivatelyControlledDomain(origins.takeAny().securityOrigin().get().host());
+        return publicSuffixStore.registrableDomain(origins.takeAny().securityOrigin().get().toURL());
     
     return emptyString();
 }

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -781,7 +781,7 @@ static void prewarmLogs()
     // This call will create container manager log objects.
     // FIXME: this can be removed if we move all calls to topPrivatelyControlledDomain out of the WebContent process.
     // This would be desirable, since the WebContent process is blocking access to the container manager daemon.
-    PublicSuffixStore::singleton().topPrivatelyControlledDomain("apple.com"_s);
+    PublicSuffixStore::singleton().registrableDomain(URL { "apple.com"_s });
 
     static std::array<std::pair<const char*, const char*>, 5> logs { {
         { "com.apple.CFBundle", "strings" },

--- a/Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp
@@ -29,6 +29,7 @@
 #include "WTFTestUtilities.h"
 #include <WebCore/PublicSuffixStore.h>
 #include <wtf/MainThread.h>
+#include <wtf/URL.h>
 
 using namespace WebCore;
 
@@ -155,34 +156,33 @@ TEST_F(PublicSuffix, IsPublicSuffix)
 TEST_F(PublicSuffix, TopPrivatelyControlledDomain)
 {
     auto& publicSuffixStore = PublicSuffixStore::singleton();
-    EXPECT_EQ(String(utf16String(u"example.\u6803\u6728.jp")), publicSuffixStore.topPrivatelyControlledDomain(utf16String(u"example.\u6803\u6728.jp")));
-    EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomain(String()));
-    EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomain(""_s));
-    EXPECT_EQ(String("test.com"_s), publicSuffixStore.topPrivatelyControlledDomain("test.com"_s));
-    EXPECT_EQ(String("test.com"_s), publicSuffixStore.topPrivatelyControlledDomain("com.test.com"_s));
-    EXPECT_EQ(String("test.com"_s), publicSuffixStore.topPrivatelyControlledDomain("subdomain.test.com"_s));
-    EXPECT_EQ(String("com.com"_s), publicSuffixStore.topPrivatelyControlledDomain("www.com.com"_s));
-    EXPECT_EQ(String("test.co.uk"_s), publicSuffixStore.topPrivatelyControlledDomain("test.co.uk"_s));
-    EXPECT_EQ(String("test.co.uk"_s), publicSuffixStore.topPrivatelyControlledDomain("subdomain.test.co.uk"_s));
-    EXPECT_EQ(String("bl.uk"_s), publicSuffixStore.topPrivatelyControlledDomain("bl.uk"_s));
-    EXPECT_EQ(String("bl.uk"_s), publicSuffixStore.topPrivatelyControlledDomain("subdomain.bl.uk"_s));
-    EXPECT_EQ(String("test.xn--zf0ao64a.tw"_s), publicSuffixStore.topPrivatelyControlledDomain("test.xn--zf0ao64a.tw"_s));
-    EXPECT_EQ(String("test.xn--zf0ao64a.tw"_s), publicSuffixStore.topPrivatelyControlledDomain("www.test.xn--zf0ao64a.tw"_s));
-    EXPECT_EQ(String("127.0.0.1"_s), publicSuffixStore.topPrivatelyControlledDomain("127.0.0.1"_s));
-    EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomain("1"_s));
-    EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomain("com"_s));
-    EXPECT_EQ(String("test.com"_s), publicSuffixStore.topPrivatelyControlledDomain("r4---asdf.test.com"_s));
-    EXPECT_EQ(String("r4---asdf.com"_s), publicSuffixStore.topPrivatelyControlledDomain("r4---asdf.com"_s));
-    EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomain("r4---asdf"_s));
-    EXPECT_EQ(utf16String(bidirectionalDomain), utf16String(bidirectionalDomain));
-    EXPECT_EQ(String("example.com"_s), publicSuffixStore.topPrivatelyControlledDomain("ExamPle.com"_s));
-    EXPECT_EQ(String("example.com"_s), publicSuffixStore.topPrivatelyControlledDomain("SUB.dOmain.ExamPle.com"_s));
-    EXPECT_EQ(String("localhost"_s), publicSuffixStore.topPrivatelyControlledDomain("localhost"_s));
-    EXPECT_EQ(String("localhost"_s), publicSuffixStore.topPrivatelyControlledDomain("LocalHost"_s));
-    EXPECT_EQ(String::fromUTF8("åäö"), publicSuffixStore.topPrivatelyControlledDomain(String::fromUTF8("åäö")));
-    EXPECT_EQ(String::fromUTF8("ÅÄÖ"), publicSuffixStore.topPrivatelyControlledDomain(String::fromUTF8("ÅÄÖ")));
-    EXPECT_EQ(String("test.com"_s), publicSuffixStore.topPrivatelyControlledDomain(".test.com"_s));
-    EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomain("...."_s));
+    EXPECT_EQ(String(utf16String(u"example.\u6803\u6728.jp")), publicSuffixStore.registrableDomain(URL { utf16String(u"example.\u6803\u6728.jp") }));
+    EXPECT_EQ(String(), publicSuffixStore.registrableDomain(URL()));
+    EXPECT_EQ(String(), publicSuffixStore.registrableDomain(URL(""_s)));
+    EXPECT_EQ(String("test.com"_s), publicSuffixStore.registrableDomain(URL("test.com"_s)));
+    EXPECT_EQ(String("test.com"_s), publicSuffixStore.registrableDomain(URL("com.test.com"_s)));
+    EXPECT_EQ(String("test.com"_s), publicSuffixStore.registrableDomain(URL("subdomain.test.com"_s)));
+    EXPECT_EQ(String("com.com"_s), publicSuffixStore.registrableDomain(URL("www.com.com"_s)));
+    EXPECT_EQ(String("test.co.uk"_s), publicSuffixStore.registrableDomain(URL("test.co.uk"_s)));
+    EXPECT_EQ(String("test.co.uk"_s), publicSuffixStore.registrableDomain(URL("subdomain.test.co.uk"_s)));
+    EXPECT_EQ(String("bl.uk"_s), publicSuffixStore.registrableDomain(URL("bl.uk"_s)));
+    EXPECT_EQ(String("bl.uk"_s), publicSuffixStore.registrableDomain(URL("subdomain.bl.uk"_s)));
+    EXPECT_EQ(String("test.xn--zf0ao64a.tw"_s), publicSuffixStore.registrableDomain(URL("test.xn--zf0ao64a.tw"_s)));
+    EXPECT_EQ(String("test.xn--zf0ao64a.tw"_s), publicSuffixStore.registrableDomain(URL("www.test.xn--zf0ao64a.tw"_s)));
+    EXPECT_EQ(String("127.0.0.1"_s), publicSuffixStore.registrableDomain(URL("127.0.0.1"_s)));
+    EXPECT_EQ(String(), publicSuffixStore.registrableDomain(URL("1"_s)));
+    EXPECT_EQ(String(), publicSuffixStore.registrableDomain(URL("com"_s)));
+    EXPECT_EQ(String("test.com"_s), publicSuffixStore.registrableDomain(URL("r4---asdf.test.com"_s)));
+    EXPECT_EQ(String("r4---asdf.com"_s), publicSuffixStore.registrableDomain(URL("r4---asdf.com"_s)));
+    EXPECT_EQ(String(), publicSuffixStore.registrableDomain(URL("r4---asdf"_s)));
+    EXPECT_EQ(String("example.com"_s), publicSuffixStore.registrableDomain(URL("ExamPle.com"_s)));
+    EXPECT_EQ(String("example.com"_s), publicSuffixStore.registrableDomain(URL("SUB.dOmain.ExamPle.com"_s)));
+    EXPECT_EQ(String("localhost"_s), publicSuffixStore.registrableDomain(URL("localhost"_s)));
+    EXPECT_EQ(String("localhost"_s), publicSuffixStore.registrableDomain(URL("LocalHost"_s)));
+    EXPECT_EQ(String::fromUTF8("åäö"), publicSuffixStore.registrableDomain(URL(String::fromUTF8("åäö"))));
+    EXPECT_EQ(String::fromUTF8("ÅÄÖ"), publicSuffixStore.registrableDomain(URL(String::fromUTF8("ÅÄÖ"))));
+    EXPECT_EQ(String("test.com"_s), publicSuffixStore.registrableDomain(URL(".test.com"_s)));
+    EXPECT_EQ(String(), publicSuffixStore.registrableDomain(URL("...."_s)));
 }
 
 #if PLATFORM(COCOA)
@@ -190,9 +190,9 @@ TEST_F(PublicSuffix, PublicSuffixCache)
 {
     auto& publicSuffixStore = PublicSuffixStore::singleton();
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix("example.example"_s));
-    EXPECT_EQ(String("example"_s), publicSuffixStore.publicSuffix("a.b.example.example"_s));
+    EXPECT_EQ(String("example"_s), publicSuffixStore.publicSuffix(URL("a.b.example.example"_s)));
     // Non-cocoa platforms currently do not use public suffix cache for topPrivatelyControlledDomain().
-    EXPECT_EQ(String("example.example"_s), publicSuffixStore.topPrivatelyControlledDomain("a.b.example.example"_s));
+    EXPECT_EQ(String("example.example"_s), publicSuffixStore.registrableDomain(URL("a.b.example.example"_s)));
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix(""_s));
 
     publicSuffixStore.enablePublicSuffixCache();
@@ -200,8 +200,8 @@ TEST_F(PublicSuffix, PublicSuffixCache)
     publicSuffixStore.addPublicSuffix("example.example"_s);
     publicSuffixStore.addPublicSuffix(""_s);
     EXPECT_TRUE(publicSuffixStore.isPublicSuffix("example.example"_s));
-    EXPECT_EQ(String("example.example"_s), publicSuffixStore.publicSuffix("a.b.example.example"_s));
-    EXPECT_EQ(String("b.example.example"_s), publicSuffixStore.topPrivatelyControlledDomain("a.b.example.example"_s));
+    EXPECT_EQ(String("example.example"_s), publicSuffixStore.publicSuffix(URL("a.b.example.example"_s)));
+    EXPECT_EQ(String("b.example.example"_s), publicSuffixStore.registrableDomain(URL("a.b.example.example"_s)));
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix(""_s));
 }
 #endif


### PR DESCRIPTION
#### bf91700b751f351fdbab28b40bc6ad1bc611e451
<pre>
Rename topPrivatelyControlledDomain() to registrableDomain()
<a href="https://bugs.webkit.org/show_bug.cgi?id=271657">https://bugs.webkit.org/show_bug.cgi?id=271657</a>
<a href="https://rdar.apple.com/125359620">rdar://125359620</a>

Reviewed by NOBODY (OOPS!).

Rename topPrivatelyControlledDomain to be consistent with spec: <a href="https://url.spec.whatwg.org/#host-registrable-domain.">https://url.spec.whatwg.org/#host-registrable-domain.</a>
Also, make PublicSuffixStore::topPrivatelyControlledDomain take a URL instead of String, because URLParser validates
input string and URL contains a lowercase host string, so topPrivatelyControlledDomain() does not need to perform checks
and convertion.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::urlForBindings const):
* Source/WebCore/page/Quirks.cpp:
(WebCore::isYahooMail):
(WebCore::Quirks::shouldHideSearchFieldResultsButton const):
(WebCore::Quirks::isAmazon const):
(WebCore::Quirks::isGoogleMaps const):
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::isSameSiteAs const):
* Source/WebCore/platform/PublicSuffixStore.cpp:
(WebCore::PublicSuffixStore::clearHostTopPrivatelyControlledDomainCache):
(WebCore::PublicSuffixStore::publicSuffix const):
(WebCore::PublicSuffixStore::registrableDomain const):
(WebCore::PublicSuffixStore::topPrivatelyControlledDomain const): Deleted.
* Source/WebCore/platform/PublicSuffixStore.h:
* Source/WebCore/platform/RegistrableDomain.h:
(WebCore::RegistrableDomain::RegistrableDomain):
(WebCore::RegistrableDomain::uncheckedCreateFromHost):
(WebCore::RegistrableDomain::registrableDomainFromURL):
(WebCore::RegistrableDomain::registrableDomainFromHost): Deleted.
* Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm:
(WebCore::PublicSuffixStore::platformRegistrableDomain const):
(WebCore::PublicSuffixStore::platformTopPrivatelyControlledDomain const): Deleted.
* Source/WebCore/platform/glib/UserAgentQuirks.cpp:
(WebCore::UserAgentQuirks::quirksForURL):
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::partitionName):
* Source/WebCore/platform/network/curl/PublicSuffixStoreCurl.cpp:
(WebCore::PublicSuffixStore::platformRegistrableDomain const):
(WebCore::PublicSuffixStore::platformTopPrivatelyControlledDomain const): Deleted.
* Source/WebCore/platform/soup/PublicSuffixStoreSoup.cpp:
(WebCore::PublicSuffixStore::platformRegistrableDomain const):
(WebCore::PublicSuffixStore::platformTopPrivatelyControlledDomain const): Deleted.
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::goToBackForwardItem):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcessForReload):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::resetStateAfterProcessTermination):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):
(WebKit::WebProcessProxy::didExceedMemoryFootprintThreshold):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataRecord.cpp:
(WebKit::WebsiteDataRecord::displayNameForHostName):
(WebKit::WebsiteDataRecord::displayNameForOrigin):
(WebKit::WebsiteDataRecord::topPrivatelyControlledDomain):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::prewarmLogs):
* Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp:
(TestWebKitAPI::TEST_F):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf91700b751f351fdbab28b40bc6ad1bc611e451

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47766 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47909 "Hash bf91700b for PR 26420 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41254 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21761 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/47909 "Hash bf91700b for PR 26420 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45824 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21415 "Found 5 new test failures: http/tests/cache/partitioned-cache-iframe.html, http/tests/cache/partitioned-cache.html, http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html, http/tests/security/credentials-iframes.html, http/wpt/clear-site-data/partitioning.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39024 "5 api tests failed or timed out") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/47909 "Hash bf91700b for PR 26420 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18828 "Found 13 new test failures: imported/w3c/web-platform-tests/css/css-content/quotes-007.html, imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-001.html, imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-unrelated-element.html, imported/w3c/web-platform-tests/fetch/metadata/generated/audioworklet.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/element-script.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/fetch-via-serviceworker.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/fetch.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/script-module-import-dynamic.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/script-module-import-static.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/worker-dedicated-importscripts.https.sub.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40106 "Found 4 new test failures: http/tests/cache/partitioned-cache-iframe.html, http/tests/cache/partitioned-cache.html, http/tests/security/credentials-iframes.html, imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm (failure)") | [❌ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3293 "Hash bf91700b for PR 26420 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41511 "Found 6 new API test failures: TestWebKitAPI.PublicSuffix.PublicSuffixCache, TestWebKitAPI.InAppBrowserPrivacy.GetCookieForNonAppBoundDomainFails, TestWebKitAPI.InAppBrowserPrivacy.SetCookieForNonAppBoundDomainFails, TestWebKitAPI.RegistrableDomain.UncheckedCreateFromHost, TestWebKitAPI.PublicSuffix.TopPrivatelyControlledDomain, TestWebKitAPI.ResourceLoadStatistics.UserGestureLogsUserInteraction (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40423 "Found 12 new test failures: http/tests/cache/partitioned-cache-iframe.html, http/tests/cache/partitioned-cache.html, http/tests/security/credentials-iframes.html, http/wpt/clear-site-data/partitioning.html, imported/w3c/web-platform-tests/fetch/metadata/generated/audioworklet.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/element-script.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/fetch-via-serviceworker.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/fetch.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/script-module-import-dynamic.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/script-module-import-static.https.sub.html ... (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49614 "Hash bf91700b for PR 26420 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20228 "Failed to checkout and rebase branch from PR 26420") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16758 "Found 12 new test failures: http/tests/cache/partitioned-cache-iframe.html, http/tests/cache/partitioned-cache.html, http/tests/security/credentials-iframes.html, http/wpt/clear-site-data/partitioning.html, imported/w3c/web-platform-tests/fetch/metadata/generated/audioworklet.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/element-script.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/fetch-via-serviceworker.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/fetch.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/script-module-import-dynamic.https.sub.html, imported/w3c/web-platform-tests/fetch/metadata/generated/script-module-import-static.https.sub.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/49614 "Hash bf91700b for PR 26420 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21534 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/49614 "Hash bf91700b for PR 26420 does not build (failure)") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21895 "Failed to checkout and rebase branch from PR 26420") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->