### PR TITLE
[results.webkit.org] Separate failures between runs sharing a configuration

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/investigate.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/investigate.js
@@ -114,8 +114,6 @@ function prioritizedFailures(failures, max = 0, willFilterExpected = false)
         failuresToDisplay[max - 1] = null;
     }
 
-
-
     return `<div>${failuresToDisplay.map(failure => {
         if (failure === null) {
             const params = failures.toParams();
@@ -367,7 +365,11 @@ class _InvestigateDrawer {
             this.data.forEach(datum => {
                 datum.failures = new Failures(this.suite, datum.configuration);
                 failures.forEach(failure => {
-                    if (datum.configuration.compare(failure.configuration) === 0)
+                    if (
+                        datum.configuration.compare(failure.configuration) === 0 &&
+                        failure.uuid_range[0] <= datum.uuid && datum.uuid <= failure.uuid_range[1] &&
+                        failure.start_time_range[0] <= datum.start_time && datum.start_time <= failure.start_time_range[1]
+                    )
                         datum.failures = Failures.combine(datum.failures, failure);
                 });
             });


### PR DESCRIPTION
#### 72cd3b4c65c7f440b6e95947bb01e0de389181a7
<pre>
[results.webkit.org] Separate failures between runs sharing a configuration
<a href="https://bugs.webkit.org/show_bug.cgi?id=271807">https://bugs.webkit.org/show_bug.cgi?id=271807</a>
<a href="https://rdar.apple.com/125515440">rdar://125515440</a>

Reviewed by Ryan Haddad.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/investigate.js:
(_InvestigateDrawer.prototype.dispatch): Only assign a Failure object to a run if the UUID and
build time of the Failure match the current run.

Canonical link: <a href="https://commits.webkit.org/276786@main">https://commits.webkit.org/276786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77cd2931d58bafc9f73ec636cf6ca6ad1a7a2dd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48283 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41650 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/28997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22137 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37363 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39347 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18502 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/45479 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40435 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3659 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41920 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50025 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44454 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/45653 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21909 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43290 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22269 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6360 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21596 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->