### PR TITLE
Adjust <input type=checkbox switch> iOS animation

### DIFF
--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -58,6 +58,8 @@
 
 namespace WebCore {
 
+static constexpr Seconds switchHeldDelay = 200_ms;
+
 const AtomString& CheckboxInputType::formControlType() const
 {
     return InputTypeNames::checkbox();
@@ -133,17 +135,28 @@ void CheckboxInputType::handleMouseMoveEvent(MouseEvent& event)
 }
 
 #if ENABLE(IOS_TOUCH_EVENTS)
-// FIXME: Share this function with SliderThumbElement somehow? Some of the logic in
-// handleTouchEvent() could maybe do with some abstraction as well.
+// FIXME: Share these functions with SliderThumbElement somehow?
 static Touch* findTouchWithIdentifier(TouchList& list, unsigned identifier)
 {
     unsigned length = list.length();
     for (unsigned i = 0; i < length; ++i) {
-        RefPtr<Touch> touch = list.item(i);
+        RefPtr touch = list.item(i);
         if (touch->identifier() == identifier)
             return touch.get();
     }
     return nullptr;
+}
+
+Touch* CheckboxInputType::subsequentTouchEventTouch(const TouchEvent& event) const
+{
+    if (!m_switchPointerTrackingTouchIdentifier)
+        return nullptr;
+
+    RefPtr targetTouches = event.targetTouches();
+    if (!targetTouches)
+        return nullptr;
+
+    return findTouchWithIdentifier(*targetTouches, *m_switchPointerTrackingTouchIdentifier);
 }
 
 void CheckboxInputType::handleTouchEvent(TouchEvent& event)
@@ -159,45 +172,43 @@ void CheckboxInputType::handleTouchEvent(TouchEvent& event)
     const AtomString& eventType = event.type();
     auto& eventNames = WebCore::eventNames();
     if (eventType == eventNames.touchstartEvent) {
-        RefPtr<TouchList> targetTouches = event.targetTouches();
-        if (!targetTouches)
+        RefPtr targetTouches = event.targetTouches();
+        if (!targetTouches || targetTouches->length() != 1)
             return;
-        if (targetTouches->length() != 1)
-            return;
-        RefPtr<Touch> touch = targetTouches->item(0);
+        RefPtr touch = targetTouches->item(0);
 
-        startSwitchPointerTracking({ touch->pageX(), touch->pageY() }, touch->identifier());
-        performSwitchAnimation(SwitchAnimationType::Pressed);
+        m_switchPointerTrackingTouchIdentifier = touch->identifier();
+        if (!m_switchHeldTimer) {
+            m_switchHeldTimer = makeUnique<Timer>([protectedThis = Ref { *this }, touch] {
+                if (!protectedThis->isSwitch() || !protectedThis->element() || !protectedThis->element()->renderer())
+                    return;
+                protectedThis->startSwitchPointerTracking({ touch->pageX(), touch->pageY() });
+                protectedThis->setIsSwitchHeld(true);
+            });
+        }
+        m_switchHeldTimer->startOneShot(switchHeldDelay);
         event.setDefaultHandled();
     } else if (eventType == eventNames.touchmoveEvent) {
-        if (!m_switchPointerTrackingTouchIdentifier || !isSwitchPointerTracking())
+        if (!isSwitchPointerTracking())
             return;
-
-        RefPtr<TouchList> targetTouches = event.targetTouches();
-        if (!targetTouches)
-            return;
-
-        RefPtr<Touch> touch = findTouchWithIdentifier(*targetTouches, *m_switchPointerTrackingTouchIdentifier);
+        RefPtr touch = subsequentTouchEventTouch(event);
         if (!touch)
             return;
 
         updateIsSwitchVisuallyOnFromAbsoluteLocation({ touch->pageX(), touch->pageY() });
         event.setDefaultHandled();
     } else if (eventType == eventNames.touchendEvent || eventType == eventNames.touchcancelEvent) {
-        if (!m_switchPointerTrackingTouchIdentifier || !isSwitchPointerTracking())
-            return;
-
-        RefPtr<TouchList> targetTouches = event.targetTouches();
-        if (!targetTouches)
-            return;
-
         // If our touch still exists, this is not our touchend/touchcancel.
-        RefPtr<Touch> touch = findTouchWithIdentifier(*targetTouches, *m_switchPointerTrackingTouchIdentifier);
+        RefPtr touch = subsequentTouchEventTouch(event);
         if (touch)
             return;
 
-        performSwitchAnimation(SwitchAnimationType::Pressed);
-        element->dispatchSimulatedClick(&event);
+        m_switchPointerTrackingTouchIdentifier = { };
+        if (m_switchHeldTimer)
+            m_switchHeldTimer->stop();
+        if (std::exchange(m_isSwitchHeld, false))
+            performSwitchAnimation(SwitchAnimationType::Held);
+        element->dispatchSimulatedClick(&event, SendNoEvents);
     }
 }
 #endif
