### PR TITLE
REGRESSION (274826@main): [ iOS ] imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm is a constant failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7023,8 +7023,6 @@ imported/w3c/web-platform-tests/svg/import/animate-elem-30-t-manual.svg [ Failur
 imported/w3c/web-platform-tests/svg/import/animate-elem-85-t-manual.svg [ Failure ]
 imported/w3c/web-platform-tests/svg/import/animate-pservers-grad-01-b-manual.svg [ Failure ]
 
-webkit.org/b/271770 imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm [ Pass Failure ]
-
 webkit.org/b/271784 fast/viewport/viewport-legacy-xhtmlmp.html [ Failure ]
 webkit.org/b/271784 fast/viewport/viewport-legacy-xhtmlmp-remove-and-add.html [ Failure ]
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive-expected.txt
@@ -1,0 +1,4 @@
+
+PASS XMLHttpRequest: setRequestHeader() - headers that differ in case
+FAIL XMLHttpRequest: setRequestHeader() - headers that differ in case 1 assert_regexp_match: expected object "/content-TYPE/" but got "Host: localhost:8800\nContent-Type: x/x\nConnection: keep-alive\nTHIS-IS-A-TEST: 1, 2\nAccept: */*\nUser-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148\nReferer: http://localhost:8800/xhr/setrequestheader-case-insensitive.htm\nAccept-Language: en-US,en;q=0.9\nAccept-Encoding: gzip, deflate\n\n"
+


### PR DESCRIPTION
#### 6d841f6f07cd270d28426c401ab635d539afe6d9
<pre>
REGRESSION (274826@main): [ iOS ] imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=271857">https://bugs.webkit.org/show_bug.cgi?id=271857</a>
<a href="https://rdar.apple.com/125582859">rdar://125582859</a>

Reviewed by Charlie Wolfe and Anne van Kesteren.

This test has been a constant failure since the test expectation was changed in
274826@main. This change rebaselines for iOS.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/276959@main">https://commits.webkit.org/276959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20c168d77a14273217bce870b63fbf4bc19a35a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48427 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41792 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37462 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21960 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18618 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40557 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3801 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42065 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50206 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44599 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22053 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43465 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10244 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->