### PR TITLE
[CSS] Relative origin color might be unresolved (with currentcolor or system color)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4694,9 +4694,6 @@ webkit.org/b/245347 imported/w3c/web-platform-tests/css/css-color/oklch-009.html
 webkit.org/b/245347 imported/w3c/web-platform-tests/css/css-color/oklch-010.html [ ImageOnlyFailure ]
 
 # currentColor support in relative color syntax.
-# webkit.org/b/271775(REGRESSION:(276695@main) imported/w3c/web-platform-t ests/css/css-color/parsing/ color* (layout-tests) are constant text failures (271775))
-webkit.org/b/245970 imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color.html [ Failure Crash ]
-webkit.org/b/245970 imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color.html [ Failure Crash ]
 webkit.org/b/245970 imported/w3c/web-platform-tests/css/css-color/relative-currentcolor-a98rgb-01.html [ ImageOnlyFailure ]
 webkit.org/b/245970 imported/w3c/web-platform-tests/css/css-color/relative-currentcolor-displayp3-01.html [ ImageOnlyFailure ]
 webkit.org/b/245970 imported/w3c/web-platform-tests/css/css-color/relative-currentcolor-hsl-01.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt
@@ -153,32 +153,32 @@ Expected: color(srgb 0.2 0.6 0.4).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from rebeccapurple b alpha r / g)" should set the property value Colors do not match.
 Actual:   rgba(153, 255, 102, 0.2)
-Expected: color(srgb 0.6 1 0.4 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
+Expected: color(srgb 0.6 0.004 0.4).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "rgb(from rebeccapurple r r r / r)" should set the property value Colors do not match.
 Actual:   rgba(102, 102, 102, 0.4)
-Expected: color(srgb 0.4 0.4 0.4 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
+Expected: color(srgb 0.4 0.4 0.4).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "rgb(from rebeccapurple alpha alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgb(255, 255, 255)
-Expected: color(srgb 1 1 1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
+Expected: color(srgb 0.004 0.004 0.004).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.004 +/- 0.01, expected 0.004 but got 255
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) g b r)" should set the property value Colors do not match.
 Actual:   rgb(102, 153, 51)
 Expected: color(srgb 0.4 0.6 0.2 / 0.8).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 4 got 3
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) b alpha r / g)" should set the property value Colors do not match.
 Actual:   rgba(153, 204, 51, 0.4)
-Expected: color(srgb 0.6 0.8 0.2 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
+Expected: color(srgb 0.6 0.003 0.2).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) r r r / r)" should set the property value Colors do not match.
 Actual:   rgba(51, 51, 51, 0.2)
