### PR TITLE
Revise sandbox to allow necessary sysctl calls

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -221,7 +221,9 @@
         "kern.osproductversion"
         "kern.osrelease"
         "kern.ostype"
+        "kern.osversion"
         "kern.version"
+        "kern.willshutdown"
         "vm.malloc_ranges") ;; <rdar://problem/105161083>
     (sysctl-name-prefix "hw.optional.") ;; <rdar://problem/71462790>
     (sysctl-name-prefix "hw.perflevel") ;; <rdar://problem/76783596>
@@ -230,6 +232,8 @@
 (deny sysctl-read (with no-report)
     (sysctl-name
         "security.mac.amfi.qa_root_certs_allowed"
+        "sysctl.proc_translated"
+        "vm.page_wire_count"
         "vm.task_no_footprint_for_debug"))
 
 (deny iokit-get-properties)

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -304,9 +304,13 @@
         "kern.osversion" ;; Needed by WebKit and ASL logging.
         "kern.tcsm_available" ;; Needed for IndexedDB support.
         "kern.tcsm_enable"
+        "kern.willshutdown"
         "vm.malloc_ranges") ;; <rdar://problem/105161083>
     (sysctl-name-prefix "kern.proc.pid.")
     (sysctl-name-prefix "net.routetable"))
+
+(deny sysctl-read (with no-report)
+    (sysctl-name "sysctl.proc_translated"))
 
 (allow sysctl-write
     (sysctl-name

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -451,6 +451,7 @@
         "kern.osversion"
         "kern.safeboot"
         "kern.version"
+        "kern.willshutdown" ;; Silence after <rdar://125745970> is resolved.
         "machdep.cpu.brand_string"
         "security.mac.sandbox.sentinel"
         "sysctl.name2oid"
@@ -463,7 +464,9 @@
 )
 
 (deny sysctl-read (with no-report)
-    (sysctl-name "vm.task_no_footprint_for_debug"))
+    (sysctl-name
+        "sysctl.proc_translated"
+        "vm.task_no_footprint_for_debug"))
 
 #if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (require-not (webcontent-process-launched))

--- a/Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in
+++ b/Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in
@@ -143,16 +143,20 @@
         "kern.osversion"
         "kern.safeboot"
         "kern.version"
-        "machdep.cpu.brand_string"
-        "security.mac.sandbox.sentinel"
         "kern.tcsm_enable"
         "kern.tcsm_available"
+        "kern.willshutdown"
+        "machdep.cpu.brand_string"
+        "security.mac.sandbox.sentinel"
         "vm.footprint_suspend"
         "vm.malloc_ranges") ;; <rdar://problem/105161083>
     (sysctl-name-prefix "net.routetable")
     (sysctl-name-prefix "hw.optional.") ;; <rdar://problem/71462790>
     (sysctl-name-prefix "hw.perflevel") ;; <rdar://problem/76783596>
 )
+
+(deny sysctl-read (with no-report)
+    (sysctl-name "sysctl.proc_translated"))
 
 (allow sysctl-write
     (sysctl-name

--- a/Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.relocatable.mac.sb.in
+++ b/Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.relocatable.mac.sb.in
@@ -142,17 +142,21 @@
         "kern.osvariant_status"
         "kern.osversion"
         "kern.safeboot"
-        "kern.version"
-        "machdep.cpu.brand_string"
-        "security.mac.sandbox.sentinel"
         "kern.tcsm_enable"
         "kern.tcsm_available"
+        "kern.version"
+        "kern.willshutdown"
+        "machdep.cpu.brand_string"
+        "security.mac.sandbox.sentinel"
         "vm.footprint_suspend"
         "vm.malloc_ranges") ;; <rdar://problem/105161083>
     (sysctl-name-prefix "net.routetable")
     (sysctl-name-prefix "hw.optional.") ;; <rdar://problem/71462790>
     (sysctl-name-prefix "hw.perflevel") ;; <rdar://problem/76783596>
 )
+
+(deny sysctl-read (with no-report)
+    (sysctl-name "sysctl.proc_translated"))
 
 (allow sysctl-write
     (sysctl-name


### PR DESCRIPTION
#### b64091ecce1bc486b4621fcbcdfe4c047d9093d8
<pre>
Revise sandbox to allow necessary sysctl calls
<a href="https://rdar.apple.com/107428604">rdar://107428604</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=271899">https://bugs.webkit.org/show_bug.cgi?id=271899</a>

Reviewed by Per Arne Vollan.

Telemetry has revealed a sysctl-read call that is needed in normal use:

    kern.willshutdown

We can also silence a few sysctl-read calls that are only needed for use
cases where WebKit does not run:

    sysctl.proc_translated
    vm.page_wire_count

We should add them to the sandbox to avoid spurious logging.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:
* Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in:
* Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.relocatable.mac.sb.in:

Canonical link: <a href="https://commits.webkit.org/276953@main">https://commits.webkit.org/276953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8aff16e35d2ecde74bebb6427d35b42dd3161e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48838 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42208 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37724 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39817 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18930 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19760 "Found unexpected failure with change (failure)") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4211 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42463 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50634 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17656 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44898 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22463 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43806 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10241 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22822 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->