### PR TITLE
Invalidate SVG filter results in SVGResourcesCache::clientLayoutChanged()

### DIFF
--- a/LayoutTests/svg/foreignObject/filter-repaint-expected.svg
+++ b/LayoutTests/svg/foreignObject/filter-repaint-expected.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+  <g>
+    <foreignObject width="100%" height="100%">
+      <xhtml:div id="div" style="width: 100px; height: 100px; background-color: green;"></xhtml:div>
+    </foreignObject>
+  </g>
+</svg>

--- a/LayoutTests/svg/foreignObject/filter-repaint.svg
+++ b/LayoutTests/svg/foreignObject/filter-repaint.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     xmlns:xhtml="http://www.w3.org/1999/xhtml" onload="runTest()">
+
+  <!-- Test for http://crbug.com/165180 -->
+  <defs>
+    <filter id="f">
+      <feOffset/>
+    </filter>
+  </defs>
+
+  <rect id="r" width="100%" height="100%" fill="yellow"/>
+  <g filter="url(#f)">
+    <foreignObject width="100%" height="100%">
+      <xhtml:div id="div" style="width: 99px; height: 100px; background-color: red;"></xhtml:div>
+    </foreignObject>
+  </g>
+
+  <script>
+    function runTest() {
+        if (window.testRunner) {
+          testRunner.waitUntilDone();
+        }
+
+        window.requestAnimationFrame(function() {
+            setTimeout(function() {
+                document.getElementById('div').style.backgroundColor = 'green';
+                document.getElementById('div').style.width = '100px';
+
+                // Force a full redraw to get rid of the display() shade and make ref-testing feasible.
+                document.getElementById('r').setAttribute('fill', 'none');
+
+                if (window.testRunner)
+                  testRunner.notifyDone();
+            }, 0);
+        });
+    }
+  </script>
+</svg>

--- a/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/SVGResourcesCache.cpp
@@ -121,7 +121,7 @@ void SVGResourcesCache::clientLayoutChanged(RenderElement& renderer)
 
     // Invalidate the resources if either the RenderElement itself changed,
     // or we have filter resources, which could depend on the layout of children.
-    if (renderer.selfNeedsLayout() && hasResourcesRequiringRemovalOnClientLayoutChange(*resources))
+    if ((renderer.selfNeedsLayout() || resources->filter()) && hasResourcesRequiringRemovalOnClientLayoutChange(*resources))
         resources->removeClientFromCache(renderer, false);
 }
 


### PR DESCRIPTION
#### 34cb73b0f69df082842d0ab58ae7a05a530afba7
<pre>
Invalidate SVG filter results in SVGResourcesCache::clientLayoutChanged()

<a href="https://bugs.webkit.org/show_bug.cgi?id=271449">https://bugs.webkit.org/show_bug.cgi?id=271449</a>

Reviewed by Simon Fraser.

This patch is to align WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/25d72ebd50bec9a4caa426e735e5ee7292c4da69">https://chromium.googlesource.com/chromium/blink/+/25d72ebd50bec9a4caa426e735e5ee7292c4da69</a>

^ Also import `skipped` test from Blink / Chromium upstream.

This patch effectively fix regression introduced by 91851@main.

For the SVG tree, filter result invalidation is handled by LegacyRenderSVGResource::markForLayoutAndParentResourceInvalidation.
But non-SVG content (such as a &lt;foreignObject&gt; HTML subtree) does not call markForLayoutAndParentResourceInvalidation
and instead uses the regular setNeedsLayout() invalidation path.

Hence, changes in the HTML subtree do not invalidate cached results for filters applied on
ancestor SVG elements. In order to cover this case, clientLayoutChanged() needs to
invalidate filter results even if the SVG element itself does not need a re-layout. Note
that prior to 91851@main the method used to do exactly that, but the branch was removed on
the assumption that markForLayoutAndParentResourceInvalidation() is already taking care of
it. Obviously, the assumption doesn&apos;t hold for non-SVG content.

* Source/WebCore/rendering/svg/SVGResourcesCache.cpp:
(SVGResourcesCache::clientLayoutChanged():
* LayoutTests/svg/foreignObject/filter-repaint.svg: Add Test Case
* LayoutTests/svg/foreignObject/filter-repaint-expected.svg: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/276808@main">https://commits.webkit.org/276808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cd7011e8ec444a7a6a6b555adaab2bbd2b3c30f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48274 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41638 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37356 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18492 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40424 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3650 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50016 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44444 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21898 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43279 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10158 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22260 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->