### PR TITLE
Web Inspector: Dark Mode: Increase contrast in audit tab for @media (prefers-color-scheme: dark) and @media (prefers-contrast: more)

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/AuditTestGroupContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/AuditTestGroupContentView.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -55,6 +56,13 @@
 
 .content-view.audit-test-group > section > .audit-test-group.contains-test-case > header {
     top: -1px;
+}
+
+.content-view.audit-test-group {
+    /* FIXME: Use CSS4 color blend functions once they're available. */
+    --percentage-pass-color: hsla(0, 0%, 88%, 0.5);
+    /* FIXME: Use CSS4 color blend functions once they're available. */
+    --percentage-pass-color-span: hsla(0, 0%, 88%, 0.65);
 }
 
 .content-view.audit-test-group.contains-test-case + .audit-test-group.contains-test-case,
@@ -133,14 +141,12 @@
     font-size: 16px;
     text-align: end;
     font-weight: bold;
-    /* FIXME: Use CSS4 color blend functions once they're available. */
-    color: hsla(0, 0%, 0%, 0.5);
+    color: var(--percentage-pass-color);
 }
 
 .content-view.audit-test-group > header > .percentage-pass > span {
     font-size: 24px;
-    /* FIXME: Use CSS4 color blend functions once they're available. */
-    color: hsla(0, 0%, 0%, 0.65);
+    color: var(--percentage-pass-color-span);
 }
 
 .content-view.audit-test-group > section > .audit-test-case:first-child,
@@ -159,13 +165,45 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .content-view.audit-test-group > header > .percentage-pass {
+    .content-view.audit-test-group {
         /* FIXME: Use CSS4 color blend functions once they're available. */
-        color: hsla(0, 0%, 88%, 0.5);
+        --percentage-pass-color: hsla(0, 0%, 88%, 0.5);
+        /* FIXME: Use CSS4 color blend functions once they're available. */
+        --percentage-pass-color-span: hsla(0, 0%, 88%, 0.65);
+    }
+
+    .content-view.audit-test-group > header > .percentage-pass {
+        color: var(--percentage-pass-color);
     }
 
     .content-view.audit-test-group > header > .percentage-pass > span {
-        /* FIXME: Use CSS4 color blend functions once they're available. */
-        color: hsla(0, 0%, 88%, 0.65);
+        color: var(--percentage-pass-color-span);
+    }
+
+    @media (prefers-contrast: more) {
+        .content-view.audit-test-group {
+            /* FIXME: Use CSS4 color blend functions once they're available. */
+            --percentage-pass-color: hsla(0, 0%, 95%, .8);
+            /* FIXME: Use CSS4 color blend functions once they're available. */
+            --percentage-pass-color-span: hsla(0, 0%, 95%, .9);
+        }
+
+        .content-view.audit-test-group > header > .percentage-pass {
+            color: var(--percentage-pass-color);
+        }
+
+        .content-view.audit-test-group > header > .percentage-pass > span {
+            color: var(--percentage-pass-color-span);
+        }
+
+        .content-view-container > .content-view.audit-test-group > header {
+            background-color: hsla(0, 0%, 7%);
+        }
+
+        .content-view.audit-test-group.contains-test-case:not(.contains-test-group) > section,
+        .content-view.audit-test-group.contains-test-case.contains-test-group > section > .audit-test-case  {
+            --audit-test-header-background-color: hsla(0, 0%, 13%);
+            background-color: var(--audit-test-header-background-color);
+        }
     }
 }


### PR DESCRIPTION
#### 9b9f43652b7ca8d9a02aff4ca4a7cc50f0c25715
<pre>
Web Inspector: Dark Mode: Increase contrast in audit tab for @media (prefers-color-scheme: dark) and @media (prefers-contrast: more)
<a href="https://bugs.webkit.org/show_bug.cgi?id=271776">https://bugs.webkit.org/show_bug.cgi?id=271776</a>

Reviewed by NOBODY (OOPS!).

Create --percentage-pass-color and --percentage-pass-color-span and move FIXMEs.
Use --percentage-pass-color and --percentage-pass-color-span for percentage pass and percentage-pass-span.
Use --audit-test-header-background-color for header background colors.

* Source/WebInspectorUI/UserInterface/Views/AuditTestGroupContentView.css:
(.content-view.audit-test-group):
(.content-view.audit-test-group &gt; header &gt; .percentage-pass):
(.content-view.audit-test-group &gt; header &gt; .percentage-pass &gt; span):
(@media (prefers-color-scheme: dark) .content-view.audit-test-group):
(@media (prefers-color-scheme: dark) .content-view.audit-test-group &gt; header &gt; .percentage-pass):
(@media (prefers-color-scheme: dark) .content-view.audit-test-group &gt; header &gt; .percentage-pass &gt; span):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view.audit-test-group):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view.audit-test-group &gt; header &gt; .percentage-pass):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view.audit-test-group &gt; header &gt; .percentage-pass &gt; span):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view-container &gt; .content-view.audit-test-group &gt; header):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view.audit-test-group.contains-test-case:not(.contains-test-group) &gt; section,):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b9f43652b7ca8d9a02aff4ca4a7cc50f0c25715

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50549 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43921 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38949 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42566 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5915 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44223 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52443 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46255 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24178 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45295 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24969 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->