### PR TITLE
Replacing AES impls with interop

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -1026,6 +1026,9 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
 Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::Vector(const Vector& other)
     : Base(other.size(), other.size())
 {
+#ifdef __swift__
+    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("C++ copy constructors are not memory safe in Swift. Try to find a way to borrow the object instead.");
+#endif
     asanSetInitialBufferSizeTo(other.size());
 
     if (begin())
@@ -1037,6 +1040,9 @@ template<size_t otherCapacity, typename otherOverflowBehaviour, size_t otherMini
 Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::Vector(const Vector<T, otherCapacity, otherOverflowBehaviour, otherMinimumCapacity, OtherMalloc>& other)
     : Base(other.size(), other.size())
 {
+#ifdef __swift__
+    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("C++ copy constructors are not memory safe in Swift. Try to find a way to borrow the object instead.");
+#endif
     asanSetInitialBufferSizeTo(other.size());
 
     if (begin())

--- a/Source/WebCore/Configurations/WebCore.xcconfig
+++ b/Source/WebCore/Configurations/WebCore.xcconfig
@@ -35,7 +35,7 @@ WK_APPLEJPEGXL_PREPROCESSOR_DEFINITIONS_YES = USE_JPEGXL=1;
 
 // FIXME: remove the interop setting here when rdar://124492036 is resolved.
 WK_HAVE_SWIFT_CPP_INTEROP = HAVE_SWIFT_CPP_INTEROP=0;
-WK_HAVE_SWIFT_CPP_INTEROP[sdk=macos14*] = ;
+WK_HAVE_SWIFT_CPP_INTEROP[sdk=macosx14*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=iphoneos17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=iphonesimulator17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=appletvos17*] = ;

--- a/Source/WebCore/PAL/Configurations/PAL.xcconfig
+++ b/Source/WebCore/PAL/Configurations/PAL.xcconfig
@@ -26,7 +26,7 @@
 
 // FIXME: remove the interop setting here when rdar://124492036 is resolved.
 WK_HAVE_SWIFT_CPP_INTEROP = HAVE_SWIFT_CPP_INTEROP=0;
-WK_HAVE_SWIFT_CPP_INTEROP[sdk=macos14*] = ;
+WK_HAVE_SWIFT_CPP_INTEROP[sdk=macosx14*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=iphoneos17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=iphonesimulator17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=appletvos17*] = ;
@@ -101,7 +101,7 @@ OTHER_SWIFT_FLAGS_TVOS_SINCE_17 = -Xcc -std=c++20 -I $(SRCROOT)/pal -I $(SRCROOT
 
 // FIXME: remove the interop setting here when rdar://124492036 is resolved.
 EXCLUDED_SOURCE_FILE_NAMES = CryptoKitShim.swift UnsafeOverlays.swift
-EXCLUDED_SOURCE_FILE_NAMES[sdk=macos14*] = ;
+EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx14*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos17*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator17*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvos17*] = ;

--- a/Source/WebCore/PAL/pal/PALSwift.h
+++ b/Source/WebCore/PAL/pal/PALSwift.h
@@ -28,8 +28,20 @@
 #include <cstdint>
 #include <wtf/Vector.h>
 
+namespace Cpp {
+
 using VectorUInt8 = WTF::Vector<uint8_t>;
 using SpanConstUInt8 = std::span<const uint8_t>;
+using OptionalVectorUInt8 = std::optional<WTF::Vector<uint8_t>>;
+
+
+// FIXME: remove when swift support is available rdar://118026392
+inline OptionalVectorUInt8 makeOptional(VectorUInt8 val)
+{
+    return val;
+}
+
+} // PAL
 
 #ifndef __swift__
 #include "PALSwift-Generated.h"

--- a/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
@@ -30,12 +30,97 @@ import CryptoKit
 
 import PALSwift
 
+enum UnsafeErrors: Error {
+    case invalidLength
+    case emptySpan
+}
+
 extension HashFunction {
     mutating func update(data: SpanConstUInt8) {
-        self.update(
-            bufferPointer: UnsafeRawBufferPointer(
-                start: data.__dataUnsafe(), count: data.size()))
+        if data.empty() {
+            self.update(data: Data.empty())
+        } else {
+            self.update(
+                bufferPointer: UnsafeRawBufferPointer(
+                    start: data.__dataUnsafe(), count: data.size()))
+        }
     }
 }
 
+extension ContiguousBytes {
+    public func copyToVectorUInt8() -> VectorUInt8 {
+        return self.withUnsafeBytes { buf in
+            let result = VectorUInt8(buf.count)
+            buf.copyBytes(
+                to: UnsafeMutableRawBufferPointer(
+                    start: UnsafeMutableRawPointer(mutating: result.__dataUnsafe()),
+                    count: result.size()), count: result.size())
+            return result
+        }
+    }
+}
+
+extension Data {
+    static let emptyData = Data()
+    fileprivate static func temporaryDataFromSpan(spanNoCopy: SpanConstUInt8) -> Data {
+        if spanNoCopy.empty() {
+            return Data.empty()
+        } else {
+            return Data(
+                bytesNoCopy: UnsafeMutablePointer(mutating: spanNoCopy.__dataUnsafe()),
+                count: spanNoCopy.size(), deallocator: .none)
+        }
+    }
+
+    // CryptoKit does not support a null pointer with zero length. We instead need to pass an empty Data. This class provides that.
+    public static func empty() -> Data {
+        return emptyData
+    }
+}
+
+private class _WorkAroundRadar116406681 {
+    // rdar://116406681
+    private func forceLinkageForVectorDestructor() {
+        let _ = VectorUInt8()
+    }
+}
+
+extension AES.GCM {
+    public static func seal(
+        _ message: SpanConstUInt8, key: SpanConstUInt8, iv: SpanConstUInt8, ad: SpanConstUInt8
+    ) throws -> AES.GCM.SealedBox {
+        if ad.size() > 0 {
+            return try AES.GCM.seal(
+                Data.temporaryDataFromSpan(spanNoCopy: message),
+                using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key)),
+                nonce: AES.GCM.Nonce(data: Data.temporaryDataFromSpan(spanNoCopy: iv)),
+                authenticating: Data.temporaryDataFromSpan(spanNoCopy: ad))
+        } else {
+            return try AES.GCM.seal(
+                Data.temporaryDataFromSpan(spanNoCopy: message),
+                using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: key)),
+                nonce: AES.GCM.Nonce(data: Data.temporaryDataFromSpan(spanNoCopy: iv))
+            )
+        }
+    }
+}
+
+extension AES.KeyWrap {
+    public static func unwrap(_ wrapped: SpanConstUInt8, using: SpanConstUInt8) throws
+        -> SymmetricKey
+    {
+        return try AES.KeyWrap.unwrap(
+            Data.temporaryDataFromSpan(spanNoCopy: wrapped),
+            using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: using)))
+
+    }
+    public static func wrap(_ keyToWrap: SpanConstUInt8, using: SpanConstUInt8) throws
+        -> VectorUInt8
+    {
+        return try AES.KeyWrap.wrap(
+            SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: keyToWrap)),
+            using: SymmetricKey(data: Data.temporaryDataFromSpan(spanNoCopy: using))
+        ).copyToVectorUInt8()
+    }
+}
 #endif

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp
@@ -54,14 +54,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if HAVE(SWIFT_CPP_INTEROP)
 static ExceptionOr<Vector<uint8_t>> encryptCryptoKitAESGCM(const Vector<uint8_t>& iv, const Vector<uint8_t>& key, const Vector<uint8_t>& plainText, const Vector<uint8_t>& additionalData, size_t desiredTagLengthInBytes)
 {
-    // Protect against underflow in the subtraction below.
-    if (desiredTagLengthInBytes > CryptoAlgorithmAESGCM::DefaultTagLength / 8)
+    auto rv = PAL::AesGcm::encrypt(key.span(), iv.span(), additionalData.span(), plainText.span(), desiredTagLengthInBytes);
+    if (!rv.getErrorCode().isSuccess())
         return Exception { ExceptionCode::OperationError };
-    Vector<uint8_t> cipherText(plainText.size() + CryptoAlgorithmAESGCM::DefaultTagLength);
-    if (!PAL::AesGcm::encrypt(key.data(), key.size(), iv.data(), iv.size(), additionalData.data(), additionalData.size(), plainText.data(), plainText.size(), cipherText.data()).isSuccess())
-        return Exception { ExceptionCode::OperationError };
-    cipherText.resize(cipherText.size() - (CryptoAlgorithmAESGCM::DefaultTagLength - desiredTagLengthInBytes));
-    return WTFMove(cipherText);
+    return WTFMove(*rv.getCipherText());
 }
 #endif
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp
@@ -63,26 +63,18 @@ static ExceptionOr<Vector<uint8_t>> unwrapKeyAESKW(const Vector<uint8_t>& key, c
 #if HAVE(SWIFT_CPP_INTEROP)
 static ExceptionOr<Vector<uint8_t>> wrapKeyAESKWCryptoKit(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
-    Vector<uint8_t> result(data.size() + CryptoAlgorithmAESKW::s_extraSize);
-    uint64_t resultSize = result.size();
-    const PAL::AesKwRV rv = PAL::AesKw::wrap(key.data(), key.size(), data.data(), data.size(), result.data(), resultSize);
+    auto rv = PAL::AesKw::wrap(data.span(), key.span());
     if (!rv.getErrCode().isSuccess())
         return Exception { ExceptionCode::OperationError };
-    result.shrink(rv.getOutputSize());
-    return WTFMove(result);
+    return WTFMove(*rv.getResult());
 }
 
 static ExceptionOr<Vector<uint8_t>> unwrapKeyAESKWCryptoKit(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
-    Vector<uint8_t> dataOut(data.size());
-    uint64_t dataOutSize = dataOut.size();
-    const PAL::AesKwRV rv = PAL::AesKw::unwrap(key.data(), key.size(), data.data(), data.size(), dataOut.data(), dataOutSize);
+    auto rv = PAL::AesKw::unwrap(data.span(), key.span());
     if (!rv.getErrCode().isSuccess())
         return Exception { ExceptionCode::OperationError };
-    if (rv.getOutputSize() % 8)
-        return Exception { ExceptionCode::OperationError };
-    dataOut.shrink(rv.getOutputSize());
-    return WTFMove(dataOut);
+    return WTFMove(*rv.getResult());
 }
 #endif
 


### PR DESCRIPTION
#### 8cab381a36560866a220e47f934fa4b1bb717e0c
<pre>
Replacing AES impls with interop
<a href="https://bugs.webkit.org/show_bug.cgi?id=271680">https://bugs.webkit.org/show_bug.cgi?id=271680</a>
radar://125367961

Reviewed by Geoffrey Garen.

All the Unsafe Bits are now in UnsafeOverlays.swift.
Also all the Cpp wrappers to work around interop shortcomings are now
inside a namespace to keep them away from global scope.

Any wrappers deemed Unsafe are now inside namespace Cpp.Unsafe.

WTF::Vector Copy operation is hard fail from Swift. This is to guard
against swift&apos;s strategy of implicity copies of C++ types for exclusivity and
memory safety.

Also the quirk added in 276651@main for destructor linkage
 is moved out of the execution path.

* Source/WTF/wtf/Vector.h:
(WTF::Malloc&gt;::Vector):
* Source/WebCore/Configurations/WebCore.xcconfig:
* Source/WebCore/PAL/Configurations/PAL.xcconfig:
* Source/WebCore/PAL/pal/PALSwift.h:
(Cpp::toOptionalVectorUInt8):
(Cpp::createVectorUInt8FromSpan):
(Cpp::appendSpanToVectorUInt8):
(Cpp::Unsafe::createConstUInt8Span):
* Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift:
(AesGcmRV.cipherText):
(AesGcmRV.errorCode):
(AesGcm.ciphertext):
(AesKwRV.result):
(AesKw.wrap(_:keyToBeWrapped:)):
(AesKw.unwrap(_:wrappedKey:)):
(AesKwRV.outputSize): Deleted.
* Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift:
(HashFunction.update(_:)):
(ContiguousBytes.createConstUInt8Span(_:)):
(ContiguousBytes.createConstUInt8Span):
(VectorUInt8.appendSpan(_:)):
(VectorUInt8.appendContiguousBytes(_:)):
(Data.fromSpan(_:)):
(_CompilerBugDontUse.forceLinkageForVectorDestructor):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp:
(WebCore::encryptCryptoKitAESGCM):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp:
(WebCore::wrapKeyAESKWCryptoKit):
(WebCore::unwrapKeyAESKWCryptoKit):

Canonical link: <a href="https://commits.webkit.org/277285@main">https://commits.webkit.org/277285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bdff99ac029c0b6d8c89ad5e99a48969420f556

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42644 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48906 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23218 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38000 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40162 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19267 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41278 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4644 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39846 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51125 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46081 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18008 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45264 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22896 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44215 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10412 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23338 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53224 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22599 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10916 "Passed tests") | 
<!--EWS-Status-Bubble-End-->