### PR TITLE
[UnifiedPDF] Move the ShouldUpdateAutoSizeScale state out of PDFDocumentLayout

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -41,6 +41,8 @@ class IntRect;
 
 namespace WebKit {
 
+enum class ShouldUpdateAutoSizeScale : bool { No, Yes };
+
 class PDFDocumentLayout {
 public:
     using PageIndex = size_t; // This is a zero-based index.
@@ -51,8 +53,6 @@ public:
         TwoUpDiscrete,
         TwoUpContinuous,
     };
-
-    enum class ShouldUpdateAutoSizeScale : bool { No, Yes };
 
     PDFDocumentLayout();
     ~PDFDocumentLayout();
@@ -86,7 +86,7 @@ public:
     // This is the scale that scales the largest page or pair of pages up or down to fit the available width.
     float scale() const { return m_scale; }
 
-    void updateLayout(WebCore::IntSize pluginSize);
+    void updateLayout(WebCore::IntSize pluginSize, ShouldUpdateAutoSizeScale);
     WebCore::FloatSize scaledContentsSize() const;
 
     void setDisplayMode(DisplayMode displayMode) { m_displayMode = displayMode; }
@@ -95,9 +95,6 @@ public:
     bool isTwoUpDisplayMode() const { return m_displayMode == DisplayMode::TwoUpDiscrete || m_displayMode == DisplayMode::TwoUpContinuous; }
 
     unsigned pagesPerRow() const { return isSinglePageDisplayMode() ? 1 : 2; }
-
-    void setShouldUpdateAutoSizeScale(ShouldUpdateAutoSizeScale autoSizeState) { m_autoSizeState = autoSizeState; }
-    ShouldUpdateAutoSizeScale shouldUpdateAutoSizeScale() const { return m_autoSizeState; }
 
     struct PageGeometry {
         WebCore::FloatRect cropBox;
@@ -109,17 +106,16 @@ public:
     WebCore::AffineTransform toPageTransform(const PageGeometry&) const;
 
 private:
-    void layoutPages(float availableWidth, float maxRowWidth);
+    void layoutPages(float availableWidth, float maxRowWidth, ShouldUpdateAutoSizeScale);
 
-    void layoutSingleColumn(float availableWidth, float maxRowWidth);
-    void layoutTwoUpColumn(float availableWidth, float maxRowWidth);
+    void layoutSingleColumn(float availableWidth, float maxRowWidth, ShouldUpdateAutoSizeScale);
+    void layoutTwoUpColumn(float availableWidth, float maxRowWidth, ShouldUpdateAutoSizeScale);
 
     RetainPtr<PDFDocument> m_pdfDocument;
     Vector<PageGeometry> m_pageGeometry;
     WebCore::FloatRect m_documentBounds;
     float m_scale { 1 };
     DisplayMode m_displayMode { DisplayMode::SinglePageContinuous };
-    ShouldUpdateAutoSizeScale m_autoSizeState { ShouldUpdateAutoSizeScale::Yes };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -113,7 +113,7 @@ PDFDocumentLayout::PageIndex PDFDocumentLayout::nearestPageIndexForDocumentPoint
     return pageCount - 1;
 }
 
-void PDFDocumentLayout::updateLayout(IntSize pluginSize)
+void PDFDocumentLayout::updateLayout(IntSize pluginSize, ShouldUpdateAutoSizeScale shouldUpdateScale)
 {
     auto pageCount = this->pageCount();
     m_pageGeometry.clear();
@@ -172,28 +172,28 @@ void PDFDocumentLayout::updateLayout(IntSize pluginSize)
 
     maxRowWidth += 2 * documentMargin.width();
 
-    layoutPages(pluginSize.width(), maxRowWidth);
+    layoutPages(pluginSize.width(), maxRowWidth, shouldUpdateScale);
 
     LOG_WITH_STREAM(PDF, stream << "PDFDocumentLayout::updateLayout() - plugin size " << pluginSize << " document bounds " << m_documentBounds << " scale " << m_scale);
 }
 
-void PDFDocumentLayout::layoutPages(float availableWidth, float maxRowWidth)
+void PDFDocumentLayout::layoutPages(float availableWidth, float maxRowWidth, ShouldUpdateAutoSizeScale shouldUpdateScale)
 {
     // We always lay out in a continuous mode. We handle non-continuous mode via scroll snap.
     switch (m_displayMode) {
     case DisplayMode::SinglePageDiscrete:
     case DisplayMode::SinglePageContinuous:
-        layoutSingleColumn(availableWidth, maxRowWidth);
+        layoutSingleColumn(availableWidth, maxRowWidth, shouldUpdateScale);
         break;
 
     case DisplayMode::TwoUpDiscrete:
     case DisplayMode::TwoUpContinuous:
-        layoutTwoUpColumn(availableWidth, maxRowWidth);
+        layoutTwoUpColumn(availableWidth, maxRowWidth, shouldUpdateScale);
         break;
     }
 }
 
-void PDFDocumentLayout::layoutSingleColumn(float availableWidth, float maxRowWidth)
+void PDFDocumentLayout::layoutSingleColumn(float availableWidth, float maxRowWidth, ShouldUpdateAutoSizeScale shouldUpdateScale)
 {
     float currentYOffset = documentMargin.height();
     auto pageCount = this->pageCount();
@@ -217,14 +217,14 @@ void PDFDocumentLayout::layoutSingleColumn(float availableWidth, float maxRowWid
     currentYOffset -= pageMargin.height();
     currentYOffset += documentMargin.height();
 
-    if (m_autoSizeState == ShouldUpdateAutoSizeScale::Yes)
+    if (shouldUpdateScale == ShouldUpdateAutoSizeScale::Yes)
         m_scale = std::max<float>(availableWidth / maxRowWidth, minScale);
     m_documentBounds = FloatRect { 0, 0, maxRowWidth, currentYOffset };
 
     LOG_WITH_STREAM(PDF, stream << "PDFDocumentLayout::layoutSingleColumn - document bounds " << m_documentBounds << " scale " << m_scale);
 }
 
-void PDFDocumentLayout::layoutTwoUpColumn(float availableWidth, float maxRowWidth)
+void PDFDocumentLayout::layoutTwoUpColumn(float availableWidth, float maxRowWidth, ShouldUpdateAutoSizeScale shouldUpdateScale)
 {
     FloatSize currentRowSize;
     float currentYOffset = documentMargin.height();
@@ -275,7 +275,7 @@ void PDFDocumentLayout::layoutTwoUpColumn(float availableWidth, float maxRowWidt
     currentYOffset -= pageMargin.height();
     currentYOffset += documentMargin.height();
 
-    if (m_autoSizeState == ShouldUpdateAutoSizeScale::Yes)
+    if (shouldUpdateScale == ShouldUpdateAutoSizeScale::Yes)
         m_scale = std::max<float>(availableWidth / maxRowWidth, minScale);
     m_documentBounds = FloatRect { 0, 0, maxRowWidth, currentYOffset };
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -510,6 +510,8 @@ private:
     bool m_didAttachScrollingTreeNode { false };
     bool m_didScrollToFragment { false };
 
+    ShouldUpdateAutoSizeScale m_shouldUpdateAutoSizeScale { ShouldUpdateAutoSizeScale::Yes };
+
     AnnotationTrackingState m_annotationTrackingState;
 
     struct SelectionTrackingData {


### PR DESCRIPTION
#### aa53cbad39408afbc5434f6d2a11f790c221a437
<pre>
[UnifiedPDF] Move the ShouldUpdateAutoSizeScale state out of PDFDocumentLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=271851">https://bugs.webkit.org/show_bug.cgi?id=271851</a>
<a href="https://rdar.apple.com/125580423">rdar://125580423</a>

Reviewed by Sammy Gill.

It&apos;s surprising that the behavior of PDFDocumentLayout in terms of
setting m_scale after layout is stateful, based on `m_autoSizeState`.
Move this statefulness to UnifiedPDFPlugin where it makes more sense.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
(WebKit::PDFDocumentLayout::setShouldUpdateAutoSizeScale): Deleted.
(WebKit::PDFDocumentLayout::shouldUpdateAutoSizeScale const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::updateLayout):
(WebKit::PDFDocumentLayout::layoutPages):
(WebKit::PDFDocumentLayout::layoutSingleColumn):
(WebKit::PDFDocumentLayout::layoutTwoUpColumn):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::setPageScaleFactor):
(WebKit::UnifiedPDFPlugin::updateLayout):
(WebKit::UnifiedPDFPlugin::contextMenuItem const):
(WebKit::UnifiedPDFPlugin::performContextMenuAction):
(WebKit::UnifiedPDFPlugin::zoomIn):
(WebKit::UnifiedPDFPlugin::zoomOut):

Canonical link: <a href="https://commits.webkit.org/276818@main">https://commits.webkit.org/276818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/540fdbe6d6541209874d7a8e082e7b2dfa6fb504

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48418 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41783 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22273 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37454 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18609 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19352 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3792 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50172 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17250 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22044 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43428 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10162 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22403 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21733 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->