### PR TITLE
Disable the watch simulator build for swift interop

### DIFF
--- a/Source/WebCore/Configurations/WebCore.xcconfig
+++ b/Source/WebCore/Configurations/WebCore.xcconfig
@@ -41,7 +41,7 @@ WK_HAVE_SWIFT_CPP_INTEROP[sdk=iphonesimulator17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=appletvos17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=appletvsimulator17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=watchos10*] = ;
-WK_HAVE_SWIFT_CPP_INTEROP[sdk=watchsimulator10*] = ;
+//WK_HAVE_SWIFT_CPP_INTEROP[sdk=watchsimulator10*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=xros1*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=xrsimulator1*] = ;
 

--- a/Source/WebCore/PAL/Configurations/PAL.xcconfig
+++ b/Source/WebCore/PAL/Configurations/PAL.xcconfig
@@ -32,7 +32,7 @@ WK_HAVE_SWIFT_CPP_INTEROP[sdk=iphonesimulator17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=appletvos17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=appletvsimulator17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=watchos10*] = ;
-WK_HAVE_SWIFT_CPP_INTEROP[sdk=watchsimulator10*] = ;
+//WK_HAVE_SWIFT_CPP_INTEROP[sdk=watchsimulator10*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=xros1*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=xrsimulator1*] = ;
 
@@ -107,6 +107,6 @@ EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator17*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvos17*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvsimulator17*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=watchos10*] = ;
-EXCLUDED_SOURCE_FILE_NAMES[sdk=watchsimulator10*] = ;
+//EXCLUDED_SOURCE_FILE_NAMES[sdk=watchsimulator10*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=xros1*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=xrsimulator1*] = ;


### PR DESCRIPTION
#### 8960dbf9f899cc5b593eb91ebc71cc470024d875
<pre>
Disable the watch simulator build for swift interop
<a href="https://bugs.webkit.org/show_bug.cgi?id=271846">https://bugs.webkit.org/show_bug.cgi?id=271846</a>
<a href="https://rdar.apple.com/125574008">rdar://125574008</a>

Reviewed by NOBODY (OOPS!).

Temporarily disable the specific platform build until the
correct fix is identified.

* Source/WebCore/Configurations/WebCore.xcconfig:
* Source/WebCore/PAL/Configurations/PAL.xcconfig:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8960dbf9f899cc5b593eb91ebc71cc470024d875

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48406 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41771 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37449 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18601 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19335 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40545 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3780 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50159 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44559 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22032 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43409 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22391 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->