### PR TITLE
Enable WebGPU in WebKitTestRunner

### DIFF
--- a/LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt
@@ -10,6 +10,7 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
+navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK
@@ -39,6 +40,7 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
+navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK

--- a/LayoutTests/fast/webgpu/accelerated-image-conversion-failure.html
+++ b/LayoutTests/fast/webgpu/accelerated-image-conversion-failure.html
@@ -14,11 +14,9 @@ function videoWithData() {
 }
 
 onload = async () => {
-    try {
-        let video1 = await videoWithData();
-        let imageBitmap4 = await createImageBitmap(video1);
-        let videoFrame7 = new VideoFrame(imageBitmap4, {timestamp: 0});
-    } catch { }
+    let video1 = await videoWithData();
+    let imageBitmap4 = await createImageBitmap(video1);
+    let videoFrame7 = new VideoFrame(imageBitmap4, {timestamp: 0});
     if (window.testRunner) { testRunner.notifyDone() }
 };
 </script>

--- a/LayoutTests/fast/webgpu/bind-group-layout-invalid.html
+++ b/LayoutTests/fast/webgpu/bind-group-layout-invalid.html
@@ -3,7 +3,6 @@ if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
 const log = globalThis.$vm?.print ?? console.log;
 
 onload = async () => {
-  try {
     adapter1 = await navigator.gpu.requestAdapter( { } );
     let promise3 = adapter1.requestDevice(
     {
@@ -11,8 +10,6 @@ onload = async () => {
     requiredFeatures: [
     'depth-clip-control',
     'depth32float-stencil8',
-    'texture-compression-etc2',
-    'texture-compression-astc',
     'indirect-first-instance',
     'shader-f16',
     'rg11b10ufloat-renderable',
@@ -22,11 +19,10 @@ onload = async () => {
     maxVertexAttributes: 22,
     maxVertexBufferArrayStride: 60002,
     maxStorageTexturesPerShaderStage: 36,
-    maxBindingsPerBindGroup: 9205,
+    maxBindingsPerBindGroup: 205,
     },
     }
     );
-
 
     let device1 = await promise3;
 
@@ -164,8 +160,7 @@ onload = async () => {
     );
 
     bindGroupLayout11.label = '\u0afc';
-  } catch { }
-  if (window.testRunner) { testRunner.notifyDone() }
+    if (window.testRunner) { testRunner.notifyDone() }
 };
 </script>
 This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/command-buffer-after-destruction.html
+++ b/LayoutTests/fast/webgpu/command-buffer-after-destruction.html
@@ -12,7 +12,6 @@ function videoWithData() {
   });
 }
 onload = async () => {
-  try {
     let adapter0 = await navigator.gpu.requestAdapter(
     {
     }
@@ -23,7 +22,6 @@ onload = async () => {
     requiredFeatures: [
     'depth-clip-control',
     'depth32float-stencil8',
-    'texture-compression-astc',
     'indirect-first-instance',
     'shader-f16',
     'rg11b10ufloat-renderable'
@@ -32,12 +30,12 @@ onload = async () => {
     maxColorAttachmentBytesPerSample: 34,
     maxVertexBufferArrayStride: 8035,
     maxStorageTexturesPerShaderStage: 9,
-    maxBindingsPerBindGroup: 6910,
+    maxBindingsPerBindGroup: 910,
     maxTextureArrayLayers: 980,
     maxTextureDimension1D: 8875,
     maxTextureDimension2D: 14193,
-    minStorageBufferOffsetAlignment: 32,
-    minUniformBufferOffsetAlignment: 128,
+    minStorageBufferOffsetAlignment: 256,
+    minUniformBufferOffsetAlignment: 256,
     },
     }
     );
@@ -60,8 +58,7 @@ onload = async () => {
     device1.destroy();
     let texture10 = gpuCanvasContext1.getCurrentTexture();
     let video3 = await videoWithData();
-  } catch { }
-  if (window.testRunner) { testRunner.notifyDone() }
+    if (window.testRunner) { testRunner.notifyDone() }
 };
 </script>
 This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/conversion-to-rg8unorm.html
+++ b/LayoutTests/fast/webgpu/conversion-to-rg8unorm.html
@@ -1,7 +1,6 @@
 <script>
 if (window.testRunner) { testRunner.dumpAsText(); testRunner.waitUntilDone() }
 onload = async () => {
-  try {
     let adapter0 = await navigator.gpu.requestAdapter(
     {
     }
@@ -12,8 +11,6 @@ onload = async () => {
     label: 'a',
     requiredFeatures: [
     'depth-clip-control',
-    'texture-compression-etc2',
-    'texture-compression-astc',
     'indirect-first-instance',
     'shader-f16',
     'rg11b10ufloat-renderable',
@@ -23,7 +20,7 @@ onload = async () => {
     maxVertexAttributes: 23,
     maxVertexBufferArrayStride: 46861,
     maxStorageTexturesPerShaderStage: 33,
-    maxBindingsPerBindGroup: 1499,
+    maxBindingsPerBindGroup: 499,
     },
     }
     );
@@ -73,8 +70,7 @@ onload = async () => {
     4191
     ]
     );
-  } catch { }
-  if (window.testRunner) { testRunner.notifyDone() }
+    if (window.testRunner) { testRunner.notifyDone() }
 };
 </script>
 This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/copy-texture-more-than-4gb.html
+++ b/LayoutTests/fast/webgpu/copy-texture-more-than-4gb.html
@@ -1,68 +1,64 @@
 <script>
 if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
 onload = async () => {
-    try {
-        let adapter0 = await navigator.gpu.requestAdapter();
-        let device0 = await adapter0.requestDevice(
-        {
-        label: '\u0a1d',
-        requiredFeatures: [
-        'depth-clip-control',
-        'depth32float-stencil8',
-        'texture-compression-etc2',
-        'texture-compression-astc',
-        'indirect-first-instance',
-        'shader-f16',
-        'rg11b10ufloat-renderable',
-        'bgra8unorm-storage'
-        ],
-        }
-        );
+    let adapter0 = await navigator.gpu.requestAdapter();
+    let device0 = await adapter0.requestDevice(
+    {
+    label: '\u0a1d',
+    requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage'
+    ],
+    }
+    );
 
-        let imageData1 = new ImageData(104, 188);
-        let texture17 = device0.createTexture(
-        {
-        label: '\u2801',
-        size: {
-        width: 1177,
-        height: 963,
-        depthOrArrayLayers: 319,
-        },
-        mipLevelCount: 1,
-        sampleCount: 1,
-        dimension: '3d',
-        format: 'bgra8unorm-srgb',
-        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
-        viewFormats: [
-        'bgra8unorm',
-        'bgra8unorm-srgb',
-        'bgra8unorm-srgb',
-        'bgra8unorm-srgb',
-        'bgra8unorm',
-        'bgra8unorm-srgb',
-        'bgra8unorm',
-        'bgra8unorm',
-        'bgra8unorm-srgb'
-        ],
-        }
-        );
-        device0.queue.copyExternalImageToTexture(
-        {
-          source: imageData1,
-          origin: { x: 45, y: 127 },
-          flipY: true,
-        },
-        {
-          texture: texture17,
-          mipLevel: 0,
-          origin: { x: 261, y: 0, z: 114 },
-          aspect: 'all',
-          colorSpace: 'srgb',
-          premultipliedAlpha: true,
-        },
-        {width: 56, height: 1, depthOrArrayLayers: 0}
-        );
-    } catch {}
+    let imageData1 = new ImageData(104, 188);
+    let texture17 = device0.createTexture(
+    {
+    label: '\u2801',
+    size: {
+    width: 1177,
+    height: 963,
+    depthOrArrayLayers: 319,
+    },
+    mipLevelCount: 1,
+    sampleCount: 1,
+    dimension: '3d',
+    format: 'bgra8unorm-srgb',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+    viewFormats: [
+    'bgra8unorm',
+    'bgra8unorm-srgb',
+    'bgra8unorm-srgb',
+    'bgra8unorm-srgb',
+    'bgra8unorm',
+    'bgra8unorm-srgb',
+    'bgra8unorm',
+    'bgra8unorm',
+    'bgra8unorm-srgb'
+    ],
+    }
+    );
+    device0.queue.copyExternalImageToTexture(
+    {
+      source: imageData1,
+      origin: { x: 45, y: 127 },
+      flipY: true,
+    },
+    {
+      texture: texture17,
+      mipLevel: 0,
+      origin: { x: 261, y: 0, z: 114 },
+      aspect: 'all',
+      colorSpace: 'srgb',
+      premultipliedAlpha: true,
+    },
+    {width: 56, height: 1, depthOrArrayLayers: 0}
+    );
     if (window.testRunner) { testRunner.notifyDone() }
 };
 </script>

--- a/LayoutTests/fast/webgpu/forbid-bottom-struct-member.html
+++ b/LayoutTests/fast/webgpu/forbid-bottom-struct-member.html
@@ -2,16 +2,14 @@
   <body>
     <script>
       const doTest = async () => {
-        try {
-            const adapter = await navigator.gpu.requestAdapter();
-            const device = await adapter.requestDevice();
-            const module = device.createShaderModule({
-              code: `
-                       struct S { x : u23 }
-                           @must_use fn foo() -> S { return S(); }
-                    `,
-            });
-        } catch (e) { }
+        const adapter = await navigator.gpu.requestAdapter();
+        const device = await adapter.requestDevice();
+        const module = device.createShaderModule({
+          code: `
+                   struct S { x : u23 }
+                       @must_use fn foo() -> S { return S(); }
+                `,
+        });
         if (window.testRunner) { testRunner.notifyDone() }
       };
       if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }

--- a/LayoutTests/fast/webgpu/image-data-8-bytes-per-pixel.html
+++ b/LayoutTests/fast/webgpu/image-data-8-bytes-per-pixel.html
@@ -24,75 +24,65 @@
 
     if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
     onload = async () => {
-        try {
-            let adapter0 = await navigator.gpu.requestAdapter(
-            {
-            }
-            );
+        let adapter0 = await navigator.gpu.requestAdapter(
+        {
+        }
+        );
 
-            let device0 = await adapter0.requestDevice(
-            {
-            requiredFeatures: [
-            'depth-clip-control',
-            'depth32float-stencil8',
-            'texture-compression-etc2',
-            'texture-compression-astc',
-            'shader-f16',
-            'rg11b10ufloat-renderable',
-            'bgra8unorm-storage'
-            ],
-            }
-            );
-            
-            let img0 = await imageWithData(2, 245, '#b84778');
+        let device0 = await adapter0.requestDevice(
+        {
+        requiredFeatures: [
+        'depth-clip-control',
+        'depth32float-stencil8',
+        'shader-f16',
+        'rg11b10ufloat-renderable',
+        'bgra8unorm-storage'
+        ],
+        }
+        );
+        
+        let img0 = await imageWithData(2, 245, '#b84778');
 
-            let texture3 = device0.createTexture(
-            {
-            size: {
-            width: 5209,
-            height: 5392,
-            depthOrArrayLayers: 1,
-            },
-            mipLevelCount: 7,
-            sampleCount: 1,
-            dimension: '3d',
-            format: 'astc-10x6-unorm',
-            usage: GPUTextureUsage.COPY_SRC,
-            viewFormats: [
-            'eac-r11snorm',
-            'rg8unorm',
-            'rg32float',
-            'eac-rg11snorm',
-            'rg16sint',
-            'rg32sint',
-            'etc2-rgba8unorm'
-            ],
-            }
-            );
-            
-            device0.queue.copyExternalImageToTexture(
-            {
-            source: img0,
-            origin: [
+        let texture3 = device0.createTexture(
+        {
+        size: {
+        width: 5209,
+        height: 5392,
+        depthOrArrayLayers: 1,
+        },
+        mipLevelCount: 7,
+        sampleCount: 1,
+        dimension: '3d',
+        format: 'rgba16float',
+        usage: GPUTextureUsage.COPY_SRC,
+        viewFormats: [
+        'rgb9e5ufloat'
+        ],
+        }
+        );
+        
+        device0.queue.copyExternalImageToTexture(
+        {
+        source: img0,
+        origin: [
 
-            ],
-            },
-            {
-            texture: texture3,
-            mipLevel: 6208,
-            origin: [
-            2518,
-            3374
-            ],
-            aspect: 'depth-only',
-            colorSpace: 'srgb',
-            premultipliedAlpha: true,
-            },
-            [
+        ],
+        },
+        {
+        texture: texture3,
+        mipLevel: 6208,
+        origin: [
+        2518,
+        3374
+        ],
+        aspect: 'depth-only',
+        colorSpace: 'srgb',
+        premultipliedAlpha: true,
+        },
+        [
 
-            ]
-            );
-        } catch {}
+        ]
+        );
         if (window.testRunner) { testRunner.notifyDone() }
     };
 </script>

--- a/LayoutTests/fast/webgpu/invalid-surface-height.html
+++ b/LayoutTests/fast/webgpu/invalid-surface-height.html
@@ -2,7 +2,6 @@
 if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
 
 onload = async () => {
-  try {
     let adapter0 = await navigator.gpu.requestAdapter(
     {
     }
@@ -13,8 +12,6 @@ onload = async () => {
     requiredFeatures: [
     'depth-clip-control',
     'depth32float-stencil8',
-    'texture-compression-etc2',
-    'texture-compression-astc',
     'shader-f16',
     'rg11b10ufloat-renderable',
     'bgra8unorm-storage'
@@ -24,13 +21,13 @@ onload = async () => {
     maxVertexAttributes: 17,
     maxVertexBufferArrayStride: 18611,
     maxStorageTexturesPerShaderStage: 41,
-    maxBindingsPerBindGroup: 7922,
+    maxBindingsPerBindGroup: 922,
     maxTextureArrayLayers: 402,
     maxTextureDimension1D: 12869,
     maxTextureDimension2D: 8698,
     maxVertexBuffers: 10,
-    minStorageBufferOffsetAlignment: 64,
-    minUniformBufferOffsetAlignment: 32,
+    minStorageBufferOffsetAlignment: 256,
+    minUniformBufferOffsetAlignment: 256,
     },
     }
     );
@@ -48,15 +45,10 @@ onload = async () => {
     format: 'rgba8unorm',
     usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_DST,
     viewFormats: [
-    'astc-5x5-unorm',
     'rg8sint',
     'r16sint',
     'bgra8unorm-srgb',
-    'etc2-rgb8a1unorm-srgb',
     'rgba32float',
-    'astc-4x4-unorm',
-    'astc-8x6-unorm',
-    'astc-12x12-unorm'
     ],
     colorSpace: 'srgb',
     alphaMode: 'premultiplied',
@@ -70,20 +62,17 @@ onload = async () => {
     maxVertexAttributes: 18,
     maxVertexBufferArrayStride: 51506,
     maxStorageTexturesPerShaderStage: 26,
-    maxBindingsPerBindGroup: 9286,
+    maxBindingsPerBindGroup: 286,
     maxTextureArrayLayers: 1815,
     maxTextureDimension1D: 9422,
     maxTextureDimension2D: 15639,
     maxVertexBuffers: 12,
-    minStorageBufferOffsetAlignment: 32,
-    minUniformBufferOffsetAlignment: 64,
+    minStorageBufferOffsetAlignment: 256,
+    minUniformBufferOffsetAlignment: 256,
     },
     }
     );
-  } catch (e) {
-
-  }
-  if (window.testRunner) { testRunner.notifyDone() }
+    if (window.testRunner) { testRunner.notifyDone() }
 };
 </script>
 This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/multidimensional-texture-bounds.html
