### PR TITLE
[iOS] 3 fast/viewport/ios/viewport-fit-*.html layout tests constantly failing.

### DIFF
--- a/LayoutTests/fast/viewport/ios/viewport-fit-auto-expected.txt
+++ b/LayoutTests/fast/viewport/ios/viewport-fit-auto-expected.txt
@@ -1,8 +1,8 @@
 Viewport: initial-scale=1, viewport-fit=auto
 
-Window Size: 260 x 538
+Window Size: 330 x 787
 
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"-40.00000","top":"-10.00000","width":"320.00000","height":"548.00000"}
+visibleRect	{"left":"-40.00000","top":"-10.00000","width":"390.00000","height":"797.00000"}

--- a/LayoutTests/fast/viewport/ios/viewport-fit-auto.html
+++ b/LayoutTests/fast/viewport/ios/viewport-fit-auto.html
@@ -10,7 +10,7 @@
             return `
             (function() {
                 uiController.setSafeAreaInsets(10, 20, 30, 40);
-                uiController.doAfterVisibleContentRectUpdate(function () {
+                uiController.doAfterNextVisibleContentRectAndStablePresentationUpdate(function () {
                     uiController.uiScriptComplete();
                 })
             })();`

--- a/LayoutTests/fast/viewport/ios/viewport-fit-contain-expected.txt
+++ b/LayoutTests/fast/viewport/ios/viewport-fit-contain-expected.txt
@@ -1,8 +1,8 @@
 Viewport: initial-scale=1, viewport-fit=contain
 
-Window Size: 260 x 538
+Window Size: 330 x 787
 
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"-40.00000","top":"-10.00000","width":"320.00000","height":"548.00000"}
+visibleRect	{"left":"-40.00000","top":"-10.00000","width":"390.00000","height":"797.00000"}

--- a/LayoutTests/fast/viewport/ios/viewport-fit-contain.html
+++ b/LayoutTests/fast/viewport/ios/viewport-fit-contain.html
@@ -10,7 +10,7 @@
             return `
             (function() {
                 uiController.setSafeAreaInsets(10, 20, 30, 40);
-                uiController.doAfterVisibleContentRectUpdate(function () {
+                uiController.doAfterNextVisibleContentRectAndStablePresentationUpdate(function () {
                     uiController.uiScriptComplete();
                 })
             })();`

--- a/LayoutTests/fast/viewport/ios/viewport-fit-cover-expected.txt
+++ b/LayoutTests/fast/viewport/ios/viewport-fit-cover-expected.txt
@@ -1,8 +1,8 @@
 Viewport: initial-scale=1, viewport-fit=cover
 
-Window Size: 320 x 548
+Window Size: 390 x 797
 
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"320.00000","height":"548.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"390.00000","height":"797.00000"}

--- a/LayoutTests/fast/viewport/ios/viewport-fit-cover.html
+++ b/LayoutTests/fast/viewport/ios/viewport-fit-cover.html
@@ -10,7 +10,7 @@
             return `
             (function() {
                 uiController.setSafeAreaInsets(10, 20, 30, 40);
-                uiController.doAfterVisibleContentRectUpdate(function () {
+                uiController.doAfterNextVisibleContentRectAndStablePresentationUpdate(function () {
                     uiController.uiScriptComplete();
                 })
             })();`

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -1369,11 +1369,6 @@ http/wpt/crypto/rsa-pss-crash.any.worker.html [ Pass ]
 # Depend on iOS 11 API.
 fast/css/variables/env/ios [ Pass ]
 
-# webkit.org/b/271778 (3 fast/viewport/ios/viewport-fit-*.html layout tests constantly failing.)
-fast/viewport/ios/viewport-fit-contain.html [ Failure ]
-fast/viewport/ios/viewport-fit-cover.html [ Failure ]
-fast/viewport/ios/viewport-fit-auto.html [ Failure ]
-
 ###
 # Known failures
 ##

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -92,6 +92,8 @@
 
 + (void)_resetPresentLockdownModeMessage;
 
+- (void)_doAfterNextVisibleContentRectAndStablePresentationUpdate:(void (^)(void))updateBlock;
+
 @end
 
 #endif // TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -489,6 +489,13 @@ static void dumpUIView(TextStream& ts, UIView *view)
 #endif
 }
 