-Expected: color(srgb 0.2 0.2 0.2 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
+Expected: color(srgb 0.2 0.2 0.2).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "rgb(from rgb(20%, 40%, 60%, 80%) alpha alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgba(204, 204, 204, 0.8)
-Expected: color(srgb 0.8 0.8 0.8 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.01, expected 0.8 but got 204
+Expected: color(srgb 0.003 0.003 0.003 / 0.8).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.003 +/- 0.01, expected 0.003 but got 204
 FAIL e.style['color'] = "rgb(from rebeccapurple r 20% 10)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 10)
 Expected: color(srgb 0.4 0.2 0.0392).
@@ -272,6 +272,77 @@ Actual:   rgba(51, 102, 153, 0)
 Expected: color(srgb 0.2 0.4 0.6 / 0).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "rgb(from currentColor r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgb(from color-mix(in srgb, red, red) r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from hsl(120deg 20% 50% / .5) r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(from rebeccapurple r g b) r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple 0 0 0)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple 0 0 0 / 0)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple 0 g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r 0 b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r g 0 / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r g b / 0)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) 0 g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r 0 b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r g 0 / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r g b / 0)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple 25 g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r 25 b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r g 25 / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r g b / .25)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) 25 g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r 25 b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r g 25 / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r g b / .20)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple 20% g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r 20% b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r g 20% / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r g b / 20%)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) 20% g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r 20% b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r g 20% / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r g b / 20%)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple 25 g b / 25%)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r 25 b / 25%)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r g 25 / 25%)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) 25 g b / 25%)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r 25 b / 25%)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r g 25 / 25%)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple g b r)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple b alpha r / g)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r r r / r)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple alpha alpha alpha / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) g b r)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) b alpha r / g)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r r r / r)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) alpha alpha alpha / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r 20% 10)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r 10 20%)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple 0% 10 10)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r 20% 10)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) r 10 20%)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) 0% 10 10)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple calc(r) calc(g) calc(b))" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r calc(g * 2) 10)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple b calc(r * .5) 10)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r calc(g * .5 + g * .5) 10)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r calc(b * .5 - g * .5) 10)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20%, 40%, 60%, 80%) calc(r) calc(g) calc(b) / calc(alpha))" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple none none none)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple none none none / none)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r g none)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r g none / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rebeccapurple r g b / none)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20% 40% 60% / 80%) r g none / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20% 40% 60% / 80%) r g b / none)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(none none none) r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(none none none / none) r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20% none 60%) r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from rgb(20% 40% 60% / none) r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from currentColor r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "rgba(from color-mix(in srgb, red, red) r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['color'] = "hsl(from rebeccapurple h s l)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
@@ -394,32 +465,32 @@ Expected: color(srgb 0.5 0.3 0.7).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hsl(from rebeccapurple h alpha l / s)" should set the property value Colors do not match.
 Actual:   rgba(102, 0, 204, 0.5)
-Expected: color(srgb 0.4 0 0.8 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
+Expected: color(srgb 0.4  0.396 0.404).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "hsl(from rebeccapurple h l l / l)" should set the property value Colors do not match.
 Actual:   rgba(102, 61, 143, 0.4)
-Expected: color(srgb 0.4 0.24 0.56 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.4 +/- 0.01, expected 0.4 but got 102
+Expected: color(srgb 0.4 0.24 0.56).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "hsl(from rebeccapurple h alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgb(255, 255, 255)
-Expected: color(srgb 1 1 1).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
+Expected: color(srgb 0.01 0.01 0.01).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.01 +/- 0.01, expected 0.01 but got 255
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h l s)" should set the property value Colors do not match.
 Actual:   rgb(77, 128, 179)
 Expected: color(srgb 0.3 0.5 0.7 / 0.8).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 4 got 3
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h alpha l / s)" should set the property value Colors do not match.
 Actual:   rgba(20, 102, 184, 0.5)
-Expected: color(srgb 0.08 0.4 0.72 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.08 +/- 0.01, expected 0.08 but got 20
+Expected: color(srgb 0.4 0.4 0.4).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h l l / l)" should set the property value Colors do not match.
 Actual:   rgba(61, 102, 143, 0.4)
-Expected: color(srgb 0.24 0.4 0.56 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.24 +/- 0.01, expected 0.24 but got 61
+Expected: color(srgb 0.24 0.4 0.56).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "hsl(from rgb(20%, 40%, 60%, 80%) h alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgba(163, 204, 245, 0.8)
-Expected: color(srgb 0.64 0.8 0.96 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.64 +/- 0.01, expected 0.64 but got 163
+Expected: color(srgb 0.01 0.01 0.01 / 0.8).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.01 +/- 0.01, expected 0.01 but got 163
 FAIL e.style['color'] = "hsl(from rebeccapurple calc(h) calc(s) calc(l))" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
@@ -430,40 +501,40 @@ Expected: color(srgb 0.2 0.4 0.6 / 0.8).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hsl(from rebeccapurple none none none)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
-Expected: color(srgb none none none).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 0 got 3
+Expected: color(srgb 0 0 0).
+Error: assert_equals: Color format is correct. expected "color(srgb   )" but got "rgb(, , )"
 FAIL e.style['color'] = "hsl(from rebeccapurple none none none / none)" should set the property value Colors do not match.
 Actual:   rgba(0, 0, 0, 0)
-Expected: color(srgb none none none / none).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 0 got 4
+Expected: color(srgb 0 0 0 / 0).
+Error: assert_equals: Color format is correct. expected "color(srgb    / )" but got "rgba(, , , )"
 FAIL e.style['color'] = "hsl(from rebeccapurple h s none)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
-Expected: color(srgb 0 0 none).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 2 got 3
+Expected: color(srgb 0 0 0).
+Error: assert_equals: Color format is correct. expected "color(srgb   )" but got "rgb(, , )"
 FAIL e.style['color'] = "hsl(from rebeccapurple h s none / alpha)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
-Expected: color(srgb 0 0 none).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 2 got 3
+Expected: color(srgb 0 0 0).
+Error: assert_equals: Color format is correct. expected "color(srgb   )" but got "rgb(, , )"
 FAIL e.style['color'] = "hsl(from rebeccapurple h s l / none)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0)
 Expected: color(srgb 0.4 0.2 0.6 / none).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "hsl(from rebeccapurple none s l / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 51)
-Expected: color(srgb none 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 2 got 3
+Expected: color(srgb 0.6 0.2 0.2).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from hsl(120deg 20% 50% / .5) h s none / alpha)" should set the property value Colors do not match.
 Actual:   rgba(0, 0, 0, 0.5)
-Expected: color(srgb 0 0 none / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
+Expected: color(srgb 0 0 0 / 0.5).
+Error: assert_equals: Color format is correct. expected "color(srgb    / )" but got "rgba(, , , )"
 FAIL e.style['color'] = "hsl(from hsl(120deg 20% 50% / .5) h s l / none)" should set the property value Colors do not match.
 Actual:   rgba(102, 153, 102, 0)
 Expected: color(srgb 0.4 0.6 0.4 / none).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "hsl(from hsl(120deg 20% 50% / .5) none s l / alpha)" should set the property value Colors do not match.
 Actual:   rgba(153, 102, 102, 0.5)
-Expected: color(srgb none 0.4 0.4 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
+Expected: color(srgb 0.6 0.4 0.4 / 0.5).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from hsl(none none none) h s l)" should set the property value Colors do not match.
 Actual:   rgb(0, 0, 0)
 Expected: color(srgb 0 0 0).
@@ -485,6 +556,62 @@ Actual:   rgba(153, 102, 102, 0.5)
 Expected: color(srgb 0.6 0.4 0.4 / 0.5).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hsl(from currentColor h s l)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsl(from color-mix(in srgb, red, red) h s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h s l)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) h s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from hsl(120deg 20% 50% / .5) h s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from hsl(from rebeccapurple h s l) h s l)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple 0 0% 0%)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple 0deg 0% 0%)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple 0 0% 0% / 0)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple 0deg 0% 0% / 0)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple 0 s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple 0deg s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h 0% l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h s 0% / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h s l / 0)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) 0 s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) 0deg s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) h 0% l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) h s 0% / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) h s l / 0)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple 25 s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple 25deg s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h 20% l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h s 20% / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h s l / .25)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) 25 s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) 25deg s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) h 20% l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) h s 20% / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) h s l / .2)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h l s)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h alpha l / s)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h l l / l)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h alpha alpha / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) h l s)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) h alpha l / s)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) h l l / l)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) h alpha alpha / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple calc(h) calc(s) calc(l))" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rgb(20%, 40%, 60%, 80%) calc(h) calc(s) calc(l) / calc(alpha))" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple none none none)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple none none none / none)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h s none)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h s none / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple h s l / none)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from rebeccapurple none s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from hsl(120deg 20% 50% / .5) h s none / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from hsl(120deg 20% 50% / .5) h s l / none)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from hsl(120deg 20% 50% / .5) none s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from hsl(none none none) h s l)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from hsl(none none none / none) h s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from hsl(120deg none 50% / .5) h s l)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from hsl(120deg 20% 50% / none) h s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from hsl(none 20% 50% / .5) h s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from currentColor h s l)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hsla(from color-mix(in srgb, red, red) h s l / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['color'] = "hwb(from rebeccapurple h w b)" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
@@ -607,15 +734,15 @@ Expected: color(srgb 0.6 0.4 0.8).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple h alpha w / b)" should set the property value Colors do not match.
 Actual:   rgba(213, 213, 213, 0.4)
