### PR TITLE
Merge back - [ Monterey+ wk2 Release ] media/track/media-element-enqueue-event-crash.html  is a flaky crash

### DIFF
--- a/Source/WebCore/dom/ActiveDOMObject.cpp
+++ b/Source/WebCore/dom/ActiveDOMObject.cpp
@@ -109,6 +109,15 @@ void ActiveDOMObject::assertSuspendIfNeededWasCalled() const
 
 #endif // ASSERT_ENABLED
 
+void ActiveDOMObject::didMoveToNewDocument(Document& newDocument)
+{
+    if (RefPtr context = scriptExecutionContext())
+        context->willDestroyActiveDOMObject(*this);
+    Ref newScriptExecutionContext = newDocument.contextDocument();
+    observeContext(newScriptExecutionContext.ptr());
+    newScriptExecutionContext->didCreateActiveDOMObject(*this);
+}
+
 void ActiveDOMObject::suspend(ReasonForSuspension)
 {
 }

--- a/Source/WebCore/dom/ActiveDOMObject.h
+++ b/Source/WebCore/dom/ActiveDOMObject.h
@@ -56,6 +56,8 @@ public:
     void suspendIfNeeded();
     void assertSuspendIfNeededWasCalled() const;
 
+    void didMoveToNewDocument(Document&);
+
     // This function is used by JS bindings to determine if the JS wrapper should be kept alive or not.
     bool hasPendingActivity() const { return m_pendingActivityInstanceCount || virtualHasPendingActivity(); }
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -963,6 +963,7 @@ void HTMLCanvasElement::eventListenersDidChange()
 
 void HTMLCanvasElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
 {
+    ActiveDOMObject::didMoveToNewDocument(newDocument);
     auto* context = renderingContext();
     if (context) {
         oldDocument.removeCanvasNeedingPreparationForDisplayOrFlush(*context);

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -813,6 +813,7 @@ void HTMLImageElement::addCandidateSubresourceURLs(ListHashSet<URL>& urls) const
 
 void HTMLImageElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
 {
+    ActiveDOMObject::didMoveToNewDocument(newDocument);
     oldDocument.removeDynamicMediaQueryDependentImage(*this);
 
     selectImageSource(RelevantMutation::No);

--- a/Source/WebCore/html/HTMLMarqueeElement.cpp
+++ b/Source/WebCore/html/HTMLMarqueeElement.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLMarqueeElement);
 using namespace HTMLNames;
 
 inline HTMLMarqueeElement::HTMLMarqueeElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+    : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
     , ActiveDOMObject(document)
 {
     ASSERT(hasTagName(marqueeTag));
@@ -186,6 +186,12 @@ ExceptionOr<void> HTMLMarqueeElement::setLoop(int loop)
         return Exception { ExceptionCode::IndexSizeError };
     setIntegralAttribute(loopAttr, loop);
     return { };
+}
+
+void HTMLMarqueeElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
+{
+    HTMLElement::didMoveToNewDocument(oldDocument, newDocument);
+    ActiveDOMObject::didMoveToNewDocument(newDocument);
 }
 
 void HTMLMarqueeElement::suspend(ReasonForSuspension)

--- a/Source/WebCore/html/HTMLMarqueeElement.h
+++ b/Source/WebCore/html/HTMLMarqueeElement.h
@@ -57,6 +57,7 @@ private:
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 
+    void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
     void suspend(ReasonForSuspension) final;
     void resume() final;
     const char* activeDOMObjectName() const final { return "HTMLMarqueeElement"; }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -755,6 +755,7 @@ void HTMLMediaElement::unregisterWithDocument(Document& document)
 
 void HTMLMediaElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
 {
+    ActiveDOMObject::didMoveToNewDocument(newDocument);
     ALWAYS_LOG(LOGIDENTIFIER);
 
     ASSERT_WITH_SECURITY_IMPLICATION(&document() == &newDocument);
@@ -762,6 +763,13 @@ void HTMLMediaElement::didMoveToNewDocument(Document& oldDocument, Document& new
         oldDocument.decrementLoadEventDelayCount();
         newDocument.incrementLoadEventDelayCount();
     }
+
+    if (RefPtr audioTracks = m_audioTracks)
+        audioTracks->didMoveToNewDocument(newDocument);
+    if (RefPtr textTracks = m_textTracks)
+        textTracks->didMoveToNewDocument(newDocument);
+    if (RefPtr videoTracks = m_videoTracks)
+        videoTracks->didMoveToNewDocument(newDocument);
 
     unregisterWithDocument(oldDocument);
     registerWithDocument(newDocument);
@@ -8252,7 +8260,7 @@ bool HTMLMediaElement::ensureMediaControls()
         return true;
 
     auto mediaControlsScripts = RenderTheme::singleton().mediaControlsScripts();
-    if (mediaControlsScripts.isEmpty())
+    if (mediaControlsScripts.isEmpty() || isSuspended())
         return false;
 
     INFO_LOG(LOGIDENTIFIER);
@@ -8530,6 +8538,7 @@ bool HTMLMediaElement::canProduceAudio() const
 
 bool HTMLMediaElement::isSuspended() const
 {
+    ASSERT(Node::scriptExecutionContext() == ActiveDOMObject::scriptExecutionContext());
     return document().activeDOMObjectsAreSuspended() || document().activeDOMObjectsAreStopped();
 }
 

--- a/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/Source/WebCore/html/HTMLSourceElement.cpp
@@ -54,7 +54,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLSourceElement);
 using namespace HTMLNames;
 
 inline HTMLSourceElement::HTMLSourceElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+    : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
     , ActiveDOMObject(document)
 {
     LOG(Media, "HTMLSourceElement::HTMLSourceElement - %p", this);
@@ -121,6 +121,12 @@ void HTMLSourceElement::removedFromAncestor(RemovalType removalType, ContainerNo
             m_shouldCallSourcesChanged = false;
         }
     }
+}
+
+void HTMLSourceElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
+{
+    HTMLElement::didMoveToNewDocument(oldDocument, newDocument);
+    ActiveDOMObject::didMoveToNewDocument(newDocument);
 }
 
 void HTMLSourceElement::scheduleErrorEvent()

--- a/Source/WebCore/html/HTMLSourceElement.h
+++ b/Source/WebCore/html/HTMLSourceElement.h
@@ -57,6 +57,8 @@ private:
     
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;
+    void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
+
     bool isURLAttribute(const Attribute&) const final;
     bool attributeContainsURL(const Attribute&) const final;
     Attribute replaceURLsInAttributeValue(const Attribute&, const HashMap<String, String>&) const override;

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -62,7 +62,7 @@ static String urlForLoggingTrack(const URL& url)
 #endif
     
 inline HTMLTrackElement::HTMLTrackElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+    : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
     , ActiveDOMObject(document)
     , m_track(LoadableTextTrack::create(*this, attributeWithoutSynchronization(kindAttr).convertToASCIILowercase(), label(), srclang()))
 {
@@ -106,6 +106,12 @@ void HTMLTrackElement::removedFromAncestor(RemovalType removalType, ContainerNod
         if (auto* mediaElement = dynamicDowncast<HTMLMediaElement>(oldParentOfRemovedTree))
             mediaElement->didRemoveTextTrack(*this);
     }
+}
+
+void HTMLTrackElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
+{
+    HTMLElement::didMoveToNewDocument(oldDocument, newDocument);
+    ActiveDOMObject::didMoveToNewDocument(newDocument);
 }
 
 void HTMLTrackElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -79,6 +79,7 @@ private:
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;
+    void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 
     bool isURLAttribute(const Attribute&) const final;
 

--- a/Source/WebCore/html/track/TextTrack.cpp
+++ b/Source/WebCore/html/track/TextTrack.cpp
@@ -142,6 +142,18 @@ TextTrack::~TextTrack()
     }
 }
 
