### PR TITLE
Web Inspector: Dark Mode: Increase contrast in common files for @media (prefers-color-scheme: dark) and @media (prefers-contrast: more)

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -115,5 +116,23 @@ body.window-inactive .navigation-bar .item.button.disabled > img {
 
     .navigation-bar .item.button.disabled > img {
         filter: invert();
+    }
+
+    @media (prefers-contrast: more) {
+        .navigation-bar .item.button > .glyph {
+            opacity: 85%;
+        }
+
+        .navigation-bar .item.button:not(.disabled) > .glyph {
+            color: var(--glyph-color);
+        }
+
+        .navigation-bar .item.button:not(.disabled):is(.activate.activated, .radio.selected) > .glyph {
+            color: hsl(212, 100%, 90%);
+        }
+
+        .navigation-bar .item.button:not(.disabled):active:is(.activate.activated, .radio.selected) > .glyph {
+            color: hsl(212, 92%, 90%);;
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -298,5 +299,11 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline.dom:focus-with
 
     .tree-outline.dom .html-pseudo-element {
         color: hsl(0, 80%, 65%);
+    }
+
+    @media (prefers-contrast: more) {
+        .content-view.dom-tree.deemphasize-unrendered .tree-outline.dom li:not(.rendered, .selected) > span > *:not(.html-comment), .content-view.dom-tree.deemphasize-unrendered .tree-outline.dom:not(:focus-within) li.selected:not(.rendered) > span > *:not(.html-comment), body:is(.window-inactive, .window-docked-inactive) .content-view.dom-tree.deemphasize-unrendered .tree-outline.dom li.selected:not(.rendered) > span > *:not(.html-comment) {
+            opacity: 1;
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -392,5 +393,11 @@ body:not(.window-inactive, .window-docked-inactive) .data-grid:focus tr.editable
 
     .data-grid th:is(.sort-ascending, .sort-descending) > .header-cell-content:first-child::after {
         filter: invert();
+    }
+
+    @media (prefers-contrast: more) {
+        .data-grid tr.filler td {
+            background: hsl(0, 0%, 15%);
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DetailsSection.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -312,5 +313,21 @@ body[dir=rtl] .details-section > .header::before {
     .details-section > .header > label,
     .details-section > .content > .group > .row.simple > .label {
         color: var(--text-color-secondary);
+    }
+
+    @media (prefers-contrast: more) {
+        .details-section > .header {
+            --details-section-header-color: white;
+            color: var(--details-section-header-color);
+        }
+
+        .details-section > .content > .group > .row:is(.empty, .text) {
+            color: var(--details-section-header-color);
+        }
+
+        .details-section > .header > label,
+        .details-section > .content > .group > .row.simple > .label {
+            color: var(--details-section-header-color);
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/FilterBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FilterBar.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -115,4 +116,16 @@
 
 :is(.filter-bar, .search-bar).invalid > input[type="search"] {
     border-color: var(--error-text-color);
+}
+
+@media (prefers-color-scheme: dark) {
+    @media (prefers-contrast: more) {
+        :is(.filter-bar, .search-bar) > input[type="search"] {
+            color: white;
+        }
+
+        .filter-bar > .navigation-bar > .item.button {
+            background: hsl(0, 0%, 15%);
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/FindBanner.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FindBanner.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+  * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -224,8 +225,31 @@ body[dir=rtl] .find-banner > button.segmented.next-result:active:not(:disabled) 
         filter: invert();
     }
 
+    .find-banner > button:active:not(:disabled) {
+        border: 1px solid var(--border-color);
+        background-color: grey;
+    }
+
     .find-banner > input[type="search"] {
         background-color: var(--background-color-alternate);
         border-color: var(--background-color-selected);
+    }
+
+    @media (prefers-contrast: more) {
+        .find-banner > button {
+            background-color: hsl(0, 0%, 20%);
+        }
+
+        .find-banner > button:active:not(:disabled) {
+            background-color: hsl(0, 0%, 90%);
+        }
+
+        body[dir=ltr] .find-banner > button.segmented > .glyph {
+            opacity: 200%;
+        }
+
+        body[dir=ltr] .find-banner > button.segmented.previous-result > .glyph:active:not(:disabled) {
+            opacity: 300%;
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/Main.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Main.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -504,7 +505,7 @@ body[dir=rtl] [dir=ltr] .go-to-arrow {
     height: var(--reference-page-link-size);
     font-size: 14px;
     line-height: 18px;
-    color: var(--text-color);
+    color: var(--question-mark-color);
     text-decoration: none;
     background-color: var(--button-background-color);
     border: var(--stroke-width) solid var(--border-color);
@@ -536,18 +537,16 @@ body[dir=rtl] [dir=ltr] .go-to-arrow {
     .reference-page-link:active {
         background-color: hsl(0, 0%, 50%);
     }
-}
 
-@keyframes tab-bar-console-item-pulse {
-    50% { opacity: 0.6; }
-}
+    @keyframes tab-bar-console-item-pulse {
+        50% { opacity: 0.6; }
+    }
 
-.tab-bar > .navigation-bar :is(.console-warnings, .console-errors):not(.disabled).pulsing {
-    animation-name: tab-bar-console-item-pulse;
-    animation-duration: 0.75s;
-}
+    .tab-bar > .navigation-bar :is(.console-warnings, .console-errors):not(.disabled).pulsing {
+        animation-name: tab-bar-console-item-pulse;
+        animation-duration: 0.75s;
+    }
 
-@media (prefers-color-scheme: dark) {
     #undocked-title-area {
         box-shadow: none;
     }
@@ -587,5 +586,25 @@ body[dir=rtl] [dir=ltr] .go-to-arrow {
 
     :is(img, canvas).show-grid {
         --checkerboard-dark-square: hsl(0, 0%, 5%);
+    }
+
+    @media (prefers-contrast: more) {
+        .search-settings > .glyph {
+            --glyph-color: white;
+            color: var(--glyph-color);
+        }
+
+        .search-settings:active > .glyph {
+            color: var(--glyph-color);
+        }
+
+        .search-settings:active.active > .glyph {
+            color: var(--glyph-color);
+        }
+
+        body {
+            color: white;
+            background-size: contain;
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/RadioButtonNavigationItem.css
+++ b/Source/WebInspectorUI/UserInterface/Views/RadioButtonNavigationItem.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -60,4 +61,12 @@
 
 .navigation-bar .item.radio.button.text-only.selected:active::before {
     filter: brightness(0.8);
+}
+
+@media (prefers-color-scheme: dark) {
+    @media (prefers-contrast: more) {
+        .navigation-bar .item.button:not(.disabled):is(.activate.activated, .radio.selected) > .glyph {
+            color: hsl(212, 100%, 70%);
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -118,4 +119,21 @@
     margin-top: -1px;
     margin-bottom: -1px;
     margin-inline: 6px 2px;
+}
+
+@media (prefers-color-scheme: dark) {
+    @media (prefers-contrast: more) {
+        .scope-bar > li {
+            color: hsl(0, 0%, 90%);
+            --scope-bar-border-color: var(--scope-bar-border-color-override, transparent);
+        }
+
+        .scope-bar > li:is(.selected, :hover) {
+            --scope-bar-background-color-default: hsl(212, 100%, 35%);
+        }
+
+        .scope-bar > li:is(.selected, :hover) {
+            --scope-bar-background-color-default: hsl(212, 100%, 35%);
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -169,5 +170,14 @@
     .spreadsheet-css-declaration .origin .go-to-link:hover {
         color: var(--text-color-secondary);
     }
-}
 
+    @media (prefers-contrast: more) {
+        .spreadsheet-css-declaration .origin {
+            color: hsl(0, 0%, 90%);
+        }
+
+        .spreadsheet-css-declaration .selector.editing:focus, .spreadsheet-css-declaration .selector > .matched {
+            color: hsl(0, 0%, 100%);
+        }
+    }
+}

--- a/Source/WebInspectorUI/UserInterface/Views/SyntaxHighlightingDefaultTheme.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SyntaxHighlightingDefaultTheme.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -161,5 +162,35 @@
 
     .cm-s-default .cm-builtin {
         color: hsl(218, 64%, 76%);
+    }
+
+    .syntax-highlighted :is(.html-doctype, .html-processing-instruction) {
+        color: hsl(0, 0%, 90%);
+    }
+
+    @media (prefers-contrast: more) {
+        .cm-s-default .cm-meta {
+            --text-color: hsl(0, 0%, 100%);
+        }
+
+        .cm-s-default .cm-attribute {
+            color: hsl(222, 100%, 80%);
+        }
+
+        .cm-s-default .cm-variable-3 {
+            color: hsl(160, 69%, 80%);
+        }
+
+        .cm-s-default .cm-meta {
+            color: hsl(0, 0%, 80%);
+        }
+
+        .cm-s-default .cm-variable-3 {
+            color: hsl(160, 69%, 80%);
+        }
+
+        .cm-s-default .cm-builtin {
+            color: hsl(218, 64%, 80%);
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TabBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TabBar.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -415,5 +416,38 @@ body.window-inactive .tab-bar > .tabs.animating.closing-tab > .item:not(.disable
 
     body:not(.mac-platform.monterey, .mac-platform.big-sur).window-inactive .tab-bar > .tabs > .item:not(.disabled).selected {
         --tab-item-background: hsl(0, 0%, 19%);
+    }
+
+    @media (prefers-contrast: more) {
+        .tab-bar > .tabs > .item:not(.disabled).selected > .name {
+            color: hsl(0, 0%, var(--foreground-lightness));
+        }
+
+        .tab-bar > .tabs > .item:not(.selected):hover > .name {
+            color: hsl(0, 0%, var(--foreground-lightness));
+        }
+
+        .tab-bar > .tabs > .item > .name {
+            color: hsla(0, 0%, var(--foreground-lightness));
+        }
+
+        @media (prefers-contrast: more) {
+            .tab-bar > .tabs > .item > .icon {
+                color: hsl(0, 0%, 90%);
+            }
+
+            .tab-bar > .tabs > .item:not(.disabled).selected > .name {
+                color: hsl(0, 0%, 100%);
+            }
+
+            .tab-bar > .tabs > .item > .name {
+                color: hsla(0, 0%, 90%);
+                border: white;
+            }
+
+            .tab-bar > .tabs > .item:not(.selected):hover > .name {
+                color: hsl(0, 0%, 100%);
+            }
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TreeOutline.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TreeOutline.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -251,6 +252,16 @@ body:not(.window-inactive, .window-docked-inactive) .tree-outline:not(.large):fo
 
 @media (prefers-color-scheme: dark) {
     .tree-outline .item .subtitle {
-        color: var(--text-color-secondary);
+        color: hsl(0, 0%, 90%);
+    }
+
+    @media (prefers-contrast: more) {
+        .tree-outline .item .highlighted {
+            background-color: hsl(53, 83%, 30%);
+        }
+
+        .tree-outline .item.selected {
+            background-color: hsl(53, 83%, 35%);
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -21,10 +21,9 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
- */
+  */
 
-:root {
-    --z-index-highlight: 64;
+    :root {
     --z-index-header: 128;
     --z-index-resizer: 256;
     --z-index-popover: 512;
@@ -287,8 +286,6 @@
         --border-color: hsl(0, 0%, 33%);
         --border-color-secondary: hsl(0, 0%, 27%);
 
-        --button-background-color: hsl(0, 0%, 43%);
-        --button-background-color-hover: var(--button-background-color);
         --button-background-color-pressed: hsl(0, 0%, 55%);
         --button-background-color-inactive: hsl(0, 0%, 28%);
 
@@ -423,7 +420,7 @@ body {
             --border-color-secondary: hsl(0, 0%, 24%);
         }
     }
-    
+
     &:not(.mac-platform.monterey, .mac-platform.big-sur):not(.docked) {
         /* keep in sync with `WI.undockedTitleAreaHeight` */
         --undocked-title-area-height: calc(22px / var(--zoom-factor));


### PR DESCRIPTION
#### a65fd36f20fc4842021f2fa439bdea3af2bc5167
<pre>
Web Inspector: Dark Mode: Increase contrast in common files for @media (prefers-color-scheme: dark) and @media (prefers-contrast: more)
<a href="https://bugs.webkit.org/show_bug.cgi?id=271742">https://bugs.webkit.org/show_bug.cgi?id=271742</a>

Reviewed by NOBODY (OOPS!).

In @media (prefers-color-scheme: dark) and @media (prefers-contrast: more):
Lighten glyphs in ButtonNavigationItem.css.
Darken background in DataGrid.css.
Whiten text colors in DetailsSection.css.
Whiten background and darken the color of the navigation bar button in FilterBar.css.
Darken done button background in FindBanner.css.
Whiten text colors and the glyph colors in Main.css.
Darken scope bars and lighten the glyphs in RadioButtonNavigationItem.css.
Lighten texts of scope bars and darken the scope bars in ScopeBar.css.
Lighten highlights in SyntaxHighlightingDefaultTheme.css.
Increase opacity to 1 when the tree outline is highlighted or selected in TreeOutline.css.

* Source/WebInspectorUI/UserInterface/Views/ButtonNavigationItem.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .navigation-bar .item.button &gt; .glyph):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .navigation-bar .item.button:not(.disabled) &gt; .glyph):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .navigation-bar .item.button:not(.disabled):is(.activate.activated, .radio.selected) &gt; .glyph):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .navigation-bar .item.button:not(.disabled):active:is(.activate.activated, .radio.selected) &gt; .glyph):
* Source/WebInspectorUI/UserInterface/Views/DOMTreeOutline.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view.dom-tree.deemphasize-unrendered .tree-outline.dom li:not(.rendered, .selected) &gt; span &gt; *:not(.html-comment), .content-view.dom-tree.deemphasize-unrendered .tree-outline.dom:not(:focus-within) li.selected:not(.rendered) &gt; span &gt; *:not(.html-comment), body:is(.window-inactive, .window-docked-inactive) .content-view.dom-tree.deemphasize-unrendered .tree-outline.dom li.selected:not(.rendered) &gt; span &gt; *:not(.html-comment)):
* Source/WebInspectorUI/UserInterface/Views/DataGrid.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .data-grid tr.filler td):
* Source/WebInspectorUI/UserInterface/Views/DetailsSection.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section &gt; .header):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section &gt; .content &gt; .group &gt; .row:is(.empty, .text)):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .details-section &gt; .header &gt; label,):
* Source/WebInspectorUI/UserInterface/Views/FilterBar.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) :is(.filter-bar, .search-bar) &gt; input[type=&quot;search&quot;]):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .filter-bar &gt; .navigation-bar &gt; .item.button):
* Source/WebInspectorUI/UserInterface/Views/FindBanner.css:
(@media (prefers-color-scheme: dark) .find-banner &gt; button:active:not(:disabled)):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .find-banner &gt; button):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .find-banner &gt; button:active:not(:disabled)):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) body[dir=ltr] .find-banner &gt; button.segmented &gt; .glyph):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) body[dir=ltr] .find-banner &gt; button.segmented.previous-result &gt; .glyph:active:not(:disabled)):
* Source/WebInspectorUI/UserInterface/Views/Main.css:
(.reference-page-link):
(@media (prefers-color-scheme: dark) .reference-page-link:active):
(@media (prefers-color-scheme: dark) @keyframes tab-bar-console-item-pulse):
(.tab-bar &gt; .navigation-bar :is(.console-warnings, .console-errors):not(.disabled).pulsing):
(@media (prefers-contrast: more) .search-settings &gt; .glyph):
(@media (prefers-contrast: more) .search-settings:active &gt; .glyph):
(@media (prefers-contrast: more) .search-settings:active.active &gt; .glyph):
(@media (prefers-contrast: more) body):
(@keyframes tab-bar-console-item-pulse): Deleted.
(@media (prefers-color-scheme: dark) #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) body:is(.mac-platform.monterey, .mac-platform.big-sur) #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) body:not(.mac-platform.monterey, .mac-platform.big-sur) #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) body:is(.mac-platform.monterey, .mac-platform.big-sur).window-inactive #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) body:not(.mac-platform.monterey, .mac-platform.big-sur).window-inactive #undocked-title-area): Deleted.
(@media (prefers-color-scheme: dark) .go-to-arrow): Deleted.
(@media (prefers-color-scheme: dark) :focus .selected .go-to-arrow,): Deleted.
(@media (prefers-color-scheme: dark) .css-documentation-button): Deleted.
(@media (prefers-color-scheme: dark) .expand-list-button): Deleted.
(@media (prefers-color-scheme: dark) :is(img, canvas).show-grid): Deleted.
* Source/WebInspectorUI/UserInterface/Views/RadioButtonNavigationItem.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .navigation-bar .item.button:not(.disabled):is(.activate.activated, .radio.selected) &gt; .glyph):
* Source/WebInspectorUI/UserInterface/Views/ScopeBar.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .scope-bar &gt; li):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .scope-bar &gt; li:is(.selected, :hover)):
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetCSSStyleDeclarationSection.css:
(@media (prefers-color-scheme: dark) .spreadsheet-css-declaration .origin .go-to-link,):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .spreadsheet-css-declaration .origin):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .spreadsheet-css-declaration .selector.editing:focus, .spreadsheet-css-declaration .selector &gt; .matched):
* Source/WebInspectorUI/UserInterface/Views/SyntaxHighlightingDefaultTheme.css:
(@media (prefers-color-scheme: dark) .syntax-highlighted :is(.html-doctype, .html-processing-instruction)):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .cm-s-default .cm-meta):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .cm-s-default .cm-attribute):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .cm-s-default .cm-variable-3):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .cm-s-default .cm-builtin):
* Source/WebInspectorUI/UserInterface/Views/TabBar.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected &gt; .name):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .tab-bar &gt; .tabs &gt; .item:not(.selected):hover &gt; .name):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .tab-bar &gt; .tabs &gt; .item &gt; .name):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) @media (prefers-contrast: more) .tab-bar &gt; .tabs &gt; .item &gt; .icon):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) @media (prefers-contrast: more) .tab-bar &gt; .tabs &gt; .item:not(.disabled).selected &gt; .name):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) @media (prefers-contrast: more) .tab-bar &gt; .tabs &gt; .item &gt; .name):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) @media (prefers-contrast: more) .tab-bar &gt; .tabs &gt; .item:not(.selected):hover &gt; .name):
* Source/WebInspectorUI/UserInterface/Views/TreeOutline.css:
(@media (prefers-color-scheme: dark) .tree-outline .item .subtitle):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .tree-outline .item .highlighted):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .tree-outline .item.selected):
* Source/WebInspectorUI/UserInterface/Views/Variables.css:
(:root):
(body): Deleted.
(&amp;:is(.mac-platform.monterey, .mac-platform.big-sur)): Deleted.
(&amp;:not(.mac-platform.monterey, .mac-platform.big-sur):not(.docked)): Deleted.
(&amp;:is(.mac-platform.monterey, .mac-platform.big-sur):not(.docked)): Deleted.
(&amp;.mac-platform): Deleted.
* Websites/browserbench.org/Speedometer3.0/resources/newssite/news-site-css/dist/variables.css:
(:root): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a65fd36f20fc4842021f2fa439bdea3af2bc5167

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52461 "Failed to checkout and rebase branch from PR 26498") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31794 "Failed to checkout and rebase branch from PR 26498") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4883 "Failed to checkout and rebase branch from PR 26498") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55735 "Failed to checkout and rebase branch from PR 26498") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3184 "Failed to checkout and rebase branch from PR 26498") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38305 "Failed to checkout and rebase branch from PR 26498") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2883 "Failed to checkout and rebase branch from PR 26498") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/55735 "Failed to checkout and rebase branch from PR 26498") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/3184 "Failed to checkout and rebase branch from PR 26498") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54557 "Failed to checkout and rebase branch from PR 26498") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/38305 "Failed to checkout and rebase branch from PR 26498") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/4883 "Failed to checkout and rebase branch from PR 26498") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/55735 "Failed to checkout and rebase branch from PR 26498") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/38305 "Failed to checkout and rebase branch from PR 26498") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/4883 "Failed to checkout and rebase branch from PR 26498") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1343 "Failed to checkout and rebase branch from PR 26498") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/38305 "Failed to checkout and rebase branch from PR 26498") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/4883 "Failed to checkout and rebase branch from PR 26498") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57331 "Failed to checkout and rebase branch from PR 26498") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27588 "Failed to checkout and rebase branch from PR 26498") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/2883 "Failed to checkout and rebase branch from PR 26498") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/57331 "Failed to checkout and rebase branch from PR 26498") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28821 "Failed to checkout and rebase branch from PR 26498") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/4883 "Failed to checkout and rebase branch from PR 26498") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/57331 "Failed to checkout and rebase branch from PR 26498") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29732 "Failed to checkout and rebase branch from PR 26498") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28566 "Failed to checkout and rebase branch from PR 26498") | | | 
<!--EWS-Status-Bubble-End-->