+- (void)_doAfterNextVisibleContentRectAndStablePresentationUpdate:(void (^)(void))updateBlock
+{
+    [self _doAfterNextVisibleContentRectUpdate:makeBlockPtr([strongSelf = retainPtr(self), updateBlock = makeBlockPtr(updateBlock)] {
+        [strongSelf _doAfterNextStablePresentationUpdate:updateBlock.get()];
+    }).get()];
+}
+
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -56,6 +56,7 @@ interface UIScriptController {
     undefined doAfterNextStablePresentationUpdate(object callback);
     undefined ensurePositionInformationIsUpToDateAt(long x, long y, object callback);
     undefined doAfterVisibleContentRectUpdate(object callback);
+    undefined doAfterNextVisibleContentRectAndStablePresentationUpdate(object callback);
 
     undefined doAfterDoubleTapDelay(object callback);
 

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -83,6 +83,7 @@ public:
     virtual void doAfterNextStablePresentationUpdate(JSValueRef callback) { doAfterPresentationUpdate(callback); }
     virtual void ensurePositionInformationIsUpToDateAt(long, long, JSValueRef callback) { doAsyncTask(callback); }
     virtual void doAfterVisibleContentRectUpdate(JSValueRef callback) { doAsyncTask(callback); }
+    virtual void doAfterNextVisibleContentRectAndStablePresentationUpdate(JSValueRef callback) { doAsyncTask(callback); }
 
     virtual void doAfterDoubleTapDelay(JSValueRef callback) { doAsyncTask(callback); }
 

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -56,6 +56,7 @@ private:
     void doAfterNextStablePresentationUpdate(JSValueRef) override;
     void ensurePositionInformationIsUpToDateAt(long x, long y, JSValueRef) override;
     void doAfterVisibleContentRectUpdate(JSValueRef) override;
+    void doAfterNextVisibleContentRectAndStablePresentationUpdate(JSValueRef) override;
     void doAfterDoubleTapDelay(JSValueRef) override;
     void zoomToScale(double scale, JSValueRef) override;
     void retrieveSpeakSelectionContent(JSValueRef) override;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -221,6 +221,16 @@ void UIScriptControllerIOS::doAfterVisibleContentRectUpdate(JSValueRef callback)
     }).get()];
 }
 
+void UIScriptControllerIOS::doAfterNextVisibleContentRectAndStablePresentationUpdate(JSValueRef callback)
+{
+    unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
+    [webView() _doAfterNextVisibleContentRectAndStablePresentationUpdate:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
+        if (!m_context)
+            return;
+        m_context->asyncTaskComplete(callbackID);
+    }).get()];
+}
+
 void UIScriptControllerIOS::zoomToScale(double scale, JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);


### PR DESCRIPTION
#### dfe516cf9002fa5b9936644df7af3ff9f8e7c217
<pre>
[iOS] 3 fast/viewport/ios/viewport-fit-*.html layout tests constantly failing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=271778">https://bugs.webkit.org/show_bug.cgi?id=271778</a>
<a href="https://rdar.apple.com/125502337">rdar://125502337</a>

Reviewed by Wenson Hsieh.

This patch addresses the failing fast/viewport/ios/viewport-fit-*.html
layout tests in two distinct ways:

1. The test expectations around the screen dimensions were updated to
   reflect the fact that layout tests now run in an iPhone 12 simulator,
   and not an iPhone SE simulator, which the stale expectations
   correspond to.

2. The tests sometimes flakily fail because some overriden safe area
   inset values are not reflected in the screen dimensions queried
   post visible rect update. This is fixed by delegating that same test
   query to after a visible rect update and the next stable presentation
   update, which required hooking up some new functionality in WKWebView
   testing API, as well as UIScriptController.

* LayoutTests/fast/viewport/ios/viewport-fit-auto-expected.txt:
* LayoutTests/fast/viewport/ios/viewport-fit-auto.html:
* LayoutTests/fast/viewport/ios/viewport-fit-contain-expected.txt:
* LayoutTests/fast/viewport/ios/viewport-fit-contain.html:
* LayoutTests/fast/viewport/ios/viewport-fit-cover-expected.txt:
* LayoutTests/fast/viewport/ios/viewport-fit-cover.html:

* LayoutTests/platform/ios/TestExpectations:
Remove the failing annotations for the tests we&apos;re addressing.

* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _doAfterNextVisibleContentRectAndStablePresentationUpdate:]):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::doAfterNextVisibleContentRectAndStablePresentationUpdate):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::doAfterNextVisibleContentRectAndStablePresentationUpdate):
(WTR::UIScriptControllerIOS::zoomToScale):
(WTR::setModifierFlagsForUIPhysicalKeyboardEvent): Deleted.

Canonical link: <a href="https://commits.webkit.org/276847@main">https://commits.webkit.org/276847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46d9f6666856a32b864ccdd0322ab950df46db9d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48543 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48178 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37538 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18713 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40656 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3916 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42171 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50313 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17363 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44667 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43546 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10181 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21859 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->