### PR TITLE
Add SIMD containsHTMLLineBreak

### DIFF
--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -500,9 +500,10 @@ void TextFieldInputType::createDataListDropdownIndicator()
 
 static String limitLength(const String& string, unsigned maxLength)
 {
-    unsigned newLength = std::min(maxLength, string.length());
-    if (newLength == string.length())
+    if (LIKELY(string.length() <= maxLength))
         return string;
+
+    unsigned newLength = maxLength;
     if (newLength > 0 && U16_IS_LEAD(string[newLength - 1]))
         --newLength;
     return string.left(newLength);
@@ -585,6 +586,9 @@ static bool isAutoFillButtonTypeChanged(const AtomString& attribute, AutoFillBut
 
 String TextFieldInputType::sanitizeValue(const String& proposedValue) const
 {
+    if (LIKELY(!containsHTMLLineBreak(proposedValue)))
+        return limitLength(proposedValue, HTMLInputElement::maxEffectiveLength);
+
     // Passing a lambda instead of a function name helps the compiler inline isHTMLLineBreak.
     auto proposedValueWithoutLineBreaks = proposedValue.removeCharacters([](auto character) {
         return isHTMLLineBreak(character);

--- a/Source/WebCore/html/parser/HTMLParserIdioms.h
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.h
@@ -96,6 +96,13 @@ inline bool isHTMLLineBreak(UChar character)
     return character <= '\r' && (character == '\n' || character == '\r');
 }
 
+ALWAYS_INLINE bool containsHTMLLineBreak(StringView view)
+{
+    if (view.is8Bit())
+        return charactersContain<LChar, '\r', '\n'>(view.span8());
+    return charactersContain<UChar, '\r', '\n'>(view.span16());
+}
+
 template<typename CharacterType> inline bool isComma(CharacterType character)
 {
     return character == ',';

--- a/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
@@ -203,4 +203,112 @@ TEST(WTF_StringCommon, CopyElements32To16)
         EXPECT_EQ(destination[4096 + 4 + i], static_cast<uint16_t>(i));
 }
 
+TEST(WTF_StringCommon, CharactersContain8)
+{
+    {
+        Vector<LChar> source;
+        EXPECT_FALSE((charactersContain<LChar, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<LChar, 0, 1>(source.span())));
+        EXPECT_FALSE((charactersContain<LChar, 0, 1, 2>(source.span())));
+    }
+
+    {
+        Vector<LChar> source;
+        for (unsigned i = 0; i < 15; ++i)
+            source.append(i);
+        EXPECT_TRUE((charactersContain<LChar, 0>(source.span())));
+        EXPECT_TRUE((charactersContain<LChar, 1>(source.span())));
+        EXPECT_TRUE((charactersContain<LChar, 2>(source.span())));
+        EXPECT_TRUE((charactersContain<LChar, 2, 3>(source.span())));
+        EXPECT_TRUE((charactersContain<LChar, 16, 14>(source.span())));
+        EXPECT_FALSE((charactersContain<LChar, 16>(source.span())));
+        EXPECT_FALSE((charactersContain<LChar, 16, 15>(source.span())));
+        EXPECT_FALSE((charactersContain<LChar, 16, 15, 17>(source.span())));
+        EXPECT_FALSE((charactersContain<LChar, 16, 15, 17, 18>(source.span())));
+        EXPECT_FALSE((charactersContain<LChar, 0x81>(source.span())));
+        EXPECT_FALSE((charactersContain<LChar, 0x81, 0x82>(source.span())));
+    }
+
+    {
+        Vector<LChar> source;
+        for (unsigned i = 0; i < 250; ++i) {
+            if (i & 0x1)
+                source.append(i);
+        }
+        EXPECT_FALSE((charactersContain<LChar, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<LChar, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<LChar, 0xff>(source.span())));
+        EXPECT_TRUE((charactersContain<LChar, 0x81>(source.span())));
+        EXPECT_FALSE((charactersContain<LChar, 250>(source.span())));
+        EXPECT_TRUE((charactersContain<LChar, 249>(source.span())));
+    }
+}
+
+TEST(WTF_StringCommon, CharactersContain16)
+{
+    {
+        Vector<UChar> source;
+        EXPECT_FALSE((charactersContain<UChar, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0, 1>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0, 1, 2>(source.span())));
+    }
+
+    {
+        Vector<UChar> source;
+        for (unsigned i = 0; i < 15; ++i)
+            source.append(i);
+        EXPECT_TRUE((charactersContain<UChar, 0>(source.span())));
+        EXPECT_TRUE((charactersContain<UChar, 1>(source.span())));
+        EXPECT_TRUE((charactersContain<UChar, 2>(source.span())));
+        EXPECT_TRUE((charactersContain<UChar, 2, 3>(source.span())));
+        EXPECT_TRUE((charactersContain<UChar, 16, 14>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 16>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 16, 15>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 16, 15, 17>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 16, 15, 17, 18>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0x81>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0x81, 0x82>(source.span())));
+    }
+
+    {
+        Vector<UChar> source;
+        for (unsigned i = 0; i < 250; ++i) {
+            if (i & 0x1)
+                source.append(i);
+        }
+        EXPECT_FALSE((charactersContain<UChar, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0xff>(source.span())));
+        EXPECT_TRUE((charactersContain<UChar, 0x81>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 250>(source.span())));
+        EXPECT_TRUE((charactersContain<UChar, 249>(source.span())));
+        EXPECT_TRUE((charactersContain<UChar, 0, 249>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0x101>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0x1001>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0x1001, 0x1001>(source.span())));
+    }
+
+    {
+        Vector<UChar> source;
+        for (unsigned i = 0; i < 250; ++i) {
+            if (i & 0x1)
+                source.append(i + 0x1000);
+        }
+        EXPECT_FALSE((charactersContain<UChar, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0xff>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0x81>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 250>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 249>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0x101>(source.span())));
+        EXPECT_TRUE((charactersContain<UChar, 0x1001>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0x1000>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0x1100>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0x1000 + 256>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0x1000 + 250>(source.span())));
+        EXPECT_TRUE((charactersContain<UChar, 0x1000 + 249>(source.span())));
+        EXPECT_TRUE((charactersContain<UChar, 0x1000 + 249, 0>(source.span())));
+        EXPECT_FALSE((charactersContain<UChar, 0x1000 + 250, 0>(source.span())));
+    }
+}
+
 } // namespace


### PR DESCRIPTION
#### 4a75c60f3cc10a3dc100d40c8f017c1247a886cb
<pre>
Add SIMD containsHTMLLineBreak
<a href="https://bugs.webkit.org/show_bug.cgi?id=271878">https://bugs.webkit.org/show_bug.cgi?id=271878</a>
<a href="https://rdar.apple.com/125595924">rdar://125595924</a>

Reviewed by Mark Lam.

This patch adds WTF::charactersContain SIMD function which scans entire string to check if one of character is included.
This function is aligned to charactersAreAllASCII. The intention of this new function is assuming that the given characters rarely
include specified characters. So this function super quickly scans entire string and returning the answer with SIMD.

* Source/WTF/wtf/text/StringCommon.h:
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::limitLength):
(WebCore::TextFieldInputType::sanitizeValue const):
* Source/WebCore/html/parser/HTMLParserIdioms.h:
(WebCore::containsHTMLLineBreak):
* Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp:
(TestWebKitAPI::TEST(WTF_StringCommon, CharactersContain8)):
(TestWebKitAPI::TEST(WTF_StringCommon, CharactersContain16)):

Canonical link: <a href="https://commits.webkit.org/276842@main">https://commits.webkit.org/276842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cbb0583b2269f7b632e5e5688600224ec92493b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48524 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41890 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37527 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18702 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40649 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3897 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39085 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50306 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45326 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20847 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17345 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44668 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22149 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43547 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22508 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52478 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6394 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21840 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10726 "Passed tests") | 
<!--EWS-Status-Bubble-End-->