### PR TITLE
Typing into Bitbucket comment fields is sometimes dropping characters/sending editing back to the start of the field

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7332,3 +7332,5 @@ webkit.org/b/271994 imported/w3c/web-platform-tests/css/css-transforms/transform
 fast/forms/switch/click-animation-redundant-checked.html [ ImageOnlyFailure ]
 fast/forms/switch/click-animation-redundant-disabled.html [ ImageOnlyFailure ]
 fast/forms/switch/click-animation.html [ ImageOnlyFailure ]
+
+webkit.org/b/271969 accessibility/ios-simulator/inline-prediction-attributed-string.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1715,7 +1715,8 @@ webkit.org/b/239627 [ arm64 ] fast/scrolling/mac/adjust-scroll-snap-during-gestu
 
 webkit.org/b/260917 [ Ventura ] fast/forms/border-color-relayout.html [ Pass ImageOnlyFailure ]
 # Enable Sonoma only test added in rdar://110488738.
-[ Sonoma+ ] accessibility/mac/attributed-string/attributed-string-has-completion-annotation.html [ Pass ]
+# webkit.org/b/271969
+[ Sonoma+ ] accessibility/mac/attributed-string/attributed-string-has-completion-annotation.html [ Failure ]
 
 # rdar://103251644 (REGRESSION : [ GuardMalloc ] com.apple.MediaToolbox: PerformTransferBytePumpAsync)
 editing/text-iterator/backwards-text-iterator-basic.html [ Crash ]

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -250,6 +250,7 @@
         "-internal-loading-auto-fill-button": {
             "user-agent-part": true
         },
