### PR TITLE
GroupSession.swift tvOS compilation error

### DIFF
--- a/Source/WebKit/WebKitSwift/GroupActivities/GroupSession.swift
+++ b/Source/WebKit/WebKitSwift/GroupActivities/GroupSession.swift
@@ -28,7 +28,7 @@ import Combine
 @_spi(Safari) import GroupActivities
 import Foundation
 
-@available(macOS 15.0, iOS 18.0, *)
+@available(macOS 9999.0, iOS 9999.0, tvOS 9999.0, *)
 @objc(WKGroupSessionState)
 public enum GroupSessionState : Int {
     case waiting = 0
@@ -36,7 +36,7 @@ public enum GroupSessionState : Int {
     case invalidated = 2
 }
 
-@available(macOS 15.0, iOS 18.0, *)
+@available(macOS 9999.0, iOS 9999.0, tvOS 9999.0, *)
 @objc(WKURLActivity)
 public final class URLActivityWrapper : NSObject {
     private var urlActivity: URLActivity
@@ -50,7 +50,7 @@ public final class URLActivityWrapper : NSObject {
     }
 }
 
-@available(macOS 15.0, iOS 18.0, *)
+@available(macOS 9999.0, iOS 9999.0, tvOS 9999.0, *)
 @objc(WKGroupSession)
 public final class GroupSessionWrapper : NSObject {
     private var groupSession: GroupSession<URLActivity>
@@ -128,7 +128,7 @@ public final class GroupSessionWrapper : NSObject {
     }
 }
 
-@available(macOS 15.0, iOS 18.0, *)
+@available(macOS 9999.0, iOS 9999.0, tvOS 9999.0, *)
 @objc(WKGroupSessionObserver)
 public class GroupSessionObserver : NSObject {
     @objc public var newSessionCallback: ((GroupSessionWrapper) -> Void)?


### PR DESCRIPTION
#### 9038ec05b3626d118eeb656a9b7558d331fc0c43
<pre>
GroupSession.swift tvOS compilation error
<a href="https://rdar.apple.com/125359350">rdar://125359350</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=271656">https://bugs.webkit.org/show_bug.cgi?id=271656</a>

Reviewed by Pascoe.

Compile error with newest SDKs. Refer to radar for more info.

* Source/WebKit/WebKitSwift/GroupActivities/GroupSession.swift:

Canonical link: <a href="https://commits.webkit.org/276678@main">https://commits.webkit.org/276678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f47888b958328c58865fc07ba5b3c0bfd856cbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47932 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41277 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37126 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39044 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18226 "Found 1 new API test failure: /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18850 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3316 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41544 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49638 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44165 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21557 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42969 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10078 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->