### PR TITLE
Remove trusted types enforcement from object and embed elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-setAttribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-setAttribute-expected.txt
@@ -1,5 +1,4 @@
 
-PASS embed.src assigned via policy (successful ScriptURL transformation)
 PASS script.src assigned via policy (successful ScriptURL transformation)
 PASS iframe.srcdoc assigned via policy (successful HTML transformation)
 PASS script.src assigned via policy (successful script transformation)

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-setAttribute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-setAttribute.html
@@ -8,7 +8,6 @@
 <script>
   // TrustedScriptURL Assignments
   let scriptTestCases = [
-    [ 'embed', 'src' ],
     [ 'script', 'src' ]
   ];
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
@@ -4,29 +4,18 @@ CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the fol
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-Blocked access to external URL https://example.test/
-Blocked access to external URL https://example.test/
-
 hello
 hello
 
 hello
 
 
-PASS TT disabled: embed.src = TrustedScript on a connected element.
-PASS TT disabled: embed.src = TrustedScript on a non-connected element.
-PASS TT disabled: embed.src = String on a connected element.
-PASS TT disabled: embed.src = String on a non-connected element.
 PASS TT disabled: script.src = TrustedScript on a connected element.
 PASS TT disabled: script.src = TrustedScript on a non-connected element.
 PASS TT disabled: script.src = String on a connected element.
@@ -51,10 +40,6 @@ PASS TT disabled: script.textContent = TrustedScript on a connected element.
 PASS TT disabled: script.textContent = TrustedScript on a non-connected element.
 PASS TT disabled: script.textContent = String on a connected element.
 PASS TT disabled: script.textContent = String on a non-connected element.
