### PR TITLE
[GStreamer][Quirks] Apply configureElement to every requested quirk

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp
@@ -48,21 +48,17 @@ GstElement* GStreamerQuirkAmLogic::createWebAudioSink()
     return sink;
 }
 
-bool GStreamerQuirkAmLogic::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
+void GStreamerQuirkAmLogic::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
 {
     if (gstObjectHasProperty(element, "disable-xrun")) {
         GST_INFO("Set property disable-xrun to TRUE");
         g_object_set(element, "disable-xrun", TRUE, nullptr);
-    } else
-        return false;
+    }
 
     if (characteristics.contains(ElementRuntimeCharacteristics::HasVideo) && gstObjectHasProperty(element, "wait-video")) {
         GST_INFO("Set property wait-video to TRUE");
         g_object_set(element, "wait-video", TRUE, nullptr);
-    } else
-        return false;
-
-    return true;
+    }
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
@@ -32,8 +32,7 @@ public:
     const char* identifier() final { return "AmLogic"; }
 
     GstElement* createWebAudioSink() final;
-    bool configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
-
+    void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp
@@ -37,7 +37,7 @@ GStreamerQuirkBroadcom::GStreamerQuirkBroadcom()
     m_disallowedWebAudioDecoders = { "brcmaudfilter"_s };
 }
 
-bool GStreamerQuirkBroadcom::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
+void GStreamerQuirkBroadcom::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
 {
     if (g_str_has_prefix(GST_ELEMENT_NAME(element), "brcmaudiosink"))
         g_object_set(G_OBJECT(element), "async", TRUE, nullptr);
@@ -48,14 +48,12 @@ bool GStreamerQuirkBroadcom::configureElement(GstElement* element, const OptionS
     }
 
     if (!characteristics.contains(ElementRuntimeCharacteristics::IsMediaStream))
-        return true;
+        return;
 
     if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstBrcmPCMSink") && gstObjectHasProperty(element, "low_latency")) {
         GST_DEBUG("Set 'low_latency' in brcmpcmsink");
         g_object_set(element, "low_latency", TRUE, "low_latency_max_queued_ms", 60, nullptr);
     }
-
-    return true;
 }
 
 std::optional<bool> GStreamerQuirkBroadcom::isHardwareAccelerated(GstElementFactory* factory)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h
@@ -32,7 +32,7 @@ public:
     GStreamerQuirkBroadcom();
     const char* identifier() final { return "Broadcom"; }
 
-    bool configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
+    void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
     std::optional<GstElementFactoryListType> audioVideoDecoderFactoryListType() const final { return GST_ELEMENT_FACTORY_TYPE_PARSER; }
     Vector<String> disallowedWebAudioDecoders() const final { return m_disallowedWebAudioDecoders; }

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp
@@ -55,10 +55,10 @@ GstElement* GStreamerQuirkRealtek::createWebAudioSink()
     return sink;
 }
 
-bool GStreamerQuirkRealtek::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
+void GStreamerQuirkRealtek::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
 {
     if (!characteristics.contains(ElementRuntimeCharacteristics::IsMediaStream))
-        return false;
+        return;
 
     if (gstObjectHasProperty(element, "media-tunnel")) {
         GST_INFO("Enable 'immediate-output' in rtkaudiosink");
@@ -69,8 +69,6 @@ bool GStreamerQuirkRealtek::configureElement(GstElement* element, const OptionSe
         GST_INFO("Enable 'lowdelay-mode' in rtk omx decoder");
         g_object_set(element, "lowdelay-mode", TRUE, nullptr);
     }
-
-    return true;
 }
 
 std::optional<bool> GStreamerQuirkRealtek::isHardwareAccelerated(GstElementFactory* factory)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
@@ -32,7 +32,7 @@ public:
     const char* identifier() final { return "Realtek"; }
 
     GstElement* createWebAudioSink() final;
-    bool configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
+    void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
     Vector<String> disallowedWebAudioDecoders() const final { return m_disallowedWebAudioDecoders; }
 

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp
@@ -51,7 +51,7 @@ GStreamerQuirkWesteros::GStreamerQuirkWesteros()
     }
 }
 
