### PR TITLE
REGRESSION (276513@main): [ iOS ] fast/images/async-image-intersect-different-size-for-drawing.html is a consistent failure

### DIFF
--- a/LayoutTests/fast/images/async-image-intersect-different-size-for-drawing.html
+++ b/LayoutTests/fast/images/async-image-intersect-different-size-for-drawing.html
@@ -82,8 +82,7 @@
  
         loadImageAndDraw(intialBox, image1, "resources/green-400x400.png").then(() => {
             requestAnimationFrame(() => {
-                decodingOptions = internals.imageLastDecodingOptions(image1);
-                shouldBeEqualToString("decodingOptions", "{ decodingMode : Asynchronous, sizeForDrawing : { 500, 500 } }");
+                debug("decodingOptions = " + internals.imageLastDecodingOptions(image1));
 
                 finalBox.appendChild(image1.cloneNode(true));
                 finalBox.style.display = "block";
@@ -94,8 +93,7 @@
                     testRunner.display();
 
                 requestAnimationFrame(() => {
-                    decodingOptions = internals.imageLastDecodingOptions(image1);
-                    shouldBeEqualToString("decodingOptions", "{ decodingMode : Synchronous, sizeForDrawing : { 1000, 1000 } }");
+                    debug("decodingOptions = " + internals.imageLastDecodingOptions(image1));
                     finishJSTest();
                 });
             });

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2767,8 +2767,6 @@ imported/w3c/web-platform-tests/content-security-policy/script-src/script-src-re
 
 webkit.org/b/271445 fast/events/ios/rotation/resize-iframe-after-orientation-change.html [ Pass Failure ]
 
-webkit.org/b/271669 fast/images/async-image-intersect-different-size-for-drawing.html [ Failure ]
-
 webkit.org/b/271678 imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-unrelated-element.html [ ImageOnlyFailure ]
 
 webkit.org/b/271682 imported/w3c/web-platform-tests/css/css-content/quotes-007.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/ios-wk2/fast/images/async-image-intersect-different-size-for-drawing-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/images/async-image-intersect-different-size-for-drawing-expected.txt
@@ -3,8 +3,8 @@ Ensures a renderer will decode its image synchronously if it intersects with ano
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-decodingOptions = { decodingMode : Asynchronous, sizeForDrawing : { 500, 500 } }
-decodingOptions = { decodingMode : Synchronous, sizeForDrawing : { 1000, 1000 } }
+decodingOptions = { decodingMode : Asynchronous, sizeForDrawing : { 1000, 1000 } }
+decodingOptions = { decodingMode : Synchronous, sizeForDrawing : { 2000, 2000 } }
 PASS successfullyParsed is true
 
 TEST COMPLETE


### PR DESCRIPTION
#### 4a2e6597ff86a77e9a33d18d240b22df74bac6cb
<pre>
REGRESSION (276513@main): [ iOS ] fast/images/async-image-intersect-different-size-for-drawing.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=271669">https://bugs.webkit.org/show_bug.cgi?id=271669</a>
<a href="https://rdar.apple.com/125372071">rdar://125372071</a>

Unreviewed test gardening.

Since WKTR run in 2x on iOS simulator, we need to add a platform iOS expected
results for this test.

* LayoutTests/fast/images/async-image-intersect-different-size-for-drawing-expected.txt:
* LayoutTests/fast/images/async-image-intersect-different-size-for-drawing.html:
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/ios-wk2/fast/images/async-image-intersect-different-size-for-drawing-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/276703@main">https://commits.webkit.org/276703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86500eb8eb129f12c63dd81aa64c348293138b7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48050 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41394 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21903 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21583 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/39161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18328 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40239 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3433 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49770 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16895 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44267 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43085 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10103 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21365 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->