### PR TITLE
Registered scripts aren't injected when an extension is reloaded

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm
@@ -32,7 +32,6 @@
 
 #import "CocoaHelpers.h"
 #import "Logging.h"
-#import "WebExtensionDynamicScripts.h"
 #import "_WKWebExtensionSQLiteDatabase.h"
 #import "_WKWebExtensionSQLiteHelpers.h"
 #import "_WKWebExtensionSQLiteRow.h"

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -300,7 +300,9 @@ bool WebExtensionContext::unload(NSError **outError)
     writeStateToStorage();
 
     unloadBackgroundWebView();
+
     removeInjectedContent();
+    m_registeredScriptsMap.clear();
 
     invalidateStorage();
     unloadDeclarativeNetRequestState();
@@ -525,9 +527,14 @@ void WebExtensionContext::setUnsupportedAPIs(HashSet<String>&& unsupported)
     m_unsupportedAPIs = WTFMove(unsupported);
 }
 
-const WebExtensionContext::InjectedContentVector& WebExtensionContext::injectedContents()
+WebExtensionContext::InjectedContentVector WebExtensionContext::injectedContents() const
 {
-    return m_extension->staticInjectedContents();
+    InjectedContentVector result = m_extension->staticInjectedContents();
+
+    for (auto& entry : m_registeredScriptsMap)
+        result.append(entry.value->injectedContent());
+
+    return result;
 }
 
 bool WebExtensionContext::hasInjectedContentForURL(const URL& url)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -211,13 +211,6 @@ WebExtensionScriptInjectionResultParameters toInjectionResultParameters(id resul
     return parameters;
 }
 
