### PR TITLE
ComplexTextController: Handle unpaired surrogates

### DIFF
--- a/LayoutTests/fast/text/unpaired-surrogate-complex-expected.txt
+++ b/LayoutTests/fast/text/unpaired-surrogate-complex-expected.txt
@@ -1,0 +1,12 @@
+An unpaired surrogate should show a glyph. "ਅ\uD800ਆ" should be longer than "ਅਆ"
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS target.clientWidth is > ref.clientWidth
+PASS successfullyParsed is true
+
+TEST COMPLETE
+ਅ�ਆ
+ਅਆ
+

--- a/LayoutTests/fast/text/unpaired-surrogate-complex.html
+++ b/LayoutTests/fast/text/unpaired-surrogate-complex.html
@@ -5,16 +5,15 @@
       background: lightblue;
       display: inline-block;
       font-size: 100px;
-      text-rendering: optimizeSpeed; // To take the simple text code path
   }
 </style>
 <body>
   <span id="target"></span><br>
   <span id="ref"></span><br>
   <script>
-    description('An unpaired surrogate should show a glyph. "a\\uD800b" should be longer than "ab"');
-    document.getElementById("target").textContent = 'a\uD800b';
-    document.getElementById("ref").textContent = 'ab';
+    description('An unpaired surrogate should show a glyph. "\u0A05\\uD800\u0A06" should be longer than "\u0A05\u0A06"');
+    document.getElementById("target").textContent = '\u0A05\uD800\u0A06';
+    document.getElementById("ref").textContent = '\u0A05\u0A06';
     shouldBeGreaterThan("target.clientWidth", "ref.clientWidth");
   </script>
 </body>

--- a/LayoutTests/fast/text/unpaired-surrogate-expected-mismatch.html
+++ b/LayoutTests/fast/text/unpaired-surrogate-expected-mismatch.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-</head>
-<body>
-<div id="target" style="font-size: 100px;">a</div>
-</body>
-</html>

--- a/LayoutTests/fast/text/unpaired-surrogate-expected.txt
+++ b/LayoutTests/fast/text/unpaired-surrogate-expected.txt
@@ -1,0 +1,12 @@
+An unpaired surrogate should show a glyph. "a\uD800b" should be longer than "ab"
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS target.clientWidth is > ref.clientWidth
+PASS successfullyParsed is true
+
+TEST COMPLETE
+a�b
+ab
+

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -3276,7 +3276,6 @@ fast/text/tatechuyoko.html [ Pass Failure ]
 
 webkit.org/b/271132 [ Debug ] fast/text/crash-grapheme-cluster-spanning-adjacent-textitems.html [ Skip ] # Crash
 webkit.org/b/271132 [ Debug ] fast/text/minimum-width-break-on-empty-content-crash.html [ Skip ] # Crash
-webkit.org/b/271132 [ Debug ] fast/text/word-break-column-gap-display-flex-utf16-surrogates.html [ Skip ] # Crash
 
 http/tests/workers/service/indexeddb-cryptokey-put-get.https.html [ Failure ]
 

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -262,7 +262,7 @@ unsigned ComplexTextController::offsetForPosition(float h, bool includePartialGl
     return 0;
 }
 