-Expected: color(srgb 0.8333 0.8333 0.8333 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8333 +/- 0.01, expected 0.8333 but got 213
+Expected: color(srgb 0.405 0.01 0.8 / 1).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.405 +/- 0.01, expected 0.405 but got 213
 FAIL e.style['color'] = "hwb(from rebeccapurple h w w / w)" should set the property value Colors do not match.
 Actual:   rgba(128, 51, 204, 0.2)
-Expected: color(srgb 0.5 0.2 0.8 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
+Expected: color(srgb 0.5 0.2 0.8).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "hwb(from rebeccapurple h alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgb(128, 128, 128)
-Expected: color(srgb 0.5 0.5 0.5).
+Expected: color(srgb 0.5 0.01 0.99).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h b w)" should set the property value Colors do not match.
 Actual:   rgb(102, 153, 204)
@@ -623,16 +750,16 @@ Expected: color(srgb 0.4 0.6 0.8 / 0.8).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 4 got 3
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h alpha w / b)" should set the property value Colors do not match.
 Actual:   rgba(204, 204, 204, 0.4)
-Expected: color(srgb 0.8 0.8 0.8 / 0.4).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.8 +/- 0.01, expected 0.8 but got 204
+Expected: color(srgb 0.01 0.404 0.8).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h w w / w)" should set the property value Colors do not match.
 Actual:   rgba(51, 128, 204, 0.2)
-Expected: color(srgb 0.2 0.5 0.8 / 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
+Expected: color(srgb 0.2 0.5 0.8).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "hwb(from rgb(20%, 40%, 60%, 80%) h alpha alpha / alpha)" should set the property value Colors do not match.
 Actual:   rgba(128, 128, 128, 0.8)
-Expected: color(srgb 0.5 0.5 0.5 / 0.8).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
+Expected: color(srgb 0.01 0.5 0.99 / 0.8).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.01 +/- 0.01, expected 0.01 but got 128
 FAIL e.style['color'] = "hwb(from rebeccapurple calc(h) calc(w) calc(b))" should set the property value Colors do not match.
 Actual:   rgb(102, 51, 153)
 Expected: color(srgb 0.4 0.2 0.6).
@@ -643,40 +770,40 @@ Expected: color(srgb 0.2 0.4 0.6 / 0.8).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from rebeccapurple none none none)" should set the property value Colors do not match.
 Actual:   rgb(255, 0, 0)
