### PR TITLE
Implement https://w3c.github.io/mediacapture-extensions/#exposing-mediastreamtrack-source-background-blur-support

### DIFF
--- a/LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints-expected.txt
@@ -22,6 +22,7 @@ PASS supportedConstraints.width is true
 PASS supportedConstraints.zoom is true
 
 PASS supportedConstraints["aspectRatio"] is true
+PASS supportedConstraints["backgroundBlur"] is true
 PASS supportedConstraints["deviceId"] is true
 PASS supportedConstraints["displaySurface"] is true
 PASS supportedConstraints["echoCancellation"] is true

--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt
@@ -5,6 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 video track capabilities:
   capabilities.aspectRatio = { max: 2560, min: 0.001 }
+  capabilities.backgroundBlur = [ false ]
   capabilities.deviceId = <UUID>
   capabilities.facingMode = [ user ]
   capabilities.frameRate = { max: 30, min: 1 }
@@ -21,6 +22,7 @@ audio track capabilities:
 
 video track capabilities:
   capabilities.aspectRatio = { max: 3840, min: 0.000 }
+  capabilities.backgroundBlur = [ true ]
   capabilities.deviceId = <UUID>
   capabilities.facingMode = [ environment ]
   capabilities.focusDistance = { min: 0.200 }
@@ -41,6 +43,7 @@ audio track capabilities:
 
 video track capabilities:
   capabilities.aspectRatio = { max: 3840, min: 0.000 }
+  capabilities.backgroundBlur = [ true ]
   capabilities.deviceId = <UUID>
   capabilities.facingMode = [ environment ]
   capabilities.focusDistance = { min: 0.200 }

--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getSettings-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getSettings-expected.txt
@@ -5,6 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 video track settings:
   settings.aspectRatio = 1.333
+  settings.backgroundBlur = false
   settings.deviceId = <UUID>
   settings.facingMode = user
   settings.frameRate = 30
@@ -22,6 +23,7 @@ audio track settings:
 According to the spec: "[every setting] MUST be a member of the set defined for that property by getCapabilities()"
 
 PASS "aspectRatio" in track.getCapabilities() is true
+PASS "backgroundBlur" in track.getCapabilities() is true
 PASS "deviceId" in track.getCapabilities() is true
 PASS "facingMode" in track.getCapabilities() is true
 PASS "frameRate" in track.getCapabilities() is true

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-backgroundBlur-expected.txt
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-backgroundBlur-expected.txt
@@ -1,0 +1,4 @@
+
+PASS getUserMedia backgroundBlur on
+PASS getUserMedia backgroundBlur off
+

--- a/LayoutTests/fast/mediastream/mediastreamtrack-video-backgroundBlur.html
+++ b/LayoutTests/fast/mediastream/mediastreamtrack-video-backgroundBlur.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <title>Camera background blur</title>
+    <script src='../../resources/testharness.js'></script>
+    <script src='../../resources/testharnessreport.js'></script>
+</head>
+<body>
+    <script>
+        promise_test(async (test) => {
+            assert_true(navigator.mediaDevices.getSupportedConstraints().backgroundBlur, "supported constraint");
+
+            const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode : "environment" } });
+            assert_array_equals(stream.getVideoTracks()[0].getCapabilities().backgroundBlur, [true], 'capabilities');
+            assert_true(stream.getVideoTracks()[0].getSettings().backgroundBlur, 'settings');
+        }, 'getUserMedia backgroundBlur on');
+
+        promise_test(async (test) => {
+            const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode : "user" } });
+            assert_array_equals(stream.getVideoTracks()[0].getCapabilities().backgroundBlur, [false], 'capabilities');
+            assert_false(stream.getVideoTracks()[0].getSettings().backgroundBlur, 'settings');
+        }, 'getUserMedia backgroundBlur off');
+    </script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -232,6 +232,7 @@ static bool hasInvalidGetDisplayMediaConstraint(const MediaConstraints& constrai
         case MediaConstraintType::WhiteBalanceMode:
         case MediaConstraintType::Zoom:
         case MediaConstraintType::Torch:
+        case MediaConstraintType::BackgroundBlur:
             // Ignored.
             break;
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -291,6 +291,9 @@ MediaStreamTrack::TrackSettings MediaStreamTrack::getSettings() const
     if (settings.supportsTorch())
         result.torch = settings.torch();
 
+    if (settings.supportsBackgroundBlur())
+        result.backgroundBlur = settings.backgroundBlur();
+
     return result;
 }
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -122,6 +122,7 @@ public:
         String whiteBalanceMode;
         std::optional<double> zoom;
         std::optional<bool> torch;
+        std::optional<bool> backgroundBlur;
     };
     TrackSettings getSettings() const;
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
@@ -94,4 +94,5 @@ enum MediaStreamTrackState { "live", "ended" };
 
     boolean torch;
 
+    boolean backgroundBlur;
 };

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
@@ -77,6 +77,25 @@ static Vector<bool> capabilityBooleanVector(RealtimeMediaSourceCapabilities::Ech
     return result;
 }
 
