### PR TITLE
Inserting consecutive <picture> elements displays the same image twice

### DIFF
--- a/LayoutTests/editing/inserting/insert-text-after-picture-expected.txt
+++ b/LayoutTests/editing/inserting/insert-text-after-picture-expected.txt
@@ -1,0 +1,17 @@
+Test text insertion after <picture>.
+
+Initial state:
+| <picture>
+|   <source>
+|     srcset="../resources/abe.png"
+|   <img>
+|     src=""
+|   <#selection-caret>
+
+After insertion:
+| <picture>
+|   <source>
+|     srcset="../resources/abe.png"
+|   <img>
+|     src=""
+| "abe<#selection-caret>"

--- a/LayoutTests/editing/inserting/insert-text-after-picture.html
+++ b/LayoutTests/editing/inserting/insert-text-after-picture.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/dump-as-markup.js"></script>
+<div id="editor" contenteditable><picture><source srcset="../resources/abe.png"/><img src=""></picture></div>
+<script>
+
+Markup.description('Test text insertion after <picture>.');
+
+var picture = document.querySelector('picture');
+window.getSelection().setBaseAndExtent(picture, 2, picture, 2);
+Markup.dump(editor, 'Initial state');
+
+document.execCommand('InsertText', false, 'abe');
+Markup.dump(editor, 'After insertion');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/pasteboard/copy-picture-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-picture-expected.txt
@@ -1,0 +1,11 @@
+This tests that copying and pasting an image in a picture element preserves the picture and source elements.
+| <picture>
+|   id="picture"
+|   <source>
+|     media="(min-width: 600px)"
+|     srcset="resources/apple.gif"
+|   <source>
+|     srcset="resources/mozilla.gif"
+|   <img>
+|     src=""
+|   <#selection-caret>

--- a/LayoutTests/editing/pasteboard/copy-picture.html
+++ b/LayoutTests/editing/pasteboard/copy-picture.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+Markup.description("This tests that copying and pasting an image in a picture element preserves the picture and source elements.");
+Markup.noAutoDump();
+
+function runTest()
+{
+    var picture = document.getElementById("picture");
+    execSetSelectionCommand(picture, 2, picture, 3);
+    execCopyCommand();
+
+    document.getElementById("paste-contenteditable").innerHTML = "";
+    selection.setPosition(document.getElementById("paste-contenteditable"), 0);
+    execPasteCommand();
+    Markup.dump("paste-contenteditable");
+}
+
+window.onload = function()
+{
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    runTest();
+
+    Markup.notifyDone();
+};
+</script>
+</head>
+<body>
+<div id="copy-contenteditable" contenteditable>
+Test<picture id="picture"><source srcset="resources/apple.gif" media="(min-width: 600px)"/><source srcset="resources/mozilla.gif"/><img src=""></picture>
+</div>
+
+<div id="paste-contenteditable" contentEditable="true"></div>
+</body>
+</html>

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -42,6 +42,7 @@
 #include "HTMLNames.h"
 #include "HTMLOListElement.h"
 #include "HTMLParagraphElement.h"
+#include "HTMLPictureElement.h"
 #include "HTMLSpanElement.h"
 #include "HTMLTableElement.h"
 #include "HTMLTextFormControlElement.h"
@@ -73,7 +74,7 @@ static bool isVisiblyAdjacent(const Position&, const Position&);
 
 bool canHaveChildrenForEditing(const Node& node)
 {
-    return !is<Text>(node) && node.canContainRangeEndPoint();
+    return !is<Text>(node) && !is<HTMLPictureElement>(node) && node.canContainRangeEndPoint();
 }
 
 // Atomic means that the node has no children, or has children which are ignored for the purposes of editing.

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -62,6 +62,7 @@
 #include "HTMLHtmlElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLNames.h"
+#include "HTMLPictureElement.h"
 #include "HTMLStyleElement.h"
 #include "HTMLTableElement.h"
 #include "HTMLTextAreaElement.h"
@@ -989,6 +990,9 @@ static RefPtr<Node> highestAncestorToWrapMarkup(const Position& start, const Pos
     if (RefPtr enclosingAnchor = enclosingElementWithTag(firstPositionInNode(specialCommonAncestor ? specialCommonAncestor.get() : &commonAncestor), aTag))
         specialCommonAncestor = WTFMove(enclosingAnchor);
 
+    if (RefPtr enclosingPicture = enclosingElementWithTag(firstPositionInNode(specialCommonAncestor ? specialCommonAncestor.get() : &commonAncestor), pictureTag))
+        specialCommonAncestor = WTFMove(enclosingPicture);
+
     return specialCommonAncestor;
 }
 
