### PR TITLE
Skipped-by-default ignored for second-and-later device_types

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -384,18 +384,47 @@ class Manager(object):
         enabled_pixel_tests_in_retry = False
 
         max_child_processes_for_run = 1
-        child_processes_option_value = self._options.child_processes
+        child_processes_option_value = int(self._options.child_processes or 0)
         uploads = []
 
+        for i, device_type in enumerate(device_type_list):
+            specified_child_processes = (
+                child_processes_option_value
+                or self._port.default_child_processes(device_type=device_type)
+            )
 
-        for device_type in device_type_list:
-            self._options.child_processes = min(self._port.max_child_processes(device_type=device_type), int(child_processes_option_value or self._port.default_child_processes(device_type=device_type)))
-        # Adding an option to only boot 1 child process/simulator instance upon retry or follow-up test runs after the preceeding test run completes.
-            child_processes_option_value = 1
+            max_child_processes = self._port.max_child_processes(
+                device_type=device_type
+            )
+
+            if i > 0 and self._port.is_simulator():
+                # Limit the number of simulators we end up booting by only using one for
+                # all devices after the first, assuming we run the vast majority of
+                # tests on the first device.
+                max_child_processes = min(1, max_child_processes)
+
+            self._options.child_processes = min(
+                max_child_processes, specified_child_processes
+            )
 
             _log.info('')
             if not self._options.child_processes:
-                _log.info('Skipping {} because {} is not available'.format(pluralize(len(tests_to_run_by_device[device_type]), 'test'), str(device_type)))
+                skipped_by_default = (
+                    specified_child_processes == 0 and max_child_processes > 0
+                )
+
+                if skipped_by_default:
+                    skip_reason = 'skipped by default'
+                else:
+                    skip_reason = 'not available'
+
+                _log.info(
+                    'Skipping {} because {} is {}'.format(
+                        pluralize(len(tests_to_run_by_device[device_type]), 'test'),
+                        str(device_type),
+                        skip_reason,
+                    )
+                )
                 _log.info('')
                 continue
 

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -163,6 +163,9 @@ class Port(object):
     def target_host(self, worker_number=None):
         return self.host
 
+    def is_simulator(self):
+        return False
+
     def architecture(self):
         return self.get_option('architecture') or self.DEFAULT_ARCHITECTURE
 

--- a/Tools/Scripts/webkitpy/port/ios_device_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_device_unittest.py
@@ -22,6 +22,8 @@
 
 import time
 
+from mock import Mock
+
 from webkitcorepy import Version
 
 from webkitpy.common.system.executive_mock import MockExecutive2, ScriptError
@@ -38,6 +40,11 @@ class IOSDeviceTest(ios_testcase.IOSTest):
     os_version = None
     port_name = 'ios-device'
     port_maker = IOSDevicePort
+
+    def make_port(self, *args, **kwargs):
+        port = super(IOSDeviceTest, self).make_port(*args, **kwargs)
+        port.DEVICE_MANAGER = Mock(INITIALIZED_DEVICES=None)
+        return port
 
     def test_operating_system(self):
         self.assertEqual('ios-device', self.make_port().operating_system())


### PR DESCRIPTION
#### 0de43f2ad98a839ab622d10b37e3f4287d5af70a
<pre>
Skipped-by-default ignored for second-and-later device_types
<a href="https://bugs.webkit.org/show_bug.cgi?id=271716">https://bugs.webkit.org/show_bug.cgi?id=271716</a>

Reviewed by Jonathan Bedard.

The intention of 267745@main was to limit the number of simulators we&apos;re
using for all devices besides the first.

However, it inadvertently led to us never skipping those devices when
Port.default_child_processes() is zero and Port.max_child_processes() is
not, and made it harder to reason about what we&apos;re doing in this already
gnarly loop (not helped by the comment being incorrect: this doesn&apos;t
affect retries).

Instead, let&apos;s track if we&apos;re running against a simulator, and if so
explicitly limit the max child processes to one for devices besides
the first, which was the intention of that change.

While we&apos;re at it, make the logging account for the possibility of a
device that isn&apos;t run by default.

* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager.run):
* Tools/Scripts/webkitpy/port/base.py:
(Port.is_simulator):
* Tools/Scripts/webkitpy/port/device_port.py:
(DevicePort.is_simulator):
(DevicePort.max_child_processes):
(DevicePort.supported_device_types):
(DevicePort.configuration_for_upload):
* Tools/Scripts/webkitpy/port/ios_device_unittest.py:
(IOSDeviceTest.make_port):

Canonical link: <a href="https://commits.webkit.org/277755@main">https://commits.webkit.org/277755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/092a4ad1c52c251b6a2ca355e1c259a5464fc372

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50996 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44373 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39463 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20608 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/48165 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22701 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42906 "Found 1 new test failure: fast/css/viewport-height-outline.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6364 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44659 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52900 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46807 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24620 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45720 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25425 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6904 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->