### PR TITLE
[Remote Inspection] Make it possible to target ::before/::after pseudo elements

### DIFF
--- a/LayoutTests/fast/element-targeting/target-pseudo-elements-expected.html
+++ b/LayoutTests/fast/element-targeting/target-pseudo-elements-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>This test requires WebKitTestRunner</body>
+</html>

--- a/LayoutTests/fast/element-targeting/target-pseudo-elements.html
+++ b/LayoutTests/fast/element-targeting/target-pseudo-elements.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+body::after {
+    top: 0;
+    left: 0;
+    z-index: 100;
+}
+
+body::before {
+    bottom: 0;
+    right: 0;
+    z-index: 10;
+}
+
+body::before, body::after {
+    position: fixed;
+    display: block;
+    content: " ";
+    width: 128px;
+    height: 128px;
+    background-image: url(../images/resources/green-256x256.png);
+    background-repeat: no-repeat;
+    background-size: 128px 128px;
+}
+</style>
+</head>
+<body>This test requires WebKitTestRunner</body>
+<script>
+addEventListener("load", async event => {
+    testRunner.waitUntilDone();
+    const firstSelector = await UIHelper.adjustVisibilityForFrontmostTarget(64, 64);
+    const secondSelector = await UIHelper.adjustVisibilityForFrontmostTarget(innerWidth - 64, innerHeight - 64);
+
+    if (firstSelector.toLowerCase() !== "body::after")
+        document.writeln(`FAIL: first selector was ${firstSelector}`);
+
+    if (secondSelector.toLowerCase() !== "body::before")
+        document.writeln(`FAIL: second selector was ${secondSelector}`);
+    testRunner.notifyDone();
+});
+</script>
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1069,6 +1069,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     dom/UserTypingGestureIndicator.h
     dom/ValidityStateFlags.h
     dom/ViewTransition.h
+    dom/VisibilityAdjustment.h
     dom/ViewTransitionUpdateCallback.h
     dom/ViewportArguments.h
     dom/VisibilityChangeClient.h

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -145,6 +145,7 @@
 #include "TextIterator.h"
 #include "TouchAction.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include "VisibilityAdjustment.h"
 #include "VoidCallback.h"
 #include "WebAnimation.h"
 #include "WebAnimationTypes.h"
@@ -5635,14 +5636,16 @@ CustomStateSet& Element::ensureCustomStateSet()
     return *rareData.customStateSet();
 }
 
-bool Element::isVisibilityAdjustmentRoot() const
+OptionSet<VisibilityAdjustment> Element::visibilityAdjustment() const
 {
-    return hasRareData() && elementRareData()->isVisibilityAdjustmentRoot();
+    if (!hasRareData())
+        return { };
+    return elementRareData()->visibilityAdjustment();
 }
 
