### PR TITLE
_WKWebExtensionMessagePort should not throw on invalid messages.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.h
@@ -36,10 +36,12 @@ WK_EXTERN NSErrorDomain const _WKWebExtensionMessagePortErrorDomain WK_API_AVAIL
  @abstract Constants used by NSError to indicate errors in the `_WKWebExtensionMessagePort` domain.
  @constant WKWebExtensionMessagePortErrorUnknown  Indicates that an unknown error occurred.
  @constant WKWebExtensionMessagePortErrorNotConnected  Indicates that the message port is disconnected.
+ @constant WKWebExtensionMessagePortErrorMessageInvalid Indicates that the message is invalid. The message must be an object that is JSON-serializable.
  */
 typedef NS_ERROR_ENUM(_WKWebExtensionMessagePortErrorDomain, _WKWebExtensionMessagePortError) {
     _WKWebExtensionMessagePortErrorUnknown,
     _WKWebExtensionMessagePortErrorNotConnected,
+    _WKWebExtensionMessagePortErrorMessageInvalid,
 } NS_SWIFT_NAME(_WKWebExtensionMessagePort.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 /*!

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -225,8 +225,10 @@ void WebExtensionContext::runtimeSendNativeMessage(const String& applicationID, 
             return;
         }
 
-        if (replyMessage)
-            THROW_UNLESS(isValidJSONObject(replyMessage, JSONOptions::FragmentsAllowed), @"Reply message is not JSON-serializable");
+        if (replyMessage && !isValidJSONObject(replyMessage, JSONOptions::FragmentsAllowed)) {
+            completionHandler(toWebExtensionError(apiName, nil, @"reply message was not JSON-serializable"));
+            return;
+        }
 
         completionHandler(String(encodeJSONString(replyMessage, JSONOptions::FragmentsAllowed)));
     }).get()];

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
@@ -58,6 +58,7 @@ public:
     enum class ErrorType : uint8_t {
         Unknown,
         NotConnected,
+        MessageInvalid,
     };
 
     using Error = std::optional<std::pair<ErrorType, std::optional<String>>>;

--- a/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm
@@ -85,7 +85,7 @@
     if (_openOptionsPage)
         _openOptionsPage(extensionContext, completionHandler);
     else
-        completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"runtime.openOptionsPage() not implemneted" }]);
+        completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"runtime.openOptionsPage() not implemented" }]);
 }
 
 - (void)webExtensionController:(_WKWebExtensionController *)controller promptForPermissions:(NSSet<_WKWebExtensionPermission> *)permissions inTab:(id<_WKWebExtensionTab>)tab forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSSet<_WKWebExtensionPermission> *allowedPermissions, NSDate *expirationDate))completionHandler
@@ -117,7 +117,7 @@
     if (_sendMessage)
         _sendMessage(message, applicationIdentifier, replyHandler);
     else
-        replyHandler(nil, [NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"runtime.sendNativeMessage() not implemneted" }]);
+        replyHandler(nil, [NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"runtime.sendNativeMessage() not implemented" }]);
 }
 
 - (void)webExtensionController:(_WKWebExtensionController *)controller connectUsingMessagePort:(_WKWebExtensionMessagePort *)port forExtensionContext:(_WKWebExtensionContext *)extensionContext completionHandler:(void (^)(NSError *error))completionHandler
@@ -126,7 +126,7 @@
         _connectUsingMessagePort(port);
         completionHandler(nil);
     } else
-        completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"runtime.connectNative() not implemneted" }]);
+        completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"runtime.connectNative() not implemented" }]);
 }
 
 - (void)webExtensionController:(_WKWebExtensionController *)controller presentPopupForAction:(_WKWebExtensionAction *)action forExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
@@ -135,7 +135,7 @@
         _presentPopupForAction(action);
         completionHandler(nil);
     } else
-        completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"action.showPopup() not implemneted" }]);
+        completionHandler([NSError errorWithDomain:NSCocoaErrorDomain code:0 userInfo:@{ NSDebugDescriptionErrorKey: @"action.showPopup() not implemented" }]);
 }
 
 @end


### PR DESCRIPTION
#### 32ee401ab706355455e48265e18665e04268ea11
<pre>
_WKWebExtensionMessagePort should not throw on invalid messages.
<a href="https://webkit.org/b/271796">https://webkit.org/b/271796</a>
<a href="https://rdar.apple.com/125505726">rdar://125505726</a>

Reviewed by Jeff Miller.

Change the exception that was thrown in -[_WKWebExtensionMessagePort sendMessage::] to an
error that is returned to the completion handler instead.

Also fixed the reply message handling for runtime.sendNativeMessage() so it returns the
error to the extension instead of throwing an exception.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.h:
(NS_ERROR_ENUM): Added _WKWebExtensionMessagePortErrorMessageInvalid.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeSendNativeMessage): Changed THROW_UNLESS into a check that returns
and error to the completion handler.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm:
(WebKit::toAPI): Added cases for ErrorType::MessageInvalid.
(WebKit::WebExtensionMessagePort::sendMessage): Changed THROW_UNLESS into a check that returns
_WKWebExtensionMessagePortErrorMessageInvalid error to the completion handler.
* Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TEST(WKWebExtensionAPIRuntime, SendNativeMessageWithInvalidReply)): Added.
(TEST(WKWebExtensionAPIRuntime, ConnectNativeWithInvalidMessage)): Added.
* Tools/TestWebKitAPI/cocoa/TestWebExtensionsDelegate.mm:
(-[TestWebExtensionsDelegate webExtensionController:openOptionsPageForExtensionContext:completionHandler:]): Fix typo.
(-[TestWebExtensionsDelegate webExtensionController:sendMessage:toApplicationIdentifier:forExtensionContext:replyHandler:]): Ditto.
(-[TestWebExtensionsDelegate webExtensionController:connectUsingMessagePort:forExtensionContext:completionHandler:]): Ditto.
(-[TestWebExtensionsDelegate webExtensionController:presentPopupForAction:forExtensionContext:completionHandler:]): Ditto.

Canonical link: <a href="https://commits.webkit.org/276760@main">https://commits.webkit.org/276760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86bc0e81a89b7892b190bf7cb436b2dac6833cd7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48250 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41592 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22100 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40411 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3626 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41886 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49988 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20571 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17101 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/43270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6348 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->