### PR TITLE
Use std::span for StringView::find() / StringView::reverseFind()

### DIFF
--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -135,32 +135,32 @@ size_t StringView::find(AdaptiveStringSearcherTables& tables, StringView matchSt
     return searchStringRaw(tables, characters16(), length(), matchString.characters16(), matchString.length(), start);
 }
 
-size_t StringView::find(const LChar* match, unsigned matchLength, unsigned start) const
+size_t StringView::find(std::span<const LChar> match, unsigned start) const
 {
-    ASSERT(matchLength);
+    ASSERT(!match.empty());
     auto length = this->length();
     if (start > length)
         return notFound;
 
     unsigned searchLength = length - start;
-    if (matchLength > searchLength)
+    if (match.size() > searchLength)
         return notFound;
 
     if (is8Bit())
-        return findInner(characters8() + start, match, start, searchLength, matchLength);
-    return findInner(characters16() + start, match, start, searchLength, matchLength);
+        return findInner(characters8() + start, match.data(), start, searchLength, match.size());
+    return findInner(characters16() + start, match.data(), start, searchLength, match.size());
 }
 
-size_t StringView::reverseFind(const LChar* match, unsigned matchLength, unsigned start) const
+size_t StringView::reverseFind(std::span<const LChar> match, unsigned start) const
 {
-    ASSERT(matchLength);
+    ASSERT(!match.empty());
     auto length = this->length();
-    if (matchLength > length)
+    if (match.size() > length)
         return notFound;
 
     if (is8Bit())
-        return reverseFindInner(characters8(), match, start, length, matchLength);
-    return reverseFindInner(characters16(), match, start, length, matchLength);
+        return reverseFindInner(characters8(), match.data(), start, length, match.size());
+    return reverseFindInner(characters16(), match.data(), start, length, match.size());
 }
 
 void StringView::SplitResult::Iterator::findNextSubstring()

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -162,12 +162,12 @@ public:
     ALWAYS_INLINE size_t find(char c, unsigned start = 0) const { return find(static_cast<LChar>(c), start); }
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
     size_t find(CodeUnitMatchFunction&&, unsigned start = 0) const;
-    ALWAYS_INLINE size_t find(ASCIILiteral literal, unsigned start = 0) const { return find(literal.characters8(), literal.length(), start); }
+    ALWAYS_INLINE size_t find(ASCIILiteral literal, unsigned start = 0) const { return find(literal.span8(), start); }
     WTF_EXPORT_PRIVATE size_t find(StringView, unsigned start = 0) const;
     WTF_EXPORT_PRIVATE size_t find(AdaptiveStringSearcherTables&, StringView, unsigned start = 0) const;
 
     size_t reverseFind(UChar, unsigned index = std::numeric_limits<unsigned>::max()) const;
-    ALWAYS_INLINE size_t reverseFind(ASCIILiteral literal, unsigned start = std::numeric_limits<unsigned>::max()) const { return reverseFind(literal.characters8(), literal.length(), start); }
+    ALWAYS_INLINE size_t reverseFind(ASCIILiteral literal, unsigned start = std::numeric_limits<unsigned>::max()) const { return reverseFind(literal.span8(), start); }
     WTF_EXPORT_PRIVATE size_t reverseFind(StringView, unsigned start = std::numeric_limits<unsigned>::max()) const;
 
     WTF_EXPORT_PRIVATE size_t findIgnoringASCIICase(StringView) const;
@@ -217,8 +217,8 @@ private:
     void initialize(std::span<const LChar>);
     void initialize(std::span<const UChar>);
 
-    WTF_EXPORT_PRIVATE size_t find(const LChar* match, unsigned matchLength, unsigned start) const;
-    WTF_EXPORT_PRIVATE size_t reverseFind(const LChar* match, unsigned matchLength, unsigned start) const;
+    WTF_EXPORT_PRIVATE size_t find(std::span<const LChar> match, unsigned start) const;
+    WTF_EXPORT_PRIVATE size_t reverseFind(std::span<const LChar> match, unsigned start) const;
 
     template<typename CharacterType, typename MatchedCharacterPredicate>
     StringView trim(const CharacterType*, const MatchedCharacterPredicate&) const;


### PR DESCRIPTION
#### bee5958dfa29d3ee3d7bfe38264d6e23f209615a
<pre>
Use std::span for StringView::find() / StringView::reverseFind()
<a href="https://bugs.webkit.org/show_bug.cgi?id=271689">https://bugs.webkit.org/show_bug.cgi?id=271689</a>

Reviewed by Brent Fulgham.

* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::find const):
(WTF::StringView::reverseFind const):
* Source/WTF/wtf/text/StringView.h:

Canonical link: <a href="https://commits.webkit.org/276715@main">https://commits.webkit.org/276715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fe63f0b222937d798bda207a63badf491356925

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/47993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41337 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37171 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18273 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40186 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3376 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38549 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40505 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49707 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44798 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44216 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21619 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43025 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21979 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/51957 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6323 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21307 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10611 "Passed tests") | 
<!--EWS-Status-Bubble-End-->