-void Element::setIsVisibilityAdjustmentRoot()
+void Element::addVisibilityAdjustment(OptionSet<VisibilityAdjustment> adjustment)
 {
-    ensureElementRareData().setIsVisibilityAdjustmentRoot();
+    ensureElementRareData().addVisibilityAdjustment(adjustment);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -99,6 +99,7 @@ enum class IsSyntheticClick : bool { No, Yes };
 enum class ParserContentPolicy : uint8_t;
 enum class ResolveURLs : uint8_t { No, NoExcludingURLsForPrivacy, Yes, YesExcludingURLsForPrivacy };
 enum class SelectionRestorationMode : uint8_t;
+enum class VisibilityAdjustment : uint8_t;
 
 struct CheckVisibilityOptions;
 struct FullscreenOptions;
@@ -632,8 +633,8 @@ public:
     WEBCORE_EXPORT void requestPointerLock();
 #endif
 
-    bool isVisibilityAdjustmentRoot() const;
-    void setIsVisibilityAdjustmentRoot();
+    OptionSet<VisibilityAdjustment> visibilityAdjustment() const;
+    void addVisibilityAdjustment(OptionSet<VisibilityAdjustment>);
 
     bool isSpellCheckingEnabled() const;
     WEBCORE_EXPORT bool isWritingSuggestionsEnabled() const;

--- a/Source/WebCore/dom/ElementRareData.cpp
+++ b/Source/WebCore/dom/ElementRareData.cpp
@@ -45,7 +45,7 @@ struct SameSizeAsElementRareData : NodeRareData {
     void* resizeObserverData;
     Markable<LayoutUnit, LayoutUnitMarkableTraits> lastRemembedSize[2];
     ExplicitlySetAttrElementsMap explicitlySetAttrElementsMap;
-    bool isVisibilityAdjustmentRoot;
+    uint8_t visibilityAdjustment;
 };
 
 static_assert(sizeof(ElementRareData) == sizeof(SameSizeAsElementRareData), "ElementRareData should stay small");

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -41,6 +41,7 @@
 #include "SpaceSplitString.h"
 #include "StylePropertyMap.h"
 #include "StylePropertyMapReadOnly.h"
+#include "VisibilityAdjustment.h"
 #include <wtf/Markable.h>
 
 namespace WebCore {
@@ -153,8 +154,8 @@ public:
     CustomStateSet* customStateSet() { return m_customStateSet.get(); }
     void setCustomStateSet(Ref<CustomStateSet>&& customStateSet) { m_customStateSet = WTFMove(customStateSet); }
 
-    bool isVisibilityAdjustmentRoot() const { return m_isVisibilityAdjustmentRoot; }
-    void setIsVisibilityAdjustmentRoot() { m_isVisibilityAdjustmentRoot = true; }
+    OptionSet<VisibilityAdjustment> visibilityAdjustment() const { return m_visibilityAdjustment; }
+    void addVisibilityAdjustment(OptionSet<VisibilityAdjustment> adjustment) { m_visibilityAdjustment.add(adjustment); }
 
 #if DUMP_NODE_STATISTICS
     OptionSet<UseType> useTypes() const
@@ -259,7 +260,7 @@ private:
 
     RefPtr<CustomStateSet> m_customStateSet;
 
-    bool m_isVisibilityAdjustmentRoot { false };
+    OptionSet<VisibilityAdjustment> m_visibilityAdjustment;
 };
 
 inline ElementRareData::ElementRareData()

--- a/Source/WebCore/dom/VisibilityAdjustment.h
+++ b/Source/WebCore/dom/VisibilityAdjustment.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+
+enum class VisibilityAdjustment : uint8_t {
+    Subtree         = 1 << 0,
+    BeforePseudo    = 1 << 1,
+    AfterPseudo     = 1 << 2,
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/ElementTargetingTypes.h
+++ b/Source/WebCore/page/ElementTargetingTypes.h
@@ -52,6 +52,7 @@ struct TargetedElementInfo {
     PositionType positionType { PositionType::Static };
     Vector<FrameIdentifier> childFrameIdentifiers;
     bool isUnderPoint { true };
+    bool isPseudoElement { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -71,6 +71,7 @@
 #include "TouchAction.h"
 #include "TypedElementDescendantIterator.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include "VisibilityAdjustment.h"
 #include "WebAnimationTypes.h"
 #include <wtf/RobinHoodHashSet.h>
 
@@ -602,7 +603,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
                 style.setHeight(Length(200, LengthType::Fixed));
         }
 
-        if (UNLIKELY(m_element->isVisibilityAdjustmentRoot() || m_parentStyle.isInVisibilityAdjustmentSubtree()))
+        if (UNLIKELY(m_element->visibilityAdjustment().contains(VisibilityAdjustment::Subtree) || m_parentStyle.isInVisibilityAdjustmentSubtree()))
             style.setIsInVisibilityAdjustmentSubtree();
     }
 
@@ -1138,6 +1139,13 @@ bool Adjuster::adjustForTextAutosizing(RenderStyle& style, const Element& elemen
     return adjustForTextAutosizing(style, element, adjustmentForTextAutosizing(style, element));
 }
 #endif
+
+void Adjuster::adjustVisibilityForPseudoElement(RenderStyle& style, const Element& host)
+{
+    if ((style.pseudoElementType() == PseudoId::After && host.visibilityAdjustment().contains(VisibilityAdjustment::AfterPseudo))
+        || (style.pseudoElementType() == PseudoId::Before && host.visibilityAdjustment().contains(VisibilityAdjustment::BeforePseudo)))
+        style.setIsInVisibilityAdjustmentSubtree();
+}
 
 }
 }