+static Vector<bool> capabilityBooleanVector(RealtimeMediaSourceCapabilities::BackgroundBlur backgroundBlur)
+{
+    Vector<bool> result;
+    result.reserveInitialCapacity(2);
+    switch (backgroundBlur) {
+    case RealtimeMediaSourceCapabilities::BackgroundBlur::On:
+        result.append(true);
+        break;
+    case RealtimeMediaSourceCapabilities::BackgroundBlur::Off:
+        result.append(false);
+        break;
+    case RealtimeMediaSourceCapabilities::BackgroundBlur::OnOff:
+        result.append(false);
+        result.append(true);
+        break;
+    }
+    return result;
+}
+
 MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities& capabilities, const String& groupId)
 {
     MediaTrackCapabilities result;
@@ -110,6 +129,8 @@ MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabil
         result.zoom = capabilityDoubleRange(capabilities.zoom());
     if (capabilities.supportsTorch())
         result.torch = capabilities.torch();
+    if (capabilities.supportsBackgroundBlur())
+        result.backgroundBlur = capabilityBooleanVector(capabilities.backgroundBlur());
 
     return result;
 }

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h
@@ -52,6 +52,7 @@ struct MediaTrackCapabilities {
     std::optional<Vector<String>> whiteBalanceMode;
     std::optional<DoubleRange> zoom;
     std::optional<bool> torch;
+    std::optional<Vector<bool>> backgroundBlur;
 };
 
 MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities&, const String& groupId);

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.idl
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.idl
@@ -62,4 +62,6 @@
     DoubleRange zoom;
 
     boolean torch;
+
+    sequence<boolean> backgroundBlur;
 };

--- a/Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp
@@ -178,6 +178,7 @@ static MediaTrackConstraintSetMap convertToInternalForm(ConstraintSetType setTyp
     set(result, setType, MediaConstraintType::Zoom, constraintSet.zoom);
     set(result, setType, MediaConstraintType::Torch, constraintSet.torch);
 
+    set(result, setType, MediaConstraintType::BackgroundBlur, constraintSet.backgroundBlur);
     return result;
 }
 

--- a/Source/WebCore/Modules/mediastream/MediaTrackConstraints.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackConstraints.h
@@ -79,6 +79,8 @@ struct MediaTrackConstraintSet {
     std::optional<ConstrainDOMString> whiteBalanceMode;
     std::optional<ConstrainDouble> zoom;
     std::optional<ConstrainBoolean> torch;
+
+    std::optional<ConstrainBoolean> backgroundBlur;
 };
 
 struct MediaTrackConstraints : MediaTrackConstraintSet {

--- a/Source/WebCore/Modules/mediastream/MediaTrackConstraints.idl
+++ b/Source/WebCore/Modules/mediastream/MediaTrackConstraints.idl
@@ -70,6 +70,7 @@
 
     ConstrainBoolean torch;
 
+    ConstrainBoolean backgroundBlur;
 };
 
 typedef (double or ConstrainDoubleRange) ConstrainDouble;

--- a/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h
@@ -50,6 +50,7 @@ struct MediaTrackSupportedConstraints {
     bool whiteBalanceMode { true };
     bool zoom { true };
     bool torch { true };
+    bool backgroundBlur { true };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl
+++ b/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl
@@ -65,4 +65,5 @@
     boolean zoom = true;
     boolean torch = true;
 
+    boolean backgroundBlur = true;
 };

--- a/Source/WebCore/platform/mediastream/MediaConstraintType.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraintType.cpp
@@ -68,6 +68,8 @@ String convertToString(MediaConstraintType type)
         return "zoom"_s;
     case MediaConstraintType::Torch:
         return "torch"_s;
+    case MediaConstraintType::BackgroundBlur:
+        return "backgroundBlur"_s;
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/mediastream/MediaConstraintType.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraintType.h
@@ -47,6 +47,7 @@ enum class MediaConstraintType : uint8_t {
     WhiteBalanceMode,
     Zoom,
     Torch,
+    BackgroundBlur,
 };
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/MediaConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.cpp
@@ -192,6 +192,7 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::WhiteBalanceMode:
     case MediaConstraintType::Zoom:
     case MediaConstraintType::Torch:
+    case MediaConstraintType::BackgroundBlur:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -227,6 +228,7 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::FocusDistance:
     case MediaConstraintType::WhiteBalanceMode:
     case MediaConstraintType::Torch:
+    case MediaConstraintType::BackgroundBlur:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -249,7 +251,9 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::Torch:
         m_torch = WTFMove(constraint);
         break;
-
+    case MediaConstraintType::BackgroundBlur:
+        m_backgroundBlur = WTFMove(constraint);
+        break;
     case MediaConstraintType::Width:
     case MediaConstraintType::Height:
     case MediaConstraintType::SampleRate:
@@ -300,6 +304,7 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::FocusDistance:
     case MediaConstraintType::Zoom:
     case MediaConstraintType::Torch:
