### PR TITLE
Regression: Third-party service worker processes get killed when trying to do loads

### DIFF
--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.cpp
@@ -138,7 +138,7 @@ void SWServerToContextConnection::terminateWhenPossible()
 
     bool hasServiceWorkerWithPendingEvents = false;
     protectedServer()->forEachServiceWorker([&](auto& worker) {
-        if (worker.isRunning() && worker.registrableDomain() == m_registrableDomain && worker.hasPendingEvents()) {
+        if (worker.isRunning() && worker.topRegistrableDomain() == m_registrableDomain && worker.hasPendingEvents()) {
             hasServiceWorkerWithPendingEvents = true;
             return false;
         }

--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -58,11 +58,11 @@ SWServerWorker::SWServerWorker(SWServer& server, SWServerRegistration& registrat
     , m_contentSecurityPolicy(contentSecurityPolicy)
     , m_crossOriginEmbedderPolicy(crossOriginEmbedderPolicy)
     , m_referrerPolicy(WTFMove(referrerPolicy))
-    , m_registrableDomain(m_data.scriptURL)
+    , m_topRegistrableDomain(m_registrationKey.topOrigin())
     , m_scriptResourceMap(WTFMove(scriptResourceMap))
     , m_terminationTimer(*this, &SWServerWorker::terminationTimerFired)
     , m_terminationIfPossibleTimer(*this, &SWServerWorker::terminationIfPossibleTimerFired)
-    , m_lastNavigationWasAppInitiated(m_server->clientIsAppInitiatedForRegistrableDomain(m_registrableDomain))
+    , m_lastNavigationWasAppInitiated(m_server->clientIsAppInitiatedForRegistrableDomain(m_topRegistrableDomain))
 {
     m_data.scriptURL.removeFragmentIdentifier();
 
@@ -180,7 +180,7 @@ const ClientOrigin& SWServerWorker::origin() const
 SWServerToContextConnection* SWServerWorker::contextConnection()
 {
     RefPtrAllowingPartiallyDestroyed<SWServer> server = m_server.get();
-    return server ? server->contextConnectionForRegistrableDomain(registrableDomain()) : nullptr;
+    return server ? server->contextConnectionForRegistrableDomain(topRegistrableDomain()) : nullptr;
 }
 
 void SWServerWorker::scriptContextFailedToStart(const std::optional<ServiceWorkerJobDataIdentifier>& jobDataIdentifier, const String& message)
@@ -441,7 +441,7 @@ void SWServerWorker::terminationIfPossibleTimerFired()
         return;
 
     terminate();
-    protectedServer()->removeContextConnectionIfPossible(registrableDomain());
+    protectedServer()->removeContextConnectionIfPossible(topRegistrableDomain());
 }
 
 bool SWServerWorker::isClientActiveServiceWorker(ScriptExecutionContextIdentifier clientIdentifier) const

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -118,7 +118,7 @@ public:
     ServiceWorkerContextData contextData() const;
 
     WEBCORE_EXPORT const ClientOrigin& origin() const;
-    const RegistrableDomain& registrableDomain() const { return m_registrableDomain; }
+    const RegistrableDomain& topRegistrableDomain() const { return m_topRegistrableDomain; }
     WEBCORE_EXPORT std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier() const;
 
     WEBCORE_EXPORT SWServerToContextConnection* contextConnection();
@@ -176,7 +176,7 @@ private:
     bool m_hasPendingEvents { false };
     State m_state { State::NotRunning };
     mutable std::optional<ClientOrigin> m_origin;
-    RegistrableDomain m_registrableDomain;
+    RegistrableDomain m_topRegistrableDomain;
     bool m_isSkipWaitingFlagSet { false };
     Vector<CompletionHandler<void(bool)>> m_whenActivatedHandlers;
     MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript> m_scriptResourceMap;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp
@@ -292,7 +292,7 @@ void WebSWServerConnection::startFetch(ServiceWorkerFetchTask& task, SWServerWor
         }
 
         if (!worker->contextConnection())
-            server->createContextConnection(worker->registrableDomain(), worker->serviceWorkerPageIdentifier());
+            server->createContextConnection(worker->topRegistrableDomain(), worker->serviceWorkerPageIdentifier());
 
         auto identifier = task->serviceWorkerIdentifier();
         server->runServiceWorkerIfNecessary(identifier, [weakThis = WTFMove(weakThis), this, task = WTFMove(task)](auto* contextConnection) mutable {

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.cpp
@@ -67,9 +67,9 @@ WebSharedWorker* WebSharedWorker::fromIdentifier(WebCore::SharedWorkerIdentifier
     return allWorkers().get(identifier);
 }
 
-WebCore::RegistrableDomain WebSharedWorker::registrableDomain() const
+WebCore::RegistrableDomain WebSharedWorker::topRegistrableDomain() const
 {
-    return WebCore::RegistrableDomain { url() };
+    return WebCore::RegistrableDomain { m_key.origin.topOrigin };
 }
 
 void WebSharedWorker::setFetchResult(WebCore::WorkerFetchResult&& fetchResult)
@@ -172,7 +172,7 @@ std::optional<WebCore::ProcessIdentifier> WebSharedWorker::firstSharedWorkerObje
 
 WebSharedWorkerServerToContextConnection* WebSharedWorker::contextConnection() const
 {
-    return m_server.contextConnectionForRegistrableDomain(registrableDomain());
+    return m_server.contextConnectionForRegistrableDomain(topRegistrableDomain());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
@@ -58,7 +58,7 @@ public:
     const WebCore::WorkerOptions& workerOptions() const { return m_workerOptions; }
     const WebCore::ClientOrigin& origin() const { return m_key.origin; }
     const URL& url() const { return m_key.url; }
-    WebCore::RegistrableDomain registrableDomain() const;
+    WebCore::RegistrableDomain topRegistrableDomain() const;
     WebSharedWorkerServerToContextConnection* contextConnection() const;
 
     void addSharedWorkerObject(WebCore::SharedWorkerObjectIdentifier, const WebCore::TransferredMessagePort&);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -125,16 +125,16 @@ void WebSharedWorkerServer::didFinishFetchingSharedWorkerScript(WebSharedWorker&
     sharedWorker.setInitializationData(WTFMove(initializationData));
     sharedWorker.setFetchResult(WTFMove(fetchResult));
 
-    if (auto* connection = m_contextConnections.get(sharedWorker.registrableDomain()))
+    if (auto* connection = m_contextConnections.get(sharedWorker.topRegistrableDomain()))
         sharedWorker.launch(*connection);
     else
-        createContextConnection(sharedWorker.registrableDomain(), sharedWorker.firstSharedWorkerObjectProcess());
+        createContextConnection(sharedWorker.topRegistrableDomain(), sharedWorker.firstSharedWorkerObjectProcess());
 }
 
 bool WebSharedWorkerServer::needsContextConnectionForRegistrableDomain(const WebCore::RegistrableDomain& registrableDomain) const
 {
     for (auto& sharedWorker : m_sharedWorkers.values()) {
-        if (registrableDomain.matches(sharedWorker->url()))
+        if (registrableDomain == sharedWorker->topRegistrableDomain())
             return true;
     }
     return false;
@@ -197,7 +197,7 @@ void WebSharedWorkerServer::contextConnectionCreated(WebSharedWorkerServerToCont
     RELEASE_LOG(SharedWorker, "WebSharedWorkerServer::contextConnectionCreated(%p) webProcessIdentifier=%" PRIu64, &contextConnection, contextConnection.webProcessIdentifier().toUInt64());
     auto& registrableDomain = contextConnection.registrableDomain();
     for (auto& sharedWorker : m_sharedWorkers.values()) {
-        if (!registrableDomain.matches(sharedWorker->url()))
+        if (registrableDomain != sharedWorker->topRegistrableDomain())
             continue;
 
         sharedWorker->didCreateContextConnection(contextConnection);


### PR DESCRIPTION
#### e3a44192dffa8a8c75699347efd3df4ac4defbd0
<pre>
Regression: Third-party service worker processes get killed when trying to do loads
<a href="https://bugs.webkit.org/show_bug.cgi?id=267298">https://bugs.webkit.org/show_bug.cgi?id=267298</a>
<a href="https://rdar.apple.com/120587179">rdar://120587179</a>

Reviewed by Youenn Fablet.

We recently added origin IPC message checks to make sure that WebProcesses can
only access cookies from specific origins. Due to a bug in our service worker
code, the network process would allow the wrong origin in the case of
third-party service workers (it would allow the client origin instead of the
top origin). As a result, the network process would kill the third-party
service worker process as soon as it would try to attempt a load. This was
occurring on <a href="https://boingboing.net/2024/01/06/stanley-water-bottle-madness-grips-america.html">https://boingboing.net/2024/01/06/stanley-water-bottle-madness-grips-america.html</a>
for example, with the tiktok.com service worker.

When the network process needs to launch a service worker process, it sends an
EstablishRemoteWorkerContextConnectionToNetworkProcess IPC to the UIProcess,
with a given registrable domain. The UIProcess would use this registrable
domain to select a suitable WebProcess or launch one. When launching a new
process, the UIProcess would send an IPC to the network process telling it this
new WebProcess is allowed to access cookies under the given registrable domain.

Both from the process selection point of view and from the network process
cookie access point of view, we expect this registrable domain to be the top
origin&apos;s registrable domain. As a result, in the example above, the third-party
tiktok.com service worker under boingboing.net, would be expected to use a
&quot;boingboing.net&quot; WebProcess and only have access to cookies under the
&quot;boingboing.net&quot; first party.

However, our service worker logic was using the registrable domain of the
service worker script URL instead. As a result, we would select a &quot;tiktok.com&quot;
WebProcess for the service worker process, which was wrong from a site
isolation perspective (since top-level tiktok.com would share the same process
as tiktok.com under boingboing.net). Also, the network process would allow
access to top-level tiktok.com cookies if the WebProcess requested them, which
was wrong too.

Later on, the service worker would try to do a load. The network request would
request use &quot;boingboing.net&quot; as firstParty for cookies, which is correct.
However, the network process would reject such load, since the process is only
allowed to use &quot;tiktok.com&quot; as first party for cookies. It would then kill the
service worker process for good measure since it would assume it is compromised.

To address the issue, we now properly use the registrable domain of the top
level origin when sending the EstablishRemoteWorkerContextConnectionToNetworkProcess
IPC for and service worker connection selection in general. I updated the shared
worker code as well to maintain consistency.

Note that in order to write an API test for this, I had to restore the service
worker from disk first. When the service worker is newly registered by JS, we
would first tell the network process to allow the wrong client origin. However,
a later IPC to tell the network process to also allow the top level origin. As
a result, newly registered third-party service workers would not get terminated
which is why our tests were passing. Those service worker origins were allowed
access to cookies they shouldn&apos;t have access to though so there was a security
issue still for them.
When restoring the service worker from disk though, we&apos;d only send a single IPC
to the network process telling it to allow the original of the service worker
script URL. This allowed me to write a test and explains the service worker
processes terminations on boingboing.net.

* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::addRegistrationFromStore):
(WebCore::SWServer::scheduleJob):
(WebCore::SWServer::tryInstallContextData):
(WebCore::SWServer::runServiceWorkerIfNecessary):
(WebCore::SWServer::markAllWorkersForRegistrableDomainAsTerminated):
(WebCore::SWServer::removeContextConnectionIfPossible):
(WebCore::SWServer::fireFunctionalEvent):
* Source/WebCore/workers/service/server/SWServerToContextConnection.cpp:
(WebCore::SWServerToContextConnection::terminateWhenPossible):
* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::m_lastNavigationWasAppInitiated):
(WebCore::SWServerWorker::contextConnection):
(WebCore::SWServerWorker::terminationIfPossibleTimerFired):
* Source/WebCore/workers/service/server/SWServerWorker.h:
(WebCore::SWServerWorker::topRegistrableDomain const):
(WebCore::SWServerWorker::registrableDomain const): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.cpp:
(WebKit::WebSWServerConnection::startFetch):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
(-[SWMessageHandlerForRestoreFromDiskTest resetExpectedMessage:]):

Originally-landed-as: 272448.87@safari-7618-branch (b70a943d3745). <a href="https://rdar.apple.com/124556696">rdar://124556696</a>
Canonical link: <a href="https://commits.webkit.org/276704@main">https://commits.webkit.org/276704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e226e379b9ad313b563d179a296535e62b37d34e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45378 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48041 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41385 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21894 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45956 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39148 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18321 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/18981 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40228 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3424 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41669 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49761 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16887 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21669 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43081 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10101 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22028 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->