### PR TITLE
Signed loads should not zero-def their destination.

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -751,7 +751,7 @@ ZeroExtend8To32 U:G:8, ZD:G:32
     x86: Addr, Tmp as load8
     x86: Index, Tmp as load8
 
-SignExtend8To32 U:G:8, ZD:G:32
+SignExtend8To32 U:G:8, D:G:32
     Tmp, Tmp
     x86: Addr, Tmp as load8SignedExtendTo32
     x86: Index, Tmp as load8SignedExtendTo32
@@ -761,7 +761,7 @@ ZeroExtend16To32 U:G:16, ZD:G:32
     x86: Addr, Tmp as load16
     x86: Index, Tmp as load16
 
-SignExtend16To32 U:G:16, ZD:G:32
+SignExtend16To32 U:G:16, D:G:32
     Tmp, Tmp
     x86: Addr, Tmp as load16SignedExtendTo32
     x86: Index, Tmp as load16SignedExtendTo32
@@ -861,11 +861,11 @@ Store8 U:G:8, D:G:8
 arm64: StoreRel8 U:G:8, D:G:8 /effects
     Tmp, SimpleAddr
 
-Load8SignedExtendTo32 U:G:8, ZD:G:32
+Load8SignedExtendTo32 U:G:8, D:G:32
     Addr, Tmp
     Index, Tmp
 
-arm64: LoadAcq8SignedExtendTo32 U:G:8, ZD:G:32 /effects
+arm64: LoadAcq8SignedExtendTo32 U:G:8, D:G:32 /effects
     SimpleAddr, Tmp
 
 Load16 U:G:16, ZD:G:32
@@ -875,11 +875,11 @@ Load16 U:G:16, ZD:G:32
 arm64: LoadAcq16 U:G:16, ZD:G:32 /effects
     SimpleAddr, Tmp
 
-Load16SignedExtendTo32 U:G:16, ZD:G:32
+Load16SignedExtendTo32 U:G:16, D:G:32
     Addr, Tmp
     Index, Tmp
 
-arm64: LoadAcq16SignedExtendTo32 U:G:16, ZD:G:32 /effects
+arm64: LoadAcq16SignedExtendTo32 U:G:16, D:G:32 /effects
     SimpleAddr, Tmp
 
 Store16 U:G:16, D:G:16
@@ -993,13 +993,13 @@ arm64: ExtractInsertBitfieldAtLowEnd32 U:G:32, U:G:32, U:G:32, UZD:G:32
 arm64: ExtractInsertBitfieldAtLowEnd64 U:G:64, U:G:32, U:G:32, UD:G:64
     Tmp, Imm, Imm, Tmp
 
-arm64: InsertSignedBitfieldInZero32 U:G:32, U:G:32, U:G:32, ZD:G:32
+arm64: InsertSignedBitfieldInZero32 U:G:32, U:G:32, U:G:32, D:G:32
     Tmp, Imm, Imm, Tmp
 
 arm64: InsertSignedBitfieldInZero64 U:G:64, U:G:32, U:G:32, D:G:64
     Tmp, Imm, Imm, Tmp
 
-arm64: ExtractSignedBitfield32 U:G:32, U:G:32, U:G:32, ZD:G:32
+arm64: ExtractSignedBitfield32 U:G:32, U:G:32, U:G:32, D:G:32
     Tmp, Imm, Imm, Tmp
 
 arm64: ExtractSignedBitfield64 U:G:64, U:G:32, U:G:32, D:G:64
@@ -1757,11 +1757,11 @@ RetDouble U:F:64 /return
     Imm, Tmp, Tmp
 64: VectorExtractLaneInt32 U:G:8, U:F:128, ZD:G:32
     Imm, Tmp, Tmp
-64: VectorExtractLaneSignedInt16 U:G:8, U:F:128, ZD:G:32
+64: VectorExtractLaneSignedInt16 U:G:8, U:F:128, D:G:32
     Imm, Tmp, Tmp
 64: VectorExtractLaneUnsignedInt16 U:G:8, U:F:128, ZD:G:16
     Imm, Tmp, Tmp
-64: VectorExtractLaneSignedInt8 U:G:8, U:F:128, ZD:G:32
+64: VectorExtractLaneSignedInt8 U:G:8, U:F:128, D:G:32
     Imm, Tmp, Tmp
 64: VectorExtractLaneUnsignedInt8 U:G:8, U:F:128, ZD:G:8
     Imm, Tmp, Tmp


### PR DESCRIPTION
#### 58389979b17a533801e90121829b5e1e2b4068cc
<pre>
Signed loads should not zero-def their destination.
<a href="https://bugs.webkit.org/show_bug.cgi?id=271866">https://bugs.webkit.org/show_bug.cgi?id=271866</a>
<a href="https://rdar.apple.com/122959696">rdar://122959696</a>

Reviewed by Yusuke Suzuki.

This fixes a hang in Google Meet when applying the Black Noir filter.

Suppose we have:

```
@a = Load8SignedExtendTo32(@x)

@b = Trunc(ZExt32(@a))
```

B3 reduceStrength will convert @b to @a. The Air register allocator will
see that we ZDef 64 bits in @a, but on ARM64, we actually sign-extend them.

This was caught by changing reduceStrength:

```
case Trunc:
    // Turn this: Trunc(SExt32(value)) or Trunc(ZExt32(value))
    // Into this: value
    if (m_value-&gt;child(0)-&gt;opcode() == SExt32 || m_value-&gt;child(0)-&gt;opcode() == ZExt32) {
        auto* value = m_value-&gt;child(0)-&gt;child(0);
        auto* patchpoint = m_insertionSet.insert&lt;PatchpointValue&gt;(
            m_index, m_value-&gt;type(), m_value-&gt;origin());

        patchpoint-&gt;effects = Effects();
        patchpoint-&gt;effects.reads = HeapRange::top();
        patchpoint-&gt;effects.exitsSideways = true;

        patchpoint-&gt;append(value);
        patchpoint-&gt;setGenerator([&amp;] (CCallHelpers&amp; jit, const StackmapGenerationParams&amp; params) {
            RELEASE_ASSERT(params.size() == 2);
            RELEASE_ASSERT(params[0].isGPR());
            RELEASE_ASSERT(params[1].isGPR());
            auto dst = params[0].gpr();
            auto a = params[1].gpr();
            auto branch = jit.branchTest64(CCallHelpers::Zero, a, MacroAssembler::TrustedImm64(0xFFFFFFFF00000000));
            jit.breakpoint();
            jit.breakpoint(0);
            jit.breakpoint(1);
            jit.breakpoint(2);
            branch.link(&amp;jit);
            jit.move(a, dst);
        });

        replaceWithNew&lt;Value&gt;(Identity, m_value-&gt;origin(), patchpoint);
```

* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:

Canonical link: <a href="https://commits.webkit.org/276829@main">https://commits.webkit.org/276829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f74efe47776503aa6de40b789f460ce96fff8def

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41815 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37482 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/21984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39489 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18642 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19383 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40582 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3823 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39009 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42087 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50204 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45251 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44597 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22075 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43463 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22434 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52404 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6386 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21764 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10711 "Passed tests") | 
<!--EWS-Status-Bubble-End-->