### PR TITLE
CSS Typed OM doesn't schedule mutation records

### DIFF
--- a/LayoutTests/fast/custom-elements/mutation-observer-for-style-attribute-on-custom-elements-expected.txt
+++ b/LayoutTests/fast/custom-elements/mutation-observer-for-style-attribute-on-custom-elements-expected.txt
@@ -1,0 +1,30 @@
+This tests observing a custom element, which observes "style" content attribute, with a MutationObserver.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS observer.takeRecords().length is 0
+PASS attributeChanges.length is 0
+element = document.createElement("some-element"); observer.observe(element, {attributes: true});
+element.style.width = "100px";
+PASS records = observer.takeRecords(); records.length is 1
+PASS records[0].target is element
+PASS records[0].type is "attributes"
+PASS records[0].oldValue is null
+PASS attributeChanges.length is 1
+PASS attributeChanges[0].name is "style"
+PASS attributeChanges[0].oldValue is null
+PASS attributeChanges[0].newValue is "width: 100px;"
+element.style.color = "red";
+PASS records = observer.takeRecords(); records.length is 1
+PASS records[0].target is element
+PASS records[0].type is "attributes"
+PASS records[0].oldValue is null
+PASS attributeChanges.length is 2
+PASS attributeChanges[1].name is "style"
+PASS attributeChanges[1].oldValue is "width: 100px;"
+PASS attributeChanges[1].newValue is "width: 100px; color: red;"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/custom-elements/mutation-observer-for-style-attribute-on-custom-elements.html
+++ b/LayoutTests/fast/custom-elements/mutation-observer-for-style-attribute-on-custom-elements.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description('This tests observing a custom element, which observes "style" content attribute, with a MutationObserver.');
+
+let attributeChanges = [];
+class SomeElement extends HTMLElement {
+    static observedAttributes = ["style"]; 
+    constructor() {
+        super();
+    }
+    attributeChangedCallback(name, oldValue, newValue) {
+        attributeChanges.push({name, oldValue, newValue});
+    }
+};
+customElements.define('some-element', SomeElement);
+
+const observer = new MutationObserver((records) => { });
+shouldBe('observer.takeRecords().length', '0');
+shouldBe('attributeChanges.length', '0');
+evalAndLog('element = document.createElement("some-element"); observer.observe(element, {attributes: true});');
+evalAndLog('element.style.width = "100px";');
+shouldBe('records = observer.takeRecords(); records.length', '1');
+shouldBe('records[0].target', 'element');
+shouldBeEqualToString('records[0].type', 'attributes');
+shouldBe('records[0].oldValue', 'null');
+shouldBe('attributeChanges.length', '1');
+shouldBeEqualToString('attributeChanges[0].name', 'style');
+shouldBe('attributeChanges[0].oldValue', 'null');
+shouldBeEqualToString('attributeChanges[0].newValue', 'width: 100px;');
+evalAndLog('element.style.color = "red";');
+shouldBe('records = observer.takeRecords(); records.length', '1');
+shouldBe('records[0].target', 'element');
+shouldBeEqualToString('records[0].type', 'attributes');
+shouldBe('records[0].oldValue', 'null');
+shouldBe('attributeChanges.length', '2');
+shouldBeEqualToString('attributeChanges[1].name', 'style');
+shouldBeEqualToString('attributeChanges[1].oldValue', 'width: 100px;');
+shouldBeEqualToString('attributeChanges[1].newValue', 'width: 100px; color: red;');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/dom/MutationObserver/observe-attributes-expected.txt
+++ b/LayoutTests/fast/dom/MutationObserver/observe-attributes-expected.txt
@@ -183,6 +183,37 @@ PASS mutations is null
 Testing that a no-op style property mutation does not create Mutation Records.
 PASS mutations is null
 
