### PR TITLE
Stop canonicalizing HTTP header names

### DIFF
--- a/Source/WebCore/platform/network/HTTPHeaderMap.h
+++ b/Source/WebCore/platform/network/HTTPHeaderMap.h
@@ -38,10 +38,11 @@ class HTTPHeaderMap {
 public:
     struct CommonHeader {
         HTTPHeaderName key;
+        String customKey;
         String value;
 
-        CommonHeader isolatedCopy() const & { return { key , value.isolatedCopy() }; }
-        CommonHeader isolatedCopy() && { return { key , WTFMove(value).isolatedCopy() }; }
+        CommonHeader isolatedCopy() const & { return { key, customKey.isolatedCopy(), value.isolatedCopy() }; }
+        CommonHeader isolatedCopy() && { return { key, customKey.isolatedCopy(), WTFMove(value).isolatedCopy() }; }
 
         friend bool operator==(const CommonHeader&, const CommonHeader&) = default;
     };
@@ -56,8 +57,8 @@ public:
         friend bool operator==(const UncommonHeader&, const UncommonHeader&) = default;
     };
 
-    typedef Vector<CommonHeader, 0, CrashOnOverflow, 6> CommonHeadersVector;
-    typedef Vector<UncommonHeader, 0, CrashOnOverflow, 0> UncommonHeadersVector;
+    using CommonHeadersVector = Vector<CommonHeader, 0, CrashOnOverflow, 6>;
+    using UncommonHeadersVector = Vector<UncommonHeader, 0, CrashOnOverflow, 0>;
 
     class HTTPHeaderMapConstIterator {
     public:
@@ -111,7 +112,7 @@ public:
         {
             if (it == m_table.commonHeaders().end())
                 return false;
-            m_keyValue.key = httpHeaderNameString(it->key);
+            m_keyValue.key = it->customKey.isEmpty() ? httpHeaderNameString(it->key) : it->customKey;
             m_keyValue.keyAsHTTPHeaderName = it->key;
             m_keyValue.value = it->value;
             return true;
@@ -173,7 +174,9 @@ public:
 
     WEBCORE_EXPORT String get(HTTPHeaderName) const;
     void set(HTTPHeaderName, const String& value);
+    void set(HTTPHeaderName, const String& customKey, const String& value);
     void add(HTTPHeaderName, const String& value);
+    void add(HTTPHeaderName, const String& customKey, const String& value);
     bool addIfNotPresent(HTTPHeaderName, const String&);
     WEBCORE_EXPORT bool contains(HTTPHeaderName) const;
     WEBCORE_EXPORT bool remove(HTTPHeaderName);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1912,6 +1912,7 @@ struct WebCore::ViewportArguments {
 header: <WebCore/HTTPHeaderMap.h>
 [Nested, CustomHeader] struct WebCore::HTTPHeaderMap::CommonHeader {
     WebCore::HTTPHeaderName key;
+    String customKey;
     String value;
 };
 


### PR DESCRIPTION
#### 42150d883630e4394e7c054e83e6fd2cf345c39a
<pre>
Stop canonicalizing HTTP header names
<a href="https://bugs.webkit.org/show_bug.cgi?id=271917">https://bugs.webkit.org/show_bug.cgi?id=271917</a>
<a href="https://rdar.apple.com/125631913">rdar://125631913</a>

Reviewed by NOBODY (OOPS!).

When a header name is contained on the &quot;common&quot; headers list, then we always
use the canonical capitalization. This is perfectly reasonable behavior if
WebKit is setting the header, but if the header is being set by script, then we
shouldn&apos;t modify the header name.

* Source/WebCore/platform/network/HTTPHeaderMap.cpp:
(WebCore::HTTPHeaderMap::set):
(WebCore::HTTPHeaderMap::add):
(WebCore::HTTPHeaderMap::append):
(WebCore::HTTPHeaderMap::addIfNotPresent):
* Source/WebCore/platform/network/HTTPHeaderMap.h:
(WebCore::HTTPHeaderMap::CommonHeader::isolatedCopy const):
(WebCore::HTTPHeaderMap::CommonHeader::isolatedCopy):
(WebCore::HTTPHeaderMap::HTTPHeaderMapConstIterator::updateKeyValue):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42150d883630e4394e7c054e83e6fd2cf345c39a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48564 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41932 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48199 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22419 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37550 "Failure limit exceed. At least found 19 new test failures: http/tests/cache/disk-cache/disk-cache-204-status-code.html, http/tests/cache/disk-cache/disk-cache-307-status-code.html, http/tests/cache/disk-cache/disk-cache-404-status-code.html, http/tests/cache/disk-cache/disk-cache-disable.html, http/tests/cache/disk-cache/disk-cache-fragments.html, http/tests/cache/disk-cache/disk-cache-last-modified.html, http/tests/cache/disk-cache/disk-cache-media.html, http/tests/cache/disk-cache/disk-cache-range.html, http/tests/cache/disk-cache/disk-cache-redirect.html, http/tests/cache/disk-cache/disk-cache-request-headers.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46471 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22100 "Found 16 new test failures: http/tests/cache/disk-cache/disk-cache-307-status-code.html, http/tests/cache/disk-cache/disk-cache-404-status-code.html, http/tests/cache/disk-cache/disk-cache-disable.html, http/tests/cache/disk-cache/disk-cache-fragments.html, http/tests/cache/disk-cache/disk-cache-last-modified.html, http/tests/cache/disk-cache/disk-cache-media.html, http/tests/cache/disk-cache/disk-cache-range.html, http/tests/cache/disk-cache/disk-cache-revalidation-new-expire-header.html, http/tests/cache/disk-cache/disk-cache-validation-attachment.html, http/tests/cache/disk-cache/disk-cache-validation-back-navigation-policy-high-priority.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18727 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19495 "Found 60 new test failures: imported/w3c/web-platform-tests/beacon/beacon-cors.https.window.html, imported/w3c/web-platform-tests/cors/304.htm, imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-001.html, imported/w3c/web-platform-tests/fetch/api/basic/conditional-get.any.html, imported/w3c/web-platform-tests/fetch/api/basic/conditional-get.any.serviceworker.html, imported/w3c/web-platform-tests/fetch/api/basic/conditional-get.any.sharedworker.html, imported/w3c/web-platform-tests/fetch/api/basic/conditional-get.any.worker.html, imported/w3c/web-platform-tests/fetch/api/request/request-cache-default.any.html, imported/w3c/web-platform-tests/fetch/api/request/request-cache-default.any.serviceworker.html, imported/w3c/web-platform-tests/fetch/api/request/request-cache-default.any.sharedworker.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40684 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3937 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42199 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41035 "Found 60 new test failures: http/tests/cache/disk-cache/disk-cache-307-status-code.html, http/tests/cache/disk-cache/disk-cache-404-status-code.html, http/tests/cache/disk-cache/disk-cache-disable.html, http/tests/cache/disk-cache/disk-cache-fragments.html, http/tests/cache/disk-cache/disk-cache-last-modified.html, http/tests/cache/disk-cache/disk-cache-media.html, http/tests/cache/disk-cache/disk-cache-range.html, http/tests/cache/disk-cache/disk-cache-redirect.html, http/tests/cache/disk-cache/disk-cache-request-headers.html, http/tests/cache/disk-cache/disk-cache-request-max-stale.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50335 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20891 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17380 "Found 60 new test failures: animations/stop-animation-on-suspend.html, compositing/plugins/pdf/pdf-plugin-hang-during-destruction.html, fast/css/aspect-ratio-min-height-replaced.html, fast/images/async-image-multiple-clients-repaint.html, http/tests/cache/disk-cache/disk-cache-307-status-code.html, http/tests/cache/disk-cache/disk-cache-404-status-code.html, http/tests/cache/disk-cache/disk-cache-fragments.html, http/tests/cache/disk-cache/disk-cache-media.html, http/tests/cache/disk-cache/disk-cache-range.html, http/tests/cache/disk-cache/disk-cache-redirect.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44683 "Found 90 new test failures: http/tests/cache-storage/cache-records-persistency.https.html, http/tests/cache/disk-cache/disk-cache-204-status-code.html, http/tests/cache/disk-cache/disk-cache-disable.html, http/tests/cache/disk-cache/disk-cache-last-modified.html, http/tests/cache/disk-cache/disk-cache-media.html, http/tests/cache/disk-cache/disk-cache-range.html, http/tests/cache/disk-cache/disk-cache-redirect.html, http/tests/cache/disk-cache/disk-cache-request-headers.html, http/tests/cache/disk-cache/disk-cache-request-max-stale.html, http/tests/cache/disk-cache/disk-cache-revalidation-new-expire-header.html ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22189 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43563 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22548 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21880 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->