### PR TITLE
Add release assertion to verify public suffix added to cache is correct

### DIFF
--- a/Source/WebCore/platform/PublicSuffixStore.h
+++ b/Source/WebCore/platform/PublicSuffixStore.h
@@ -43,7 +43,8 @@ public:
     WEBCORE_EXPORT void clearHostTopPrivatelyControlledDomainCache();
 
 #if PLATFORM(COCOA)
-    WEBCORE_EXPORT void enablePublicSuffixCache();
+    enum class CanAcceptCustomPublicSuffix : bool { No, Yes };
+    WEBCORE_EXPORT void enablePublicSuffixCache(CanAcceptCustomPublicSuffix = CanAcceptCustomPublicSuffix::No);
     WEBCORE_EXPORT void addPublicSuffix(const String& publicSuffix);
 #endif
 
@@ -59,6 +60,7 @@ private:
 #if PLATFORM(COCOA)
     mutable Lock m_publicSuffixCacheLock;
     std::optional<HashSet<String, ASCIICaseInsensitiveHash>> m_publicSuffixCache WTF_GUARDED_BY_LOCK(m_publicSuffixCacheLock);
+    bool m_canAcceptCustomPublicSuffix { false };
 #endif
 };
 

--- a/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm
@@ -60,11 +60,12 @@ String PublicSuffixStore::platformTopPrivatelyControlledDomain(const String& hos
     return { };
 }
 
-void PublicSuffixStore::enablePublicSuffixCache()
+void PublicSuffixStore::enablePublicSuffixCache(CanAcceptCustomPublicSuffix canAcceptCustomPublicSuffix)
 {
     Locker locker { m_publicSuffixCacheLock };
     ASSERT(!m_publicSuffixCache);
 
+    m_canAcceptCustomPublicSuffix = (canAcceptCustomPublicSuffix == CanAcceptCustomPublicSuffix::Yes);
     m_publicSuffixCache = HashSet<String, ASCIICaseInsensitiveHash> { };
 }
 
@@ -74,6 +75,12 @@ void PublicSuffixStore::addPublicSuffix(const String& publicSuffix)
         return;
 
     Locker locker { m_publicSuffixCacheLock };
+
+    if (!m_publicSuffixCache)
+        return;
+
+    if (!m_canAcceptCustomPublicSuffix)
+        RELEASE_ASSERT(isPublicSuffixCF(publicSuffix));
 
     if (m_publicSuffixCache)
         m_publicSuffixCache->add(crossThreadCopy(publicSuffix));

--- a/Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp
@@ -195,7 +195,7 @@ TEST_F(PublicSuffix, PublicSuffixCache)
     EXPECT_EQ(String("example.example"_s), publicSuffixStore.topPrivatelyControlledDomain("a.b.example.example"_s));
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix(""_s));
 
-    publicSuffixStore.enablePublicSuffixCache();
+    publicSuffixStore.enablePublicSuffixCache(PublicSuffixStore::CanAcceptCustomPublicSuffix::Yes);
     publicSuffixStore.clearHostTopPrivatelyControlledDomainCache();
     publicSuffixStore.addPublicSuffix("example.example"_s);
     publicSuffixStore.addPublicSuffix(""_s);


### PR DESCRIPTION
#### ba786023a496b001be96a51f56d52977d1617d05
<pre>
Add release assertion to verify public suffix added to cache is correct
<a href="https://bugs.webkit.org/show_bug.cgi?id=271811">https://bugs.webkit.org/show_bug.cgi?id=271811</a>
<a href="https://rdar.apple.com/125417343">rdar://125417343</a>

Reviewed by Brady Eidson.

To help debug a crash found in ToT WebKit.

* Source/WebCore/platform/PublicSuffixStore.h:
* Source/WebCore/platform/cocoa/PublicSuffixStoreCocoa.mm:
(WebCore::PublicSuffixStore::enablePublicSuffixCache):
(WebCore::PublicSuffixStore::addPublicSuffix):
* Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/276834@main">https://commits.webkit.org/276834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df2c7bcc67d728b69c2e72e20b784213ca1f80b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48393 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41759 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37444 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39449 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18596 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40539 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3768 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50145 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44553 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22020 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43411 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10173 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22378 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->