### PR TITLE
Clean up Signals and remove hardened fallback

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3522,9 +3522,6 @@ int main(int argc, char** argv WTF_TZONE_EXTRA_MAIN_ARGS)
 
 #if OS(UNIX)
     if (getenv("JS_SHELL_WAIT_FOR_SIGUSR2_TO_EXIT")) {
-        uint32_t key = 0;
-        int mask = 0;
-        initializeSignalHandling(key, mask);
         addSignalHandler(Signal::Usr, SignalHandler([&] (Signal, SigInfo&, PlatformRegisters&) {
             dataLogLn("Signal handler hit, we can exit now.");
             waitToExit.signal();
@@ -3998,20 +3995,6 @@ void CommandLine::parseArguments(int argc, char** argv)
         }
         if (!strcmp(arg, "-s")) {
 #if OS(UNIX)
-            uint32_t key = 0;
-            int mask = 0;
-#if HAVE(MACH_EXCEPTIONS)
-            mask |= toMachMask(Signal::IllegalInstruction);
-            mask |= toMachMask(Signal::AccessFault);
-            mask |= toMachMask(Signal::FloatingPoint);
-            mask |= toMachMask(Signal::Breakpoint);
-#if !OS(DARWIN)
-            mask |= toMachMask(Signal::Abort);
-#endif // !OS(DARWIN)
-#endif // HAVE(MACH_EXCEPTIONS)
-
-            initializeSignalHandling(key, mask);
-
             SignalAction (*exit)(Signal, SigInfo&, PlatformRegisters&) = [] (Signal, SigInfo&, PlatformRegisters&) {
                 dataLogLn("Signal handler hit. Exiting with status 0");
                 // Deliberate exit with a SIGKILL code greater than 130.
@@ -4034,7 +4017,6 @@ void CommandLine::parseArguments(int argc, char** argv)
             addSignalHandler(Signal::Abort, SignalHandler(exit));
             activateSignalHandlersFor(Signal::Abort);
 #endif
-            finalizeSignalHandlers();
 #endif
             continue;
         }

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -136,23 +136,11 @@ void initialize()
             WTF::fastEnableMiniMode();
 
         if (Wasm::isSupported() || !Options::usePollingTraps()) {
-            // JSLock::lock() can call registerThreadForMachExceptionHandling() which crashes if this has not been called first.
-            int mask = 0;
-#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-            JSC::Wasm::MachExceptionSigningKey keygen;
-            uint32_t signingKey = keygen.randomSigningKey;
-            mask |= toMachMask(Signal::AccessFault);
-#else
-            uint32_t signingKey = 0;
-#endif // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-            initializeSignalHandling(signingKey, mask);
-
             if (!Options::usePollingTraps())
                 VMTraps::initializeSignals();
             if (Wasm::isSupported())
                 Wasm::prepareSignalingMemory();
-        } else
-            disableSignalHandling();
+        }
 
         WTF::compilerFence();
         RELEASE_ASSERT(!g_jscConfig.initializeHasBeenCalled);

--- a/Source/JavaScriptCore/runtime/JSCConfig.cpp
+++ b/Source/JavaScriptCore/runtime/JSCConfig.cpp
@@ -42,12 +42,6 @@ Config& Config::singleton()
     return g_jscConfig;
 }
 
-void Config::disableFreezingForTesting()
-{
-    RELEASE_ASSERT(!g_jscConfig.isPermanentlyFrozen());
-    g_jscConfig.disabledFreezingForTesting = true;
-}
-
 void Config::enableRestrictedOptions()
 {
     RELEASE_ASSERT(!g_jscConfig.isPermanentlyFrozen());

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -44,9 +44,9 @@ using JITWriteSeparateHeapsFunction = void (*)(off_t, const void*, size_t);
 struct Config {
     static Config& singleton();
 
-    JS_EXPORT_PRIVATE static void disableFreezingForTesting();
+    static void disableFreezingForTesting() { g_wtfConfig.disableFreezingForTesting(); }
     JS_EXPORT_PRIVATE static void enableRestrictedOptions();
-    static void permanentlyFreeze() { WTF::Config::permanentlyFreeze(); }
+    static void finalize() { WTF::Config::finalize(); }
 
     static void configureForTesting()
     {
@@ -60,8 +60,8 @@ struct Config {
     // All the fields in this struct should be chosen such that their
     // initial value is 0 / null / falsy because Config is instantiated
     // as a global singleton.
+    // FIXME: We should use a placement new constructor from JSC::initialize so we can use default initializers.
 
-    bool disabledFreezingForTesting;
     bool restrictedOptionsEnabled;
     bool jitDisabled;
     bool vmCreationDisallowed;

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -434,8 +434,7 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
         jitSizeStatistics = makeUnique<JITSizeStatistics>();
 #endif
 
-    if (!g_jscConfig.disabledFreezingForTesting)
-        Config::permanentlyFreeze();
+    Config::finalize();
 
     // We must set this at the end only after the VM is fully initialized.
     WTF::storeStoreFence();

--- a/Source/JavaScriptCore/runtime/VMEntryScope.cpp
+++ b/Source/JavaScriptCore/runtime/VMEntryScope.cpp
@@ -48,8 +48,7 @@ void VMEntryScope::setUpSlow()
         if (Wasm::isSupported())
             Wasm::startTrackingCurrentThread();
 #if HAVE(MACH_EXCEPTIONS)
-        if (g_wtfConfig.signalHandlers.initState == WTF::SignalHandlers::InitState::AddedHandlers)
-            registerThreadForMachExceptionHandling(thread);
+        registerThreadForMachExceptionHandling(thread);
 #endif
     }
 

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -201,7 +201,6 @@ public:
         , m_vm(vm)
     {
         activateSignalHandlersFor(Signal::AccessFault);
-        finalizeSignalHandlers();
     }
 
     static void initializeSignals()

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2922,7 +2922,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(functionCallWithStackSize, SUPPRESS_ASA
         return throwVMError(globalObject, throwScope, "Not supported for this platform"_s);
 
 #if ENABLE(ASSEMBLER)
-    if (g_jscConfig.isPermanentlyFrozen() || !g_jscConfig.disabledFreezingForTesting)
+    if (g_jscConfig.isPermanentlyFrozen() || !g_wtfConfig.disabledFreezingForTesting)
         return throwVMError(globalObject, throwScope, "Options are frozen"_s);
 
     if (callFrame->argumentCount() < 2)

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -39,7 +39,6 @@
 #include "WasmMemory.h"
 #include "WasmThunks.h"
 #include <wtf/CodePtr.h>
-#include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/threads/Signals.h>
@@ -49,18 +48,8 @@ namespace JSC { namespace Wasm {
 using WTF::CodePtr;
 
 #if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-void* presignedTrampoline = { };
-
-MachExceptionSigningKey::MachExceptionSigningKey()
-{
-    // Sign the trampoline pointer using a random diversifier and stash it away before webcontent has started so that
-    // even a PAC signing gadget cannot fake this random diversifier
-    randomSigningKey = WTF::cryptographicallyRandomNumber<uint32_t>() & __DARWIN_ARM_THREAD_STATE64_USER_DIVERSIFIER_MASK;
-    uint64_t diversifier = ptrauth_blend_discriminator((void *)(unsigned long)randomSigningKey, ptrauth_string_discriminator("pc"));
-    presignedTrampoline = JSC::LLInt::getCodePtr<CFunctionPtrTag>(wasm_throw_from_fault_handler_trampoline_reg_instance).untaggedPtr();
-    presignedTrampoline = ptrauth_sign_unauthenticated(presignedTrampoline, ptrauth_key_function_pointer, diversifier);
-}
-#endif // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
+void* presignedTrampoline { nullptr };
+#endif
 
 namespace {
 namespace WasmFaultSignalHandlerInternal {
@@ -115,12 +104,10 @@ static SignalAction trapHandler(Signal signal, SigInfo& sigInfo, PlatformRegiste
 
             if (didFaultInWasm(faultingInstruction)) {
 #if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-                if (!WTF::fallbackToOldExceptions.load()) {
-                    MachineContext::setInstructionPointer(context, presignedTrampoline);
-                    return SignalAction::Handled;
-                }
-#endif
+                MachineContext::setInstructionPointer(context, presignedTrampoline);
+#else
                 MachineContext::setInstructionPointer(context, LLInt::getCodePtr<CFunctionPtrTag>(wasm_throw_from_fault_handler_trampoline_reg_instance));
+#endif
                 return SignalAction::Handled;
             }
         }
@@ -139,7 +126,6 @@ void activateSignalingMemory()
             return;
 
         activateSignalHandlersFor(Signal::AccessFault);
-        WTF::finalizeSignalHandlers();
     });
 }
 
@@ -153,6 +139,9 @@ void prepareSignalingMemory()
         if (!Options::useWasmFaultSignalHandler())
             return;
 
+#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
+        presignedTrampoline = g_wtfConfig.signalHandlers.presignReturnPCForHandler(LLInt::getCodePtr<NoPtrTag>(wasm_throw_from_fault_handler_trampoline_reg_instance));
+#endif
         addSignalHandler(Signal::AccessFault, [] (Signal signal, SigInfo& sigInfo, PlatformRegisters& ucontext) {
             return trapHandler(signal, sigInfo, ucontext);
         });

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
@@ -36,12 +36,4 @@ inline void activateSignalingMemory() { }
 inline void prepareSignalingMemory() { }
 #endif // ENABLE(WEBASSEMBLY)
 
-#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-class MachExceptionSigningKey {
-public:
-    uint32_t randomSigningKey = { };
-    MachExceptionSigningKey();
-};
-#endif // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-
 } } // namespace JSC::Wasm

--- a/Source/WTF/wtf/PlatformRegisters.cpp
+++ b/Source/WTF/wtf/PlatformRegisters.cpp
@@ -54,8 +54,8 @@ void* threadStateLRInternal(PlatformRegisters& regs)
 void* threadStatePCInternal(PlatformRegisters& regs)
 {
 #if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-    // If userspace has modified the PC and set it to the presignedTrampoline,
-    // we want to avoid authing the value as it is using a custom ptrauth signing scheme.
+    // If we have modified the PC and set it to a presigned function we want to avoid
+    // authing the value as it is using a custom ptrauth signing scheme.
     _STRUCT_ARM_THREAD_STATE64* ts = &(regs);
     if (!(ts->__opaque_flags & __DARWIN_ARM_THREAD_STATE64_FLAGS_KERNEL_SIGNED_PC))
         return nullptr;

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -500,9 +500,6 @@ void initialize()
 #endif
         initializeDates();
         Thread::initializePlatformThreading();
-#if USE(PTHREADS) && HAVE(MACHINE_CONTEXT)
-        SignalHandlers::initialize();
-#endif
 #if PLATFORM(COCOA)
         initializeLibraryPathDiagnostics();
 #endif

--- a/Source/WTF/wtf/WTFConfig.cpp
+++ b/Source/WTF/wtf/WTFConfig.cpp
@@ -100,6 +100,7 @@ void setPermissionsOfConfigPage()
 
 void Config::initialize()
 {
+    // FIXME: We should do a placement new for Config so we can use default initializers.
     []() -> void {
         uintptr_t onePage = pageSize(); // At least, first one page must be unmapped.
 #if OS(DARWIN)
@@ -124,14 +125,23 @@ void Config::initialize()
         g_wtfConfig.lowestAccessibleAddress = onePage;
     }();
     g_wtfConfig.highestAccessibleAddress = static_cast<uintptr_t>((1ULL << OS_CONSTANT(EFFECTIVE_ADDRESS_WIDTH)) - 1);
+    SignalHandlers::initialize();
+}
+
+void Config::finalize()
+{
+    static std::once_flag once;
+    std::call_once(once, [] {
+        SignalHandlers::finalize();
+        if (!g_wtfConfig.disabledFreezingForTesting)
+            Config::permanentlyFreeze();
+    });
 }
 
 void Config::permanentlyFreeze()
 {
-    static Lock configLock;
-    Locker locker { configLock };
-
     RELEASE_ASSERT(roundUpToMultipleOf(pageSize(), ConfigSizeToProtect) == ConfigSizeToProtect);
+    ASSERT(!g_wtfConfig.disabledFreezingForTesting);
 
     if (!g_wtfConfig.isPermanentlyFrozen) {
         g_wtfConfig.isPermanentlyFrozen = true;
@@ -165,6 +175,12 @@ void Config::permanentlyFreeze()
 
     RELEASE_ASSERT(!result);
     RELEASE_ASSERT(g_wtfConfig.isPermanentlyFrozen);
+}
+
+void Config::disableFreezingForTesting()
+{
+    RELEASE_ASSERT(!g_wtfConfig.isPermanentlyFrozen);
+    g_wtfConfig.disabledFreezingForTesting = true;
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/WTFConfig.h
+++ b/Source/WTF/wtf/WTFConfig.h
@@ -69,6 +69,8 @@ constexpr size_t ConfigSizeToProtect = std::max(CeilingOnPageSize, 16 * KB);
 struct Config {
     WTF_EXPORT_PRIVATE static void permanentlyFreeze();
     WTF_EXPORT_PRIVATE static void initialize();
+    WTF_EXPORT_PRIVATE static void finalize();
+    WTF_EXPORT_PRIVATE static void disableFreezingForTesting();
 
     struct AssertNotFrozenScope {
         AssertNotFrozenScope();
@@ -83,6 +85,7 @@ struct Config {
     uintptr_t highestAccessibleAddress;
 
     bool isPermanentlyFrozen;
+    bool disabledFreezingForTesting;
     bool useSpecialAbortForExtraSecurityImplications;
 #if PLATFORM(COCOA)
     bool disableForwardingVPrintfStdErrToOSLog;

--- a/Source/WTF/wtf/threads/Signals.h
+++ b/Source/WTF/wtf/threads/Signals.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/CodePtr.h>
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
 #include <wtf/PlatformRegisters.h>
@@ -59,7 +60,7 @@ enum class Signal {
     AccessFault, // For posix this is both SIGSEGV and SIGBUS
     NumberOfSignals = AccessFault + 2, // AccessFault is really two signals.
     Unknown = NumberOfSignals
-#else
+#else // not OS(UNIX)
     FloatingPoint,
     IllegalInstruction,
     AccessFault,
@@ -81,13 +82,19 @@ struct SigInfo {
 using SignalHandler = Function<SignalAction(Signal, SigInfo&, PlatformRegisters&)>;
 using SignalHandlerMemory = std::aligned_storage<sizeof(SignalHandler), std::alignment_of<SignalHandler>::value>::type;
 
-extern Atomic<bool> fallbackToOldExceptions;
 struct SignalHandlers {
     static void initialize();
+    static void finalize();
 
     void add(Signal, SignalHandler&&);
     template<typename Func>
     void forEachHandler(Signal, const Func&) const;
+
+    // We intentionally disallow presigning the return PC on platforms that can't authenticate it so
+    // we don't accidentally leave an unfrozen pointer in the heap somewhere.
+#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
+    void* presignReturnPCForHandler(CodePtr<NoPtrTag>);
+#endif
 
     static constexpr size_t numberOfSignals = static_cast<size_t>(Signal::NumberOfSignals);
     static constexpr size_t maxNumberOfHandlers = 4;
@@ -98,16 +105,16 @@ struct SignalHandlers {
     mach_port_t exceptionPort;
     exception_mask_t addedExceptions;
     bool useMach;
-
-    enum class InitState : uint8_t {
-        Uninitialized = 0,
-        InitializedHandlerThread,
-        AddedHandlers
-    };
-    InitState initState;
 #else
     static constexpr bool useMach = false;
 #endif
+    enum class InitState : uint8_t {
+        Uninitialized = 0,
+        Initializing,
+        Finalized,
+    };
+    InitState initState;
+
     uint8_t numberOfHandlers[numberOfSignals];
     SignalHandlerMemory handlers[numberOfSignals][maxNumberOfHandlers];
 
@@ -124,38 +131,16 @@ struct SignalHandlers {
 // These functions are a one way street i.e. once installed, a signal handler cannot be uninstalled
 // and once commited they can't be turned off.
 WTF_EXPORT_PRIVATE void addSignalHandler(Signal, SignalHandler&&);
+// Note: This function doesn't necessarily activate the signal right away. Signals are
+// activated when SignalHandlers::finalize() runs and that signal has been turned on.
+// This also only currently does something if using Mach exceptions rather than posix/windows signals.
 WTF_EXPORT_PRIVATE void activateSignalHandlersFor(Signal);
-WTF_EXPORT_PRIVATE void finalizeSignalHandlers();
-
-#if OS(UNIX) && HAVE(MACH_EXCEPTIONS)
-inline exception_mask_t toMachMask(Signal signal)
-{
-    switch (signal) {
-    case Signal::AccessFault: return EXC_MASK_BAD_ACCESS;
-    case Signal::IllegalInstruction: return EXC_MASK_BAD_INSTRUCTION;
-    case Signal::FloatingPoint: return EXC_MASK_ARITHMETIC;
-    case Signal::Breakpoint: return EXC_MASK_BREAKPOINT;
-    default: break;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-#endif // OS(UNIX) && HAVE(MACH_EXCEPTIONS)
 
 #if HAVE(MACH_EXCEPTIONS)
+void handleSignalsWithMach();
+
 class Thread;
 void registerThreadForMachExceptionHandling(Thread&);
-WTF_EXPORT_PRIVATE void initMachExceptionHandlerThread(bool, uint32_t, exception_mask_t);
-inline void initializeSignalHandling(uint32_t signingKey, exception_mask_t mask) { initMachExceptionHandlerThread(true, signingKey, mask); }
-inline void disableSignalHandling() { initMachExceptionHandlerThread(false, 0, 0); }
-
-void handleSignalsWithMach();
-#else
-inline void initializeSignalHandling(uint32_t signingKey, int mask)
-{
-    UNUSED_PARAM(signingKey);
-    UNUSED_PARAM(mask);
-}
-inline void disableSignalHandling() { }
 #endif // HAVE(MACH_EXCEPTIONS)
 
 } // namespace WTF
@@ -171,6 +156,3 @@ using WTF::SignalAction;
 using WTF::SignalHandler;
 using WTF::addSignalHandler;
 using WTF::activateSignalHandlersFor;
-using WTF::finalizeSignalHandlers;
-using WTF::initializeSignalHandling;
-using WTF::disableSignalHandling;

--- a/Source/WTF/wtf/win/SignalsWin.cpp
+++ b/Source/WTF/wtf/win/SignalsWin.cpp
@@ -47,8 +47,8 @@ namespace WTF {
 void SignalHandlers::add(Signal signal, SignalHandler&& handler)
 {
     Config::AssertNotFrozenScope assertScope;
-    static Lock lock;
-    Locker locker { lock };
+    ASSERT(signal < Signal::Unknown);
+    RELEASE_ASSERT(initState == SignalHandlers::InitState::Initializing);
 
     size_t signalIndex = static_cast<size_t>(signal);
     size_t nextFree = numberOfHandlers[signalIndex];
@@ -56,12 +56,7 @@ void SignalHandlers::add(Signal signal, SignalHandler&& handler)
     SignalHandlerMemory* memory = &handlers[signalIndex][nextFree];
     new (memory) SignalHandler(WTFMove(handler));
 
-    // We deliberately do not want to increment the count until after we've
-    // fully initialized the memory. This way, forEachHandler() won't see a
-    // partially initialized handler.
-    storeStoreFence();
     numberOfHandlers[signalIndex]++;
-    loadLoadFence();
 }
 
 template<typename Func>
@@ -128,30 +123,37 @@ void addSignalHandler(Signal signal, SignalHandler&& handler)
 {
     Config::AssertNotFrozenScope assertScope;
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    ASSERT(signal < Signal::Unknown);
-
-    static std::once_flag initializeOnceFlags[static_cast<size_t>(Signal::NumberOfSignals)];
-    std::call_once(initializeOnceFlags[static_cast<size_t>(signal)], [&] {
-        Config::AssertNotFrozenScope assertScope;
-        AddVectoredExceptionHandler(1, vectoredHandler);
-    });
-
     handlers.add(signal, WTFMove(handler));
 }
 
 void activateSignalHandlersFor(Signal signal)
 {
-    UNUSED_PARAM(signal);
+    const SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    ASSERT_UNUSED(signal, signal < Signal::Unknown);
+    RELEASE_ASSERT(handlers.initState >= SignalHandlers::InitState::Initializing);
 }
 
 void SignalHandlers::initialize()
 {
-    // noop
+    Config::AssertNotFrozenScope assertScope;
+    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    RELEASE_ASSERT(handlers.initState == SignalHandlers::InitState::Uninitialized);
+    handlers.initState = SignalHandlers::InitState::Initializing;
 }
 
-void finalizeSignalHandlers()
+void SignalHandlers::finalize()
 {
-    // noop
+    Config::AssertNotFrozenScope assertScope;
+    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    RELEASE_ASSERT(handlers.initState == SignalHandlers::InitState::Finalized);
+    handlers.initState = SignalHandlers::InitState::Finalized;
+
+    for (unsigned i = 0; i < numberOfSignals; ++i) {
+        if (handlers.numberOfHandlers[i]) {
+            AddVectoredExceptionHandler(1, vectoredHandler);
+            break;
+        }
+    }
 }
 
 } // namespace WTF

--- a/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
+++ b/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
@@ -66,5 +66,5 @@ void GPU_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t initializ
     WebKit::XPCServiceInitializer<WebKit::GPUProcess, WebKit::GPUServiceInitializerDelegate>(connection, initializerMessage);
 #endif // ENABLE(GPU_PROCESS)
 
-    JSC::Config::permanentlyFreeze();
+    JSC::Config::finalize();
 }

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1392,10 +1392,6 @@
         thread_info
         thread_policy
         thread_policy_set))
-
-; This rule is only temporary and should be removed shortly
-; See: rdar://125256111.
-(mobile-preferences-read "com.apple.webkit-new-sandbox-test")
     
 (allow mach-kernel-endpoint
     (apply-message-filter
@@ -1437,25 +1433,12 @@
 #if HAVE(HARDENED_MACH_EXCEPTIONS)
         (with-filter (require-not (lockdown-mode))
             (allow mach-message-send (kernel-mig-routine thread_adopt_exception_handler))
-#if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
             (with-filter (require-not (webcontent-process-launched))
-                (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler)))
-#else
-            (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler))
-#endif ;; ENABLE(BLOCK_SET_EXCEPTION_PORTS)
-        )
+                (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler))))
 #else
         (with-filter (require-not (lockdown-mode))
-#if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
-            (with-filter (require-not (webcontent-process-launched))
-                (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
-#else
-            (allow mach-message-send (kernel-mig-routine thread_set_exception_ports))
-#endif ;; ENABLE(BLOCK_SET_EXCEPTION_PORTS)
-        )
+            (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
 #endif ;; HAVE(HARDENED_MACH_EXCEPTIONS)
-
-
 
         (with-filter (lockdown-mode)
             (deny mach-message-send (with telemetry) (with message "Lockdown mode")


### PR DESCRIPTION
#### b3eceeb22f58375c3ae39ccdc376335e417881fe
<pre>
Clean up Signals and remove hardened fallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=271766">https://bugs.webkit.org/show_bug.cgi?id=271766</a>
<a href="https://rdar.apple.com/125256111">rdar://125256111</a>

Reviewed by Justin Michaud.

This change does a couple of things:

1) Refactor the signal handler API after <a href="https://commits.webkit.org/276579@main">https://commits.webkit.org/276579@main</a> which had mach exception users
   pass the mask of exceptions they would ever want to handle at initialization time (before they register their handler).
   Instead the new signal handler API registers our handlers with the kernel at finalization time. At which point we
   have a list of every exception handler added.

2) Remove the finalizeSignalHandlers function and finalize signal handlers when WTF::Config finalizes.

3) Remove disableSignalHandling function as it never really worked (signals could still get registered before we called disable)
   and we mostly rely on the sandbox to block signals in lockdown mode.

3) Rename SignalHandlers::InitState entries to better reflect the new design and use it for all configurations not just mach ports.

4) Remove the fallback we added to <a href="https://commits.webkit.org/276579@main">https://commits.webkit.org/276579@main</a> as a stopgap for internal folks running on old sandboxes.

5) Remove `isX86BinaryRunningOnARM()` check since that didn&apos;t seem to work anyway. We&apos;ll probably have to remove signal handling under
   Rosetta as I couldn&apos;t get it to work.

6) Save the secret key for our hardened handler in Signals.cpp before finalization and only let API users see it via presignReturnPCForHandler
   so they can&apos;t accidentally save it somewhere an attacker could see later. We also carefully zero it at finalization time after passing
   it to the kernel via `task_register_hardened_exception_handler`.

7) Move disabledFreezingForTesting to WTF::Config since that&apos;s the config that actually does the freezing not JSC::Config.
   This allows WTF::Config to control finalizing signal handlers.

8) Remove some cases from com.apple.WebKit.WebContent.sb.in to simplify the profile slightly. We don&apos;t need to guard the
   `(require-not (webcontent-process-launched))` check on `ENABLE(BLOCK_SET_EXCEPTION_PORTS)` because we have
   `webcontent-process-launched` anywhere we `HAVE(HARDENED_MACH_EXCEPTIONS)` anyway.

* Source/JavaScriptCore/jsc.cpp:
(main):
(CommandLine::parseArguments):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/JSCConfig.cpp:
(JSC::Config::disableFreezingForTesting): Deleted.
* Source/JavaScriptCore/runtime/JSCConfig.h:
(JSC::Config::disableFreezingForTesting):
(JSC::Config::finalize):
(JSC::Config::permanentlyFreeze): Deleted.
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
* Source/JavaScriptCore/runtime/VMEntryScope.cpp:
(JSC::VMEntryScope::setUpSlow):
* Source/JavaScriptCore/runtime/VMTraps.cpp:
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES):
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp:
(JSC::Wasm::trapHandler):
(JSC::Wasm::activateSignalingMemory):
(JSC::Wasm::prepareSignalingMemory):
(JSC::Wasm::MachExceptionSigningKey::MachExceptionSigningKey): Deleted.
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h:
* Source/WTF/wtf/PlatformRegisters.cpp:
(WTF::threadStatePCInternal):
* Source/WTF/wtf/Threading.cpp:
(WTF::initialize):
* Source/WTF/wtf/WTFConfig.cpp:
(WTF::Config::initialize):
(WTF::Config::finalize):
(WTF::Config::permanentlyFreeze):
(WTF::Config::disableFreezingForTesting):
* Source/WTF/wtf/WTFConfig.h:
* Source/WTF/wtf/threads/Signals.cpp:
(WTF::SignalHandlers::add):
(WTF::SignalHandlers::presignReturnPCForHandler):
(WTF::initMachExceptionHandlerThread):
(WTF::toMachMask):
(WTF::setExceptionPorts):
(WTF::activeThreads):
(WTF::registerThreadForMachExceptionHandling):
(WTF::activateSignalHandlersFor):
(WTF::addSignalHandler):
(WTF::disableSignalHandling):
(WTF::jscSignalHandler):
(WTF::SignalHandlers::initialize):
(WTF::SignalHandlers::finalize):
(WTF::finalizeSignalHandlers): Deleted.
* Source/WTF/wtf/threads/Signals.h:
(WTF::toMachMask): Deleted.
(WTF::initializeSignalHandling): Deleted.
(WTF::disableSignalHandling): Deleted.
* Source/WTF/wtf/win/SignalsWin.cpp:
(WTF::SignalHandlers::add):
(WTF::addSignalHandler):
(WTF::activateSignalHandlersFor):
(WTF::SignalHandlers::initialize):
(WTF::SignalHandlers::finalize):
(WTF::finalizeSignalHandlers): Deleted.
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:

Canonical link: <a href="https://commits.webkit.org/277136@main">https://commits.webkit.org/277136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30232091f91bf7b1f85295d0af258d416c82a93b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49469 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42839 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23419 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22955 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19416 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41440 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4838 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/40039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51342 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46275 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21801 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18154 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23089 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44364 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10338 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53417 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/22798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10968 "Passed tests") | 
<!--EWS-Status-Bubble-End-->