### PR TITLE
Allow for <input type=checkbox switch> haptic feedback on click

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1266,6 +1266,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/PermissionsPolicy.h
     html/PluginDocument.h
     html/StepRange.h
+    html/SwitchTrigger.h
     html/TimeRanges.h
     html/TypeAhead.h
     html/URLDecomposition.h

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -31,11 +32,11 @@
 #pragma once
 
 #include "BaseCheckableInputType.h"
+#include "SwitchTrigger.h"
 
 namespace WebCore {
 
 enum class WasSetByJavaScript : bool;
-
 enum class SwitchAnimationType : bool { VisuallyOn, Pressed };
 
 class CheckboxInputType final : public BaseCheckableInputType {
@@ -79,6 +80,7 @@ private:
     void setSwitchAnimationStartTime(SwitchAnimationType, Seconds);
     bool isSwitchAnimating(SwitchAnimationType) const;
     void performSwitchAnimation(SwitchAnimationType);
+    void performSwitchVisuallyOnAnimation(SwitchTrigger);
     void stopSwitchAnimation(SwitchAnimationType);
     float switchAnimationProgress(SwitchAnimationType) const;
     void updateIsSwitchVisuallyOnFromAbsoluteLocation(LayoutPoint);

--- a/Source/WebCore/html/SwitchTrigger.h
+++ b/Source/WebCore/html/SwitchTrigger.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class SwitchTrigger : bool { Click, PointerTracking };
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -26,6 +26,7 @@
 #include "PopupMenuStyle.h"
 #include "ScrollTypes.h"
 #include "StyleColor.h"
+#include "SwitchTrigger.h"
 #include "ThemeTypes.h"
 #include <wtf/HashMap.h>
 
@@ -256,6 +257,7 @@ public:
     virtual Seconds switchAnimationVisuallyOnDuration() const { return 0_s; }
     virtual Seconds switchAnimationPressedDuration() const { return 0_s; }
     float switchPointerTrackingMagnitudeProportion() const { return 0.4f; }
+    virtual bool hasSwitchHapticFeedback(SwitchTrigger) const { return false; }
 
 protected:
     OptionSet<ControlStyle::State> extractControlStyleStatesForRenderer(const RenderObject&) const;

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -101,11 +101,14 @@ private:
 
     void adjustSliderThumbSize(RenderStyle&, const Element*) const override;
 
-    void adjustSwitchStyle(RenderStyle&, const Element*) const override;
-    bool paintSwitchThumb(const RenderObject&, const PaintInfo&, const FloatRect&) override;
-    bool paintSwitchTrack(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+    void adjustSwitchStyle(RenderStyle&, const Element*) const final;
+    bool paintSwitchThumb(const RenderObject&, const PaintInfo&, const FloatRect&) final;
+    bool paintSwitchTrack(const RenderObject&, const PaintInfo&, const FloatRect&) final;
     Seconds switchAnimationVisuallyOnDuration() const final { return 300_ms; }
     Seconds switchAnimationPressedDuration() const final { return 300_ms; }
+#if HAVE(UI_IMPACT_FEEDBACK_GENERATOR)
+    bool hasSwitchHapticFeedback(SwitchTrigger) const final { return true; }
+#endif
 
     bool paintProgressBar(const RenderObject&, const PaintInfo&, const IntRect&) override;
 

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -121,6 +121,7 @@ private:
     void adjustSearchFieldResultsButtonStyle(RenderStyle&, const Element*) const final;
 
     Seconds switchAnimationVisuallyOnDuration() const final { return 300_ms; }
+    bool hasSwitchHapticFeedback(SwitchTrigger trigger) const final { return trigger == SwitchTrigger::PointerTracking; }
 
 #if ENABLE(DATALIST_ELEMENT)
     void adjustListButtonStyle(RenderStyle&, const Element*) const final;


### PR DESCRIPTION
#### a81bf20129ac80f7b807079fe7e5323eecb3e4df
<pre>
Allow for &lt;input type=checkbox switch&gt; haptic feedback on click
<a href="https://bugs.webkit.org/show_bug.cgi?id=271711">https://bugs.webkit.org/show_bug.cgi?id=271711</a>

Reviewed by Aditya Keerthi.

And enable this on HAVE(UI_IMPACT_FEEDBACK_GENERATOR) platforms. For
macOS there should no functional change.

(Not guarding the click path on macOS appears to have the same end
result as well as the haptic cannot be observed, but that does not seem
optimal as more code ends up being executed.)

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::willDispatchClick):
(WebCore::switchAnimationUpdateInterval):
(WebCore::CheckboxInputType::performSwitchVisuallyOnAnimation):
(WebCore::CheckboxInputType::updateIsSwitchVisuallyOnFromAbsoluteLocation):
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/SwitchTrigger.h: Added.
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::hasSwitchHapticFeedback const):
* Source/WebCore/rendering/ios/RenderThemeIOS.h:
* Source/WebCore/rendering/mac/RenderThemeMac.h:

Canonical link: <a href="https://commits.webkit.org/276727@main">https://commits.webkit.org/276727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4f3f6e7e85cdb190f7b658c01e39b84df402ca2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48169 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41511 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22022 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21713 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/39263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18414 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19111 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/40350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3548 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41822 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/40677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49902 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20490 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17019 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44365 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21796 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/43197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10115 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->