### PR TITLE
[ iOS17 ] fast/scrolling/ios/scroll-anchoring-momentum-scroll.html(layout-tests) is a constant TEXT failure

### DIFF
--- a/LayoutTests/fast/scrolling/ios/scroll-anchoring-momentum-scroll-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/scroll-anchoring-momentum-scroll-expected.txt
@@ -3,7 +3,7 @@ Verifies that a scroll anchoring adjustment does not cancel a momentum scroll.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS document.scrollingElement.scrollTop is > 900
+PASS document.scrollingElement.scrollTop is > 600
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/scrolling/ios/scroll-anchoring-momentum-scroll.html
+++ b/LayoutTests/fast/scrolling/ios/scroll-anchoring-momentum-scroll.html
@@ -38,7 +38,7 @@ async function runTest()
     await UIHelper.dragFromPointToPoint(150, 420, 150, 400, 0.01);
     document.querySelector("#block1").style.height = "200px";
     await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
-    shouldBeGreaterThan("document.scrollingElement.scrollTop", "900");
+    shouldBeGreaterThan("document.scrollingElement.scrollTop", "600");
     finishJSTest();
 }
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7013,8 +7013,6 @@ webkit.org/b/271682 imported/w3c/web-platform-tests/css/css-content/quotes-007.h
 
 webkit.org/b/271712 [ Debug ] fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html [ Timeout ]
 
-webkit.org/b/266010 fast/scrolling/ios/scroll-anchoring-momentum-scroll.html [ Pass Failure ]
-
 # webkit.org/b/271772 REGRESSION (276683@main): [ iOS ] 3X imported/w3c/web-platform-tests/svg/import/animate tests are consistent failures
 imported/w3c/web-platform-tests/svg/import/animate-elem-30-t-manual.svg [ Failure ]
 imported/w3c/web-platform-tests/svg/import/animate-elem-85-t-manual.svg [ Failure ]


### PR DESCRIPTION
#### d159d134072de7caa8ba548fafd398491a91e633
<pre>
[ iOS17 ] fast/scrolling/ios/scroll-anchoring-momentum-scroll.html(layout-tests) is a constant TEXT failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=266010">https://bugs.webkit.org/show_bug.cgi?id=266010</a>
<a href="https://rdar.apple.com/119684431">rdar://119684431</a>

Reviewed by Simon Fraser.

When originally testing this test I was using an iPhone 14 simulator, which produces a different value
than the iPhone 12 simulator. Fixing this value should cause it to pass on both simulators.

* LayoutTests/fast/scrolling/ios/scroll-anchoring-momentum-scroll-expected.txt:
* LayoutTests/fast/scrolling/ios/scroll-anchoring-momentum-scroll.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/276981@main">https://commits.webkit.org/276981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afa128b19ee4850274d9bee89626fc3dfc0d371c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48445 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41810 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37477 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18637 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40573 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3819 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42099 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50200 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44593 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43457 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10252 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21760 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->