### PR TITLE
Simplify WKWebViewConfiguration handling in WebKitTestRunner

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp
@@ -124,9 +124,3 @@ void WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(WKPageConfi
 {
     toImpl(configuration)->setPortsForUpgradingInsecureSchemeForTesting(upgradeFromInsecurePort, upgradeToSecurePort);
 }
-
-void WKPageConfigurationCopySiteIsolationState(WKPageConfigurationRef destination, WKPageConfigurationRef source)
-{
-    toImpl(destination)->setBrowsingContextGroup(&toImpl(source)->browsingContextGroup());
-    toImpl(destination)->setOpenerProcess(toImpl(source)->openerProcess());
-}

--- a/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h
@@ -58,8 +58,6 @@ WK_EXPORT void WKPageConfigurationSetWebsiteDataStore(WKPageConfigurationRef con
 WK_EXPORT void WKPageConfigurationSetInitialCapitalizationEnabled(WKPageConfigurationRef configuration, bool enabled);
 WK_EXPORT void WKPageConfigurationSetBackgroundCPULimit(WKPageConfigurationRef configuration, double cpuLimit); // Terminates process if it uses more than CPU limit over an extended period of time while in the background.
 
-WK_EXPORT void WKPageConfigurationCopySiteIsolationState(WKPageConfigurationRef destination, WKPageConfigurationRef source);
-
 WK_EXPORT void WKPageConfigurationSetAllowTestOnlyIPC(WKPageConfigurationRef configuration, bool allowTestOnlyIPC);
 
 WK_EXPORT void WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting(WKPageConfigurationRef configuration, uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort);

--- a/Tools/WebKitTestRunner/PlatformWebView.h
+++ b/Tools/WebKitTestRunner/PlatformWebView.h
@@ -71,11 +71,7 @@ namespace WTR {
 class PlatformWebView {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-#if PLATFORM(COCOA)
-    PlatformWebView(WKWebViewConfiguration*, const TestOptions&);
-#else
     PlatformWebView(WKPageConfigurationRef, const TestOptions&);
-#endif
     ~PlatformWebView();
 
     WKPageRef page();

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -327,7 +327,7 @@ void TestController::platformCreateWebView(WKPageConfigurationRef, const TestOpt
     [copiedConfiguration _setAllowTestOnlyIPC:options.allowTestOnlyIPC()];
     [copiedConfiguration _setPortsForUpgradingInsecureSchemeForTesting:@[@(options.insecureUpgradePort()), @(options.secureUpgradePort())]];
 
-    m_mainWebView = makeUnique<PlatformWebView>(copiedConfiguration.get(), options);
+    m_mainWebView = makeUnique<PlatformWebView>((__bridge WKPageConfigurationRef)copiedConfiguration.get(), options);
     finishCreatingPlatformWebView(m_mainWebView.get(), options);
 
     if (options.punchOutWhiteBackgroundsInDarkMode())
@@ -340,16 +340,9 @@ void TestController::platformCreateWebView(WKPageConfigurationRef, const TestOpt
     [m_mainWebView->platformView() _setShareSheetCompletesImmediatelyWithResolutionForTesting:YES];
 }
 
-UniqueRef<PlatformWebView> TestController::platformCreateOtherPage(PlatformWebView* parentView, WKPageConfigurationRef originalConfiguration, const TestOptions& options)
+UniqueRef<PlatformWebView> TestController::platformCreateOtherPage(PlatformWebView* parentView, WKPageConfigurationRef configuration, const TestOptions& options)
 {
-    auto newConfiguration = adoptNS([globalWebViewConfiguration() copy]);
-    if (parentView)
-        [newConfiguration _setRelatedWebView:static_cast<WKWebView*>(parentView->platformView())];
-    if ([newConfiguration _relatedWebView])
-        [newConfiguration setWebsiteDataStore:[newConfiguration _relatedWebView].configuration.websiteDataStore];
-    WKPageConfigurationCopySiteIsolationState((__bridge WKPageConfigurationRef)newConfiguration.get(), originalConfiguration);
-    [newConfiguration _setPortsForUpgradingInsecureSchemeForTesting:@[@(options.insecureUpgradePort()), @(options.secureUpgradePort())]];
-    auto view = makeUniqueRef<PlatformWebView>(newConfiguration.get(), options);
+    auto view = makeUniqueRef<PlatformWebView>(configuration, options);
     finishCreatingPlatformWebView(view.ptr(), options);
     return view;
 }

--- a/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
+++ b/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
@@ -213,7 +213,7 @@ static CGRect viewRectForWindowRect(CGRect windowRect, PlatformWebView::WebViewS
     return CGRectMake(windowRect.origin.x, windowRect.origin.y + statusBarBottom, windowRect.size.width, windowRect.size.height - (mode == PlatformWebView::WebViewSizingMode::HeightRespectsStatusBar ? statusBarBottom : 0));
 }
 
-PlatformWebView::PlatformWebView(WKWebViewConfiguration* configuration, const TestOptions& options)
+PlatformWebView::PlatformWebView(WKPageConfigurationRef configuration, const TestOptions& options)
     : m_windowIsKey(true)
     , m_options(options)
 {
@@ -227,7 +227,7 @@ PlatformWebView::PlatformWebView(WKWebViewConfiguration* configuration, const Te
     [webViewController setHorizontalSystemMinimumLayoutMargin:options.horizontalSystemMinimumLayoutMargin()];
     [m_window setRootViewController:webViewController.get()];
 
-    m_view = [[TestRunnerWKWebView alloc] initWithFrame:viewRectForWindowRect(rect, WebViewSizingMode::Default) configuration:configuration];
+    m_view = [[TestRunnerWKWebView alloc] initWithFrame:viewRectForWindowRect(rect, WebViewSizingMode::Default) configuration:(__bridge WKWebViewConfiguration *)configuration];
 
     [m_window.rootViewController.view addSubview:m_view];
     [m_view becomeFirstResponder];

--- a/Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm
+++ b/Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm
@@ -58,7 +58,7 @@ enum {
 
 namespace WTR {
 
-PlatformWebView::PlatformWebView(WKWebViewConfiguration* configuration, const TestOptions& options)
+PlatformWebView::PlatformWebView(WKPageConfigurationRef configuration, const TestOptions& options)
     : m_windowIsKey(true)
     , m_options(options)
 {
@@ -68,11 +68,10 @@ PlatformWebView::PlatformWebView(WKWebViewConfiguration* configuration, const Te
     if (m_options.noUseRemoteLayerTree())
         [[NSUserDefaults standardUserDefaults] setValue:@NO forKey:@"WebKit2UseRemoteLayerTreeDrawingArea"];
 
-    auto copiedConfiguration = adoptNS([configuration copy]);
-    WKPreferencesSetThreadedScrollingEnabled((__bridge WKPreferencesRef)[copiedConfiguration preferences], m_options.useThreadedScrolling());
+    WKPreferencesSetThreadedScrollingEnabled((__bridge WKPreferencesRef)[(__bridge WKWebViewConfiguration *)configuration preferences], m_options.useThreadedScrolling());
 
     NSRect rect = NSMakeRect(0, 0, options.viewWidth(), options.viewHeight());
-    m_view = [[TestRunnerWKWebView alloc] initWithFrame:rect configuration:copiedConfiguration.get()];
+    m_view = [[TestRunnerWKWebView alloc] initWithFrame:rect configuration:(__bridge WKWebViewConfiguration *)configuration];
     [m_view _setWindowOcclusionDetectionEnabled:NO];
 
     NSScreen *firstScreen = [[NSScreen screens] objectAtIndex:0];


### PR DESCRIPTION
#### f01c6123341051af8531de0eb3e7158c3211b2bd
<pre>
Simplify WKWebViewConfiguration handling in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=271671">https://bugs.webkit.org/show_bug.cgi?id=271671</a>
<a href="https://rdar.apple.com/125373165">rdar://125373165</a>

Reviewed by Charlie Wolfe.

Now that WKWebViewConfiguration and WKPageConfigurationRef are equivalent,
we can remove some of the strange Cocoa-specific stuff in WebKitTestRunner.

* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.cpp:
(WKPageConfigurationSetPortsForUpgradingInsecureSchemeForTesting):
(WKPageConfigurationCopySiteIsolationState): Deleted.
* Source/WebKit/UIProcess/API/C/WKPageConfigurationRef.h:
* Tools/WebKitTestRunner/PlatformWebView.h:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::platformCreateWebView):
(WTR::TestController::platformCreateOtherPage):
* Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm:
(WTR::PlatformWebView::PlatformWebView):
* Tools/WebKitTestRunner/mac/PlatformWebViewMac.mm:
(WTR::PlatformWebView::PlatformWebView):

Canonical link: <a href="https://commits.webkit.org/276692@main">https://commits.webkit.org/276692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffa0510de84c8584dbec87822690b22113fe9c15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45283 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47947 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41291 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37135 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45861 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18235 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40141 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3330 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49655 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44170 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21572 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/42974 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21933 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6314 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->