--- a/Source/WebCore/style/StyleAdjuster.h
+++ b/Source/WebCore/style/StyleAdjuster.h
@@ -51,6 +51,7 @@ public:
     void adjust(RenderStyle&, const RenderStyle* userAgentAppearanceStyle) const;
     void adjustAnimatedStyle(RenderStyle&, OptionSet<AnimationImpact>) const;
 
+    static void adjustVisibilityForPseudoElement(RenderStyle&, const Element& host);
     static void adjustSVGElementStyle(RenderStyle&, const SVGElement&);
     static bool adjustEventListenerRegionTypesForRootStyle(RenderStyle&, const Document&);
     static void propagateToDocumentElementAndInitialContainingBlock(Update&, const Document&);

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -78,6 +78,7 @@
 #include "StyleSheetContents.h"
 #include "UserAgentParts.h"
 #include "UserAgentStyle.h"
+#include "VisibilityAdjustment.h"
 #include "VisitedLinkState.h"
 #include "WebAnimationTypes.h"
 #include "WebKitFontFamilyNames.h"
@@ -514,6 +515,8 @@ std::optional<ResolvedStyle> Resolver::styleForPseudoElement(const Element& elem
 
     Adjuster adjuster(document(), *state.parentStyle(), context.parentBoxStyle, nullptr);
     adjuster.adjust(*state.style(), state.userAgentAppearanceStyle());
+
+    Adjuster::adjustVisibilityForPseudoElement(*state.style(), element);
 
     if (state.style()->usesViewportUnits())
         document().setHasStyleWithViewportUnits();

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -815,6 +815,9 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveStartingStyle(const ResolvedSt
     if (startingStyle->display() == DisplayType::None)
         return nullptr;
 
+    // FIXME: This logic seems wrong, because passing a non-null Element to Adjuster corresponds
+    // to the absence (not presence) of a pseudo ID. We should instead refactor this code to
+    // pass a non-null element, along with an optional pseudo element identifier.
     Adjuster adjuster(m_document, parentAfterChangeStyle, resolutionContext.parentBoxStyle, styleable.pseudoElementIdentifier ? &styleable.element : nullptr);
     adjuster.adjust(*startingStyle, nullptr);
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -900,6 +900,7 @@ header: <WebCore/ElementTargetingTypes.h>
     WebCore::PositionType positionType
     Vector<WebCore::FrameIdentifier> childFrameIdentifiers
     bool isUnderPoint
+    bool isPseudoElement
 };
 
 header: <WebCore/RenderStyleConstants.h>

--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
@@ -57,6 +57,7 @@ public:
     WebCore::FloatRect boundsInWebView() const;
 
     bool isUnderPoint() const { return m_info.isUnderPoint; }
+    bool isPseudoElement() const { return m_info.isPseudoElement; }
 
     void childFrames(CompletionHandler<void(Vector<Ref<FrameTreeNode>>&&)>&&) const;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
@@ -43,6 +43,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @property (nonatomic, readonly) _WKTargetedElementPosition positionType;
 @property (nonatomic, readonly) CGRect bounds;
 @property (nonatomic, readonly, getter=isUnderPoint) BOOL underPoint;
+@property (nonatomic, readonly, getter=isPseudoElement) BOOL pseudoElement;
 
 @property (nonatomic, readonly, copy) NSArray<NSString *> *selectors;
 @property (nonatomic, readonly, copy) NSString *renderedText;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -115,4 +115,9 @@
     return _info->isUnderPoint();
 }
 