+Testing that modifying an elements attiuteStyleMap property dispatches Mutation Records.
+PASS mutations.length is 3
+PASS mutations[0].type is "attributes"
+PASS mutations[0].attributeName is "style"
+PASS mutations[0].oldValue is null
+PASS mutations[1].type is "attributes"
+PASS mutations[1].attributeName is "style"
+PASS mutations[1].oldValue is null
+PASS mutations[2].type is "attributes"
+PASS mutations[2].attributeName is "style"
+PASS mutations[2].oldValue is null
+...mutation record created.
+PASS mutations is null
+
+Testing that modifying an elements attiuteStyleMap property dispatches Mutation Records with correct oldValues.
+PASS mutations.length is 3
+PASS mutations[0].type is "attributes"
+PASS mutations[0].attributeName is "style"
+PASS mutations[0].oldValue is "color: yellow; height: 200px;"
+PASS mutations[1].type is "attributes"
+PASS mutations[1].attributeName is "style"
+PASS mutations[1].oldValue is "color: red; height: 200px;"
+PASS mutations[2].type is "attributes"
+PASS mutations[2].attributeName is "style"
+PASS mutations[2].oldValue is "color: red; height: 100px;"
+...mutation record created.
+PASS mutations is null
+
+Testing that a no-op attiuteStyleMap property mutation does not create Mutation Records.
+PASS mutations is null
+
 Test that mutating an attribute through an attr node delivers mutation records
 PASS mutations.length is 1
 PASS mutations[0].target is div

--- a/LayoutTests/fast/dom/MutationObserver/observe-attributes.html
+++ b/LayoutTests/fast/dom/MutationObserver/observe-attributes.html
@@ -769,6 +769,141 @@ function testStyleAttributePropertyAccessIgnoreNoop() {
     start();
 }
 
