### PR TITLE
[Remote Inspection] Make the repeated element targeting heuristic robust in the case where elements are unparented

### DIFF
--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -25,9 +25,13 @@
 
 #pragma once
 
+#include "ElementIdentifier.h"
 #include "ElementTargetingTypes.h"
+#include "IntRect.h"
 #include "Region.h"
+#include "ScriptExecutionContextIdentifier.h"
 #include <wtf/CheckedPtr.h>
+#include <wtf/HashMap.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -35,7 +39,6 @@
 namespace WebCore {
 
 class Document;
-class Element;
 class Page;
 
 class ElementTargetingController : public CanMakeCheckedPtr {
@@ -45,13 +48,14 @@ public:
 
     WEBCORE_EXPORT Vector<TargetedElementInfo> findTargets(TargetedElementRequest&&);
 
-    WEBCORE_EXPORT bool adjustVisibility(const Vector<Ref<Element>>&);
+    WEBCORE_EXPORT bool adjustVisibility(const Vector<std::pair<ElementIdentifier, ScriptExecutionContextIdentifier>>&);
     void adjustVisibilityInRepeatedlyTargetedRegions(Document&);
 
     void resetAdjustmentRegions();
 
 private:
     SingleThreadWeakPtr<Page> m_page;
+    HashMap<ElementIdentifier, IntRect> m_pendingAdjustmentClientRects;
     Region m_adjustmentClientRegion;
     Region m_repeatedAdjustmentClientRegion;
     FloatSize m_viewportSizeForVisibilityAdjustment;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9426,21 +9426,10 @@ void WebPage::remoteViewPointToRootView(FrameIdentifier frameID, FloatPoint poin
     remoteViewToRootView(frameID, point, WTFMove(completionHandler));
 }
 
-void WebPage::adjustVisibilityForTargetedElements(const Vector<std::pair<WebCore::ElementIdentifier, WebCore::ScriptExecutionContextIdentifier>>& identifiers, CompletionHandler<void(bool)>&& completion)
+void WebPage::adjustVisibilityForTargetedElements(const Vector<std::pair<ElementIdentifier, ScriptExecutionContextIdentifier>>& identifiers, CompletionHandler<void(bool)>&& completion)
 {
     RefPtr page = corePage();
-    if (!page)
-        return completion(false);
-
-    Vector<Ref<Element>> elements;
-    elements.reserveInitialCapacity(identifiers.size());
-    for (auto [elementID, documentID] : identifiers) {
-        RefPtr foundElement = Element::fromIdentifier(elementID);
-        if (!foundElement || foundElement->document().identifier() != documentID)
-            continue;
-        elements.append(foundElement.releaseNonNull());
-    }
-    completion(page->checkedElementTargetingController()->adjustVisibility(elements));
+    completion(page && page->checkedElementTargetingController()->adjustVisibility(identifiers));
 }
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/PlatformUtilities.h
+++ b/Tools/TestWebKitAPI/PlatformUtilities.h
@@ -40,6 +40,15 @@ OBJC_CLASS NSDictionary;
 typedef double NSTimeInterval;
 #endif
 
+#if PLATFORM(COCOA)
+OBJC_CLASS NSImage;
+OBJC_CLASS NSWindow;
+OBJC_CLASS UIImage;
+OBJC_CLASS UIWindow;
+struct CGImage;
+using CGImageRef = CGImage*;
+#endif
+
 namespace TestWebKitAPI {
 namespace Util {
 
@@ -86,8 +95,17 @@ static inline ::testing::AssertionResult assertWKStringEqual(const char* expecte
 #define EXPECT_WK_STREQ(expected, actual) \
     EXPECT_PRED_FORMAT2(TestWebKitAPI::Util::assertWKStringEqual, expected, actual)
 
+#if PLATFORM(MAC)
+using PlatformImage = NSImage;
+using PlatformWindow = NSWindow;
+#elif PLATFORM(IOS_FAMILY)
+using PlatformImage = UIImage;
+using PlatformWindow = UIWindow;
+#endif
+
 #if PLATFORM(COCOA)
 extern NSString * const TestPlugInClassNameParameter;
+extern RetainPtr<CGImageRef> convertToCGImage(PlatformImage *);
 #endif
 
 } // namespace Util

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
@@ -44,25 +44,6 @@
 
 namespace TestWebKitAPI {
 
-#if PLATFORM(MAC)
-typedef NSImage *PlatformImage;
-typedef NSWindow *PlatformWindow;
-
-static RetainPtr<CGImageRef> convertToCGImage(NSImage *image)
-{
-    return [image CGImageForProposedRect:nil context:nil hints:nil];
-}
-
-#else
-typedef UIImage *PlatformImage;
-typedef UIWindow *PlatformWindow;
-
-static RetainPtr<CGImageRef> convertToCGImage(UIImage *image)
-{
-    return image.CGImage;
-}
-#endif
-
 static NSInteger getPixelIndex(NSInteger x, NSInteger y, NSInteger width)
 {
     return (y * width + x) * 4;
@@ -508,7 +489,7 @@ TEST(GPUProcess, CanvasBasicCrashHandling)
     NSInteger viewHeight = 400;
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, viewWidth, viewHeight) configuration:configuration.get() addToWindow:NO]);
 
-    RetainPtr<PlatformWindow> window;
+    RetainPtr<Util::PlatformWindow> window;
     CGFloat backingScaleFactor;
 
 #if PLATFORM(MAC)
@@ -550,10 +531,10 @@ TEST(GPUProcess, CanvasBasicCrashHandling)
 
     // Make sure a red square is painted.
     done = false;
-    [webView takeSnapshotWithConfiguration:snapshotConfiguration.get() completionHandler:^(PlatformImage snapshotImage, NSError *error) {
+    [webView takeSnapshotWithConfiguration:snapshotConfiguration.get() completionHandler:^(Util::PlatformImage *snapshotImage, NSError *error) {
         EXPECT_TRUE(!error);
 
-        RetainPtr<CGImageRef> cgImage = convertToCGImage(snapshotImage);
+        RetainPtr cgImage = Util::convertToCGImage(snapshotImage);
         RetainPtr<CGColorSpaceRef> colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
 
         NSInteger viewWidthInPixels = viewWidth * backingScaleFactor;
@@ -605,10 +586,10 @@ TEST(GPUProcess, CanvasBasicCrashHandling)
 
     // Make sure a green square is painted.
     done = false;
-    [webView takeSnapshotWithConfiguration:snapshotConfiguration.get() completionHandler:^(PlatformImage snapshotImage, NSError *error) {
+    [webView takeSnapshotWithConfiguration:snapshotConfiguration.get() completionHandler:^(Util::PlatformImage *snapshotImage, NSError *error) {
         EXPECT_TRUE(!error);
 
-        RetainPtr<CGImageRef> cgImage = convertToCGImage(snapshotImage);
+        RetainPtr cgImage = Util::convertToCGImage(snapshotImage);
         RetainPtr<CGColorSpaceRef> colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
 
         NSInteger viewWidthInPixels = viewWidth * backingScaleFactor;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-2.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-2.html
@@ -11,6 +11,7 @@ body, html {
     font-size: 16px;
     line-height: 200%;
     -webkit-text-size-adjust: none;
+    color: white;
 }
 
 .fixed {
@@ -56,5 +57,15 @@ body, html {
     <div class="absolute bottom-left"></div>
     <div class="absolute top-right"></div>
     <main>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</main>
+    <script>
+        const overlays = [...document.querySelectorAll(".fixed, .absolute")];
+        function removeOverlays() {
+            overlays.forEach(overlay => overlay.remove());
+        }
+
+        function addOverlays() {
+            overlays.forEach(overlay => document.body.appendChild(overlay));
+        }
+    </script>
 </body>
 </html>

--- a/Tools/TestWebKitAPI/cocoa/PlatformUtilitiesCocoa.mm
+++ b/Tools/TestWebKitAPI/cocoa/PlatformUtilitiesCocoa.mm
@@ -92,6 +92,15 @@ void waitForConditionWithLogging(std::function<bool()>&& condition, NSTimeInterv
     }
 }
 
+RetainPtr<CGImageRef> convertToCGImage(PlatformImage *image)
+{
+#if PLATFORM(MAC)
+    return [image CGImageForProposedRect:nil context:nil hints:nil];
+#else
+    return image.CGImage;
+#endif
+}
+
 NSString * const TestPlugInClassNameParameter = @"TestPlugInPrincipalClassName";
 
 } // namespace Util

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -92,6 +92,7 @@ struct AutocorrectionContext {
 - (void)extendSelectionToEndOfParagraph;
 #endif // PLATFORM(IOS_FAMILY)
 
+@property (nonatomic, readonly) CGImageRef snapshotAfterScreenUpdates;
 @property (nonatomic, readonly) NSUInteger gpuToWebProcessConnectionCount;
 @property (nonatomic, readonly) NSString *contentsAsString;
 @property (nonatomic, readonly) NSArray<NSString *> *tagsInBody;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -28,6 +28,7 @@
 
 #import "ClassMethodSwizzler.h"
 #import "InstanceMethodSwizzler.h"
+#import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestNavigationDelegate.h"
 #import "Utilities.h"
@@ -591,6 +592,20 @@ static WebEvent *unwrap(BEKeyEntry *event)
 {
     auto rect = [self elementRectFromSelector:selector];
     return CGPointMake(CGRectGetMidX(rect), CGRectGetMidY(rect));
+}
+
+- (CGImageRef)snapshotAfterScreenUpdates
+{
+    __block RetainPtr<CGImage> result;
+    __block bool done = false;
+    RetainPtr configuration = adoptNS([WKSnapshotConfiguration new]);
+    [configuration setAfterScreenUpdates:YES];
+    [self takeSnapshotWithConfiguration:configuration.get() completionHandler:^(TestWebKitAPI::Util::PlatformImage *snapshot, NSError *) {
+        result = TestWebKitAPI::Util::convertToCGImage(snapshot);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    return result.autorelease();
 }
 
 @end


### PR DESCRIPTION
#### 8af90c08dbd9df112cb58f4ed043180dc8c7d512
<pre>
[Remote Inspection] Make the repeated element targeting heuristic robust in the case where elements are unparented
<a href="https://bugs.webkit.org/show_bug.cgi?id=271848">https://bugs.webkit.org/show_bug.cgi?id=271848</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Currently, client rects for visibility adjustment are added at visibility adjustment time, based on
the current client rect of the target element. This has a major drawback, in that a target could be
unparented (or otherwise prematurely hidden) by the page, and we&apos;ll fail to add any client rects
corresponding to the target element.

Instead, this patch refactors that mechanism to be more robust, by computing and caching the last
set of targeted element client rects up front when finding targets. Later, when we actually go and
apply visibility adjustment, we&apos;ll consult these cached target rects instead of reading the current
element state.

Test: ElementTargeting.AdjustVisibilityForUnparentedElement

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::computeClientRect):

Move this static helper function up in this file.

(WebCore::ElementTargetingController::findTargets):
(WebCore::ElementTargetingController::adjustVisibility):

Also refactor this logic to update adjustment regions, such that it happens before any of the
targeted elements are hidden. This is possible now that we only rely on the element identifiers and
`m_pendingAdjustmentClientRects` (from the last element targeting call).

(WebCore::ElementTargetingController::resetAdjustmentRegions):
* Source/WebCore/page/ElementTargetingController.h:

Add `m_pendingAdjustmentClientRects`, which tracks the last set of targeted elements which might be
imminently hidden. Keeping around only this recent state helps avoided unbounded growth as the user
targets more elements around the page, but still allows us to handle this corner case where targeted
elements can no longer be hidden.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::adjustVisibilityForTargetedElements):

Adjust the WebCore method to take a list of element identifiers instead of elements; see above for
more details.

* Tools/TestWebKitAPI/PlatformUtilities.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(-[WKWebView adjustVisibilityForTargets:]):

Add a new API test to exercise the change.

(TestWebKitAPI::TEST(ElementTargeting, AdjustVisibilityForUnparentedElement)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm:
(TestWebKitAPI::TEST(GPUProcess, CanvasBasicCrashHandling)):
(TestWebKitAPI::convertToCGImage): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm:
(-[TestSnapshotWrapper takeSnapshotWithWebView:configuration:completionHandler:]):
(TestWebKitAPI::TEST(WKWebView, SnapshotImageError)):
(TestWebKitAPI::TEST(WKWebView, SnapshotImageEmptyRect)):
(TestWebKitAPI::TEST(WKWebView, SnapshotImageZeroWidth)):
(TestWebKitAPI::TEST(WKWebView, SnapshotImageZeroSizeView)):
(TestWebKitAPI::TEST(WKWebView, SnapshotImageZeroSizeViewNoConfiguration)):
(TestWebKitAPI::TEST(WKWebView, SnapshotImageBaseCase)):
(TestWebKitAPI::TEST(WKWebView, SnapshotImageScale)):
(TestWebKitAPI::TEST(WKWebView, SnapshotImageNilConfiguration)):
(TestWebKitAPI::TEST(WKWebView, SnapshotImageUninitializedConfiguration)):
(TestWebKitAPI::TEST(WKWebView, SnapshotImageUninitializedSnapshotWidth)):
(TestWebKitAPI::TEST(WKWebView, SnapshotImageLargeAsyncDecoding)):
(TestWebKitAPI::TEST(WKWebView, SnapshotAfterScreenUpdates)):
(TestWebKitAPI::TEST(WKWebView, SnapshotWithoutAfterScreenUpdates)):
(TestWebKitAPI::TEST(WKWebView, SnapshotWebGL)):
(TestWebKitAPI::TEST(WKWebView, SnapshotWithoutSelectionHighlighting)):
(TestWebKitAPI::TEST(WKWebView, SnapshotWithContentsRect)):

Refactor some existing API tests to use the new `CGImage` conversion helpers.

(convertToCGImage): Deleted.
(TEST(WKWebView, SnapshotImageError)): Deleted.
(TEST(WKWebView, SnapshotImageEmptyRect)): Deleted.
(TEST(WKWebView, SnapshotImageZeroWidth)): Deleted.
(TEST(WKWebView, SnapshotImageZeroSizeView)): Deleted.
(TEST(WKWebView, SnapshotImageZeroSizeViewNoConfiguration)): Deleted.
(TEST(WKWebView, SnapshotImageEmptyWithOutOfScopeCompletionHandler)): Deleted.
(TEST(WKWebView, SnapshotImageBaseCase)): Deleted.
(TEST(WKWebView, SnapshotImageScale)): Deleted.
(TEST(WKWebView, SnapshotImageNilConfiguration)): Deleted.
(TEST(WKWebView, SnapshotImageUninitializedConfiguration)): Deleted.
(TEST(WKWebView, SnapshotImageUninitializedSnapshotWidth)): Deleted.
(TEST(WKWebView, SnapshotImageLargeAsyncDecoding)): Deleted.
(TEST(WKWebView, SnapshotAfterScreenUpdates)): Deleted.
(TEST(WKWebView, SnapshotWithoutAfterScreenUpdates)): Deleted.
(TEST(WKWebView, SnapshotWebGL)): Deleted.
(TEST(WKWebView, SnapshotWithoutSelectionHighlighting)): Deleted.
(TEST(WKWebView, SnapshotWithContentsRect)): Deleted.

Refactor some existing API tests to use the new `CGImage` conversion helpers.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-2.html:
* Tools/TestWebKitAPI/cocoa/PlatformUtilitiesCocoa.mm:
(TestWebKitAPI::Util::convertToCGImage):

Pull out some helper functions to convert platform `NSImage` / `UIImage` into `CGImage`.

* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView snapshotAfterScreenUpdates]):

Add a new helper method for testing, that grabs a snapshot of the web view (after screen updates) as
a `CGImage`.

Canonical link: <a href="https://commits.webkit.org/276824@main">https://commits.webkit.org/276824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12e0a08c22abf36a903cf09e7f6509c6082aa804

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48472 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41839 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22328 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39507 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18663 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40602 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3846 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42108 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50232 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17301 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44614 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22098 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43481 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10169 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22457 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->