### PR TITLE
[Remote Inspection] Element targeting should additionally find nearby out-of-flow elements

### DIFF
--- a/Source/WebCore/page/ElementTargetingTypes.h
+++ b/Source/WebCore/page/ElementTargetingTypes.h
@@ -39,6 +39,7 @@ namespace WebCore {
 
 struct TargetedElementRequest {
     FloatPoint pointInRootView;
+    bool canIncludeNearbyElements { true };
 };
 
 struct TargetedElementInfo {
@@ -50,6 +51,7 @@ struct TargetedElementInfo {
     FloatRect boundsInRootView;
     PositionType positionType { PositionType::Static };
     Vector<FrameIdentifier> childFrameIdentifiers;
+    bool isUnderPoint { true };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -886,6 +886,7 @@ enum class WebCore::ShareDataOriginator : bool
 header: <WebCore/ElementTargetingTypes.h>
 [CustomHeader] struct WebCore::TargetedElementRequest {
     WebCore::FloatPoint pointInRootView
+    bool canIncludeNearbyElements
 };
 
 header: <WebCore/ElementTargetingTypes.h>
@@ -898,6 +899,7 @@ header: <WebCore/ElementTargetingTypes.h>
     WebCore::FloatRect boundsInRootView
     WebCore::PositionType positionType
     Vector<WebCore::FrameIdentifier> childFrameIdentifiers
+    bool isUnderPoint
 };
 
 header: <WebCore/RenderStyleConstants.h>

--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
@@ -56,6 +56,8 @@ public:
     WebCore::FloatRect boundsInRootView() const { return m_info.boundsInRootView; }
     WebCore::FloatRect boundsInWebView() const;
 
+    bool isUnderPoint() const { return m_info.isUnderPoint; }
+
     void childFrames(CompletionHandler<void(Vector<Ref<FrameTreeNode>>&&)>&&) const;
 
     bool isSameElement(const TargetedElementInfo&) const;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2753,6 +2753,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 #else
         request.point,
 #endif
+        static_cast<bool>(request.canIncludeNearbyElements)
     };
     _page->requestTargetedElement(WTFMove(coreRequest), [completion = makeBlockPtr(completion)](auto& elements) {
         completion(createNSArray(elements, [](auto& element) {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
@@ -42,6 +42,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 
 @property (nonatomic, readonly) _WKTargetedElementPosition positionType;
 @property (nonatomic, readonly) CGRect bounds;
+@property (nonatomic, readonly, getter=isUnderPoint) BOOL underPoint;
 
 @property (nonatomic, readonly, copy) NSArray<NSString *> *selectors;
 @property (nonatomic, readonly, copy) NSString *renderedText;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -110,4 +110,9 @@
     return _info->isSameElement(*other->_info);
 }
 
+- (BOOL)isUnderPoint
+{
+    return _info->isUnderPoint();
+}
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.h
@@ -33,5 +33,6 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @interface _WKTargetedElementRequest : NSObject
 
 @property (nonatomic) CGPoint point;
+@property (nonatomic) BOOL canIncludeNearbyElements;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm
@@ -28,4 +28,13 @@
 
 @implementation _WKTargetedElementRequest
 
+- (instancetype)init
+{
+    if (!(self = [super init]))
+        return nil;
+
+    _canIncludeNearbyElements = YES;
+    return self;
+}
+
 @end

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1168,6 +1168,7 @@
 		F42F081227449892007E0D90 /* multiple-images.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F42F0811274497C8007E0D90 /* multiple-images.html */; };
 		F434CA1A22E65BCA005DDB26 /* ScrollToRevealSelection.mm in Sources */ = {isa = PBXBuildFile; fileRef = F434CA1922E65BCA005DDB26 /* ScrollToRevealSelection.mm */; };
 		F4352F9F26D403DE00E605E4 /* editable-responsive-body.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4352F9E26D4037000E605E4 /* editable-responsive-body.html */; };
+		F4365E2B2BB11829005E8C1A /* element-targeting-2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4365E232BB1181A005E8C1A /* element-targeting-2.html */; };
 		F43CAB1D278A326500C8D0A2 /* CloseWhileCommittingLoad.mm in Sources */ = {isa = PBXBuildFile; fileRef = F43CAB1C278A326500C8D0A2 /* CloseWhileCommittingLoad.mm */; };
 		F43E3BBF20DADA1E00A4E7ED /* WKScrollViewTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F43E3BBE20DADA1E00A4E7ED /* WKScrollViewTests.mm */; };
 		F43E3BC120DADBC500A4E7ED /* fixed-nav-bar.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F43E3BC020DADB8000A4E7ED /* fixed-nav-bar.html */; };
@@ -1623,6 +1624,7 @@
 				F44D06451F395C26001A0E29 /* editor-state-test-harness.html in Copy Resources */,
 				F4BDA43027F8D19C00F9647D /* element-fullscreen.html in Copy Resources */,
 				F4DADD072BABAD0F008B398F /* element-targeting-1.html in Copy Resources */,
+				F4365E2B2BB11829005E8C1A /* element-targeting-2.html in Copy Resources */,
 				51C8E1A91F27F49600BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist in Copy Resources */,
 				49D902B328209B3300E2C3B8 /* emptyTable.html in Copy Resources */,
 				A14AAB651E78DC5400C1ADC2 /* encrypted.pdf in Copy Resources */,
