### PR TITLE
REGRESSION (276119@main): [ macOS iOS ] http/tests/navigation/page-cache-getUserMedia-pending-promise.html is a flaky timeout

### DIFF
--- a/LayoutTests/http/tests/navigation/page-cache-getUserMedia-pending-promise.html
+++ b/LayoutTests/http/tests/navigation/page-cache-getUserMedia-pending-promise.html
@@ -12,7 +12,7 @@ let restoredFromPageCache = false;
 let getUserMediaRejected = false;
 
 if (window.testRunner)
-    testRunner.setUserMediaPermission(true);
+    testRunner.setUserMediaPermission(false);
 
 function getUserMediaCompleted() {
     // Avoid invoking getUserMedia again.


### PR DESCRIPTION
#### 0d17a4e9d153af2f1937cbc4539579fd1301deb8
<pre>
REGRESSION (276119@main): [ macOS iOS ] http/tests/navigation/page-cache-getUserMedia-pending-promise.html is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=271063">https://bugs.webkit.org/show_bug.cgi?id=271063</a>
<a href="https://rdar.apple.com/124698382">rdar://124698382</a>

Reviewed by Chris Dumez.

276618@main made the test go from consistent timeout to flakily failure. The test fails because user media permission
request is granted, and the test expects it to be denied. The test expects the request result to be denied because our
current implementation invalidates (denies) pending permission request when main Document changes for the page. However,
there is a race between request handled by UI process and UI process gets notification about Document change. If the
request is handled before notification, UI process will grant it because the test sets the permission to allowed with
setUserMediaPermission.

To avoid the flakiness, this patch makes the test to set the permission to false. By doing this, the permission request
result will be rejected consistently.

* LayoutTests/http/tests/navigation/page-cache-getUserMedia-pending-promise.html:

Canonical link: <a href="https://commits.webkit.org/276836@main">https://commits.webkit.org/276836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c4d2904186601d2811c7a3ee76f6290a3780103

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48423 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41788 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37459 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18614 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40554 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3797 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42059 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50177 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44573 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39615 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43446 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10174 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->