### PR TITLE
Promote debug assertion to release assertion for more downcast<>() overloads on Intel

### DIFF
--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -322,13 +322,7 @@ inline Ref<match_constness_t<Source, Target>> downcast(Ref<Source, PtrTraits, Re
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
-    // FIXME: This is too expensive to enable on x86 for now but we should try and
-    // enable the RELEASE_ASSERT() on all architectures.
-#if CPU(ARM64)
     RELEASE_ASSERT(is<Target>(source));
-#else
-    ASSERT_WITH_SECURITY_IMPLICATION(is<Target>(source));
-#endif
     return static_reference_cast<match_constness_t<Source, Target>>(WTFMove(source));
 }
 

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -267,13 +267,7 @@ inline RefPtr<match_constness_t<Source, Target>> downcast(RefPtr<Source, PtrTrai
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
-    // FIXME: This is too expensive to enable on x86 for now but we should try and
-    // enable the RELEASE_ASSERT() on all architectures.
-#if CPU(ARM64)
     RELEASE_ASSERT(!source || is<Target>(*source));
-#else
-    ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
-#endif
     return static_pointer_cast<match_constness_t<Source, Target>>(WTFMove(source));
 }
 

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -484,13 +484,7 @@ inline WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl, PtrTraits> downca
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
-    // FIXME: This is too expensive to enable on x86 for now but we should try and
-    // enable the RELEASE_ASSERT() on all architectures.
-#if CPU(ARM64)
     RELEASE_ASSERT(!source || is<Target>(*source));
-#else
-    ASSERT_WITH_SECURITY_IMPLICATION(!source || is<Target>(*source));
-#endif
     return WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl, PtrTraits> { static_pointer_cast<match_constness_t<Source, Target>>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
 }
 

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -291,13 +291,7 @@ inline WeakRef<match_constness_t<Source, Target>, WeakPtrImpl> downcast(WeakRef<
 {
     static_assert(!std::is_same_v<Source, Target>, "Unnecessary cast to same type");
     static_assert(std::is_base_of_v<Source, Target>, "Should be a downcast");
-    // FIXME: This is too expensive to enable on x86 for now but we should try and
-    // enable the RELEASE_ASSERT() on all architectures.
-#if CPU(ARM64)
     RELEASE_ASSERT(is<Target>(source));
-#else
-    ASSERT_WITH_SECURITY_IMPLICATION(is<Target>(source));
-#endif
     return WeakRef<match_constness_t<Source, Target>, WeakPtrImpl> { static_reference_cast<match_constness_t<Source, Target>>(source.releaseImpl()), source.enableWeakPtrThreadingAssertions() };
 }
 


### PR DESCRIPTION
#### 8dfa8c35be20695dca2005967793b58c9e6fb686
<pre>
Promote debug assertion to release assertion for more downcast&lt;&gt;() overloads on Intel
<a href="https://bugs.webkit.org/show_bug.cgi?id=271686">https://bugs.webkit.org/show_bug.cgi?id=271686</a>

Reviewed by Darin Adler and Anne van Kesteren.

Promote debug assertion to release assertion for more downcast&lt;&gt;() overloads on Intel,
to match ARM. This is performance neutral on the benchmarks we track.

* Source/WTF/wtf/Ref.h:
(WTF::downcast):
* Source/WTF/wtf/RefPtr.h:
(WTF::downcast):
* Source/WTF/wtf/WeakPtr.h:
(WTF::downcast):
* Source/WTF/wtf/WeakRef.h:
(WTF::downcast):

Canonical link: <a href="https://commits.webkit.org/276675@main">https://commits.webkit.org/276675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2fa617e2ad11a6cf3280dd5fc753e5979a63ad2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41328 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21837 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45898 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/21521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/39092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18263 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/18925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40177 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3367 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/38540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/41613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49706 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/44789 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16830 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21610 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43022 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/21970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51948 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6310 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21298 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->