### PR TITLE
[LibWebRTC][Linux] Make PulseAudio support optional

### DIFF
--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -2154,14 +2154,25 @@ else ()
 
         Source/webrtc/modules/audio_device/linux/alsasymboltable_linux.cc
         Source/webrtc/modules/audio_device/linux/audio_device_alsa_linux.cc
-        Source/webrtc/modules/audio_device/linux/audio_device_pulse_linux.cc
         Source/webrtc/modules/audio_device/linux/audio_mixer_manager_alsa_linux.cc
-        Source/webrtc/modules/audio_device/linux/audio_mixer_manager_pulse_linux.cc
         Source/webrtc/modules/audio_device/linux/latebindingsymboltable_linux.cc
-        Source/webrtc/modules/audio_device/linux/pulseaudiosymboltable_linux.cc
 
         Source/webrtc/modules/video_coding/codecs/h264/h264.cc
     )
+
+    find_package(LibPulse)
+    if (NOT LIBPULSE_FOUND)
+        message(STATUS "libpulse is not found, not building support.")
+    else()
+        list(APPEND webrtc_SOURCES
+            Source/webrtc/modules/audio_device/linux/audio_device_pulse_linux.cc
+            Source/webrtc/modules/audio_device/linux/audio_mixer_manager_pulse_linux.cc
+            Source/webrtc/modules/audio_device/linux/pulseaudiosymboltable_linux.cc
+        )
+        target_include_directories(webrtc PRIVATE ${LibPulse_INCLUDE_DIRS})
+        target_compile_options(webrtc PRIVATE ${LibPulse_COMPILE_OPTIONS})
+    endif ()
+
 endif ()
 
 add_library(webrtc STATIC ${webrtc_SOURCES})

--- a/Source/ThirdParty/libwebrtc/cmake/FindLibPulse.cmake
+++ b/Source/ThirdParty/libwebrtc/cmake/FindLibPulse.cmake
@@ -1,0 +1,31 @@
+# Copyright 2023 RDK Management
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+find_package(PkgConfig)
+pkg_check_modules(PC_LIBPULSE libpulse)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LibPulse DEFAULT_MSG PC_LIBPULSE_VERSION)
+
+set(LibPulse_INCLUDE_DIRS ${PC_LIBPULSE_INCLUDE_DIRS})
+set(LibPulse_COMPILE_OPTIONS ${PC_LIBPULSE_CFLAGS_OTHER})


### PR DESCRIPTION
#### b5a59471fd2982e20b75567a89fbbe8d3cccfd91
<pre>
[LibWebRTC][Linux] Make PulseAudio support optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=271696">https://bugs.webkit.org/show_bug.cgi?id=271696</a>

Reviewed by Adrian Perez de Castro.

Based on original patch by: Eugene Mutavchi &lt;Ievgen_Mutavchi@comcast.com&gt;

* Source/ThirdParty/libwebrtc/CMakeLists.txt:
* Source/ThirdParty/libwebrtc/cmake/FindLibPulse.cmake: Added.

Canonical link: <a href="https://commits.webkit.org/276708@main">https://commits.webkit.org/276708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e08119153e23e3767ac1a0ae507d7bfc59b14932

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48039 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41383 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37210 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21571 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18312 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40230 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3422 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49759 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20359 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16882 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44259 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21666 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43075 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10105 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21353 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->