### PR TITLE
[UnifiedPDF] PDFDocumentLayout::nearestPageIndexForDocumentPoint sometimes returns the incorrect page index

### DIFF
--- a/Source/WebCore/platform/graphics/GeometryUtilities.h
+++ b/Source/WebCore/platform/graphics/GeometryUtilities.h
@@ -36,7 +36,7 @@ namespace WebCore {
 class FloatQuad;
 
 float euclidianDistance(const FloatSize&);
-float euclidianDistance(const FloatPoint&, const FloatPoint&);
+WEBCORE_EXPORT float euclidianDistance(const FloatPoint&, const FloatPoint&);
 
 // Find point where lines through the two pairs of points intersect. Returns false if the lines don't intersect.
 WEBCORE_EXPORT bool findIntersection(const FloatPoint& p1, const FloatPoint& p2, const FloatPoint& d1, const FloatPoint& d2, FloatPoint& intersection);


### PR DESCRIPTION
#### 59d1217ce34444006a187f88917be67d5ed8100b
<pre>
[UnifiedPDF] PDFDocumentLayout::nearestPageIndexForDocumentPoint sometimes returns the incorrect page index
<a href="https://bugs.webkit.org/show_bug.cgi?id=271777">https://bugs.webkit.org/show_bug.cgi?id=271777</a>
<a href="https://rdar.apple.com/125502090">rdar://125502090</a>

Reviewed by Abrar Rahman Protyasha.

The current heuristic worked well for the purposes of next/previous page
context menu navigation, but it likely will not be sufficient to adopt
anywhere else. In order to make this much more precise in two up mode,
we need to rework the heuristic. There are two main changes:

1.) Now iterate over the pairs of pages rather than individual ones.
This makes the rest of the logic much more intuitive since in two up
mode we are almost always working with pairs of pages. There are cases
where we may only have one page, but this is handled naturally by the
fact that the second page in PairedPageLayoutBounds is optional.

2.) Instead of picking the page with the closer x coordinate after
determining the pair of pages to consider, we should instead compare
the distance from the point in document space to various points on the
pages. In particular, we should compare the distance to the corners of
the page and to the side of the page it is next to (if possible). The
smallest distance between all of these points should represent the page
closest to the point in question.

One other change I made is related to the logic when the document point
is below the PDF. In this case we should perform the same type of logic
with the last pages instead of blindly returning the last page index
like we were doing before.

* Source/WebCore/platform/graphics/GeometryUtilities.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::nearestPageIndexForDocumentPoint const):

Canonical link: <a href="https://commits.webkit.org/276852@main">https://commits.webkit.org/276852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9054f1fc0e64913961f67268eb6e16a8da0b83a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48589 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41958 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22444 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22120 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/39610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18738 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/40706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3962 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42218 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/41057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50360 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17402 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43581 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10182 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21908 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->