### PR TITLE
TrustedTypesPolicyFactory getPropertyType returns TrustedScript for event handlers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType-expected.txt
@@ -23,4 +23,5 @@ PASS OBJECT[codebase] is defined
 PASS OBJECT.codebase is maybe defined
 PASS oBjEcT[codebase] is defined
 PASS oBjEcT.codebase is maybe defined
+PASS getPropertyType vs getAttributeType for event handler.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType.html
@@ -104,5 +104,10 @@
       }, `${elem}.${attr} is maybe defined`);
     }
   }
+
+  test(t => {
+    assert_equals(trustedTypes.getPropertyType("img", "onerror"), null);
+    assert_equals(trustedTypes.getAttributeType("img", "onerror"), "TrustedScript");
+  }, "getPropertyType vs getAttributeType for event handler.");
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-metadata-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-metadata-expected.txt
@@ -16,21 +16,21 @@ PASS Test assignment of TrustedScript on madeup.id
 PASS Test assignment of TrustedScript on madeup.setAttribute(id,..)
 PASS Test assignment of TrustedScriptURL on madeup.id
 PASS Test assignment of TrustedScriptURL on madeup.setAttribute(id,..)
-FAIL Test assignment of string on madeup.onerror assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+PASS Test assignment of string on madeup.onerror
 FAIL Test assignment of string on madeup.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
-FAIL Test assignment of TrustedHTML on madeup.onerror assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+PASS Test assignment of TrustedHTML on madeup.onerror
 FAIL Test assignment of TrustedHTML on madeup.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
 PASS Test assignment of TrustedScript on madeup.onerror
 PASS Test assignment of TrustedScript on madeup.setAttribute(onerror,..)
-FAIL Test assignment of TrustedScriptURL on madeup.onerror assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+PASS Test assignment of TrustedScriptURL on madeup.onerror
 FAIL Test assignment of TrustedScriptURL on madeup.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
-FAIL Test assignment of string on madeup.onclick assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+PASS Test assignment of string on madeup.onclick
 FAIL Test assignment of string on madeup.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
-FAIL Test assignment of TrustedHTML on madeup.onclick assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+PASS Test assignment of TrustedHTML on madeup.onclick
 FAIL Test assignment of TrustedHTML on madeup.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
 PASS Test assignment of TrustedScript on madeup.onclick
 PASS Test assignment of TrustedScript on madeup.setAttribute(onclick,..)
-FAIL Test assignment of TrustedScriptURL on madeup.onclick assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+PASS Test assignment of TrustedScriptURL on madeup.onclick
 FAIL Test assignment of TrustedScriptURL on madeup.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
 PASS Test assignment of string on b.madeup
 PASS Test assignment of string on b.setAttribute(madeup,..)
@@ -48,20 +48,20 @@ PASS Test assignment of TrustedScript on b.id
 PASS Test assignment of TrustedScript on b.setAttribute(id,..)
 PASS Test assignment of TrustedScriptURL on b.id
 PASS Test assignment of TrustedScriptURL on b.setAttribute(id,..)
-FAIL Test assignment of string on b.onerror assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+PASS Test assignment of string on b.onerror
 FAIL Test assignment of string on b.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
-FAIL Test assignment of TrustedHTML on b.onerror assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+PASS Test assignment of TrustedHTML on b.onerror
 FAIL Test assignment of TrustedHTML on b.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
 PASS Test assignment of TrustedScript on b.onerror
 PASS Test assignment of TrustedScript on b.setAttribute(onerror,..)
-FAIL Test assignment of TrustedScriptURL on b.onerror assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+PASS Test assignment of TrustedScriptURL on b.onerror
 FAIL Test assignment of TrustedScriptURL on b.setAttribute(onerror,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
-FAIL Test assignment of string on b.onclick assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+PASS Test assignment of string on b.onclick
 FAIL Test assignment of string on b.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
-FAIL Test assignment of TrustedHTML on b.onclick assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+PASS Test assignment of TrustedHTML on b.onclick
 FAIL Test assignment of TrustedHTML on b.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
 PASS Test assignment of TrustedScript on b.onclick
 PASS Test assignment of TrustedScript on b.setAttribute(onclick,..)
-FAIL Test assignment of TrustedScriptURL on b.onclick assert_throws_js: throws function "_ => { element[property] = value; }" did not throw
+PASS Test assignment of TrustedScriptURL on b.onclick
 FAIL Test assignment of TrustedScriptURL on b.setAttribute(onclick,..) assert_throws_js: throws function "_ => { element.setAttribute(property, value); }" did not throw
 

--- a/Source/WebCore/dom/TrustedTypePolicyFactory.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicyFactory.cpp
@@ -134,9 +134,6 @@ String TrustedTypePolicyFactory::getPropertyType(const String& tagName, const St
     auto localName = tagName.convertToASCIILowercase();
     AtomString elementNS = elementNamespace.isEmpty() ? HTMLNames::xhtmlNamespaceURI : AtomString(elementNamespace);
 
-    if (property.startsWith("on"_s))
-        return trustedTypeToString(TrustedType::TrustedScript);
-
     if (property == "innerHTML"_s || property == "outerHTML"_s)
         return trustedTypeToString(TrustedType::TrustedHTML);
 


### PR DESCRIPTION
#### 40089a95fed02486c5a38b2c831b85dca7f09e1c
<pre>
TrustedTypesPolicyFactory getPropertyType returns TrustedScript for event handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=271822">https://bugs.webkit.org/show_bug.cgi?id=271822</a>

Reviewed by Anne van Kesteren.

Previously getPropertyType would return TrustedScript for event handlers. This patch fixes it
so that it correctly returns null. Only getAttributeType should handle event handlers.

Also adds a test to check for this.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-metadata-expected.txt:
* Source/WebCore/dom/TrustedTypePolicyFactory.cpp:
(WebCore::TrustedTypePolicyFactory::getPropertyType const):

Canonical link: <a href="https://commits.webkit.org/276788@main">https://commits.webkit.org/276788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6432718d3a0bc0ea989735b96ef15c3f49b6e666

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48354 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/47991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37408 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21886 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39407 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18557 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40499 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3729 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/41988 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40831 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50103 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20674 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44511 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/21979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43355 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10148 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22339 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21668 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->