### PR TITLE
REGRESSION (273999@main): Elements fail to render in Spinnaker

### DIFF
--- a/LayoutTests/compositing/shared-backing/composited-descendants-should-prevent-sharing-expected.html
+++ b/LayoutTests/compositing/shared-backing/composited-descendants-should-prevent-sharing-expected.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+  <head>
+    <style>
+        .first-scroller {
+            position: relative;
+            z-index: 0;
+            margin: 20px;
+            width: 500px;
+            height: 100px;
+            border: 1px solid black;
+            overflow: auto;
+        }
+        
+        .second-layer {
+            position: relative;
+            height: 400px;
+            width: 500px;
+            margin: 20px;
+            border: 1px solid black;
+        }
+
+        .second-scroller {
+            height: 300px;
+            width: 450px;
+            overflow: scroll;
+            border: 1px solid blue;
+            padding: 10px;
+            background-color: rgba(255, 255, 255, 0.85);
+        }
+
+        .inner-scroller {
+            width: 400px;
+            height: 200px;
+            overflow: scroll;
+            border: 1px solid black;
+        }
+        
+        .contents {
+            height: 200%;
+        }
+
+        .indicator {
+            position: relative;
+            margin: 10px;
+            width: 400px;
+            height: 80px;
+            background-color: green;
+        }
+
+        .spacer {
+            height: 200px;
+        }
+        
+    </style>
+  </head>
+  <body>
+        <div class="first-scroller">
+            <div class="contents">There should be a dark green rectangle inside the blue outline below</div>
+        </div>
+        <div class="second-layer">
+            <div class="second-scroller">
+                <div class="inner-scroller">
+                    <div class="contents"></div>
+                </div>
+                <div class="indicator"></div>
+                <div class="spacer"></div>
+            </div>
+        </div>
+  </body>
+</html>

--- a/LayoutTests/compositing/shared-backing/composited-descendants-should-prevent-sharing.html
+++ b/LayoutTests/compositing/shared-backing/composited-descendants-should-prevent-sharing.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+  <head>
+    <style>
+        .first-scroller {
+            position: relative;
+            z-index: 0;
+            margin: 20px;
+            width: 500px;
+            height: 100px;
+            border: 1px solid black;
+            overflow: auto;
+        }
+        
+        .second-layer {
+            position: relative;
+            overflow: hidden;
+            height: 400px;
+            width: 500px;
+            margin: 20px;
+            border: 1px solid black;
+        }
+
+        .second-scroller {
+            height: 300px;
+            width: 450px;
+            overflow: scroll;
+            border: 1px solid blue;
+            padding: 10px;
+            background-color: rgba(255, 255, 255, 0.85);
+        }
+
+        .inner-scroller {
+            width: 400px;
+            height: 200px;
+            overflow: scroll;
+            border: 1px solid black;
+        }
+        
+        .contents {
+            height: 200%;
+        }
+
+        .indicator {
+            position: relative;
+            margin: 10px;
+            width: 400px;
+            height: 80px;
+            background-color: green;
+        }
+
+        .spacer {
+            height: 200px;
+        }
+        
+    </style>
+  </head>
+  <body>
+        <div class="first-scroller">
+            <div class="contents">There should be a dark green rectangle inside the blue outline below</div>
+        </div>
+        <div class="second-layer">
+            <div class="second-scroller">
+                <div class="inner-scroller">
+                    <div class="contents"></div>
+                </div>
+                <div class="indicator"></div>
+                <div class="spacer"></div>
+            </div>
+        </div>
+  </body>
+</html>

--- a/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll-expected.txt
+++ b/LayoutTests/platform/ios-wk2/scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll-expected.txt
@@ -11,7 +11,7 @@
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,421))
   (behavior for fixed 1)
-  (children 1
+  (children 2
     (Overflow scrolling node
       (scrollable area size 310 310)
       (contents size 310 1112)
@@ -33,6 +33,9 @@
             (allows horizontal scrolling 1))
         )
       )
