### PR TITLE
[visionOS] Captions do not render in Linear Media Player

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h
@@ -35,15 +35,17 @@ class FloatSize;
 
 class VideoFullscreenCaptions {
 public:
+    WEBCORE_EXPORT virtual ~VideoFullscreenCaptions();
+
     WEBCORE_EXPORT void setTrackRepresentationImage(PlatformImagePtr textTrack);
     WEBCORE_EXPORT void setTrackRepresentationContentsScale(float);
     WEBCORE_EXPORT void setTrackRepresentationHidden(bool);
-    
+
     WEBCORE_EXPORT CALayer* captionsLayer();
     WEBCORE_EXPORT void setCaptionsFrame(const CGRect&);
-    WEBCORE_EXPORT void setupCaptionsLayer(CALayer* parent, const FloatSize&);
+    WEBCORE_EXPORT virtual void setupCaptionsLayer(CALayer *parent, const FloatSize&);
     WEBCORE_EXPORT void removeCaptionsLayer();
-    
+
 private:
     RetainPtr<CALayer> m_captionsLayer;
 };

--- a/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm
@@ -31,7 +31,9 @@
 #import <QuartzCore/CATransaction.h>
 
 namespace WebCore {
-    
+
+VideoFullscreenCaptions::~VideoFullscreenCaptions() = default;
+
 void VideoFullscreenCaptions::setTrackRepresentationImage(PlatformImagePtr textTrack)
 {
     [m_captionsLayer setContents:(__bridge id)textTrack.get()];
@@ -61,7 +63,7 @@ void VideoFullscreenCaptions::setCaptionsFrame(const CGRect& frame)
     [captionsLayer() setFrame:frame];
 }
 
-void VideoFullscreenCaptions::setupCaptionsLayer(CALayer* parent, const WebCore::FloatSize& initialSize)
+void VideoFullscreenCaptions::setupCaptionsLayer(CALayer *parent, const WebCore::FloatSize& initialSize)
 {
     [CATransaction begin];
     [CATransaction setDisableActions:YES];

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
@@ -44,7 +44,7 @@ public:
         return adoptRef(*new NullVideoPresentationInterface(playbackSessionInterface));
     }
 
-    virtual ~NullVideoPresentationInterface() = default;
+    ~NullVideoPresentationInterface() = default;
     NullPlaybackSessionInterface& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
 

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -63,7 +63,7 @@ class VideoPresentationInterfaceIOS
     , public VideoFullscreenCaptions
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoPresentationInterfaceIOS, WTF::DestructionThread::MainRunLoop> {
 public:
-    WEBCORE_EXPORT virtual ~VideoPresentationInterfaceIOS();
+    WEBCORE_EXPORT ~VideoPresentationInterfaceIOS();
     WEBCORE_EXPORT void setVideoPresentationModel(VideoPresentationModel*);
     PlaybackSessionInterfaceIOS& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -58,7 +58,7 @@ public:
     {
         return adoptRef(*new VideoPresentationInterfaceMac(playbackSessionInterface));
     }
-    virtual ~VideoPresentationInterfaceMac();
+    ~VideoPresentationInterfaceMac();
     PlaybackSessionInterfaceMac& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
     RefPtr<VideoPresentationModel> videoPresentationModel() const { return m_videoPresentationModel.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -69,6 +69,7 @@ private:
     void setAllowsPictureInPicturePlayback(bool) final { }
     bool isExternalPlaybackActive() const final { return false; }
     AVPlayerViewController *avPlayerViewController() const final { return nullptr; }
+    void setupCaptionsLayer(CALayer *parent, const FloatSize&) final;
 
     WKSLinearMediaPlayer *linearMediaPlayer() const;
 

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -68,10 +68,9 @@ void VideoPresentationInterfaceLMK::setupPlayerViewController()
         return;
 
     linearMediaPlayer().allowFullScreenFromInline = YES;
+    linearMediaPlayer().captionLayer = captionsLayer();
     linearMediaPlayer().contentType = WKSLinearMediaContentTypePlanar;
     linearMediaPlayer().presentationMode = WKSLinearMediaPresentationModeInline;
-    // FIXME: pass a valid caption layer (rdar://124223292)
-    linearMediaPlayer().captionLayer = CALayer.layer;
 
     m_playerViewController = [linearMediaPlayer() makeViewController];
 }
@@ -108,6 +107,16 @@ void VideoPresentationInterfaceLMK::setContentDimensions(const FloatSize& conten
 void VideoPresentationInterfaceLMK::setShowsPlaybackControls(bool showsPlaybackControls)
 {
     linearMediaPlayer().showsPlaybackControls = showsPlaybackControls;
+}
+
+void VideoPresentationInterfaceLMK::setupCaptionsLayer(CALayer *, const FloatSize& initialSize)
+{
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    [captionsLayer() removeFromSuperlayer];
+    [captionsLayer() setAnchorPoint:CGPointZero];
+    [captionsLayer() setBounds:CGRectMake(0, 0, initialSize.width(), initialSize.height())];
+    [CATransaction commit];
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### bbfd3d9efcbb9c24abb655b8759ee700ef5d5f34
<pre>
[visionOS] Captions do not render in Linear Media Player
<a href="https://bugs.webkit.org/show_bug.cgi?id=271797">https://bugs.webkit.org/show_bug.cgi?id=271797</a>
<a href="https://rdar.apple.com/124223292">rdar://124223292</a>

Reviewed by Jer Noble.

Re-enabled captions by setting VideoPresentationInterfaceLMK::captionsLayer() as
WKSLinearMediaPlayer&apos;s captionLayer. Fixed the bug that caused us to previously disable captions by
ensuring the captions layer is unparented and does not have an explicit zPosition. LinearMediaKit
expects to insert the caption layer into its hierarchy and manage its z-order.

* Source/WebCore/platform/cocoa/VideoFullscreenCaptions.h:
* Source/WebCore/platform/cocoa/VideoFullscreenCaptions.mm:
(WebCore::VideoFullscreenCaptions::setupCaptionsLayer):
* Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::setupPlayerViewController):
(WebKit::VideoPresentationInterfaceLMK::setupCaptionsLayer):

Canonical link: <a href="https://commits.webkit.org/276771@main">https://commits.webkit.org/276771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/977a415628c117c177d7e7c7b84e9c39bef0f2c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45623 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48291 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41658 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22145 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37372 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18513 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19221 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40443 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3667 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50033 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44463 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21917 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43299 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10139 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21604 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->