### PR TITLE
[Do not land] Uploading Justin's change just for EWS

### DIFF
--- a/JSTests/microbenchmarks/wasm-cc-int-to-int.js
+++ b/JSTests/microbenchmarks/wasm-cc-int-to-int.js
@@ -1,0 +1,38 @@
+//@runDefault("--useWebAssembly=1")
+var wasm_code;
+try {
+    wasm_code = read('../../JSTests/microbenchmarks/wasm-cc-int-to-int.wasm', 'binary')
+} catch {
+    try {
+        wasm_code = read('wasm-cc-int-to-int.wasm', 'binary')
+    } catch {
+        wasm_code = read('JSTests/microbenchmarks/wasm-cc-int-to-int.wasm', 'binary')
+    }
+}
+var wasm_module = new WebAssembly.Module(wasm_code);
+var wasm_instance = new WebAssembly.Instance(wasm_module);
+const { test, test_with_call, test_with_call_indirect } = wasm_instance.exports
+
+for (let i = 0; i < 100000; ++i) {
+    test(5)
+    test()
+    test(null)
+    test({ })
+    test({ }, 10)
+    test(20.1, 10)
+    test(10, 20.1)
+    test_with_call(5)
+    test_with_call()
+    test_with_call(null)
+    test_with_call({ })
+    test_with_call({ }, 10)
+    test_with_call(20.1, 10)
+    test_with_call(10, 20.1)
+    test_with_call_indirect(5)
+    test_with_call_indirect()
+    test_with_call_indirect(null)
+    test_with_call_indirect({ })
+    test_with_call_indirect({ }, 10)
+    test_with_call_indirect(20.1, 10)
+    test_with_call_indirect(10, 20.1)
+}

--- a/JSTests/microbenchmarks/wasm-cc-int-to-int.wat
+++ b/JSTests/microbenchmarks/wasm-cc-int-to-int.wat
@@ -1,0 +1,20 @@
+(module
+    (type $sig_test (func (param i32) (result i32)))
+    (table $t 1 funcref)
+    (elem (i32.const 0) $test)
+
+    (func $test (export "test") (param $x i32) (result i32)
+        (i32.add (local.get $x) (i32.const 42))
+    )
+
+    (func (export "test_with_call") (param $x i32) (result i32)
+        (i32.add (local.get $x) (call $test (i32.const 1337)))
+    )
+
+    (func (export "test_with_call_indirect") (param $x i32) (result i32)
+        (local.get $x)
+        (i32.const 98)
+        (call_indirect $t (type $sig_test) (i32.const 0))
+        i32.add
+    )
+)