+function testAttributeStyleMapAccess() {
+    var div, path;
+    var observer;
+
+    function start() {
+        debug('Testing that modifying an elements attiuteStyleMap property dispatches Mutation Records.');
+
+        mutations = null;
+        observer = new MutationObserver(function(m) {
+            mutations = m;
+        });
+
+        div = document.createElement('div');
+        div.setAttribute('style', 'color: yellow; height: 200px;');
+        observer.observe(div, { attributes: true });
+        div.attributeStyleMap.set('color', CSSStyleValue.parse('color', 'red'));
+        div.attributeStyleMap.set('height', CSS.px(100));
+        div.attributeStyleMap.set('color', CSSStyleValue.parse('color', 'blue'));
+
+        setTimeout(checkAndContinue, 0);
+    }
+
+    function checkAndContinue() {
+        shouldBe('mutations.length', '3');
+        shouldBe('mutations[0].type', '"attributes"');
+        shouldBe('mutations[0].attributeName', '"style"');
+        shouldBe('mutations[0].oldValue', 'null');
+        shouldBe('mutations[1].type', '"attributes"');
+        shouldBe('mutations[1].attributeName', '"style"');
+        shouldBe('mutations[1].oldValue', 'null');
+        shouldBe('mutations[2].type', '"attributes"');
+        shouldBe('mutations[2].attributeName', '"style"');
+        shouldBe('mutations[2].oldValue', 'null');
+
+        mutations = null;
+        div.getAttribute('style');
+        setTimeout(finish, 0);
+    }
+
+    function finish() {
+        debug('...mutation record created.');
+
+        shouldBe('mutations', 'null');
+
+        observer.disconnect();
+        debug('');
+        runNextTest();
+    }
+
+    start();
+}
+
+function testAttributeStyleMapAccessOldValue() {
+    var div, path;
+    var observer;
+
+    function start() {
+        debug('Testing that modifying an elements attiuteStyleMap property dispatches Mutation Records with correct oldValues.');
+
+        mutations = null;
+        observer = new MutationObserver(function(m) {
+            mutations = m;
+        });
+
+        div = document.createElement('div');
+        div.setAttribute('style', 'color: yellow; height: 200px;');
+        observer.observe(div, { attributes: true, attributeOldValue: true });
+        div.attributeStyleMap.set('color', CSSStyleValue.parse('color', 'red'));
+        div.attributeStyleMap.set('height', CSS.px(100));
+        div.attributeStyleMap.set('color', CSSStyleValue.parse('color', 'blue'));
+
+        setTimeout(checkAndContinue, 0);
+    }
+
+    function checkAndContinue() {
+        shouldBe('mutations.length', '3');
+        shouldBe('mutations[0].type', '"attributes"');
+        shouldBe('mutations[0].attributeName', '"style"');
+        shouldBe('mutations[0].oldValue', '"color: yellow; height: 200px;"');
+        shouldBe('mutations[1].type', '"attributes"');
+        shouldBe('mutations[1].attributeName', '"style"');
+        shouldBe('mutations[1].oldValue', '"color: red; height: 200px;"');
+        shouldBe('mutations[2].type', '"attributes"');
+        shouldBe('mutations[2].attributeName', '"style"');
+        shouldBe('mutations[2].oldValue', '"color: red; height: 100px;"');
+
+        mutations = null;
+        div.getAttribute('style');
+        setTimeout(finish, 0);
+    }
+
+    function finish() {
+        debug('...mutation record created.');
+
+        shouldBe('mutations', 'null');
+
+        observer.disconnect();
+        debug('');
+        runNextTest();
+    }
+
+    start();
+}
+
+function testAttributeStyleMapAccessIgnoreNoop() {
+    var div, path;
+    var observer;
+
+    function start() {
+        debug('Testing that a no-op attiuteStyleMap property mutation does not create Mutation Records.');
+
+        mutations = null;
+        observer = new MutationObserver(function(m) {
+            mutations = m;
+        });
+
+        div = document.createElement('div');
+        div.setAttribute('style', 'color: yellow; height: 100px;');
+        observer.observe(div, { attributes: true });
+        div.attributeStyleMap.delete('width');
+
+        setTimeout(finish, 0);
+    }
+
+    function finish() {
+        shouldBe('mutations', 'null');
+
+        observer.disconnect();
+        debug('');
+        runNextTest();
+    }
+
+    start();
+}
+
 function testMutateThroughAttrNodeValue() {
     var observer;
 
@@ -948,6 +1083,9 @@ var tests = [
     testStyleAttributePropertyAccess,
     testStyleAttributePropertyAccessOldValue,
     testStyleAttributePropertyAccessIgnoreNoop,
+    testAttributeStyleMapAccess,
+    testAttributeStyleMapAccessOldValue,
+    testAttributeStyleMapAccessIgnoreNoop,
     testMutateThroughAttrNodeValue,
     testSetAndRemoveAttributeNode,
     testMixedNodeAndElementOperations,

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -939,6 +939,7 @@ css/SVGCSSComputedStyleDeclaration.cpp
 css/SelectorChecker.cpp
 css/SelectorFilter.cpp
 css/ShorthandSerializer.cpp
+css/StyleAttributeMutationScope.cpp
 css/StyleColor.cpp
 css/StyleMedia.cpp
 css/StyleProperties.cpp

--- a/Source/WebCore/css/StyleAttributeMutationScope.cpp
+++ b/Source/WebCore/css/StyleAttributeMutationScope.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "StyleAttributeMutationScope.h"
+
+namespace WebCore {
+
+unsigned StyleAttributeMutationScope::s_scopeCount = 0;
+StyleAttributeMutationScope* StyleAttributeMutationScope::s_currentScope = nullptr;
+
+} // namespace WebCore

--- a/Source/WebCore/css/StyleAttributeMutationScope.h
+++ b/Source/WebCore/css/StyleAttributeMutationScope.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CustomElementReactionQueue.h"
+#include "Element.h"
+#include "HTMLNames.h"
+#include "MutationObserverInterestGroup.h"
+#include "MutationRecord.h"
+
+namespace WebCore {
+
+class StyleAttributeMutationScope {
+    WTF_MAKE_NONCOPYABLE(StyleAttributeMutationScope);
+public:
+    StyleAttributeMutationScope(Element* element)
+        : m_element(element)
+    {
+        ++s_scopeCount;
+
+        if (s_scopeCount != 1) {
+            ASSERT(s_currentScope->m_element == element);
+            return;
+        }
+
+        ASSERT(!s_currentScope);
+        s_currentScope = this;
+
+        if (!m_element)
+            return;
+
+        bool shouldReadOldValue = false;
+
+        m_mutationRecipients = MutationObserverInterestGroup::createForAttributesMutation(*m_element, HTMLNames::styleAttr);
+        if (m_mutationRecipients && m_mutationRecipients->isOldValueRequested())
+            shouldReadOldValue = true;
+
+        if (UNLIKELY(m_element->isDefinedCustomElement())) {
+            auto* reactionQueue = m_element->reactionQueue();
+            if (reactionQueue && reactionQueue->observesStyleAttribute()) {
+                m_isCustomElement = true;
+                shouldReadOldValue = true;
+            }
+        }
+
+        if (shouldReadOldValue)
+            m_oldValue = m_element->getAttribute(HTMLNames::styleAttr);
+    }
+
+    ~StyleAttributeMutationScope()
+    {
+        --s_scopeCount;
+        if (s_scopeCount)
+            return;
+        ASSERT(s_currentScope == this);
+        s_currentScope = nullptr;
+
+        if (!m_shouldDeliver || !m_element)
+            return;
+
+        if (m_mutationRecipients) {
+            auto mutation = MutationRecord::createAttributes(*m_element, HTMLNames::styleAttr, m_oldValue);
+            m_mutationRecipients->enqueueMutationRecord(WTFMove(mutation));
+        }
+
+        if (m_isCustomElement) {
+            auto& newValue = m_element->getAttribute(HTMLNames::styleAttr);
+            CustomElementReactionQueue::enqueueAttributeChangedCallbackIfNeeded(*m_element, HTMLNames::styleAttr, m_oldValue, newValue);
+        }
+    }
+
+    void enqueueMutationRecord()
+    {
+        m_shouldDeliver = true;
+    }
+
+private:
+    static unsigned s_scopeCount;
+    static StyleAttributeMutationScope* s_currentScope;
+
+    std::unique_ptr<MutationObserverInterestGroup> m_mutationRecipients;
+    AtomString m_oldValue;
+    RefPtr<Element> m_element;
+    bool m_isCustomElement { false };
+    bool m_shouldDeliver { false };
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### 73bff01abebed57416a48b73cf105b223ae59049
<pre>
CSS Typed OM doesn&apos;t schedule mutation records
<a href="https://bugs.webkit.org/show_bug.cgi?id=267063">https://bugs.webkit.org/show_bug.cgi?id=267063</a>

Reviewed by Antti Koivisto.

This PR fixes the bug that mutating element&apos;s inline style with attributeStyleMap does not enqueue
mutation record for mutation observers. To do this, this PR extracts StyleAttributeMutationScope
out of PropertySetCSSStyleDeclaration.cpp into its own cpp/h files and generalizes it to support
both CSSStyleDeclaration and attributeStyleMap.

* LayoutTests/fast/custom-elements/mutation-observer-for-style-attribute-on-custom-elements-expected.txt: Added.
* LayoutTests/fast/custom-elements/mutation-observer-for-style-attribute-on-custom-elements.html: Added.
* LayoutTests/fast/dom/MutationObserver/observe-attributes-expected.txt:
* LayoutTests/fast/dom/MutationObserver/observe-attributes.html: Added test cases.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/PropertySetCSSStyleDeclaration.cpp:
(WebCore::PropertySetCSSStyleDeclaration::setCssText):
(WebCore::PropertySetCSSStyleDeclaration::setProperty):
(WebCore::PropertySetCSSStyleDeclaration::removeProperty):
(WebCore::PropertySetCSSStyleDeclaration::setPropertyInternal):
(WebCore::InlineCSSStyleDeclaration::didMutate):
(WebCore::StyleAttributeMutationScope::StyleAttributeMutationScope): Deleted.
(WebCore::StyleAttributeMutationScope::~StyleAttributeMutationScope): Deleted.
(WebCore::StyleAttributeMutationScope::enqueueMutationRecord): Deleted.
(WebCore::StyleAttributeMutationScope::didInvalidateStyleAttr): Deleted.
* Source/WebCore/css/StyleAttributeMutationScope.cpp: Added.
* Source/WebCore/css/StyleAttributeMutationScope.h: Added.
(WebCore::StyleAttributeMutationScope::StyleAttributeMutationScope): Added.
(WebCore::StyleAttributeMutationScope::~StyleAttributeMutationScope): Added.
(WebCore::StyleAttributeMutationScope::enqueueMutationRecord): Added.
* Source/WebCore/css/typedom/InlineStylePropertyMap.cpp:
(WebCore::InlineStylePropertyMap::removeProperty):
(WebCore::InlineStylePropertyMap::setShorthandProperty):
(WebCore::InlineStylePropertyMap::setProperty):
(WebCore::InlineStylePropertyMap::setCustomProperty):
(WebCore::InlineStylePropertyMap::removeCustomProperty):
(WebCore::InlineStylePropertyMap::clear):
* Source/WebCore/css/typedom/InlineStylePropertyMap.h:

Canonical link: <a href="https://commits.webkit.org/276782@main">https://commits.webkit.org/276782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/390911964e8ea9db81055bba480f470228ddc819

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48334 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37393 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18542 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40481 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3710 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41970 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40813 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50083 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44495 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39543 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43339 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22320 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6357 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21649 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->