### PR TITLE
[PDF] Clean up some scales and #ifdefs in PDFPlugin code

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -116,8 +116,8 @@ public:
     WebCore::IntPoint convertFromRootViewToPDFView(const WebCore::IntPoint&) const;
     WebCore::FloatRect convertFromPDFViewToScreen(const WebCore::FloatRect&) const;
 
-    CGFloat scaleFactor() const override;
-    float contentScaleFactor() const final;
+    double scaleFactor() const override;
+    double contentScaleFactor() const final;
     CGSize contentSizeRespectingZoom() const;
 
 private:

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1260,7 +1260,7 @@ void PDFPlugin::showDefinitionForAttributedString(NSAttributedString *string, CG
     
     NSRect rangeRect;
     rangeRect.origin = NSMakePoint(point.x, point.y);
-    CGFloat scaleFactor = PDFPlugin::scaleFactor();
+    auto scaleFactor = PDFPlugin::scaleFactor();
 
     rangeRect.size.height = string.size.height * scaleFactor;
     rangeRect.size.width = string.size.width * scaleFactor;
@@ -1536,12 +1536,12 @@ CGSize PDFPlugin::contentSizeRespectingZoom() const
     return [m_pdfLayerController contentSizeRespectingZoom];
 }
 
-CGFloat PDFPlugin::scaleFactor() const
+double PDFPlugin::scaleFactor() const
 {
     return [m_pdfLayerController contentScaleFactor];
 }
 
-float PDFPlugin::contentScaleFactor() const
+double PDFPlugin::contentScaleFactor() const
 {
     return scaleFactor();
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(LEGACY_PDFKIT_PLUGIN)
+#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
 
 #include <WebCore/EventListener.h>
 #include <wtf/RefCounted.h>
@@ -109,4 +109,4 @@ private:
 
 } // namespace WebKit
 
-#endif // ENABLE(LEGACY_PDFKIT_PLUGIN)
+#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
@@ -26,14 +26,15 @@
 #import "config.h"
 #import "PDFPluginAnnotation.h"
 
-#if ENABLE(LEGACY_PDFKIT_PLUGIN)
+#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
 
 #import "PDFLayerControllerSPI.h"
 #import "PDFPlugin.h"
 #import "PDFPluginBase.h"
 #import "PDFPluginChoiceAnnotation.h"
 #import "PDFPluginTextAnnotation.h"
-#import <Quartz/Quartz.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import <PDFKit/PDFKit.h>
 #import <WebCore/AddEventListenerOptions.h>
 #import <WebCore/CSSPrimitiveValue.h>
 #import <WebCore/CSSPropertyNames.h>