+++ b/LayoutTests/fast/webgpu/multidimensional-texture-bounds.html
@@ -1,71 +1,68 @@
 <script>
 if (window.testRunner) { testRunner.dumpAsText(); testRunner.waitUntilDone() }
 onload = async () => {
-    try {
-        let adapter1 = await navigator.gpu.requestAdapter({ });
-        let device3 = await adapter1.requestDevice(
-        {
-        label: '\u0f95',
-        requiredFeatures: [
-        'depth-clip-control',
-        'texture-compression-etc2',
-        'indirect-first-instance',
-        'shader-f16',
-        'rg11b10ufloat-renderable',
-        'bgra8unorm-storage'
-        ],
-        requiredLimits: {
-        maxColorAttachmentBytesPerSample: 49,
-        maxVertexAttributes: 22,
-        maxVertexBufferArrayStride: 22731,
-        maxStorageTexturesPerShaderStage: 13,
-        maxBindingsPerBindGroup: 2463,
-        maxTextureArrayLayers: 717,
-        maxTextureDimension1D: 9624,
-        maxTextureDimension2D: 12505,
-        maxVertexBuffers: 12,
-        minUniformBufferOffsetAlignment: 32,
-        },
-        }
-        );
-        
-        let texture10 = device3.createTexture(
-        {
-        label: '\udec9',
-        size: {width: 1521, height: 1, depthOrArrayLayers: 1613},
-        mipLevelCount: 3,
-        dimension: '3d',
-        format: 'rg32uint',
-        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
-        viewFormats: [
-        'rg32uint',
-        'rg32uint',
-        'rg32uint',
-        'rg32uint',
-        'rg32uint',
-        'rg32uint',
-        'rg32uint',
-        'rg32uint',
-        'rg32uint'
-        ],
-        }
-        );
-        
-        device3.queue.writeTexture(
-        {
-          texture: texture10,
-          mipLevel: 0,
-          origin: { x: 218, y: 0, z: 616 },
-          aspect: 'all',
-        },
-        new ArrayBuffer(4250119698), {
-        offset: 70,
-        bytesPerRow: 10739,
-        rowsPerImage: 652,
-        },
-        {width: 1254, height: 1, depthOrArrayLayers: 608}
-        );
-    } catch {}
+    let adapter1 = await navigator.gpu.requestAdapter({ });
+    let device3 = await adapter1.requestDevice(
+    {
+    label: '\u0f95',
+    requiredFeatures: [
+    'depth-clip-control',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage'
+    ],
+    requiredLimits: {
+    maxColorAttachmentBytesPerSample: 49,
+    maxVertexAttributes: 22,
+    maxVertexBufferArrayStride: 22731,
+    maxStorageTexturesPerShaderStage: 13,
+    maxBindingsPerBindGroup: 463,
+    maxTextureArrayLayers: 717,
+    maxTextureDimension1D: 9624,
+    maxTextureDimension2D: 12505,
+    maxVertexBuffers: 12,
+    minUniformBufferOffsetAlignment: 256,
+    },
+    }
+    );
+    
+    let texture10 = device3.createTexture(
+    {
+    label: '\udec9',
+    size: {width: 1521, height: 1, depthOrArrayLayers: 1613},
+    mipLevelCount: 3,
+    dimension: '3d',
+    format: 'rg32uint',
+    usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    viewFormats: [
+    'rg32uint',
+    'rg32uint',
+    'rg32uint',
+    'rg32uint',
+    'rg32uint',
+    'rg32uint',
+    'rg32uint',
+    'rg32uint',
+    'rg32uint'
+    ],
+    }
+    );
+    
+    device3.queue.writeTexture(
+    {
+      texture: texture10,
+      mipLevel: 0,
+      origin: { x: 218, y: 0, z: 616 },
+      aspect: 'all',
+    },
+    new ArrayBuffer(4250119698), {
+    offset: 70,
+    bytesPerRow: 10739,
+    rowsPerImage: 652,
+    },
+    {width: 1254, height: 1, depthOrArrayLayers: 608}
+    );
     
     setTimeout(()=>{
         if (window.testRunner) { testRunner.notifyDone() }

--- a/LayoutTests/fast/webgpu/null-video-texture.html
+++ b/LayoutTests/fast/webgpu/null-video-texture.html
@@ -1,7 +1,6 @@
 <script>
 if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
 onload = async () => {
-  try {
     let adapter1 = await navigator.gpu.requestAdapter(
     {
     }
@@ -15,13 +14,13 @@ onload = async () => {
     maxVertexAttributes: 30,
     maxVertexBufferArrayStride: 52234,
     maxStorageTexturesPerShaderStage: 5,
-    maxBindingsPerBindGroup: 2969,
+    maxBindingsPerBindGroup: 969,
     maxTextureArrayLayers: 896,
     maxTextureDimension1D: 12165,
     maxTextureDimension2D: 10419,
     maxVertexBuffers: 12,
-    minStorageBufferOffsetAlignment: 32,
-    minUniformBufferOffsetAlignment: 64,
+    minStorageBufferOffsetAlignment: 256,
+    minUniformBufferOffsetAlignment: 256,
     },
     }
     );
@@ -68,8 +67,7 @@ onload = async () => {
     },
     {width: 10, height: 0, depthOrArrayLayers: 1}
     );
-  } catch { }
-  if (window.testRunner) { testRunner.notifyDone() }
+    if (window.testRunner) { testRunner.notifyDone() }
 };
 </script>
 This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/optional-media-identifier.html
+++ b/LayoutTests/fast/webgpu/optional-media-identifier.html
@@ -13,7 +13,6 @@ function videoWithData() {
 }
 
 onload = async () => {
-  try {
     let video = await videoWithData();
     let videoFrame = new VideoFrame(video, {timestamp: 0});
     try { videoFrame.close() } catch {}
@@ -23,8 +22,6 @@ onload = async () => {
       label: 'a',
       requiredFeatures: [
         'depth32float-stencil8',
-        'texture-compression-etc2',
-        'texture-compression-astc',
         'shader-f16',
         'rg11b10ufloat-renderable'
       ],
@@ -32,12 +29,11 @@ onload = async () => {
       maxVertexAttributes: 22,
       maxVertexBufferArrayStride: 51879,
       maxStorageTexturesPerShaderStage: 25,
-      maxBindingsPerBindGroup: 1319,
+      maxBindingsPerBindGroup: 319,
       },
     });
     let externalTexture15 = device3.importExternalTexture({ label: 'a', source: video6, colorSpace: 'srgb', });
-  } catch {}
-  globalThis.testRunner?.notifyDone();
+    globalThis.testRunner?.notifyDone();
 };
 </script>
 This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/present-without-compute-pipeline.html
