### PR TITLE
[IPC] Remove EnumTraits<WebExtensionDataType>

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionDataType.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionDataType.h
@@ -57,14 +57,6 @@ namespace WTF {
 
 template<> struct DefaultHash<WebKit::WebExtensionDataType> : IntHash<WebKit::WebExtensionDataType> { };
 template<> struct HashTraits<WebKit::WebExtensionDataType> : StrongEnumHashTraits<WebKit::WebExtensionDataType> { };
-template<> struct EnumTraits<WebKit::WebExtensionDataType> {
-    using values = EnumValues<
-        WebKit::WebExtensionDataType,
-        WebKit::WebExtensionDataType::Local,
-        WebKit::WebExtensionDataType::Session,
-        WebKit::WebExtensionDataType::Sync
-    >;
-};
 
 } // namespace WTF
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionStorage.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionStorage.serialization.in
@@ -29,7 +29,7 @@ enum class WebKit::WebExtensionStorageAccessLevel : uint8_t {
     TrustedAndUntrustedContexts,
 }
 
-[OptionSet] enum class WebKit::WebExtensionDataType : uint8_t {
+enum class WebKit::WebExtensionDataType : uint8_t {
     Local,
     Session,
     Sync,


### PR DESCRIPTION
#### 9a0c584ccaa2b3b7694bc4b97dfd4afb610a4bb6
<pre>
[IPC] Remove EnumTraits&lt;WebExtensionDataType&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=271887">https://bugs.webkit.org/show_bug.cgi?id=271887</a>

Reviewed by Timothy Hatcher.

Delete the EnumTraits in favor of the serialization format, already implemented
in 274603@main. This patch also removes the [OptionSet] attribute as it is not needed.

* Source/WebKit/Shared/Extensions/WebExtensionDataType.h:
* Source/WebKit/Shared/Extensions/WebExtensionStorage.serialization.in:

Canonical link: <a href="https://commits.webkit.org/276879@main">https://commits.webkit.org/276879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ad4f0aeaf07da33c10a515bae0446ea23706def

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/24962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48505 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41871 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37512 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39533 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18687 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19434 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3878 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42135 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/40977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50272 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44640 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22130 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43516 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10198 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->