### PR TITLE
[Cocoa] Use download progress API

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -78,11 +78,7 @@ void Download::platformCancelNetworkLoad(CompletionHandler<void(std::span<const 
 void Download::platformDestroyDownload()
 {
     if (m_progress)
-#if HAVE(NSPROGRESS_PUBLISHING_SPI)
-        [m_progress _unpublish];
-#else
         [m_progress unpublish];
-#endif
 }
 
 void Download::publishProgress(const URL& url, SandboxExtension::Handle&& sandboxExtensionHandle)
@@ -97,11 +93,7 @@ void Download::publishProgress(const URL& url, SandboxExtension::Handle&& sandbo
         return;
 
     m_progress = adoptNS([[WKDownloadProgress alloc] initWithDownloadTask:m_downloadTask.get() download:*this URL:(NSURL *)url sandboxExtension:sandboxExtension]);
-#if HAVE(NSPROGRESS_PUBLISHING_SPI)
-    [m_progress _publish];
-#else
     [m_progress publish];
-#endif
 }
 
 }

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
@@ -77,35 +77,19 @@ static NSString * const countOfBytesReceivedKeyPath = @"countOfBytesReceived";
     return self;
 }
 
-#if HAVE(NSPROGRESS_PUBLISHING_SPI)
-- (void)_publish
-#else
 - (void)publish
-#endif
 {
     BOOL consumedExtension = m_sandboxExtension->consume();
     ASSERT_UNUSED(consumedExtension, consumedExtension);
 
-#if HAVE(NSPROGRESS_PUBLISHING_SPI)
-    [super _publish];
-#else
     [super publish];
-#endif
 }
 
-#if HAVE(NSPROGRESS_PUBLISHING_SPI)
-- (void)_unpublish
-#else
 - (void)unpublish
-#endif
 {
     [self _updateProgressExtendedAttributeOnProgressFile];
 
-#if HAVE(NSPROGRESS_PUBLISHING_SPI)
-    [super _unpublish];
-#else
     [super unpublish];
-#endif
 
     m_sandboxExtension->revoke();
     m_sandboxExtension = nullptr;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm
@@ -182,11 +182,7 @@ static void* progressObservingContext = &progressObservingContext;
     }
 
     if (m_progressSubscriber) {
-#if HAVE(NSPROGRESS_PUBLISHING_SPI)
-        [NSProgress _removeSubscriber:m_progressSubscriber.get()];
-#else
         [NSProgress removeSubscriber:m_progressSubscriber.get()];
-#endif
         m_progressSubscriber = nullptr;
     }
 
@@ -225,11 +221,7 @@ static void* progressObservingContext = &progressObservingContext;
             return static_cast<NSProgressUnpublishingHandler>(nil);
         });
 
-#if HAVE(NSPROGRESS_PUBLISHING_SPI)
-        m_progressSubscriber = [NSProgress _addSubscriberForFileURL:m_progressURL.get() withPublishingHandler:publishingHandler.get()];
-#else
         m_progressSubscriber = [NSProgress addSubscriberForFileURL:m_progressURL.get() withPublishingHandler:publishingHandler.get()];
-#endif
     }
     TestWebKitAPI::Util::run(&m_hasProgress);
 }


### PR DESCRIPTION
#### 98e295e6c8de44af5b84bbc2562698043d5ae312
<pre>
[Cocoa] Use download progress API
<a href="https://bugs.webkit.org/show_bug.cgi?id=271761">https://bugs.webkit.org/show_bug.cgi?id=271761</a>
<a href="https://rdar.apple.com/125487811">rdar://125487811</a>

Reviewed by NOBODY (OOPS!).

Use available download progress API on Cocoa platforms.

* Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm:
(WebKit::Download::platformDestroyDownload):
(WebKit::Download::publishProgress):
* Source/WebKit/NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm:
(-[WKDownloadProgress publish]):
(-[WKDownloadProgress unpublish]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm:
(-[DownloadProgressTestRunner tearDown]):
(-[DownloadProgressTestRunner subscribeAndWaitForProgress]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98e295e6c8de44af5b84bbc2562698043d5ae312

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24657 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48070 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48199 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41540 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47838 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22051 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37322 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21752 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/48070 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18444 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; 1 api test failed or timed out; Running compile-webkit-without-change") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19151 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/48070 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3577 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41855 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/48070 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49937 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20519 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17058 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44398 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21825 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/48070 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43229 "Found 1 new API test failure: /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-empty-realm (failure)") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22185 "Build is in progress. Recent messages:OS: Sonoma (14.3.1), Xcode: 15.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21513 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->