@@ -250,7 +261,7 @@ static int switchPointerTrackingLogicalLeftPosition(Element& element, LayoutPoin
     return isVertical ? localLocation.y() : localLocation.x();
 }
 
-void CheckboxInputType::startSwitchPointerTracking(LayoutPoint absoluteLocation, std::optional<unsigned> touchIdentifier)
+void CheckboxInputType::startSwitchPointerTracking(LayoutPoint absoluteLocation)
 {
     ASSERT(element());
     ASSERT(element()->renderer());
@@ -258,7 +269,6 @@ void CheckboxInputType::startSwitchPointerTracking(LayoutPoint absoluteLocation,
         frame->eventHandler().setCapturingMouseEventsElement(element());
         m_isSwitchVisuallyOn = element()->checked();
         m_switchPointerTrackingLogicalLeftPositionStart = switchPointerTrackingLogicalLeftPosition(*element(), absoluteLocation);
-        m_switchPointerTrackingTouchIdentifier = touchIdentifier;
     }
 }
 
@@ -271,8 +281,7 @@ void CheckboxInputType::stopSwitchPointerTracking()
     if (RefPtr frame = element()->document().frame())
         frame->eventHandler().setCapturingMouseEventsElement(nullptr);
     m_hasSwitchVisuallyOnChanged = false;
-    m_switchPointerTrackingLogicalLeftPositionStart = std::nullopt;
-    m_switchPointerTrackingTouchIdentifier = std::nullopt;
+    m_switchPointerTrackingLogicalLeftPositionStart = { };
 }
 
 bool CheckboxInputType::isSwitchPointerTracking() const
@@ -295,7 +304,7 @@ void CheckboxInputType::disabledStateChanged()
     ASSERT(element);
     if (element->isDisabledFormControl()) {
         stopSwitchAnimation(SwitchAnimationType::VisuallyOn);
-        stopSwitchAnimation(SwitchAnimationType::Pressed);
+        stopSwitchAnimation(SwitchAnimationType::Held);
         stopSwitchPointerTracking();
     }
 }
@@ -305,7 +314,7 @@ void CheckboxInputType::willUpdateCheckedness(bool, WasSetByJavaScript wasChecke
     ASSERT(element());
     if (isSwitch() && wasCheckedByJavaScript == WasSetByJavaScript::Yes) {
         stopSwitchAnimation(SwitchAnimationType::VisuallyOn);
-        stopSwitchAnimation(SwitchAnimationType::Pressed);
+        stopSwitchAnimation(SwitchAnimationType::Held);
         stopSwitchPointerTracking();
     }
 }
@@ -323,14 +332,14 @@ static Seconds switchAnimationDuration(SwitchAnimationType type)
 {
     if (type == SwitchAnimationType::VisuallyOn)
         return RenderTheme::singleton().switchAnimationVisuallyOnDuration();
-    return RenderTheme::singleton().switchAnimationPressedDuration();
+    return RenderTheme::singleton().switchAnimationHeldDuration();
 }
 
 Seconds CheckboxInputType::switchAnimationStartTime(SwitchAnimationType type) const
 {
     if (type == SwitchAnimationType::VisuallyOn)
         return m_switchAnimationVisuallyOnStartTime;
-    return m_switchAnimationPressedStartTime;
+    return m_switchAnimationHeldStartTime;
 }
 
 void CheckboxInputType::setSwitchAnimationStartTime(SwitchAnimationType type, Seconds time)