-bool GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
+void GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionSet<ElementRuntimeCharacteristics>& characteristics)
 {
     if (g_str_has_prefix(GST_ELEMENT_NAME(element), "uridecodebin3")) {
         GRefPtr<GstCaps> defaultCaps;
@@ -59,17 +59,16 @@ bool GStreamerQuirkWesteros::configureElement(GstElement* element, const OptionS
         defaultCaps = adoptGRef(gst_caps_merge(gst_caps_ref(m_sinkCaps.get()), defaultCaps.leakRef()));
         GST_INFO("Setting stop caps to %" GST_PTR_FORMAT, defaultCaps.get());
         g_object_set(element, "caps", defaultCaps.get(), nullptr);
-        return true;
+        return;
     }
 
     if (!characteristics.contains(ElementRuntimeCharacteristics::IsMediaStream))
-        return false;
+        return;
 
     if (!g_strcmp0(G_OBJECT_TYPE_NAME(G_OBJECT(element)), "GstWesterosSink") && gstObjectHasProperty(element, "immediate-output")) {
         GST_INFO("Enable 'immediate-output' in WesterosSink");
         g_object_set(element, "immediate-output", TRUE, nullptr);
     }
-    return true;
 }
 
 std::optional<bool> GStreamerQuirkWesteros::isHardwareAccelerated(GstElementFactory* factory)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
@@ -31,7 +31,7 @@ public:
     GStreamerQuirkWesteros();
     const char* identifier() final { return "Westeros"; }
 
-    bool configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
+    void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
 
 private:

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -174,10 +174,8 @@ bool GStreamerQuirksManager::sinksRequireClockSynchronization() const
 void GStreamerQuirksManager::configureElement(GstElement* element, OptionSet<ElementRuntimeCharacteristics>&& characteristics)
 {
     GST_DEBUG("Configuring element %" GST_PTR_FORMAT, element);
-    for (const auto& quirk : m_quirks) {
-        if (quirk->configureElement(element, characteristics))
-            return;
-    }
+    for (const auto& quirk : m_quirks)
+        quirk->configureElement(element, characteristics);
 }
 
 std::optional<bool> GStreamerQuirksManager::isHardwareAccelerated(GstElementFactory* factory) const

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
@@ -55,7 +55,7 @@ public:
 
     virtual bool isPlatformSupported() const { return true; }
     virtual GstElement* createWebAudioSink() { return nullptr; }
-    virtual bool configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) { return false; }
+    virtual void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) { }
     virtual std::optional<bool> isHardwareAccelerated(GstElementFactory*) { return std::nullopt; }
     virtual std::optional<GstElementFactoryListType> audioVideoDecoderFactoryListType() const { return std::nullopt; }
     virtual Vector<String> disallowedWebAudioDecoders() const { return { }; }


### PR DESCRIPTION
#### 000e4448b8aa69a4a29a0da1d52f4208d79200f9
<pre>
[GStreamer][Quirks] Apply configureElement to every requested quirk
<a href="https://bugs.webkit.org/show_bug.cgi?id=271697">https://bugs.webkit.org/show_bug.cgi?id=271697</a>

Reviewed by Xabier Rodriguez-Calvar.

On some platforms it is desirable to apply that quirk unconditionally, because multiple
platform-specific quirks are requested.

* Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.cpp:
(WebCore::GStreamerQuirkAmLogic::configureElement):
* Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.cpp:
(WebCore::GStreamerQuirkBroadcom::configureElement):
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.cpp:
(WebCore::GStreamerQuirkRealtek::configureElement):
* Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.cpp:
(WebCore::GStreamerQuirkWesteros::configureElement):
* Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::configureElement):
* Source/WebCore/platform/gstreamer/GStreamerQuirks.h:
(WebCore::GStreamerQuirk::configureElement):

Canonical link: <a href="https://commits.webkit.org/276872@main">https://commits.webkit.org/276872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/319a0458e4ce46060e9eafcda9a31b5bdceac83b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41352 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37182 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18285 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18936 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40194 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3391 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49724 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16851 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44228 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21634 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43038 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10194 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/21994 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->