### PR TITLE
Prevent compile options from being added to MASM within VS

### DIFF
--- a/Source/cmake/OptionsMSVC.cmake
+++ b/Source/cmake/OptionsMSVC.cmake
@@ -1,9 +1,15 @@
+function(MSVC_ADD_COMPILE_OPTIONS)
+    foreach (_option ${ARGV})
+        add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:${_option}>)
+    endforeach ()
+endfunction()
+
 if (NOT COMPILER_IS_CLANG_CL)
     # List of disabled warnings
     # When adding to the list add a short description and link to the warning's text if available
     #
     # https://bugs.webkit.org/show_bug.cgi?id=221508 is for tracking removal of warnings
-    add_compile_options(
+    MSVC_ADD_COMPILE_OPTIONS(
         /wd4018 # 'token' : signed/unsigned mismatch
                 # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4018
 
@@ -118,7 +124,7 @@ if (NOT COMPILER_IS_CLANG_CL)
 endif ()
 
 # Create pdb files for debugging purposes, also for Release builds
-add_compile_options(/Zi /GS)
+MSVC_ADD_COMPILE_OPTIONS(/Zi /GS)
 
 # Disable ICF (identical code folding) optimization,
 # as it makes it unsafe to pointer-compare functions with identical definitions.
@@ -127,10 +133,10 @@ string(APPEND CMAKE_EXE_LINKER_FLAGS " /DEBUG /OPT:NOICF /OPT:REF")
 
 # We do not use exceptions
 add_definitions(-D_HAS_EXCEPTIONS=0)
-add_compile_options(/EHa- /EHc- /EHs- /fp:except-)
+MSVC_ADD_COMPILE_OPTIONS(/EHa- /EHc- /EHs- /fp:except-)
 
 # We have some very large object files that have to be linked
-add_compile_options(/analyze- /bigobj)
+MSVC_ADD_COMPILE_OPTIONS(/analyze- /bigobj)
 
 # Use CRT security features
 add_definitions(-D_CRT_SECURE_NO_WARNINGS)
@@ -138,10 +144,10 @@ if (NOT COMPILER_IS_CLANG_CL)
     add_definitions(-D_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES=1)
 endif ()
 
-add_compile_options(-D_ENABLE_EXTENDED_ALIGNED_STORAGE)
+add_definitions(-D_ENABLE_EXTENDED_ALIGNED_STORAGE)
 
 # Specify the source code encoding
-add_compile_options(/utf-8 /validate-charset)
+MSVC_ADD_COMPILE_OPTIONS(/utf-8 /validate-charset)
 
 if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
     string(APPEND CMAKE_SHARED_LINKER_FLAGS " /OPT:NOREF")
@@ -152,7 +158,7 @@ if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
     #set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /VERBOSE /VERBOSE:INCR /TIME")
     #set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /VERBOSE /VERBOSE:INCR /TIME")
 elseif (${CMAKE_BUILD_TYPE} MATCHES "Release")
-    add_compile_options(/Oy-)
+    MSVC_ADD_COMPILE_OPTIONS(/Oy-)
 endif ()
 
 if (NOT ${CMAKE_GENERATOR} MATCHES "Ninja")
@@ -197,5 +203,5 @@ endif ()
 
 # Enable the new lambda processor for better C++ conformance
 if (NOT COMPILER_IS_CLANG_CL AND MSVC_VERSION GREATER_EQUAL 1928)
-    add_compile_options(/Zc:lambda)
+    MSVC_ADD_COMPILE_OPTIONS(/Zc:lambda)
 endif ()


### PR DESCRIPTION
#### 641e3aa79194b53c4ea7d52113bca8c68713a255
<pre>
Prevent compile options from being added to MASM within VS
<a href="https://bugs.webkit.org/show_bug.cgi?id=271861">https://bugs.webkit.org/show_bug.cgi?id=271861</a>

Reviewed by Fujii Hironori.

When building within Visual Studio the CMake generator ends up adding values
from `add_compile_options` to the MASM compilation. This breaks compilation of
assembly files. Work around this by adding a CMake function that uses a
generator expression based on the language.

* Source/cmake/OptionsMSVC.cmake:

Canonical link: <a href="https://commits.webkit.org/276831@main">https://commits.webkit.org/276831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a89ecb8aa33e76f715f8c75035483de7b9cb5dd9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45783 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48453 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41820 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37483 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39494 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18644 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19399 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3827 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39013 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42089 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50209 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45255 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44600 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22079 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43466 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10172 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22438 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52408 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21768 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10712 "Passed tests") | 
<!--EWS-Status-Bubble-End-->