@@ -338,7 +347,7 @@ void CheckboxInputType::setSwitchAnimationStartTime(SwitchAnimationType type, Se
     if (type == SwitchAnimationType::VisuallyOn)
         m_switchAnimationVisuallyOnStartTime = time;
     else
-        m_switchAnimationPressedStartTime = time;
+        m_switchAnimationHeldStartTime = time;
 }
 
 bool CheckboxInputType::isSwitchAnimating(SwitchAnimationType type) const
@@ -384,6 +393,12 @@ void CheckboxInputType::performSwitchVisuallyOnAnimation(SwitchTrigger trigger)
         page->chrome().client().performSwitchHapticFeedback();
 }
 
+void CheckboxInputType::setIsSwitchHeld(bool isHeld)
+{
+    m_isSwitchHeld = isHeld;
+    performSwitchAnimation(SwitchAnimationType::Held);
+}
+
 void CheckboxInputType::stopSwitchAnimation(SwitchAnimationType type)
 {
     setSwitchAnimationStartTime(type, 0_s);
@@ -405,19 +420,26 @@ float CheckboxInputType::switchAnimationVisuallyOnProgress() const
     return switchAnimationProgress(SwitchAnimationType::VisuallyOn);
 }
 
-float CheckboxInputType::switchAnimationPressedProgress() const
-{
-    ASSERT(isSwitch());
-    ASSERT(switchAnimationDuration(SwitchAnimationType::Pressed) > 0_s);
-
-    return switchAnimationProgress(SwitchAnimationType::Pressed);
-}
-
 bool CheckboxInputType::isSwitchVisuallyOn() const
 {
     ASSERT(element());
     ASSERT(isSwitch());
     return isSwitchPointerTracking() ? m_isSwitchVisuallyOn : element()->checked();
+}
+
+float CheckboxInputType::switchAnimationHeldProgress() const
+{
+    ASSERT(isSwitch());
+    ASSERT(switchAnimationDuration(SwitchAnimationType::Held) > 0_s);
+
+    return switchAnimationProgress(SwitchAnimationType::Held);
+}
+
+bool CheckboxInputType::isSwitchHeld() const
+{
+    ASSERT(element());
+    ASSERT(isSwitch());
+    return m_isSwitchHeld;
 }
 
 void CheckboxInputType::updateIsSwitchVisuallyOnFromAbsoluteLocation(LayoutPoint absoluteLocation)
@@ -460,14 +482,14 @@ void CheckboxInputType::switchAnimationTimerFired()
 
     auto currentTime = MonotonicTime::now().secondsSinceEpoch();
     auto isVisuallyOnOngoing = currentTime - switchAnimationStartTime(SwitchAnimationType::VisuallyOn) < switchAnimationDuration(SwitchAnimationType::VisuallyOn);