@@ -106,7 +107,7 @@ PDFPluginAnnotation::~PDFPluginAnnotation()
 
 void PDFPluginAnnotation::updateGeometry()
 {
-    NSRect annotationRect = NSRectFromCGRect(m_plugin->pluginBoundsForAnnotation(m_annotation));
+    auto annotationRect = m_plugin->pluginBoundsForAnnotation(m_annotation);
 
     StyledElement* styledElement = static_cast<StyledElement*>(element());
     styledElement->setInlineStyleProperty(CSSPropertyWidth, annotationRect.size.width, CSSUnitType::CSS_PX);
@@ -133,4 +134,4 @@ void PDFPluginAnnotation::PDFPluginAnnotationEventListener::handleEvent(ScriptEx
 
 } // namespace WebKit
 
-#endif // ENABLE(LEGACY_PDFKIT_PLUGIN)
+#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -91,6 +91,8 @@ class PDFPluginBase : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PDF
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(PDFPluginBase);
     friend class PDFIncrementalLoader;
+    friend class PDFPluginChoiceAnnotation;
+    friend class PDFPluginTextAnnotation;
 public:
     static WebCore::PluginInfo pluginInfo();
 
@@ -120,8 +122,8 @@ public:
     virtual RefPtr<WebCore::ShareableBitmap> snapshot() { return nullptr; }
     virtual void paint(WebCore::GraphicsContext&, const WebCore::IntRect&) { }
 
-    virtual CGFloat scaleFactor() const = 0;
-    virtual float contentScaleFactor() const = 0;
+    virtual double scaleFactor() const = 0;
+    virtual void setPageScaleFactor(double, std::optional<WebCore::IntPoint> origin) = 0;
 
     virtual CGFloat minScaleFactor() const { return 0.25; }
     virtual CGFloat maxScaleFactor() const { return 5; }
@@ -138,7 +140,6 @@ public:
     bool handlesPageScaleFactor() const;
     virtual void didBeginMagnificationGesture() { }
     virtual void didEndMagnificationGesture() { }
-    virtual void setPageScaleFactor(double, std::optional<WebCore::IntPoint> origin) = 0;
 
     void updateControlTints(WebCore::GraphicsContext&);
 
@@ -254,6 +255,9 @@ public:
 #endif
 
     uint64_t streamedBytes() const;
+
+protected:
+    virtual double contentScaleFactor() const = 0;
 
 private:
     bool documentFinishedLoading() const { return m_documentFinishedLoading; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1088,7 +1088,7 @@ DictionaryPopupInfo PDFPluginBase::dictionaryPopupInfoForSelection(PDFSelection 
     NSAttributedString *nsAttributedString = selection.attributedString;
     RetainPtr scaledNSAttributedString = adoptNS([[NSMutableAttributedString alloc] initWithString:[nsAttributedString string]]);
     NSFontManager *fontManager = [NSFontManager sharedFontManager];
-    CGFloat scaleFactor = contentScaleFactor();
+    auto scaleFactor = contentScaleFactor();
 
     [nsAttributedString enumerateAttributesInRange:NSMakeRange(0, [nsAttributedString length]) options:0 usingBlock:^(NSDictionary *attributes, NSRange range, BOOL *stop) {
         RetainPtr<NSMutableDictionary> scaledAttributes = adoptNS([attributes mutableCopy]);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(LEGACY_PDFKIT_PLUGIN)
+#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
 
 #include "PDFPluginAnnotation.h"
 
@@ -59,4 +59,4 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 } // namespace WebKit
 
-#endif // ENABLE(LEGACY_PDFKIT_PLUGIN)
+#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
@@ -23,10 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if ENABLE(LEGACY_PDFKIT_PLUGIN)
-
 #import "config.h"
 #import "PDFPluginChoiceAnnotation.h"
+
+#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
 
 #import <WebCore/CSSPrimitiveValue.h>
 #import <WebCore/CSSPropertyNames.h>
@@ -94,4 +94,4 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 } // namespace WebKit
 
-#endif // ENABLE(LEGACY_PDFKIT_PLUGIN)
+#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.h
@@ -23,10 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef PDFPluginPasswordField_h
-#define PDFPluginPasswordField_h
+#pragma once
 
-#if ENABLE(LEGACY_PDFKIT_PLUGIN)
+#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
 
 #include "PDFPluginTextAnnotation.h"
 
@@ -54,6 +53,4 @@ private:
 
 } // namespace WebKit
 
-#endif // ENABLE(LEGACY_PDFKIT_PLUGIN)
-
-#endif // PDFPluginTextAnnotation_h
+#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
@@ -26,7 +26,7 @@
 #import "config.h"
 #import "PDFPluginPasswordField.h"
 
-#if ENABLE(LEGACY_PDFKIT_PLUGIN)
+#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
 
 #import "PDFLayerControllerSPI.h"
 #import "PDFPlugin.h"
@@ -84,4 +84,4 @@ void PDFPluginPasswordField::resetField()
     
 } // namespace WebKit
 
-#endif // ENABLE(LEGACY_PDFKIT_PLUGIN)
+#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.h
@@ -23,10 +23,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef PDFPluginTextAnnotation_h
-#define PDFPluginTextAnnotation_h
+#pragma once
 
-#if ENABLE(LEGACY_PDFKIT_PLUGIN)
+#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
 
 #include "PDFPluginAnnotation.h"
 
@@ -69,6 +68,4 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 } // namespace WebKit
 
-#endif // ENABLE(LEGACY_PDFKIT_PLUGIN)
-
-#endif // PDFPluginTextAnnotation_h
+#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
@@ -26,7 +26,7 @@
 #import "config.h"
 #import "PDFPluginTextAnnotation.h"
 
