### PR TITLE
Web Inspector: Console code completion doesn't suggest variables unless inspector is re-opened

### DIFF
--- a/LayoutTests/inspector/console/js-completions-expected.txt
+++ b/LayoutTests/inspector/console/js-completions-expected.txt
@@ -1,0 +1,15 @@
+Tests for the JavaScript code completion feature used by the console and other code inputs in various breakpoint editors.
+
+
+== Running test suite: console.jsCompletions
+-- Running test case: console.jsCompletions.variableCompletions
+PASS: Completions should not contain myVariable by default.
+PASS: Completions should not change before cache is cleared.
+PASS: Completions should still not contain myVariable before cache is cleared.
+PASS: Completions should change after cache is cleared.
+PASS: Completions should contain myVariable after it's created by code run in console.
+PASS: Completions should not change before cache is cleared.
+PASS: Completions should still contain myVariable before cache is cleared.
+PASS: Completions should change after cache is cleared.
+PASS: Completions should not contain myVariable after it's deleted by code run in console.
+

--- a/LayoutTests/inspector/console/js-completions.html
+++ b/LayoutTests/inspector/console/js-completions.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("console.jsCompletions");
+
+    suite.addTestCase({
+        name: "console.jsCompletions.variableCompletions",
+        description: "Test that the JavaScript completions for variables and its cache work as expected.",
+        async test() {
+            const generateJSCompletions = () => new Promise((resolve, reject) => {
+                let mockCompletionController = {
+                    mode: null,
+                    updateCompletions: (completions) => {
+                        resolve(completions);
+                    },
+                };
+
+                const defaultCompletions = [];
+                const baseString = "";
+                const prefix = "";
+                const suffix = "";
+                const forced = true;
+                WI.javaScriptRuntimeCompletionProvider.completionControllerCompletionsNeeded(mockCompletionController, defaultCompletions, baseString, prefix, suffix, forced);
+            });
+
+            let completionsBeforeEvaluating = await generateJSCompletions();
+            InspectorTest.expectFalse(completionsBeforeEvaluating.includes("myVariable"), "Completions should not contain myVariable by default.");
+
+            await InspectorTest.evaluateInPage(`myVariable = 42;`);
+            let completionsAfterEvaluatingBeforeClearing = await generateJSCompletions();
+            InspectorTest.expectShallowEqual(completionsAfterEvaluatingBeforeClearing, completionsBeforeEvaluating, "Completions should not change before cache is cleared.");
+            InspectorTest.expectFalse(completionsAfterEvaluatingBeforeClearing.includes("myVariable"), "Completions should still not contain myVariable before cache is cleared.");
+
+            WI.javaScriptRuntimeCompletionProvider.clearCachedPropertyNames();
+            let completionsAfterEvaluatingAndClearing = await generateJSCompletions();
+            InspectorTest.expectNotShallowEqual(completionsAfterEvaluatingAndClearing, completionsAfterEvaluatingBeforeClearing, "Completions should change after cache is cleared.");
+            InspectorTest.expectTrue(completionsAfterEvaluatingAndClearing.includes("myVariable"), "Completions should contain myVariable after it's created by code run in console.");
+
+            await InspectorTest.evaluateInPage(`delete myVariable;`);
+            let completionsAfterDeletingBeforeClearing = await generateJSCompletions();
+            InspectorTest.expectShallowEqual(completionsAfterDeletingBeforeClearing, completionsAfterEvaluatingAndClearing, "Completions should not change before cache is cleared.");
+            InspectorTest.expectTrue(completionsAfterDeletingBeforeClearing.includes("myVariable"), "Completions should still contain myVariable before cache is cleared.");
+
+            WI.javaScriptRuntimeCompletionProvider.clearCachedPropertyNames();
+            let completionsAfterDeletingAndClearing = await generateJSCompletions();
+            InspectorTest.expectNotShallowEqual(completionsAfterDeletingAndClearing, completionsAfterDeletingBeforeClearing, "Completions should change after cache is cleared.");
+            InspectorTest.expectFalse(completionsAfterDeletingAndClearing.includes("myVariable"), "Completions should not contain myVariable after it's deleted by code run in console.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>
+Tests for the JavaScript code completion feature used by the console and other code inputs in various breakpoint editors.
+</p>
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js
@@ -194,6 +194,7 @@ WI.ConsoleManager = class ConsoleManager extends WI.Object
         }
 
         WI.ConsoleCommandResultMessage.clearMaximumSavedResultIndex();
+        WI.javaScriptRuntimeCompletionProvider.clearCachedPropertyNames();
 
         // COMPATIBILITY (iOS 16.4, macOS 13.3): `Console.ClearReason` did not exist.
         if (!reason) {

--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js
@@ -263,6 +263,8 @@ WI.JavaScriptLogViewController = class JavaScriptLogViewController extends WI.Ob
             sourceURLAppender: appendWebInspectorConsoleEvaluationSourceURL,
         };
 
+        WI.javaScriptRuntimeCompletionProvider.clearCachedPropertyNames();
+
         WI.runtimeManager.evaluateInInspectedWindow(text, options, printResult.bind(this));
     }
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
@@ -43,7 +43,7 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
 
         this._ongoingCompletionRequests = 0;
 
-        WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.ActiveCallFrameDidChange, this._clearLastProperties, this);
+        WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.ActiveCallFrameDidChange, this.clearCachedPropertyNames, this);
     }
 
     // Static
