### PR TITLE
Make PublicSuffixStore::publicSuffix take URL as parameter

### DIFF
--- a/Source/WebCore/platform/PublicSuffixStore.cpp
+++ b/Source/WebCore/platform/PublicSuffixStore.cpp
@@ -52,21 +52,20 @@ bool PublicSuffixStore::isPublicSuffix(StringView domain) const
     return platformIsPublicSuffix(domain);
 }
 
-String PublicSuffixStore::publicSuffix(const String& host) const
+String PublicSuffixStore::publicSuffix(const URL& url) const
 {
-    // FIXME: if host is a URL, we could drop these checks.
-    if (host.isEmpty() || !host.containsOnlyASCII())
+    if (!url.isValid())
         return { };
 
-    const auto lowercaseHost = host.convertToASCIILowercase();
-    if (URL::hostIsIPAddress(lowercaseHost))
+    auto host = url.host();
+    if (URL::hostIsIPAddress(host))
         return { };
 
     size_t separatorPosition;
     for (unsigned labelStart = 0; (separatorPosition = host.find('.', labelStart)) != notFound; labelStart = separatorPosition + 1) {
-        auto candidate = lowercaseHost.substring(separatorPosition + 1);
+        auto candidate = host.substring(separatorPosition + 1);
         if (isPublicSuffix(candidate))
-            return candidate;
+            return candidate.toString();
     }
 
     return { };

--- a/Source/WebCore/platform/PublicSuffixStore.h
+++ b/Source/WebCore/platform/PublicSuffixStore.h
@@ -38,7 +38,7 @@ public:
 
     // https://url.spec.whatwg.org/#host-public-suffix
     WEBCORE_EXPORT bool isPublicSuffix(StringView domain) const;
-    WEBCORE_EXPORT String publicSuffix(const String& domain) const;
+    WEBCORE_EXPORT String publicSuffix(const URL&) const;
     WEBCORE_EXPORT String topPrivatelyControlledDomain(const String& host) const;
     WEBCORE_EXPORT void clearHostTopPrivatelyControlledDomainCache();
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -292,7 +292,7 @@ void ProvisionalPageProxy::goToBackForwardItem(API::Navigation& navigation, WebB
     URL itemURL { item.url() };
     m_page->maybeInitializeSandboxExtensionHandle(process(), itemURL, item.resourceDirectoryURL(), sandboxExtensionHandle);
 
-    auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(item.url()).host().toString());
+    auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(item.url()));
     GoToBackForwardItemParameters parameters { navigation.navigationID(), item.itemID(), *navigation.backForwardFrameLoadType(), shouldTreatAsContinuingLoad, WTFMove(websitePoliciesData), m_page->lastNavigationWasAppInitiated(), existingNetworkResourceLoadIdentifierToResume, WTFMove(publicSuffix), WTFMove(sandboxExtensionHandle) };
     if (!process().isLaunching() || !itemURL.protocolIsFile())
         send(Messages::WebPage::GoToBackForwardItem(WTFMove(parameters)));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1431,7 +1431,7 @@ RefPtr<API::Navigation> WebPageProxy::launchProcessForReload()
         internals().pageLoadState.setPendingAPIRequest(transaction, { navigation->navigationID(), url });
     }
 
-    auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(m_backForwardList->currentItem()->url()).host().toString());
+    auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(m_backForwardList->currentItem()->url()));
 
     // We allow stale content when reloading a WebProcess that's been killed or crashed.
     send(Messages::WebPage::GoToBackForwardItem({ navigation->navigationID(), m_backForwardList->currentItem()->itemID(), FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, std::nullopt, publicSuffix, { } }));
