### PR TITLE
[CSS] CSSSelectorList class should have a const_iterator

### DIFF
--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -132,8 +132,8 @@ static bool forEachTagSelector(Functor& functor, const CSSSelector* selector)
         if (functor(selector))
             return true;
         if (const CSSSelectorList* selectorList = selector->selectorList()) {
-            for (const CSSSelector* subSelector = selectorList->first(); subSelector; subSelector = CSSSelectorList::next(subSelector)) {
-                if (forEachTagSelector(functor, subSelector))
+            for (const auto& subSelector : *selectorList) {
+                if (forEachTagSelector(functor, &subSelector))
                     return true;
             }
         }
@@ -143,10 +143,10 @@ static bool forEachTagSelector(Functor& functor, const CSSSelector* selector)
 }
 
 template <typename Functor>
-static bool forEachSelector(Functor& functor, const CSSSelectorList* selectorList)
+static bool forEachSelector(Functor& functor, const CSSSelectorList& selectorList)
 {
-    for (const CSSSelector* selector = selectorList->first(); selector; selector = CSSSelectorList::next(selector)) {
-        if (forEachTagSelector(functor, selector))
+    for (const auto& selector : selectorList) {
+        if (forEachTagSelector(functor, &selector))
             return true;
     }
 
@@ -159,7 +159,7 @@ bool CSSSelectorList::hasExplicitNestingParent() const
         return selector->hasExplicitNestingParent();
     };
 
-    return forEachSelector(functor, this);
+    return forEachSelector(functor, *this);
 }
 
 bool CSSSelectorList::hasOnlyNestingSelector() const

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CSSSelector.h"
+#include <iterator>
 #include <memory>
 #include <wtf/UniqueArray.h>
 
@@ -57,6 +58,29 @@ public:
             return notFound;
         return current - m_selectorArray.get();
     }