-    auto isPressedOngoing = currentTime - switchAnimationStartTime(SwitchAnimationType::Pressed) < switchAnimationDuration(SwitchAnimationType::Pressed);
-    if (isVisuallyOnOngoing || isPressedOngoing)
+    auto isHeldOngoing = currentTime - switchAnimationStartTime(SwitchAnimationType::Held) < switchAnimationDuration(SwitchAnimationType::Held);
+    if (isVisuallyOnOngoing || isHeldOngoing)
         m_switchAnimationTimer->startOneShot(updateInterval);
     else {
         if (!isVisuallyOnOngoing)
             stopSwitchAnimation(SwitchAnimationType::VisuallyOn);
-        if (!isPressedOngoing)
-            stopSwitchAnimation(SwitchAnimationType::Pressed);
+        if (!isHeldOngoing)
+            stopSwitchAnimation(SwitchAnimationType::Held);
     }
 
     element()->renderer()->repaint();

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -36,8 +36,12 @@
 
 namespace WebCore {
 
+#if ENABLE(IOS_TOUCH_EVENTS)
+class Touch;
+#endif
+
 enum class WasSetByJavaScript : bool;
-enum class SwitchAnimationType : bool { VisuallyOn, Pressed };
+enum class SwitchAnimationType : bool { VisuallyOn, Held };
 
 class CheckboxInputType final : public BaseCheckableInputType {
 public:
@@ -49,7 +53,8 @@ public:
     bool valueMissing(const String&) const final;
     float switchAnimationVisuallyOnProgress() const;
     bool isSwitchVisuallyOn() const;
-    float switchAnimationPressedProgress() const;
+    float switchAnimationHeldProgress() const;
+    bool isSwitchHeld() const;
 
 private:
     explicit CheckboxInputType(HTMLInputElement& element)
@@ -66,9 +71,10 @@ private:
 // FIXME: It should not be iOS-specific, but it's not been tested with a non-iOS touch
 // implementation thus far.
 #if ENABLE(IOS_TOUCH_EVENTS)
+    Touch* subsequentTouchEventTouch(const TouchEvent&) const;
     void handleTouchEvent(TouchEvent&) final;
 #endif
-    void startSwitchPointerTracking(LayoutPoint, std::optional<unsigned> = std::nullopt);
+    void startSwitchPointerTracking(LayoutPoint);
     void stopSwitchPointerTracking();
     bool isSwitchPointerTracking() const;
     void willDispatchClick(InputElementClickState&) final;
@@ -81,6 +87,7 @@ private:
     bool isSwitchAnimating(SwitchAnimationType) const;
     void performSwitchAnimation(SwitchAnimationType);
     void performSwitchVisuallyOnAnimation(SwitchTrigger);
+    void setIsSwitchHeld(bool /* isHeld */);
     void stopSwitchAnimation(SwitchAnimationType);
     float switchAnimationProgress(SwitchAnimationType) const;
     void updateIsSwitchVisuallyOnFromAbsoluteLocation(LayoutPoint);
@@ -91,10 +98,14 @@ private:
     std::optional<int> m_switchPointerTrackingLogicalLeftPositionStart { std::nullopt };
     bool m_hasSwitchVisuallyOnChanged { false };
     bool m_isSwitchVisuallyOn { false };
+    bool m_isSwitchHeld { false };
     Seconds m_switchAnimationVisuallyOnStartTime { 0_s };
-    Seconds m_switchAnimationPressedStartTime { 0_s };
+    Seconds m_switchAnimationHeldStartTime { 0_s };
     std::unique_ptr<Timer> m_switchAnimationTimer;
+#if ENABLE(IOS_TOUCH_EVENTS)
+    std::unique_ptr<Timer> m_switchHeldTimer;
     std::optional<unsigned> m_switchPointerTrackingTouchIdentifier { std::nullopt };
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  * Copyright (C) 2007 Samuel Weinig (sam@webkit.org)
  * Copyright (C) 2010-2021 Google Inc. All rights reserved.
@@ -2371,10 +2371,16 @@ bool HTMLInputElement::isSwitchVisuallyOn() const
     return downcast<CheckboxInputType>(*m_inputType).isSwitchVisuallyOn();
 }
 
-float HTMLInputElement::switchAnimationPressedProgress() const
+float HTMLInputElement::switchAnimationHeldProgress() const
 {
     ASSERT(isSwitch());
-    return downcast<CheckboxInputType>(*m_inputType).switchAnimationPressedProgress();
+    return downcast<CheckboxInputType>(*m_inputType).switchAnimationHeldProgress();
+}
+
+bool HTMLInputElement::isSwitchHeld() const
+{
+    ASSERT(isSwitch());
+    return downcast<CheckboxInputType>(*m_inputType).isSwitchHeld();
 }
 
 } // namespace

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Samsung Electronics. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -344,7 +344,8 @@ public:
 
     float switchAnimationVisuallyOnProgress() const;
     bool isSwitchVisuallyOn() const;
-    float switchAnimationPressedProgress() const;
+    float switchAnimationHeldProgress() const;
+    bool isSwitchHeld() const;
 
     void initializeInputTypeAfterParsingOrCloning();
 

--- a/Source/WebCore/platform/graphics/SpringSolver.h
+++ b/Source/WebCore/platform/graphics/SpringSolver.h
@@ -46,7 +46,7 @@ public:
         }
     }
 
