### PR TITLE
Output better metadata for baseline_search_path and expectations_files

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py
@@ -237,6 +237,8 @@ def summarize_results(port_obj, expectations_by_type, initial_results, retry_res
     results = {}
     results['version'] = 4
 
+    device_type_list = list(expectations_by_type.keys())
+
     tbe = initial_results.tests_by_expectation
     tbt = initial_results.tests_by_timeline
     results['fixable'] = len(tbt[test_expectations.NOW] - tbe[test_expectations.PASS])
@@ -390,9 +392,16 @@ def summarize_results(port_obj, expectations_by_type, initial_results, retry_res
     results['date'] = datetime.datetime.now().strftime("%I:%M%p on %B %d, %Y")
     results['port_name'] = port_obj.name()
     results['test_configuration'] = dict(port_obj.test_configuration().items())
+
+    # These use the first device type, because we've long ago merged the results for all
+    # the device types we ran.
     results['baseline_search_path'] = [
         port_obj.host.filesystem.relpath(p, port_obj.layout_tests_dir())
-        for p in port_obj.baseline_search_path()
+        for p in port_obj.baseline_search_path(device_type=device_type_list[0])
+    ]
+    results['expectations_files'] = [
+        port_obj.host.filesystem.relpath(p, port_obj.layout_tests_dir())
+        for p in port_obj.expectations_files(device_type=device_type_list[0])
     ]
 
     try:

--- a/Tools/Scripts/webkitpy/layout_tests/views/printing.py
+++ b/Tools/Scripts/webkitpy/layout_tests/views/printing.py
@@ -98,6 +98,7 @@ class Printer(object):
     def print_baseline_search_path(self, device_type=None):
         fs = self._port.host.filesystem
         full_baseline_search_path = self._port.baseline_search_path(device_type=device_type)
+        full_expectations_files = self._port.expectations_files(device_type=device_type)
         normalize_baseline = lambda baseline_search_path: [
             fs.relpath(x, self._port.layout_tests_dir()).replace("../", "") for x in baseline_search_path]
 
@@ -107,6 +108,14 @@ class Printer(object):
         self._print_default('')
         self._print_default(u'Baseline search path: {} -> generic'.format(
             u' -> '.join(normalize_baseline([path for path in full_baseline_search_path if fs.exists(path)]))))
+        self._print_default('')
+
+        self._print_default(u'Verbose test expectations: {}'.format(
+            u' -> '.join(normalize_baseline(reversed(full_expectations_files)))))
+
+        self._print_default('')
+        self._print_default(u'Test expectations: {}'.format(
+            u' -> '.join(normalize_baseline([path for path in reversed(full_expectations_files) if fs.exists(path)]))))
         self._print_default('')
 
     def print_found(self, num_all_test_files, num_to_run, repeat_each, iterations):

--- a/Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py
@@ -121,6 +121,9 @@ class  Testprinter(unittest.TestCase):
         self.assertIn('Verbose baseline search path: platform/test-mac-leopard -> platform/test-mac-snowleopard -> generic', err.getvalue())
         self.assertIn('Baseline search path: platform/test-mac-leopard -> generic', err.getvalue())
 
+        self.assertIn('Verbose test expectations: platform/test-mac-leopard/TestExpectations -> platform/test/TestExpectations -> TestExpectations', err.getvalue())
+        self.assertIn('Test expectations: platform/test/TestExpectations', err.getvalue())
+
         self.reset(err)
         printer._options.quiet = True
         printer.print_baseline_search_path()


### PR DESCRIPTION
#### aacb258efde8d3398b183c10719d8ab5baee5abb
<pre>
Output better metadata for baseline_search_path and expectations_files
<a href="https://bugs.webkit.org/show_bug.cgi?id=271719">https://bugs.webkit.org/show_bug.cgi?id=271719</a>

Reviewed by Jonathan Bedard.

This adds output for expectations_files, and moves the full_results.json
output to use the first device_type we ran.

* Tools/Scripts/webkitpy/layout_tests/models/test_run_results.py:
(summarize_results):
* Tools/Scripts/webkitpy/layout_tests/views/printing.py:
(Printer.print_baseline_search_path):
* Tools/Scripts/webkitpy/layout_tests/views/printing_unittest.py:
(Testprinter.test_print_baseline_search_path):

Canonical link: <a href="https://commits.webkit.org/276719@main">https://commits.webkit.org/276719@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6141b190afaee8338523d10a42a4b8bc9c4c2442

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45404 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48068 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41411 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37237 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21642 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39174 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18342 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/45270 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19053 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40252 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3450 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41750 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40576 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49788 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44288 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21695 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43110 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22055 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6325 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->