+
+    struct const_iterator {
+        friend class CSSSelectorList;
+        using value_type = CSSSelector;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const CSSSelector*;
+        using reference = const CSSSelector&;
+        using iterator_category = std::forward_iterator_tag;
+        reference operator*() const { return *m_ptr; }
+        pointer operator->() const { return m_ptr; }
+        bool operator!=(const const_iterator& other) const { return m_ptr != other.m_ptr; }
+        const_iterator() = default;
+        const_iterator(pointer ptr) : m_ptr(ptr) { };
+        const_iterator& operator++()
+        {
+            m_ptr = CSSSelectorList::next(m_ptr);
+            return *this;
+        }
+    private:
+        pointer m_ptr = nullptr;
+    };
+    const_iterator begin() const { return { first() }; };
+    const_iterator end() const { return { }; }
 
     bool hasExplicitNestingParent() const;
     bool hasOnlyNestingSelector() const;

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -709,14 +709,14 @@ static FunctionType addNthChildType(const CSSSelector& selector, SelectorContext
             globalFunctionType = FunctionType::SelectorCheckerWithCheckingContext;
 
         SelectorFragmentList* selectorFragments = nullptr;
-        for (const CSSSelector* subselector = selectorList->first(); subselector; subselector = CSSSelectorList::next(subselector)) {
+        for (const auto& subselector : *selectorList) {
             if (!selectorFragments) {
                 nthChildOfSelectorInfo.selectorList.append(SelectorFragmentList());
                 selectorFragments = &nthChildOfSelectorInfo.selectorList.last();
             }
 
             VisitedMode ignoreVisitedMode = VisitedMode::None;
-            FunctionType functionType = constructFragments(subselector, selectorContext, *selectorFragments, FragmentsLevel::InFunctionalPseudoType, positionInRootFragments, visitedMatchEnabled, ignoreVisitedMode, PseudoElementMatchingBehavior::NeverMatch);
+            FunctionType functionType = constructFragments(&subselector, selectorContext, *selectorFragments, FragmentsLevel::InFunctionalPseudoType, positionInRootFragments, visitedMatchEnabled, ignoreVisitedMode, PseudoElementMatchingBehavior::NeverMatch);
             ASSERT_WITH_MESSAGE(ignoreVisitedMode == VisitedMode::None, ":visited is disabled in the functional pseudo classes");
             switch (functionType) {
             case FunctionType::SimpleSelectorChecker:
@@ -1261,14 +1261,14 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
 
             FunctionType functionType = FunctionType::SimpleSelectorChecker;
             SelectorFragmentList* selectorFragments = nullptr;
-            for (const CSSSelector* subselector = selectorList->first(); subselector; subselector = CSSSelectorList::next(subselector)) {
+            for (const auto& subselector : *selectorList) {
                 if (!selectorFragments) {
                     fragment.notFilters.append(SelectorFragmentList());
                     selectorFragments = &fragment.notFilters.last();
                 }
 
                 VisitedMode ignoreVisitedMode = VisitedMode::None;
-                FunctionType localFunctionType = constructFragments(subselector, selectorContext, *selectorFragments, FragmentsLevel::InFunctionalPseudoType, positionInRootFragments, visitedMatchEnabled, ignoreVisitedMode, PseudoElementMatchingBehavior::NeverMatch);
+                FunctionType localFunctionType = constructFragments(&subselector, selectorContext, *selectorFragments, FragmentsLevel::InFunctionalPseudoType, positionInRootFragments, visitedMatchEnabled, ignoreVisitedMode, PseudoElementMatchingBehavior::NeverMatch);
                 ASSERT_WITH_MESSAGE(ignoreVisitedMode == VisitedMode::None, ":visited is disabled in the functional pseudo classes");
 
                 // Since this is not pseudo class filter, CannotMatchAnything implies this filter always passes.
@@ -1312,16 +1312,17 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
         {
             SelectorList matchesList;
             const CSSSelectorList* selectorList = selector.selectorList();
+            ASSERT(selectorList);
             FunctionType functionType = FunctionType::SimpleSelectorChecker;
             SelectorFragmentList* selectorFragments = nullptr;
-            for (const CSSSelector* subselector = selectorList->first(); subselector; subselector = CSSSelectorList::next(subselector)) {
+            for (const auto& subselector : *selectorList) {
                 if (!selectorFragments) {
                     matchesList.append(SelectorFragmentList());
                     selectorFragments = &matchesList.last();
                 }
 
                 VisitedMode ignoreVisitedMode = VisitedMode::None;
-                FunctionType localFunctionType = constructFragments(subselector, selectorContext, *selectorFragments, FragmentsLevel::InFunctionalPseudoType, positionInRootFragments, visitedMatchEnabled, ignoreVisitedMode, pseudoElementMatchingBehavior);
+                FunctionType localFunctionType = constructFragments(&subselector, selectorContext, *selectorFragments, FragmentsLevel::InFunctionalPseudoType, positionInRootFragments, visitedMatchEnabled, ignoreVisitedMode, pseudoElementMatchingBehavior);
                 ASSERT_WITH_MESSAGE(ignoreVisitedMode == VisitedMode::None, ":visited is disabled in the functional pseudo classes");
 
                 // Since this fragment never matches against the element, don't insert it to matchesList.


### PR DESCRIPTION
#### ade1396f85a02c79312ec9f7ec361f296cf7229d
<pre>
[CSS] CSSSelectorList class should have a const_iterator
<a href="https://bugs.webkit.org/show_bug.cgi?id=271672">https://bugs.webkit.org/show_bug.cgi?id=271672</a>
<a href="https://rdar.apple.com/125373236">rdar://125373236</a>

Reviewed by Antti Koivisto.

CSSSelectorList is an optimized contiguous memory
representation of a list.
This patch adds a forward const iterator interface to it
to be able to use range based for-loop.

* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::forEachTagSelector):
(WebCore::forEachSelector):
(WebCore::CSSSelectorList::hasExplicitNestingParent const):
* Source/WebCore/css/CSSSelectorList.h:
(WebCore::CSSSelectorList::const_iterator::operator* const):
(WebCore::CSSSelectorList::const_iterator::operator-&gt; const):
(WebCore::CSSSelectorList::const_iterator::operator!= const):
(WebCore::CSSSelectorList::const_iterator::const_iterator):
(WebCore::CSSSelectorList::const_iterator::operator++):
(WebCore::CSSSelectorList::begin const):
(WebCore::CSSSelectorList::end const):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::addNthChildType):
(WebCore::SelectorCompiler::addPseudoClassType):

Canonical link: <a href="https://commits.webkit.org/276697@main">https://commits.webkit.org/276697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2af35e1fd60e9a46acdbb03856c121dcfcccbb7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41387 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21896 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39152 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18320 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40232 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3426 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40553 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/49778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16889 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44266 "layout-tests (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21671 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/43083 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10097 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22030 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21358 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->