### PR TITLE
Update the PreviewWindowController to use a PreviewConfiguration

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -223,10 +223,10 @@ void WebFullScreenManagerProxy::exitFullScreen()
 #if ENABLE(QUICKLOOK_FULLSCREEN)
 void WebFullScreenManagerProxy::prepareQuickLookImageURL(CompletionHandler<void(URL&&)>&& completionHandler) const
 {
-    sharedQuickLookFileQueue().dispatch([buffer = m_imageBuffer, mimeType = crossThreadCopy(m_imageMIMEType), completionHandler = WTFMove(completionHandler)]() mutable {
-        if (!buffer)
-            return completionHandler(URL());
+    if (!m_imageBuffer)
+        return completionHandler(URL());
 
+    sharedQuickLookFileQueue().dispatch([buffer = m_imageBuffer, mimeType = crossThreadCopy(m_imageMIMEType), completionHandler = WTFMove(completionHandler)]() mutable {
         auto suffix = makeString('.', WebCore::MIMETypeRegistry::preferredExtensionForMIMEType(mimeType));
         auto [filePath, fileHandle] = FileSystem::openTemporaryFile("QuickLook"_s, suffix);
         ASSERT(FileSystem::isHandleValid(fileHandle));

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1873,8 +1873,9 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     if (manager && manager->isImageElement()) {
         if (enter) {
             inWindowAlpha = 0;
-            manager->prepareQuickLookImageURL([strongSelf = retainPtr(self), self] (URL&& url) mutable {
-                _previewWindowController = adoptNS([WebKit::allocWKSPreviewWindowControllerInstance() initWithURL:url]);
+            manager->prepareQuickLookImageURL([strongSelf = retainPtr(self), self, inWindow = retainPtr(inWindow)] (URL&& url) mutable {
+                UIWindowScene *scene = [inWindow windowScene];
+                _previewWindowController = adoptNS([WebKit::allocWKSPreviewWindowControllerInstance() initWithURL:url sceneID:scene._sceneIdentifier]);
                 [_previewWindowController setDelegate:self];
                 [_previewWindowController presentWindow];
             });

--- a/Source/WebKit/WebKitSwift/Preview/PreviewWindowController.swift
+++ b/Source/WebKit/WebKitSwift/Preview/PreviewWindowController.swift
@@ -23,7 +23,7 @@
 
 #if os(visionOS)
 
-#if canImport(QuickLook, _version: 956)
+#if canImport(QuickLook, _version: 957)
 import OSLog
 import WebKitSwift
 
@@ -33,19 +33,27 @@ import WebKitSwift
 public final class PreviewWindowController: NSObject {
     private static let logger = Logger(subsystem: "com.apple.WebKit", category: "Fullscreen")
 
-    private var item: PreviewItem
+    private let item: PreviewItem
+    private let previewConfiguration: PreviewApplication.PreviewConfiguration
     private var previewSession: PreviewSession?
     private var isClosing = false
 
     @objc public weak var delegate: WKSPreviewWindowControllerDelegate?
 
-    @objc(initWithURL:) public init(url: URL) {
+    @objc(initWithURL:sceneID:) public init(url: URL, sceneID: String) {
         self.item = PreviewItem(url: url, displayName: nil, editingMode: .disabled);
+
+        var configuration = PreviewApplication.PreviewConfiguration()
+        configuration.hideDocumentMenu = true
+        configuration.showCloseButton = true
+        configuration.matchScenePlacementID = sceneID
+        self.previewConfiguration = configuration
+
         super.init()
     }
 
     @objc public func presentWindow() {
-        previewSession = PreviewApplication.open(items: [self.item], selectedItem: nil)
+        previewSession = PreviewApplication.open(items: [self.item], selectedItem: nil, configuration: previewConfiguration)
 
         Task.detached { [weak self] in
             guard let session = self?.previewSession else { return }

--- a/Source/WebKit/WebKitSwift/Preview/WKSPreviewWindowController.h
+++ b/Source/WebKit/WebKitSwift/Preview/WKSPreviewWindowController.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface WKSPreviewWindowController : NSObject
 @property (nonatomic, weak, nullable) id <WKSPreviewWindowControllerDelegate> delegate;
 
-- (instancetype)initWithURL:(NSURL *)url NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithURL:(NSURL *)url sceneID:(NSString *)sceneID NS_DESIGNATED_INITIALIZER;
 - (void)presentWindow;
 - (void)dismissWindow;
 @end


### PR DESCRIPTION
#### ce53b481818409c6679295e82430c744f801753e
<pre>
Update the PreviewWindowController to use a PreviewConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=271734">https://bugs.webkit.org/show_bug.cgi?id=271734</a>
&lt;<a href="https://rdar.apple.com/120903062">rdar://120903062</a>&gt;

Reviewed by Andy Estes.

Update the PreviewWindowController to use a PreviewConfiguration. Our
configuration takes a `sceneID` so the WKSPreviewWindowController&apos;s init
method is updated to accept one.

* Source/WebKit/WebKitSwift/Preview/WKSPreviewWindowController.h:
Update the designated initializer.
* Source/WebKit/WebKitSwift/Preview/PreviewWindowController.swift:
Generate a PreviewConfiguration on init and pass it when opening the
PreviewApplication.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _performSpatialFullScreenTransition:completionHandler:]):
Use the new initializer. The closure now needs to capture the `inWindow`
so we can get to its scene identifier.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::prepareQuickLookImageURL const):

Drive-by fix: always call the completion handler on the main thread.
Canonical link: <a href="https://commits.webkit.org/276928@main">https://commits.webkit.org/276928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53c38e1404dcc78bf3a9163d9954367236c82002

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48117 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41459 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37261 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18380 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19077 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3497 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49841 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20436 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44319 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21744 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43145 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10225 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->