### PR TITLE
Match `video-test.js` and `full-screen-test.js` with `js-test.js` for `consoleWrite` to use `span`

### DIFF
--- a/LayoutTests/fullscreen/full-screen-test.js
+++ b/LayoutTests/fullscreen/full-screen-test.js
@@ -187,7 +187,9 @@ function consoleWrite(text)
 {
     if (testEnded)
         return;
-    logConsole().innerHTML += text + "<br>";
+    var span = document.createElement("span");
+    logConsole().appendChild(span);
+    span.innerHTML = text + '<br>';
 }
 
 

--- a/LayoutTests/media/video-test.js
+++ b/LayoutTests/media/video-test.js
@@ -453,7 +453,9 @@ function consoleWrite(text)
 {
     if (testEnded)
         return;
-    logConsole().innerHTML += text + "<br>";
+    var span = document.createElement("span");
+    logConsole().appendChild(span);
+    span.innerHTML = text + '<br>';
 }
 
 function relativeURL(url)


### PR DESCRIPTION
#### 48954ab8460f70dad5e57480bf47f7df2b13226c
<pre>
Match `video-test.js` and `full-screen-test.js` with `js-test.js` for `consoleWrite` to use `span`

<a href="https://bugs.webkit.org/show_bug.cgi?id=271723">https://bugs.webkit.org/show_bug.cgi?id=271723</a>

Reviewed by Ryosuke Niwa.

This changes match `video-test.js` and `full-screen-test.js` with `js-test.js`,
which uses `span` rather than direct &apos;innerHTML&apos;.

Merge &amp; Extended: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=150592

* LayoutTests/fullscreen/full-screen-test.js:
(consoleWrite):
* LayoutTests/media/video-test.js:
(consoleWrite):

Canonical link: <a href="https://commits.webkit.org/276718@main">https://commits.webkit.org/276718@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dd36445d4bf0c491bdf4eb56f0a23eb5843d394

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48070 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41419 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21922 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37240 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18345 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19018 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40260 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3452 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49791 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44286 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21697 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43107 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10111 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22058 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21384 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->