-Expected: color(srgb none none none).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 0 got 3
+Expected: color(srgb 1 0 0).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 1 +/- 0.01, expected 1 but got 255
 FAIL e.style['color'] = "hwb(from rebeccapurple none none none / none)" should set the property value Colors do not match.
 Actual:   rgba(255, 0, 0, 0)
-Expected: color(srgb none none none / none).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 0 got 4
+Expected: color(srgb 1 0 0 / none).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "hwb(from rebeccapurple h w none)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 255)
-Expected: color(srgb 0.6 0.2 none).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 2 got 3
+Expected: color(srgb 0.6 0.2 1).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple h w none / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 255)
-Expected: color(srgb 0.6 0.2 none).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 2 got 3
+Expected: color(srgb 0.6 0.2 1).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from rebeccapurple h w b / none)" should set the property value Colors do not match.
 Actual:   rgba(102, 51, 153, 0)
 Expected: color(srgb 0.4 0.2 0.6 / none).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "hwb(from rebeccapurple none w b / alpha)" should set the property value Colors do not match.
 Actual:   rgb(153, 51, 51)
-Expected: color(srgb none 0.2 0.2).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 2 got 3
+Expected: color(srgb 0.6 0.2 0.2).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.6 +/- 0.01, expected 0.6 but got 153
 FAIL e.style['color'] = "hwb(from hwb(120deg 20% 50% / .5) h w none / alpha)" should set the property value Colors do not match.
 Actual:   rgba(51, 255, 51, 0.5)
-Expected: color(srgb 0.2 1 none / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
+Expected: color(srgb 0.2 1 0.2 / 0.5).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.2 +/- 0.01, expected 0.2 but got 51
 FAIL e.style['color'] = "hwb(from hwb(120deg 20% 50% / .5) h w b / none)" should set the property value Colors do not match.
 Actual:   rgba(51, 128, 51, 0)
 Expected: color(srgb 0.2 0.5 0.2 / none).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
 FAIL e.style['color'] = "hwb(from hwb(120deg 20% 50% / .5) none w b / alpha)" should set the property value Colors do not match.
 Actual:   rgba(128, 51, 51, 0.5)
-Expected: color(srgb none 0.2 0.2 / 0.5).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. lengths differ, expected 3 got 4
+Expected: color(srgb 0.5 0.2 0.2 / 0.5).
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from hwb(none none none) h w b)" should set the property value Colors do not match.
 Actual:   rgb(255, 0, 0)
 Expected: color(srgb 1 0 0).
@@ -698,6 +825,7 @@ Actual:   rgba(128, 51, 51, 0.5)
 Expected: color(srgb 0.5 0.2 0.2 / 0.5).
 Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.5 +/- 0.01, expected 0.5 but got 128
 FAIL e.style['color'] = "hwb(from currentColor h w b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "hwb(from color-mix(in srgb, red, red) h w b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "lab(from lab(25 20 50) l a b)" should set the property value
 PASS e.style['color'] = "lab(from lab(25 20 50) l a b / alpha)" should set the property value
 PASS e.style['color'] = "lab(from lab(25 20 50 / 40%) l a b / alpha)" should set the property value
@@ -748,6 +876,7 @@ PASS e.style['color'] = "lab(from lab(none none none / none) l a b / alpha)" sho
 PASS e.style['color'] = "lab(from lab(25 none 50) l a b)" should set the property value
 PASS e.style['color'] = "lab(from lab(25 20 50 / none) l a b / alpha)" should set the property value
 FAIL e.style['color'] = "lab(from currentColor l a b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "lab(from color-mix(in lab, lab(25 20 50), lab(25 20 50)) l a b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5) l a b)" should set the property value
 PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5) l a b / alpha)" should set the property value
 PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5 / 40%) l a b / alpha)" should set the property value
@@ -785,10 +914,7 @@ PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5 / 40%) l a a / a)" should
 PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5) calc(l) calc(a) calc(b))" should set the property value
 PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5 / 40%) calc(l) calc(a) calc(b) / calc(alpha))" should set the property value
 PASS e.style['color'] = "oklab(from oklab(0.7 0.25 -0.15) calc(l - 0.2) a b)" should set the property value
-FAIL e.style['color'] = "oklab(from oklab(0.7 0.25 -0.15) l calc(a / 2) calc(b / 3))" should set the property value Colors do not match.
-Actual:   oklab(0.7 0.125 -0.05)
-Expected: oklab(0.7 0.125 -0.075).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 2, expected -0.075 +/- 0.01, expected -0.075 but got -0.05
+PASS e.style['color'] = "oklab(from oklab(0.7 0.25 -0.15) l calc(a / 2) calc(b / 3))" should set the property value
 PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5) none none none)" should set the property value
 PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5) none none none / none)" should set the property value
 PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5) l a none)" should set the property value