@@ -91,7 +91,17 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
         return JavaScriptRuntimeCompletionProvider.__cachedCommandLineAPIKeys;
     }
 
-    // Protected
+    // Public
+
+    clearCachedPropertyNames()
+    {
+        if (this._clearCachedPropertyNamesTimeout) {
+            clearTimeout(this._clearCachedPropertyNamesTimeout);
+            this._clearCachedPropertyNamesTimeout = null;
+        }
+
+        this._lastPropertyNames = null;
+    }
 
     completionControllerCompletionsNeeded(completionController, defaultCompletions, base, prefix, suffix, forced)
     {
@@ -139,8 +149,8 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
         // If the base is the same as the last time, we can reuse the property names we have already gathered.
         // Doing this eliminates delay caused by the async nature of the code below and it only calls getters
         // and functions once instead of repetitively. Sure, there can be difference each time the base is evaluated,
-        // but this optimization gives us more of a win. We clear the cache after 30 seconds or when stepping in the
-        // debugger to make sure we don't use stale properties in most cases.
+        // but this optimization gives us more of a win. We clear the cache when a new command gets executed in the
+        // quick console and at least every 30 seconds, to make sure we don't use stale properties in most cases.
         if (this._lastMode === completionController.mode && this._lastBase === base && this._lastPropertyNames) {
             receivedPropertyNames.call(this, this._lastPropertyNames);
             return;
@@ -160,9 +170,11 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
 
         function updateLastPropertyNames(propertyNames)
         {
-            if (this._clearLastPropertiesTimeout)
-                clearTimeout(this._clearLastPropertiesTimeout);
-            this._clearLastPropertiesTimeout = setTimeout(this._clearLastProperties.bind(this), WI.JavaScriptLogViewController.CachedPropertiesDuration);
+            if (this._clearCachedPropertyNamesTimeout)
+                clearTimeout(this._clearCachedPropertyNamesTimeout);
+            // Clear the cache after sitting idle for some time to pick up any changes to the property list due to JavaScript running in background.
+            // FIXME: <https://webkit.org/b/272100> Cache should be cleared more proactively.
+            this._clearCachedPropertyNamesTimeout = setTimeout(this.clearCachedPropertyNames.bind(this), WI.JavaScriptLogViewController.CachedPropertiesDuration);
 
             this._lastPropertyNames = propertyNames || [];
         }
@@ -332,7 +344,6 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
                     break;
                 }
 
-                // FIXME: Due to caching, sometimes old $n values show up as completion results even though they are not available. We should clear that proactively.
                 for (var i = 1; i <= WI.ConsoleCommandResultMessage.maximumSavedResultIndex; ++i) {
                     propertyNames.push("$" + i);
                     if (savedResultAlias)
@@ -410,17 +421,5 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
 
         if (this._ongoingCompletionRequests <= 0)
             WI.runtimeManager.activeExecutionContext.target.RuntimeAgent.releaseObjectGroup("completion");
-    }
-
-    _clearLastProperties()
-    {
-        if (this._clearLastPropertiesTimeout) {
-            clearTimeout(this._clearLastPropertiesTimeout);
-            delete this._clearLastPropertiesTimeout;
-        }
-
-        // Clear the cache of property names so any changes while stepping or sitting idle get picked up if the same
-        // expression is evaluated again.
-        this._lastPropertyNames = null;
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Test.html
+++ b/Source/WebInspectorUI/UserInterface/Test.html
@@ -260,6 +260,9 @@
     <script src="Proxies/HeapSnapshotWorkerProxy.js"></script>
 
     <script src="Controllers/QueryController.js"></script>
+    <script src="Controllers/CodeMirrorCompletionController.js"></script>
+    <script src="Controllers/JavaScriptLogViewController.js"></script>
+    <script src="Controllers/JavaScriptRuntimeCompletionProvider.js"></script>
 
     <script src="Controllers/AnimationManager.js"></script>
     <script src="Controllers/AuditManager.js"></script>


### PR DESCRIPTION
#### 5c6736f3f9ad8508918c6a2c2ece135498603d9c
<pre>
Web Inspector: Console code completion doesn&apos;t suggest variables unless inspector is re-opened
<a href="https://rdar.apple.com/125035133">rdar://125035133</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=271265">https://bugs.webkit.org/show_bug.cgi?id=271265</a>

Reviewed by Devin Rousso.

In the current JavaScriptRuntimeCompletionProvider, there&apos;s work done
to cache the list of property names present in the runtime. This
property name cache is cleared / forced to be re-fetched either when 30
seconds have passed or when the code typed starts accessing a different
object&apos;s properties (the object to the left of a dot operator). However,
when variables are created by executing a command, the cache is not
updated, resulting in those new variables missing from the suggestions.

This commit simply makes it so that executing a command from the console
also forces clearing the cache, so that new variables, in case created,
are immediately collected as suggestions when typing a new command. The
cache is also cleared when the console clears, so when the page is
reloaded with the console opened, the variable completion still gets
properly reset.

* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js:
(WI.JavaScriptRuntimeCompletionProvider):
(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded):
   - Update the comment on the need of loading the list of property
     names from cache to reflect now there can be additional
     opportunities that the cache should be cleared.
   - Remove the `// Protected` section comment as this function is
     accessed by others.

(WI.JavaScriptRuntimeCompletionProvider):
(WI.JavaScriptRuntimeCompletionProvider.prototype.clearCachedPropertyNames):
(WI.JavaScriptRuntimeCompletionProvider.prototype._clearLastProperties): Deleted
   - Expose the logic of clearing the property name cache so that the
     completion provider&apos;s users can also force a reload of property
     names.

(WI.JavaScriptRuntimeCompletionProvider.prototype.completionControllerCompletionsNeeded.updateLastPropertyNames):
   - Adapt to the cache-clearing logic being exposed to public.

* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptLogViewController.js:
(WI.JavaScriptLogViewController.prototype.consolePromptTextCommitted):
   - Clear cached property names whenever a new command is executed in
     the console, since new commands are what can possibly introduce
     changes to existing variables (additions from `x = ...` or `let x`,
     and deletions from `delete x`).

* Source/WebInspectorUI/UserInterface/Controllers/ConsoleManager.js:
(WI.ConsoleManager.prototype.messagesCleared):
   - Clear cached property names when the console is cleared because the
     page might&apos;ve been reloaded and therefore variables were reset
     as a result.

* Source/WebInspectorUI/UserInterface/Test.html:
* LayoutTests/inspector/console/js-completions.html: Added.
* LayoutTests/inspector/console/js-completions-expected.txt: Added.
   - Add a simple test to demonstrate how `clearCachedPropertyNames`
     is used.

Canonical link: <a href="https://commits.webkit.org/277261@main">https://commits.webkit.org/277261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b0a0b42b1c43fc2f022d555c341a1e680821edd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26331 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49835 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43201 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38410 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47733 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19719 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41786 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5196 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51711 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22177 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18547 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40779 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44712 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10397 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23171 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->