-#if ENABLE(LEGACY_PDFKIT_PLUGIN)
+#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
 
 #import "PDFAnnotationTextWidgetDetails.h"
 #import "PDFLayerControllerSPI.h"
@@ -153,4 +153,4 @@ bool PDFPluginTextAnnotation::handleEvent(Event& event)
 
 } // namespace WebKit
 
-#endif // ENABLE(LEGACY_PDFKIT_PLUGIN)
+#endif // ENABLE(PDF_PLUGIN) && PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -197,9 +197,9 @@ private:
     PDFDataDetectorOverlayController& dataDetectorOverlayController() { return *m_dataDetectorOverlayController; }
 #endif
 
-    float scaleForActualSize() const;
-    float initialScale() const;
-    float scaleForFitToView() const;
+    double scaleForActualSize() const;
+    double initialScale() const;
+    double scaleForFitToView() const;
 
     /*
         Unified PDF Plugin scales, in depth order:
@@ -218,8 +218,8 @@ private:
 
         - "contentScaleFactor": the scale between the plugin and document space (scaleFactor * document layout scale)
     */
-    CGFloat scaleFactor() const override;
-    float contentScaleFactor() const final;
+    double scaleFactor() const override;
+    double contentScaleFactor() const final;
 
     void didBeginMagnificationGesture() override;
     void didEndMagnificationGesture() override;
@@ -502,7 +502,7 @@ private:
 
     WebCore::ScrollingNodeID m_scrollingNodeID;
 
-    float m_scaleFactor { 1 };
+    double m_scaleFactor { 1 };
     bool m_inMagnificationGesture { false };
     std::optional<WebCore::IntPoint> m_magnificationOriginInContentCoordinates;
     std::optional<WebCore::IntPoint> m_magnificationOriginInPluginCoordinates;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -122,9 +122,9 @@
 
 // FIXME: We should rationalize these with the values in ViewGestureController.
 // For now, we'll leave them differing as they do in PDFPlugin.
-static constexpr CGFloat minimumZoomScale = 0.2;
-static constexpr CGFloat maximumZoomScale = 6.0;
-static constexpr CGFloat zoomIncrement = 1.18920;
+static constexpr double minimumZoomScale = 0.2;
+static constexpr double maximumZoomScale = 6.0;
+static constexpr double zoomIncrement = 1.18920;
 
 namespace WebKit {
 using namespace WebCore;
@@ -979,7 +979,7 @@ std::optional<PDFDocumentLayout::PageIndex> UnifiedPDFPlugin::pageIndexWithHover
     return pageIndex;
 }
 
-float UnifiedPDFPlugin::scaleForActualSize() const
+double UnifiedPDFPlugin::scaleForActualSize() const
 {
 #if PLATFORM(MAC)
     if (!m_frame || !m_frame->coreLocalFrame())
@@ -1009,7 +1009,7 @@ float UnifiedPDFPlugin::scaleForActualSize() const
     return 1;
 }
 
-float UnifiedPDFPlugin::scaleForFitToView() const
+double UnifiedPDFPlugin::scaleForFitToView() const
 {
     auto contentsSize = m_documentLayout.scaledContentsSize();
     auto availableSize = FloatSize { availableContentsRect().size() };
@@ -1021,22 +1021,22 @@ float UnifiedPDFPlugin::scaleForFitToView() const
     return aspectRatioFitRect.width() / size().width();
 }
 
-float UnifiedPDFPlugin::initialScale() const
+double UnifiedPDFPlugin::initialScale() const
 {
     auto actualSizeScale = scaleForActualSize();
     auto fitToViewScale = scaleForFitToView();
     auto initialScale = std::max(actualSizeScale, fitToViewScale);
     // Only let actual size scaling scale down, not up.
-    initialScale = std::min(initialScale, 1.0f);
+    initialScale = std::min(initialScale, 1.0);
     return initialScale;
 }
 
-CGFloat UnifiedPDFPlugin::scaleFactor() const
+double UnifiedPDFPlugin::scaleFactor() const
 {
     return m_scaleFactor;
 }
 
