### PR TITLE
[WPE] Holepunch doesn't work when the video element has rounded corners

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -683,7 +683,8 @@ void TextureMapper::drawSolidColor(const FloatRect& rect, const TransformationMa
 
     if (clipStack().isRoundedRectClipEnabled()) {
         options.add(TextureMapperShaderProgram::RoundedRectClip);
-        flags.add(TextureMapperFlags::ShouldBlend);
+        if (isBlendingAllowed)
+            flags.add(TextureMapperFlags::ShouldBlend);
     }
 
     Ref<TextureMapperShaderProgram> program = data().getShaderProgram(options);


### PR DESCRIPTION
#### 5e4935006d800fff897c52435b38db22ef2ced70
<pre>
[WPE] Holepunch doesn&apos;t work when the video element has rounded corners
<a href="https://bugs.webkit.org/show_bug.cgi?id=271653">https://bugs.webkit.org/show_bug.cgi?id=271653</a>

Reviewed by Carlos Garcia Campos.

Modify the rounded rectangle clipping in the TextureMapper so it can work
when blending is disabled. To do this, the fragments that are out of rounded
rectangle are discarded by the fragment shader, instead of painting them
transparent.

When blending is enabled, we can do some antialiasing of the pixels on the
rounded corners by reducing their opacity depending on how much they are
inside the rect.

When blending is disabled we can&apos;t do antialiasing of the rounded corners,
so the visual result is a bit worse. The good thing is that blending is
only disabled when we&apos;re rendering a holepunch buffer, so it&apos;s not a big
problem.

* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::drawSolidColor):
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp:

Canonical link: <a href="https://commits.webkit.org/276876@main">https://commits.webkit.org/276876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b3dfb7ba3267d6e52a30854479dbe6bf58c72c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48022 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41366 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37198 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39132 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18300 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18983 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40215 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3405 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49740 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16865 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44245 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21648 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43074 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10195 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22008 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21336 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->