+inline RefPtr<TextTrackCueList> TextTrack::protectedCues() const
+{
+    return m_cues.copyRef();
+}
+
+void TextTrack::didMoveToNewDocument(Document& newDocument)
+{
+    TrackBase::didMoveToNewDocument(newDocument);
+    ActiveDOMObject::didMoveToNewDocument(newDocument);
+    protectedCues()->didMoveToNewDocument(newDocument);
+}
+
 TextTrackList* TextTrack::textTrackList() const
 {
     return downcast<TextTrackList>(trackList());

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -50,6 +50,8 @@ public:
     static Ref<TextTrack> create(ScriptExecutionContext*, const AtomString& kind, const AtomString& id, const AtomString& label, const AtomString& language);
     virtual ~TextTrack();
 
+    void didMoveToNewDocument(Document& newDocument) final;
+
     static TextTrack& captionMenuOffItem();
     static TextTrack& captionMenuAutomaticItem();
 
@@ -81,6 +83,7 @@ public:
     TextTrackCueList* activeCues() const;
 
     TextTrackCueList* cuesInternal() const { return m_cues.get(); }
+    inline RefPtr<TextTrackCueList> protectedCues() const;
 
     void addClient(TextTrackClient&);
     void clearClient(TextTrackClient&);

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -226,6 +226,15 @@ TextTrackCue::TextTrackCue(Document& document, const MediaTime& start, const Med
 {
 }
 
+void TextTrackCue::didMoveToNewDocument(Document& newDocument)
+{
+    ActiveDOMObject::didMoveToNewDocument(newDocument);
+    if (RefPtr cueNode = m_cueNode)
+        cueNode->setTreeScopeRecursively(newDocument);
+    if (RefPtr displayTree = m_displayTree)
+        displayTree->setTreeScopeRecursively(newDocument);
+}
+
 ScriptExecutionContext* TextTrackCue::scriptExecutionContext() const
 {
     return ActiveDOMObject::scriptExecutionContext();

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -69,6 +69,8 @@ class TextTrackCue : public RefCounted<TextTrackCue>, public EventTarget, public
 public:
     static ExceptionOr<Ref<TextTrackCue>> create(Document&, double start, double end, DocumentFragment&);
 
+    void didMoveToNewDocument(Document&);
+
     TextTrack* track() const;
     RefPtr<TextTrack> protectedTrack() const;
     void setTrack(TextTrack*);

--- a/Source/WebCore/html/track/TextTrackCueList.cpp
+++ b/Source/WebCore/html/track/TextTrackCueList.cpp
@@ -54,6 +54,12 @@ Ref<TextTrackCueList> TextTrackCueList::create()
     return adoptRef(*new TextTrackCueList);
 }
 
+void TextTrackCueList::didMoveToNewDocument(Document& newDocument)
+{
+    for (RefPtr cue : m_vector)
+        cue->didMoveToNewDocument(newDocument);
+}
+
 unsigned TextTrackCueList::cueIndex(const TextTrackCue& cue) const
 {
     ASSERT(m_vector.contains(&cue));

--- a/Source/WebCore/html/track/TextTrackCueList.h
+++ b/Source/WebCore/html/track/TextTrackCueList.h
@@ -32,9 +32,13 @@
 
 namespace WebCore {
 
+class Document;
+
 class TextTrackCueList : public RefCounted<TextTrackCueList> {
 public:
     static Ref<TextTrackCueList> create();
+
+    void didMoveToNewDocument(Document&);
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
     unsigned length() const;

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -75,6 +75,11 @@ TrackBase::TrackBase(ScriptExecutionContext* context, Type type, const std::opti
 #endif
 }
 
+void TrackBase::didMoveToNewDocument(Document& newDocument)
+{
+    observeContext(&newDocument.contextDocument());
+}
+
 void TrackBase::setTrackList(TrackListBase& trackList)
 {
     m_trackList = trackList;

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -51,6 +51,8 @@ class TrackBase
 public:
     virtual ~TrackBase() = default;
 
+    virtual void didMoveToNewDocument(Document&);
+
     enum Type { BaseTrack, TextTrack, AudioTrack, VideoTrack };
     Type type() const { return m_type; }
 

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -46,6 +46,13 @@ TrackListBase::TrackListBase(ScriptExecutionContext* context, Type type)
 
 TrackListBase::~TrackListBase() = default;
 
+void TrackListBase::didMoveToNewDocument(Document& newDocument)
+{
+    ActiveDOMObject::didMoveToNewDocument(newDocument);
+    for (RefPtr track : m_inbandTracks)
+        track->didMoveToNewDocument(newDocument);
+}
+
 WebCoreOpaqueRoot TrackListBase::opaqueRoot()
 {
     if (auto* rootObserver = m_opaqueRootObserver.get())

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -61,6 +61,8 @@ public:
     using RefCounted<TrackListBase>::deref;
     ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
 
+    void didMoveToNewDocument(Document&);
+
     WebCoreOpaqueRoot opaqueRoot();
 
     using OpaqueRootObserver = WTF::Observer<WebCoreOpaqueRoot()>;


### PR DESCRIPTION
#### cc385e995d6be0726844bc986d671be9adf566c2
<pre>
Merge back - [ Monterey+ wk2 Release ] media/track/media-element-enqueue-event-crash.html  is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=271727">https://bugs.webkit.org/show_bug.cgi?id=271727</a>

Reviewed by Chris Dumez.

This PR introduces ActiveDOMObject::didMoveToNewDocument, which migrates ActiveDOMObject from
one document to another, and deploys it in every ActiveDOMObject owned by Node subclasses such
as HTMLImageElement and TextTrackCue.

* Source/WebCore/dom/ActiveDOMObject.cpp:
(WebCore::ActiveDOMObject::didMoveToNewDocument):
* Source/WebCore/dom/ActiveDOMObject.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::didMoveToNewDocument):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::didMoveToNewDocument):
* Source/WebCore/html/HTMLMarqueeElement.cpp:
(WebCore::HTMLMarqueeElement::HTMLMarqueeElement):
(WebCore::HTMLMarqueeElement::didMoveToNewDocument):
* Source/WebCore/html/HTMLMarqueeElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::didMoveToNewDocument):
(WebCore::HTMLMediaElement::ensureMediaControls): Fixed a bug whereby which this code tries
to initialize CSSFontSelector object, which is an active DOM object, in the middle of
Document trying to stop itself.
(WebCore::HTMLMediaElement::isSuspended const): Added a debug assertion that the script
execution context associated with Node superclass and ActiveDOMObject superclass match.
* Source/WebCore/html/HTMLSourceElement.cpp:
(WebCore::HTMLSourceElement::HTMLSourceElement):
(WebCore::HTMLSourceElement::didMoveToNewDocument):
* Source/WebCore/html/HTMLSourceElement.h:
* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::HTMLTrackElement):
(WebCore::HTMLTrackElement::didMoveToNewDocument):
* Source/WebCore/html/HTMLTrackElement.h:
* Source/WebCore/html/track/TextTrack.cpp:
(WebCore::TextTrack::protectedCues const):
(WebCore::TextTrack::didMoveToNewDocument):
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::TextTrackCue::didMoveToNewDocument):
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/html/track/TextTrackCueList.cpp:
(WebCore::TextTrackCueList::didMoveToNewDocument):
* Source/WebCore/html/track/TextTrackCueList.h:
* Source/WebCore/html/track/TrackBase.cpp:
(WebCore::TrackBase::didMoveToNewDocument):
* Source/WebCore/html/track/TrackBase.h:
* Source/WebCore/html/track/TrackListBase.cpp:
(WebCore::TrackListBase::didMoveToNewDocument):
* Source/WebCore/html/track/TrackListBase.h:

Originally-landed-as: 272448.471@safari-7618-branch (f2f5469a4376). <a href="https://rdar.apple.com/124558625">rdar://124558625</a>
Canonical link: <a href="https://commits.webkit.org/276714@main">https://commits.webkit.org/276714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e93dd036990c7169378d93daf2497ff86bf284ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48079 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41422 "Hash e93dd036 for PR 26482 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21930 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/45992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21611 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/39187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18352 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40268 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3460 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41711 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49801 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20398 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/16928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44296 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21705 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/43120 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22066 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6322 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21393 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->