### PR TITLE
Web Inspector: Dark Mode: Increase the contrast in the network tab in @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/NetworkDetailView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkDetailView.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -86,5 +87,11 @@
 
     .network-detail .item.close > .glyph {
         background-color: hsla(0, 0%, 100%, 0.2);
+    }
+
+    @media (prefers-contrast: more) {
+        .network-detail {
+            background-color: hsl(0, 0%, 15%);
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -441,5 +442,19 @@ body[dir=rtl] .waterfall.network .block {
 
     .network-table > .table .cell.dom-node.name .icon {
         content: url(../Images/TypeIcons.svg#DOMElement-dark);
+    }
+
+    @media (prefers-contrast: more) {
+        .network-table > .table .data-container .cell.name .range {
+            color: var(--text-color-active);
+        }
+
+        .network-table > .table :not(.header) .cell.waterfall .waterfall-container > .area.dom-fullscreen {
+            background-color: hsl(0, 0%, 20%);
+        }
+
+        .network-table .error {
+            color: hsl(0, 86%, 80%);
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceDetailsSection.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceDetailsSection.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,8 +47,8 @@
 }
 
 .resource-details > section.incomplete > .details {
-    color: var(--console-secondary-text-color) !important;
-    border-color: var(--console-secondary-text-color) !important;
+    color: var(--console-secondary-text-color);
+    border-color: var(--console-secondary-text-color);
 }
 
 .resource-details > section > .details > .pair {
@@ -75,4 +76,17 @@ body[dir] .resource-details > section.error > .details {
 
 .resource-details > section.error > .details > .pair > .key {
     color: var(--network-error-color);
+}
+
+@media (prefers-color-scheme: dark) {
+    @media (prefers-contrast: more) {
+        .resource-details > section > .title {
+            color: hsl(0, 0%, 95%);
+        }
+
+        .resource-details > section.incomplete > .details,
+        .resource-sizes > .content .label {
+           color: hsl(0, 0%, 90%);
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceSizesContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceSizesContentView.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -111,5 +112,11 @@
 @media (prefers-color-scheme: dark) {
     .resource-sizes > .content .label {
         color: var(--text-color-secondary);
+    }
+
+    @media (prefers-contrast: more) {
+        .resource-sizes > .content .label {
+            color: hsl(0, 0%, 95%);
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ResourceTimingBreakdownView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ResourceTimingBreakdownView.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -64,8 +65,8 @@
 }
 
 .resource-timing-breakdown .waterfall .block {
-    top: 1px !important;
-    height: 14px !important;
+    top: 1px;
+    height: 14px;
 }
 
 /* Additional styles used from `WI.NetworkTableContentView`. */
@@ -82,5 +83,16 @@
 
     .resource-timing-breakdown > table hr {
         border-color: var(--text-color-quaternary);
+    }
+
+    @media (prefers-contrast: more) {
+        .resource-timing-breakdown > table > tr > td.label,
+        .resource-timing-breakdown > table > tr > td.time {
+            color: hsl(0, 0%, 90%);
+        }
+
+        .resource-timing-breakdown > table > tr.header:not(.total-row) > td {
+            color: hsl(0, 0%, 95%);
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/Table.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Table.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -123,14 +124,14 @@
 }
 
 .table > .data-container > .data-list > li.selected {
-    background-color: var(--selected-background-color-unfocused) !important;
-    color: inherit !important;
+    background-color: var(--selected-background-color-unfocused);
+    color: inherit;
     background-clip: padding-box;
 }
 
 .table:focus > .data-container > .data-list li.selected {
-    background-color: var(--selected-background-color) !important;
-    color: var(--selected-foreground-color) !important;
+    background-color: var(--selected-background-color);
+    color: var(--selected-foreground-color);
 }
 
 .table .cell {
@@ -181,5 +182,12 @@
 @media (prefers-color-scheme: dark) {
     .table > .header > :is(.sort-ascending, .sort-descending)::after {
         filter: invert();
+    }
+
+    @media (prefers-contrast: more) {
+        .table > .data-container > .data-list.even-first-zebra-stripe,
+        .table > .data-container > .data-list {
+            --even-zebra-stripe-row-background-color: hsl(0, 0%, 20%);
+            --odd-zebra-stripe-row-background-color: hsl(0, 0%, 17%);}
     }
 }


### PR DESCRIPTION
#### 682dc731eb2a59e9474899e829f6f5cf2772a461
<pre>
Web Inspector: Dark Mode: Increase the contrast in the network tab in @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)
<a href="https://bugs.webkit.org/show_bug.cgi?id=271860">https://bugs.webkit.org/show_bug.cgi?id=271860</a>

Reviewed by NOBODY (OOPS!).

Darken the background of the detail panel in NetworkDetailView.css.
Darken the backgrounds in NetworkTableContentView.css.
Lighten the error text color in NetworkTableContentView.css.
Lighten the title, label, and details in ResourceDetailsSection.css.
Increase the lightness of the time, label, and headers in ResourceTimingBreakdownView.css.
Darken the zebra stripes in Table.css.

* Source/WebInspectorUI/UserInterface/Views/NetworkDetailView.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .network-detail):
* Source/WebInspectorUI/UserInterface/Views/NetworkTableContentView.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .network-table &gt; .table .data-container .cell.name .range):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .network-table &gt; .table :not(.header) .cell.waterfall .waterfall-container &gt; .area.dom-fullscreen):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-browser &gt; .navigation-bar .item):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .network-table .error):
* Source/WebInspectorUI/UserInterface/Views/ResourceDetailsSection.css:
(.resource-details &gt; section.incomplete &gt; .details):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .resource-details &gt; section &gt; .title):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .resource-details &gt; section.incomplete &gt; .details,):
* Source/WebInspectorUI/UserInterface/Views/ResourceSizesContentView.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .resource-sizes &gt; .content .label):
* Source/WebInspectorUI/UserInterface/Views/ResourceTimingBreakdownView.css:
(.resource-timing-breakdown .waterfall .block):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .resource-timing-breakdown &gt; table &gt; tr &gt; td.label,):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .resource-timing-breakdown &gt; table &gt; tr.header:not(.total-row) &gt; td):
* Source/WebInspectorUI/UserInterface/Views/Table.css:
(.table &gt; .data-container &gt; .data-list &gt; li.selected):
(.table:focus &gt; .data-container &gt; .data-list li.selected):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .table &gt; .data-container &gt; .data-list.even-first-zebra-stripe,):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/682dc731eb2a59e9474899e829f6f5cf2772a461

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47520 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26704 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50182 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50203 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43574 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38698 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20003 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42137 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5563 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52082 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18889 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46002 "Passed tests") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45025 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 4 api tests failed or timed out; Running re-run-api-tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24616 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->