### PR TITLE
Web Inspector: Console and code editor completion does not auto-scroll suggestion into view

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/CompletionSuggestionsView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/CompletionSuggestionsView.js
@@ -175,10 +175,9 @@ WI.CompletionSuggestionsView = class CompletionSuggestionsView extends WI.Object
         if (typeof selectedIndex === "number")
             this._selectedIndex = selectedIndex;
 
-        for (let [index, completion] of completions.entries()) {
+        for (let completion of completions) {
             var itemElement = document.createElement("div");
             itemElement.classList.add("item");
-            itemElement.classList.toggle("selected", index === this._selectedIndex);
 
             if (typeof completion === "string")
                 itemElement.textContent = completion;
@@ -187,6 +186,12 @@ WI.CompletionSuggestionsView = class CompletionSuggestionsView extends WI.Object
 
             this._containerElement.appendChild(itemElement);
             this._delegate?.completionSuggestionsViewCustomizeCompletionElement?.(this, itemElement, completion);
+        }
+
+        let selectedItemElement = this._selectedItemElement;
+        if (selectedItemElement) {
+            selectedItemElement.classList.add("selected");
+            selectedItemElement.scrollIntoViewIfNeeded(false);
         }
     }
 


### PR DESCRIPTION
#### fb425171fec8fd7ecc3a326e6f62aafcbc674974
<pre>
Web Inspector: Console and code editor completion does not auto-scroll suggestion into view
<a href="https://rdar.apple.com/124979790">rdar://124979790</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=271205">https://bugs.webkit.org/show_bug.cgi?id=271205</a>

Reviewed by Devin Rousso.

In the original code, there is logic to scroll a newly-selected item
into view in the `CompletionSuggestionsView.selectedIndex` setter, but
when the list of suggestions is updated with the `update` method, there
is no similar logic to scroll the default selection into view.

* Source/WebInspectorUI/UserInterface/Views/CompletionSuggestionsView.js:
(WI.CompletionSuggestionsView.prototype.update):
   - Make sure to let the to-be-selected element scrollIntoViewIfNeeded.

Canonical link: <a href="https://commits.webkit.org/277034@main">https://commits.webkit.org/277034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16ca898e6066bdc165bc1b6ce941b539e1549cd7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48747 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42116 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37677 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18878 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19725 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40846 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4120 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42424 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50538 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44841 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22372 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43743 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10279 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22731 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->