### PR TITLE
Add support for specifying unsupported Web Extension APIs.

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h
@@ -41,6 +41,7 @@ struct WebExtensionContextParameters {
 
     URL baseURL;
     String uniqueIdentifier;
+    HashSet<String> unsupportedAPIs;
 
     HashMap<String, WallTime> grantedPermissions;
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in
@@ -27,6 +27,7 @@ struct WebKit::WebExtensionContextParameters {
 
     URL baseURL;
     String uniqueIdentifier;
+    HashSet<String> unsupportedAPIs;
 
     HashMap<String, WallTime> grantedPermissions;
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionDataType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionDataType.h
@@ -39,15 +39,15 @@ enum class WebExtensionDataType : uint8_t {
     Sync    = 1 << 2,
 };
 
-inline String toAPIPrefixString(WebExtensionDataType dataType)
+inline String toAPIString(WebExtensionDataType dataType)
 {
     switch (dataType) {
     case WebExtensionDataType::Local:
-        return "browser.local"_s;
+        return "local"_s;
     case WebExtensionDataType::Session:
-        return "browser.session"_s;
+        return "session"_s;
     case WebExtensionDataType::Sync:
-        return "browser.sync"_s;
+        return "sync"_s;
     }
 }
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h
@@ -94,6 +94,128 @@ enum class WebExtensionEventListenerType : uint8_t {
     WindowsOnRemoved,
 };
 
+inline String toAPIString(WebExtensionEventListenerType eventType)
+{
+    switch (eventType) {
+    case WebExtensionEventListenerType::Unknown:
+        return nullString();
+    case WebExtensionEventListenerType::ActionOnClicked:
+        return "onClicked"_s;
+    case WebExtensionEventListenerType::AlarmsOnAlarm:
+        return "onAlarm"_s;
+    case WebExtensionEventListenerType::CommandsOnChanged:
+        return "onChanged"_s;
+    case WebExtensionEventListenerType::CommandsOnCommand:
+        return "onCommand"_s;
+    case WebExtensionEventListenerType::CookiesOnChanged:
+        return "onChanged"_s;
+    case WebExtensionEventListenerType::DevToolsElementsPanelOnSelectionChanged:
+        return "onSelectionChanged"_s;
+    case WebExtensionEventListenerType::DevToolsExtensionPanelOnHidden:
+        return "onHidden"_s;
+    case WebExtensionEventListenerType::DevToolsExtensionPanelOnSearch:
+        return "onSearch"_s;
+    case WebExtensionEventListenerType::DevToolsExtensionPanelOnShown:
+        return "onShown"_s;
+    case WebExtensionEventListenerType::DevToolsExtensionSidebarPaneOnHidden:
+        return "onHidden"_s;
+    case WebExtensionEventListenerType::DevToolsExtensionSidebarPaneOnShown:
+        return "onShown"_s;
+    case WebExtensionEventListenerType::DevToolsInspectedWindowOnResourceAdded:
+        return "onResourceAdded"_s;
+    case WebExtensionEventListenerType::DevToolsNetworkOnNavigated:
+        return "onNavigated"_s;
+    case WebExtensionEventListenerType::DevToolsNetworkOnRequestFinished:
+        return "onRequestFinished"_s;
+    case WebExtensionEventListenerType::DevToolsPanelsOnThemeChanged:
+        return "onThemeChanged"_s;
+    case WebExtensionEventListenerType::DownloadsOnChanged:
+        return "onChanged"_s;
+    case WebExtensionEventListenerType::DownloadsOnCreated:
+        return "onCreated"_s;
+    case WebExtensionEventListenerType::MenusOnClicked:
+        return "onClicked"_s;
+    case WebExtensionEventListenerType::NotificationsOnButtonClicked:
+        return "onButtonClicked"_s;
+    case WebExtensionEventListenerType::NotificationsOnClicked:
+        return "onClicked"_s;
+    case WebExtensionEventListenerType::PermissionsOnAdded:
+        return "onAdded"_s;
+    case WebExtensionEventListenerType::PermissionsOnRemoved:
+        return "onRemoved"_s;
+    case WebExtensionEventListenerType::PortOnDisconnect:
+        return "onDisconnect"_s;
+    case WebExtensionEventListenerType::PortOnMessage:
+        return "onMessage"_s;
+    case WebExtensionEventListenerType::RuntimeOnConnect:
+        return "onConnect"_s;
+    case WebExtensionEventListenerType::RuntimeOnConnectExternal:
+        return "onConnectExternal"_s;
+    case WebExtensionEventListenerType::RuntimeOnInstalled:
+        return "onInstalled"_s;
+    case WebExtensionEventListenerType::RuntimeOnMessage:
+        return "onMessage"_s;
+    case WebExtensionEventListenerType::RuntimeOnMessageExternal:
+        return "onMessageExternal"_s;
+    case WebExtensionEventListenerType::RuntimeOnStartup:
+        return "onStartup"_s;
+    case WebExtensionEventListenerType::StorageOnChanged:
+        return "onChanged"_s;
+    case WebExtensionEventListenerType::TabsOnActivated:
+        return "onActivated"_s;
+    case WebExtensionEventListenerType::TabsOnAttached:
+        return "onAttached"_s;
+    case WebExtensionEventListenerType::TabsOnCreated:
+        return "onCreated"_s;
+    case WebExtensionEventListenerType::TabsOnDetached:
+        return "onDetached"_s;
+    case WebExtensionEventListenerType::TabsOnHighlighted:
+        return "onHighlighted"_s;
+    case WebExtensionEventListenerType::TabsOnMoved:
+        return "onMoved"_s;
+    case WebExtensionEventListenerType::TabsOnRemoved:
+        return "onRemoved"_s;
+    case WebExtensionEventListenerType::TabsOnReplaced:
+        return "onReplaced"_s;
+    case WebExtensionEventListenerType::TabsOnUpdated:
+        return "onUpdated"_s;
+    case WebExtensionEventListenerType::WebNavigationOnBeforeNavigate:
+        return "onBeforeNavigate"_s;
+    case WebExtensionEventListenerType::WebNavigationOnCommitted:
+        return "onCommitted"_s;
+    case WebExtensionEventListenerType::WebNavigationOnCompleted:
+        return "onCompleted"_s;
+    case WebExtensionEventListenerType::WebNavigationOnDOMContentLoaded:
+        return "onDOMContentLoaded"_s;
+    case WebExtensionEventListenerType::WebNavigationOnErrorOccurred:
+        return "onErrorOccurred"_s;
+    case WebExtensionEventListenerType::WebRequestOnAuthRequired:
+        return "onAuthRequired"_s;
+    case WebExtensionEventListenerType::WebRequestOnBeforeRedirect:
+        return "onBeforeRedirect"_s;
+    case WebExtensionEventListenerType::WebRequestOnBeforeRequest:
+        return "onBeforeRequest"_s;
+    case WebExtensionEventListenerType::WebRequestOnBeforeSendHeaders:
+        return "onBeforeSendHeaders"_s;
+    case WebExtensionEventListenerType::WebRequestOnCompleted:
+        return "onCompleted"_s;
+    case WebExtensionEventListenerType::WebRequestOnErrorOccurred:
+        return "onErrorOccurred"_s;
+    case WebExtensionEventListenerType::WebRequestOnHeadersReceived:
+        return "onHeadersReceived"_s;
+    case WebExtensionEventListenerType::WebRequestOnResponseStarted:
+        return "onResponseStarted"_s;
+    case WebExtensionEventListenerType::WebRequestOnSendHeaders:
+        return "onSendHeaders"_s;
+    case WebExtensionEventListenerType::WindowsOnCreated:
+        return "onCreated"_s;
+    case WebExtensionEventListenerType::WindowsOnFocusChanged:
+        return "onFocusChanged"_s;
+    case WebExtensionEventListenerType::WindowsOnRemoved:
+        return "onRemoved"_s;
+    }
+}
+
 using WebExtensionEventListenerTypeWorldPair = std::pair<WebExtensionEventListenerType, WebExtensionContentWorldType>;
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h
@@ -186,6 +186,18 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 @property (nonatomic, getter=isInspectable) BOOL inspectable;
 
 /*!
+ @abstract Specifies unsupported APIs for this extension, making them `undefined` in JavaScript.
+ @discussion This property allows the app to specify a subset of web extension APIs that it chooses not to support, effectively making
+ these APIs `undefined` within the extension's JavaScript contexts. This enables extensions to employ feature detection techniques
+ for unsupported APIs, allowing them to adapt their behavior based on the APIs actually supported by the app. Setting is only allowed when
+ the context is not loaded. Only certain APIs can be specified here, particularly those within the `browser` namespace and other dynamic
+ functions and properties, anything else will be silently ignored.
+ @note For example, specifying `"browser.windows.create"` and `"browser.storage"` in this set will result in the
+ `browser.windows.create()` function and `browser.storage` property being `undefined`.
+ */
+@property (nonatomic, null_resettable, copy) NSSet<NSString *> *unsupportedAPIs;
+
+/*!
  @abstract The web view configuration to use for web views that load pages from this extension.
  @discussion Returns a customized copy of the configuration, originally set in the web extension controller configuration, for this extension.
  The app must use this configuration when initializing web views intended to navigate to a URL originating from this extension's base URL.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm
@@ -144,6 +144,18 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionContext, WebExtensionContex
     _webExtensionContext->setInspectable(inspectable);
 }
 
+- (NSSet<NSString *> *)unsupportedAPIs
+{
+    return WebKit::toAPI(_webExtensionContext->unsupportedAPIs());
+}
+
+- (void)setUnsupportedAPIs:(NSSet<NSString *> *)unsupportedAPIs
+{
+    NSParameterAssert(!unsupportedAPIs || [unsupportedAPIs isKindOfClass:NSSet.class]);
+
+    _webExtensionContext->setUnsupportedAPIs(WebKit::toImpl(unsupportedAPIs));
+}
+
 - (WKWebViewConfiguration *)webViewConfiguration
 {
     return _webExtensionContext->webViewConfiguration(WebKit::WebExtensionContext::WebViewPurpose::Tab);
@@ -865,6 +877,15 @@ static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(_WKWe
 }
 
 - (void)setInspectable:(BOOL)inspectable
+{
+}
+
+- (NSSet<NSString *> *)unsupportedAPIs
+{
+    return nil;
+}
+
+- (void)setUnsupportedAPIs:(NSSet<NSString *> *)unsupportedAPIs
 {
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -516,6 +516,15 @@ void WebExtensionContext::setInspectable(bool inspectable)
         entry.key.cocoaView().get().inspectable = inspectable;
 }
 
+void WebExtensionContext::setUnsupportedAPIs(HashSet<String>&& unsupported)
+{
+    ASSERT(!isLoaded());
+    if (isLoaded())
+        return;
+
+    m_unsupportedAPIs = WTFMove(unsupported);
+}
+
 const WebExtensionContext::InjectedContentVector& WebExtensionContext::injectedContents()
 {
     return m_extension->staticInjectedContents();

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -62,6 +62,7 @@ WebExtensionContextParameters WebExtensionContext::parameters() const
         identifier(),
         baseURL(),
         uniqueIdentifier(),
+        unsupportedAPIs(),
         m_grantedPermissions,
         extension().serializeLocalization(),
         extension().serializeManifest(),

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -290,6 +290,9 @@ public:
     bool isInspectable() const { return m_inspectable; }
     void setInspectable(bool);
 
+    HashSet<String> unsupportedAPIs() const { return m_unsupportedAPIs; }
+    void setUnsupportedAPIs(HashSet<String>&&);
+
     const InjectedContentVector& injectedContents();
     bool hasInjectedContentForURL(const URL&);
     bool hasInjectedContent();
@@ -847,6 +850,8 @@ private:
     bool m_customUniqueIdentifier { false };
 
     bool m_inspectable { false };
+
+    HashSet<String> m_unsupportedAPIs;
 
     RefPtr<API::ContentWorld> m_contentScriptWorld;
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -88,6 +88,9 @@ bool WebExtensionAPIExtension::parseViewFilters(NSDictionary *filter, std::optio
 
 bool WebExtensionAPIExtension::isPropertyAllowed(const ASCIILiteral& name, WebPage&)
 {
+    if (UNLIKELY(extensionContext().isUnsupportedAPI(propertyPath(), name)))
+        return false;
+
     // This method was removed in manifest version 3.
     if (name == "getURL"_s)
         return !extensionContext().supportsManifestVersion(3);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -40,6 +40,9 @@ namespace WebKit {
 
 bool WebExtensionAPINamespace::isPropertyAllowed(const ASCIILiteral& name, WebPage& page)
 {
+    if (UNLIKELY(extensionContext().isUnsupportedAPI(propertyPath(), name)))
+        return false;
+
     if (name == "action"_s)
         return extensionContext().supportsManifestVersion(3) && objectForKey<NSDictionary>(extensionContext().manifest(), @"action", false);
 
@@ -199,8 +202,10 @@ WebExtensionAPIRuntime& WebExtensionAPINamespace::runtime() const
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime
 
-    if (!m_runtime)
+    if (!m_runtime) {
         m_runtime = WebExtensionAPIRuntime::create(contentWorldType(), extensionContext());
+        m_runtime->setPropertyPath("runtime"_s, this);
+    }
 
     return *m_runtime;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -153,6 +153,9 @@ bool WebExtensionAPIRuntime::parseConnectOptions(NSDictionary *options, std::opt
 
 bool WebExtensionAPIRuntime::isPropertyAllowed(const ASCIILiteral& name, WebPage&)
 {
+    if (UNLIKELY(extensionContext().isUnsupportedAPI(propertyPath(), name)))
+        return false;
+
     if (name == "connectNative"_s || name == "sendNativeMessage"_s)
         return extensionContext().hasPermission("nativeMessaging"_s);
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
@@ -42,6 +42,9 @@ namespace WebKit {
 
 bool WebExtensionAPIStorage::isPropertyAllowed(const ASCIILiteral& propertyName, WebPage&)
 {
+    if (UNLIKELY(extensionContext().isUnsupportedAPI(propertyPath(), propertyName)))
+        return false;
+
     if (propertyName == "session"_s)
         return extensionContext().isSessionStorageAllowedInContentScripts() || isForMainWorld();
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -546,6 +546,9 @@ bool isValid(std::optional<WebExtensionTabIdentifier> identifier, NSString **out
 
 bool WebExtensionAPITabs::isPropertyAllowed(const ASCIILiteral& name, WebPage&)
 {
+    if (UNLIKELY(extensionContext().isUnsupportedAPI(propertyPath(), name)))
+        return false;
+
     static NeverDestroyed<HashSet<AtomString>> removedInManifestVersion3 { HashSet { AtomString("executeScript"_s), AtomString("getSelected"_s), AtomString("insertCSS"_s), AtomString("removeCSS"_s) } };
     if (removedInManifestVersion3.get().contains(name))
         return !extensionContext().supportsManifestVersion(3);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm
@@ -56,8 +56,10 @@ WebExtensionAPIWebPageRuntime& WebExtensionAPIWebPageNamespace::runtime() const
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime
 
-    if (!m_runtime)
+    if (!m_runtime) {
         m_runtime = WebExtensionAPIWebPageRuntime::create(contentWorldType());
+        m_runtime->setPropertyPath("runtime"_s, this);
+    }
 
     return *m_runtime;
 }
@@ -67,7 +69,7 @@ WebExtensionAPITest& WebExtensionAPIWebPageNamespace::test()
     // Documentation: None (Testing Only)
 
     if (!m_test)
-        m_test = WebExtensionAPITest::create(contentWorldType());
+        m_test = WebExtensionAPITest::create(*this);
 
     return *m_test;
 }

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -378,6 +378,9 @@ bool isValid(std::optional<WebExtensionWindowIdentifier> identifier, NSString **
 
 bool WebExtensionAPIWindows::isPropertyAllowed(const ASCIILiteral& name, WebPage&)
 {
+    if (UNLIKELY(extensionContext().isUnsupportedAPI(propertyPath(), name)))
+        return false;
+
 #if PLATFORM(MAC)
     return true;
 #else

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
@@ -37,7 +37,7 @@ OBJC_CLASS NSString;
 namespace WebKit {
 
 class WebExtensionAPIAction : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIAction, action);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIAction, action, action);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h
@@ -37,7 +37,7 @@ OBJC_CLASS NSString;
 namespace WebKit {
 
 class WebExtensionAPIAlarms : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIAlarms, alarms);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIAlarms, alarms, alarms);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPICommands.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPICommands.h
@@ -34,7 +34,7 @@
 namespace WebKit {
 
 class WebExtensionAPICommands : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPICommands, commands);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPICommands, commands, commands);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPICookies.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPICookies.h
@@ -37,7 +37,7 @@ OBJC_CLASS NSString;
 namespace WebKit {
 
 class WebExtensionAPICookies : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPICookies, cookies);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPICookies, cookies, cookies);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h
@@ -36,7 +36,7 @@ namespace WebKit {
 class WebPage;
 
 class WebExtensionAPIDeclarativeNetRequest : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIDeclarativeNetRequest, declarativeNetRequest);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIDeclarativeNetRequest, declarativeNetRequest, declarativeNetRequest);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevTools.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevTools.h
@@ -36,7 +36,7 @@
 namespace WebKit {
 
 class WebExtensionAPIDevTools : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIDevTools, devTools);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIDevTools, devTools, devtools);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsExtensionPanel.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsExtensionPanel.h
@@ -34,7 +34,7 @@
 namespace WebKit {
 
 class WebExtensionAPIDevToolsExtensionPanel : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIDevToolsExtensionPanel, devToolsExtensionPanel);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIDevToolsExtensionPanel, devToolsExtensionPanel, devtools.panels.extension);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h
@@ -36,7 +36,7 @@ namespace WebKit {
 class WebPage;
 
 class WebExtensionAPIDevToolsInspectedWindow : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIDevToolsInspectedWindow, devToolsInspectedWindow);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIDevToolsInspectedWindow, devToolsInspectedWindow, devtools.inspectedWindow);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsNetwork.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsNetwork.h
@@ -34,7 +34,7 @@
 namespace WebKit {
 
 class WebExtensionAPIDevToolsNetwork : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIDevToolsNetwork, devToolsNetwork);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIDevToolsNetwork, devToolsNetwork, devtools.network);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h
@@ -37,7 +37,7 @@ namespace WebKit {
 class WebPage;
 
 class WebExtensionAPIDevToolsPanels : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIDevToolsPanels, devToolsPanels);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIDevToolsPanels, devToolsPanels, devtools.panels);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h
@@ -38,7 +38,7 @@ OBJC_CLASS JSValue;
 namespace WebKit {
 
 class WebExtensionAPIEvent : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIEvent, event);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIEvent, event, event);
 
 public:
     using ListenerVector = Vector<RefPtr<WebExtensionCallbackHandler>>;
@@ -66,6 +66,7 @@ private:
         : WebExtensionAPIObject(parentObject)
         , m_type(type)
     {
+        setPropertyPath(toAPIString(type), &parentObject);
     }
 
     WebPageProxyIdentifier m_pageProxyIdentifier;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIExtension.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIExtension.h
@@ -38,7 +38,7 @@ namespace WebKit {
 class WebPage;
 
 class WebExtensionAPIExtension : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIExtension, extension);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIExtension, extension, extension);
 
 public:
     enum class ViewType : uint8_t {

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h
@@ -33,7 +33,7 @@
 namespace WebKit {
 
 class WebExtensionAPILocalization : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPILocalization, localization);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPILocalization, localization, i18n);
 
 public:
     NSString *getMessage(NSString* messageName, id substitutions);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h
@@ -38,7 +38,7 @@ OBJC_CLASS NSString;
 namespace WebKit {
 
 class WebExtensionAPIMenus : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIMenus, menus);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIMenus, menus, menus);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -55,7 +55,7 @@ class WebExtensionAPIExtension;
 class WebExtensionAPIRuntime;
 
 class WebExtensionAPINamespace : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPINamespace, namespace);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPINamespace, namespace, browser);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINotifications.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINotifications.h
@@ -34,7 +34,7 @@
 namespace WebKit {
 
 class WebExtensionAPINotifications : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPINotifications, notifications);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPINotifications, notifications, notifications);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
@@ -74,19 +74,31 @@ public:
     WebExtensionContentWorldType contentWorldType() const { return m_contentWorldType; }
 
     virtual WebExtensionAPIRuntimeBase& runtime() const { return *m_runtime; }
-    WebExtensionContextProxy& extensionContext() const { return *m_extensionContext; }
 
+    WebExtensionContextProxy& extensionContext() const { return *m_extensionContext; }
     bool hasExtensionContext() const { return !!m_extensionContext; }
+
+    const String& propertyPath() const { return m_propertyPath; }
+    void setPropertyPath(const String& propertyName, const WebExtensionAPIObject* parentObject = nullptr)
+    {
+        ASSERT(!propertyName.isEmpty());
+
+        if (parentObject && !parentObject->propertyPath().isEmpty())
+            m_propertyPath = makeString(parentObject->propertyPath(), '.', propertyName);
+        else
+            m_propertyPath = propertyName;
+    }
 
 private:
     WebExtensionContentWorldType m_contentWorldType { WebExtensionContentWorldType::Main };
     RefPtr<WebExtensionAPIRuntimeBase> m_runtime;
     RefPtr<WebExtensionContextProxy> m_extensionContext;
+    String m_propertyPath;
 };
 
 } // namespace WebKit
 
-#define WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(ImplClass, ScriptClass) \
+#define WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(ImplClass, ScriptClass, PropertyName) \
 public: \
     template<typename... Args> \
     static Ref<ImplClass> create(Args&&... args) \
@@ -98,21 +110,25 @@ private: \
     explicit ImplClass(WebExtensionContentWorldType contentWorldType) \
         : WebExtensionAPIObject(contentWorldType) \
     { \
+        setPropertyPath(#PropertyName##_s); \
     } \
 \
     explicit ImplClass(WebExtensionContentWorldType contentWorldType, WebExtensionContextProxy& context) \
         : WebExtensionAPIObject(contentWorldType, context) \
     { \
+        setPropertyPath(#PropertyName##_s); \
     } \
 \
     explicit ImplClass(WebExtensionContentWorldType contentWorldType, WebExtensionAPIRuntimeBase& runtime, WebExtensionContextProxy& context) \
         : WebExtensionAPIObject(contentWorldType, runtime, context) \
     { \
+        setPropertyPath(#PropertyName##_s); \
     } \
 \
     explicit ImplClass(const WebExtensionAPIObject& parentObject) \
         : WebExtensionAPIObject(parentObject) \
     { \
+        setPropertyPath(#PropertyName##_s, &parentObject); \
     } \
 \
     JSClassRef wrapperClass() final { return JS##ImplClass::ScriptClass##Class(); } \

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPermissions.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPermissions.h
@@ -35,7 +35,7 @@
 namespace WebKit {
 
 class WebExtensionAPIPermissions : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIPermissions, permissions);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIPermissions, permissions, permissions);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -41,7 +41,7 @@ OBJC_CLASS NSString;
 namespace WebKit {
 
 class WebExtensionAPIPort : public WebExtensionAPIObject, public JSWebExtensionWrappable, public CanMakeWeakPtr<WebExtensionAPIPort> {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIPort, port);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIPort, port, port);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -57,7 +57,7 @@ private:
 };
 
 class WebExtensionAPIRuntime : public WebExtensionAPIObject, public WebExtensionAPIRuntimeBase {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIRuntime, runtime);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIRuntime, runtime, runtime);
 
 public:
     WebExtensionAPIRuntime& runtime() const final { return const_cast<WebExtensionAPIRuntime&>(*this); }
@@ -108,7 +108,7 @@ private:
 };
 
 class WebExtensionAPIWebPageRuntime : public WebExtensionAPIObject, public WebExtensionAPIRuntimeBase {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebPageRuntime, webPageRuntime);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebPageRuntime, webPageRuntime, webPageRuntime);
 
 public:
     WebExtensionAPIWebPageRuntime& runtime() const final { return const_cast<WebExtensionAPIWebPageRuntime&>(*this); }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h
@@ -41,7 +41,7 @@ using FirstTimeRegistration = WebExtensionDynamicScripts::WebExtensionRegistered
 class WebExtension;
 
 class WebExtensionAPIScripting : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIScripting, scripting);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIScripting, scripting, scripting);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorage.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorage.h
@@ -37,7 +37,7 @@ namespace WebKit {
 class WebExtensionAPIStorageArea;
 
 class WebExtensionAPIStorage : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIStorage, storage);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIStorage, storage, storage);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
@@ -36,7 +36,7 @@
 namespace WebKit {
 
 class WebExtensionAPIStorageArea : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIStorageArea, storageArea);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIStorageArea, storageArea, storageArea);
 
 public:
 #if PLATFORM(COCOA)
@@ -66,6 +66,7 @@ private:
         : WebExtensionAPIObject(parentObject)
         , m_type(type)
     {
+        setPropertyPath(toAPIString(type), &parentObject);
     }
 
     WebExtensionDataType m_type { WebExtensionDataType::Local };

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h
@@ -44,7 +44,7 @@ struct WebExtensionTabParameters;
 struct WebExtensionTabQueryParameters;
 
 class WebExtensionAPITabs : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPITabs, tabs);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPITabs, tabs, tabs);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h
@@ -39,7 +39,7 @@ namespace WebKit {
 class WebPage;
 
 class WebExtensionAPITest : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPITest, test);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPITest, test, test);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigation.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigation.h
@@ -36,7 +36,7 @@ namespace WebKit {
 class WebPage;
 
 class WebExtensionAPIWebNavigation : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebNavigation, webNavigation);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebNavigation, webNavigation, webNavigation);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h
@@ -42,7 +42,7 @@ OBJC_CLASS _WKWebExtensionWebNavigationURLFilter;
 namespace WebKit {
 
 class WebExtensionAPIWebNavigationEvent : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebNavigationEvent, webNavigationEvent);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebNavigationEvent, webNavigationEvent, event);
 
 public:
     using FilterAndCallbackPair = std::pair<RefPtr<WebExtensionCallbackHandler>, RetainPtr<_WKWebExtensionWebNavigationURLFilter>>;
@@ -68,6 +68,7 @@ private:
         : WebExtensionAPIObject(parentObject)
         , m_type(type)
     {
+        setPropertyPath(toAPIString(type), &parentObject);
     }
 
     WebPageProxyIdentifier m_pageProxyIdentifier;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
@@ -38,7 +38,7 @@ class WebExtensionAPIWebPageRuntime;
 class WebPage;
 
 class WebExtensionAPIWebPageNamespace : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebPageNamespace, webPageNamespace);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebPageNamespace, webPageNamespace, browser);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequest.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequest.h
@@ -36,7 +36,7 @@ namespace WebKit {
 class WebPage;
 
 class WebExtensionAPIWebRequest : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebRequest, webRequest);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebRequest, webRequest, webRequest);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h
@@ -42,7 +42,7 @@ OBJC_CLASS _WKWebExtensionWebRequestFilter;
 namespace WebKit {
 
 class WebExtensionAPIWebRequestEvent : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebRequestEvent, webRequestEvent);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWebRequestEvent, webRequestEvent, event);
 
 public:
     using FilterAndCallbackPair = std::pair<RefPtr<WebExtensionCallbackHandler>, RetainPtr<_WKWebExtensionWebRequestFilter>>;
@@ -68,6 +68,7 @@ private:
         : WebExtensionAPIObject(parentObject)
         , m_type(type)
     {
+        setPropertyPath(toAPIString(type), &parentObject);
     }
 
     WebPageProxyIdentifier m_pageProxyIdentifier;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h
@@ -41,7 +41,7 @@ namespace WebKit {
 class WebPage;
 
 class WebExtensionAPIWindows : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWindows, windows);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWindows, windows, windows);
 
 public:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h
@@ -38,7 +38,7 @@ OBJC_CLASS NSString;
 namespace WebKit {
 
 class WebExtensionAPIWindowsEvent : public WebExtensionAPIObject, public JSWebExtensionWrappable {
-    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWindowsEvent, windowsEvent);
+    WEB_EXTENSION_DECLARE_JS_WRAPPER_CLASS(WebExtensionAPIWindowsEvent, windowsEvent, event);
 
 public:
     using WindowTypeFilter = WebExtensionWindow::TypeFilter;
@@ -65,6 +65,7 @@ private:
         : WebExtensionAPIObject(parentObject)
         , m_type(type)
     {
+        setPropertyPath(toAPIString(type), &parentObject);
     }
 
     WebPageProxyIdentifier m_pageProxyIdentifier;

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm
@@ -77,6 +77,7 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(const WebExt
         context.m_extensionControllerProxy = extensionControllerProxy;
         context.m_baseURL = parameters.baseURL;
         context.m_uniqueIdentifier = parameters.uniqueIdentifier;
+        context.m_unsupportedAPIs = parameters.unsupportedAPIs;
         context.m_grantedPermissions = parameters.grantedPermissions;
         context.m_localization = parseLocalization(parameters.localizationJSON.get(), parameters.baseURL);
         context.m_manifest = parseJSON(parameters.manifestJSON.get());
@@ -126,6 +127,12 @@ Ref<WebExtensionContextProxy> WebExtensionContextProxy::getOrCreate(const WebExt
     Ref result = adoptRef(*new WebExtensionContextProxy(parameters));
     updateProperties(result);
     return result;
+}
+
+bool WebExtensionContextProxy::isUnsupportedAPI(const String& propertyPath, const ASCIILiteral& propertyName) const
+{
+    auto fullPropertyPath = !propertyPath.isEmpty() ? makeString(propertyPath, '.', propertyName) : propertyName;
+    return m_unsupportedAPIs.contains(fullPropertyPath);
 }
 
 bool WebExtensionContextProxy::hasPermission(const String& permission) const

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -104,6 +104,8 @@ public:
     RefPtr<WebPage> backgroundPage() const;
     void setBackgroundPage(WebPage&);
 
+    bool isUnsupportedAPI(const String& propertyPath, const ASCIILiteral& propertyName) const;
+
     bool hasPermission(const String& permission) const;
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
@@ -215,6 +217,7 @@ private:
     WeakPtr<WebExtensionControllerProxy> m_extensionControllerProxy;
     URL m_baseURL;
     String m_uniqueIdentifier;
+    HashSet<String> m_unsupportedAPIs;
     RetainPtr<_WKWebExtensionLocalization> m_localization;
     RetainPtr<NSDictionary> m_manifest;
     double m_manifestVersion { 0 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm
@@ -127,6 +127,32 @@ TEST(WKWebExtensionAPINamespace, NotificationsObjectWithPermission)
     Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
 }
 
+TEST(WKWebExtensionAPINamespace, NotificationsUnsupported)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"permissions": @[ @"notifications" ],
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO
+        }
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.notifications, undefined)",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().context.unsupportedAPIs = [NSSet setWithObject:@"browser.notifications"];
+
+    [manager loadAndRun];
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm
@@ -654,6 +654,22 @@ TEST(WKWebExtensionAPIWindows, Remove)
     Util::loadAndRunExtension(windowsManifest, @{ @"background.js": backgroundScript });
 }
 
+TEST(WKWebExtensionAPIWindows, RemoveUnsupported)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.windows.remove, undefined)",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:windowsManifest resources:@{ @"background.js": backgroundScript }]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().context.unsupportedAPIs = [NSSet setWithObject:@"browser.windows.remove"];
+
+    [manager loadAndRun];
+}
+
 #endif // PLATFORM(MAC)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 1d5b797b0b1d4322de1ae6a4fb4b48e1fd840efc
<pre>
Add support for specifying unsupported Web Extension APIs.
<a href="https://webkit.org/b/271733">https://webkit.org/b/271733</a>
<a href="https://rdar.apple.com/116824851">rdar://116824851</a>

Reviewed by Jeff Miller.

Add an `unsupportedAPIs` property on `_WKWebExtensionContext` that allows the app to specify a
subset of web extension APIs that it chooses not to support, effectively making these APIs
`undefined` within the extension&apos;s JavaScript contexts. This enables extensions to employ
feature detection techniques for unsupported APIs, allowing them to adapt their behavior based
on the APIs actually supported by the app. Setting is only allowed when the context is not
loaded. Only certain APIs can be specified here, particularly those within the `browser`
namespace and other dynamic functions and properties, anything else will be silently ignored.

This adds a new `propertyPath()` method on `WebExtensionAPIObject` that allows the individual
APIs to know the full JavaScript path to their object for lookup purposes, and can be used for
logging and error strings in the future.

* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.h:
* Source/WebKit/Shared/Extensions/WebExtensionContextParameters.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionDataType.h:
(WebKit::toAPIString): Added.
(WebKit::toAPIPrefixString): Deleted.
* Source/WebKit/Shared/Extensions/WebExtensionEventListenerType.h:
(WebKit::toAPIString): Added.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionContext.mm:
(-[_WKWebExtensionContext unsupportedAPIs]): Added.
(-[_WKWebExtensionContext setUnsupportedAPIs:]): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIStorageCocoa.mm:
(WebKit::WebExtensionContext::storageGet): Fixed callingAPIName, since it should not be static.
(WebKit::WebExtensionContext::storageGetBytesInUse): Ditto.
(WebKit::WebExtensionContext::storageSet): Ditto.
(WebKit::WebExtensionContext::storageRemove): Ditto.
(WebKit::WebExtensionContext::storageClear): Ditto.
(WebKit::WebExtensionContext::storageSetAccessLevel): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::setUnsupportedAPIs): Added.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::parameters const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
(WebKit::WebExtensionContext::unsupportedAPIs const):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::isPropertyAllowed):
(WebKit::WebExtensionAPINamespace::runtime const):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::isPropertyAllowed):
(WebKit::WebExtensionAPIStorageArea::get): Fixed the path to include storage.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm:
(WebKit::WebExtensionAPIStorage::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm:
(WebKit::WebExtensionAPIWebPageNamespace::runtime const):
(WebKit::WebExtensionAPIWebPageNamespace::test):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAlarms.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPICommands.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPICookies.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDeclarativeNetRequest.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevTools.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsExtensionPanel.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsInspectedWindow.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsNetwork.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIDevToolsPanels.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIEvent.h:
(WebKit::WebExtensionAPIEvent::WebExtensionAPIEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIExtension.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPILocalization.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIMenus.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINotifications.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h:
(WebKit::WebExtensionAPIObject::propertyPath const): Added.
(WebKit::WebExtensionAPIObject::setPropertyPath): Added.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPermissions.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIScripting.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorage.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h:
(WebKit::WebExtensionAPIStorageArea::WebExtensionAPIStorageArea):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITabs.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigation.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebNavigationEvent.h:
(WebKit::WebExtensionAPIWebNavigationEvent::WebExtensionAPIWebNavigationEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequest.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebRequestEvent.h:
(WebKit::WebExtensionAPIWebRequestEvent::WebExtensionAPIWebRequestEvent):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindows.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWindowsEvent.h:
(WebKit::WebExtensionAPIWindowsEvent::WebExtensionAPIWindowsEvent):
* Source/WebKit/WebProcess/Extensions/Cocoa/WebExtensionContextProxyCocoa.mm:
(WebKit::WebExtensionContextProxy::getOrCreate):
(WebKit::WebExtensionContextProxy::isUnsupportedAPI const):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm:
(TEST(WKWebExtensionAPINamespace, NotificationsUnsupported)): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIWindows.mm:
(TEST(WKWebExtensionAPIWindows, RemoveUnsupported)): Added.

Canonical link: <a href="https://commits.webkit.org/276717@main">https://commits.webkit.org/276717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/627fc4e911fdd0724198a0068ef4666e6daa2fe1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45431 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48097 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21947 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18366 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19046 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40283 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3477 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49821 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16943 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44312 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21723 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43137 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22083 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6324 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->