+++ b/LayoutTests/fast/webgpu/present-without-compute-pipeline.html
@@ -55,7 +55,6 @@ async function imageWithData(width, height, color) {
 }
 
 onload = async () => {
-  try {
 let adapter0 = await navigator.gpu.requestAdapter(
 {
 }
@@ -107,7 +106,7 @@ depthOrArrayLayers: 244,
 mipLevelCount: 3,
 sampleCount: 1,
 dimension: '3d',
-format: 'rgba8unorm',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.TEXTURE_BINDING,
 viewFormats: [
 'bgra8unorm',
@@ -125,12 +124,9 @@ let renderBundle0 = device0.createRenderBundleEncoder(
 {
 label: 'a',
 colorFormats: [
-'rgba8unorm-srgb',
-'rgb10a2unorm',
-'rgb10a2uint',
-'bgra8unorm'
+'rgb9e5ufloat'
 ],
-depthStencilFormat: 'rgba32uint',
+depthStencilFormat: 'rgb9e5ufloat',
 sampleCount: 3191352,
 stencilReadOnly: true,
 }
@@ -228,7 +224,7 @@ size: {
 width: 5072,
 },
 mipLevelCount: 12,
-format: 'depth32float',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
 }
 );
@@ -290,8 +286,6 @@ label: 'a',
 requiredFeatures: [
 'depth-clip-control',
 'depth32float-stencil8',
-'texture-compression-etc2',
-'texture-compression-astc',
 'indirect-first-instance',
 'shader-f16',
 'rg11b10ufloat-renderable',
@@ -355,14 +349,10 @@ size: [
 mipLevelCount: 3,
 sampleCount: 0,
 dimension: '3d',
-format: 'astc-4x4-unorm-srgb',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
 viewFormats: [
-'astc-5x4-unorm-srgb',
-'astc-8x6-unorm',
 'rgba32sint',
-'astc-6x6-unorm-srgb',
-'astc-10x8-unorm-srgb'
 ],
 }
 );
@@ -433,7 +423,7 @@ depthOrArrayLayers: 8444,
 },
 mipLevelCount: 8,
 sampleCount: 1,
-format: 'rgba32sint',
+format: 'rgb9e5ufloat',
 usage: 0,
 }
 );
@@ -471,13 +461,9 @@ computePassEncoder2.dispatchWorkgroups(
 let renderBundle1 = device1.createRenderBundleEncoder(
 {
 colorFormats: [
-'rg16float',
-'bgra8unorm',
-'astc-10x10-unorm-srgb',
-'astc-5x4-unorm-srgb',
-'astc-6x5-unorm-srgb'
+'rgb9e5ufloat'
 ],
-depthStencilFormat: 'eac-r11snorm',
+depthStencilFormat: 'rgb9e5ufloat',
 stencilReadOnly: true,
 }
 ).finish();
@@ -569,8 +555,6 @@ let device2 = await adapter2.requestDevice(
 label: 'a',
 requiredFeatures: [
 'depth32float-stencil8',
-'texture-compression-etc2',
-'texture-compression-astc',
 'indirect-first-instance',
 'shader-f16',
 'rg11b10ufloat-renderable',
@@ -594,7 +578,7 @@ visibility: GPUShaderStage.VERTEX,
 storageTexture: {
 access: 'read-only',
 viewDimension: '2d-array',
-format: 'rgba8unorm',
+format: 'rgb9e5ufloat',
 },
 },
 {
@@ -610,7 +594,7 @@ multisampled: true,
 },
 storageTexture: {
 access: 'read-only',
-format: 'rgb10a2unorm',
+format: 'rgb9e5ufloat',
 viewDimension: '1d',
 },
 externalTexture: {},
@@ -637,7 +621,7 @@ visibility: GPUShaderStage.VERTEX,
 storageTexture: {
 access: 'read-only',
 viewDimension: '3d',
-format: 'rgba32sint',
+format: 'rgb9e5ufloat',
 },
 }
 ],
