### PR TITLE
[SVG] Clean up SVGTextMetricsBuilder

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/text-intro-02-b-manual-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/import/text-intro-02-b-manual-expected.txt
@@ -25,8 +25,8 @@ layer at (0,0) size 800x600
         RenderSVGText {text} at (10,263) size 397x21 contains 1 chunk(s)
           RenderSVGInlineText {#text} at (0,0) size 397x20
             chunk 1 (end anchor) text run 1 at (10.00,280.00) startOffset 0 endOffset 12 width 92.40: "is in Hebrew"
-            chunk 1 (end anchor) text run 1 at (102.40,280.00) startOffset 0 endOffset 40 width 271.74 RTL: " \"\x{5D0}\x{5E0}\x{5D9} \x{5D9}\x{5DB}\x{5D5}\x{5DC} \x{5DC}\x{5D0}\x{5DB}\x{5D5}\x{5DC} \x{5D6}\x{5DB}\x{5D5}\x{5DB}\x{5D9}\x{5EA} \x{5D5}\x{5D6}\x{5D4} \x{5DC}\x{5D0} \x{5DE}\x{5D6}\x{5D9}\x{5E7} \x{5DC}\x{5D9}\" "
-            chunk 1 (end anchor) text run 1 at (374.14,280.00) startOffset 0 endOffset 4 width 32.40: "Text"
+            chunk 1 (end anchor) text run 1 at (102.40,280.00) startOffset 0 endOffset 40 width 273.00 RTL: " \"\x{5D0}\x{5E0}\x{5D9} \x{5D9}\x{5DB}\x{5D5}\x{5DC} \x{5DC}\x{5D0}\x{5DB}\x{5D5}\x{5DC} \x{5D6}\x{5DB}\x{5D5}\x{5DB}\x{5D9}\x{5EA} \x{5D5}\x{5D6}\x{5D4} \x{5DC}\x{5D0} \x{5DE}\x{5D6}\x{5D9}\x{5E7} \x{5DC}\x{5D9}\" "
+            chunk 1 (end anchor) text run 1 at (375.40,280.00) startOffset 0 endOffset 4 width 31.14: "Text"
     RenderSVGContainer {g} at (16,518) size 418x60
       RenderSVGText {text} at (10,311) size 251x36 contains 1 chunk(s)
         RenderSVGInlineText {#text} at (0,0) size 251x36

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -583,11 +583,10 @@ static bool canUseSimplifiedTextMeasuringForCharacters(std::span<const Character
     return true;
 }
 
-bool TextUtil::canUseSimplifiedTextMeasuring(StringView textContent, const RenderStyle& style, const RenderStyle* firstLineStyle)
+bool TextUtil::canUseSimplifiedTextMeasuring(StringView textContent, const FontCascade& fontCascade, bool whitespaceIsCollapsed, const RenderStyle* firstLineStyle)
 {
     ASSERT(textContent.is8Bit() || FontCascade::characterRangeCodePath(textContent.characters16(), textContent.length()) == FontCascade::CodePath::Simple);
     // FIXME: All these checks should be more fine-grained at the inline item level.
-    auto& fontCascade = style.fontCascade();
     if (fontCascade.wordSpacing() || fontCascade.letterSpacing())
         return false;
 
@@ -604,7 +603,6 @@ bool TextUtil::canUseSimplifiedTextMeasuring(StringView textContent, const Rende
     if (primaryFont.syntheticBoldOffset())
         return false;
 
-    auto whitespaceIsCollapsed = style.collapseWhiteSpace();
     if (textContent.is8Bit())
         return canUseSimplifiedTextMeasuringForCharacters(textContent.span8(), fontCascade, primaryFont, whitespaceIsCollapsed);
     return canUseSimplifiedTextMeasuringForCharacters(textContent.span16(), fontCascade, primaryFont, whitespaceIsCollapsed);

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
@@ -98,7 +98,7 @@ public:
     static bool hasHangableStopOrCommaEnd(const InlineTextItem&, const RenderStyle&);
     static float hangableStopOrCommaEndWidth(const InlineTextItem&, const RenderStyle&);
 
-    static bool canUseSimplifiedTextMeasuring(StringView, const RenderStyle& style, const RenderStyle* firstLineStyle);
+    static bool canUseSimplifiedTextMeasuring(StringView, const FontCascade&, bool whitespaceIsCollapsed, const RenderStyle* firstLineStyle);
     static bool hasPositionDependentContentWidth(StringView);
 };
 

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
@@ -199,7 +199,7 @@ UniqueRef<Layout::Box> BoxTree::createLayoutBox(RenderObject& renderer)
         auto canUseSimpleFontCodePath = textRenderer->canUseSimpleFontCodePath();
         auto canUseSimplifiedTextMeasuring = textRenderer->canUseSimplifiedTextMeasuring();
         if (!canUseSimplifiedTextMeasuring) {
-            canUseSimplifiedTextMeasuring = canUseSimpleFontCodePath && Layout::TextUtil::canUseSimplifiedTextMeasuring(text, style, firstLineStyle.get());
+            canUseSimplifiedTextMeasuring = canUseSimpleFontCodePath && Layout::TextUtil::canUseSimplifiedTextMeasuring(text, style.fontCascade(), style.collapseWhiteSpace(), firstLineStyle.get());
             textRenderer->setCanUseSimplifiedTextMeasuring(*canUseSimplifiedTextMeasuring);
         }
 
@@ -302,7 +302,7 @@ void BoxTree::updateContent(const RenderText& textRenderer)
     auto contentCharacteristic = OptionSet<Layout::InlineTextBox::ContentCharacteristic> { };
     if (textRenderer.canUseSimpleFontCodePath())
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::CanUseSimpledFontCodepath);
-    if (textRenderer.canUseSimpleFontCodePath() && Layout::TextUtil::canUseSimplifiedTextMeasuring(text, style, &inlineTextBox.firstLineStyle()))
+    if (textRenderer.canUseSimpleFontCodePath() && Layout::TextUtil::canUseSimplifiedTextMeasuring(text, style.fontCascade(), style.collapseWhiteSpace(), &inlineTextBox.firstLineStyle()))
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::CanUseSimplifiedContentMeasuring);
     if (Layout::TextUtil::hasPositionDependentContentWidth(text))
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::HasPositionDependentContentWidth);

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -357,7 +357,7 @@ NEVER_INLINE float FontCascade::widthForSimpleTextSlow(StringView text, TextDire
 
 float FontCascade::widthForSimpleTextWithFixedPitch(StringView text, bool whitespaceIsCollapsed) const
 {
-    if (text.isNull() || text.isEmpty())
+    if (text.isEmpty())
         return 0;
 
     auto monospaceCharacterWidth = primaryFont().spaceWidth();

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -410,7 +410,7 @@ inline float FontCascade::tabWidth(const Font& font, const TabSize& tabSize, flo
 
 inline float FontCascade::widthForTextUsingSimplifiedMeasuring(StringView text, TextDirection textDirection) const
 {
-    if (text.isNull() || text.isEmpty())
+    if (text.isEmpty())
         return 0;
     ASSERT(codePath(TextRun(text)) != CodePath::Complex);
     float* cacheEntry = protectedFonts()->widthCache().add(text, std::numeric_limits<float>::quiet_NaN());

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -249,7 +249,9 @@ private:
 
     String m_text;
 
+protected:
     std::optional<bool> m_canUseSimplifiedTextMeasuring;
+private:
     std::optional<bool> m_hasPositionDependentContentWidth;
     std::optional<bool> m_hasStrongDirectionalityContent;
     unsigned m_hasBreakableChar : 1 { false }; // Whether or not we can be broken into multiple lines.

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -206,7 +206,8 @@ VisiblePosition RenderSVGInlineText::positionForPoint(const LayoutPoint& point, 
 
 void RenderSVGInlineText::updateScaledFont()
 {
-    computeNewScaledFontForStyle(*this, style(), m_scalingFactor, m_scaledFont);
+    if (computeNewScaledFontForStyle(*this, style(), m_scalingFactor, m_scaledFont))
+        m_canUseSimplifiedTextMeasuring = { };
 }
 
 float RenderSVGInlineText::computeScalingFactorForRenderer(const RenderObject& renderer)
@@ -218,14 +219,14 @@ float RenderSVGInlineText::computeScalingFactorForRenderer(const RenderObject& r
     return SVGRenderingContext::calculateScreenFontSizeScalingFactor(renderer);
 }
 
-void RenderSVGInlineText::computeNewScaledFontForStyle(const RenderObject& renderer, const RenderStyle& style, float& scalingFactor, FontCascade& scaledFont)
+bool RenderSVGInlineText::computeNewScaledFontForStyle(const RenderObject& renderer, const RenderStyle& style, float& scalingFactor, FontCascade& scaledFont)
 {
     // Alter font-size to the right on-screen value to avoid scaling the glyphs themselves, except when GeometricPrecision is specified
     scalingFactor = computeScalingFactorForRenderer(renderer);
     if (!scalingFactor || style.fontDescription().textRenderingMode() == TextRenderingMode::GeometricPrecision) {
         scalingFactor = 1;
         scaledFont = style.fontCascade();
-        return;
+        return false;
     }
 
     auto fontDescription = style.fontDescription();
@@ -240,6 +241,7 @@ void RenderSVGInlineText::computeNewScaledFontForStyle(const RenderObject& rende
 
     scaledFont = FontCascade(WTFMove(fontDescription));
     scaledFont.update(renderer.document().protectedFontSelector().ptr());
+    return true;
 }
 
 SVGInlineTextBox* RenderSVGInlineText::firstTextBox() const

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.h
@@ -48,7 +48,7 @@ public:
     float scalingFactor() const { return m_scalingFactor; }
     const FontCascade& scaledFont() const { return m_scaledFont; }
     void updateScaledFont();
-    static void computeNewScaledFontForStyle(const RenderObject&, const RenderStyle&, float& scalingFactor, FontCascade& scaledFont);
+    static bool computeNewScaledFontForStyle(const RenderObject&, const RenderStyle&, float& scalingFactor, FontCascade& scaledFont);
 
     // Preserves floating point precision for the use in DRT. It knows how to round and does a better job than enclosingIntRect.
     FloatRect floatLinesBoundingBox() const;

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -262,18 +262,6 @@ void RenderSVGText::subtreeChildWasRemoved(const Vector<SVGTextLayoutAttributes*
         m_layoutAttributesBuilder.buildLayoutAttributesForTextRenderer(affectedAttributes[i]->context());
 }
 
-void RenderSVGText::willLayout()
-{
-    if (!shouldHandleSubtreeMutations() || renderTreeBeingDestroyed())
-        return;
-
-    checkLayoutAttributesConsistency(this, m_layoutAttributes);
-
-    // Only update the metrics cache, but not the text positioning element cache
-    // nor the layout attributes cached in the leaf #text renderers.
-    m_layoutAttributesBuilder.rebuildMetricsForSubtree(*this);
-}
-
 void RenderSVGText::subtreeTextDidChange(RenderSVGInlineText* text)
 {
     ASSERT(text);
@@ -298,14 +286,12 @@ void RenderSVGText::subtreeTextDidChange(RenderSVGInlineText* text)
     setNeedsLayout();
 }
 
-static inline void updateFontInAllDescendants(RenderSVGText& text, SVGTextLayoutAttributesBuilder* builder = nullptr)
+static inline void updateFontInAllDescendants(RenderSVGText& text)
 {
     for (RenderObject* descendant = &text; descendant; descendant = descendant->nextInPreOrder(&text)) {
         if (auto* text = dynamicDowncast<RenderSVGInlineText>(*descendant))
             text->updateScaledFont();
     }
-    if (builder)
-        builder->rebuildMetricsForSubtree(text);
 }
 
 void RenderSVGText::layout()
@@ -317,7 +303,8 @@ void RenderSVGText::layout()
     StackStats::LayoutCheckPoint layoutCheckPoint;
     ASSERT(needsLayout());
 
-    willLayout();
+    if (shouldHandleSubtreeMutations() && !renderTreeBeingDestroyed())
+        checkLayoutAttributesConsistency(this, m_layoutAttributes);
 
     LayoutRepainter repainter(*this, isLayerBasedSVGEngineEnabled() ? checkForRepaintDuringLayout() : SVGRenderSupport::checkForSVGRepaintDuringLayout(*this));
 
@@ -346,13 +333,11 @@ void RenderSVGText::layout()
     } else if (m_needsPositioningValuesUpdate) {
         // When the x/y/dx/dy/rotate lists change, recompute the layout attributes, and eventually
         // update the on-screen font objects as well in all descendants.
-        if (m_needsTextMetricsUpdate) {
+        if (m_needsTextMetricsUpdate)
             updateFontInAllDescendants(*this);
-            m_needsTextMetricsUpdate = false;
-        }
-
         m_layoutAttributesBuilder.buildLayoutAttributesForForSubtree(*this);
         m_needsReordering = true;
+        m_needsTextMetricsUpdate = false;
         m_needsPositioningValuesUpdate = false;
         updateCachedBoundariesInParents = true;
     } else {
@@ -365,13 +350,14 @@ void RenderSVGText::layout()
         if (m_needsTextMetricsUpdate || isLayoutSizeChanged) {
             // If the root layout size changed (eg. window size changes) or the transform to the root
             // context has changed then recompute the on-screen font size.
-            updateFontInAllDescendants(*this, &m_layoutAttributesBuilder);
+            updateFontInAllDescendants(*this);
 
             ASSERT(!m_needsReordering);
             ASSERT(!m_needsPositioningValuesUpdate);
             m_needsTextMetricsUpdate = false;
             updateCachedBoundariesInParents = true;
         }
+        m_layoutAttributesBuilder.rebuildMetricsForSubtree(*this);
     }
 
     checkLayoutAttributesConsistency(this, m_layoutAttributes);

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -58,7 +58,6 @@ public:
     void subtreeChildWasAdded(RenderObject*);
     void subtreeChildWillBeRemoved(RenderObject*, Vector<SVGTextLayoutAttributes*, 2>& affectedAttributes);
     void subtreeChildWasRemoved(const Vector<SVGTextLayoutAttributes*, 2>& affectedAttributes);
-    void willLayout();
     void subtreeTextDidChange(RenderSVGInlineText*);
 
     FloatRect objectBoundingBox() const final { return m_objectBoundingBox; }

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.cpp
@@ -33,7 +33,7 @@ SVGTextLayoutAttributes::SVGTextLayoutAttributes(RenderSVGInlineText& context)
 void SVGTextLayoutAttributes::clear()
 {
     m_characterDataMap.clear();
-    m_textMetricsValues.clear();
+    m_textMetricsValues.resize(0);
 }
 
 float SVGTextLayoutAttributes::emptyValue()

--- a/Source/WebCore/rendering/svg/SVGTextMetrics.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetrics.cpp
@@ -25,20 +25,6 @@
 
 namespace WebCore {
 
-SVGTextMetrics::SVGTextMetrics()
-    : m_width(0)
-    , m_height(0)
-    , m_length(0)
-{
-}
-
-SVGTextMetrics::SVGTextMetrics(SVGTextMetrics::MetricsType)
-    : m_width(0)
-    , m_height(0)
-    , m_length(1)
-{
-}
-
 SVGTextMetrics::SVGTextMetrics(RenderSVGInlineText& textRenderer, const TextRun& run)
 {
     float scalingFactor = textRenderer.scalingFactor();

--- a/Source/WebCore/rendering/svg/SVGTextMetrics.h
+++ b/Source/WebCore/rendering/svg/SVGTextMetrics.h
@@ -31,9 +31,16 @@ class SVGTextMetrics {
 public:
     enum MetricsType { SkippedSpaceMetrics };
 
-    SVGTextMetrics();
-    explicit SVGTextMetrics(MetricsType);
+    SVGTextMetrics() = default;
+    explicit SVGTextMetrics(MetricsType)
+        : m_length(1)
+    { }
     SVGTextMetrics(RenderSVGInlineText&, unsigned length, float width);
+    SVGTextMetrics(unsigned length, float scaledWidth, float scaledHeight)
+        : m_width(scaledWidth)
+        , m_height(scaledHeight)
+        , m_length(length)
+    { }
 
     static SVGTextMetrics measureCharacterRange(RenderSVGInlineText&, unsigned position, unsigned length);
     static TextRun constructTextRun(RenderSVGInlineText&, unsigned position = 0, unsigned length = std::numeric_limits<unsigned>::max());
@@ -63,9 +70,9 @@ public:
 private:
     SVGTextMetrics(RenderSVGInlineText&, const TextRun&);
 
-    float m_width;
-    float m_height;
-    unsigned m_length;
+    float m_width { 0 };
+    float m_height { 0 };
+    unsigned m_length { 0 };
     Glyph m_glyph;
 };
 

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h
@@ -44,13 +44,14 @@ private:
     bool currentCharacterStartsSurrogatePair() const;
 
     void initializeMeasurementWithTextRenderer(RenderSVGInlineText&);
-    void walkTree(RenderElement&, RenderSVGInlineText* stopAtLeaf, MeasureTextData*);
-    void measureTextRenderer(RenderSVGInlineText&, MeasureTextData*);
+    void walkTree(RenderElement&, RenderSVGInlineText* stopAtLeaf, MeasureTextData&);
+    std::tuple<unsigned, UChar> measureTextRenderer(RenderSVGInlineText&, const MeasureTextData&, std::tuple<unsigned, UChar>);
 
     RenderSVGInlineText* m_text;
     TextRun m_run;
     unsigned m_textPosition;
-    bool m_isComplexText;
+    bool m_isComplexText { false };
+    bool m_canUseSimplifiedTextMeasuring { false };
     SVGTextMetrics m_currentMetrics;
     float m_totalWidth;
 


### PR DESCRIPTION
#### d0ecc42ca2afd958eb7831d67e5bdb19c48ab007
<pre>
[SVG] Clean up SVGTextMetricsBuilder
<a href="https://bugs.webkit.org/show_bug.cgi?id=271717">https://bugs.webkit.org/show_bug.cgi?id=271717</a>
<a href="https://rdar.apple.com/125428940">rdar://125428940</a>

Reviewed by Cameron McCormack.

This patch adds optimized fast path for SVGTextMetricsBuilder.

1. We reorganized RenderSVGText::layout so that we no longer call SVGTextMetricsBuilder multiple times
   unnecessarily in one layout. We should call once per layout.
2. We use canUseSimplifiedTextMeasuring information from RenderSVGInlineText (this flag gets updated correctly based on style change etc.).
   And based on that, we use super tuned fast path for SVGTextMetrics collection. We use FontCascade&apos;s WidthCache well. And we skip various
   unnecessarily costly operation done for per character basis on the normal path.
3. Clean up SVGTextMetricsBuilder code. Make MeasureTextData const parameter for SVGTextMetricsBuilder::measureTextRenderer to make input
   and output much more explicit and stateless. Remove many unnecessary branches.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::widthForSimpleTextWithFixedPitch const):
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::widthForTextUsingSimplifiedMeasuring const):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::updateFontInAllDescendants):
(WebCore::RenderSVGText::layout):
(WebCore::RenderSVGText::willLayout): Deleted.
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp:
(WebCore::SVGTextMetricsBuilder::initializeMeasurementWithTextRenderer):
(WebCore::MeasureTextData::MeasureTextData):
(WebCore::SVGTextMetricsBuilder::measureTextRenderer):
(WebCore::SVGTextMetricsBuilder::walkTree):
(WebCore::SVGTextMetricsBuilder::buildMetricsAndLayoutAttributes):
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h:

Canonical link: <a href="https://commits.webkit.org/277214@main">https://commits.webkit.org/277214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5554e58a6012aa12dcd391d6b9d91f48d6a91003

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49698 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43063 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49323 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/31336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23651 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47597 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/31336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/19599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/31336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5061 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/31336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51574 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/23317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6595 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/23028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->