### PR TITLE
[WPE] Add a soft limit to the amount of GPU memory BitmapTexturePool can hold

### DIFF
--- a/Source/WebCore/PlatformWPE.cmake
+++ b/Source/WebCore/PlatformWPE.cmake
@@ -151,3 +151,11 @@ if (ENABLE_SPEECH_SYNTHESIS)
         ${Flite_LIBRARIES}
     )
 endif ()
+
+# This sets the maximum amount of memory that BitmapTexturePool can hold before being more
+# aggressive trying to release the unused textures.
+# Use a big value as the default size limit (80MB, enough for ten 1920x1080 layers).
+# Embedded users will want to set this limit depending on the capabilities of their platform.
+list(APPEND WebCore_PRIVATE_DEFINITIONS
+     BITMAP_TEXTURE_POOL_MAX_SIZE_IN_MB=80
+)

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
@@ -31,11 +31,21 @@
 
 namespace WebCore {
 
+#if defined(BITMAP_TEXTURE_POOL_MAX_SIZE_IN_MB) && BITMAP_TEXTURE_POOL_MAX_SIZE_IN_MB > 0
+static constexpr size_t poolSizeLimit = BITMAP_TEXTURE_POOL_MAX_SIZE_IN_MB * MB;
+#else
+static constexpr size_t poolSizeLimit = std::numeric_limits<size_t>::max();
+#endif
+
 static const Seconds releaseUnusedSecondsTolerance { 3_s };
 static const Seconds releaseUnusedTexturesTimerInterval { 500_ms };
+static const Seconds releaseUnusedSecondsToleranceOnLimitExceeded { 50_ms };
+static const Seconds releaseUnusedTexturesTimerIntervalOnLimitExceeded { 200_ms };
 
 BitmapTexturePool::BitmapTexturePool()
     : m_releaseUnusedTexturesTimer(RunLoop::current(), this, &BitmapTexturePool::releaseUnusedTexturesTimerFired)
+    , m_releaseUnusedSecondsTolerance(releaseUnusedSecondsTolerance)
+    , m_releaseUnusedTexturesTimerInterval(releaseUnusedTexturesTimerInterval)
 {
 }
 
@@ -51,10 +61,14 @@ RefPtr<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, Opt
     if (selectedEntry == m_textures.end()) {
         m_textures.append(Entry(BitmapTexture::create(size, flags)));
         selectedEntry = &m_textures.last();
+        m_poolSize += size.unclampedArea();
     } else
         selectedEntry->m_texture->reset(size, flags);
 
+    enterLimitExceededModeIfNeeded();
+
     scheduleReleaseUnusedTextures();
+
     selectedEntry->markIsInUse();
     return selectedEntry->m_texture.copyRef();
 }
@@ -64,7 +78,7 @@ void BitmapTexturePool::scheduleReleaseUnusedTextures()
     if (m_releaseUnusedTexturesTimer.isActive())
         return;
 
-    m_releaseUnusedTexturesTimer.startOneShot(releaseUnusedTexturesTimerInterval);
+    m_releaseUnusedTexturesTimer.startOneShot(m_releaseUnusedTexturesTimerInterval);
 }
 
 void BitmapTexturePool::releaseUnusedTexturesTimerFired()
@@ -73,14 +87,51 @@ void BitmapTexturePool::releaseUnusedTexturesTimerFired()
         return;
 
     // Delete entries, which have been unused in releaseUnusedSecondsTolerance.
-    MonotonicTime minUsedTime = MonotonicTime::now() - releaseUnusedSecondsTolerance;
+    MonotonicTime minUsedTime = MonotonicTime::now() - m_releaseUnusedSecondsTolerance;
 
-    m_textures.removeAllMatching([&minUsedTime](const Entry& entry) {
-        return entry.canBeReleased(minUsedTime);
+    m_textures.removeAllMatching([this, &minUsedTime](const Entry& entry) {
+        if (entry.canBeReleased(minUsedTime)) {
+            m_poolSize -= entry.m_texture->size().unclampedArea();
+            return true;
+        }
+        return false;
     });
+
+    exitLimitExceededModeIfNeeded();
 
     if (!m_textures.isEmpty())
         scheduleReleaseUnusedTextures();
+}
+
+void BitmapTexturePool::enterLimitExceededModeIfNeeded()
+{
+    if (m_onLimitExceededMode)
+        return;
+
+    if (m_poolSize > poolSizeLimit) {
+        // If we allocated a new texture and this caused that we went over the size limit, enter limit exceeded mode,
+        // set values for tolerance and interval for this mode, and trigger an immediate request to release textures.
+        // While on limit exceeded mode, we are more aggressive releasing textures, by polling more often and keeping
+        // the unused textures in the pool for smaller periods of time.
+        m_onLimitExceededMode = true;
+        m_releaseUnusedSecondsTolerance = releaseUnusedSecondsToleranceOnLimitExceeded;
+        m_releaseUnusedTexturesTimerInterval = releaseUnusedTexturesTimerIntervalOnLimitExceeded;
+        m_releaseUnusedTexturesTimer.startOneShot(0_s);
+    }
+}
+
+void BitmapTexturePool::exitLimitExceededModeIfNeeded()
+{
+    if (!m_onLimitExceededMode)
+        return;
+
+    // If we're in limit exceeded mode and the pool size has become smaller than the limit,
+    // exit the limit exceeded mode and set the default values for interval and tolerance again.
+    if (m_poolSize <= poolSizeLimit) {
+        m_onLimitExceededMode = false;
+        m_releaseUnusedSecondsTolerance = releaseUnusedSecondsTolerance;
+        m_releaseUnusedTexturesTimerInterval = releaseUnusedTexturesTimerInterval;
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
@@ -57,9 +57,15 @@ private:
     };
 
     void scheduleReleaseUnusedTextures();
+    void enterLimitExceededModeIfNeeded();
+    void exitLimitExceededModeIfNeeded();
 
     Vector<Entry> m_textures;
     RunLoop::Timer m_releaseUnusedTexturesTimer;
+    uint64_t m_poolSize { 0 };
+    bool m_onLimitExceededMode { false };
+    Seconds m_releaseUnusedSecondsTolerance;
+    Seconds m_releaseUnusedTexturesTimerInterval;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### eff294d622ac02b2267f5093ffe7e384d3f554aa
<pre>
[WPE] Add a soft limit to the amount of GPU memory BitmapTexturePool can hold
<a href="https://bugs.webkit.org/show_bug.cgi?id=271765">https://bugs.webkit.org/show_bug.cgi?id=271765</a>

Reviewed by Carlos Garcia Campos.

Add a soft limit to the amount of memory that BitmapTexturePool can hold. When
the limit is reached, be more aggressive trying to release the stored textures.

* Source/WebCore/PlatformWPE.cmake:
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp:
(WebCore::BitmapTexturePool::BitmapTexturePool):
(WebCore::BitmapTexturePool::acquireTexture):
(WebCore::BitmapTexturePool::scheduleReleaseUnusedTextures):
(WebCore::BitmapTexturePool::releaseUnusedTexturesTimerFired):
(WebCore::BitmapTexturePool::enterLimitExceededModeIfNeeded):
(WebCore::BitmapTexturePool::exitLimitExceededModeIfNeeded):
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h:

Canonical link: <a href="https://commits.webkit.org/276997@main">https://commits.webkit.org/276997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f9871b46d753953abae0516ed1dd802993ed332

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49064 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37858 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39992 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19098 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41097 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4434 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50893 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45092 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22685 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44020 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10263 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22384 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->