### PR TITLE
Avoid tree traversal in FrameSelection::nodeWillBeRemoved in most cases

### DIFF
--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1479,6 +1479,7 @@ void Node::queueTaskToDispatchEvent(TaskSource source, Ref<Event>&& event)
 
 Node::InsertedIntoAncestorResult Node::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
+    ASSERT(!containsSelectionEndPoint());
     if (insertionType.connectedToDocument)
         setEventTargetFlag(EventTargetFlag::IsConnected);
     if (parentOfInsertedTree.isInShadowTree())
@@ -1491,6 +1492,7 @@ Node::InsertedIntoAncestorResult Node::insertedIntoAncestor(InsertionType insert
 
 void Node::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
+    ASSERT(!containsSelectionEndPoint());
     if (removalType.disconnectedFromDocument)
         clearEventTargetFlag(EventTargetFlag::IsConnected);
     if (isInShadowTree() && !treeScope().rootNode().isShadowRoot())

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -603,6 +603,9 @@ public:
 
     bool deletionHasBegun() const { return hasStateFlag(StateFlag::HasStartedDeletion); }
 
+    bool containsSelectionEndPoint() const { return hasStateFlag(StateFlag::ContainsSelectionEndPoint); }
+    void setContainsSelectionEndPoint(bool value) { setStateFlag(StateFlag::ContainsSelectionEndPoint, value); }
+
 protected:
     enum class TypeFlag : uint16_t {
         IsCharacterData = 1 << 0,
@@ -636,7 +639,8 @@ protected:
         ContainsOnlyASCIIWhitespaceIsValid = 1 << 7, // Only used on CharacterData.
         HasHeldBackChildrenChanged = 1 << 8,
         HasStartedDeletion = 1 << 9,
-        // 6-bits free.
+        ContainsSelectionEndPoint = 1 << 10,
+        // 5-bits free.
     };
 
     enum class ElementStateFlag : uint16_t {

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -287,6 +287,7 @@ private:
     void updateDataDetectorsForSelection();
 
     bool setSelectionWithoutUpdatingAppearance(const VisibleSelection&, OptionSet<SetSelectionOption>, CursorAlignOnScroll, TextGranularity);
+    void setNodeFlags(VisibleSelection&, bool value);
 
     void respondToNodeModification(Node&, bool anchorRemoved, bool focusRemoved, bool baseRemoved, bool extentRemoved, bool startRemoved, bool endRemoved);
     TextDirection directionOfEnclosingBlock();


### PR DESCRIPTION
#### f5e6dd1893d0ba8146411e4e62891fd8f6056eb5
<pre>
Avoid tree traversal in FrameSelection::nodeWillBeRemoved in most cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=271748">https://bugs.webkit.org/show_bug.cgi?id=271748</a>

Reviewed by Wenson Hsieh and Yusuke Suzuki.

This PR introduces a new node flag, StateFlag::ContainsSelectionEndPoint, which indicates whether
a given node contains a selection end point (start, end, base, extent, focus, or anchor), and uses
it to avoid tree walks in FrameSelection::nodeWillBeRemoved.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::insertedIntoAncestor): Assert that the node flag isn&apos;t set when a node is just
inserted into a DOM tree.
(WebCore::Node::removedFromAncestor): Ditto for removal.

* Source/WebCore/dom/Node.h:
(WebCore::Node::containsSelectionEndPoint const): Added.
(WebCore::Node::setContainsSelectionEndPoint): Added.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::setSelectionWithoutUpdatingAppearance):
(WebCore::setNodeContainsSelectionEndPoint): Added. Sets the node flag on all ancestor nodes given
a position.
(WebCore::FrameSelection::setNodeFlags): Added. Sets the node flag on ancestor nodes of each
selection end points: start, end, base, extent, focus, or anchor.
(WebCore::FrameSelection::nodeWillBeRemoved): Added the optimization.
(WebCore::FrameSelection::respondToNodeModification):
(WebCore::FrameSelection::willBeModified):

* Source/WebCore/editing/FrameSelection.h:

Canonical link: <a href="https://commits.webkit.org/276766@main">https://commits.webkit.org/276766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b22bd763382296f4c8c08f2f052985d07666edcb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48273 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41628 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22127 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37358 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18496 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40432 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3649 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50015 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44449 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21897 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43282 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6351 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->