### PR TITLE
[webkitcorepy] Add "smart" date utilities functions.

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/date_utils.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/date_utils.py
@@ -1,0 +1,64 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import calendar
+import sys
+
+from time import time
+from datetime import datetime, tzinfo
+
+if sys.version_info > (3, 2):
+    from datetime import timezone
+
+    def fromtimestamp(timestamp=0, tz=None):
+        # type: (float, tzinfo|None) -> datetime
+        '''Passthrough to `datetime.fromtimestamp` where compatible with `datetime.timezone` (python >=3.2).'''
+        fn_kwargs = {'tz': tz} if tz is not None and type(tz) is timezone else {}
+        return datetime.fromtimestamp(timestamp, **fn_kwargs)
+
+    def utcfromtimestamp(timestamp=0):
+        # type: (float) -> datetime
+        '''Converts a `utcfromtimestamp` call to use `fromtimestamp` to avoid deprecation warnings.'''
+        return fromtimestamp(timestamp, timezone.utc).replace(tzinfo=None)
+
+else:
+    def fromtimestamp(timestamp=0, *_):
+        # type: (float, Any) -> datetime
+        '''Passthrough to `datetime.fromtimestamp`.'''
+        return datetime.fromtimestamp(timestamp)
+
+    def utcfromtimestamp(timestamp=0):
+        # type: (float) -> datetime
+        '''Passthrough to `datetime.utcfromtimestamp`.'''
+        return datetime.utcfromtimestamp(timestamp)
+
+
+def timestamp(dt):
+    # type: (datetime) -> float
+    '''Converts a `datetime` object to a timestamp.'''
+    return calendar.timegm(dt.timetuple()) + (dt.microsecond / 1000000.0)
+
+
+def utcnow():
+    # type: () -> datetime
+    '''Return the current UTC date and time.'''
+    return utcfromtimestamp(time())

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/date_utils_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/date_utils_unittest.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import time
+import unittest
+
+from datetime import datetime
+from webkitcorepy import date_utils
+
+
+class DateUtils(unittest.TestCase):
+    now = time.time()
+
+    def test_fromtimestamp(self):
+        self.assertEqual(datetime.fromtimestamp(self.now), date_utils.fromtimestamp(self.now))
+
+    def test_utcfromtimestamp(self):
+        self.assertEqual(datetime.utcfromtimestamp(self.now), date_utils.utcfromtimestamp(self.now))
+
+    def test_timestamp(self):
+        self.assertEqual(datetime.fromtimestamp(self.now), date_utils.fromtimestamp(self.now))
+
+    def test_utcnow(self):
+        self.assertAlmostEqual(date_utils.timestamp(datetime.utcnow()), date_utils.timestamp(date_utils.utcnow()), places=-1)

--- a/Tools/Scripts/webkitpy/test/main.py
+++ b/Tools/Scripts/webkitpy/test/main.py
@@ -135,6 +135,7 @@ def main():
         "webkitcorepy.tests.null_context_unittest",
         "webkitcorepy.tests.output_capture_unittest",
         "webkitcorepy.tests.partial_proxy_unittest",
+        "webkitcorepy.tests.date_utils_unittest",
         "webkitcorepy.tests.string_utils_unittest",
         "webkitcorepy.tests.subprocess_utils_unittest",
         "webkitcorepy.tests.task_pool_unittest",


### PR DESCRIPTION
#### 52d53da07b10bcfbc81382fad4849abd3f375280
<pre>
[webkitcorepy] Add &quot;smart&quot; date utilities functions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=271925">https://bugs.webkit.org/show_bug.cgi?id=271925</a>
<a href="https://rdar.apple.com/125642316">rdar://125642316</a>

Reviewed by NOBODY (OOPS!).

`datetime.utcnow()` and `datetime.utcfromtimestamp()` are deprecated as of python 3.12.
WebKit still uses these functions in many places due to a lack of alternative/necessity.

To remedy this (and provide a standardized date/time library moving forward), this PR
adds a new file to webkitcorepy that can &quot;smartly&quot; detect python version and determine
the appropriate functions to use.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/date_utils.py: Added.
    (fromtimestamp): Passthrough to `datetime.fromtimestamp`.
    (utcfromtimestamp): If python 2, uses `datetime.utcfromtimestamp`.
                        If python 3, uses `datetime.fromtimestamp` and changes the timezone.
    (timestamp): Converts a `datetime` object to a float containing seconds since the epoch.
    (utcnow): If python 2, uses `datetime.utcnow`.
            If python 3, uses `datetime.now` and changes the timezone.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/date_utils_unittest.py: Added unit tests for new functions.
* Tools/Scripts/webkitpy/test/main.py: Added unit tests to python 2 allowlist.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52d53da07b10bcfbc81382fad4849abd3f375280

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48606 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41975 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37568 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18748 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/45800 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40715 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3979 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50379 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44707 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/45974 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22231 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43591 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22590 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->