+    case MediaConstraintType::BackgroundBlur:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -364,6 +369,7 @@ void MediaTrackConstraintSetMap::merge(MediaConstraintType constraintType, const
     case MediaConstraintType::LogicalSurface:
     case MediaConstraintType::Torch:
     case MediaConstraintType::FocusDistance:
+    case MediaConstraintType::BackgroundBlur:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -410,6 +416,7 @@ void MediaTrackConstraintSetMap::merge(MediaConstraintType constraintType, const
     case MediaConstraintType::LogicalSurface:
     case MediaConstraintType::Torch:
     case MediaConstraintType::FocusDistance:
+    case MediaConstraintType::BackgroundBlur:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -456,6 +463,7 @@ void MediaTrackConstraintSetMap::merge(MediaConstraintType constraintType, const
     case MediaConstraintType::LogicalSurface:
     case MediaConstraintType::Torch:
     case MediaConstraintType::FocusDistance:
+    case MediaConstraintType::BackgroundBlur:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -489,6 +497,13 @@ void MediaTrackConstraintSetMap::merge(MediaConstraintType constraintType, const
         else
             m_torch->merge(constraint);
         break;
+    case MediaConstraintType::BackgroundBlur:
+        if (!m_backgroundBlur)
+            m_backgroundBlur = constraint;
+        else
+            m_backgroundBlur->merge(constraint);
+        break;
+
     case MediaConstraintType::FacingMode:
     case MediaConstraintType::DeviceId:
     case MediaConstraintType::GroupId:
@@ -642,7 +657,7 @@ StringConstraint StringConstraint::isolatedCopy() const
 
 MediaTrackConstraintSetMap MediaTrackConstraintSetMap::isolatedCopy() const
 {
-    return { m_width, m_height, m_sampleRate, m_sampleSize, m_aspectRatio, m_frameRate, m_volume, m_echoCancellation, m_displaySurface, m_logicalSurface, crossThreadCopy(m_facingMode), crossThreadCopy(m_deviceId), crossThreadCopy(m_groupId), crossThreadCopy(m_whiteBalanceMode), m_zoom, m_torch };
+    return { m_width, m_height, m_sampleRate, m_sampleSize, m_aspectRatio, m_frameRate, m_volume, m_echoCancellation, m_displaySurface, m_logicalSurface, crossThreadCopy(m_facingMode), crossThreadCopy(m_deviceId), crossThreadCopy(m_groupId), crossThreadCopy(m_whiteBalanceMode), m_zoom, m_torch, m_backgroundBlur };
 }
 
 MediaConstraints MediaConstraints::isolatedCopy() const

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -583,7 +583,7 @@ private:
 class MediaTrackConstraintSetMap {
 public:
     MediaTrackConstraintSetMap() = default;
-    MediaTrackConstraintSetMap(std::optional<IntConstraint> width, std::optional<IntConstraint> height, std::optional<IntConstraint> sampleRate, std::optional<IntConstraint> sampleSize, std::optional<DoubleConstraint> aspectRatio, std::optional<DoubleConstraint> frameRate, std::optional<DoubleConstraint> volume, std::optional<BooleanConstraint> echoCancellation, std::optional<BooleanConstraint> displaySurface, std::optional<BooleanConstraint> logicalSurface, std::optional<StringConstraint>&& facingMode, std::optional<StringConstraint>&& deviceId, std::optional<StringConstraint>&& groupId, std::optional<StringConstraint>&& whiteBalanceMode, std::optional<DoubleConstraint> zoom, std::optional<BooleanConstraint> torch)
+    MediaTrackConstraintSetMap(std::optional<IntConstraint> width, std::optional<IntConstraint> height, std::optional<IntConstraint> sampleRate, std::optional<IntConstraint> sampleSize, std::optional<DoubleConstraint> aspectRatio, std::optional<DoubleConstraint> frameRate, std::optional<DoubleConstraint> volume, std::optional<BooleanConstraint> echoCancellation, std::optional<BooleanConstraint> displaySurface, std::optional<BooleanConstraint> logicalSurface, std::optional<StringConstraint>&& facingMode, std::optional<StringConstraint>&& deviceId, std::optional<StringConstraint>&& groupId, std::optional<StringConstraint>&& whiteBalanceMode, std::optional<DoubleConstraint> zoom, std::optional<BooleanConstraint> torch, std::optional<BooleanConstraint> backgroundBlur)
         : m_width(width)
         , m_height(height)
         , m_sampleRate(sampleRate)
@@ -600,6 +600,7 @@ public:
         , m_whiteBalanceMode(WTFMove(whiteBalanceMode))
         , m_zoom(zoom)
         , m_torch(torch)
+        , m_backgroundBlur(backgroundBlur)
     {
     }
 
@@ -640,6 +641,7 @@ public:
     const std::optional<StringConstraint>& whiteBalanceMode() const { return m_whiteBalanceMode; }
     const std::optional<DoubleConstraint>& zoom() const { return m_zoom; }
     const std::optional<BooleanConstraint>& torch() const { return m_torch; }
+    const std::optional<BooleanConstraint>& backgroundBlur() const { return m_backgroundBlur; }
 
     MediaTrackConstraintSetMap isolatedCopy() const;
 
@@ -665,6 +667,8 @@ private:
     std::optional<StringConstraint> m_whiteBalanceMode;
     std::optional<DoubleConstraint> m_zoom;
     std::optional<BooleanConstraint> m_torch;
+
+    std::optional<BooleanConstraint> m_backgroundBlur;
 };
 
 struct MediaConstraints {

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -601,6 +601,7 @@ double RealtimeMediaSource::fitnessDistance(MediaConstraintType constraintType, 
     case MediaConstraintType::DisplaySurface:
     case MediaConstraintType::LogicalSurface:
     case MediaConstraintType::FocusDistance:
+    case MediaConstraintType::BackgroundBlur:
     case MediaConstraintType::Unknown:
         break;
     }
@@ -646,6 +647,7 @@ double RealtimeMediaSource::fitnessDistance(MediaConstraintType constraintType, 
     case MediaConstraintType::DisplaySurface:
     case MediaConstraintType::LogicalSurface:
     case MediaConstraintType::FocusDistance:
+    case MediaConstraintType::BackgroundBlur:
     case MediaConstraintType::Unknown:
         break;
     }
@@ -694,6 +696,7 @@ double RealtimeMediaSource::fitnessDistance(MediaConstraintType constraintType, 
     case MediaConstraintType::DisplaySurface:
     case MediaConstraintType::LogicalSurface:
     case MediaConstraintType::FocusDistance:
+    case MediaConstraintType::BackgroundBlur:
     case MediaConstraintType::Unknown:
         break;
     }
@@ -719,6 +722,8 @@ double RealtimeMediaSource::fitnessDistance(MediaConstraintType constraintType, 
             return 0;
 
         return constraint.fitnessDistance(capabilities.torch());
+    case MediaConstraintType::BackgroundBlur:
+        return 0;
     case MediaConstraintType::Width:
     case MediaConstraintType::Height:
     case MediaConstraintType::FrameRate:
@@ -920,6 +925,11 @@ void RealtimeMediaSource::applyConstraint(MediaConstraintType constraintType, co
             setTorch(setting);
         break;
     }
+    case MediaConstraintType::BackgroundBlur: {
+        ASSERT(constraint.isBoolean());
+        // FIXME: Add support
+        break;
+    }
 
     case MediaConstraintType::DeviceId:
     case MediaConstraintType::GroupId:
@@ -1087,6 +1097,8 @@ bool RealtimeMediaSource::supportsConstraint(MediaConstraintType constraintType)
         return capabilities.supportsZoom();
     case MediaConstraintType::Torch:
         return capabilities.supportsTorch();
+    case MediaConstraintType::BackgroundBlur:
+        return capabilities.supportsBackgroundBlur();
     case MediaConstraintType::DisplaySurface:
     case MediaConstraintType::LogicalSurface:
         // https://www.w3.org/TR/screen-capture/#new-constraints-for-captured-display-surfaces
@@ -1138,6 +1150,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::hasAnyInvalidConstraint(
         case MediaConstraintType::WhiteBalanceMode:
         case MediaConstraintType::Zoom:
         case MediaConstraintType::Torch:
+        case MediaConstraintType::BackgroundBlur:
         case MediaConstraintType::Unknown:
             m_fitnessScore += distance ? 1 : 2;
             break;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
@@ -86,8 +86,13 @@ public:
         ReadOnly = 0,
         ReadWrite = 1,
     };
-    
-    RealtimeMediaSourceCapabilities(LongCapabilityRange width, LongCapabilityRange height, DoubleCapabilityRange aspectRatio, DoubleCapabilityRange frameRate, Vector<VideoFacingMode>&& facingMode, DoubleCapabilityRange volume, LongCapabilityRange sampleRate, LongCapabilityRange sampleSize, EchoCancellation echoCancellation, String&& deviceId, String&& groupId, DoubleCapabilityRange focusDistance, Vector<MeteringMode>&& whiteBalanceModes, DoubleCapabilityRange zoom, bool torch, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+    enum class BackgroundBlur : uint8_t {
+        Off,
+        On,
+        OnOff,
+    };
+
+    RealtimeMediaSourceCapabilities(LongCapabilityRange width, LongCapabilityRange height, DoubleCapabilityRange aspectRatio, DoubleCapabilityRange frameRate, Vector<VideoFacingMode>&& facingMode, DoubleCapabilityRange volume, LongCapabilityRange sampleRate, LongCapabilityRange sampleSize, EchoCancellation echoCancellation, String&& deviceId, String&& groupId, DoubleCapabilityRange focusDistance, Vector<MeteringMode>&& whiteBalanceModes, DoubleCapabilityRange zoom, bool torch, BackgroundBlur backgroundBlur, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
         : m_width(WTFMove(width))
         , m_height(WTFMove(height))
         , m_aspectRatio(WTFMove(aspectRatio))
@@ -103,6 +108,7 @@ public:
         , m_whiteBalanceModes(whiteBalanceModes)
         , m_zoom(WTFMove(zoom))
         , m_torch(torch)
+        , m_backgroundBlur(backgroundBlur)
         , m_supportedConstraints(WTFMove(supportedConstraints))
     {
     }
@@ -175,10 +181,14 @@ public:
     bool torch() const { return m_torch; }
     void setTorch(bool torch) { m_torch = torch; }
 
+    bool supportsBackgroundBlur() const { return m_supportedConstraints.supportsBackgroundBlur(); }
+    BackgroundBlur backgroundBlur() const { return m_backgroundBlur; }
+    void setBackgroundBlur(BackgroundBlur backgroundBlur) { m_backgroundBlur = backgroundBlur; }
+
     const RealtimeMediaSourceSupportedConstraints& supportedConstraints() const { return m_supportedConstraints; }
     void setSupportedConstraints(const RealtimeMediaSourceSupportedConstraints& constraints) { m_supportedConstraints = constraints; }
 
-    RealtimeMediaSourceCapabilities isolatedCopy() const { return { m_width, m_height, m_aspectRatio, m_frameRate, Vector<VideoFacingMode> { m_facingMode }, m_volume, m_sampleRate, m_sampleSize, m_echoCancellation, m_deviceId.isolatedCopy(), m_groupId.isolatedCopy(), m_focusDistance, Vector<MeteringMode> { m_whiteBalanceModes }, m_zoom, m_torch, RealtimeMediaSourceSupportedConstraints { m_supportedConstraints } }; }
+    RealtimeMediaSourceCapabilities isolatedCopy() const { return { m_width, m_height, m_aspectRatio, m_frameRate, Vector<VideoFacingMode> { m_facingMode }, m_volume, m_sampleRate, m_sampleSize, m_echoCancellation, m_deviceId.isolatedCopy(), m_groupId.isolatedCopy(), m_focusDistance, Vector<MeteringMode> { m_whiteBalanceModes }, m_zoom, m_torch, m_backgroundBlur, RealtimeMediaSourceSupportedConstraints { m_supportedConstraints } }; }
 
 private:
     LongCapabilityRange m_width;
@@ -197,6 +207,8 @@ private:
     Vector<MeteringMode> m_whiteBalanceModes;
     DoubleCapabilityRange m_zoom;
     bool m_torch { false };
+
+    BackgroundBlur m_backgroundBlur { BackgroundBlur::Off };
 
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;
 };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 
 RealtimeMediaSourceSettings RealtimeMediaSourceSettings::isolatedCopy() const
 {
-    return { m_width, m_height , m_frameRate, m_facingMode, m_volume , m_sampleRate, m_sampleSize, m_echoCancellation, m_deviceId.isolatedCopy(), m_groupId.isolatedCopy(), m_label.isolatedCopy(), m_displaySurface, m_logicalSurface, m_whiteBalanceMode, m_zoom, m_torch, RealtimeMediaSourceSupportedConstraints { m_supportedConstraints } };
+    return { m_width, m_height , m_frameRate, m_facingMode, m_volume , m_sampleRate, m_sampleSize, m_echoCancellation, m_deviceId.isolatedCopy(), m_groupId.isolatedCopy(), m_label.isolatedCopy(), m_displaySurface, m_logicalSurface, m_whiteBalanceMode, m_zoom, m_torch, m_backgroundBlur, RealtimeMediaSourceSupportedConstraints { m_supportedConstraints } };
 }
 
 VideoFacingMode RealtimeMediaSourceSettings::videoFacingModeEnum(const String& mode)
@@ -115,6 +115,9 @@ String RealtimeMediaSourceSettings::convertFlagsToString(const OptionSet<Realtim
         case RealtimeMediaSourceSettings::Torch:
             builder.append("Torch");
             break;
+        case RealtimeMediaSourceSettings::BackgroundBlur:
+            builder.append("BackgroundBlur");
+            break;
         }
     }
     builder.append(" ]");
@@ -158,6 +161,8 @@ OptionSet<RealtimeMediaSourceSettings::Flag> RealtimeMediaSourceSettings::differ
         difference.add(RealtimeMediaSourceSettings::Zoom);
     if (torch() != that.torch())
         difference.add(RealtimeMediaSourceSettings::Torch);
+    if (backgroundBlur() != that.backgroundBlur())
+        difference.add(RealtimeMediaSourceSettings::BackgroundBlur);
 
     return difference;
 }

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
@@ -74,14 +74,15 @@ public:
         WhiteBalanceMode = 1 << 13,
         Zoom = 1 << 14,
         Torch = 1 << 15,
+        BackgroundBlur = 1 << 16,
     };
 
-    static constexpr OptionSet<Flag> allFlags() { return { Width, Height, FrameRate, FacingMode, Volume, SampleRate, SampleSize, EchoCancellation, DeviceId, GroupId, Label, DisplaySurface, LogicalSurface, WhiteBalanceMode, Zoom, Torch }; }
+    static constexpr OptionSet<Flag> allFlags() { return { Width, Height, FrameRate, FacingMode, Volume, SampleRate, SampleSize, EchoCancellation, DeviceId, GroupId, Label, DisplaySurface, LogicalSurface, WhiteBalanceMode, Zoom, Torch, BackgroundBlur }; }
 
     WEBCORE_EXPORT OptionSet<RealtimeMediaSourceSettings::Flag> difference(const RealtimeMediaSourceSettings&) const;
 
     RealtimeMediaSourceSettings() = default;
-    RealtimeMediaSourceSettings(uint32_t width, uint32_t height, float frameRate, VideoFacingMode facingMode, double volume, uint32_t sampleRate, uint32_t sampleSize, bool echoCancellation, String&& deviceId, String&& groupId, String&& label, DisplaySurfaceType displaySurface, bool logicalSurface, MeteringMode whiteBalanceMode, double zoom, bool torch, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+    RealtimeMediaSourceSettings(uint32_t width, uint32_t height, float frameRate, VideoFacingMode facingMode, double volume, uint32_t sampleRate, uint32_t sampleSize, bool echoCancellation, String&& deviceId, String&& groupId, String&& label, DisplaySurfaceType displaySurface, bool logicalSurface, MeteringMode whiteBalanceMode, double zoom, bool torch, bool backgroundBlur, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
         : m_width(width)
         , m_height(height)
         , m_frameRate(frameRate)
@@ -98,6 +99,7 @@ public:
         , m_whiteBalanceMode(whiteBalanceMode)
         , m_zoom(zoom)
         , m_torch(torch)
+        , m_backgroundBlur(backgroundBlur)
         , m_supportedConstraints(WTFMove(supportedConstraints))
     {
     }
@@ -164,6 +166,10 @@ public:
     bool torch() const { return m_torch; }
     void setTorch(bool torch) { m_torch = torch; }
 
+    bool supportsBackgroundBlur() const { return m_supportedConstraints.supportsBackgroundBlur(); }
+    bool backgroundBlur() const { return m_backgroundBlur; }
+    void setBackgroundBlur(bool backgroundBlur) { m_backgroundBlur = backgroundBlur; }
+
     const RealtimeMediaSourceSupportedConstraints& supportedConstraints() const { return m_supportedConstraints; }
     void setSupportedConstraints(const RealtimeMediaSourceSupportedConstraints& supportedConstraints) { m_supportedConstraints = supportedConstraints; }
 
@@ -194,6 +200,7 @@ private:
     MeteringMode m_whiteBalanceMode { MeteringMode::None };
     double m_zoom { 1.0 };
     bool m_torch { false };
+    bool m_backgroundBlur { false };
 
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;
 };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.cpp
@@ -69,6 +69,8 @@ bool RealtimeMediaSourceSupportedConstraints::supportsConstraint(MediaConstraint
         return supportsZoom();
     case MediaConstraintType::Torch:
         return supportsTorch();
+    case MediaConstraintType::BackgroundBlur:
+        return supportsBackgroundBlur();
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
@@ -42,7 +42,7 @@ public:
     {
     }
     
-    RealtimeMediaSourceSupportedConstraints(bool supportsWidth, bool supportsHeight, bool supportsAspectRatio, bool supportsFrameRate, bool supportsFacingMode, bool supportsVolume, bool supportsSampleRate, bool supportsSampleSize, bool supportsEchoCancellation, bool supportsDeviceId, bool supportsGroupId, bool supportsDisplaySurface, bool supportsLogicalSurface, bool supportsFocusDistance, bool supportsWhiteBalanceMode, bool supportsZoom, bool supportsTorch)
+    RealtimeMediaSourceSupportedConstraints(bool supportsWidth, bool supportsHeight, bool supportsAspectRatio, bool supportsFrameRate, bool supportsFacingMode, bool supportsVolume, bool supportsSampleRate, bool supportsSampleSize, bool supportsEchoCancellation, bool supportsDeviceId, bool supportsGroupId, bool supportsDisplaySurface, bool supportsLogicalSurface, bool supportsFocusDistance, bool supportsWhiteBalanceMode, bool supportsZoom, bool supportsTorch, bool supportsBackgroundBlur)
         : m_supportsWidth(supportsWidth)
         , m_supportsHeight(supportsHeight)
         , m_supportsAspectRatio(supportsAspectRatio)
@@ -60,6 +60,7 @@ public:
         , m_supportsWhiteBalanceMode(supportsWhiteBalanceMode)
         , m_supportsZoom(supportsZoom)
         , m_supportsTorch(supportsTorch)
+        , m_supportsBackgroundBlur(supportsBackgroundBlur)
     {
     }
 
@@ -116,6 +117,9 @@ public:
     bool supportsTorch() const { return m_supportsTorch; }
     void setSupportsTorch(bool value) { m_supportsTorch = value; }
 
+    bool supportsBackgroundBlur() const { return m_supportsBackgroundBlur; }
+    void setSupportsBackgroundBlur(bool value) { m_supportsBackgroundBlur = value; }
+
 private:
     bool m_supportsWidth { false };
     bool m_supportsHeight { false };
@@ -134,6 +138,7 @@ private:
     bool m_supportsWhiteBalanceMode { false };
     bool m_supportsZoom { false };
     bool m_supportsTorch { false };
+    bool m_supportsBackgroundBlur { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -444,6 +444,7 @@ const RealtimeMediaSourceSettings& AVVideoCaptureSource::settings()
     settings.setHeight(size.height());
     settings.setDeviceId(hashedId());
     settings.setGroupId(captureDevice().groupId());
+    settings.setBackgroundBlur(!!device().portraitEffectActive);
 
     RealtimeMediaSourceSupportedConstraints supportedConstraints;
     supportedConstraints.setSupportsDeviceId(true);
@@ -453,6 +454,7 @@ const RealtimeMediaSourceSettings& AVVideoCaptureSource::settings()
     supportedConstraints.setSupportsHeight(true);
     supportedConstraints.setSupportsAspectRatio(true);
     supportedConstraints.setSupportsFrameRate(true);
+    supportedConstraints.setSupportsBackgroundBlur(true);
 
     if (isZoomSupported(presets())) {
         supportedConstraints.setSupportsZoom(true);
@@ -511,6 +513,9 @@ const RealtimeMediaSourceCapabilities& AVVideoCaptureSource::capabilities()
         supportedConstraints.setSupportsTorch(true);
         capabilities.setTorch(true);
     }
+
+    capabilities.setBackgroundBlur(device().portraitEffectActive ? RealtimeMediaSourceCapabilities::BackgroundBlur::On : RealtimeMediaSourceCapabilities::BackgroundBlur::Off);
+    supportedConstraints.setSupportsBackgroundBlur(true);
 
     capabilities.setSupportedConstraints(supportedConstraints);
     updateCapabilities(capabilities);

--- a/Source/WebCore/platform/mock/MockMediaDevice.h
+++ b/Source/WebCore/platform/mock/MockMediaDevice.h
@@ -52,6 +52,7 @@ struct MockCameraProperties {
     Color fillColor { Color::black };
     Vector<MeteringMode> whiteBalanceMode { MeteringMode::None };
     bool hasTorch { false };
+    bool hasBackgroundBlur { false };
 };
 
 struct MockDisplayProperties {

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -82,6 +82,7 @@ static inline Vector<MockMediaDevice> defaultDevices()
                 Color::black,
                 { }, // whiteBalanceModes
                 false, // supportsTorch
+                false, // background blur enabled
             } },
 
         MockMediaDevice { "239c24b3-2b15-11e3-8224-0800200c9a66"_s, "Mock video device 2"_s, { },
@@ -100,6 +101,7 @@ static inline Vector<MockMediaDevice> defaultDevices()
                 Color::darkGray,
                 { MeteringMode::Manual, MeteringMode::SingleShot, MeteringMode::Continuous },
                 true,
+                true, // background blur enabled
             } },
 
         MockMediaDevice { "SCREEN-1"_s, "Mock screen device 1"_s, { }, MockDisplayProperties { CaptureDevice::DeviceType::Screen, Color::lightGray, { 1920, 1080 } } },

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -231,6 +231,9 @@ const RealtimeMediaSourceCapabilities& MockRealtimeVideoSource::capabilities()
             supportedConstraints.setSupportsTorch(true);
         }
 
+        capabilities.setBackgroundBlur(std::get<MockCameraProperties>(m_device.properties).hasBackgroundBlur ? RealtimeMediaSourceCapabilities::BackgroundBlur::On : RealtimeMediaSourceCapabilities::BackgroundBlur::Off);
+        supportedConstraints.setSupportsBackgroundBlur(true);
+
         capabilities.setSupportedConstraints(supportedConstraints);
     } else if (mockDisplay()) {
         capabilities.setWidth({ 72, std::get<MockDisplayProperties>(m_device.properties).defaultSize.width() });
@@ -352,6 +355,8 @@ const RealtimeMediaSourceSettings& MockRealtimeVideoSource::settings()
             settings.setTorch(torch());
         }
 
+        supportedConstraints.setSupportsBackgroundBlur(true);
+        settings.setBackgroundBlur(std::get<MockCameraProperties>(m_device.properties).hasBackgroundBlur);
     } else {
         supportedConstraints.setSupportsDisplaySurface(true);
         supportedConstraints.setSupportsLogicalSurface(true);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2248,6 +2248,7 @@ struct WebCore::MediaStreamRequest {
     std::optional<WebCore::StringConstraint> m_whiteBalanceMode;
     std::optional<WebCore::DoubleConstraint> m_zoom;
     std::optional<WebCore::BooleanConstraint> m_torch;
+    std::optional<WebCore::BooleanConstraint> m_backgroundBlur;
 }
 #endif
 
@@ -5233,6 +5234,7 @@ class WebCore::RealtimeMediaSourceSupportedConstraints {
     bool supportsWhiteBalanceMode();
     bool supportsZoom();
     bool supportsTorch();
+    bool supportsBackgroundBlur();
 };
 
 [Nested] class WebCore::RealtimeMediaSource::Type : uint8_t {
@@ -5281,6 +5283,7 @@ class WebCore::RealtimeMediaSourceSettings {
     WebCore::MeteringMode whiteBalanceMode();
     double zoom();
     bool torch();
+    bool backgroundBlur();
     WebCore::RealtimeMediaSourceSupportedConstraints supportedConstraints();
 };
 
@@ -5311,6 +5314,11 @@ struct WebCore::CaptureDeviceWithCapabilities {
 };
 
 [Nested] enum class WebCore::RealtimeMediaSourceCapabilities::EchoCancellation : bool
+[Nested] enum class WebCore::RealtimeMediaSourceCapabilities::BackgroundBlur : uint8_t {
+    Off,
+    On,
+    OnOff
+}
 
 header: <WebCore/RealtimeMediaSourceCapabilities.h>
 [CustomHeader] class WebCore::DoubleCapabilityRange {
@@ -5340,6 +5348,7 @@ class WebCore::RealtimeMediaSourceCapabilities {
     Vector<WebCore::MeteringMode> whiteBalanceModes();
     WebCore::DoubleCapabilityRange zoom();
     bool torch();
+    WebCore::RealtimeMediaSourceCapabilities::BackgroundBlur backgroundBlur();
     WebCore::RealtimeMediaSourceSupportedConstraints supportedConstraints();
 };
 


### PR DESCRIPTION
#### 2c252b52dc9f3aee81033984e94cead97a615541
<pre>
Implement <a href="https://w3c.github.io/mediacapture-extensions/#exposing-mediastreamtrack-source-background-blur-support">https://w3c.github.io/mediacapture-extensions/#exposing-mediastreamtrack-source-background-blur-support</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=271707">https://bugs.webkit.org/show_bug.cgi?id=271707</a>
<a href="https://rdar.apple.com/125416230">rdar://125416230</a>

Reviewed by Eric Carlson.

Add backgroundBlur constraint, capability and setting as this allows web pages to know whether background blur is already enabled or not.
We implement this for AVVideoCaptureSource.
We mock this property for some devices in  MockRealtimeVideoSource.
A follow-up patch will add support for observing changes to background blur property.

* LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints-expected.txt:
* LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt:
* LayoutTests/fast/mediastream/MediaStreamTrack-getSettings-expected.txt:
* LayoutTests/fast/mediastream/mediastreamtrack-video-backgroundBlur-expected.txt: Added.
* LayoutTests/fast/mediastream/mediastreamtrack-video-backgroundBlur.html: Added.
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::hasInvalidGetDisplayMediaConstraint):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::getSettings const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.idl:
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp:
(WebCore::capabilityBooleanVector):
(WebCore::toMediaTrackCapabilities):
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h:
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.idl:
* Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp:
(WebCore::convertToInternalForm):
* Source/WebCore/Modules/mediastream/MediaTrackConstraints.h:
* Source/WebCore/Modules/mediastream/MediaTrackConstraints.idl:
* Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h:
* Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl:
* Source/WebCore/platform/mediastream/MediaConstraintType.cpp:
(WebCore::convertToString):
* Source/WebCore/platform/mediastream/MediaConstraintType.h:
* Source/WebCore/platform/mediastream/MediaConstraints.cpp:
(WebCore::MediaTrackConstraintSetMap::set):
(WebCore::MediaTrackConstraintSetMap::merge):
(WebCore::MediaTrackConstraintSetMap::isolatedCopy const):
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::MediaTrackConstraintSetMap::MediaTrackConstraintSetMap):
(WebCore::MediaTrackConstraintSetMap::backgroundBlur const):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::fitnessDistance):
(WebCore::RealtimeMediaSource::applyConstraint):
(WebCore::RealtimeMediaSource::supportsConstraint):
(WebCore::RealtimeMediaSource::hasAnyInvalidConstraint):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h:
(WebCore::RealtimeMediaSourceCapabilities::RealtimeMediaSourceCapabilities):
(WebCore::RealtimeMediaSourceCapabilities::supportsBackgroundBlur const):
(WebCore::RealtimeMediaSourceCapabilities::backgroundBlur const):
(WebCore::RealtimeMediaSourceCapabilities::setBackgroundBlur):
(WebCore::RealtimeMediaSourceCapabilities::isolatedCopy const):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp:
(WebCore::RealtimeMediaSourceSettings::isolatedCopy const):
(WebCore::RealtimeMediaSourceSettings::convertFlagsToString):
(WebCore::RealtimeMediaSourceSettings::difference const):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h:
(WebCore::RealtimeMediaSourceSettings::allFlags):
(WebCore::RealtimeMediaSourceSettings::RealtimeMediaSourceSettings):
(WebCore::RealtimeMediaSourceSettings::supportsBackgroundBlur const):
(WebCore::RealtimeMediaSourceSettings::backgroundBlur const):
(WebCore::RealtimeMediaSourceSettings::setBackgroundBlur):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.cpp:
(WebCore::RealtimeMediaSourceSupportedConstraints::supportsConstraint const):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h:
(WebCore::RealtimeMediaSourceSupportedConstraints::RealtimeMediaSourceSupportedConstraints):
(WebCore::RealtimeMediaSourceSupportedConstraints::supportsBackgroundBlur const):
(WebCore::RealtimeMediaSourceSupportedConstraints::setSupportsBackgroundBlur):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::settings):
(WebCore::AVVideoCaptureSource::capabilities):
* Source/WebCore/platform/mock/MockMediaDevice.h:
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::defaultDevices):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::capabilities):
(WebCore::MockRealtimeVideoSource::settings):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/276777@main">https://commits.webkit.org/276777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39ed1ecc72a37c7d8ab6aec68aeef0ae4795a88d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48356 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41722 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22209 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18563 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19287 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40501 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3731 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41992 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/40833 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50105 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17188 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39563 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43360 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/attributes, /WebKitGTK/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10143 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22341 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21670 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->