+- (BOOL)isPseudoElement
+{
+    return _info->isPseudoElement();
+}
+
 @end


### PR DESCRIPTION
#### 780bd128913de133fa2bcadf4fdd2127be890bcb
<pre>
[Remote Inspection] Make it possible to target ::before/::after pseudo elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=271791">https://bugs.webkit.org/show_bug.cgi?id=271791</a>

Reviewed by Megan Gardner.

(...and also incorporates suggestions from Antti).

Add support for targeting `::before` and `::after` pseudo elements, for visibility adjustment. See
below for more details.

* LayoutTests/fast/element-targeting/target-pseudo-elements-expected.html: Added.
* LayoutTests/fast/element-targeting/target-pseudo-elements.html: Added.

Add a new layout test to exercise the change (targeting both `after` and `before` pseudo elements).

* Source/WebCore/Headers.cmake:

Add a new WebCore header that just contains the new `VisibilityAdjustment` enum values.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::visibilityAdjustment const):
(WebCore::Element::addVisibilityAdjustment):
(WebCore::Element::isVisibilityAdjustmentRoot const): Deleted.
(WebCore::Element::setIsVisibilityAdjustmentRoot): Deleted.

Refactor this code — instead of having a single boolean flag that indicates whether the element is
a visibility adjustment root, turn it into an OptionSet with up to 3 bits (subtree, `::before`
pseudo element and `::after` pseudo element).

* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::visibilityAdjustment const):
(WebCore::ElementRareData::addVisibilityAdjustment):
(WebCore::ElementRareData::isVisibilityAdjustmentRoot const): Deleted.
(WebCore::ElementRareData::setIsVisibilityAdjustmentRoot): Deleted.

See above for more details — replace the single `isVisibilityAdjustmentRoot` flag with a new
`OptionSet`.

* Source/WebCore/dom/VisibilityAdjustment.h: Copied from Source/WebCore/page/ElementTargetingTypes.h.
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::selectorsForTarget):
(WebCore::targetedElementInfo):

Teach this to emit `::before` and `::after` selectors for pseudo elements.

(WebCore::isTargetCandidate):

Teach this helper function to always consider rendered `::before` and `::after` pseudo elements to
be candidates for target selection, since adjusting visibility for these elements is unlikely to
adversely affect &quot;main content&quot; on the page.

(WebCore::elementToAdjust):
(WebCore::adjustmentToApply):
(WebCore::adjustVisibilityIfNeeded):

Split some of this functionality into multiple helper methods, to make it easier to determine how
an element should be marked for visibility adjustment. In particular, for before and after pseudo
elements, we mark the pseudo host element with `VisibilityAdjustment::{Before|After}Pseudo`, and for
everything else, we mark the element subtree (i.e. the same as what we currently do).

(WebCore::ElementTargetingController::adjustVisibility):
(WebCore::ElementTargetingController::adjustVisibilityInRepeatedlyTargetedRegions):
* Source/WebCore/page/ElementTargetingTypes.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
(WebCore::Style::Adjuster::adjustVisibilityForPseudoElement):

Honor `VisibilityAdjustment::{BeforePseudo|AfterPseudo}` on the host element, by marking the
corresponding pseudo element style with visibility adjustment.

* Source/WebCore/style/StyleAdjuster.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForPseudoElement):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveStartingStyle const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APITargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo isPseudoElement]):

Add a new SPI property to surface whether or not the targeted element is a pseudo-element to the
client.

Canonical link: <a href="https://commits.webkit.org/276816@main">https://commits.webkit.org/276816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e11d2092aa101ec7c2ba235a22e430f057f1f9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48396 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37437 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18589 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40537 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3771 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42028 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50178 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17228 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43437 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10161 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22381 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->