@@ -707,8 +691,6 @@ let device3 = await adapter3.requestDevice(
 label: 'a',
 requiredFeatures: [
 'depth32float-stencil8',
-'texture-compression-etc2',
-'texture-compression-astc',
 'indirect-first-instance',
 'rg11b10ufloat-renderable'
 ],
@@ -786,7 +768,7 @@ visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
 storageTexture: {
 access: 'write-only',
 viewDimension: '1d',
-format: 'rgba8unorm',
+format: 'rgb9e5ufloat',
 },
 },
 {
@@ -806,7 +788,7 @@ size: [
 
 ],
 sampleCount: 1,
-format: 'rgb10a2unorm',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
 viewFormats: [
 'rgba32float',
@@ -935,11 +917,9 @@ size: [
 mipLevelCount: 13,
 sampleCount: 0,
 dimension: '3d',
-format: 'r32float',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
 viewFormats: [
-'astc-6x6-unorm',
-'astc-6x5-unorm-srgb',
 'depth24plus'
 ],
 }
@@ -972,9 +952,9 @@ let renderBundle2 = device2.createRenderBundleEncoder(
 {
 label: 'a',
 colorFormats: [
-
+'rgb9e5ufloat'
 ],
-depthStencilFormat: 'rg16uint',
+depthStencilFormat: 'rgb9e5ufloat',
 sampleCount: 6079640,
 depthReadOnly: true,
 stencilReadOnly: true,
@@ -1386,9 +1366,9 @@ let renderBundleEncoder0 = device0.createRenderBundleEncoder(
 {
 label: 'a',
 colorFormats: [
-
+'rgb9e5ufloat'
 ],
-depthStencilFormat: 'stencil8',
+depthStencilFormat: 'rgb9e5ufloat',
 depthReadOnly: true,
 }
 );
@@ -1560,7 +1540,7 @@ multisampled: true,
 },
 storageTexture: {
 access: 'write-only',
-format: 'astc-10x10-unorm-srgb',
+format: 'rgb9e5ufloat',
 viewDimension: '2d',
 },
 externalTexture: {},
@@ -1600,11 +1580,9 @@ size: [
 mipLevelCount: 8,
 sampleCount: 4,
 dimension: '3d',
-format: 'astc-6x5-unorm-srgb',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
 viewFormats: [
-'astc-8x6-unorm',
-'astc-6x5-unorm-srgb',
 'depth32float-stencil8',
 'rgba8snorm'
 ],
@@ -1674,7 +1652,7 @@ size: [
 9657
 ],
 mipLevelCount: 6,
-format: 'rgba16uint',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
 viewFormats: [
 'r8unorm'
@@ -1879,12 +1857,9 @@ let renderBundleEncoder1 = device1.createRenderBundleEncoder(
 {
 label: 'a',
 colorFormats: [
-'astc-12x12-unorm-srgb',
-'astc-10x6-unorm',
-'astc-8x6-unorm-srgb',
-'astc-6x5-unorm-srgb'
+'rgb9e5ufloat'
 ],
-depthStencilFormat: 'rgb10a2unorm',
+depthStencilFormat: 'rgb9e5ufloat',
 sampleCount: 4230936,
 depthReadOnly: true,
 stencilReadOnly: true,
@@ -2069,7 +2044,7 @@ binding: 221,
 visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
 storageTexture: {
 access: 'read-only',
-format: 'r32float',
+format: 'rgb9e5ufloat',
 },
 },
 {
@@ -2092,7 +2067,7 @@ visibility: GPUShaderStage.VERTEX | GPUShaderStage.COMPUTE,
 storageTexture: {
 access: 'read-only',
 viewDimension: '2d',
-format: 'rg32uint',
+format: 'rgb9e5ufloat',
 },
 },
 {
@@ -2110,7 +2085,7 @@ buffer: {
 hasDynamicOffset: true,
 },
 storageTexture: {
-format: 'r16sint',
+format: 'rgb9e5ufloat',
 viewDimension: 'cube-array',
 },
 externalTexture: {},
@@ -2121,7 +2096,7 @@ visibility: GPUShaderStage.VERTEX,
 storageTexture: {
 access: 'read-only',
 viewDimension: '2d',
-format: 'rg32float',
+format: 'rgb9e5ufloat',
 },
 },
 {
@@ -2169,9 +2144,9 @@ let renderBundleEncoder2 = device3.createRenderBundleEncoder(
 {
 label: 'a',
 colorFormats: [
-'r16sint'
+'rgb9e5ufloat'
 ],
-depthStencilFormat: 'eac-rg11snorm',
+depthStencilFormat: 'rgb9e5ufloat',
 sampleCount: 6447000,
 stencilReadOnly: true,
 }
@@ -2253,13 +2228,11 @@ depthOrArrayLayers: 1,
 },
 mipLevelCount: 7,
 sampleCount: 12,
-format: 'eac-r11unorm',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
 viewFormats: [
 'depth16unorm',
-'astc-8x5-unorm',
 'rgb10a2unorm',
-'astc-6x5-unorm',
 'r8snorm',
 'r8snorm'
 ],
@@ -2301,7 +2274,7 @@ size: [
 mipLevelCount: 5,
 sampleCount: 3,
 dimension: '3d',
-format: 'r8sint',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
 }
 );
@@ -2451,7 +2424,7 @@ size: [
 ],
 mipLevelCount: 3,
 sampleCount: 15,
-format: 'rg32uint',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
 }
 );
@@ -2485,7 +2458,6 @@ format: 'bgra8unorm',
 usage: GPUTextureUsage.RENDER_ATTACHMENT,
 viewFormats: [
 'bgra8unorm',
-'astc-6x5-unorm'
 ],
 colorSpace: 'srgb',
 alphaMode: 'premultiplied',
@@ -2981,7 +2953,7 @@ depthOrArrayLayers: 7416,
 mipLevelCount: 8,
 sampleCount: 1,
 dimension: '1d',
-format: 'rg8sint',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
 }
 );
@@ -3074,7 +3046,7 @@ size: [
 9473
 ],
 dimension: '1d',
-format: 'eac-r11unorm',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
 }
 );
@@ -3247,11 +3219,9 @@ let renderBundleEncoder3 = device0.createRenderBundleEncoder(
 {
 label: 'a',
 colorFormats: [
-'rg8unorm',
-'rgb10a2uint',
-'r8sint'
+'rgb9e5ufloat'
 ],
-depthStencilFormat: 'rgba16float',
+depthStencilFormat: 'rgb9e5ufloat',
 sampleCount: 4483064,
 depthReadOnly: true,
 stencilReadOnly: true,
@@ -3329,7 +3299,7 @@ height: 6875,
 },
 mipLevelCount: 14,
 sampleCount: 4,
-format: 'astc-10x6-unorm-srgb',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
 }
 );
@@ -3578,13 +3548,9 @@ format: 'rgba8unorm',
 usage: GPUTextureUsage.COPY_DST,
 viewFormats: [
 'rgb9e5ufloat',
-'astc-6x5-unorm',
 'r16sint',
 'rgba8sint',
-'astc-5x5-unorm-srgb',
-'astc-10x8-unorm-srgb',
-'rg8uint',
-'astc-10x8-unorm'
+'rg8uint'
 ],
 colorSpace: 'srgb',
 alphaMode: 'opaque',
@@ -3717,7 +3683,6 @@ label: 'a',
 requiredFeatures: [
 'depth-clip-control',
 'depth32float-stencil8',
-'texture-compression-astc',
 'indirect-first-instance',
 'shader-f16',
 'rg11b10ufloat-renderable',
@@ -3954,11 +3919,9 @@ let renderBundleEncoder4 = device3.createRenderBundleEncoder(
 {
 label: 'a',
 colorFormats: [
-'rg16sint',
-'depth32float',
-'rg32float'
+'rgb9e5ufloat'
 ],
-depthStencilFormat: 'rg32uint',
+depthStencilFormat: 'rgb9e5ufloat',
 depthReadOnly: true,
 stencilReadOnly: true,
 }
@@ -4379,7 +4342,7 @@ size: [
 mipLevelCount: 14,
 sampleCount: 15,
 dimension: '1d',
-format: 'r32sint',
+format: 'rgb9e5ufloat',
 usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
 }
 );
@@ -4727,9 +4690,7 @@ device: device3,
 format: 'bgra8unorm',
 viewFormats: [
 'rgba8sint',
-'depth16unorm',
-'etc2-rgb8unorm-srgb',
-'astc-8x6-unorm-srgb'
+'depth16unorm'
 ],
 colorSpace: 'srgb',
 alphaMode: 'opaque',
@@ -4847,15 +4808,11 @@ depthOrArrayLayers: 8741,
 },
 mipLevelCount: 3,
 dimension: '2d',