-WebExtensionRegisteredScript::WebExtensionRegisteredScript(WebExtensionContext& extensionContext, const WebExtensionRegisteredScriptParameters& parameters)
-    : m_extensionContext(extensionContext)
-    , m_parameters(parameters)
-{
-
-}
-
 void WebExtensionRegisteredScript::updateParameters(const WebExtensionRegisteredScriptParameters& parameters)
 {
     m_parameters = parameters;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -155,6 +155,8 @@ public:
 
     using AlarmInfoMap = HashMap<String, double>;
 
+    using DynamicInjectedContentsMap = HashMap<String, WebExtension::InjectedContentData>;
+
     using PermissionsSet = WebExtension::PermissionsSet;
     using MatchPatternSet = WebExtension::MatchPatternSet;
     using InjectedContentData = WebExtension::InjectedContentData;
@@ -172,7 +174,6 @@ public:
     using WindowIdentifierMap = HashMap<WebExtensionWindowIdentifier, Ref<WebExtensionWindow>>;
     using WindowIdentifierVector = Vector<WebExtensionWindowIdentifier>;
     using TabIdentifierMap = HashMap<WebExtensionTabIdentifier, Ref<WebExtensionTab>>;
-    using TabMapValueIterator = TabIdentifierMap::ValuesIteratorRange;
     using PageTabIdentifierMap = WeakHashMap<WebPageProxy, WebExtensionTabIdentifier>;
     using PopupPageActionMap = WeakHashMap<WebPageProxy, Ref<WebExtensionAction>>;
 
@@ -293,7 +294,7 @@ public:
     HashSet<String> unsupportedAPIs() const { return m_unsupportedAPIs; }
     void setUnsupportedAPIs(HashSet<String>&&);
 
-    const InjectedContentVector& injectedContents();
+    InjectedContentVector injectedContents() const;
     bool hasInjectedContentForURL(const URL&);
     bool hasInjectedContent();
 
@@ -773,7 +774,7 @@ private:
     void scriptingUpdateRegisteredScripts(const Vector<WebExtensionRegisteredScriptParameters>& scripts, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
     void scriptingGetRegisteredScripts(const Vector<String>&, CompletionHandler<void(Expected<Vector<WebExtensionRegisteredScriptParameters>, WebExtensionError>&&)>&&);
     void scriptingUnregisterContentScripts(const Vector<String>&, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
-    bool createInjectedContentForScripts(const Vector<WebExtensionRegisteredScriptParameters>&, WebExtensionDynamicScripts::WebExtensionRegisteredScript::FirstTimeRegistration, InjectedContentVector&, NSString *callingAPIName, NSString **errorMessage);
+    bool createInjectedContentForScripts(const Vector<WebExtensionRegisteredScriptParameters>&, WebExtensionDynamicScripts::WebExtensionRegisteredScript::FirstTimeRegistration, DynamicInjectedContentsMap&, NSString *callingAPIName, NSString **errorMessage);
 
     // Storage APIs
     bool isStorageMessageAllowed();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h
@@ -54,6 +54,7 @@ using SourcePair = std::pair<String, std::optional<URL>>;
 using SourcePairs = Vector<std::optional<SourcePair>>;
 
 using InjectionTime = WebExtension::InjectionTime;
+using InjectedContentData = WebExtension::InjectedContentData;
 
 using UserScriptVector = Vector<Ref<API::UserScript>>;
 using UserStyleSheetVector = Vector<Ref<API::UserStyleSheet>>;
@@ -77,16 +78,24 @@ public:
 
     void addUserScript(const String& identifier, API::UserScript&);
     void addUserStyleSheet(const String& identifier, API::UserStyleSheet&);
-
     void removeUserScriptsAndStyleSheets(const String& identifier);
+
+    void updateInjectedContent(InjectedContentData& injectedContent) { m_injectedContent = injectedContent; }
+    const InjectedContentData& injectedContent() const { return m_injectedContent; }
 
     WebExtensionRegisteredScriptParameters parameters() const { return m_parameters; };
 
 private:
-    explicit WebExtensionRegisteredScript(WebExtensionContext&, const WebExtensionRegisteredScriptParameters&);
+    explicit WebExtensionRegisteredScript(WebExtensionContext& extensionContext, const WebExtensionRegisteredScriptParameters& parameters, const InjectedContentData& injectedContent)
+        : m_extensionContext(extensionContext)
+        , m_parameters(parameters)
+        , m_injectedContent(injectedContent)
+    {
+    }
 
     WeakPtr<WebExtensionContext> m_extensionContext;
     WebExtensionRegisteredScriptParameters m_parameters;
+    InjectedContentData m_injectedContent;
 
     HashMap<String, UserScriptVector> m_userScriptsMap;
     HashMap<String, UserStyleSheetVector> m_userStyleSheetsMap;


### PR DESCRIPTION
#### 001f6f0f95890b04ad8df89594174c8a25bccdf8
<pre>
Registered scripts aren&apos;t injected when an extension is reloaded
<a href="https://bugs.webkit.org/show_bug.cgi?id=266291">https://bugs.webkit.org/show_bug.cgi?id=266291</a>
<a href="https://rdar.apple.com/119561550">rdar://119561550</a>

Reviewed by Brian Weinstein and Timothy Hatcher.

Remove injected content from registered scripts map when an extension unloads.
Without this, we won&apos;t inject the scripts when the extension reloads since
`WebExtensionContext::createInjectedContentForScripts()` will fail due to duplicate script IDs.

Also, update WebExtensionContext::injectedContents() to include registered scripts.
Without this, registered scripts will be removed and won&apos;t be re-injected in cases
where we call WebExtensionContext::updateInjectedContent().

* Source/WebKit/Shared/Extensions/_WKWebExtensionRegisteredScriptsSQLiteStore.mm:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::scriptingRegisterContentScripts):
(WebKit::WebExtensionContext::scriptingUpdateRegisteredScripts):
(WebKit::WebExtensionContext::loadRegisteredContentScripts):
(WebKit::WebExtensionContext::createInjectedContentForScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::unload):
(WebKit::WebExtensionContext::injectedContents):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::WebExtensionRegisteredScript): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionDynamicScripts.h:
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::updateInjectedContent):
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::injectedContent):
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::WebExtensionRegisteredScript):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, RegisteredScriptIsInjectedAfterContextReloads)): Added.

Canonical link: <a href="https://commits.webkit.org/276810@main">https://commits.webkit.org/276810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/643d90331a839b95ecef9f4da869834a26247b78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41786 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22276 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18612 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40552 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3795 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50175 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17256 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44570 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22047 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43424 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6375 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21736 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->