@@ -1021,19 +1025,23 @@ static String serializePreservingVisualAppearanceInternal(const Position& start,
 
     StyledMarkupAccumulator accumulator(start, end, nodes, resolveURLs, serializeComposedTree, ignoreUserSelectNone, annotate, standardFontFamilySerializationMode, msoListMode, needsPositionStyleConversion, specialCommonAncestor.get());
 
-    Position startAdjustedForInterchangeNewline = start;
+    Position adjustedStart = start;
+
+    if (RefPtr pictureElement = dynamicDowncast<HTMLPictureElement>(specialCommonAncestor))
+        adjustedStart = firstPositionInNode(pictureElement.get());
+
     if (annotate == AnnotateForInterchange::Yes && needInterchangeNewlineAfter(visibleStart)) {
         if (visibleStart == visibleEnd.previous())
             return interchangeNewlineString;
 
         accumulator.append(interchangeNewlineString.get());
-        startAdjustedForInterchangeNewline = visibleStart.next().deepEquivalent();
+        adjustedStart = visibleStart.next().deepEquivalent();
 
-        if (!(startAdjustedForInterchangeNewline < end))
+        if (!(adjustedStart < end))
             return interchangeNewlineString;
     }
 
-    RefPtr lastClosed = accumulator.serializeNodes(startAdjustedForInterchangeNewline, end);
+    RefPtr lastClosed = accumulator.serializeNodes(adjustedStart, end);
 
     if (specialCommonAncestor && lastClosed) {
         // Also include all of the ancestors of lastClosed up to this special ancestor.


### PR DESCRIPTION
#### afc67068fec68a95864c3a7c4b14d28c5dba277c
<pre>
Inserting consecutive &lt;picture&gt; elements displays the same image twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=271715">https://bugs.webkit.org/show_bug.cgi?id=271715</a>
<a href="https://rdar.apple.com/123795045">rdar://123795045</a>

Reviewed by Ryosuke Niwa and Wenson Hsieh.

Currently, when inserting two successive elements of the form:

```
&lt;picture&gt;
    &lt;source&gt;
    &lt;img&gt;
&lt;/picture&gt;
```

the resulting markup is:

```
&lt;picture&gt;
    &lt;source&gt;
    &lt;img&gt;
    &lt;img&gt;
&lt;/picture&gt;
```

This results in two images displaying the same `&lt;source&gt;` content.

There are two distinct issues which result in the undesirable markup.

1. The second `&lt;picture&gt;` and `&lt;source&gt;` are dropped by `serializePreservingVisualAppearance`.
   When getting `VisiblePosition`s encompassing the inserted content, only the
   `&lt;img&gt;` is selected, as the first visible position inside the inserted element
   is before the `&lt;picture&gt;`. Consequently, the inserted `&lt;picture&gt;` and
   `&lt;source&gt;` are skipped when serializing nodes.

2. As the selection is inside the first `&lt;picture&gt;` after insertion, subsequent
   content also gets added to the same `&lt;picture&gt;` element.

To fix, `serializePreservingVisualAppearance` must preserve the `&lt;picture&gt;` and
`&lt;source&gt;`. Additionally, any insertions made while the selection is inside
`&lt;picture&gt;`, should be moved outside.

* LayoutTests/editing/inserting/insert-text-after-picture-expected.txt: Added.
* LayoutTests/editing/inserting/insert-text-after-picture.html: Added.
* LayoutTests/editing/pasteboard/copy-picture-expected.txt: Added.
* LayoutTests/editing/pasteboard/copy-picture.html: Added.
* Source/WebCore/editing/Editing.cpp:
(WebCore::canHaveChildrenForEditing):

Return false to ensure children added by editing appear before or after the
`&lt;picture&gt;`, rather than inside it.

`canContainRangeEndPoint` itself is not modified, as doing that introduces
selection and caret painting issues with &lt;picture&gt;. The &lt;img&gt; element itself
should remain selectable.

* Source/WebCore/editing/markup.cpp:
(WebCore::highestAncestorToWrapMarkup):

Return the `&lt;picture&gt;` element if it is a common ancestor of start/end, ensuring
`&lt;picture&gt;` is preserved in the serialized markup.

(WebCore::serializePreservingVisualAppearanceInternal):

Adjust the start Position, so that the `&lt;source&gt;` is included.

Canonical link: <a href="https://commits.webkit.org/276754@main">https://commits.webkit.org/276754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fabcc7919197b232fc2831f7ed31008f32673a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48133 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41475 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37271 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39230 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18393 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40319 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3513 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49859 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16981 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44334 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43161 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10128 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->