-PASS TT enabled: embed.src = TrustedScript on a connected element.
-PASS TT enabled: embed.src = TrustedScript on a non-connected element.
-PASS TT enabled: embed.src = String on a connected element.
-PASS TT enabled: embed.src = String on a non-connected element.
 PASS TT enabled: script.src = TrustedScript on a connected element.
 PASS TT enabled: script.src = TrustedScript on a non-connected element.
 PASS TT enabled: script.src = String on a connected element.

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic.html
@@ -41,7 +41,6 @@ function getTrusted(element, attr) {
 // Types is currently enabled (& enforced) or not.
 function runTests(is_tt_enabled) {
   for (const [element, attr] of [
-      [ 'embed', 'src' ],
       [ 'script', 'src' ],
       [ 'div', 'innerHTML' ],
       [ 'iframe', 'srcdoc' ],

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedType-AttributeNodes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedType-AttributeNodes-expected.txt
@@ -21,17 +21,6 @@ PASS Set attribute via NamedNodeMap.setNamedItem on script.onclick.
 PASS Set attribute via attribute node on script.bla.
 PASS Set attribute via attributenode.value on script.bla.
 PASS Set attribute via NamedNodeMap.setNamedItem on script.bla.
-PASS Set attribute via attribute node on embed.src.
-PASS Set attribute via attributenode.value on embed.src.
-PASS Set attribute via NamedNodeMap.setNamedItem on embed.src.
-PASS Set attribute via attribute node on embed.srcdoc.
-PASS Set attribute via attributenode.value on embed.srcdoc.
-PASS Set attribute via NamedNodeMap.setNamedItem on embed.srcdoc.
-PASS Set attribute via attributenode.value on embed.onclick.
-PASS Set attribute via NamedNodeMap.setNamedItem on embed.onclick.
-PASS Set attribute via attribute node on embed.bla.
-PASS Set attribute via attributenode.value on embed.bla.
-PASS Set attribute via NamedNodeMap.setNamedItem on embed.bla.
 PASS Set attribute via attribute node on iframe.src.
 PASS Set attribute via attributenode.value on iframe.src.
 PASS Set attribute via NamedNodeMap.setNamedItem on iframe.src.

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedType-AttributeNodes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedType-AttributeNodes.html
@@ -10,7 +10,7 @@
   // identically. For background, se::
   // https://github.com/w3c/webappsec-trusted-types/issues/47
 
-  const elems = ["div", "script", "embed", "iframe"];
+  const elems = ["div", "script", "iframe"];
   const attrs = ["src", "srcdoc", "onclick", "bla"];
 
   const policy_callback = s => ("" + s + " [policy]");

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType-expected.txt
@@ -5,23 +5,23 @@ FAIL sanity check trustedTypes.getTypeMapping trustedTypes.getTypeMapping is not
 PASS getPropertyType tests adapted from w3c/trusted-types polyfill
 PASS getAttributeType tests adapted from w3c/trusted-types polyfill
 FAIL getTypeMapping tests adapted from w3c/trusted-types polyfill trustedTypes.getTypeMapping is not a function. (In 'trustedTypes.getTypeMapping()', 'trustedTypes.getTypeMapping' is undefined)
-PASS object[codeBase] is defined
-PASS object.codeBase is maybe defined
-PASS OBJECT[codeBase] is defined
-PASS OBJECT.codeBase is maybe defined
-PASS oBjEcT[codeBase] is defined
-PASS oBjEcT.codeBase is maybe defined
-PASS object[CODEBASE] is defined
-PASS object.CODEBASE is maybe defined
-PASS OBJECT[CODEBASE] is defined
-PASS OBJECT.CODEBASE is maybe defined
-PASS oBjEcT[CODEBASE] is defined
-PASS oBjEcT.CODEBASE is maybe defined
-PASS object[codebase] is defined
-PASS object.codebase is maybe defined
-PASS OBJECT[codebase] is defined
-PASS OBJECT.codebase is maybe defined
-PASS oBjEcT[codebase] is defined
-PASS oBjEcT.codebase is maybe defined
+PASS iframe[srcDoc] is defined
+PASS iframe.srcDoc is maybe defined
+PASS IFRAME[srcDoc] is defined
+PASS IFRAME.srcDoc is maybe defined
+PASS iFrAmE[srcDoc] is defined
+PASS iFrAmE.srcDoc is maybe defined
+PASS iframe[SRCDOC] is defined
+PASS iframe.SRCDOC is maybe defined
+PASS IFRAME[SRCDOC] is defined
+PASS IFRAME.SRCDOC is maybe defined
+PASS iFrAmE[SRCDOC] is defined
+PASS iFrAmE.SRCDOC is maybe defined
+PASS iframe[srcdoc] is defined
+PASS iframe.srcdoc is maybe defined
+PASS IFRAME[srcdoc] is defined
+PASS IFRAME.srcdoc is maybe defined
+PASS iFrAmE[srcdoc] is defined
+PASS iFrAmE.srcdoc is maybe defined
 PASS getPropertyType vs getAttributeType for event handler.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType.html
@@ -90,8 +90,8 @@
   }, "getTypeMapping tests adapted from w3c/trusted-types polyfill");
 
   // Test case handling for both attributes and properties.
-  for (let attr of ["codeBase", "CODEBASE", "codebase"]) {
-    for (let elem of ["object", "OBJECT", "oBjEcT"]) {
+  for (let attr of ["srcDoc", "SRCDOC", "srcdoc"]) {
+    for (let elem of ["iframe", "IFRAME", "iFrAmE"]) {
       test(t => {
         // attributes are case-insensitive, so all variants should be defined.
         assert_true(trustedTypes.getAttributeType(elem, attr) != undefined);
@@ -100,7 +100,7 @@
         // properties are case-sensitive, so only the "correct" spelling
         // should be defined.
         assert_equals(trustedTypes.getPropertyType(elem, attr) != undefined,
-                      attr == "codeBase");
+                      attr == "srcdoc");
       }, `${elem}.${attr} is maybe defined`);
     }
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-setAttribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-setAttribute-expected.txt
@@ -1,13 +1,4 @@
 
-FAIL embed.src accepts only TrustedScriptURL assert_throws_js: function "_ => {
-    elem.setAttribute(attribute, value);
-  }" did not throw
-FAIL object.data accepts only TrustedScriptURL assert_throws_js: function "_ => {
-    elem.setAttribute(attribute, value);
-  }" did not throw
-FAIL object.codeBase accepts only TrustedScriptURL assert_throws_js: function "_ => {
-    elem.setAttribute(attribute, value);
-  }" did not throw
 FAIL script.src accepts only TrustedScriptURL assert_throws_js: function "_ => {
     elem.setAttribute(attribute, value);
   }" did not throw
@@ -20,13 +11,7 @@ FAIL div.onclick accepts only TrustedScript assert_throws_js: function "_ => {
 FAIL `Script.prototype.setAttribute.SrC = string` throws. assert_throws_js: function "_ => {
       el.setAttribute('SrC', INPUTS.URL);
     }" did not throw