@@ -1790,7 +1790,7 @@ void WebPageProxy::loadRequestWithNavigationShared(Ref<WebProcessProxy>&& proces
         internals().pageLoadState.setPendingAPIRequest(transaction, { navigation.navigationID(), url.string() });
 
     LoadParameters loadParameters;
-    loadParameters.publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(url.host().toString());
+    loadParameters.publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(url);
     loadParameters.navigationID = navigation.navigationID();
     loadParameters.request = WTFMove(request);
     loadParameters.shouldOpenExternalURLsPolicy = shouldOpenExternalURLsPolicy;
@@ -1876,7 +1876,7 @@ RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, cons
     loadParameters.request = WTFMove(request);
     loadParameters.shouldOpenExternalURLsPolicy = ShouldOpenExternalURLsPolicy::ShouldNotAllow;
     loadParameters.userData = UserData(process().transformObjectsToHandles(userData).get());
-    loadParameters.publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(loadParameters.request.url().host().toString());
+    loadParameters.publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(loadParameters.request.url());
     loadParameters.isRequestFromClientOrUserInput = isAppInitiated;
     const bool checkAssumedReadAccessToResourceURL = false;
     Ref process = m_process;
@@ -2235,7 +2235,7 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListItem
     Ref process = m_process;
     process->markProcessAsRecentlyUsed();
 
-    auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(item.url()).host().toString());
+    auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(item.url()));
     send(Messages::WebPage::GoToBackForwardItem({ navigation->navigationID(), item.itemID(), frameLoadType, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, std::nullopt, WTFMove(publicSuffix), { } }));
     process->startResponsivenessTimer();
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp
@@ -29,6 +29,7 @@
 #include "WTFTestUtilities.h"
 #include <WebCore/PublicSuffixStore.h>
 #include <wtf/MainThread.h>
+#include <wtf/URL.h>
 
 using namespace WebCore;
 
@@ -188,9 +189,10 @@ TEST_F(PublicSuffix, TopPrivatelyControlledDomain)
 #if PLATFORM(COCOA)
 TEST_F(PublicSuffix, PublicSuffixCache)
 {
+    WTF::URL abExampleURL { "http://a.b.example.example"_s };
     auto& publicSuffixStore = PublicSuffixStore::singleton();
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix("example.example"_s));
-    EXPECT_EQ(String("example"_s), publicSuffixStore.publicSuffix("a.b.example.example"_s));
+    EXPECT_EQ(String("example"_s), publicSuffixStore.publicSuffix(abExampleURL));
     // Non-cocoa platforms currently do not use public suffix cache for topPrivatelyControlledDomain().
     EXPECT_EQ(String("example.example"_s), publicSuffixStore.topPrivatelyControlledDomain("a.b.example.example"_s));
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix(""_s));
@@ -200,7 +202,7 @@ TEST_F(PublicSuffix, PublicSuffixCache)
     publicSuffixStore.addPublicSuffix("example.example"_s);
     publicSuffixStore.addPublicSuffix(""_s);
     EXPECT_TRUE(publicSuffixStore.isPublicSuffix("example.example"_s));
-    EXPECT_EQ(String("example.example"_s), publicSuffixStore.publicSuffix("a.b.example.example"_s));
+    EXPECT_EQ(String("example.example"_s), publicSuffixStore.publicSuffix(abExampleURL));
     EXPECT_EQ(String("b.example.example"_s), publicSuffixStore.topPrivatelyControlledDomain("a.b.example.example"_s));
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix(""_s));
 }


### PR DESCRIPTION
#### 86ce5a106de21edc5f49740ccd6b96acd7c887f6
<pre>
Make PublicSuffixStore::publicSuffix take URL as parameter
<a href="https://bugs.webkit.org/show_bug.cgi?id=271911">https://bugs.webkit.org/show_bug.cgi?id=271911</a>
<a href="https://rdar.apple.com/125630180">rdar://125630180</a>

Reviewed by Per Arne Vollan.

We can eliminate unnecessary checks in  PublicSuffixStore::publicSuffix if the parameter is URL, especially as all
existing callers of this function have access to URL.

* Source/WebCore/platform/PublicSuffixStore.cpp:
(WebCore::PublicSuffixStore::publicSuffix const):
* Source/WebCore/platform/PublicSuffixStore.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::goToBackForwardItem):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcessForReload):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::goToBackForwardItem):
* Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/276870@main">https://commits.webkit.org/276870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f050b9eb9a33a53e6b28833dde0272f222391c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45887 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48558 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41925 "Hash 2f050b9e for PR 26626 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37548 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18725 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40678 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3931 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42222 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50329 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20881 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17375 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44682 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22183 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43562 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10193 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22542 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->