+        "-internal-writing-suggestions": {},
         "-webkit-caps-lock-indicator": {
             "status": "non-standard",
             "user-agent-part": true

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -311,6 +311,8 @@ PseudoId CSSSelector::pseudoId(PseudoElement type)
         return PseudoId::ViewTransitionOld;
     case PseudoElement::ViewTransitionNew:
         return PseudoId::ViewTransitionNew;
+    case PseudoElement::InternalWritingSuggestions:
+        return PseudoId::InternalWritingSuggestions;
 #if ENABLE(VIDEO)
     case PseudoElement::Cue:
 #endif

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -433,6 +433,10 @@ button {
     appearance: auto;
 }
 
+::-internal-writing-suggestions {
+    color: color-mix(in srgb, currentColor 50%, transparent);
+}
+
 input, textarea, select, button {
     margin: 0__qem;
 #if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1458,6 +1458,7 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
             case CSSSelector::PseudoElement::FirstLetter:
             case CSSSelector::PseudoElement::FirstLine:
             case CSSSelector::PseudoElement::GrammarError:
+            case CSSSelector::PseudoElement::InternalWritingSuggestions:
             case CSSSelector::PseudoElement::Marker:
             case CSSSelector::PseudoElement::WebKitResizer:
             case CSSSelector::PseudoElement::WebKitScrollbar:

--- a/Source/WebCore/dom/WritingSuggestionData.h
+++ b/Source/WebCore/dom/WritingSuggestionData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,35 +25,31 @@
 
 #pragma once
 
-#include "RenderStyleConstants.h"
-#include "RenderTreeUpdater.h"
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-class Element;
-class RenderQuote;
-
-class RenderTreeUpdater::GeneratedContent {
+class WritingSuggestionData {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    GeneratedContent(RenderTreeUpdater&);
+    WritingSuggestionData(String&& content, String&& currentText, uint64_t&& offset)
+        : m_content(WTFMove(content))
+        , m_currentText(WTFMove(currentText))
+        , m_offset(WTFMove(offset))
+    {
+        ASSERT(!m_content.isEmpty());
+    }
 
-    void updateBackdropRenderer(RenderElement&);
-    void updatePseudoElement(Element&, const Style::ElementUpdate&, PseudoId);
-    void updateRemainingQuotes();
-    void updateCounters();
-    void updateWritingSuggestionsRenderer(RenderElement&);
+    String content() const { return m_content; }
 
-    static void removeBeforePseudoElement(Element&, RenderTreeBuilder&);
-    static void removeAfterPseudoElement(Element&, RenderTreeBuilder&);
+    String currentText() const { return m_currentText; }
+
+    uint64_t offset() const { return m_offset; }
 
 private:
-    void updateQuotesUpTo(RenderQuote*);
-    
-    bool needsPseudoElement(const RenderStyle*);
-
-    RenderTreeUpdater& m_updater;
-    SingleThreadWeakPtr<RenderQuote> m_previousUpdatedQuote;
+    String m_content;
+    String m_currentText;
+    uint64_t m_offset;
 };
 
 }

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -76,6 +76,7 @@ class KillRing;
 class LocalFrame;
 class Pasteboard;
 class PasteboardWriterData;
+class RenderInline;
 class RenderLayer;
 class FragmentedSharedBuffer;
 class Font;
@@ -87,6 +88,7 @@ class Text;
 class TextCheckerClient;
 class TextEvent;
 class TextPlaceholderElement;
+class WritingSuggestionData;
 
 struct CompositionHighlight;
 struct DictationAlternative;
@@ -395,7 +397,9 @@ public:
 
     // international text input composition
     bool hasComposition() const { return m_compositionNode; }
-    WEBCORE_EXPORT void setComposition(const String&, const Vector<CompositionUnderline>&, const Vector<CompositionHighlight>&, const HashMap<String, Vector<CharacterRange>>&, unsigned selectionStart, unsigned selectionEnd);
+    WEBCORE_EXPORT void setComposition(const String&, const Vector<CompositionUnderline>&, const Vector<CompositionHighlight>&, unsigned selectionStart, unsigned selectionEnd);
+    WEBCORE_EXPORT void setWritingSuggestion(const String&, const CharacterRange& selection);
+    WEBCORE_EXPORT void setOffset(uint64_t);
     WEBCORE_EXPORT void confirmComposition();
     WEBCORE_EXPORT void confirmComposition(const String&); // if no existing composition, replaces selection
     void confirmOrCancelCompositionAndNotifyClient();
@@ -606,6 +610,13 @@ public:
     bool isPastingFromMenuOrKeyBinding() const { return m_pastingFromMenuOrKeyBinding; }
     bool isCopyingFromMenuOrKeyBinding() const { return m_copyingFromMenuOrKeyBinding; }
 
+    Element* writingSuggestionsContainerElement();
+    WritingSuggestionData* writingSuggestionData() const { return m_writingSuggestionData.get(); }
+    bool isInsertingTextForWritingSuggestion() const { return m_isInsertingTextForWritingSuggestion; }
+
+    RenderInline* writingSuggestionRenderer() const;
+    void setWritingSuggestionRenderer(RenderInline&);
+
 private:
     Document& document() const { return m_document.get(); }
     Ref<Document> protectedDocument() const { return m_document.get(); }
@@ -661,6 +672,8 @@ private:
 
     void postTextStateChangeNotificationForCut(const String&, const VisibleSelection&);
 
+    void removeWritingSuggestionIfNeeded();
+
     WeakPtr<EditorClient> m_client;
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     RefPtr<CompositeEditCommand> m_lastEditCommand;
@@ -683,6 +696,10 @@ private:
     MemoryCompactRobinHoodHashSet<String> m_insertedAttachmentIdentifiers;
     MemoryCompactRobinHoodHashSet<String> m_removedAttachmentIdentifiers;
 #endif
+
+    std::unique_ptr<WritingSuggestionData> m_writingSuggestionData;
+    SingleThreadWeakPtr<RenderInline> m_writingSuggestionRenderer;
+    bool m_isInsertingTextForWritingSuggestion { false };
 
     VisibleSelection m_mark;
     bool m_areMarkedTextMatchesHighlighted { false };

--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -175,7 +175,10 @@ void InsertTextCommand::doApply()
     // It is possible for the node that contains startPosition to contain only unrendered whitespace,
     // and so deleteInsignificantText could remove it.  Save the position before the node in case that happens.
     Position positionBeforeStartNode(positionInParentBeforeNode(startPosition.containerNode()));
-    deleteInsignificantText(startPosition, startPosition.downstream());
+
+    if (!document().editor().isInsertingTextForWritingSuggestion())
+        deleteInsignificantText(startPosition, startPosition.downstream());
+
     if (!startPosition.anchorNode()->isConnected())
         startPosition = positionBeforeStartNode;
     if (!startPosition.isCandidate())

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -442,6 +442,8 @@ std::optional<Inspector::Protocol::CSS::PseudoId> InspectorCSSAgent::protocolVal
         return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarTrackPiece;
     case PseudoId::WebKitScrollbarCorner:
         return Inspector::Protocol::CSS::PseudoId::WebKitScrollbarCorner;
+    case PseudoId::InternalWritingSuggestions:
+        return { };
 
     default:
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -862,6 +862,7 @@ TextStream& operator<<(TextStream& ts, PseudoId pseudoId)
     case PseudoId::FirstLetter: ts << "first-letter"; break;
     case PseudoId::GrammarError: ts << "grammar-error"; break;
     case PseudoId::Highlight: ts << "highlight"; break;
+    case PseudoId::InternalWritingSuggestions: ts << "-internal-writing-suggestions"; break;
     case PseudoId::Marker: ts << "marker"; break;
     case PseudoId::Backdrop: ts << "backdrop"; break;
     case PseudoId::Before: ts << "before"; break;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -109,6 +109,7 @@ enum class PseudoId : uint32_t {
     WebKitScrollbarTrackPiece,
     WebKitScrollbarCorner,
     WebKitResizer,
+    InternalWritingSuggestions,
 
     AfterLastInternalPseudoId,
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -340,6 +340,7 @@ void RenderTreeUpdater::updateAfterDescendants(Element& element, const Style::El
         return;
 
     generatedContent().updateBackdropRenderer(*renderer);
+    generatedContent().updateWritingSuggestionsRenderer(*renderer);
     if (&element == element.document().documentElement())
         viewTransition().updatePseudoElementTree(*renderer);
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -27,6 +27,7 @@
 #include "RenderTreeUpdaterGeneratedContent.h"
 
 #include "ContentData.h"
+#include "Editor.h"
 #include "InspectorInstrumentation.h"
 #include "KeyframeEffectStack.h"
 #include "PseudoElement.h"
@@ -39,6 +40,7 @@
 #include "RenderTreeUpdater.h"
 #include "RenderView.h"
 #include "StyleTreeResolver.h"
+#include "WritingSuggestionData.h"
 
 namespace WebCore {
 
@@ -261,6 +263,99 @@ void RenderTreeUpdater::GeneratedContent::removeAfterPseudoElement(Element& elem
         return;
     tearDownRenderers(*pseudoElement, TeardownType::Full, builder);
     element.clearAfterPseudoElement();
+}
+
+void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(RenderElement& renderer)
+{
+    auto destroyWritingSuggestionsIfNeeded = [&renderer, this]() {
+        if (!renderer.element())
+            return;
+
+        auto& editor = renderer.element()->document().editor();
+
+        if (WeakPtr writingSuggestionsRenderer = editor.writingSuggestionRenderer())
+            m_updater.m_builder.destroy(*writingSuggestionsRenderer);
+    };
+
+    if (!renderer.canHaveChildren())
+        return;
+
+    if (!renderer.element())
+        return;
+
+    auto& editor = renderer.element()->document().editor();
+
+    auto isWritingSuggestionElement = renderer.element() == editor.writingSuggestionsContainerElement();
+    if (!isWritingSuggestionElement)
+        return;
+
+    auto* writingSuggestionData = editor.writingSuggestionData();
+    if (!writingSuggestionData) {
+        destroyWritingSuggestionsIfNeeded();
+        return;
+    }
+
+    auto style = renderer.getCachedPseudoStyle({ PseudoId::InternalWritingSuggestions }, &renderer.style());
+    if (!style || style->display() == DisplayType::None) {
+        destroyWritingSuggestionsIfNeeded();
+        return;
+    }
+
+    auto* firstChildText = dynamicDowncast<RenderText>(renderer.firstChild());
+    if (!firstChildText) {
+        destroyWritingSuggestionsIfNeeded();
+        return;
+    }
+
+    auto textWithoutSuggestion = firstChildText->text();
+
+    auto offset = writingSuggestionData->offset();
+    auto prefix = textWithoutSuggestion.substring(0, offset);
+    auto suffix = textWithoutSuggestion.substring(offset);
+
+    firstChildText->setText(prefix);
+
+    auto newStyle = RenderStyle::clone(*style);
+    if (auto writingSuggestionsRenderer = editor.writingSuggestionRenderer()) {
+        writingSuggestionsRenderer->setStyle(WTFMove(newStyle));
+
+        auto* writingSuggestionsText = dynamicDowncast<RenderText>(writingSuggestionsRenderer->firstChild());
+        if (!writingSuggestionsText) {
+            ASSERT_NOT_REACHED();
+            destroyWritingSuggestionsIfNeeded();
+            return;
+        }
+
+        writingSuggestionsText->setText(writingSuggestionData->content());
+
+        auto* suffixText = dynamicDowncast<RenderText>(writingSuggestionsRenderer->nextSibling());
+        if (!suffixText) {
+            ASSERT_NOT_REACHED();
+            destroyWritingSuggestionsIfNeeded();
+            return;
+        }
+
+        suffixText->setText(suffix);
+    } else {
+        auto newWritingSuggestionsRenderer = WebCore::createRenderer<RenderInline>(RenderObject::Type::Inline, renderer.document(), WTFMove(newStyle));
+        newWritingSuggestionsRenderer->initializeStyle();
+
+        auto writingSuggestionsText = WebCore::createRenderer<RenderText>(RenderObject::Type::Text, renderer.document(), writingSuggestionData->content());
+        m_updater.m_builder.attach(*newWritingSuggestionsRenderer, WTFMove(writingSuggestionsText));
+
+        editor.setWritingSuggestionRenderer(*newWritingSuggestionsRenderer.get());
+        m_updater.m_builder.attach(renderer, WTFMove(newWritingSuggestionsRenderer));
+
+        auto* prefixNode = firstChildText->textNode();
+        if (!prefixNode) {
+            ASSERT_NOT_REACHED();
+            destroyWritingSuggestionsIfNeeded();
+            return;
+        }
+
+        auto suffixRenderer = WebCore::createRenderer<RenderText>(RenderObject::Type::Text, *prefixNode, suffix);
+        m_updater.m_builder.attach(renderer, WTFMove(suffixRenderer));
+    }
 }
 
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11387,7 +11387,7 @@ void WebPageProxy::firstRectForCharacterRangeAsync(const EditingRange& range, Co
     sendWithAsyncReply(Messages::WebPage::FirstRectForCharacterRangeAsync(range), WTFMove(callbackFunction));
 }
 
-void WebPageProxy::setCompositionAsync(const String& text, const Vector<CompositionUnderline>& underlines, const Vector<CompositionHighlight>& highlights, const HashMap<String, Vector<CharacterRange>>& annotations, const EditingRange& selectionRange, const EditingRange& replacementRange)
+void WebPageProxy::setCompositionAsync(const String& text, const Vector<CompositionUnderline>& underlines, const Vector<CompositionHighlight>& highlights, const EditingRange& selectionRange, const EditingRange& replacementRange)
 {
     if (!hasRunningProcess()) {
         // If this fails, we should call -discardMarkedText on input context to notify the input method.
@@ -11395,7 +11395,18 @@ void WebPageProxy::setCompositionAsync(const String& text, const Vector<Composit
         return;
     }
 
-    send(Messages::WebPage::SetCompositionAsync(text, underlines, highlights, annotations, selectionRange, replacementRange));
+    send(Messages::WebPage::SetCompositionAsync(text, underlines, highlights, selectionRange, replacementRange));
+}
+
+void WebPageProxy::setWritingSuggestion(const String& text, const EditingRange& selectionRange)
+{
+    if (!hasRunningProcess()) {
+        // If this fails, we should call -discardMarkedText on input context to notify the input method.
+        // This will happen naturally later, as part of reloading the page.
+        return;
+    }
+
+    send(Messages::WebPage::SetWritingSuggestion(text, selectionRange));
 }
 
 void WebPageProxy::confirmCompositionAsync()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1122,7 +1122,8 @@ public:
     void getSelectedRangeAsync(CompletionHandler<void(const EditingRange&)>&&);
     void characterIndexForPointAsync(const WebCore::IntPoint&, CompletionHandler<void(uint64_t)>&&);
     void firstRectForCharacterRangeAsync(const EditingRange&, CompletionHandler<void(const WebCore::IntRect&, const EditingRange&)>&&);
-    void setCompositionAsync(const String& text, const Vector<WebCore::CompositionUnderline>&, const Vector<WebCore::CompositionHighlight>&, const HashMap<String, Vector<WebCore::CharacterRange>>&, const EditingRange& selectionRange, const EditingRange& replacementRange);
+    void setCompositionAsync(const String& text, const Vector<WebCore::CompositionUnderline>&, const Vector<WebCore::CompositionHighlight>&, const EditingRange& selectionRange, const EditingRange& replacementRange);
+    void setWritingSuggestion(const String& text, const EditingRange& selectionRange);
     void confirmCompositionAsync();
 
     void setScrollPerformanceDataCollectionEnabled(bool);

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -6320,7 +6320,7 @@ static Vector<WebCore::CompositionHighlight> compositionHighlights(NSAttributedS
     _autocorrectionContextNeedsUpdate = YES;
     _candidateViewNeedsUpdate = !self.hasMarkedText && _isDeferringKeyEventsToInputMethod;
     _markedText = markedText;
-    _page->setCompositionAsync(markedText, underlines, highlights, { }, selectedRange, { });
+    _page->setCompositionAsync(markedText, underlines, highlights, selectedRange, { });
 }
 
 - (void)unmarkText

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -631,7 +631,7 @@ WKArrayRef WKBundlePageCopyTrackedRepaintRects(WKBundlePageRef pageRef)
     return WebKit::toAPI(&WebKit::toImpl(pageRef)->trackedRepaintRects().leakRef());
 }
 
-void WKBundlePageSetComposition(WKBundlePageRef pageRef, WKStringRef text, int from, int length, bool suppressUnderline, WKArrayRef highlightData, WKArrayRef annotationData)
+void WKBundlePageSetComposition(WKBundlePageRef pageRef, WKStringRef text, int from, int length, bool suppressUnderline, WKArrayRef highlightData)
 {
     Vector<WebCore::CompositionHighlight> highlights;
     if (highlightData) {
@@ -657,22 +657,8 @@ void WKBundlePageSetComposition(WKBundlePageRef pageRef, WKStringRef text, int f
             });
         }
     }
-    HashMap<String, Vector<WebCore::CharacterRange>> annotations;
-    if (annotationData) {
-        auto* annotationDataArray = WebKit::toImpl(annotationData);
-        for (auto dictionary : annotationDataArray->elementsOfType<API::Dictionary>()) {
-            auto location = static_cast<API::UInt64*>(dictionary->get("from"_s))->value();
-            auto length = static_cast<API::UInt64*>(dictionary->get("length"_s))->value();
-            auto name = static_cast<API::String*>(dictionary->get("annotation"_s))->string();
 
-            auto it = annotations.find(name);
-            if (it == annotations.end())
-                it = annotations.add(name, Vector<WebCore::CharacterRange> { }).iterator;
-            it->value.append({ location, length });
-        }
-    }
-
-    WebKit::toImpl(pageRef)->setCompositionForTesting(WebKit::toWTFString(text), from, length, suppressUnderline, highlights, annotations);
+    WebKit::toImpl(pageRef)->setCompositionForTesting(WebKit::toWTFString(text), from, length, suppressUnderline, highlights);
 }
 
 bool WKBundlePageHasComposition(WKBundlePageRef pageRef)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePagePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePagePrivate.h
@@ -83,7 +83,7 @@ WK_EXPORT bool WKBundlePageIsTrackingRepaints(WKBundlePageRef page);
 WK_EXPORT void WKBundlePageResetTrackedRepaints(WKBundlePageRef page);
 WK_EXPORT WKArrayRef WKBundlePageCopyTrackedRepaintRects(WKBundlePageRef page);
 
-WK_EXPORT void WKBundlePageSetComposition(WKBundlePageRef page, WKStringRef text, int from, int length, bool suppressUnderline, WKArrayRef highlightData, WKArrayRef annotationData);
+WK_EXPORT void WKBundlePageSetComposition(WKBundlePageRef page, WKStringRef text, int from, int length, bool suppressUnderline, WKArrayRef highlightData);
 WK_EXPORT bool WKBundlePageHasComposition(WKBundlePageRef page);
 WK_EXPORT void WKBundlePageConfirmComposition(WKBundlePageRef page);
 WK_EXPORT void WKBundlePageConfirmCompositionWithText(WKBundlePageRef page, WKStringRef text);

--- a/Source/WebKit/WebProcess/WebCoreSupport/glib/WebEditorClientGLib.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/glib/WebEditorClientGLib.cpp
@@ -49,7 +49,7 @@ void WebEditorClient::didDispatchInputMethodKeydown(KeyboardEvent& event)
     if (const auto& underlines = platformEvent->preeditUnderlines()) {
         auto rangeStart = platformEvent->preeditSelectionRangeStart().value_or(0);
         auto rangeLength = platformEvent->preeditSelectionRangeLength().value_or(0);
-        frame->editor().setComposition(platformEvent->text(), underlines.value(), { }, { }, rangeStart, rangeStart + rangeLength);
+        frame->editor().setComposition(platformEvent->text(), underlines.value(), { }, rangeStart, rangeStart + rangeLength);
     } else
         frame->editor().confirmComposition(platformEvent->text());
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6605,7 +6605,7 @@ void WebPage::handleAlternativeTextUIResult(const String& result)
 }
 #endif
 
-void WebPage::setCompositionForTesting(const String& compositionString, uint64_t from, uint64_t length, bool suppressUnderline, const Vector<CompositionHighlight>& highlights, const HashMap<String, Vector<WebCore::CharacterRange>>& annotations)
+void WebPage::setCompositionForTesting(const String& compositionString, uint64_t from, uint64_t length, bool suppressUnderline, const Vector<CompositionHighlight>& highlights)
 {
     RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
     if (!frame)
@@ -6618,7 +6618,7 @@ void WebPage::setCompositionForTesting(const String& compositionString, uint64_t
     if (!suppressUnderline)
         underlines.append(CompositionUnderline(0, compositionString.length(), CompositionUnderlineColor::TextColor, Color(Color::black), false));
 
-    frame->editor().setComposition(compositionString, underlines, highlights, annotations, from, from + length);
+    frame->editor().setComposition(compositionString, underlines, highlights, from, from + length);
 }
 
 bool WebPage::hasCompositionForTesting()
@@ -6873,7 +6873,7 @@ void WebPage::firstRectForCharacterRangeAsync(const EditingRange& editingRange, 
     completionHandler(rect, editingRange);
 }
 
-void WebPage::setCompositionAsync(const String& text, const Vector<CompositionUnderline>& underlines, const Vector<CompositionHighlight>& highlights, const HashMap<String, Vector<CharacterRange>>& annotations, const EditingRange& selection, const EditingRange& replacementEditingRange)
+void WebPage::setCompositionAsync(const String& text, const Vector<CompositionUnderline>& underlines, const Vector<CompositionHighlight>& highlights, const EditingRange& selection, const EditingRange& replacementEditingRange)
 {
     platformWillPerformEditingCommand();
 
@@ -6886,8 +6886,19 @@ void WebPage::setCompositionAsync(const String& text, const Vector<CompositionUn
             if (auto replacementRange = EditingRange::toRange(*frame, replacementEditingRange))
                 frame->selection().setSelection(VisibleSelection(*replacementRange));
         }
-        frame->editor().setComposition(text, underlines, highlights, annotations, selection.location, selection.location + selection.length);
+        frame->editor().setComposition(text, underlines, highlights, selection.location, selection.location + selection.length);
     }
+}
+
+void WebPage::setWritingSuggestion(const String& fullTextWithPrediction, const EditingRange& selection)
+{
+    platformWillPerformEditingCommand();
+
+    RefPtr frame = m_page->checkedFocusController()->focusedOrMainFrame();
+    if (!frame)
+        return;
+
+    frame->editor().setWritingSuggestion(fullTextWithPrediction, { selection.location, selection.length });
 }
 
 void WebPage::confirmCompositionAsync()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1079,7 +1079,8 @@ public:
     void getSelectedRangeAsync(CompletionHandler<void(const EditingRange&)>&&);
     void characterIndexForPointAsync(const WebCore::IntPoint&, CompletionHandler<void(uint64_t)>&&);
     void firstRectForCharacterRangeAsync(const EditingRange&, CompletionHandler<void(const WebCore::IntRect&, const EditingRange&)>&&);
-    void setCompositionAsync(const String& text, const Vector<WebCore::CompositionUnderline>&, const Vector<WebCore::CompositionHighlight>&, const HashMap<String, Vector<WebCore::CharacterRange>>&, const EditingRange& selectionRange, const EditingRange& replacementRange);
+    void setCompositionAsync(const String& text, const Vector<WebCore::CompositionUnderline>&, const Vector<WebCore::CompositionHighlight>&, const EditingRange& selectionRange, const EditingRange& replacementRange);
+    void setWritingSuggestion(const String& text, const EditingRange& selection);
     void confirmCompositionAsync();
 
     void readSelectionFromPasteboard(const String& pasteboardName, CompletionHandler<void(bool&&)>&&);
@@ -1113,7 +1114,7 @@ public:
     void replaceImageForRemoveBackground(const WebCore::ElementContext&, const Vector<String>& types, std::span<const uint8_t>);
 #endif
 
-    void setCompositionForTesting(const String& compositionString, uint64_t from, uint64_t length, bool suppressUnderline, const Vector<WebCore::CompositionHighlight>&, const HashMap<String, Vector<WebCore::CharacterRange>>&);
+    void setCompositionForTesting(const String& compositionString, uint64_t from, uint64_t length, bool suppressUnderline, const Vector<WebCore::CompositionHighlight>&);
     bool hasCompositionForTesting();
     void confirmCompositionForTesting(const String& compositionString);
     String frameTextForTestingIncludingSubframes(bool includingSubframes);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -524,7 +524,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     GetSelectedRangeAsync() -> (struct WebKit::EditingRange range)
     CharacterIndexForPointAsync(WebCore::IntPoint point) -> (uint64_t location)
     FirstRectForCharacterRangeAsync(struct WebKit::EditingRange range) -> (WebCore::IntRect rect, struct WebKit::EditingRange actualRange)
-    SetCompositionAsync(String text, Vector<WebCore::CompositionUnderline> underlines, Vector<WebCore::CompositionHighlight> highlights, HashMap<String, Vector<WebCore::CharacterRange>> annotations, struct WebKit::EditingRange selectionRange, struct WebKit::EditingRange replacementRange)
+    SetCompositionAsync(String text, Vector<WebCore::CompositionUnderline> underlines, Vector<WebCore::CompositionHighlight> highlights, struct WebKit::EditingRange selectionRange, struct WebKit::EditingRange replacementRange)
+    SetWritingSuggestion(String text, struct WebKit::EditingRange selectionRange)
     ConfirmCompositionAsync()
 #endif
 #if PLATFORM(MAC)

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -1615,7 +1615,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     
     Vector<WebCore::CompositionUnderline> underlines;
     frame->page()->chrome().client().suppressFormNotifications();
-    frame->editor().setComposition(text, underlines, { }, { }, newSelRange.location, NSMaxRange(newSelRange));
+    frame->editor().setComposition(text, underlines, { }, newSelRange.location, NSMaxRange(newSelRange));
     frame->page()->chrome().client().restoreFormNotifications();
 }
 
@@ -1626,7 +1626,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
         return;
         
     Vector<WebCore::CompositionUnderline> underlines;
-    frame->editor().setComposition(text, underlines, { }, { }, 0, [text length]);
+    frame->editor().setComposition(text, underlines, { }, 0, [text length]);
 }
 
 - (void)confirmMarkedText:(NSString *)text

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -6570,7 +6570,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (replacementRange.location != NSNotFound)
         [[self _frame] _selectNSRange:replacementRange];
 