-bool ComplexTextController::advanceByCombiningCharacterSequence(const CachedTextBreakIterator& graphemeClusterIterator, unsigned& currentIndex, char32_t& baseCharacter)
+void ComplexTextController::advanceByCombiningCharacterSequence(const CachedTextBreakIterator& graphemeClusterIterator, unsigned& currentIndex, char32_t& baseCharacter)
 {
     unsigned remainingCharacters = m_end - currentIndex;
     ASSERT(remainingCharacters);
@@ -280,7 +280,7 @@ bool ComplexTextController::advanceByCombiningCharacterSequence(const CachedText
     U16_NEXT(buffer, i, bufferLength, baseCharacter);
     if (U_IS_SURROGATE(baseCharacter)) {
         currentIndex += i;
-        return false;
+        return;
     }
 
     int delta = remainingCharacters;
@@ -288,8 +288,6 @@ bool ComplexTextController::advanceByCombiningCharacterSequence(const CachedText
         delta = *following - currentIndex;
 
     currentIndex += delta;
-
-    return true;
 }
 
 void ComplexTextController::collectComplexTextRuns()
@@ -329,8 +327,7 @@ void ComplexTextController::collectComplexTextRuns()
     CachedTextBreakIterator graphemeClusterIterator(m_run.text(), { }, TextBreakIterator::CharacterMode { }, m_font.fontDescription().computedLocale());
 
     char32_t baseCharacter;
-    if (!advanceByCombiningCharacterSequence(graphemeClusterIterator, currentIndex, baseCharacter))
-        return;
+    advanceByCombiningCharacterSequence(graphemeClusterIterator, currentIndex, baseCharacter);
 
     // We don't perform font fallback on the capitalized characters when small caps is synthesized.
     // We may want to change this code to do so in the future; if we do, then the logic in initiateFontLoadingByAccessingGlyphDataIfApplicable()
@@ -357,8 +354,7 @@ void ComplexTextController::collectComplexTextRuns()
         isSmallCaps = nextIsSmallCaps;
         auto previousIndex = currentIndex;
 
-        if (!advanceByCombiningCharacterSequence(graphemeClusterIterator, currentIndex, baseCharacter))
-            return;
+        advanceByCombiningCharacterSequence(graphemeClusterIterator, currentIndex, baseCharacter);
 
         if (synthesizedFont) {
             if (auto capitalizedBase = capitalized(baseCharacter)) {

--- a/Source/WebCore/platform/graphics/ComplexTextController.h
+++ b/Source/WebCore/platform/graphics/ComplexTextController.h
@@ -164,7 +164,7 @@ private:
 
     FloatPoint glyphOrigin(unsigned index) const { return index < m_glyphOrigins.size() ? m_glyphOrigins[index] : FloatPoint(); }
 
-    bool advanceByCombiningCharacterSequence(const WTF::CachedTextBreakIterator& graphemeClusterIterator, unsigned& location, char32_t& baseCharacter);
+    void advanceByCombiningCharacterSequence(const WTF::CachedTextBreakIterator& graphemeClusterIterator, unsigned& location, char32_t& baseCharacter);
 
     Vector<FloatSize, 256> m_adjustedBaseAdvances;
     Vector<FloatPoint, 256> m_glyphOrigins;


### PR DESCRIPTION
#### 85696a6b3a7ba449d1da02ac2f275a3f31582d0e
<pre>
ComplexTextController: Handle unpaired surrogates
<a href="https://bugs.webkit.org/show_bug.cgi?id=271691">https://bugs.webkit.org/show_bug.cgi?id=271691</a>

Reviewed by Vitor Roriz.

Unpaired surrogates displayed nothing in the complex text code path.
<a href="https://commits.webkit.org/241073@main">https://commits.webkit.org/241073@main</a> made the simple text code path
handle unpaired surrogates to display white squares. Chrome and
Firefox display a question mark or a hex code glyph for it.

241073@main added a test case fast/text/unpaired-surrogate.html. Cocoa
ports takes the simple text code path for it, but GTK and Windows
ports take the complex text code path. The test case is a mismatch
test case, but falsely passed for GTK and Windows ports. They rendered
nothing for the test, and unexpectedly passed the test.

If I add text-rendering:optimizeSpeed to the test, GTK and Windows
ports also take the simple text code path and display a white square
glyph for the unpaired surrogate.

If I use a Devanagari letter in the test, Cocoa port also takes the
complex text code path and exhibits the same problem.

ComplexTextController just ignored unpaired surrogates. It shouldn&apos;t
ignore.

Converted the mismatch test case to a JS test. And, added
text-rendering:optimizeSpeed to take the simple text code path. Added
a new test case with a complex text to test the complex text code
path.

* LayoutTests/fast/text/unpaired-surrogate-complex-expected.txt: Added.
* LayoutTests/fast/text/unpaired-surrogate-complex.html: Added.
* LayoutTests/fast/text/unpaired-surrogate-expected-mismatch.html: Removed.
* LayoutTests/fast/text/unpaired-surrogate-expected.txt: Added.
* LayoutTests/fast/text/unpaired-surrogate.html:
* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::advanceByCombiningCharacterSequence):
(WebCore::ComplexTextController::collectComplexTextRuns):
* Source/WebCore/platform/graphics/ComplexTextController.h:

Canonical link: <a href="https://commits.webkit.org/276797@main">https://commits.webkit.org/276797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d41d6324acb272403cb0b6b06bb4b335296053c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48322 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41689 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37387 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46232 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18533 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19253 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40471 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3698 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41957 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50068 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44487 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43330 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10153 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22308 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->