### PR TITLE
[Skia] Handle stroked text

### DIFF
--- a/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
@@ -52,12 +52,21 @@ void FontCascade::drawGlyphs(GraphicsContext& graphicsContext, const Font& font,
     auto blob = builder.make();
     auto* canvas = graphicsContext.platformContext();
     auto* skiaGraphicsContext = static_cast<GraphicsContextSkia*>(&graphicsContext);
-    SkPaint paint = skiaGraphicsContext->createFillPaint();
-    paint.setAntiAlias(font.allowsAntialiasing());
-    paint.setImageFilter(skiaGraphicsContext->createDropShadowFilterIfNeeded(GraphicsContextSkia::ShadowStyle::Outset));
-    paint.setColor(SkColor(skiaGraphicsContext->fillColor().colorWithAlphaMultipliedBy(skiaGraphicsContext->alpha())));
 
-    canvas->drawTextBlob(blob, SkFloatToScalar(position.x()), SkFloatToScalar(position.y()), paint);
+    if (graphicsContext.textDrawingMode().contains(TextDrawingMode::Fill)) {
+        SkPaint paint = skiaGraphicsContext->createFillPaint();
+        paint.setAntiAlias(font.allowsAntialiasing());
+        paint.setImageFilter(skiaGraphicsContext->createDropShadowFilterIfNeeded(GraphicsContextSkia::ShadowStyle::Outset));
+        skiaGraphicsContext->setupFillSource(paint);
+        canvas->drawTextBlob(blob, SkFloatToScalar(position.x()), SkFloatToScalar(position.y()), paint);
+    }
+
+    if (graphicsContext.textDrawingMode().contains(TextDrawingMode::Stroke)) {
+        SkPaint paint = skiaGraphicsContext->createStrokePaint();
+        paint.setAntiAlias(font.allowsAntialiasing());
+        skiaGraphicsContext->setupStrokeSource(paint);
+        canvas->drawTextBlob(blob, SkFloatToScalar(position.x()), SkFloatToScalar(position.y()), paint);
+    }
 }
 
 bool FontCascade::canReturnFallbackFontsForComplexText()

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -102,11 +102,11 @@ public:
     SkPaint createFillPaint() const;
     SkPaint createStrokePaint() const;
 
-private:
-    bool makeGLContextCurrentIfNeeded() const;
-
     void setupFillSource(SkPaint&) const;
     void setupStrokeSource(SkPaint&) const;
+
+private:
+    bool makeGLContextCurrentIfNeeded() const;
 
     class SkiaState {
     public:


### PR DESCRIPTION
#### e2af77163b73e9f02164663cf4c65aa24ed7e813
<pre>
[Skia] Handle stroked text
<a href="https://bugs.webkit.org/show_bug.cgi?id=271883">https://bugs.webkit.org/show_bug.cgi?id=271883</a>

Reviewed by Carlos Garcia Campos.

* Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp:
(WebCore::FontCascade::drawGlyphs):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:

Canonical link: <a href="https://commits.webkit.org/277051@main">https://commits.webkit.org/277051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2509bf6729d2f5803fb67939f2b103c7af2bd72

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25548 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49081 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42447 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37874 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40017 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19115 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41118 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4451 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42730 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50910 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45110 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22702 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44040 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23091 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6499 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->