-    coreFrame->editor().setComposition(text, underlines, { }, { }, newSelRange.location, NSMaxRange(newSelRange));
+    coreFrame->editor().setComposition(text, underlines, { }, newSelRange.location, NSMaxRange(newSelRange));
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TextInputController.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TextInputController.idl
@@ -24,7 +24,7 @@
  */
 
 interface TextInputController {
-    undefined setMarkedText(DOMString string, long from, long length, boolean suppressUnderline, object highlights, object annotations);
+    undefined setMarkedText(DOMString string, long from, long length, boolean suppressUnderline, object highlights);
     boolean hasMarkedText();
     undefined unmarkText();
     undefined insertText(DOMString string);

--- a/Tools/WebKitTestRunner/InjectedBundle/TextInputController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TextInputController.cpp
@@ -79,35 +79,12 @@ static WKArrayRef createCompositionHighlightData(JSContextRef context, JSValueRe
     return result;
 }
 
-static WKArrayRef createCompositionAnnotationData(JSContextRef context, JSValueRef jsAnnotationsValue)
-{
-    if (!jsAnnotationsValue || !JSValueIsObject(context, jsAnnotationsValue))
-        return nullptr;
-
-    auto result = WKMutableArrayCreate();
-    auto array = const_cast<JSObjectRef>(jsAnnotationsValue);
-    unsigned length = arrayLength(context, array);
-    for (unsigned i = 0; i < length; ++i) {
-        auto value = JSObjectGetPropertyAtIndex(context, array, i, nullptr);
-        if (!value || !JSValueIsObject(context, value))
-            continue;
-        auto object = const_cast<JSObjectRef>(value);
-        auto dictionary = adoptWK(WKMutableDictionaryCreate());
-        setValue(dictionary, "from", static_cast<uint64_t>(numericProperty(context, object, "from")));
-        setValue(dictionary, "length", static_cast<uint64_t>(numericProperty(context, object, "length")));
-        setValue(dictionary, "annotation", toWK(stringProperty(context, object, "annotation")));
-        WKArrayAppendItem(result, dictionary.get());
-    }
-    return result;
-}
-
-void TextInputController::setMarkedText(JSStringRef text, int from, int length, bool suppressUnderline, JSValueRef jsHighlightsValue, JSValueRef jsAnnotationsValue)
+void TextInputController::setMarkedText(JSStringRef text, int from, int length, bool suppressUnderline, JSValueRef jsHighlightsValue)
 {
     auto page = InjectedBundle::singleton().page()->page();
     auto context = WKBundleFrameGetJavaScriptContext(WKBundlePageGetMainFrame(page));
     auto highlights = adoptWK(createCompositionHighlightData(context, jsHighlightsValue));
-    auto annotations = adoptWK(createCompositionAnnotationData(context, jsAnnotationsValue));
-    WKBundlePageSetComposition(page, toWK(text).get(), from, length, suppressUnderline, highlights.get(), annotations.get());
+    WKBundlePageSetComposition(page, toWK(text).get(), from, length, suppressUnderline, highlights.get());
 }
 
 bool TextInputController::hasMarkedText()

--- a/Tools/WebKitTestRunner/InjectedBundle/TextInputController.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TextInputController.h
@@ -40,7 +40,7 @@ public:
 
     void makeWindowObject(JSContextRef);
 
-    void setMarkedText(JSStringRef text, int from, int length, bool suppressUnderline, JSValueRef highlights, JSValueRef annotations);
+    void setMarkedText(JSStringRef text, int from, int length, bool suppressUnderline, JSValueRef highlights);
     bool hasMarkedText();
     void unmarkText();
     void insertText(JSStringRef text);


### PR DESCRIPTION
#### 052c7b2a782b865f1922a7c9a691799aa815d306
<pre>
Typing into Bitbucket comment fields is sometimes dropping characters/sending editing back to the start of the field
<a href="https://bugs.webkit.org/show_bug.cgi?id=271842">https://bugs.webkit.org/show_bug.cgi?id=271842</a>
<a href="https://rdar.apple.com/125039472">rdar://125039472</a>

Reviewed by Ryosuke Niwa and Antti Koivisto.

The original implementation of writing suggestions aka inline text predictions relied on using the
same code path as IME marked text has historically used; i.e., inserting the suggestion directly into
the DOM.

While this worked for trivial, simple cases, this proved to be incompatible from a web-compatibility
perspective, since sites were not expecting this type of mutation to ever be happening in the DOM.
Because of the combination of the conflicting selection changes that both the web engine and the site
do, as well as the specific event handlers that a site may have, this resulted in erratic behavior
when inserting and editing text.

To fix, re-implement this feature using a different and significantly safer implementation; instead
of inserting the suggestion into the DON, simply render it as a pseudo-element while it is being suggested,
and only actually insert it into the DOM once the user accepts it. This significantly improves web
compatibility, and also reduces risk in general by not doing unexpected things that the site can detect.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::pseudoId):
* Source/WebCore/css/html.css:
(::-internal-writing-suggestions):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::writingSuggestionData const):
(WebCore::Element::setWritingSuggestionData):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementRareData.cpp:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::ElementRareData::writingSuggestionData const):
(WebCore::ElementRareData::setWritingSuggestionData):
* Source/WebCore/dom/WritingSuggestionData.h: Copied from Tools/WebKitTestRunner/InjectedBundle/Bindings/TextInputController.idl.
(WebCore::WritingSuggestionData::WritingSuggestionData):
(WebCore::WritingSuggestionData::content const):
(WebCore::WritingSuggestionData::offset const):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::selectedElement):
(WebCore::Editor::removeWritingSuggestionIfNeeded):
(WebCore::Editor::confirmComposition):
(WebCore::Editor::cancelComposition):
(WebCore::Editor::setWritingSuggestion):
(WebCore::Editor::setComposition):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::writingSuggestionsRenderer const):
(WebCore::RenderElement::setWritingSuggestionsRenderer):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateAfterDescendants):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setCompositionAsync):
(WebKit::WebPageProxy::setWritingSuggestion):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _setMarkedText:underlines:highlights:selectedRange:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::setMarkedText):
(WebKit::compositionAnnotations): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageSetComposition):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePagePrivate.h:
* Source/WebKit/WebProcess/WebCoreSupport/glib/WebEditorClientGLib.cpp:
(WebKit::WebEditorClient::didDispatchInputMethodKeydown):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setCompositionForTesting):
(WebKit::WebPage::setCompositionAsync):
(WebKit::WebPage::setWritingSuggestion):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame setMarkedText:selectedRange:]):
(-[WebFrame setMarkedText:forCandidates:]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView setMarkedText:selectedRange:]):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TextInputController.idl:
* Tools/WebKitTestRunner/InjectedBundle/TextInputController.cpp:
(WTR::TextInputController::setMarkedText):
(WTR::createCompositionAnnotationData): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TextInputController.h:

Canonical link: <a href="https://commits.webkit.org/277282@main">https://commits.webkit.org/277282@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb00c2471d3e63771bfc5297f1289c7ee74261de

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49868 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43234 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49492 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38438 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19750 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41827 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5229 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43569 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51744 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22212 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45731 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23487 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44739 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10410 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24274 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->