### PR TITLE
[Skia] Fix support for DragImage with GTK

### DIFF
--- a/Source/WebCore/platform/gtk/DragImageGtk.cpp
+++ b/Source/WebCore/platform/gtk/DragImageGtk.cpp
@@ -21,12 +21,19 @@
 
 #include "Element.h"
 #include "Image.h"
-#include "NotImplemented.h"
 #include "TextFlags.h"
 #include "TextIndicator.h"
 #include <cairo.h>
 #include <gdk/gdk.h>
 #include <wtf/URL.h>
+
+#if USE(SKIA)
+IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
+#include <skia/core/SkBitmap.h>
+IGNORE_CLANG_WARNINGS_END
+#include <skia/core/SkCanvas.h>
+#include <skia/core/SkImageInfo.h>
+#endif
 
 namespace WebCore {
 
@@ -36,8 +43,8 @@ IntSize dragImageSize(DragImageRef image)
     if (image)
         return { cairo_image_surface_get_width(image.get()), cairo_image_surface_get_height(image.get()) };
 #elif USE(SKIA)
-    notImplemented();
-    UNUSED_PARAM(image);
+    if (image)
+        return { image->width(), image->height() };
 #endif
 
     return { 0, 0 };
@@ -73,8 +80,18 @@ DragImageRef scaleDragImage(DragImageRef image, FloatSize scale)
 
     return scaledSurface;
 #elif USE(SKIA)
-    notImplemented();
-    return nullptr;
+    auto imageInfo = SkImageInfo::Make(scaledSize.width(), scaledSize.height(), image->imageInfo().colorType(), image->imageInfo().alphaType());
+    SkBitmap bitmap;
+    bitmap.allocPixels(imageInfo);
+
+    SkPixmap pixmap;
+    if (!bitmap.peekPixels(&pixmap))
+        return nullptr;
+
+    if (!image->scalePixels(pixmap, SkSamplingOptions(SkCubicResampler::CatmullRom())))
+        return nullptr;
+
+    return SkImages::RasterFromBitmap(bitmap);
 #endif
 }
 
@@ -93,11 +110,25 @@ DragImageRef dissolveDragImageToFraction(DragImageRef image, float fraction)
     cairo_set_operator(context.get(), CAIRO_OPERATOR_DEST_IN);
     cairo_set_source_rgba(context.get(), 0, 0, 0, fraction);
     cairo_paint(context.get());
-#elif USE(SKIA)
-    notImplemented();
-    UNUSED_PARAM(fraction);
-#endif
+
     return image;
+#elif USE(SKIA)
+    SkBitmap bitmap;
+    bitmap.allocPixels(image->imageInfo());
+
+    SkPixmap pixmap;
+    if (!bitmap.peekPixels(&pixmap))
+        return nullptr;
+
+    auto canvas = SkCanvas::MakeRasterDirect(bitmap.info(), pixmap.writable_addr(), bitmap.rowBytes());
+
+    SkPaint paint;
+    paint.setAlphaf(fraction);
+
+    canvas->drawImage(image, 0, 0,  { }, &paint);
+
+    return SkImages::RasterFromBitmap(bitmap);
+#endif
 }
 
 DragImageRef createDragImageFromImage(Image* image, ImageOrientation)

--- a/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp
@@ -30,8 +30,8 @@
 
 #include "WebKitWebViewBasePrivate.h"
 #include <WebCore/GRefPtrGtk.h>
+#include <WebCore/GdkSkiaUtilities.h>
 #include <WebCore/GtkUtilities.h>
-#include <WebCore/NotImplemented.h>
 #include <WebCore/PasteboardCustomData.h>
 #include <gtk/gtk.h>
 
@@ -142,12 +142,12 @@ void DragSource::begin(SelectionData&& selectionData, OptionSet<DragOperation> o
     if (image) {
 #if USE(CAIRO)
         RefPtr<cairo_surface_t> imageSurface(image->createCairoSurface());
+#else
+        auto skiaImage = image->createPlatformImage();
+        RefPtr<cairo_surface_t> imageSurface(skiaImageToCairoSurface(*skiaImage));
+#endif
         cairo_surface_set_device_offset(imageSurface.get(), -imageHotspot.x(), -imageHotspot.y());
         gtk_drag_set_icon_surface(m_drag.get(), imageSurface.get());
-#elif USE(SKIA)
-        notImplemented();
-        gtk_drag_set_icon_default(m_drag.get());
-#endif
     } else
         gtk_drag_set_icon_default(m_drag.get());
 }


### PR DESCRIPTION
#### 73b85d6c9c77de1051c0521be9c8686202a14643
<pre>
[Skia] Fix support for DragImage with GTK
<a href="https://bugs.webkit.org/show_bug.cgi?id=271871">https://bugs.webkit.org/show_bug.cgi?id=271871</a>

Reviewed by Carlos Garcia Campos.

* Source/WebCore/platform/gtk/DragImageGtk.cpp:
(WebCore::dragImageSize):
(WebCore::scaleDragImage):
(WebCore::dissolveDragImageToFraction):
* Source/WebKit/UIProcess/API/gtk/DragSourceGtk3.cpp:
(WebKit::DragSource::begin):
* Source/WebKit/WebProcess/WebCoreSupport/gtk/WebDragClientGtk.cpp:
(WebKit::convertSkiaImageToShareableBitmap):
(WebKit::WebDragClient::startDrag):

Canonical link: <a href="https://commits.webkit.org/276871@main">https://commits.webkit.org/276871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5390a28f5acc001bd05aaa0eda50ec2d819347b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46037 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48708 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42077 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37644 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18834 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19650 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-001.html, imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40818 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4081 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50496 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17537 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44804 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22333 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43698 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22692 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6408 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22027 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->