-format: 'depth32float',
+format: 'rgb9e5ufloat',
 usage: 0,
 viewFormats: [
 'rgb10a2uint',
-'astc-10x10-unorm',
-'astc-6x6-unorm-srgb',
 'rgb10a2uint',
-'astc-5x4-unorm-srgb',
-'astc-4x4-unorm',
 'bgra8unorm',
 'rgba16uint',
 'r8uint'
@@ -4866,13 +4823,9 @@ let renderBundle4 = device1.createRenderBundleEncoder(
 {
 label: 'a',
 colorFormats: [
-'r8unorm',
-'rg16sint',
-'astc-6x5-unorm-srgb',
-'eac-rg11unorm',
-'r32float'
+'rgb9e5ufloat'
 ],
-depthStencilFormat: 'astc-4x4-unorm-srgb',
+depthStencilFormat: 'rgb9e5ufloat',
 sampleCount: 2791232,
 depthReadOnly: true,
 }
@@ -4949,14 +4902,10 @@ device: device2,
 format: 'rgba8unorm',
 usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
 viewFormats: [
-'etc2-rgb8unorm',
 'r16float',
 'bgra8unorm-srgb',
-'etc2-rgba8unorm-srgb',
-'astc-5x5-unorm-srgb',
 'r16float',
 'r8unorm',
-'astc-12x10-unorm-srgb'
 ],
 colorSpace: 'srgb',
 alphaMode: 'premultiplied',
@@ -5113,7 +5062,6 @@ device: device4,
 format: 'rgba16float',
 usage: 0,
 viewFormats: [
-'astc-8x8-unorm-srgb',
 'r16sint',
 'r8unorm',
 'r32sint',
@@ -5145,42 +5093,7 @@ try { videoFrame3.close(); } catch {}
 
 let texture41 = gpuCanvasContext0.getCurrentTexture();
 
-  log('the end')
-  } catch (e) {
-    log('error');
-    log(e);
-    log(e[Symbol.toStringTag]);
-    log(e.stack);
-    if (e instanceof GPUPipelineError) {
-      log(`${e} - ${e.reason}`);
-      
-    } else if (e instanceof DOMException) {
-      if (e.name === 'OperationError') {
-      log(e.message);
-      
-      } else if (e.name === 'InvalidStateError' && (
-e.message === 'xxVideoFrame is detached'
-// || e.message === 'ImageBitmap is detached'
-// || e.message === 'Video element has no video frame' // ???
-// || e.message === ''
-)) {
-      } else {
-        log(e);
-        
-      }
-    } else if (e instanceof GPUValidationError) {
-      log(e);
-      
-    } else if (e instanceof TypeError) {
-      log(e);
-      
-    } else {
-      log('unexpected error type');
-      log(e);
-      
-    }
-  }
-  globalThis.testRunner?.notifyDone();
+globalThis.testRunner?.notifyDone();
 };
 </script>
 This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/queue-write-texture-offset.html
+++ b/LayoutTests/fast/webgpu/queue-write-texture-offset.html
@@ -1,7 +1,6 @@
 <script>
 if (window.testRunner) { testRunner.dumpAsText(); testRunner.waitUntilDone() }
 onload = async () => {
-  try {
     let adapter1 = await navigator.gpu.requestAdapter();
 
     let adapter2 = await navigator.gpu.requestAdapter(
@@ -21,8 +20,6 @@ onload = async () => {
     requiredFeatures: [
     'depth-clip-control',
     'depth32float-stencil8',
-    'texture-compression-etc2',
-    'texture-compression-astc',
     'indirect-first-instance',
     'shader-f16',
     'rg11b10ufloat-renderable',
@@ -32,7 +29,7 @@ onload = async () => {
     maxVertexAttributes: 18,
     maxVertexBufferArrayStride: 11955,
     maxStorageTexturesPerShaderStage: 36,
-    maxBindingsPerBindGroup: 5823,
+    maxBindingsPerBindGroup: 823,
     },
     }
     );
@@ -41,8 +38,6 @@ onload = async () => {
     {
     label: 'a',
     requiredFeatures: [
-    'texture-compression-etc2',
-    'texture-compression-astc',
     'indirect-first-instance',
     'shader-f16',
     'rg11b10ufloat-renderable',
@@ -52,7 +47,7 @@ onload = async () => {
     maxVertexAttributes: 27,
     maxVertexBufferArrayStride: 56492,
     maxStorageTexturesPerShaderStage: 20,
-    maxBindingsPerBindGroup: 1044,
+    maxBindingsPerBindGroup: 44,
     },
     }
     );
@@ -128,7 +123,7 @@ onload = async () => {
     },
     mipLevelCount: 14,
     dimension: '3d',
-    format: 'astc-10x10-unorm',
+    format: 'rgb9e5ufloat',
     usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
     viewFormats: [
     'stencil8',
@@ -182,15 +177,13 @@ onload = async () => {
     requiredFeatures: [
     'depth-clip-control',
     'depth32float-stencil8',
-    'texture-compression-etc2',
     'indirect-first-instance',
     'shader-f16',
     'rg11b10ufloat-renderable'
     ],
     }
     );
-  } catch {}
-  if (window.testRunner) { testRunner.notifyDone() }
+    if (window.testRunner) { testRunner.notifyDone() }
 };
 </script>
 This test passes if it does not crash

--- a/LayoutTests/fast/webgpu/render-bundle-validation-color-format.html
+++ b/LayoutTests/fast/webgpu/render-bundle-validation-color-format.html
@@ -4,7 +4,6 @@ if (window.testRunner) {
     testRunner.dumpAsText();
 }
 onload = async () => {
-  try {
     let adapter0 = await navigator.gpu.requestAdapter();
     let device0 = await adapter0.requestDevice();
 
@@ -233,8 +232,7 @@ onload = async () => {
     );
     
     renderBundleEncoder0.setPipeline(pipeline);
-  } catch (e) { }
-  window.testRunner?.notifyDone();
+    window.testRunner?.notifyDone();
 }
 </script>
 This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/repeated-out-of-memory-error.html
+++ b/LayoutTests/fast/webgpu/repeated-out-of-memory-error.html
@@ -6,77 +6,75 @@ This test passes if it does not crash.
     }
 
     onload = async () => {
-        try {
-            let adapter0 = await navigator.gpu.requestAdapter(
-                {
-                    powerPreference: 'high-performance',
-                }
-            );
-            let device0 = await adapter0.requestDevice(
-                {
-                    label: '\u{1fc7e}',
-                    requiredFeatures: [
-                        'depth-clip-control',
-                        'shader-f16',
-                        'bgra8unorm-storage'
-                    ],
-                    requiredLimits: {
-                        maxColorAttachmentBytesPerSample: 60,
-                        maxVertexAttributes: 30,
-                        maxVertexBufferArrayStride: 11348,
-                        maxStorageTexturesPerShaderStage: 42,
-                        maxBindingsPerBindGroup: 7372,
-                        maxTextureArrayLayers: 2011
-                    },
-                }
-            );
-            let bindGroupLayout0 = device0.createBindGroupLayout(
-                {
-                    entries: [
-                        {
-                            binding: 5869,
-                            visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
-                            texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
-                        }
-                    ],
-                }
-            );
-            device0.addEventListener('uncapturederror', e => { e.label = device0.label; });
-            device0.createTexture(
-                {
-                    label: '\u04ab',
-                    size: {
-                        width: 7798,
-                        height: 7120,
-                        depthOrArrayLayers: 377,
-                    },
-                    format: 'stencil8',
-                    usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
-                }
-            );
-            let sampler5 = device0.createSampler(
-                {
-                    addressModeU: 'repeat',
-                    addressModeV: 'mirror-repeat',
-                    addressModeW: 'mirror-repeat',
-                    minFilter: 'nearest',
-                    lodMinClamp: 45.683,
-                    lodMaxClamp: 77.763,
-                    compare: 'always',
-                }
-            );
-            let bindGroup0 = device0.createBindGroup(
-                {
-                    layout: bindGroupLayout0,
-                    entries: [
-                        {
-                            binding: 646,
-                            resource: sampler5,
-                        }
-                    ],
-                }
-            );
-        } catch (e) { }
+        let adapter0 = await navigator.gpu.requestAdapter(
+            {
+                powerPreference: 'high-performance',
+            }
+        );
+        let device0 = await adapter0.requestDevice(
+            {
+                label: '\u{1fc7e}',
+                requiredFeatures: [
+                    'depth-clip-control',
+                    'shader-f16',
+                    'bgra8unorm-storage'
+                ],
+                requiredLimits: {
+                    maxColorAttachmentBytesPerSample: 60,
+                    maxVertexAttributes: 30,
+                    maxVertexBufferArrayStride: 11348,
+                    maxStorageTexturesPerShaderStage: 42,
+                    maxBindingsPerBindGroup: 372,
+                    maxTextureArrayLayers: 2011
+                },
+            }
+        );
+        let bindGroupLayout0 = device0.createBindGroupLayout(
+            {
+                entries: [
+                    {
+                        binding: 5869,
+                        visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+                        texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+                    }
+                ],
+            }
+        );
+        device0.addEventListener('uncapturederror', e => { e.label = device0.label; });
+        device0.createTexture(
+            {
+                label: '\u04ab',
+                size: {
+                    width: 7798,
+                    height: 7120,
+                    depthOrArrayLayers: 377,
+                },
+                format: 'stencil8',
+                usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+            }
+        );
+        let sampler5 = device0.createSampler(
+            {
+                addressModeU: 'repeat',
+                addressModeV: 'mirror-repeat',
+                addressModeW: 'mirror-repeat',
+                minFilter: 'nearest',
+                lodMinClamp: 45.683,
+                lodMaxClamp: 77.763,
+                compare: 'always',
+            }
+        );
+        let bindGroup0 = device0.createBindGroup(
+            {
+                layout: bindGroupLayout0,
+                entries: [
+                    {
+                        binding: 646,
+                        resource: sampler5,
+                    }
+                ],
+            }
+        );
         if (window.testRunner)
             testRunner.notifyDone();
     };

--- a/LayoutTests/fast/webgpu/type-checker-array-without-argument.html
+++ b/LayoutTests/fast/webgpu/type-checker-array-without-argument.html
@@ -2,7 +2,6 @@
   <body>
     <script>
       const doTest = async () => {
-        try {
           const adapter = await navigator.gpu.requestAdapter();
           const device = await adapter.requestDevice();
           const module = device.createShaderModule({
@@ -36,7 +35,6 @@
               }
             `,
           });
-        } catch (e) { }
         if (window.testRunner) { testRunner.notifyDone() }
       };
       if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }

--- a/LayoutTests/fast/webgpu/use-canvas-without-layer.html
+++ b/LayoutTests/fast/webgpu/use-canvas-without-layer.html
@@ -1,7 +1,6 @@
 <script>
 if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
 onload = async () => {
-  try {
     let adapter12 = await navigator.gpu.requestAdapter({ });
     let device10 = await adapter12.requestDevice({ label: '\u0678' } );
     let canvas25 = document.createElement('canvas');
@@ -16,8 +15,7 @@ onload = async () => {
     }
     );
     let texture95 = gpuCanvasContext17.getCurrentTexture();
-  } catch (e) { }
-  if (window.testRunner) { testRunner.notifyDone() }
+    if (window.testRunner) { testRunner.notifyDone() }
 };
 </script>
 This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/write-to-destroyed-buffer.html
+++ b/LayoutTests/fast/webgpu/write-to-destroyed-buffer.html
@@ -4,7 +4,6 @@ if (window.testRunner) {
     testRunner.dumpAsText();
 }
 onload = async () => {
-  try {
 let adapter0 = await navigator.gpu.requestAdapter(
 {
 }
@@ -19,8 +18,6 @@ let device0 = await adapter0.requestDevice(
 label: 'a',
 requiredFeatures: [
 'depth-clip-control',
-'texture-compression-etc2',
-'texture-compression-astc',
 'indirect-first-instance',
 'shader-f16',
 'rg11b10ufloat-renderable',
@@ -290,7 +287,6 @@ let device2 = await (await navigator.gpu.requestAdapter(
 label: 'a',
 requiredFeatures: [
 'depth32float-stencil8',
-'texture-compression-astc',
 'shader-f16',
 'rg11b10ufloat-renderable',
 'bgra8unorm-storage'
@@ -579,8 +575,7 @@ new ArrayBuffer(3659080)
 } catch {}
 try { videoFrame0.close(); } catch {}
 try { videoFrame2.close(); } catch {}
-  } catch { }
-  if (window.testRunner) { testRunner.notifyDone() }
+if (window.testRunner) { testRunner.notifyDone() }
 };
 </script>
 This test passes if it does not crash.

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3548,6 +3548,7 @@ webkit.org/b/237108 http/tests/websocket/tests/hybi/simple-wss.html [ Failure ]
 webkit.org/b/236298 fast/text/combining-character-sequence-vertical.html [ ImageOnlyFailure ]
 webkit.org/b/236298 fast/text/strikethrough-int.html [ ImageOnlyFailure ]
 
+fast/webgpu [ Skip ]
 http/tests/webgpu/webgpu/api/operation/memory_sync/buffer/multiple_buffers.html [ Skip ]
 
 # NetworkStorageSession::deleteCookies() doesn't obey partitioning for glib ports.

--- a/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
@@ -7,6 +7,7 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
+navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK
@@ -41,6 +42,7 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
+navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4068,6 +4068,7 @@ webkit.org/b/251306 http/tests/in-app-browser-privacy/sub-frame-redirect-to-non-
 
 webkit.org/b/254714 imported/w3c/web-platform-tests/css/css-images/image-set/image-set-calc-x-rendering-2.html [ ImageOnlyFailure ]
 
+fast/webgpu [ Skip ]
 http/tests/webgpu/webgpu/idl/constants/flags.html [ Skip ]
 http/tests/webgpu/webgpu/idl/exposed.https.html [ Skip ]
 http/tests/webgpu/webgpu/idl/exposed.http.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
@@ -10,6 +10,7 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
+navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.identity is OK
 navigator.isLoggedIn() is OK
@@ -53,6 +54,7 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
+navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.identity is OK
 navigator.isLoggedIn() is OK

--- a/LayoutTests/platform/mac/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/navigator-detached-no-crash-expected.txt
@@ -8,6 +8,7 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
+navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK
@@ -35,6 +36,7 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
+navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK

--- a/LayoutTests/platform/wincairo/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/wincairo/fast/dom/navigator-detached-no-crash-expected.txt
@@ -7,6 +7,7 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
+navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK
@@ -39,6 +40,7 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
+navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK

--- a/LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt
@@ -7,6 +7,7 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
+navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK
@@ -42,6 +43,7 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
+navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
 navigator.language is OK

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCreateImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCreateImpl.cpp
@@ -50,7 +50,7 @@ RefPtr<GPU> create(ScheduleWorkFunction&& scheduleWorkFunction, const WebCore::P
 #endif
     auto scheduleWorkBlock = makeBlockPtr([scheduleWorkFunction = WTFMove(scheduleWorkFunction)](WGPUWorkItem workItem)
     {
-        scheduleWorkFunction(CompletionHandler<void(void)>(makeBlockPtr(WTFMove(workItem)), CompletionHandlerCallThread::AnyThread));
+        scheduleWorkFunction(Function<void()>(makeBlockPtr(WTFMove(workItem))));
     });
     WGPUInstanceCocoaDescriptor cocoaDescriptor {
         {

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCreateImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCreateImpl.h
@@ -38,7 +38,7 @@ class ProcessIdentity;
 
 namespace WebCore::WebGPU {
 
-using WorkItem = CompletionHandler<void(void)>;
+using WorkItem = Function<void()>;
 using ScheduleWorkFunction = Function<void(WorkItem&&)>;
 WEBCORE_EXPORT RefPtr<GPU> create(ScheduleWorkFunction&&, const WebCore::ProcessIdentity*);
 

--- a/Source/WebGPU/WebGPU/Instance.h
+++ b/Source/WebGPU/WebGPU/Instance.h
@@ -64,7 +64,7 @@ public:
     bool isValid() const { return m_isValid; }
 
     // This can be called on a background thread.
-    using WorkItem = CompletionHandler<void(void)>;
+    using WorkItem = Function<void()>;
     void scheduleWork(WorkItem&&);
     const std::optional<const MachSendRight>& webProcessID() const;
 

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -55,7 +55,7 @@ private:
     PresentationContextIOSurface(const WGPUSurfaceDescriptor&, const Instance&);
 
     void renderBuffersWereRecreated(NSArray<IOSurface *> *renderBuffers);
-    void onSubmittedWorkScheduled(CompletionHandler<void()>&&);
+    void onSubmittedWorkScheduled(Function<void()>&&);
 
     NSArray<IOSurface *> *m_ioSurfaces { nil };
     struct RenderBuffer {

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -77,7 +77,7 @@ void PresentationContextIOSurface::renderBuffersWereRecreated(NSArray<IOSurface 
     m_renderBuffers.clear();
 }
 
-void PresentationContextIOSurface::onSubmittedWorkScheduled(CompletionHandler<void()>&& completionHandler)
+void PresentationContextIOSurface::onSubmittedWorkScheduled(Function<void()>&& completionHandler)
 {
     if (m_device)
         m_device->getQueue().onSubmittedWorkScheduled(WTFMove(completionHandler));

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -68,7 +68,7 @@ public:
     void writeTexture(const WGPUImageCopyTexture& destination, void* data, size_t dataSize, const WGPUTextureDataLayout&, const WGPUExtent3D& writeSize, bool skipValidation = false);
     void setLabel(String&&);
 
-    void onSubmittedWorkScheduled(CompletionHandler<void()>&&);
+    void onSubmittedWorkScheduled(Function<void()>&&);
 
     bool isValid() const { return m_commandQueue; }
     void makeInvalid();

--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -126,11 +126,6 @@ static bool shouldDumpJSConsoleLogInStdErr(const std::string& pathOrURL)
     return false;
 }
 
-static bool shouldEnableWebGPU(const std::string& pathOrURL)
-{
-    return pathContains(pathOrURL, "webgpu/");
-}
-
 static bool shouldSetDefaultPortsForWTR(const std::string& pathOrURL)
 {
     return pathContains(pathOrURL, "localhost:8000/") || pathContains(pathOrURL, "localhost:8443/")
@@ -159,8 +154,6 @@ TestFeatures hardcodedFeaturesBasedOnPathForTest(const TestCommand& command)
         features.doubleTestRunnerFeatures.insert({ "viewWidth", viewWidthAndHeight->first });
         features.doubleTestRunnerFeatures.insert({ "viewHeight", viewWidthAndHeight->second });
     }
-    if (shouldEnableWebGPU(command.pathOrURL))
-        features.boolWebPreferenceFeatures.insert({ "WebGPUEnabled", true });
     if (shouldSetDefaultPortsForWTR(command.pathOrURL)) {
         features.uint16TestRunnerFeatures.insert({ "insecureUpgradePort", 8000 });
         features.uint16TestRunnerFeatures.insert({ "secureUpgradePort", 8443 });

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1074,6 +1074,7 @@ void TestController::resetPreferencesToConsistentValues(const TestOptions& optio
             WKPreferencesEnableAllExperimentalFeatures(preferences);
             WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("SiteIsolationEnabled").get());
             WKPreferencesSetExperimentalFeatureForKey(preferences, false, toWK("CFNetworkNetworkLoaderEnabled").get());
+            WKPreferencesSetExperimentalFeatureForKey(preferences, true, toWK("WebGPUEnabled").get());
         }
 
         WKPreferencesResetAllInternalDebugFeatures(preferences);


### PR DESCRIPTION
#### 3929136b4e632a0734bacadee8e164e28abde80e
<pre>
Enable WebGPU in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=271744">https://bugs.webkit.org/show_bug.cgi?id=271744</a>
<a href="https://rdar.apple.com/125823851">rdar://125823851</a>

Reviewed by Mike Wyrzykowski.

For some unknown and mysterious reason, enabling it in hardcodedFeaturesBasedOnPathForTest
was insufficient to actually enable WebGPU in WebKitTestRunner.  There&apos;s no reason to limit
its existence to just WebGPU tests.  Let&apos;s enable it in all tests.

I had written several tests with extra try/catch statements to work if WebGPU was enabled
or not.  Now that it&apos;s enabled in WebKitTestRunner, I can remove these and make the tests
more effective in catching regressions.

In order to make the tests run to completion on computers with different GPUs made by different
manufacturers, I had to reduce all the maxBindingsPerBindGroup values to less than 1000,
remove all requirements to have etc2 and astc texture compression extensions, and use a
more commonly supported texture format, which I arbitrarily chose to be rgb9e5ufloat.
Also minStorageBufferOffsetAlignment and minUniformBufferOffsetAlignment need to be 256.
These things were unrelated to the original issues for which I introduced the tests.

The iOS simulator is unfortunately currently unable to run WebGPU tests, so I skip them there.

In order to fix assertions in debug builds, I changed some types from CompletionHandler&lt;void()&gt;
to Function&lt;void()&gt; because StreamConnectionWorkQueue::dispatch is not actually guaranteed
to call the function if m_shouldQuit ever becomes true because stopAndWaitForCompletion is called.

* LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/fast/webgpu/accelerated-image-conversion-failure.html:
* LayoutTests/fast/webgpu/bind-group-layout-invalid.html:
* LayoutTests/fast/webgpu/command-buffer-after-destruction.html:
* LayoutTests/fast/webgpu/conversion-to-rg8unorm.html:
* LayoutTests/fast/webgpu/copy-texture-more-than-4gb.html:
* LayoutTests/fast/webgpu/forbid-bottom-struct-member.html:
* LayoutTests/fast/webgpu/image-data-8-bytes-per-pixel.html:
* LayoutTests/fast/webgpu/invalid-surface-height.html:
* LayoutTests/fast/webgpu/multidimensional-texture-bounds.html:
* LayoutTests/fast/webgpu/null-video-texture.html:
* LayoutTests/fast/webgpu/optional-media-identifier.html:
* LayoutTests/fast/webgpu/present-without-compute-pipeline.html:
* LayoutTests/fast/webgpu/queue-write-texture-offset.html:
* LayoutTests/fast/webgpu/render-bundle-validation-color-format.html:
* LayoutTests/fast/webgpu/repeated-out-of-memory-error.html:
* LayoutTests/fast/webgpu/type-checker-array-without-argument.html:
* LayoutTests/fast/webgpu/use-canvas-without-layer.html:
* LayoutTests/fast/webgpu/write-to-destroyed-buffer.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/mac/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/wincairo/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt:
* Tools/TestRunnerShared/TestFeatures.cpp:
(WTR::hardcodedFeaturesBasedOnPathForTest):
(WTR::shouldEnableWebGPU): Deleted.
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetPreferencesToConsistentValues):

Canonical link: <a href="https://commits.webkit.org/277246@main">https://commits.webkit.org/277246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/719c8fde7a434c4364b9a81281ac74de486790bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49768 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43134 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49391 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31488 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38353 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47665 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23724 "Found 1 new test failure: fast/writing-mode/english-bt-text-with-spelling-marker.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40572 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19660 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41721 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5129 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43458 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42124 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51643 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45645 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40719 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44645 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24168 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6617 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->