@@ -3523,6 +3525,7 @@
 		F42F081727449FFD007E0D90 /* ImageAnalysisTestingUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ImageAnalysisTestingUtilities.h; path = cocoa/ImageAnalysisTestingUtilities.h; sourceTree = "<group>"; };
 		F434CA1922E65BCA005DDB26 /* ScrollToRevealSelection.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollToRevealSelection.mm; sourceTree = "<group>"; };
 		F4352F9E26D4037000E605E4 /* editable-responsive-body.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "editable-responsive-body.html"; sourceTree = "<group>"; };
+		F4365E232BB1181A005E8C1A /* element-targeting-2.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-targeting-2.html"; sourceTree = "<group>"; };
 		F43C3823278133190099ABCE /* NSResponderTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NSResponderTests.mm; sourceTree = "<group>"; };
 		F43CAB1C278A326500C8D0A2 /* CloseWhileCommittingLoad.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CloseWhileCommittingLoad.mm; sourceTree = "<group>"; };
 		F43E3BBE20DADA1E00A4E7ED /* WKScrollViewTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKScrollViewTests.mm; sourceTree = "<group>"; };
@@ -4823,6 +4826,7 @@
 				F44D06441F395C0D001A0E29 /* editor-state-test-harness.html */,
 				F4BDA42F27F8CF5600F9647D /* element-fullscreen.html */,
 				F4DADCFF2BABA80C008B398F /* element-targeting-1.html */,
+				F4365E232BB1181A005E8C1A /* element-targeting-2.html */,
 				51C8E1A81F27F47300BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist */,
 				F4C2AB211DD6D94100E06D5B /* enormous-video-with-sound.html */,
 				F407FE381F1D0DE60017CF25 /* enormous.svg */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -131,4 +131,26 @@ TEST(ElementTargeting, BasicElementTargeting)
     }
 }
 
+TEST(ElementTargeting, NearbyOutOfFlowElements)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    [webView synchronouslyLoadTestPageNamed:@"element-targeting-2"];
+
+    auto elements = [webView targetedElementInfoAt:CGPointMake(100, 100)];
+    EXPECT_EQ(elements.count, 4U);
+    EXPECT_TRUE(elements[0].underPoint);
+    EXPECT_FALSE(elements[1].underPoint);
+    EXPECT_FALSE(elements[2].underPoint);
+    EXPECT_FALSE(elements[3].underPoint);
+    EXPECT_WK_STREQ(".fixed.container", elements[0].selectors.firstObject);
+    __auto_type nextThreeSelectors = [NSSet setWithArray:@[
+        elements[1].selectors.firstObject,
+        elements[2].selectors.firstObject,
+        elements[3].selectors.firstObject,
+    ]];
+    EXPECT_TRUE([nextThreeSelectors containsObject:@".absolute.top-right"]);
+    EXPECT_TRUE([nextThreeSelectors containsObject:@".absolute.bottom-left"]);
+    EXPECT_TRUE([nextThreeSelectors containsObject:@".absolute.bottom-right"]);
+}
+
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-2.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-2.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<style>
+body, html {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    font-size: 16px;
+    line-height: 200%;
+    -webkit-text-size-adjust: none;
+}
+
+.fixed {
+    width: 200px;
+    height: 200px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: tomato;
+    color: white;
+    text-align: center;
+    opacity: 0.75;
+}
+
+.absolute {
+    background: palevioletred;
+    width: 80px;
+    height: 80px;
+    position: absolute;
+    box-sizing: border-box;
+    border: 1px solid purple;
+}
+
+.bottom-right {
+    top: 110px;
+    left: 110px;
+}
+
+.bottom-left {
+    top: 110px;
+    left: 10px;
+}
+
+.top-right {
+    top: 10px;
+    left: 110px;
+}
+</style>
+</head>
+<body>
+    <div class="fixed container"></div>
+    <div class="absolute bottom-right"></div>
+    <div class="absolute bottom-left"></div>
+    <div class="absolute top-right"></div>
+    <main>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</main>
+</body>
+</html>


### PR DESCRIPTION
#### e305a091db4016a89522f646df6ae3503f1bf682
<pre>
[Remote Inspection] Element targeting should additionally find nearby out-of-flow elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=271616">https://bugs.webkit.org/show_bug.cgi?id=271616</a>

Reviewed by Abrar Protyasha.

When targeting elements for remote inspection, additionally surface nearby elements which aren&apos;t
precisely under the hit test location. Our strategy for this consists of the following:

1.  While collecting targets, aggregate a `Region` containing the rects of all targeted out-of-flow
    elements (and hit-tested elements underneath targeted elements).

2.  After building the list of targets, scan the entire DOM for out-of-flow renderers that are also
    contained in the &quot;nearby targets&quot; region, which also satisfy the same criteria for element
    targeting.

3.  Add these as &quot;nearby targets&quot; to the final list of target infos, to the end of the array.

See below for more details.

Test: ElementTargeting.NearbyOutOfFlowElements

* Source/WebCore/page/ElementTargeting.cpp:
(WebCore::targetedElementInfo):

Refactor this code to pull common logic into lambdas, and implement the steps detailed above.

(WebCore::findTargetedElements):
* Source/WebCore/page/ElementTargetingTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APITargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _requestTargetedElementInfo:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h:

Add a new `isUnderPoint` property, which is `YES` for elements that are directly hit-tested, and
`NO` for nearby targets.

* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo isUnderPoint]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.h:

Add a new `canIncludeNearbyElements` (default: `YES`) which determines whether or not element
targeting should include elements that have not been hit-tested, but are visually contained within
another element that has been hit-tested.

* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm:
(-[_WKTargetedElementRequest init]):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-2.html: Added.

Add a new API test to exercise the change.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e305a091db4016a89522f646df6ae3503f1bf682

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47976 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41320 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28639 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21829 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45890 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/21495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/39085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18257 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40170 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3359 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/41584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49685 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/20295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16824 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44198 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21602 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43006 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10072 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21290 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->