### PR TITLE
REGRESSION (276683@main): [ iOS ] 3X imported/w3c/web-platform-tests/svg/import/animate tests are consistent failures

### DIFF
--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/svg/import/animate-elem-30-t-manual-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/svg/import/animate-elem-30-t-manual-expected.txt
@@ -32,7 +32,7 @@ layer at (0,0) size 800x600
         RenderSVGHiddenContainer {defs} at (0,0) size 0x0
           RenderSVGPath {line} at (52,20) size 50x90 [stroke={[type=SOLID] [color=#105D8C] [stroke width=3.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=30.00] [y1=50.00] [x2=10.00] [y2=10.00]
         RenderSVGHiddenContainer {defs} at (0,0) size 0x0
-          RenderSVGRect {rect} at (52,127) size 136x49 [stroke={[type=SOLID] [color=#000000] [stroke width=2.00]}] [fill={[type=SOLID] [color=#FFFFFF]}] [x=10.00] [y=60.00] [width=60.00] [height=20.00]
+          RenderSVGRect {rect} at (52,127) size 136x49 [stroke={[type=SOLID] [color=#000000] [stroke width=2.00]}] [fill={[type=SOLID] [color=#0000FF]}] [x=10.00] [y=60.00] [width=60.00] [height=20.00]
         RenderSVGHiddenContainer {defs} at (0,0) size 0x0
           RenderSVGEllipse {circle} at (53,193) size 47x47 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#105D8C]}] [cx=20.00] [cy=100.00] [r=10.00]
         RenderSVGHiddenContainer {defs} at (0,0) size 0x0
@@ -44,7 +44,7 @@ layer at (0,0) size 800x600
         RenderSVGContainer {use} at (73,20) size 50x90 [transform={m=((1.00,0.00)(0.00,1.00)) t=(10.00,0.00)}]
           RenderSVGPath {line} at (73,20) size 50x90 [stroke={[type=SOLID] [color=#105D8C] [stroke width=3.00]}] [fill={[type=SOLID] [color=#000000]}] [x1=30.00] [y1=50.00] [x2=10.00] [y2=10.00]
         RenderSVGContainer {use} at (52,127) size 136x49
-          RenderSVGRect {rect} at (52,127) size 136x49 [stroke={[type=SOLID] [color=#000000] [stroke width=2.00]}] [fill={[type=SOLID] [color=#FFFFFF]}] [x=10.00] [y=60.00] [width=60.00] [height=20.00]
+          RenderSVGRect {rect} at (52,127) size 136x49 [stroke={[type=SOLID] [color=#000000] [stroke width=2.00]}] [fill={[type=SOLID] [color=#0000FF]}] [x=10.00] [y=60.00] [width=60.00] [height=20.00]
         RenderSVGContainer {use} at (75,193) size 47x47 [transform={m=((1.00,0.00)(0.00,1.00)) t=(10.00,0.00)}]
           RenderSVGEllipse {circle} at (75,193) size 47x47 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#105D8C]}] [cx=20.00] [cy=100.00] [r=10.00]
         RenderSVGContainer {use} at (464,43) size 49x87

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/svg/import/animate-elem-85-t-manual-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/svg/import/animate-elem-85-t-manual-expected.txt
@@ -5,10 +5,10 @@ layer at (0,0) size 800x600
     RenderSVGHiddenContainer {defs} at (0,0) size 0x0
     RenderSVGContainer {g} at (50,83) size 700x426
       RenderSVGContainer {g} at (50,83) size 700x167
-        RenderSVGRect {rect} at (50,83) size 150x167 [fill={[type=SOLID] [color=#000000]}] [x=30.00] [y=50.00] [width=90.00] [height=100.00]
-        RenderSVGRect {rect} at (233,83) size 151x167 [fill={[type=SOLID] [color=#000000]}] [x=140.00] [y=50.00] [width=90.00] [height=100.00]
-        RenderSVGRect {rect} at (416,83) size 151x167 [fill={[type=SOLID] [color=#000000]}] [x=250.00] [y=50.00] [width=90.00] [height=100.00]
-        RenderSVGRect {rect} at (600,83) size 150x167 [fill={[type=SOLID] [color=#000000]}] [x=360.00] [y=50.00] [width=90.00] [height=100.00]
+        RenderSVGRect {rect} at (50,83) size 150x167 [fill={[type=SOLID] [color=#FF0000]}] [x=30.00] [y=50.00] [width=90.00] [height=100.00]
+        RenderSVGRect {rect} at (233,83) size 151x167 [fill={[type=SOLID] [color=#FF0000]}] [x=140.00] [y=50.00] [width=90.00] [height=100.00]
+        RenderSVGRect {rect} at (416,83) size 151x167 [fill={[type=SOLID] [color=#FF0000]}] [x=250.00] [y=50.00] [width=90.00] [height=100.00]
+        RenderSVGRect {rect} at (600,83) size 150x167 [fill={[type=SOLID] [color=#FF0000]}] [x=360.00] [y=50.00] [width=90.00] [height=100.00]
       RenderSVGContainer {g} at (116,300) size 568x209
         RenderSVGRect {rect} at (166,300) size 468x100 [fill={[type=SOLID] [color=#0000FF]}] [x=100.00] [y=180.00] [width=280.00] [height=60.00]
         RenderSVGRect {rect} at (166,408) size 468x101 [fill={[type=SOLID] [color=#0000FF]}] [x=100.00] [y=245.00] [width=280.00] [height=60.00]

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/svg/import/animate-pservers-grad-01-b-manual-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/svg/import/animate-pservers-grad-01-b-manual-expected.txt
@@ -8,7 +8,7 @@ layer at (0,0) size 800x600
         RenderSVGContainer {g} at (0,0) size 0x0
           RenderSVGResourceLinearGradient {linearGradient} [id="MyGradient1"] [gradientUnits=objectBoundingBox] [start=(0,0)] [end=(1,0)]
             RenderSVGGradientStop {stop} [offset=0.00] [color=#008000]
-            RenderSVGGradientStop {stop} [offset=1.00] [color=#FF0000]
+            RenderSVGGradientStop {stop} [offset=1.00] [color=#FFFF00]
           RenderSVGResourceLinearGradient {linearGradient} [id="MyGradient2"] [gradientUnits=objectBoundingBox] [start=(0,0)] [end=(1,0)]
             RenderSVGGradientStop {stop} [offset=0.00] [color=#008000]
             RenderSVGGradientStop {stop} [offset=1.00] [color=#00800080]


### PR DESCRIPTION
#### ddc2ab8c1df31ce957401fa3073cf30b4d42368b
<pre>
REGRESSION (276683@main): [ iOS ] 3X imported/w3c/web-platform-tests/svg/import/animate tests are consistent failures

<a href="https://bugs.webkit.org/show_bug.cgi?id=271772">https://bugs.webkit.org/show_bug.cgi?id=271772</a>
<a href="https://rdar.apple.com/problem/125499045">rdar://problem/125499045</a>

Reviewed by Tim Nguyen.

This is platform specific rebaseline, which was not highlighted earlier by EWS.

* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/svg/import/animate-elem-30-t-manual-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/svg/import/animate-elem-85-t-manual-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/svg/import/animate-pservers-grad-01-b-manual-expected.txt:

Canonical link: <a href="https://commits.webkit.org/276769@main">https://commits.webkit.org/276769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bab380ac5a7c34f4b6e2b0c2d006c278b8deb35

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24715 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48259 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41607 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37347 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18499 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19196 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40410 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3635 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41901 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/49998 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44431 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21883 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43265 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10138 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->