-float UnifiedPDFPlugin::contentScaleFactor() const
+double UnifiedPDFPlugin::contentScaleFactor() const
 {
     return m_scaleFactor * m_documentLayout.scale();
 }
@@ -1224,7 +1224,7 @@ FloatSize UnifiedPDFPlugin::centeringOffset() const
         std::floor(std::max<float>(availableSize.height() - documentPresentationSize.height(), 0) / 2)
     };
 
-    offset.scale(1.0f / m_scaleFactor);
+    offset.scale(1 / m_scaleFactor);
     return offset;
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1004,11 +1004,6 @@ WebCore::FloatRect PluginView::rectForSelectionInRootView(PDFSelection *selectio
     return protectedPlugin()->rectForSelectionInRootView(selection);
 }
 
-CGFloat PluginView::contentScaleFactor() const
-{
-    return protectedPlugin()->contentScaleFactor();
-}
-
 bool PluginView::isUsingUISideCompositing() const
 {
     return protectedWebPage()->isUsingUISideCompositing();

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -108,7 +108,6 @@ public:
     bool performImmediateActionHitTestAtLocation(const WebCore::FloatPoint&, WebHitTestResultData&) const;
 
     WebCore::FloatRect rectForSelectionInRootView(PDFSelection *) const;
-    CGFloat contentScaleFactor() const;
     
     bool isUsingUISideCompositing() const;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2416,8 +2416,10 @@ void WebPage::setTextZoomFactor(double zoomFactor)
 double WebPage::pageZoomFactor() const
 {
 #if ENABLE(PDF_PLUGIN)
-    if (auto* pluginView = mainFramePlugIn())
+    if (auto* pluginView = mainFramePlugIn()) {
+        // Note that this maps page *scale* factor to page *zoom* factor.
         return pluginView->pageScaleFactor();
+    }
 #endif
 
     RefPtr frame = m_mainFrame->coreLocalFrame();
@@ -2430,6 +2432,7 @@ void WebPage::setPageZoomFactor(double zoomFactor)
 {
 #if ENABLE(PDF_PLUGIN)
     if (auto* pluginView = mainFramePlugIn()) {
+        // Note that this maps page *zoom* factor to page *scale* factor.
         pluginView->setPageScaleFactor(zoomFactor, std::nullopt);
         return;
     }


### PR DESCRIPTION
#### 7706664bf8e1ca841670d2e6f23e8253d57f3f6e
<pre>
[PDF] Clean up some scales and #ifdefs in PDFPlugin code
<a href="https://bugs.webkit.org/show_bug.cgi?id=271912">https://bugs.webkit.org/show_bug.cgi?id=271912</a>
<a href="https://rdar.apple.com/125630155">rdar://125630155</a>

Reviewed by Tim Horton.

Various minor bits of cleanup in PDFPlugin code:
1. Make all the scales be doubles
2. Make `contentScaleFactor()` internal to PDFPluginBase and subclasses,
   requiring some annotation classes to be friends. Stop exposing it via
   PluginView.
3. Change some ENABLE(LEGACY_PDFKIT_PLUGIN) to ENABLE(PDF_PLUGIN) for classes
   that are still used with UnifiedPDF

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::showDefinitionForAttributedString):
(WebKit::PDFPlugin::scaleFactor const):
(WebKit::PDFPlugin::contentScaleFactor const):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::didEndMagnificationGesture):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::dictionaryPopupInfoForSelection):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::scaleForActualSize const):
(WebKit::UnifiedPDFPlugin::scaleForFitToView const):
(WebKit::UnifiedPDFPlugin::initialScale const):
(WebKit::UnifiedPDFPlugin::scaleFactor const):
(WebKit::UnifiedPDFPlugin::contentScaleFactor const):
(WebKit::UnifiedPDFPlugin::centeringOffset const):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::contentScaleFactor const): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::pageZoomFactor const):
(WebKit::WebPage::setPageZoomFactor):

Canonical link: <a href="https://commits.webkit.org/276855@main">https://commits.webkit.org/276855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/240d0a9b9661a81dba12c97f8fd994b8d7d685ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41937 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37552 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18729 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19496 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3942 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42193 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50340 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17389 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44700 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22194 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43582 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10187 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22553 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21889 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->