+    )
+    (Overflow scroll proxy node
+      (related overflow scrolling node scroll position (0,0))
     )
   )
 )

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll-expected.txt
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll-expected.txt
@@ -12,7 +12,7 @@
   (min layout viewport origin (0,0))
   (max layout viewport origin (0,421))
   (behavior for fixed 1)
-  (children 1
+  (children 2
     (Overflow scrolling node
       (scrollable area size 295 295)
       (contents size 295 1112)
@@ -34,6 +34,9 @@
             (allows horizontal scrolling 1))
         )
       )
+    )
+    (Overflow scroll proxy node
+      (related overflow scrolling node scroll position (0,0))
     )
   )
 )


### PR DESCRIPTION
#### 6fa1d3b94cd776cb8af563c46495c66e3c483668
<pre>
REGRESSION (273999@main): Elements fail to render in Spinnaker
<a href="https://bugs.webkit.org/show_bug.cgi?id=271710">https://bugs.webkit.org/show_bug.cgi?id=271710</a>
<a href="https://rdar.apple.com/124483601">rdar://124483601</a>

Reviewed by Alan Baradlay.

273999@main reverted some backing sharing behavior to an older configuration, but this brought back
a bug which affects Spinnaker dashboards. The test reduction has a series of overflow scrollers, both
siblings and nested, and an element later in the tree that ends up obscured when the bug occurs.

A simplified paint-order tree dump (via the Compositing log channel) looks like this:

-S---------C-c-- 0x118000810 RenderView 0x1180002c0
-S-----------c--   + 0x118001850 RenderBlock 0x118001700 HTML 0x118001050
-S---------C-c--     + 0x1180044a0 RenderBlock (relative positioned) 0x118004350 DIV 0x118003350 class=&apos;container&apos;
-S-O-----XxC----       - 0x118004740 RenderTextControl 0x118005460 TEXTAREA 0x118003c20 class=&apos;fixed&apos;
---O-------CPc--       + 0x1180049e0 RenderBlock (relative positioned) 0x1180045f0 DIV 0x1180033d0 id=&apos;main&apos;
--NO-------C-c--         n 0x118004dd0 RenderBlock 0x118004890 DIV 0x118003530 class=&apos;outer-scroller&apos;
--NO-------C--s-           n 0x118005070 RenderBlock 0x118004c80 DIV 0x1180035b0 class=&apos;scroller&apos;
------------p-s-       + 0x1180055b0 RenderBlock (relative positioned) 0x1180051c0 DIV 0x118003790 class=&apos;indicator&apos;

Note the P on &apos;0x1180049e0&apos; indicating that it&apos;s a shared backing provider, and the p on &apos;0x1180055b0&apos; showing that
it paints into that shared backing. However, the normal flow descendant layers of 0x1180049e0 (0x118004dd0 and 0x118005070)
are both [C]composited, so they appear on top of 0x1180055b0, which is the bug.

A composited layer normally interrupts a backing sharing sequence. However, we only determined that 0x1180049e0 could
be a backing provider after traversing its descendant layers in `updateBackingSharingAfterDescendantTraversal()`,
and made it one despite it having composited descendants. So fix `updateBackingSharingAfterDescendantTraversal()`
to check that.

This undoes the backing sharing that happened in `scrollingcoordinator/scrolling-tree/absolute-in-nested-overflow-scroll`,
but that sharing was undone on scrolling anyway.

* LayoutTests/compositing/shared-backing/composited-descendants-should-prevent-sharing-expected.html: Added.
* LayoutTests/compositing/shared-backing/composited-descendants-should-prevent-sharing.html: Added.
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal):

Canonical link: <a href="https://commits.webkit.org/276720@main">https://commits.webkit.org/276720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad25cbb9443c9c60d2e8af28a09963bc37960ea6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48119 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41461 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21972 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37263 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18382 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40299 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3499 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49843 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20438 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44321 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39369 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43147 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10112 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22105 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->