-    double solve(double t)
+    double solve(double t) const
     {
         if (m_zeta < 1) {
             // Under-damped

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -254,7 +254,7 @@ public:
     virtual void paintSystemPreviewBadge(Image&, const PaintInfo&, const FloatRect&);
 #endif
     virtual Seconds switchAnimationVisuallyOnDuration() const { return 0_s; }
-    virtual Seconds switchAnimationPressedDuration() const { return 0_s; }
+    virtual Seconds switchAnimationHeldDuration() const { return 0_s; }
     float switchPointerTrackingMagnitudeProportion() const { return 0.4f; }
     virtual bool hasSwitchHapticFeedback(SwitchTrigger) const { return false; }
 

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -104,8 +104,8 @@ private:
     void adjustSwitchStyle(RenderStyle&, const Element*) const final;
     bool paintSwitchThumb(const RenderObject&, const PaintInfo&, const FloatRect&) final;
     bool paintSwitchTrack(const RenderObject&, const PaintInfo&, const FloatRect&) final;
-    Seconds switchAnimationVisuallyOnDuration() const final { return 300_ms; }
-    Seconds switchAnimationPressedDuration() const final { return 300_ms; }
+    Seconds switchAnimationVisuallyOnDuration() const final { return 0.4880138408543766_s; }
+    Seconds switchAnimationHeldDuration() const final { return 0.5073965509413827_s; }
 #if HAVE(UI_IMPACT_FEEDBACK_GENERATOR)
     bool hasSwitchHapticFeedback(SwitchTrigger) const final { return true; }
 #endif


### PR DESCRIPTION
#### fb6f64f9959f2873795185a5be1348f9c2d75cbb
<pre>
Adjust &lt;input type=checkbox switch&gt; iOS animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=271839">https://bugs.webkit.org/show_bug.cgi?id=271839</a>
<a href="https://rdar.apple.com/125563501">rdar://125563501</a>

Reviewed by Aditya Keerthi.

The pressed animation for the thumb needs a slight delay. This in turn
necessitates introducing additional state to indicate when it is
pressed, as the control generally being active is no longer sufficient
(that changes too early now).

Also make these more general improvements:

- Rename pressed to held to account for the slight change in semantics.
- Abstract finding the relevant Touch of a TouchEvent in a method.
- Call dispatchSimulatedClick with SendNoEvents for its mouse events
  argument. They are redundant and could possibly lead to non-touch
  code paths being triggered.

* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::findTouchWithIdentifier):
(WebCore::CheckboxInputType::subsequentTouchEventTouch const):
(WebCore::CheckboxInputType::handleTouchEvent):
(WebCore::CheckboxInputType::startSwitchPointerTracking):
(WebCore::CheckboxInputType::stopSwitchPointerTracking):
(WebCore::CheckboxInputType::disabledStateChanged):
(WebCore::CheckboxInputType::willUpdateCheckedness):
(WebCore::switchAnimationDuration):
(WebCore::CheckboxInputType::switchAnimationStartTime const):
(WebCore::CheckboxInputType::setSwitchAnimationStartTime):
(WebCore::CheckboxInputType::setIsSwitchHeld):
(WebCore::CheckboxInputType::isSwitchVisuallyOn const):
(WebCore::CheckboxInputType::switchAnimationHeldProgress const):
(WebCore::CheckboxInputType::isSwitchHeld const):
(WebCore::CheckboxInputType::switchAnimationTimerFired):
(WebCore::CheckboxInputType::switchAnimationPressedProgress const): Deleted.
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::switchAnimationHeldProgress const):
(WebCore::HTMLInputElement::isSwitchHeld const):
(WebCore::HTMLInputElement::switchAnimationPressedProgress const): Deleted.
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/platform/graphics/SpringSolver.h:
(WebCore::SpringSolver::solve const):
(WebCore::SpringSolver::solve): Deleted.
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::switchAnimationHeldDuration const):
(WebCore::RenderTheme::switchAnimationPressedDuration const): Deleted.
* Source/WebCore/rendering/ios/RenderThemeIOS.h:

Canonical link: <a href="https://commits.webkit.org/278311@main">https://commits.webkit.org/278311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d860986614d1694472ac2d7d8e0cee81b55f551

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53427 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/859 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/425 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40939 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22036 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24557 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/427 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8547 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/46545 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55010 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25265 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/390 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/48333 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47346 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27389 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7246 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->