### PR TITLE
prepare-ChangeLog should include names for added / changed / removed API tests.

### DIFF
--- a/Tools/Scripts/prepare-ChangeLog
+++ b/Tools/Scripts/prepare-ChangeLog
@@ -837,6 +837,7 @@ sub get_function_line_ranges_for_cpp($$)
     my $in_macro = 0;
     my $in_method_declaration = 0;
     my $in_parentheses = 0;
+    my $in_test_declaration = 0;
     my $quotation_mark;
     my $in_braces = 0;
     my $in_toplevel_array_brace = 0;
@@ -989,7 +990,7 @@ sub get_function_line_ranges_for_cpp($$)
 
 
         # Find function, interface and method names.
-        while (m&((?:[[:word:]]+::)*operator(?:[ \t]*\(\)|[^()]*)|[[:word:]<>:~]+|[(){}:;=])|\@(?:implementation|interface|protocol)\s+(\w+)[^{]*&g) {
+        while (m&((?:[[:word:]]+::)*operator(?:[ \t]*\(\)|[^()]*)|[[:word:]<>:~]+|[(){}:;=,])|\@(?:implementation|interface|protocol)\s+(\w+)[^{]*&g) {
             # Skip an array definition at the top level.
             # e.g. static int arr[] = { 1, 2, 3 };
             if ($1) {
@@ -1015,12 +1016,22 @@ sub get_function_line_ranges_for_cpp($$)
             # Open parenthesis.
             if ($1 eq "(") {
                 $potential_name = $word unless $in_parentheses || $skip_til_brace_or_semicolon || grep { $word eq $_ } ("CF_ENUM", "CF_OPTIONS", "NS_ENUM", "NS_OPTIONS");
+                $in_test_declaration = 1 if $word eq "TEST";
+                $potential_name .= "(" if $in_test_declaration;
                 $in_parentheses++;
+                next;
+            }
+
+            # Comma.
+            if ($1 eq ",") {
+                $potential_name .= ", " if $in_test_declaration;
                 next;
             }
 
             # Close parenthesis.
             if ($1 eq ")") {
+                $potential_name .= ")" if $in_test_declaration;
+                $in_test_declaration = 0;
                 $in_parentheses--;
                 next;
             }
@@ -1148,6 +1159,7 @@ sub get_function_line_ranges_for_cpp($$)
 
             # Word.
             $word = $1;
+
             if (!$skip_til_brace_or_semicolon) {
                 if ($next_word_could_be_namespace) {
                     $potential_namespace = $word;
@@ -1160,10 +1172,13 @@ sub get_function_line_ranges_for_cpp($$)
                     $potential_start = 0;
                     $potential_name = "";
                 }
+
                 if (!$potential_start) {
                     $potential_start = $.;
                     $potential_name = "";
                 }
+
+                $potential_name .= $word if $in_test_declaration;
             }
         }
     }


### PR DESCRIPTION
#### 4a2e722b4c68d9d1395d0165bc39db4f71e295f9
<pre>
prepare-ChangeLog should include names for added / changed / removed API tests.
<a href="https://webkit.org/b/271798">https://webkit.org/b/271798</a>

Reviewed by Alexey Proskuryakov.

Currently the output is like (no matter how many tests change):

    (TestWebKitAPI::TEST):

When it should be like:

    (TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ExampleNew)):
    (TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, StartupEvent)):
    (TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, Reload)): Deleted.

* Tools/Scripts/prepare-ChangeLog:
(get_function_line_ranges_for_cpp): Added $in_test_declaration to track when
we are inside a TEST() declaration, so the whole name can be captured in
the $potential_name variable.

Canonical link: <a href="https://commits.webkit.org/276758@main">https://commits.webkit.org/276758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53942706b9ba3860c0f3b075477bfac97d2d2890

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48263 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/41626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47901 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22114 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39323 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/18482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40412 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3639 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50003 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/20583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/21887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/43266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6345 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/21576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->