--- a/JSTests/wasm/stress/cc-i32-kitchen-sink.js
+++ b/JSTests/wasm/stress/cc-i32-kitchen-sink.js
@@ -1,0 +1,76 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (func $f0 (export "f0")
+        (param $x0 i32) (param $x1 i32) (param $x2 i32) (param $x3 i32)
+        (param $x4 i32) (param $x5 i32) (param $x6 i32) (param $x7 i32)
+        (result i32)
+        (i32.add (local.get $x0)
+            (i32.add (local.get $x1)
+                (i32.add (local.get $x2)
+                    (i32.add (local.get $x3)
+                        (i32.add (local.get $x4)
+                            (i32.add (local.get $x5)
+                                (i32.add (local.get $x6)
+                                    (local.get $x7))))))))
+    )
+
+    (func $f1 (export "f1")
+        (param $x0 i32) (param $x1 i32) (param $x2 i32) (param $x3 i32)
+        (param $x4 i32) (param $x5 i32) (param $x6 i32) (param $x7 i32)
+        (param $x8 i32) (param $x9 i32) (param $x10 i32) (param $x11 i32)
+        (result i32)
+        (i32.add (local.get $x0)
+            (i32.add (local.get $x1)
+                (i32.add (local.get $x2)
+                    (i32.add (local.get $x3)
+                        (i32.add (local.get $x4)
+                            (i32.add (local.get $x5)
+                                (i32.add (local.get $x6)
+                                    (i32.add (local.get $x7)
+                                        (i32.add (local.get $x8)
+                                            (i32.add (local.get $x9)
+                                                (i32.add (local.get $x10)
+                                                (local.get $x11))))))))))))
+    )
+
+    (func $f2 (export "f2")
+        (param $x0 i32) (param $x1 i32) (param $x2 i32) (param $x3 i32)
+        (param $x4 i32) (param $x5 i32) (param $x6 i32) (param $x7 i32)
+        (param $x8 i32) (param $x9 i32) (param $x10 i32) (param $x11 i32)
+        (result i32)
+        (i32.add (local.get $x0)
+            (local.get $x11))
+    )
+
+    (func $f3 (export "f3")
+        (param $x0 i32) (param $x1 i32) (param $x2 i32) (param $x3 i32)
+        (param $x4 i32) (param $x5 i32) (param $x6 i32) (param $x7 i32)
+        (param $x8 i32) (param $x9 i32) (param $x10 i32) (param $x11 i32)
+        (i32.add (local.get $x0)
+            (local.get $x11))
+        drop
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { f0, f1, f2, f3 } = instance.exports
+
+    for (let i = 0; i < 10000000; ++i) {
+        assert.eq(f0(1, 2, 3, 4, 5, 6, 7, 8), 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8)
+        assert.eq(f0(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8)
+        assert.eq(f0(1, 2, 3, 4, 5), 1 + 2 + 3 + 4 + 5)
+        assert.eq(f1(1, 2, 3, 4, 5, 6, 7, 8), 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8)
+        assert.eq(f1(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12)
+        assert.eq(f1(1, 2, 3, 4, 5), 1 + 2 + 3 + 4 + 5)
+        assert.eq(f1(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12)
+        assert.eq(f2(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), 1 + 12)
+        assert.eq(f3(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15), undefined)
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/cc-int-to-int-memory.js
+++ b/JSTests/wasm/stress/cc-int-to-int-memory.js
@@ -1,0 +1,32 @@
+//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useIPIntWrappers=1 --dumpDisassembly=0
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+let wat = `
+(module
+    (memory 1)
+
+    (data (i32.const 0) "\\2A")
+
+    (func $test (export "test") (param $x i32) (result i32)
+        (i32.add (local.get $x) (i32.load (i32.const 0)))
+    )
+)
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true })
+    const { test } = instance.exports
+
+    for (let i = 0; i < 10000000; ++i) {
+        assert.eq(test(5), 42 + 5)
+        assert.eq(test(), 42 + 0)
+        assert.eq(test(null), 42 + 0)
+        assert.eq(test({ }), 42 + 0)
+        assert.eq(test({ }, 10), 42 + 0)
+        assert.eq(test(20.1, 10), 42 + 20)
+        assert.eq(test(10, 20.1), 42 + 10)
+    }
+}
+
+assert.asyncTest(test())

--- a/JSTests/wasm/stress/cc-int-to-int-no-jit.js
+++ b/JSTests/wasm/stress/cc-int-to-int-no-jit.js
@@ -1,4 +1,4 @@
-//  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useIPIntWrappers=1 --dumpDisassembly=0
+//@ runDefault("-m", "--useJIT=0", "--useWebAssembly=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/more-than-4g-offset-access-oom.js
+++ b/JSTests/wasm/stress/more-than-4g-offset-access-oom.js
@@ -21,7 +21,7 @@ async function test() {
     // And then, accessing to redzone, and this causes fault. And signal handler throws an error correctly.
     print("ERROR THROWING");
     assert.throws(() => {
-        test(0xffffffff);
+        test(0x00);
     }, WebAssembly.RuntimeError, `Out of bounds memory access`);
     print("ERROR THROWING DONE");
 }

--- a/JSTests/wasm/stress/more-than-4g-offset-access-oom.js
+++ b/JSTests/wasm/stress/more-than-4g-offset-access-oom.js
@@ -12,11 +12,18 @@ let wat = `
 async function test() {
     const instance = await instantiate(wat, {}, {reference_types: true});
     const {test} = instance.exports;
+
+    print("ACCESSIBLE");
+    test(0x00);
+    print("ACCESSIBLE DONE");
+
     // In fast-memory configuration, this pass bound-checking (expected).
     // And then, accessing to redzone, and this causes fault. And signal handler throws an error correctly.
+    print("ERROR THROWING");
     assert.throws(() => {
-        test(0xffffffff);
+        test(0x00);
     }, WebAssembly.RuntimeError, `Out of bounds memory access`);
+    print("ERROR THROWING DONE");
 }
 
 assert.asyncTest(test());

--- a/JSTests/wasm/stress/more-than-4g-offset-access-oom.js
+++ b/JSTests/wasm/stress/more-than-4g-offset-access-oom.js
@@ -12,18 +12,11 @@ let wat = `
 async function test() {
     const instance = await instantiate(wat, {}, {reference_types: true});
     const {test} = instance.exports;
-
-    print("ACCESSIBLE");
-    test(0x00);
-    print("ACCESSIBLE DONE");
-
     // In fast-memory configuration, this pass bound-checking (expected).
     // And then, accessing to redzone, and this causes fault. And signal handler throws an error correctly.
-    print("ERROR THROWING");
     assert.throws(() => {
-        test(0x00);
+        test(0xffffffff);
     }, WebAssembly.RuntimeError, `Out of bounds memory access`);
-    print("ERROR THROWING DONE");
 }
 
 assert.asyncTest(test());

--- a/JSTests/wasm/stress/more-than-4g-offset-access-oom.js
+++ b/JSTests/wasm/stress/more-than-4g-offset-access-oom.js
@@ -21,7 +21,7 @@ async function test() {
     // And then, accessing to redzone, and this causes fault. And signal handler throws an error correctly.
     print("ERROR THROWING");
     assert.throws(() => {
-        test(0x00);
+        test(0xffffffff);
     }, WebAssembly.RuntimeError, `Out of bounds memory access`);
     print("ERROR THROWING DONE");
 }

--- a/Source/JavaScriptCore/assembler/CPU.h
+++ b/Source/JavaScriptCore/assembler/CPU.h
@@ -124,6 +124,15 @@ constexpr bool isRISCV64()
 #endif
 }
 
+constexpr bool isJSValue3264()
+{
+#if USE(JSVALUE32_64)
+    return true;
+#else
+    return false;
+#endif
+}
+
 constexpr bool is64Bit()
 {
 #if USE(JSVALUE64)

--- a/Source/JavaScriptCore/assembler/JITOperationList.cpp
+++ b/Source/JavaScriptCore/assembler/JITOperationList.cpp
@@ -110,6 +110,7 @@ LLINT_DECLARE_ROUTINE_VALIDATE(llint_function_for_construct_arity_check);
 LLINT_DECLARE_ROUTINE_VALIDATE(llint_eval_prologue);
 LLINT_DECLARE_ROUTINE_VALIDATE(llint_program_prologue);
 LLINT_DECLARE_ROUTINE_VALIDATE(llint_module_program_prologue);
+LLINT_DECLARE_ROUTINE_VALIDATE(wasm_function_prologue_trampoline);
 LLINT_DECLARE_ROUTINE_VALIDATE(wasm_function_prologue);
 LLINT_DECLARE_ROUTINE_VALIDATE(wasm_function_prologue_simd);
 LLINT_DECLARE_ROUTINE_VALIDATE(llint_throw_during_call_trampoline);
@@ -118,6 +119,7 @@ LLINT_DECLARE_ROUTINE_VALIDATE(checkpoint_osr_exit_trampoline);
 LLINT_DECLARE_ROUTINE_VALIDATE(checkpoint_osr_exit_from_inlined_call_trampoline);
 LLINT_DECLARE_ROUTINE_VALIDATE(normal_osr_exit_trampoline);
 LLINT_DECLARE_ROUTINE_VALIDATE(fuzzer_return_early_from_loop_hint);
+LLINT_DECLARE_ROUTINE_VALIDATE(js_to_wasm_wrapper_entry);
 
 #if ENABLE(JIT_OPERATION_VALIDATION)
 #define LLINT_OP_EXTRAS(validateLabel) bitwise_cast<void*>(validateLabel)
@@ -163,6 +165,7 @@ static LLIntOperations llintOperations()
             LLINT_ROUTINE(llint_eval_prologue)
             LLINT_ROUTINE(llint_program_prologue)
             LLINT_ROUTINE(llint_module_program_prologue)
+            LLINT_ROUTINE(wasm_function_prologue_trampoline)
             LLINT_ROUTINE(wasm_function_prologue)
             LLINT_ROUTINE(wasm_function_prologue_simd)
             LLINT_ROUTINE(llint_throw_during_call_trampoline)
@@ -171,6 +174,7 @@ static LLIntOperations llintOperations()
             LLINT_ROUTINE(checkpoint_osr_exit_from_inlined_call_trampoline)
             LLINT_ROUTINE(normal_osr_exit_trampoline)
             LLINT_ROUTINE(fuzzer_return_early_from_loop_hint)
+            LLINT_ROUTINE(js_to_wasm_wrapper_entry)
 
             LLINT_OP(op_catch)
             LLINT_OP(wasm_catch)

--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1425,8 +1425,10 @@ op :op_put_by_val_return_location
 op :op_iterator_open_return_location
 op :op_iterator_next_return_location
 op :op_call_direct_eval_slow_return_location
+op :wasm_function_prologue_trampoline
 op :wasm_function_prologue
 op :wasm_function_prologue_simd
+op :js_to_wasm_wrapper_entry
 
 op :js_trampoline_op_call
 op :js_trampoline_op_call_ignore_result

--- a/Source/JavaScriptCore/jit/RegisterSet.cpp
+++ b/Source/JavaScriptCore/jit/RegisterSet.cpp
@@ -438,6 +438,8 @@ RegisterSet RegisterSetBuilder::wasmPinnedRegisters()
         result.add(GPRInfo::wasmContextInstancePointer, IgnoreVectors);
     if constexpr (GPRInfo::wasmBoundsCheckingSizeRegister != InvalidGPRReg)
         result.add(GPRInfo::wasmBoundsCheckingSizeRegister, IgnoreVectors);
+    if constexpr (GPRInfo::metadataTableRegister != InvalidGPRReg)
+        result.add(GPRInfo::metadataTableRegister, IgnoreVectors);
 #if OS(WINDOWS)
     result.add(GPRInfo::wasmScratchCSR0, IgnoreVectors);
 #endif

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -111,7 +111,7 @@ const UnboxedWasmCalleeStackSlot = CallerFrame - constexpr Wasm::numberOfIPIntCa
 # Callee Save
 
 # FIXME: This happens to work because UnboxedWasmCalleeStackSlot sits in the extra space we should be more precise in case we want to use an even number of callee saves in the future.
-const IPIntCalleeSaveSpaceStackAligned = 2*CalleeSaveSpaceStackAligned
+const IPIntCalleeSaveSpaceStackAligned = 2 * CalleeSaveSpaceStackAligned
 
 macro saveIPIntRegisters()
     subp IPIntCalleeSaveSpaceStackAligned, sp

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
@@ -75,6 +75,15 @@ do { \
     RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == opcode * 256, #name); \
 } while (false);
 
+#define VALIDATE_JS_TO_WASM_WRAPPER_ENTRY(opcode, name) \
+do { \
+    void* base = reinterpret_cast<void*>(js_to_wasm_wrapper_entry_interp_LoadI32_validate); \
+    void* ptr = reinterpret_cast<void*>(js_to_wasm_wrapper_entry_interp_ ## name ## _validate); \
+    void* untaggedBase = CodePtr<CFunctionPtrTag>::fromTaggedPtr(base).template untaggedPtr(); \
+    void* untaggedPtr = CodePtr<CFunctionPtrTag>::fromTaggedPtr(ptr).template untaggedPtr(); \
+    RELEASE_ASSERT_WITH_MESSAGE((char*)(untaggedPtr) - (char*)(untaggedBase) == ((opcode) * 8 * 4), (#name)); \
+} while (false);
+
 void initialize()
 {
 #if !ENABLE(C_LOOP) && CPU(ADDRESS64) && (CPU(ARM64) || (CPU(X86_64) && !OS(WINDOWS)))
@@ -82,6 +91,11 @@ void initialize()
     FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(VALIDATE_IPINT_0xFC_OPCODE);
     FOR_EACH_IPINT_SIMD_OPCODE(VALIDATE_IPINT_SIMD_OPCODE);
     FOR_EACH_IPINT_ATOMIC_OPCODE(VALIDATE_IPINT_ATOMIC_OPCODE);
+    FOR_EACH_JS_TO_WASM_WRAPPER_METADATA_OPCODE(VALIDATE_JS_TO_WASM_WRAPPER_ENTRY);
+    // Label after last defined opcode
+    VALIDATE_JS_TO_WASM_WRAPPER_ENTRY(static_cast<int>(Wasm::JSEntrypointInterpreterCalleeMetadata::InvalidRegister), invalidop);
+    // This is the label representing the farthest possible dispatch jump
+    VALIDATE_JS_TO_WASM_WRAPPER_ENTRY(static_cast<int>(Wasm::JSEntrypointInterpreterCalleeMetadata::OpcodeMask) + 1, afterops);
 #else
     RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now).");
 #endif

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
@@ -27,6 +27,8 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "WasmCallee.h"
+
 extern "C" void ipint_entry();
 extern "C" void ipint_entry_simd();
 extern "C" void ipint_catch_entry();
@@ -34,6 +36,9 @@ extern "C" void ipint_catch_all_entry();
 
 #define IPINT_VALIDATE_DEFINE_FUNCTION(opcode, name) \
     extern "C" void ipint_ ## name ## _validate() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
+
+#define JS_TO_WASM_WRAPPER_ENTRY_VALIDATE_DEFINE_FUNCTION(opcode, name) \
+    extern "C" void js_to_wasm_wrapper_entry_interp_ ## name ## _validate() REFERENCED_FROM_ASM WTF_INTERNAL NO_REORDER;
 
 #define FOR_EACH_IPINT_OPCODE(m) \
     m(0x00, unreachable) \
@@ -562,6 +567,11 @@ FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_0xFC_TRUNC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_SIMD_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
 FOR_EACH_IPINT_ATOMIC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+FOR_EACH_JS_TO_WASM_WRAPPER_METADATA_OPCODE(JS_TO_WASM_WRAPPER_ENTRY_VALIDATE_DEFINE_FUNCTION);
+// Label after last defined opcode
+JS_TO_WASM_WRAPPER_ENTRY_VALIDATE_DEFINE_FUNCTION(_, invalidop);
+// This is the label representing the furthest possible dispatch jump
+JS_TO_WASM_WRAPPER_ENTRY_VALIDATE_DEFINE_FUNCTION(_, afterops);
 #endif
 
 namespace JSC { namespace IPInt {

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -440,6 +440,17 @@ static UGPRPair entryOSR(CodeBlock* codeBlock, const char*, EntryKind)
 }
 #endif // ENABLE(JIT)
 
+extern "C" void logWasmPrologue(uint64_t i, uint64_t* fp, uint64_t* sp)
+{
+    if (!Options::traceLLIntExecution())
+        return;
+    dataLogLn("logWasmPrologue ", i, " ", RawPointer(fp), " ", RawPointer(sp));
+    dataLogLn("FP[+Callee] ", RawHex(fp[static_cast<int>(CallFrameSlot::callee)]));
+    dataLogLn("FP[+CodeBlock] ", RawHex(fp[static_cast<int>(CallFrameSlot::codeBlock)]));
+    dataLogLn("FP[+returnpc] ", RawHex(fp[static_cast<int>(OBJECT_OFFSETOF(CallerFrameAndPC, returnPC) / 8)]));
+    dataLogLn("FP[+callerFrame] ", RawHex(fp[static_cast<int>(OBJECT_OFFSETOF(CallerFrameAndPC, callerFrame) / 8)]));
+}
+
 LLINT_SLOW_PATH_DECL(entry_osr)
 {
     UNUSED_PARAM(pc);

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.h
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.h
@@ -36,6 +36,7 @@ struct ProtoCallFrame;
 
 namespace LLInt {
 
+extern "C" void logWasmPrologue(uint64_t i, uint64_t* fp, uint64_t* sp)  REFERENCED_FROM_ASM WTF_INTERNAL;
 extern "C" UGPRPair llint_trace_operand(CallFrame*, const JSInstruction*, int fromWhere, int operand) REFERENCED_FROM_ASM WTF_INTERNAL;
 extern "C" UGPRPair llint_trace_value(CallFrame*, const JSInstruction*, int fromWhere, VirtualRegister operand) REFERENCED_FROM_ASM WTF_INTERNAL;
 extern "C" UGPRPair llint_default_call(CallFrame*, CallLinkInfo*) REFERENCED_FROM_ASM WTF_INTERNAL;

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -270,6 +270,7 @@ const NativeToJITGatePtrTag = constexpr NativeToJITGatePtrTag
 const ExceptionHandlerPtrTag = constexpr ExceptionHandlerPtrTag
 const YarrEntryPtrTag = constexpr YarrEntryPtrTag
 const CSSSelectorPtrTag = constexpr CSSSelectorPtrTag
+const LLintToWasmEntryPtrTag = constexpr LLintToWasmEntryPtrTag
 const NoPtrTag = constexpr NoPtrTag
  
 # VMTraps data
@@ -702,6 +703,11 @@ end
 #             call _cProbeCallbackFunction # to do whatever you want.
 #         end
 #     )
+#
+# LLIntSlowPaths.h
+# extern "C" __attribute__((__used__)) __attribute__((visibility("hidden"))) void cProbeCallbackFunction(uint64_t i);
+# LLIntSlowPaths.cpp:
+# extern "C" void cProbeCallbackFunction(uint64_t i) {}
 #
 if X86_64 or ARM64 or ARM64E or ARMv7
     macro probe(action)
@@ -2738,6 +2744,14 @@ _wasmLLIntPCRangeEnd:
 else
 
 # These need to be defined even when WebAssembly is disabled
+op(js_to_wasm_wrapper_entry, macro ()
+    crash()
+end)
+
+op(wasm_function_prologue_trampoline, macro ()
+    crash()
+end)
+
 op(wasm_function_prologue, macro ()
     crash()
 end)

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -411,6 +411,16 @@ if not JSVALUE64
     subp 8, ws1 # align stack pointer
 end
 
+if TRACING
+    probe(
+         macro()
+             move cfr, a1
+             move ws1, a2
+             call _logWasmPrologue
+         end
+     )
+end
+
     bpa ws1, cfr, .stackOverflow
     bpbeq Wasm::Instance::m_softStackLimit[wasmInstance], ws1, .stackHeightOK
 
@@ -569,6 +579,349 @@ end
     end
 end
     break
+end
+
+macro zeroExtend32ToWord(r)
+    if JSVALUE64
+        andq 0xffffffff, r
+    end
+end
+
+macro boxInt32(r, rTag)
+    if JSVALUE64
+        orq constexpr JSValue::NumberTag, r
+    else
+        move constexpr JSValue::Int32Tag, rTag
+    end
+end
+
+// This is the interpreted analogue to createJSToWasmWrapper
+if JSVALUE64 and not X86_64_WIN
+op(js_to_wasm_wrapper_entry, macro ()
+    if not WEBASSEMBLY or C_LOOP or C_LOOP_WIN
+        error
+    end
+
+    macro clobberVolatileRegisters()
+        if ARM64 or ARM64E
+            emit "movz  x9, #0xBAD"
+            emit "movz x10, #0xBAD"
+            emit "movz x11, #0xBAD"
+            emit "movz x12, #0xBAD"
+            emit "movz x13, #0xBAD"
+            emit "movz x14, #0xBAD"
+            emit "movz x15, #0xBAD"
+            emit "movz x16, #0xBAD"
+            emit "movz x17, #0xBAD"
+            emit "movz x18, #0xBAD"
+        end
+    end
+
+    macro clobberArgumentOnlyRegisters()
+        if ARM64 or ARM64E
+            emit "movz x2, #0xBAD"
+            emit "movz x3, #0xBAD"
+            emit "movz x4, #0xBAD"
+            emit "movz x5, #0xBAD"
+            emit "movz x6, #0xBAD"
+            emit "movz x7, #0xBAD"
+            emit "movz x8, #0xBAD"
+        end
+    end
+
+    clobberVolatileRegisters()
+
+    const MP = csr1 # Metadata / bytecode pointer
+    const AccumulatorTag = invalidGPR # Only used for JSVALUE32_64
+
+if ARM64 or ARM64E
+    const CP = ws3 # Callee prologue (jump target) pointer
+    const Accumulator = ws0
+    const Scratch = ws1
+    const Scratch2 = ws2
+else
+    const CP = r0 # Callee prologue (jump target) pointer
+    const Accumulator = ws1
+    const Scratch = csr0
+    const Scratch2 = csr2
+end
+
+    tagReturnAddress sp
+    preserveCallerPCAndCFR()
+
+    # Load metadata from the entry callee
+    # This was written by doVMEntry
+    loadp Callee[cfr], ws0 # WebAssemblyFunction*
+    loadp WebAssemblyFunction::m_jsToWasmBoxedInterpreterCallee[ws0], ws1 # JSEntrypointInterpreterCallee*
+    # Store the boxed entry callee
+    storep ws1, Callee[cfr]
+    loadp WebAssemblyFunction::m_jsToWasmInterpreterCallee[ws0], ws0 # JSEntrypointInterpreterCallee*
+
+    # Debugging sanity check to confirm we have the right kind of callee
+    loadp Wasm::JSEntrypointInterpreterCallee::ident[ws0], ws1
+    move 0xBF, wa0
+    bpeq wa0, ws1, .ident_ok
+    break
+.ident_ok:
+    leap (constexpr (Wasm::JSEntrypointInterpreterCallee::offsetOfMetadataStorage()))[ws0], t1
+    loadp Wasm::JSEntrypointInterpreterCallee::wasmFunctionPrologue[ws0], t2
+    loadp Wasm::JSEntrypointInterpreterCallee::wasmCallee[ws0], t3
+
+    # Load the FrameSize op
+    loadb [t1], ws0
+    addp 1, t1
+
+    # TODO attacker controlled sp?
+    move constexpr Wasm::JSEntrypointInterpreterCalleeMetadata::FrameSize, ws1
+    bpeq ws0, ws1, .stack
+    break
+.stack:
+    # Load the stack size
+    loadb [t1], ws0
+    addp 1, t1
+    lshiftq 3, ws0
+    subp ws0, sp
+
+    # Store Callee's wasm callee
+    storep t3, constexpr (CallFrameSlot::callee - CallerFrameAndPC::sizeInRegisters) * 8[sp]
+
+    macro forEachPreservedRegister(fn)
+        if ARM64 or ARM64E
+            fn(0 * 8, wasmInstance, memoryBase)
+            fn(2 * 8, boundsCheckingSize, MP)
+            fn(12 * 8, csr0, csr1)
+            fn(14 * 8, csr2, csr3)
+            fn(16 * 8, csr4, csr5)
+            fn(18 * 8, csr6, csr7)
+        elsif JSVALUE64
+            fn(0 * 8, wasmInstance)
+            fn(1 * 8, memoryBase)
+            fn(2 * 8, boundsCheckingSize)
+            fn(3 * 8, Scratch)
+            fn(4 * 8, Scratch2)
+            fn(5 * 8, MP)
+        else
+            fn(0 * 8, wasmInstance, MP)
+        end
+    end
+
+if ARM64 or ARM64E
+    forEachPreservedRegister(macro (offset, gpr1, gpr2)
+        storepairq gpr2, gpr1, -offset - 16[cfr]
+    end)
+elsif JSVALUE64
+    forEachPreservedRegister(macro (offset, gpr)
+        storeq gpr, -offset - 8[cfr]
+    end)
+else
+    forEachPreservedRegister(macro (offset, gprMsw, gpLsw)
+        store2ia gpLsw, gprMsw, -offset - 8[cfr]
+    end)
+end
+
+    loadp constexpr CallFrameSlot::codeBlock * 8[cfr], wasmInstance
+
+    # Callee saves are saved, so now we can use our prefered registers
+    # and free up the argument registers (t* and wa* overlap on some platforms)
+    move t1, MP
+    move t2, CP
+
+if JSVALUE64
+    move 0xBADBEEFBADBEEF, memoryBase
+    move 0xBADBEEFBADBEEF, boundsCheckingSize
+end
+
+    # Each op can have at most this number of instructions.
+    # There are at most OpcodeMask opcodes
+    # We do an unauthenticated jump, but due to the masking, it is only possible to reach
+    # one of the opcode handlers below.
+    const OpcodeSize = 8
+    const OpcodeSizeShift = 5 # 8 instructions * 4 bytes per instruction
+
+    macro advance()
+        loadb [MP], Scratch
+        addp 1, MP
+    end
+
+    macro advanceSigned()
+        loadbsq [MP], Scratch
+        addp 1, MP
+    end
+
+    macro idispatch()
+        jmp .idispatch
+    end
+
+    # FIXME: switch offlineasm unalignedglobal to take alignment and optionally pad with breakpoint instructions (rdar://113594783)
+    macro opcode(label)
+        idispatch()
+        emit ".balign 32"
+        unalignedglobal _js_to_wasm_wrapper_entry_interp_%label%_validate
+        _js_to_wasm_wrapper_entry_interp_%label%:
+        _js_to_wasm_wrapper_entry_interp_%label%_validate:
+    end
+
+    # This must be updated after adding/removing opcodes.
+    # It pads unused opcode values.
+    macro opcodesEnd()
+        idispatch()
+        break
+        emit ".balign 32"
+        unalignedglobal _js_to_wasm_wrapper_entry_interp_invalidop_validate
+        _js_to_wasm_wrapper_entry_interp_invalidop:
+        _js_to_wasm_wrapper_entry_interp_invalidop_validate:
+        # Padding, set based on release assert in InPlaceInterpreter.cpp
+        emit ".fill 240, 4, 0xBF"
+        unalignedglobal _js_to_wasm_wrapper_entry_interp_afterops_validate
+        _js_to_wasm_wrapper_entry_interp_afterops_validate:
+        break
+    end
+
+opcode(LoadI32)
+_js_to_wasm_wrapper_entry_interp_begin:
+    advanceSigned()
+    lshiftq 3, Scratch
+    addp cfr, Scratch
+    loadi [Scratch], Accumulator
+opcode(LoadI64)
+break
+opcode(LoadF32)
+break
+opcode(LoadF64)
+break
+opcode(StoreI32)
+    advanceSigned()
+    lshiftq 3, Scratch
+    addp cfr, Scratch
+    storei Accumulator, [Scratch]
+opcode(StoreI64)
+break
+opcode(StoreF32)
+break
+opcode(StoreF64)
+break
+opcode(BoxInt32)
+    zeroExtend32ToWord(Accumulator)
+    boxInt32(Accumulator, AccumulatorTag)
+opcode(BoxInt64)
+break
+opcode(BoxFloat32)
+break
+opcode(BoxFloat64)
+break
+opcode(UnBoxInt32)
+break
+opcode(UnBoxInt64)
+break
+opcode(UnBoxFloat32)
+break
+opcode(UnBoxFloat64)
+break
+opcode(Zero)
+break
+opcode(Undefined)
+    move ValueUndefined, Accumulator
+opcode(ShiftTag)
+break
+opcode(Memory)
+jmp .memory
+opcode(Call)
+jmp .call
+opcode(Done)
+jmp .done
+opcode(WA0)
+move Accumulator, wa0
+opcode(WA1)
+move Accumulator, wa1
+opcode(WA2)
+move Accumulator, wa2
+opcode(WA3)
+move Accumulator, wa3
+opcode(WA4)
+move Accumulator, wa4
+opcode(WA5)
+move Accumulator, wa5
+opcode(WA6)
+if ARM64 or ARM64E
+move Accumulator, wa6
+end
+opcode(WA7)
+if ARM64 or ARM64E
+move Accumulator, wa7
+end
+opcode(WR0)
+move Accumulator, r0
+opcode(WR0_READ)
+move r0, Accumulator
+opcode(WR1)
+move Accumulator, r1
+opcode(WAF0)
+break
+opcodesEnd()
+
+.idispatch:
+    advance()
+    andp constexpr Wasm::JSEntrypointInterpreterCalleeMetadata::OpcodeMask, Scratch
+    lshiftq OpcodeSizeShift, Scratch
+
+    if ARM64 or ARM64E
+        pcrtoaddr _js_to_wasm_wrapper_entry_interp_begin, Scratch2
+    elsif X86_64
+        leap (_js_to_wasm_wrapper_entry_interp_begin), Scratch2
+    else
+        break
+    end
+    addp Scratch2, Scratch
+    if ARM64E
+        emit "br x10" # Scratch
+    else
+        jmp Scratch
+    end
+    break
+
+.memory:
+    if ARM64 or ARM64E
+        loadpairq Wasm::Instance::m_cachedMemory[wasmInstance], memoryBase, boundsCheckingSize
+    elsif X86_64
+        loadp Wasm::Instance::m_cachedMemory[wasmInstance], memoryBase
+        loadp Wasm::Instance::m_cachedBoundsCheckingSize[wasmInstance], boundsCheckingSize
+    end
+    if not ARMv7
+        cagedPrimitiveMayBeNull(memoryBase, Scratch2)
+    end
+    idispatch()
+
+.call:
+    call CP, LLintToWasmEntryPtrTag
+    clobberVolatileRegisters()
+    clobberArgumentOnlyRegisters()
+    idispatch()
+
+.done:
+    clobberVolatileRegisters()
+
+if ARM64 or ARM64E
+    forEachPreservedRegister(macro (offset, gpr1, gpr2)
+        loadpairq -offset - 16[cfr], gpr2, gpr1
+    end)
+elsif JSVALUE64
+    forEachPreservedRegister(macro (offset, gpr)
+        loadq -offset - 8[cfr], gpr
+    end)
+else
+    forEachPreservedRegister(macro (offset, gprMsw, gpLsw)
+        load2ia -offset - 8[cfr], gpLsw, gprMsw
+    end)
+end
+
+    restoreCallerPCAndCFR()
+    ret
+    break
+end)
+else
+    op(js_to_wasm_wrapper_entry, macro ()
+        break
+    end)
 end
 
 macro traceExecution()
@@ -770,6 +1123,11 @@ macro doReturn()
 end
 
 # Entry point
+
+op(wasm_function_prologue_trampoline, macro ()
+    tagReturnAddress sp
+    jmp _wasm_function_prologue
+end)
 
 op(wasm_function_prologue, macro ()
     if not WEBASSEMBLY or C_LOOP or C_LOOP_WIN

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -623,8 +623,8 @@ end
         subp JSEntrypointInterpreterCalleeSaveSpaceStackAligned, sp
         if ARM64 or ARM64E
             storepairq metadataTable, PB, -16[cfr]
-            storepairq memoryBase, boundsCheckingSize, -24[cfr]
-            storepairq wasmInstance, MP, -32[cfr]
+            storepairq memoryBase, boundsCheckingSize, -32[cfr]
+            storepairq wasmInstance, MP, -48[cfr]
         elsif X86_64 or RISCV64
             storep PB, -0x8[cfr]
             storep PM, -0x10[cfr]
@@ -640,8 +640,8 @@ end
     macro restoreJSEntrypointInterpreterRegisters()
         if ARM64 or ARM64E
             loadpairq -16[cfr], metadataTable, PB
-            loadpairq -24[cfr], memoryBase, boundsCheckingSize
-            loadpairq -32[cfr], wasmInstance, MP
+            loadpairq -32[cfr], memoryBase, boundsCheckingSize
+            loadpairq -48[cfr], wasmInstance, MP
         elsif X86_64 or RISCV64
             loadp -0x8[cfr], PB
             loadp -0x10[cfr], PM

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -115,7 +115,7 @@ void initialize()
 
         AssemblyCommentRegistry::initialize();
 #if ENABLE(WEBASSEMBLY)
-        if (Options::useWasmIPInt())
+        if (Options::useWasmIPInt() || Options::useIPIntWrappers())
             IPInt::initialize();
 #endif
         LLInt::initialize();

--- a/Source/JavaScriptCore/runtime/JSCPtrTag.h
+++ b/Source/JavaScriptCore/runtime/JSCPtrTag.h
@@ -63,6 +63,7 @@ using PtrTag = WTF::PtrTag;
     /* Callee:JIT Caller:Native */ \
     v(NativeToJITGatePtrTag, PtrTagCalleeType::JIT, PtrTagCallerType::Native) \
     v(YarrEntryPtrTag, PtrTagCalleeType::JIT, PtrTagCallerType::Native) \
+    v(LLintToWasmEntryPtrTag, PtrTagCalleeType::JIT, PtrTagCallerType::Native) \
     v(CSSSelectorPtrTag, PtrTagCalleeType::JIT, PtrTagCallerType::Native) \
     /* Callee:Native Caller:JIT */ \
     v(OperationPtrTag, PtrTagCalleeType::Native, PtrTagCallerType::JIT) \

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -577,6 +577,7 @@ bool canUseHandlerIC();
     v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues") \
     v(Bool, wasmIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ") \
     v(Bool, wasmIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG") \
+    v(Bool, useIPIntWrappers, true, Normal, "Allow IPInt to replace JIT wasm wrappers") \
     v(Bool, forceAllFunctionsToUseSIMD, false, Normal, "Force all functions to act conservatively w.r.t fp/vector registers for testing.") \
     \
     /* Feature Flags */\

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1051,6 +1051,7 @@ static String tierName(SamplingProfiler::StackFrame& frame)
             case Wasm::CompilationMode::IPIntMode:
                 return Tiers::ipint;
             case Wasm::CompilationMode::JSEntrypointMode:
+            case Wasm::CompilationMode::JSEntrypointInterpreterMode:
             case Wasm::CompilationMode::JSToWasmICMode:
             case Wasm::CompilationMode::WasmToJSMode:
                 // Just say "Wasm" for now.

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -214,6 +214,43 @@ void BBQPlan::work(CompilationEffort effort)
         }
     }
 
+    // Replace the LLInt interpreted entry callee. Note that we can do this after we publish our
+    // callee because calling into the LLInt should still work.
+    auto* jsEntrypointCallee = m_calleeGroup->m_jsEntrypointCallees.get(m_functionIndex);
+    if (jsEntrypointCallee && jsEntrypointCallee->compilationMode() == CompilationMode::JSEntrypointInterpreterMode) {
+        Locker locker { m_lock };
+        TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[m_functionIndex];
+        const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
+
+        auto callee = JSEntrypointCallee::create();
+        context.jsEntrypointJIT = makeUnique<CCallHelpers>();
+        Vector<UnlinkedWasmToWasmCall> newCall;
+        auto jsToWasmInternalFunction = createJSToWasmWrapper(*context.jsEntrypointJIT, callee.get(), nullptr, signature, &newCall, m_moduleInformation.get(), m_mode, m_functionIndex);
+        auto linkBuffer = makeUnique<LinkBuffer>(*context.jsEntrypointJIT, &callee.get(), LinkBuffer::Profile::WasmBBQ, JITCompilationCanFail);
+
+        if (linkBuffer->isValid()) {
+            jsToWasmInternalFunction->entrypoint.compilation = makeUnique<Compilation>(
+                FINALIZE_WASM_CODE(*linkBuffer, JITCompilationPtrTag, nullptr, "(ipint upgrade edition) JS->WebAssembly entrypoint[%i] %s", m_functionIndex, signature.toString().ascii().data()),
+                nullptr);
+
+            for (auto& call : newCall) {
+                CodePtr<WasmEntryPtrTag> entrypoint;
+                if (call.functionIndexSpace < m_moduleInformation->importFunctionCount())
+                    entrypoint = m_calleeGroup->m_wasmToWasmExitStubs[call.functionIndexSpace].code();
+                else
+                    entrypoint = m_calleeGroup->wasmEntrypointCalleeFromFunctionIndexSpace(locker, call.functionIndexSpace).entrypoint().retagged<WasmEntryPtrTag>();
+
+                MacroAssembler::repatchNearCall(call.callLocation, CodeLocationLabel<WasmEntryPtrTag>(entrypoint));
+            }
+
+            callee->setEntrypoint(WTFMove(jsToWasmInternalFunction->entrypoint));
+            static_cast<JSEntrypointInterpreterCallee*>(jsEntrypointCallee)->setReplacement(callee.ptr());
+
+            auto result = m_jsToWasmInternalFunctions.add(m_functionIndex, std::tuple { WTFMove(callee), WTFMove(linkBuffer), WTFMove(jsToWasmInternalFunction) });
+            ASSERT_UNUSED(result, result.isNewEntry);
+        }
+    }
+
     dataLogLnIf(WasmBBQPlanInternal::verbose, "Finished BBQ ", m_functionIndex);
 
     Locker locker { m_lock };
@@ -348,7 +385,7 @@ void BBQPlan::initializeCallees(const CalleeInitializer& callback)
 {
     ASSERT(!failed());
     for (unsigned internalFunctionIndex = 0; internalFunctionIndex < m_wasmInternalFunctions.size(); ++internalFunctionIndex) {
-        RefPtr<JSEntrypointCallee> jsEntrypointCallee;
+        RefPtr<JITCallee> jsEntrypointCallee;
         RefPtr<BBQCallee> wasmEntrypointCallee = m_callees[internalFunctionIndex];
         {
             auto iter = m_jsToWasmInternalFunctions.find(internalFunctionIndex);

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBASSEMBLY_BBQJIT)
 
 #include "CompilationResult.h"
+#include "WasmCallee.h"
 #include "WasmEntryPlan.h"
 #include "WasmModuleInformation.h"
 #include "WasmTierUpCount.h"
@@ -65,7 +66,7 @@ public:
 
     void work(CompilationEffort) final;
 
-    using CalleeInitializer = Function<void(uint32_t, RefPtr<JSEntrypointCallee>&&, Ref<BBQCallee>&&)>;
+    using CalleeInitializer = Function<void(uint32_t, RefPtr<JITCallee>&&, Ref<BBQCallee>&&)>;
     void initializeCallees(const CalleeInitializer&);
 
     bool didReceiveFunctionData(unsigned, const FunctionData&) final;
@@ -88,7 +89,7 @@ private:
     Vector<std::unique_ptr<InternalFunction>> m_wasmInternalFunctions;
     Vector<std::unique_ptr<LinkBuffer>> m_wasmInternalFunctionLinkBuffers;
     Vector<Vector<CodeLocationLabel<ExceptionHandlerPtrTag>>> m_exceptionHandlerLocations;
-    HashMap<uint32_t, std::tuple<RefPtr<JSEntrypointCallee>, std::unique_ptr<LinkBuffer>, std::unique_ptr<InternalFunction>>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsToWasmInternalFunctions;
+    HashMap<uint32_t, std::tuple<RefPtr<JITCallee>, std::unique_ptr<LinkBuffer>, std::unique_ptr<InternalFunction>>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsToWasmInternalFunctions;
     Vector<CompilationContext> m_compilationContexts;
     Vector<RefPtr<BBQCallee>> m_callees;
     Vector<Vector<CodeLocationLabel<WasmEntryPtrTag>>> m_allLoopEntrypoints;

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -432,7 +432,6 @@ RegisterAtOffsetList* JSEntrypointInterpreterCallee::calleeSaveRegistersImpl()
 #endif
         calleeSaveRegisters.construct(WTFMove(registers));
     });
-    dataLogLn("CALLEE ", calleeSaveRegisters.get());
     return &calleeSaveRegisters.get();
 }
 

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -442,6 +442,7 @@ RegisterAtOffsetList* JSEntrypointInterpreterCallee::calleeSaveRegistersImpl()
         ASSERT(registers.numberOfSetRegisters() == 6);
         calleeSaveRegisters.construct(WTFMove(registers));
     });
+    dataLogLn("CALLEE ", calleeSaveRegisters.get());
     return &calleeSaveRegisters.get();
 }
 

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -418,7 +418,9 @@ CodePtr<WasmEntryPtrTag> JSEntrypointInterpreterCallee::entrypointImpl() const
 
 RegisterAtOffsetList* JSEntrypointInterpreterCallee::calleeSaveRegistersImpl()
 {
-    // Keep in mind that JIT JSEntrypointCallee is also having wasmPinnedRegisters.
+    // This must be the same to JSToWasm's callee save registers.
+    // The reason is that we may use m_replacementCallee which can be set at any time.
+    // So, we must store the same callee save registers at the same location to the JIT version.
     static LazyNeverDestroyed<RegisterAtOffsetList> calleeSaveRegisters;
     static std::once_flag initializeFlag;
     std::call_once(initializeFlag, [] {

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -416,6 +416,35 @@ CodePtr<WasmEntryPtrTag> JSEntrypointInterpreterCallee::entrypointImpl() const
     return LLInt::getCodeFunctionPtr<CFunctionPtrTag>(js_to_wasm_wrapper_entry);
 }
 
+RegisterAtOffsetList* JSEntrypointInterpreterCallee::calleeSaveRegistersImpl()
+{
+    // FIXME THIS HAS A BUG. We cannot swap replacement since it is recording callee save register's locations.
+    static LazyNeverDestroyed<RegisterAtOffsetList> calleeSaveRegisters;
+    static std::once_flag initializeFlag;
+    std::call_once(initializeFlag, [] {
+        RegisterSet registers;
+        registers.add(GPRInfo::regCS0, IgnoreVectors); // Wasm::Instance
+#if CPU(X86_64)
+        registers.add(GPRInfo::regCS1, IgnoreVectors); // PM (pointer to metadata)
+        registers.add(GPRInfo::regCS2, IgnoreVectors); // PB
+#elif CPU(ARM64) || CPU(RISCV64)
+        registers.add(GPRInfo::regCS1, IgnoreVectors); // MP
+        registers.add(GPRInfo::regCS3, IgnoreVectors); // PB
+        registers.add(GPRInfo::regCS4, IgnoreVectors); // PM
+        registers.add(GPRInfo::regCS6, IgnoreVectors); // PM
+        registers.add(GPRInfo::regCS7, IgnoreVectors); // PB
+#elif CPU(ARM)
+        registers.add(GPRInfo::regCS0, IgnoreVectors); // PM
+        registers.add(GPRInfo::regCS1, IgnoreVectors); // PB
+#else
+#error Unsupported architecture.
+#endif
+        ASSERT(registers.numberOfSetRegisters() == 6);
+        calleeSaveRegisters.construct(WTFMove(registers));
+    });
+    return &calleeSaveRegisters.get();
+}
+
 #if ENABLE(WEBASSEMBLY_BBQJIT)
 
 void OptimizingJITCallee::linkExceptionHandlers(Vector<UnlinkedHandlerInfo> unlinkedExceptionHandlers, Vector<CodeLocationLabel<ExceptionHandlerPtrTag>> exceptionHandlerLocations)

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -374,6 +374,8 @@ public:
 
     CodePtr<WasmEntryPtrTag> entrypointImpl() const;
 
+    JS_EXPORT_PRIVATE RegisterAtOffsetList* calleeSaveRegistersImpl();
+
     static ptrdiff_t offsetOfWasmCallee() { return OBJECT_OFFSETOF(JSEntrypointInterpreterCallee, wasmCallee); }
     static ptrdiff_t offsetOfWasmFunctionPrologue() { return OBJECT_OFFSETOF(JSEntrypointInterpreterCallee, wasmFunctionPrologue); }
     static constexpr ptrdiff_t offsetOfMetadataStorage() { return offsetOfData(); }

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -118,7 +118,7 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
             m_wasmIndirectCallWasmCallees = FixedVector<RefPtr<Wasm::Callee>>(m_calleeCount);
 
             BBQPlan* bbqPlan = static_cast<BBQPlan*>(m_plan.get());
-            bbqPlan->initializeCallees([&] (unsigned calleeIndex, RefPtr<JSEntrypointCallee>&& jsEntrypointCallee, RefPtr<BBQCallee>&& wasmEntrypoint) {
+            bbqPlan->initializeCallees([&] (unsigned calleeIndex, RefPtr<JITCallee>&& jsEntrypointCallee, RefPtr<BBQCallee>&& wasmEntrypoint) {
                 if (jsEntrypointCallee) {
                     auto result = m_jsEntrypointCallees.set(calleeIndex, WTFMove(jsEntrypointCallee));
                     ASSERT_UNUSED(result, result.isNewEntry);
@@ -187,7 +187,7 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
             m_wasmIndirectCallWasmCallees = FixedVector<RefPtr<Wasm::Callee>>(m_calleeCount);
 
             BBQPlan* bbqPlan = static_cast<BBQPlan*>(m_plan.get());
-            bbqPlan->initializeCallees([&] (unsigned calleeIndex, RefPtr<JSEntrypointCallee>&& jsEntrypointCallee, RefPtr<BBQCallee>&& wasmEntrypoint) {
+            bbqPlan->initializeCallees([&] (unsigned calleeIndex, RefPtr<JITCallee>&& jsEntrypointCallee, RefPtr<BBQCallee>&& wasmEntrypoint) {
                 if (jsEntrypointCallee) {
                     auto result = m_jsEntrypointCallees.set(calleeIndex, WTFMove(jsEntrypointCallee));
                     ASSERT_UNUSED(result, result.isNewEntry);

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -202,7 +202,7 @@ private:
 #endif
     RefPtr<IPIntCallees> m_ipintCallees;
     RefPtr<LLIntCallees> m_llintCallees;
-    HashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsEntrypointCallees;
+    HashMap<uint32_t, RefPtr<JITCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsEntrypointCallees;
     FixedVector<CodePtr<WasmEntryPtrTag>> m_wasmIndirectCallEntryPoints;
     FixedVector<RefPtr<Wasm::Callee>> m_wasmIndirectCallWasmCallees;
     FixedVector<MacroAssemblerCodeRef<WasmEntryPtrTag>> m_wasmToWasmExitStubs;

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.cpp
@@ -48,6 +48,8 @@ const char* makeString(CompilationMode mode)
         return "OMGForOSREntry";
     case CompilationMode::JSEntrypointMode:
         return "JSEntrypoint";
+    case CompilationMode::JSEntrypointInterpreterMode:
+        return "JSEntrypointInterpreter";
     case CompilationMode::JSToWasmICMode:
         return "JSToWasmIC";
     case CompilationMode::WasmToJSMode:

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.h
@@ -35,6 +35,7 @@ enum class CompilationMode : uint8_t {
     OMGMode,
     OMGForOSREntryMode,
     JSEntrypointMode,
+    JSEntrypointInterpreterMode,
     JSToWasmICMode,
     WasmToJSMode,
 };
@@ -49,6 +50,7 @@ constexpr inline bool isOSREntry(CompilationMode compilationMode)
     case CompilationMode::BBQMode:
     case CompilationMode::OMGMode:
     case CompilationMode::JSEntrypointMode:
+    case CompilationMode::JSEntrypointInterpreterMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
         return false;
@@ -70,6 +72,7 @@ constexpr inline bool isAnyBBQ(CompilationMode compilationMode)
     case CompilationMode::IPIntMode:
     case CompilationMode::OMGMode:
     case CompilationMode::JSEntrypointMode:
+    case CompilationMode::JSEntrypointInterpreterMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
         return false;
@@ -88,6 +91,7 @@ constexpr inline bool isAnyOMG(CompilationMode compilationMode)
     case CompilationMode::LLIntMode:
     case CompilationMode::IPIntMode:
     case CompilationMode::JSEntrypointMode:
+    case CompilationMode::JSEntrypointInterpreterMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
         return false;

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -165,7 +165,7 @@ void IPIntPlan::didCompleteCompilation()
             CCallHelpers jit;
             // The LLInt always bounds checks
             MemoryMode mode = MemoryMode::BoundsChecking;
-            Ref<JSEntrypointCallee> callee = JSEntrypointCallee::create();
+            Ref<JITCallee> callee = JSEntrypointCallee::create();
             std::unique_ptr<InternalFunction> function = createJSToWasmWrapper(jit, callee.get(), m_callees[functionIndex].ptr(), signature, &m_unlinkedWasmToWasmCalls[functionIndex], m_moduleInformation.get(), mode, functionIndex);
 
             LinkBuffer linkBuffer(jit, nullptr, LinkBuffer::Profile::WasmThunk, JITCompilationCanFail);

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "WasmCallee.h"
 #include "WasmEntryPlan.h"
 #include "WasmIPIntGenerator.h"
 #include "WasmLLIntPlan.h"
@@ -37,7 +38,7 @@ namespace Wasm {
 
 class IPIntCallee;
 
-using JSEntrypointCalleeMap = HashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+using JSEntrypointCalleeMap = HashMap<uint32_t, RefPtr<JITCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
 using TailCallGraph = HashMap<uint32_t, HashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "WasmCallee.h"
 #include "WasmEntryPlan.h"
 #include "WasmFunctionCodeBlockGenerator.h"
 
@@ -40,7 +41,7 @@ class LLIntCallee;
 class JSEntrypointCallee;
 class StreamingCompiler;
 
-using JSEntrypointCalleeMap = HashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+using JSEntrypointCalleeMap = HashMap<uint32_t, RefPtr<JITCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
 using TailCallGraph = HashMap<uint32_t, HashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
@@ -91,6 +92,8 @@ private:
 
     void addTailCallEdge(uint32_t, uint32_t);
     void computeTransitiveTailCalls() const;
+
+    bool makeInterpretedJSToWasmCallee(unsigned functionIndex);
 
     Vector<std::unique_ptr<FunctionCodeBlockGenerator>> m_wasmInternalFunctions;
     const Ref<LLIntCallee>* m_callees { nullptr };

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -112,10 +112,7 @@ JSC_DEFINE_HOST_FUNCTION(callWebAssemblyFunction, (JSGlobalObject* globalObject,
             return JSValue::encode(throwException(globalObject, scope, createStackOverflowError(globalObject)));
     }
     ASSERT(wasmFunction->instance());
-    dataLogLn("ENTERING");
     EncodedJSValue rawResult = vmEntryToWasm(wasmFunction->jsEntrypoint(MustCheckArity).taggedPtr(), &vm, &protoCallFrame);
-    dataLogLn("RETURNED");
-    WTFReportBacktrace();
     RETURN_IF_EXCEPTION(scope, { });
 
     // We need to make sure this is in a register or on the stack since it's stored in Vector<JSValue>.

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -465,8 +465,10 @@ Structure* WebAssemblyFunction::createStructure(VM& vm, JSGlobalObject* globalOb
 
 WebAssemblyFunction::WebAssemblyFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, Wasm::Callee& jsEntrypoint, Wasm::Callee* wasmCallee, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Wasm::TypeIndex typeIndex, RefPtr<const Wasm::RTT> rtt)
     : Base { vm, executable, globalObject, structure, instance, Wasm::WasmToWasmImportableFunction { typeIndex, wasmToWasmEntrypointLoadLocation, &m_boxedWasmCallee, rtt.get() } }
-    , m_jsEntrypoint { jsEntrypoint.entrypoint() }
+    , m_jsEntrypoint { jsEntrypoint }
     , m_boxedWasmCallee(reinterpret_cast<uint64_t>(CalleeBits::boxNativeCalleeIfExists(wasmCallee)))
+    , m_jsToWasmInterpreterCallee(jsEntrypoint.compilationMode() == Wasm::CompilationMode::JSEntrypointInterpreterMode ? static_cast<Wasm::JSEntrypointInterpreterCallee*>(&jsEntrypoint) : nullptr)
+    , m_jsToWasmBoxedInterpreterCallee(CalleeBits::boxNativeCalleeIfExists(m_jsToWasmInterpreterCallee.get()))
 { }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -160,8 +160,8 @@ static size_t trampolineReservedStackSize()
 
 CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
 {
-    // if (Options::forceICFailure())
-    return nullptr;
+    if (Options::forceICFailure())
+        return nullptr;
 
     VM& vm = this->vm();
     CCallHelpers jit;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -112,7 +112,10 @@ JSC_DEFINE_HOST_FUNCTION(callWebAssemblyFunction, (JSGlobalObject* globalObject,
             return JSValue::encode(throwException(globalObject, scope, createStackOverflowError(globalObject)));
     }
     ASSERT(wasmFunction->instance());
+    dataLogLn("ENTERING");
     EncodedJSValue rawResult = vmEntryToWasm(wasmFunction->jsEntrypoint(MustCheckArity).taggedPtr(), &vm, &protoCallFrame);
+    dataLogLn("RETURNED");
+    WTFReportBacktrace();
     RETURN_IF_EXCEPTION(scope, { });
 
     // We need to make sure this is in a register or on the stack since it's stored in Vector<JSValue>.
@@ -160,8 +163,8 @@ static size_t trampolineReservedStackSize()
 
 CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
 {
-    if (Options::forceICFailure())
-        return nullptr;
+    // if (Options::forceICFailure())
+    return nullptr;
 
     VM& vm = this->vm();
     CCallHelpers jit;

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
@@ -62,7 +62,7 @@ public:
     CodePtr<WasmEntryPtrTag> jsEntrypoint(ArityCheckMode arity)
     {
         ASSERT_UNUSED(arity, arity == ArityCheckNotRequired || arity == MustCheckArity);
-        return m_jsEntrypoint;
+        return m_jsEntrypoint.entrypoint();
     }
 
     CodePtr<JSEntryPtrTag> jsCallEntrypoint()
@@ -88,12 +88,15 @@ private:
 
     RegisterSet calleeSaves() const;
 
-    // It's safe to just hold the raw jsEntrypoint because we have a reference
+    // It's safe to just hold the raw callee because we have a reference
     // to our Instance, which points to the Module that exported us, which
     // ensures that the actual Signature/code doesn't get deallocated.
-    CodePtr<WasmEntryPtrTag> m_jsEntrypoint;
+    Wasm::Callee& m_jsEntrypoint;
     // This is the callee needed by LLInt/IPInt
     uintptr_t m_boxedWasmCallee;
+    // This let's the JS->Wasm interpreter find its metadata
+    RefPtr<Wasm::JSEntrypointInterpreterCallee> m_jsToWasmInterpreterCallee;
+    void* m_jsToWasmBoxedInterpreterCallee;
 #if ENABLE(JIT)
     RefPtr<Wasm::JSToWasmICCallee> m_jsToWasmICCallee;
 #endif

--- a/Source/bmalloc/bmalloc/Gigacage.h
+++ b/Source/bmalloc/bmalloc/Gigacage.h
@@ -132,7 +132,7 @@ BINLINE void* addressOfBasePtr(Kind kind)
     return &g_gigacageConfig.basePtrs[kind];
 }
 
-BINLINE size_t maxSize(Kind kind)
+BINLINE constexpr size_t maxSize(Kind kind)
 {
     switch (kind) {
     case Primitive:
@@ -149,7 +149,7 @@ BINLINE size_t alignment(Kind kind)
     return maxSize(kind);
 }
 
-BINLINE size_t mask(Kind kind)
+BINLINE constexpr size_t mask(Kind kind)
 {
     return gigacageSizeToMask(maxSize(kind));
 }

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.c
@@ -36,6 +36,8 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <execinfo.h>
+#include <stdio.h>
 
 #if PAS_X86_64
 
@@ -200,6 +202,14 @@ PAS_NO_RETURN PAS_NEVER_INLINE void pas_deallocation_did_fail(const char *reason
 {
     if (deallocation_did_fail_callback)
         deallocation_did_fail_callback(reason, (void*)begin);
+
+    void* stack[128];
+    int count = backtrace(stack, 128);
+    char** symbols = backtrace_symbols(stack, count);
+    fprintf(stderr, "\nStack trace:\n");
+    for (int i = 0; i < count; i++)
+        fprintf(stderr, "    %s\n", symbols[i]);
+    fflush(stderr);
     pas_panic("deallocation did fail at %p: %s\n", (void*)begin, reason);
 }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.c
@@ -36,8 +36,6 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <unistd.h>
-#include <execinfo.h>
-#include <stdio.h>
 
 #if PAS_X86_64
 
@@ -202,14 +200,6 @@ PAS_NO_RETURN PAS_NEVER_INLINE void pas_deallocation_did_fail(const char *reason
 {
     if (deallocation_did_fail_callback)
         deallocation_did_fail_callback(reason, (void*)begin);
-
-    void* stack[128];
-    int count = backtrace(stack, 128);
-    char** symbols = backtrace_symbols(stack, count);
-    fprintf(stderr, "\nStack trace:\n");
-    for (int i = 0; i < count; i++)
-        fprintf(stderr, "    %s\n", symbols[i]);
-    fflush(stderr);
     pas_panic("deallocation did fail at %p: %s\n", (void*)begin, reason);
 }
 

--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -904,10 +904,8 @@ sub runJSCStressTests
         push(@jscStressDriverCmd, "--report-execution-time");
     }
 
-    if ($filter) {
-        push(@jscStressDriverCmd, "--filter");
-        push(@jscStressDriverCmd, $filter);
-    }
+    push(@jscStressDriverCmd, "--filter");
+    push(@jscStressDriverCmd, "more-than-4g-offset-access-oom");
 
     if ($noRetry) {
         push(@jscStressDriverCmd, "--no-retry");

--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -774,40 +774,11 @@ sub runJSCStressTests
     my @testList;
     if ($runJSCStress) {
         @testList = (
-            "PerformanceTests/SunSpider/tests/sunspider-1.0",
-            "PerformanceTests/JetStream/cdjs/cdjs-tests.yaml",
-            "PerformanceTests/ARES-6/Air/airjs-tests.yaml",
-            "PerformanceTests/ARES-6/Basic/basic-tests.yaml",
-            "JSTests/executableAllocationFuzz.yaml",
-            "JSTests/exceptionFuzz.yaml",
-            "PerformanceTests/SunSpider/no-architecture-specific-optimizations.yaml",
-            "PerformanceTests/SunSpider/shadow-chicken.yaml",
-            "PerformanceTests/SunSpider/with-baseline-code-sharing.yaml",
-            "PerformanceTests/SunSpider/tests/v8-v6",
-            "JSTests/stress",
-            "JSTests/microbenchmarks",
-            "JSTests/slowMicrobenchmarks.yaml",
-            "PerformanceTests/SunSpider/profiler-test.yaml",
-            "LayoutTests/jsc-layout-tests.yaml",
-            "JSTests/typeProfiler.yaml",
-            "JSTests/controlFlowProfiler.yaml",
-            "JSTests/es6.yaml",
-            "JSTests/modules.yaml",
-            "JSTests/complex.yaml",
-            "JSTests/ChakraCore.yaml",
             "JSTests/wasm.yaml");
-
-        my $internalTestsDir = File::Spec->catdir(dirname(sourceDir()), "Internal", "Tests", "InternalJSTests");
-        if (-e $internalTestsDir and -d $internalTestsDir) {
-            push(@testList, File::Spec->catfile($internalTestsDir, "internal-js-tests.yaml"));
-            push(@testList, File::Spec->catfile($internalTestsDir, "regress.yaml"));
-        }
-
         $hasTestsToRun = 1;
     }
 
     if ($runMozillaTests) {
-        push(@testList, "JSTests/mozilla/mozilla-tests.yaml");
         $hasTestsToRun = 1;
     }
 

--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -904,8 +904,8 @@ sub runJSCStressTests
         push(@jscStressDriverCmd, "--report-execution-time");
     }
 
-    # push(@jscStressDriverCmd, "--filter");
-    # push(@jscStressDriverCmd, "more-than-4g-offset-access-oom");
+    push(@jscStressDriverCmd, "--filter");
+    push(@jscStressDriverCmd, "more-than-4g-offset-access-oom");
 
     if ($noRetry) {
         push(@jscStressDriverCmd, "--no-retry");

--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -904,8 +904,8 @@ sub runJSCStressTests
         push(@jscStressDriverCmd, "--report-execution-time");
     }
 
-    push(@jscStressDriverCmd, "--filter");
-    push(@jscStressDriverCmd, "more-than-4g-offset-access-oom");
+    # push(@jscStressDriverCmd, "--filter");
+    # push(@jscStressDriverCmd, "more-than-4g-offset-access-oom");
 
     if ($noRetry) {
         push(@jscStressDriverCmd, "--no-retry");

--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -904,8 +904,10 @@ sub runJSCStressTests
         push(@jscStressDriverCmd, "--report-execution-time");
     }
 
-    push(@jscStressDriverCmd, "--filter");
-    push(@jscStressDriverCmd, "more-than-4g-offset-access-oom");
+    if ($filter) {
+        push(@jscStressDriverCmd, "--filter");
+        push(@jscStressDriverCmd, $filter);
+    }
 
     if ($noRetry) {
         push(@jscStressDriverCmd, "--no-retry");


### PR DESCRIPTION
#### fd8f90ec8b1971ac2ff813bfec97607138514673
<pre>
[Do not land] Uploading Justin&apos;s change just for EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=271730">https://bugs.webkit.org/show_bug.cgi?id=271730</a>
<a href="https://rdar.apple.com/125440758">rdar://125440758</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* JSTests/microbenchmarks/wasm-cc-int-to-int.js: Added.
(wasm_instance.exports):
* JSTests/microbenchmarks/wasm-cc-int-to-int.wat: Added.
* JSTests/wasm/stress/cc-i32-kitchen-sink.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.func.f0.export.string_appeared_here.param.x0.i32.param.x1.i32.param.x2.i32.param.x3.i32.param.x4.i32.param.x5.i32.param.x6.i32.param.x7.i32.result.i32.i32.add.local.x0.i32.add.local.x1.i32.add.local.x2.i32.add.local.x3.i32.add.local.x4.i32.add.local.x5.i32.add.local.x6.local.x7.func.f1.export.string_appeared_here.param.x0.i32.param.x1.i32.param.x2.i32.param.x3.i32.param.x4.i32.param.x5.i32.param.x6.i32.param.x7.i32.param.x8.i32.param.x9.i32.param.x10.i32.param.x11.i32.result.i32.i32.add.local.x0.i32.add.local.x1.i32.add.local.x2.i32.add.local.x3.i32.add.local.x4.i32.add.local.x5.i32.add.local.x6.i32.add.local.x7.i32.add.local.x8.i32.add.local.x9.i32.add.local.x10.local.x11.func.f2.export.string_appeared_here.param.x0.i32.param.x1.i32.param.x2.i32.param.x3.i32.param.x4.i32.param.x5.i32.param.x6.i32.param.x7.i32.param.x8.i32.param.x9.i32.param.x10.i32.param.x11.i32.result.i32.i32.add.local.x0.local.x11.func.f3.export.string_appeared_here.param.x0.i32.param.x1.i32.param.x2.i32.param.x3.i32.param.x4.i32.param.x5.i32.param.x6.i32.param.x7.i32.param.x8.i32.param.x9.i32.param.x10.i32.param.x11.i32.i32.add.local.x0.local.x11.drop.async test):
* JSTests/wasm/stress/cc-int-to-int-memory.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.memory.1.data.i32.const.0.string_appeared_here.func.test.export.string_appeared_here.param.x.i32.result.i32.i32.add.local.x.i32.load.i32.const.0.async test):
* JSTests/wasm/stress/cc-int-to-int-no-jit.js: Copied from JSTests/wasm/stress/cc-int-to-int.js.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.type.sig_test.func.param.i32.result.i32.table.t.1.funcref.elem.i32.const.0.test.func.test.export.string_appeared_here.param.x.i32.result.i32.i32.add.local.x.i32.const.42.func.export.string_appeared_here.param.x.i32.result.i32.i32.add.local.x.call.test.i32.const.1337.func.export.string_appeared_here.param.x.i32.result.i32.local.x.i32.const.98.call_indirect.t.type.sig_test.i32.const.0.i32.add.async test):
* JSTests/wasm/stress/cc-int-to-int.js:
* Source/JavaScriptCore/assembler/CPU.h:
(JSC::isJSValue3264):
* Source/JavaScriptCore/assembler/JITOperationList.cpp:
(JSC::llintOperations):
* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/llint/InPlaceInterpreter.cpp:
(JSC::IPInt::initialize):
* Source/JavaScriptCore/llint/InPlaceInterpreter.h:
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::logWasmPrologue):
* Source/JavaScriptCore/llint/LLIntSlowPaths.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/JSCPtrTag.h:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::tierName):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
(JSC::Wasm::BBQPlan::initializeCallees):
* Source/JavaScriptCore/wasm/WasmBBQPlan.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::runWithDowncast):
(JSC::Wasm::JSEntrypointInterpreterCallee::JSEntrypointInterpreterCallee):
(JSC::Wasm::JSEntrypointInterpreterCallee::entrypointImpl const):
* Source/JavaScriptCore/wasm/WasmCallee.h:
(JSC::Wasm::jsEntrypointMetadataForGPR):
(JSC::Wasm::jsEntrypointMetadataForFPR):
(JSC::Wasm::dumpJSEntrypointInterpreterCalleeMetadata):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::CalleeGroup):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmCompilationMode.cpp:
(JSC::Wasm::makeString):
* Source/JavaScriptCore/wasm/WasmCompilationMode.h:
(JSC::Wasm::isOSREntry):
(JSC::Wasm::isAnyBBQ):
(JSC::Wasm::isAnyOMG):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.h:
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::makeInterpretedJSToWasmCallee):
(JSC::Wasm::LLIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::m_jsToWasmBoxedInterpreterCallee):
(JSC::m_boxedWasmCallee): Deleted.
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h:
* Source/bmalloc/bmalloc/Gigacage.h:
(Gigacage::maxSize):
(Gigacage::mask):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e0f77254fb0ae37936b04aaa0bdf593adaae14f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45487 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24612 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48031 "Hash 2e0f7725 for PR 26484 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48153 "Hash 2e0f7725 for PR 26484 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41496 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22006 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/48153 "Hash 2e0f7725 for PR 26484 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21700 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/48031 "Hash 2e0f7725 for PR 26484 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/48153 "Hash 2e0f7725 for PR 26484 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19101 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/48031 "Hash 2e0f7725 for PR 26484 does not build (failure)") | [❌ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3533 "Hash 2e0f7725 for PR 26484 does not build (failure)") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/38713 "Hash 2e0f7725 for PR 26484 does not build (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41807 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/48031 "Hash 2e0f7725 for PR 26484 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49883 "Hash 2e0f7725 for PR 26484 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/44955 "Found 74 new JSC stress test failures: wasm.yaml/wasm/function-tests/many-args-tail-call-sp-restored.js.default-wasm, wasm.yaml/wasm/function-tests/many-args-tail-call-sp-restored.js.wasm-agressive-inline, wasm.yaml/wasm/function-tests/many-args-tail-call-sp-restored.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/many-args-tail-call-sp-restored.js.wasm-eager, wasm.yaml/wasm/function-tests/many-args-tail-call-sp-restored.js.wasm-eager-jettison, wasm.yaml/wasm/function-tests/many-args-tail-call-sp-restored.js.wasm-no-cjit, wasm.yaml/wasm/function-tests/many-args-tail-call-sp-restored.js.wasm-omg, wasm.yaml/wasm/function-tests/many-args-tail-call-sp-restored.js.wasm-slow-memory, wasm.yaml/wasm/js-api/export-arity.js.default-wasm, wasm.yaml/wasm/js-api/export-arity.js.wasm-agressive-inline ... (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20474 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17008 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/49883 "Hash 2e0f7725 for PR 26484 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21781 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/48031 "Hash 2e0f7725 for PR 26484 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/49883 "Hash 2e0f7725 for PR 26484 does not build (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22140 "Built successfully") | | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52114 "Hash 2e0f7725 for PR 26484 does not build (failure)") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21469 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/52114 "Hash 2e0f7725 for PR 26484 does not build (failure)") | 
<!--EWS-Status-Bubble-End-->