@@ -801,6 +927,7 @@ PASS e.style['color'] = "oklab(from oklab(none none none / none) l a b / alpha)"
 PASS e.style['color'] = "oklab(from oklab(0.25 none 0.5) l a b)" should set the property value
 PASS e.style['color'] = "oklab(from oklab(0.25 0.2 0.5 / none) l a b / alpha)" should set the property value
 FAIL e.style['color'] = "oklab(from currentColor l a b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "oklab(from color-mix(in oklab, oklab(0.25 0.2 0.5), oklab(0.25 0.2 0.5)) l a b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "lch(from lch(0.7 45 30) l c h)" should set the property value
 PASS e.style['color'] = "lch(from lch(0.7 45 30) l c h / alpha)" should set the property value
 PASS e.style['color'] = "lch(from lch(0.7 45 30 / 40%) l c h / alpha)" should set the property value
@@ -856,6 +983,7 @@ PASS e.style['color'] = "lch(from lch(none none none / none) l c h / alpha)" sho
 PASS e.style['color'] = "lch(from lch(0.7 none 30) l c h)" should set the property value
 PASS e.style['color'] = "lch(from lch(0.7 45 30 / none) l c h / alpha)" should set the property value
 FAIL e.style['color'] = "lch(from currentColor) l c h)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "lch(from color-mix(in lch, lch(70 45 30), lch(70 45 30)) l c h / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "oklch(from oklch(0.7 0.45 30) l c h)" should set the property value
 PASS e.style['color'] = "oklch(from oklch(0.7 0.45 30) l c h / alpha)" should set the property value
 PASS e.style['color'] = "oklch(from oklch(0.7 0.45 30 / 40%) l c h / alpha)" should set the property value
@@ -910,6 +1038,7 @@ PASS e.style['color'] = "oklch(from oklch(none none none) l c h)" should set the
 PASS e.style['color'] = "oklch(from oklch(none none none / none) l c h / alpha)" should set the property value
 PASS e.style['color'] = "oklch(from oklch(0.7 none 30) l c h)" should set the property value
 PASS e.style['color'] = "oklch(from oklch(0.7 0.45 30 / none) l c h / alpha)" should set the property value
+FAIL e.style['color'] = "oklch(from color-mix(in oklch, oklch(0.7 0.45 30), oklch(0.7 0.45 30)) l c h / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 FAIL e.style['color'] = "oklch(from currentColor l c h)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "color(from color(srgb 0.7 0.5 0.3) srgb r g b)" should set the property value
 PASS e.style['color'] = "color(from color(srgb 0.7 0.5 0.3) srgb r g b / alpha)" should set the property value
@@ -989,6 +1118,7 @@ PASS e.style['color'] = "color(from color(srgb none none none / none) srgb r g b
 PASS e.style['color'] = "color(from color(srgb 0.7 none 0.3) srgb r g b)" should set the property value
 PASS e.style['color'] = "color(from color(srgb 0.7 0.5 0.3 / none) srgb r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor srgb r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "color(from color-mix(in xyz, color(srgb 0.7 0.5 0.3), color(srgb 0.7 0.5 0.3)) srgb r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "color(from color(srgb-linear 0.7 0.5 0.3) srgb-linear r g b)" should set the property value
 PASS e.style['color'] = "color(from color(srgb-linear 0.7 0.5 0.3) srgb-linear r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(srgb-linear 0.7 0.5 0.3 / 40%) srgb-linear r g b)" should set the property value Colors do not match.
@@ -1067,6 +1197,7 @@ PASS e.style['color'] = "color(from color(srgb-linear none none none / none) srg
 PASS e.style['color'] = "color(from color(srgb-linear 0.7 none 0.3) srgb-linear r g b)" should set the property value
 PASS e.style['color'] = "color(from color(srgb-linear 0.7 0.5 0.3 / none) srgb-linear r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor srgb-linear r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "color(from color-mix(in xyz, color(srgb-linear 0.7 0.5 0.3), color(srgb-linear 0.7 0.5 0.3)) srgb-linear r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "color(from color(a98-rgb 0.7 0.5 0.3) a98-rgb r g b)" should set the property value
 PASS e.style['color'] = "color(from color(a98-rgb 0.7 0.5 0.3) a98-rgb r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(a98-rgb 0.7 0.5 0.3 / 40%) a98-rgb r g b)" should set the property value Colors do not match.
@@ -1145,6 +1276,7 @@ PASS e.style['color'] = "color(from color(a98-rgb none none none / none) a98-rgb
 PASS e.style['color'] = "color(from color(a98-rgb 0.7 none 0.3) a98-rgb r g b)" should set the property value
 PASS e.style['color'] = "color(from color(a98-rgb 0.7 0.5 0.3 / none) a98-rgb r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor a98-rgb r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "color(from color-mix(in xyz, color(a98-rgb 0.7 0.5 0.3), color(a98-rgb 0.7 0.5 0.3)) a98-rgb r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "color(from color(rec2020 0.7 0.5 0.3) rec2020 r g b)" should set the property value
 PASS e.style['color'] = "color(from color(rec2020 0.7 0.5 0.3) rec2020 r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(rec2020 0.7 0.5 0.3 / 40%) rec2020 r g b)" should set the property value Colors do not match.
@@ -1223,6 +1355,7 @@ PASS e.style['color'] = "color(from color(rec2020 none none none / none) rec2020
 PASS e.style['color'] = "color(from color(rec2020 0.7 none 0.3) rec2020 r g b)" should set the property value
 PASS e.style['color'] = "color(from color(rec2020 0.7 0.5 0.3 / none) rec2020 r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor rec2020 r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "color(from color-mix(in xyz, color(rec2020 0.7 0.5 0.3), color(rec2020 0.7 0.5 0.3)) rec2020 r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "color(from color(prophoto-rgb 0.7 0.5 0.3) prophoto-rgb r g b)" should set the property value
 PASS e.style['color'] = "color(from color(prophoto-rgb 0.7 0.5 0.3) prophoto-rgb r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(prophoto-rgb 0.7 0.5 0.3 / 40%) prophoto-rgb r g b)" should set the property value Colors do not match.
@@ -1301,6 +1434,7 @@ PASS e.style['color'] = "color(from color(prophoto-rgb none none none / none) pr
 PASS e.style['color'] = "color(from color(prophoto-rgb 0.7 none 0.3) prophoto-rgb r g b)" should set the property value
 PASS e.style['color'] = "color(from color(prophoto-rgb 0.7 0.5 0.3 / none) prophoto-rgb r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor prophoto-rgb r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "color(from color-mix(in xyz, color(prophoto-rgb 0.7 0.5 0.3), color(prophoto-rgb 0.7 0.5 0.3)) prophoto-rgb r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "color(from color(display-p3 0.7 0.5 0.3) display-p3 r g b)" should set the property value
 PASS e.style['color'] = "color(from color(display-p3 0.7 0.5 0.3) display-p3 r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(display-p3 0.7 0.5 0.3 / 40%) display-p3 r g b)" should set the property value Colors do not match.
@@ -1379,6 +1513,7 @@ PASS e.style['color'] = "color(from color(display-p3 none none none / none) disp
 PASS e.style['color'] = "color(from color(display-p3 0.7 none 0.3) display-p3 r g b)" should set the property value
 PASS e.style['color'] = "color(from color(display-p3 0.7 0.5 0.3 / none) display-p3 r g b / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor display-p3 r g b)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "color(from color-mix(in xyz, color(display-p3 0.7 0.5 0.3), color(display-p3 0.7 0.5 0.3)) display-p3 r g b / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "color(from color(xyz 7 -20.5 100) xyz x y z)" should set the property value
 PASS e.style['color'] = "color(from color(xyz 7 -20.5 100) xyz x y z / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(xyz 7 -20.5 100 / 40%) xyz x y z)" should set the property value Colors do not match.
@@ -1427,6 +1562,7 @@ PASS e.style['color'] = "color(from color(xyz none none none / none) xyz x y z /
 PASS e.style['color'] = "color(from color(xyz 7 none 100) xyz x y z)" should set the property value
 PASS e.style['color'] = "color(from color(xyz 7 -20.5 100 / none) xyz x y z / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor xyz x y z)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "color(from color-mix(in xyz, color(xyz 0.7 0.5 0.3), color(xyz 0.7 0.5 0.3)) xyz x y z / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "color(from color(xyz-d50 7 -20.5 100) xyz-d50 x y z)" should set the property value
 PASS e.style['color'] = "color(from color(xyz-d50 7 -20.5 100) xyz-d50 x y z / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(xyz-d50 7 -20.5 100 / 40%) xyz-d50 x y z)" should set the property value Colors do not match.
@@ -1475,6 +1611,7 @@ PASS e.style['color'] = "color(from color(xyz-d50 none none none / none) xyz-d50
 PASS e.style['color'] = "color(from color(xyz-d50 7 none 100) xyz-d50 x y z)" should set the property value
 PASS e.style['color'] = "color(from color(xyz-d50 7 -20.5 100 / none) xyz-d50 x y z / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor xyz-d50 x y z)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "color(from color-mix(in xyz, color(xyz-d50 0.7 0.5 0.3), color(xyz-d50 0.7 0.5 0.3)) xyz-d50 x y z / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "color(from color(xyz-d65 7 -20.5 100) xyz-d65 x y z)" should set the property value
 PASS e.style['color'] = "color(from color(xyz-d65 7 -20.5 100) xyz-d65 x y z / alpha)" should set the property value
 FAIL e.style['color'] = "color(from color(xyz-d65 7 -20.5 100 / 40%) xyz-d65 x y z)" should set the property value Colors do not match.
@@ -1523,6 +1660,7 @@ PASS e.style['color'] = "color(from color(xyz-d65 none none none / none) xyz-d65
 PASS e.style['color'] = "color(from color(xyz-d65 7 none 100) xyz-d65 x y z)" should set the property value
 PASS e.style['color'] = "color(from color(xyz-d65 7 -20.5 100 / none) xyz-d65 x y z / alpha)" should set the property value
 FAIL e.style['color'] = "color(from currentColor xyz-d65 x y z)" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['color'] = "color(from color-mix(in xyz, color(xyz-d65 0.7 0.5 0.3), color(xyz-d65 0.7 0.5 0.3)) xyz-d65 x y z / alpha)" should set the property value assert_not_equals: property should be set got disallowed value ""
 PASS e.style['color'] = "rgb(from var(--bg-color) r g b / 80%)" should set the property value
 PASS e.style['color'] = "lch(from var(--color) calc(l / 2) c h)" should set the property value
 PASS e.style['color'] = "rgb(from var(--color) calc(r * .3 + g * .59 + b * .11) calc(r * .3 + g * .59 + b * .11) calc(r * .3 + g * .59 + b * .11))" should set the property value

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color-expected.txt
@@ -1568,17 +1568,17 @@ PASS Property color value 'color(from lch(67.5345% 42.5 258.2) srgb r g b)'
 PASS Property color value 'oklch(from color(srgb 0.25 0.5 0.75) l c h)'
 PASS Property color value 'color(from oklch(72.322% 0.12403 247.996) srgb r g b)'
 FAIL Property color value 'color(from rgb(from color(xyz-d50 0.99 0.88 0.77) r g b) xyz-d50 x y z)' Colors do not match.
-Actual:   color(xyz-d50 0.88595104 0.8687143 0.75824773)
+Actual:   color(xyz-d50 0.8859511 0.8687142 0.7582477)
 Expected: color(xyz-d50 0.99 0.88 0.77).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 0.88595104
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 0.8859511
 FAIL Property color value 'color(from hsl(from color(xyz-d50 0.99 0.88 0.77) h s l) xyz-d50 x y z)' Colors do not match.
-Actual:   color(xyz-d50 0.88595104 0.8687143 0.75824773)
+Actual:   color(xyz-d50 0.8859511 0.8687142 0.7582477)
 Expected: color(xyz-d50 0.99 0.88 0.77).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 0.88595104
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 0.8859511
 FAIL Property color value 'color(from hwb(from color(xyz-d50 0.99 0.88 0.77) h w b) xyz-d50 x y z)' Colors do not match.
-Actual:   color(xyz-d50 0.88595104 0.8687143 0.75824773)
+Actual:   color(xyz-d50 0.8859511 0.8687142 0.7582477)
 Expected: color(xyz-d50 0.99 0.88 0.77).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 0.88595104
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 0.8859511
 PASS Property color value 'color(from lab(from color(xyz-d50 0.99 0.88 0.77) l a b) xyz-d50 x y z)'
 PASS Property color value 'color(from lch(from color(xyz-d50 0.99 0.88 0.77) l c h) xyz-d50 x y z)'
 PASS Property color value 'color(from oklab(from color(xyz-d50 0.99 0.88 0.77) l a b) xyz-d50 x y z)'
@@ -1587,26 +1587,26 @@ PASS Property color value 'color(from color(from color(xyz-d50 0.99 0.88 0.77) s
 PASS Property color value 'color(from color(from color(xyz-d50 0.99 0.88 0.77) srgb-linear r g b) xyz-d50 x y z)'
 PASS Property color value 'color(from color(from color(xyz-d50 0.99 0.88 0.77) display-p3 r g b) xyz-d50 x y z)'
 FAIL Property color value 'color(from color(from color(xyz-d50 0.99 0.88 0.77) a98-rgb r g b) xyz-d50 x y z)' Colors do not match.
-Actual:   color(xyz-d50 1.0303222 0.91025 0.77190775)
+Actual:   color(xyz-d50 1.0303223 0.9102499 0.7719076)
 Expected: color(xyz-d50 0.99 0.88 0.77).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 1.0303222
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 1.0303223
 PASS Property color value 'color(from color(from color(xyz-d50 0.99 0.88 0.77) prophoto-rgb r g b) xyz-d50 x y z)'
 PASS Property color value 'color(from color(from color(xyz-d50 0.99 0.88 0.77) rec2020 r g b) xyz-d50 x y z)'
 PASS Property color value 'color(from color(from color(xyz-d50 0.99 0.88 0.77) xyz x y z) xyz-d50 x y z)'
 PASS Property color value 'color(from color(from color(xyz-d50 0.99 0.88 0.77) xyz-d50 x y z) xyz-d50 x y z)'
 PASS Property color value 'color(from color(from color(xyz-d50 0.99 0.88 0.77) xyz-d65 x y z) xyz-d50 x y z)'
 FAIL Property color value 'color(from rgb(from color(xyz-d65 0.99 0.88 0.77) r g b) xyz-d65 x y z)' Colors do not match.
-Actual:   color(xyz-d65 0.8753521 0.89166594 0.9349127)
+Actual:   color(xyz-d65 0.875352 0.8916659 0.9349127)
 Expected: color(xyz-d65 0.99 0.88 0.77).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 0.8753521
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 0.875352
 FAIL Property color value 'color(from hsl(from color(xyz-d65 0.99 0.88 0.77) h s l) xyz-d65 x y z)' Colors do not match.
-Actual:   color(xyz-d65 0.8753521 0.89166594 0.9349127)
+Actual:   color(xyz-d65 0.875352 0.8916659 0.9349127)
 Expected: color(xyz-d65 0.99 0.88 0.77).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 0.8753521
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 0.875352
 FAIL Property color value 'color(from hwb(from color(xyz-d65 0.99 0.88 0.77) h w b) xyz-d65 x y z)' Colors do not match.
-Actual:   color(xyz-d65 0.8753521 0.89166594 0.9349127)
+Actual:   color(xyz-d65 0.875352 0.8916659 0.9349127)
 Expected: color(xyz-d65 0.99 0.88 0.77).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 0.8753521
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 0.875352
 PASS Property color value 'color(from lab(from color(xyz-d65 0.99 0.88 0.77) l a b) xyz-d65 x y z)'
 PASS Property color value 'color(from lch(from color(xyz-d65 0.99 0.88 0.77) l c h) xyz-d65 x y z)'
 PASS Property color value 'color(from oklab(from color(xyz-d65 0.99 0.88 0.77) l a b) xyz-d65 x y z)'
@@ -1615,9 +1615,9 @@ PASS Property color value 'color(from color(from color(xyz-d65 0.99 0.88 0.77) s
 PASS Property color value 'color(from color(from color(xyz-d65 0.99 0.88 0.77) srgb-linear r g b) xyz-d65 x y z)'
 PASS Property color value 'color(from color(from color(xyz-d65 0.99 0.88 0.77) display-p3 r g b) xyz-d65 x y z)'
 FAIL Property color value 'color(from color(from color(xyz-d65 0.99 0.88 0.77) a98-rgb r g b) xyz-d65 x y z)' Colors do not match.
-Actual:   color(xyz-d65 1.0436506 0.9205588 0.78822374)
+Actual:   color(xyz-d65 1.0436507 0.92055875 0.78822374)
 Expected: color(xyz-d65 0.99 0.88 0.77).
-Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 1.0436506
+Error: assert_array_approx_equals: Numeric parameters are approximately equal. property 0, expected 0.99 +/- 0.0001, expected 0.99 but got 1.0436507
 PASS Property color value 'color(from color(from color(xyz-d65 0.99 0.88 0.77) prophoto-rgb r g b) xyz-d65 x y z)'
 PASS Property color value 'color(from color(from color(xyz-d65 0.99 0.88 0.77) rec2020 r g b) xyz-d65 x y z)'
 PASS Property color value 'color(from color(from color(xyz-d65 0.99 0.88 0.77) xyz x y z) xyz-d65 x y z)'

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -1778,6 +1778,11 @@ static Color consumeOriginColorRaw(CSSParserTokenRange& args, const CSSParserCon
     if (value->isColor())
         return value->color();
 
+    // FIXME: We don't know how to deal with unresolved origin color at parse time.
+    // https://bugs.webkit.org/show_bug.cgi?id=245970
+    if (value->isUnresolvedColor())
+        return { };
+
     ASSERT(value->isValueID());
     auto keyword = value->valueID();
 


### PR DESCRIPTION
#### 6d68a3ed57fff4edd760968f4b709e0ad1a8fa67
<pre>
[CSS] Relative origin color might be unresolved (with currentcolor or system color)
<a href="https://bugs.webkit.org/show_bug.cgi?id=271856">https://bugs.webkit.org/show_bug.cgi?id=271856</a>
<a href="https://rdar.apple.com/125582744">rdar://125582744</a>

Reviewed by Tim Nguyen.

We don&apos;t support that yet : tracking bug <a href="https://bugs.webkit.org/show_bug.cgi?id=245970">https://bugs.webkit.org/show_bug.cgi?id=245970</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-valid-relative-color-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-color/parsing/color-computed-relative-color-expected.txt.
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeOriginColorRaw):

Canonical link: <a href="https://commits.webkit.org/277062@main">https://commits.webkit.org/277062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa7670387fc82ff8c8c0a72b9e89c48f3c99c225

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46484 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49160 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42525 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37930 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19180 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41190 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4529 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41566 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50999 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17930 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45176 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22781 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44115 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10294 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->