### PR TITLE
Paths in browser.action.setIcon should be relative.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
@@ -592,8 +592,12 @@ CocoaImage *WebExtensionAction::icon(CGSize idealSize)
     if (!extensionContext())
         return nil;
 
-    if (m_customIcons)
-        return extensionContext()->extension().bestImageInIconsDictionary(m_customIcons.get(), idealSize.width > idealSize.height ? idealSize.width : idealSize.height);
+    if (m_customIcons) {
+        if (CocoaImage *result = extensionContext()->extension().bestImageInIconsDictionary(m_customIcons.get(), idealSize.width > idealSize.height ? idealSize.width : idealSize.height))
+            return result;
+
+        // If custom icons fail, fallback to the default icons.
+    }
 
     if (RefPtr fallback = fallbackAction())
         return fallback->icon(idealSize);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h
@@ -54,7 +54,7 @@ public:
     void disable(double tabIdentifier, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void isEnabled(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
-    void setIcon(JSContextRef, NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
+    void setIcon(WebFrame&, NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     void getPopup(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void setPopup(NSDictionary *details, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl
@@ -42,7 +42,7 @@
     [RaisesException] void disable([Optional] double tabId, [Optional, CallbackHandler] function callback);
     [RaisesException] void isEnabled([Optional, NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
 
-    [RaisesException, NeedsScriptContext] void setIcon([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
+    [RaisesException, NeedsFrame] void setIcon([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
 
     [RaisesException] void setPopup([NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);
     [RaisesException] void getPopup([Optional, NSDictionary=NullAllowed] any details, [Optional, CallbackHandler] function callback);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm
@@ -596,6 +596,60 @@ TEST(WKWebExtensionAPIAction, SetIconSinglePath)
     [manager loadAndRun];
 }
 
+TEST(WKWebExtensionAPIAction, SetIconSinglePathRelative)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"await browser.action.setIcon({ path: '../icons/toolbar-48.png' })",
+
+        @"browser.action.openPopup()"
+    ]);
+
+    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+
+    auto *resources = @{
+        @"background/index.html": @"<script type='module' src='script.js'></script>",
+        @"background/script.js": backgroundScript,
+        @"icons/toolbar-48.png": extraLargeToolbarIcon,
+        @"popup.html": @"Hello world!",
+    };
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Action Test",
+        @"description": @"Action Test",
+        @"version": @"1",
+
+        @"background": @{
+            @"page": @"background/index.html",
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+
+        @"action": @{
+            @"default_title": @"Test Action",
+            @"default_popup": @"popup.html",
+            @"default_icon": @{
+                @"16": @"icons/toolbar-16.png",
+                @"32": @"icons/toolbar-32.png",
+            },
+        },
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
+        auto *icon = [action iconForSize:CGSizeMake(48, 48)];
+        EXPECT_NOT_NULL(icon);
+        EXPECT_TRUE(CGSizeEqualToSize(icon.size, CGSizeMake(48, 48)));
+
+        [manager done];
+    };
+
+    [manager loadAndRun];
+}
+
 TEST(WKWebExtensionAPIAction, SetIconMultipleSizes)
 {
     auto *backgroundScript = Util::constructScript(@[
@@ -617,6 +671,81 @@ TEST(WKWebExtensionAPIAction, SetIconMultipleSizes)
     };
 
     auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:actionPopupManifest resources:resources]);
+    auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
+
+    manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {
+        auto *icon48 = [action iconForSize:CGSizeMake(48, 48)];
+        auto *icon96 = [action iconForSize:CGSizeMake(96, 96)];
+        auto *icon128 = [action iconForSize:CGSizeMake(128, 128)];
+
+        EXPECT_NOT_NULL(icon48);
+#if USE(APPKIT)
+        EXPECT_TRUE(CGSizeEqualToSize(icon48.size, CGSizeMake(48, 48)));
+#else
+        EXPECT_TRUE(CGSizeEqualToSize(icon48.size, CGSizeMake(128, 128)));
+#endif
+
+        EXPECT_NOT_NULL(icon96);
+#if USE(APPKIT)
+        EXPECT_TRUE(CGSizeEqualToSize(icon96.size, CGSizeMake(96, 96)));
+#else
+        EXPECT_TRUE(CGSizeEqualToSize(icon96.size, CGSizeMake(128, 128)));
+#endif
+
+        EXPECT_NOT_NULL(icon128);
+        EXPECT_TRUE(CGSizeEqualToSize(icon128.size, CGSizeMake(128, 128)));
+
+        [manager done];
+    };
+
+    [manager loadAndRun];
+}
+
+TEST(WKWebExtensionAPIAction, SetIconMultipleSizesRelative)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"await browser.action.setIcon({ path: { '48': '../icons/toolbar-48.png', '96': '../icons/toolbar-96.png', '128': '../icons/toolbar-128.png' } })",
+
+        @"browser.action.openPopup()"
+    ]);
+
+    auto *largeToolbarIcon = Util::makePNGData(CGSizeMake(48, 48), @selector(yellowColor));
+    auto *extraLargeToolbarIcon = Util::makePNGData(CGSizeMake(96, 96), @selector(greenColor));
+    auto *superExtraLargeToolbarIcon = Util::makePNGData(CGSizeMake(128, 128), @selector(purpleColor));
+
+    auto *resources = @{
+        @"background/index.html": @"<script type='module' src='script.js'></script>",
+        @"background/script.js": backgroundScript,
+        @"icons/toolbar-48.png": largeToolbarIcon,
+        @"icons/toolbar-96.png": extraLargeToolbarIcon,
+        @"icons/toolbar-128.png": superExtraLargeToolbarIcon,
+        @"popup.html": @"Hello world!",
+    };
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Action Test",
+        @"description": @"Action Test",
+        @"version": @"1",
+
+        @"background": @{
+            @"page": @"background/index.html",
+            @"type": @"module",
+            @"persistent": @NO,
+        },
+
+        @"action": @{
+            @"default_title": @"Test Action",
+            @"default_popup": @"popup.html",
+            @"default_icon": @{
+                @"16": @"icons/toolbar-16.png",
+                @"32": @"icons/toolbar-32.png",
+            },
+        },
+    };
+
+    auto extension = adoptNS([[_WKWebExtension alloc] _initWithManifestDictionary:manifest resources:resources]);
     auto manager = adoptNS([[TestWebExtensionManager alloc] initForExtension:extension.get()]);
 
     manager.get().internalDelegate.presentPopupForAction = ^(_WKWebExtensionAction *action) {


### PR DESCRIPTION
#### d1de4e4831588a251562b79e7ce98382cc0b9340
<pre>
Paths in browser.action.setIcon should be relative.
<a href="https://webkit.org/b/271739">https://webkit.org/b/271739</a>
<a href="https://rdar.apple.com/125436223">rdar://125436223</a>

Reviewed by Brian Weinstein.

Resolve the path passed to action.setIcon() as relative to the current document.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm:
(WebKit::WebExtensionAction::icon): If custom icons fail, fallback to the default icons.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
(WebKit::WebExtensionAPIAction::setIcon): Resolve paths as relative against the frame&apos;s URL,
unless it is a data URL.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIAction.h:
* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPIAction.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIAction.mm:
(TEST(WKWebExtensionAPIAction, SetIconSinglePathRelative)): Added.
(TEST(WKWebExtensionAPIAction, SetIconMultipleSizesRelative)): Added.

Canonical link: <a href="https://commits.webkit.org/276733@main">https://commits.webkit.org/276733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8cdba1a0a7e2b4b5918bf4eb32162767f2b7263

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/47994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48126 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41468 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47767 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/21979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37267 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18386 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40309 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3506 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49862 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/16974 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44338 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21753 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43166 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22112 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6330 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->