-PASS embed.src accepts string and null after default policy was created.
-PASS object.data accepts string and null after default policy was created.
-PASS object.codeBase accepts string and null after default policy was created.
 PASS script.src accepts string and null after default policy was created.
-FAIL embed.src's mutationobservers receive the default policy's value. assert_equals: expected "http://this.is.a.successful.test/" but got "http://this.is.a.scripturl.test/"
-FAIL object.data's mutationobservers receive the default policy's value. assert_equals: expected "http://this.is.a.successful.test/" but got "http://this.is.a.scripturl.test/"
-FAIL object.codeBase's mutationobservers receive the default policy's value. assert_equals: expected "http://this.is.a.successful.test/" but got "http://this.is.a.scripturl.test/"
 FAIL script.src's mutationobservers receive the default policy's value. assert_equals: expected "http://this.is.a.successful.test/" but got "http://this.is.a.scripturl.test/"
 FAIL iframe.srcdoc's mutationobservers receive the default policy's value. assert_equals: expected "Quack, I want to be a duck!" but got "Hi, I want to be transformed!"
 FAIL div.onclick's mutationobservers receive the default policy's value. assert_equals: expected "Meow, I want to be a cat!" but got "Hi, I want to be transformed!"

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-setAttribute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-setAttribute.html
@@ -13,9 +13,6 @@
 
   // TrustedScriptURL Assignments
   const scriptURLTestCases = [
-    [ 'embed', 'src', INPUTS.SCRIPTURL, RESULTS.SCRIPTURL],
-    [ 'object', 'data', INPUTS.SCRIPTURL, RESULTS.SCRIPTURL ],
-    [ 'object', 'codeBase', INPUTS.SCRIPTURL, RESULTS.SCRIPTURL ],
     [ 'script', 'src', INPUTS.SCRIPTURL, RESULTS.SCRIPTURL ]
   ];
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-setAttributeNS-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-setAttributeNS-expected.txt
@@ -9,10 +9,7 @@ FAIL Blocking non-TrustedScriptURL assignment to <svg:script xlink:href=...> wor
           elem.setAttributeNS(xlinkNamespace, "href", v);
         }" did not throw
 PASS Check `setAttributeNS` allows setting non-trusted string for non-lowercase attribute "SRCDOC" (ns=null) for "iframe" element (ns=http://www.w3.org/1999/xhtml).
-PASS Check `setAttributeNS` allows setting non-trusted string for non-lowercase attribute "SRC" (ns=null) for "embed" element (ns=http://www.w3.org/1999/xhtml).
 PASS Check `setAttributeNS` allows setting non-trusted string for non-lowercase attribute "SRC" (ns=null) for "script" element (ns=http://www.w3.org/1999/xhtml).
-PASS Check `setAttributeNS` allows setting non-trusted string for non-lowercase attribute "DATA" (ns=null) for "object" element (ns=http://www.w3.org/1999/xhtml).
-PASS Check `setAttributeNS` allows setting non-trusted string for non-lowercase attribute "CODEBASE" (ns=null) for "object" element (ns=http://www.w3.org/1999/xhtml).
 PASS Check `setAttributeNS` allows setting non-trusted string for non-lowercase attribute "HREF" (ns=null) for "script" element (ns=http://www.w3.org/2000/svg).
 PASS Check `setAttributeNS` allows setting non-trusted string for non-lowercase attribute "HREF" (ns=http://www.w3.org/1999/xlink) for "script" element (ns=http://www.w3.org/2000/svg).
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-setAttributeNS.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-setAttributeNS.html
@@ -63,10 +63,7 @@
     // <https://w3c.github.io/trusted-types/dist/spec/#validate-attribute-mutation>.
     const nonLowerCaseTests = [
       { element: "iframe", attribute: "SRCDOC", elementNamespace: htmlNamespace },
-      { element: "embed", attribute: "SRC", elementNamespace: htmlNamespace },
       { element: "script", attribute: "SRC", elementNamespace: htmlNamespace },
-      { element: "object", attribute: "DATA", elementNamespace: htmlNamespace },
-      { element: "object", attribute: "CODEBASE", elementNamespace: htmlNamespace },
       { element: "script", attribute: "HREF", elementNamespace: svgNamespace },
       { element: "script", attribute: "HREF", elementNamespace: svgNamespace,
         attributeNamespace: xlinkNamespace },

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-HTMLElement-generic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-HTMLElement-generic-expected.txt
@@ -1,11 +1,5 @@
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
@@ -13,15 +7,9 @@ CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the followin
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 
-PASS embed.src accepts only TrustedScriptURL
-PASS object.codeBase accepts only TrustedScriptURL
-PASS object.data accepts only TrustedScriptURL
 PASS script.src accepts only TrustedScriptURL
 PASS div.innerHTML accepts only TrustedHTML
 PASS iframe.srcdoc accepts only TrustedHTML
-PASS embed.src accepts string and null after default policy was created
-PASS object.codeBase accepts string and null after default policy was created
-PASS object.data accepts string and null after default policy was created
 PASS script.src accepts string and null after default policy was created
 PASS div.innerHTML accepts string and null after default policy was created
 PASS iframe.srcdoc accepts string and null after default policy was created

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-HTMLElement-generic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-HTMLElement-generic.html
@@ -12,9 +12,6 @@
   var testnb = 0;
   // TrustedScriptURL Assignments
   const scriptURLTestCases = [
-    [ 'embed', 'src' ],
-    [ 'object', 'codeBase' ],
-    [ 'object', 'data' ],
     [ 'script', 'src' ]
   ];
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-attribute-via-attribute-node-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-attribute-via-attribute-node-expected.txt
@@ -1,24 +1,6 @@
 
 
 PASS Sanity check: Setting non-TT attributes still works.
-FAIL Set embed.src via textContent assert_throws_js: function "_ => {
-      element.attributes[0].textContent = "sldkjsfldk";
-    }" did not throw
-FAIL Set embed.src via nodeValue assert_throws_js: function "_ => {
-      element.attributes[0].nodeValue = "sdflkgjdlkgjdg";
-    }" did not throw
-FAIL Set object.data via textContent assert_throws_js: function "_ => {
-      element.attributes[0].textContent = "sldkjsfldk";
-    }" did not throw
-FAIL Set object.data via nodeValue assert_throws_js: function "_ => {
-      element.attributes[0].nodeValue = "sdflkgjdlkgjdg";
-    }" did not throw
-FAIL Set object.codebase via textContent assert_throws_js: function "_ => {
-      element.attributes[0].textContent = "sldkjsfldk";
-    }" did not throw
-FAIL Set object.codebase via nodeValue assert_throws_js: function "_ => {
-      element.attributes[0].nodeValue = "sdflkgjdlkgjdg";
-    }" did not throw
 FAIL Set script.src via textContent assert_throws_js: function "_ => {
       element.attributes[0].textContent = "sldkjsfldk";
     }" did not throw

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-attribute-via-attribute-node.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-attribute-via-attribute-node.html
@@ -7,9 +7,6 @@
 </head>
 <body>
 <div id="testcases">
-  <embed src="x"></embed>
-  <object data="x"></object>
-  <object codeBase="x"></object>
   <script src="x"></script>
   <iframe srcdoc="x"></iframe>
   <div onclick="x"></div>

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
@@ -2,27 +2,18 @@ CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the fol
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-
 hello
 hello
 
 hello
 
 
-PASS TT disabled: embed.src = TrustedScript on a connected element.
-PASS TT disabled: embed.src = TrustedScript on a non-connected element.
-PASS TT disabled: embed.src = String on a connected element.
-PASS TT disabled: embed.src = String on a non-connected element.
 PASS TT disabled: script.src = TrustedScript on a connected element.
 PASS TT disabled: script.src = TrustedScript on a non-connected element.
 PASS TT disabled: script.src = String on a connected element.
@@ -47,10 +38,6 @@ PASS TT disabled: script.textContent = TrustedScript on a connected element.
 PASS TT disabled: script.textContent = TrustedScript on a non-connected element.
 PASS TT disabled: script.textContent = String on a connected element.
 PASS TT disabled: script.textContent = String on a non-connected element.
-PASS TT enabled: embed.src = TrustedScript on a connected element.
-PASS TT enabled: embed.src = TrustedScript on a non-connected element.
-PASS TT enabled: embed.src = String on a connected element.
-PASS TT enabled: embed.src = String on a non-connected element.
 PASS TT enabled: script.src = TrustedScript on a connected element.
 PASS TT enabled: script.src = TrustedScript on a non-connected element.
 PASS TT enabled: script.src = String on a connected element.

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
@@ -1,11 +1,5 @@
 Blocked access to external URL https://example.test/
 Blocked access to external URL https://example.test/
-Blocked access to external URL https://example.test/
-Blocked access to external URL https://example.test/
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
@@ -16,17 +10,12 @@ CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the followin
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-
 hello
 hello
 
 hello
 
 
-PASS TT disabled: embed.src = TrustedScript on a connected element.
-PASS TT disabled: embed.src = TrustedScript on a non-connected element.
-PASS TT disabled: embed.src = String on a connected element.
-PASS TT disabled: embed.src = String on a non-connected element.
 PASS TT disabled: script.src = TrustedScript on a connected element.
 PASS TT disabled: script.src = TrustedScript on a non-connected element.
 PASS TT disabled: script.src = String on a connected element.
@@ -51,10 +40,6 @@ PASS TT disabled: script.textContent = TrustedScript on a connected element.
 PASS TT disabled: script.textContent = TrustedScript on a non-connected element.
 PASS TT disabled: script.textContent = String on a connected element.
 PASS TT disabled: script.textContent = String on a non-connected element.
-PASS TT enabled: embed.src = TrustedScript on a connected element.
-PASS TT enabled: embed.src = TrustedScript on a non-connected element.
-PASS TT enabled: embed.src = String on a connected element.
-PASS TT enabled: embed.src = String on a non-connected element.
 PASS TT enabled: script.src = TrustedScript on a connected element.
 PASS TT enabled: script.src = TrustedScript on a non-connected element.
 PASS TT enabled: script.src = String on a connected element.

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt
@@ -2,27 +2,18 @@ CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the fol
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
-
 hello
 hello
 
 hello
 
 
-PASS TT disabled: embed.src = TrustedScript on a connected element.
-PASS TT disabled: embed.src = TrustedScript on a non-connected element.
-PASS TT disabled: embed.src = String on a connected element.
-PASS TT disabled: embed.src = String on a non-connected element.
 PASS TT disabled: script.src = TrustedScript on a connected element.
 PASS TT disabled: script.src = TrustedScript on a non-connected element.
 PASS TT disabled: script.src = String on a connected element.
@@ -47,10 +38,6 @@ PASS TT disabled: script.textContent = TrustedScript on a connected element.
 PASS TT disabled: script.textContent = TrustedScript on a non-connected element.
 PASS TT disabled: script.textContent = String on a connected element.
 PASS TT disabled: script.textContent = String on a non-connected element.
-PASS TT enabled: embed.src = TrustedScript on a connected element.
-PASS TT enabled: embed.src = TrustedScript on a non-connected element.
-PASS TT enabled: embed.src = String on a connected element.
-PASS TT enabled: embed.src = String on a non-connected element.
 PASS TT enabled: script.src = TrustedScript on a connected element.
 PASS TT enabled: script.src = TrustedScript on a non-connected element.
 PASS TT enabled: script.src = String on a connected element.

--- a/Source/WebCore/dom/TrustedTypePolicyFactory.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicyFactory.cpp
@@ -120,13 +120,9 @@ String TrustedTypePolicyFactory::getAttributeType(const String& tagName, const S
     QualifiedName element(nullAtom(), AtomString(localName), elementNS);
     QualifiedName attribute(nullAtom(), AtomString(attributeName), attributeNS);
 
-    if (element.matches(HTMLNames::embedTag) && attribute.matches(HTMLNames::srcAttr))
-        return trustedTypeToString(TrustedType::TrustedScriptURL);
     if (element.matches(HTMLNames::iframeTag) && attribute.matches(HTMLNames::srcdocAttr))
         return trustedTypeToString(TrustedType::TrustedHTML);
-    if (element.matches(HTMLNames::objectTag) && (attribute.matches(HTMLNames::codebaseAttr) || attribute.matches(HTMLNames::dataAttr)))
-        return trustedTypeToString(TrustedType::TrustedScriptURL);
-    if (element.matches(HTMLNames::scriptTag) && (attribute.matches(HTMLNames::srcAttr) || attribute.matches(HTMLNames::dataAttr)))
+    if (element.matches(HTMLNames::scriptTag) && attribute.matches(HTMLNames::srcAttr))
         return trustedTypeToString(TrustedType::TrustedScriptURL);
     if (element.matches(SVGNames::scriptTag) && (attribute.matches(SVGNames::hrefAttr) || attribute.matches(XLinkNames::hrefAttr)))
         return trustedTypeToString(TrustedType::TrustedScriptURL);
@@ -144,12 +140,8 @@ String TrustedTypePolicyFactory::getPropertyType(const String& tagName, const St
 
     const QualifiedName element(nullAtom(), AtomString(localName), elementNS);
 
-    if (element.matches(HTMLNames::embedTag) && property == "src"_s)
-        return trustedTypeToString(TrustedType::TrustedScriptURL);
     if (element.matches(HTMLNames::iframeTag) && property == "srcdoc"_s)
         return trustedTypeToString(TrustedType::TrustedHTML);
-    if (element.matches(HTMLNames::objectTag) && (property == "codeBase"_s || property == "data"_s))
-        return trustedTypeToString(TrustedType::TrustedScriptURL);
     if (element.matches(HTMLNames::scriptTag) && property == "src"_s)
         return trustedTypeToString(TrustedType::TrustedScriptURL);
     if (element.matches(HTMLNames::scriptTag) && (property == "innerText"_s || property == "textContent"_s || property == "text"_s))

--- a/Source/WebCore/html/HTMLEmbedElement.idl
+++ b/Source/WebCore/html/HTMLEmbedElement.idl
@@ -26,11 +26,9 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString align;
     [CEReactions=NotNeeded, Reflect] attribute DOMString height;
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
-    [CEReactions=NotNeeded, Reflect, URL] attribute ScriptURLString src;
+    [CEReactions=NotNeeded, Reflect, URL] attribute USVString src;
     [CEReactions=NotNeeded, Reflect] attribute DOMString type;
     [CEReactions=NotNeeded, Reflect] attribute DOMString width;
 
     [CheckSecurityForNode] Document getSVGDocument();
 };
-
-typedef [StringContext=TrustedScriptURL] USVString ScriptURLString;

--- a/Source/WebCore/html/HTMLObjectElement.idl
+++ b/Source/WebCore/html/HTMLObjectElement.idl
@@ -27,9 +27,9 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString align;
     [CEReactions=NotNeeded, Reflect] attribute DOMString archive;
     [CEReactions=NotNeeded, Reflect] attribute [LegacyNullToEmptyString] DOMString border;
-    [CEReactions=NotNeeded, Reflect, URL] attribute ScriptURLString codeBase;
+    [CEReactions=NotNeeded, Reflect, URL] attribute USVString codeBase;
     [CEReactions=NotNeeded, Reflect] attribute DOMString codeType;
-    [CEReactions=NotNeeded, Reflect, URL] attribute ScriptURLString data;
+    [CEReactions=NotNeeded, Reflect, URL] attribute USVString data;
     [CEReactions=NotNeeded, Reflect] attribute boolean declare;
     [CEReactions=NotNeeded, Reflect] attribute DOMString height;
     [CEReactions=NotNeeded, Reflect] attribute unsigned long hspace;
@@ -51,5 +51,3 @@
 
     [CheckSecurityForNode] Document getSVGDocument();
 };
-
-typedef [StringContext=TrustedScriptURL] USVString ScriptURLString;


### PR DESCRIPTION
#### 18692f5a98be6dcc54fca171bd358e136660ec4b
<pre>
Remove trusted types enforcement from object and embed elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=271824">https://bugs.webkit.org/show_bug.cgi?id=271824</a>

Reviewed by Anne van Kesteren.

This removes TT coverage of object and embed elements.
These no longer need protecting as they&apos;re not XSS sinks anymore.

Also updates the test suite to remove coverage of them.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-setAttribute-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-setAttribute.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedType-AttributeNodes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedType-AttributeNodes.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getPropertyType.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-setAttribute-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-setAttribute.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-setAttributeNS-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-Element-setAttributeNS.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-HTMLElement-generic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-HTMLElement-generic.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-attribute-via-attribute-node-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-string-assignment-to-attribute-via-attribute-node.html:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/trusted-types/HTMLElement-generic-expected.txt:
* Source/WebCore/dom/TrustedTypePolicyFactory.cpp:
(WebCore::TrustedTypePolicyFactory::getAttributeType const):
(WebCore::TrustedTypePolicyFactory::getPropertyType const):
* Source/WebCore/html/HTMLEmbedElement.idl:
* Source/WebCore/html/HTMLObjectElement.idl:

Canonical link: <a href="https://commits.webkit.org/277201@main">https://commits.webkit.org/277201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62f95a1b9d647c2f3d340b53f29b671a22e987b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46961 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49643 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43009 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38252 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19561 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20914 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41600 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5007 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43343 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51517 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45546 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44531 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/10373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24021 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6585 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22974 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->