### PR TITLE
Camera is paused occasionally when torch is enabled

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -145,6 +145,8 @@ private:
     void updateWhiteBalanceMode();
     void updateTorch();
 
+    void reconfigureIfNeeded();
+
     void rejectPendingPhotoRequest(const String&);
     void resolvePendingPhotoRequest(Vector<uint8_t>&&, const String&);
     RetainPtr<AVCapturePhotoSettings> photoConfiguration(const PhotoSettings&);
@@ -180,6 +182,9 @@ private:
     bool m_interrupted { false };
     bool m_isRunning { false };
     bool m_hasBegunConfigurationForConstraints { false };
+    bool m_needsResolutionReconfiguration { false };
+    bool m_needsTorchReconfiguration { false };
+    bool m_needsWhiteBalanceReconfiguration { false };
 
     static constexpr Seconds verifyCaptureInterval = 30_s;
     static const uint64_t framesToDropWhenStarting = 4;


### PR DESCRIPTION
#### 7d9473d140a132515243ab15386c58a6db656b90
<pre>
Camera is paused occasionally when torch is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=270831">https://bugs.webkit.org/show_bug.cgi?id=270831</a>
<a href="https://rdar.apple.com/124434403">rdar://124434403</a>

Reviewed by Andy Estes.

We do not want to update AV capture devices before the session is running, as it may trigger interruption.
We now apply changes to device as soon as the session is running, but not before.
We apply this to torch, white balance, resolution and frame rate.

Whenever we want to update any of these, if the session is not running, we exit early and we remember to reconfigure.
When the session resumes, we check whether we need to reconfigure and do so.

* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::setSessionSizeFrameRateAndZoom):
(WebCore::AVVideoCaptureSource::updateWhiteBalanceMode):
(WebCore::AVVideoCaptureSource::updateTorch):
(WebCore::AVVideoCaptureSource::reconfigure):
(WebCore::AVVideoCaptureSource::captureSessionIsRunningDidChange):

Canonical link: <a href="https://commits.webkit.org/276773@main">https://commits.webkit.org/276773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d3a54e2c4776a056a37cffa6bf310faa822d08c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48335 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41702 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47973 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29063 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37394 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40484 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3711 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50086 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44497 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21961 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43341 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10142 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22321 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21650 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->