### PR TITLE
Web Inspector: Dark Mode: Increase the contrast in the console tab in @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -351,5 +352,32 @@
     .console-message .go-to-link:hover,
     .console-message .go-to-link:focus {
         color: var(--selected-secondary-text-color-active);
+    }
+
+    @media (prefers-contrast: more) {
+        .console-error-level .console-message-body {
+            color: hsl(10, 100%, 80%);
+        }
+
+        .console-user-command > .console-message-body {
+            color: hsl(209, 100%, 80%);
+        }
+
+        .console-warning-level .console-message-body {
+            color: hsl(53, 80%, 80%);
+        }
+
+        .console-message .repeat-count {
+            background-color: hsl(218, 70%, 80%);
+        }
+
+        .console-saved-variable {
+            color: hsl(0, 0%, 90%);
+        }
+
+        .console-messages {
+            --console-background-color-selected: hsl(233, 30%, 15%);
+            --console-border-color-selected: hsl(224, 30%, 20%);
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/LogContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/LogContentView.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -201,11 +202,12 @@
 
 .console-messages:focus .console-item.selected {
     background-color: hsl(210, 98%, 96%);
-    border-color: hsl(210, 90%, 93%);
+    --console-border-color: hsl(210, 90%, 93%);
+    border-color: var(--console-border-color);
 }
 
 .console-messages:focus .console-item.selected + .console-item {
-    border-top-color: hsl(210, 90%, 93%);
+    border-top-color: var(--console-border-color);
 }
 
 .console-messages:focus .console-item.selected::after {
@@ -362,19 +364,19 @@ body[dir=rtl] .console-group-title::before {
     }
 
     .console-messages {
-        --background-color-selected: hsl(233, 30%, 30%);
-        --border-color-selected: hsl(224, 30%, 35%);
-        --border-color-error: hsla(20, 100%, 50%, 0.12);
-        --border-color-warning: hsla(40, 100%, 50%, 0.12);
+        --console-background-color-selected: hsl(233, 30%, 30%);
+        --console-border-color-selected: hsl(224, 30%, 35%);
+        --console-border-color-error: hsla(20, 100%, 50%, 0.12);
+        --console-border-color-warning: hsla(40, 100%, 50%, 0.12);
     }
 
     .console-messages:focus .console-item.selected {
-        background-color: var(--background-color-selected);
-        border-color: var(--border-color-selected);
+        background-color: var(--console-background-color-selected);
+        border-color: var(--console-border-color-selected);
     }
 
     .console-messages:focus .console-item.selected + .console-item {
-        border-color: var(--border-color-selected);
+        border-color: var(--console-border-color-selected);
     }
 
     .console-session:first-of-type .console-session-header {
@@ -397,20 +399,20 @@ body[dir=rtl] .console-group-title::before {
 
     .console-error-level {
         background-color: var(--error-background-color-secondary);
-        border-color: var(--border-color-error);
+        border-color: var(--console-border-color-error);
     }
 
     .console-error-level:not(.filtered-out, .filtered-out-by-search), .console-error-level:not(.filtered-out, .filtered-out-by-search) + .console-item {
-        border-top-color: var(--border-color-error);
+        border-top-color: var(--console-border-color-error);
     }
 
     .console-warning-level {
         background-color: var(--warning-background-color-secondary);
-        border-color: var(--border-color-warning);
+        border-color: var(--console-border-color-warning);
     }
 
     .console-warning-level:not(.filtered-out, .filtered-out-by-search), .console-warning-level:not(.filtered-out, .filtered-out-by-search) + .console-item {
-        border-top-color: var(--border-color-warning);
+        border-top-color: var(--console-border-color-warning);
     }
     
     .console-group-sourcemap-errors {
@@ -426,5 +428,34 @@ body[dir=rtl] .console-group-title::before {
     .search-in-progress .console-item:not(.filtered-out-by-search) .highlighted.selected {
         color: var(--search-highlight-text-color-active);
         background-color: var(--search-highlight-background-color-active);
+    }
+
+    @media (prefers-contrast: more) {
+        .console-error-level:not(.filtered-out, .filtered-out-by-search),
+        .console-error-level:not(.filtered-out, .filtered-out-by-search) + .console-item {
+            --console-border-top-color: hsla(0, 100%, 90%, 70%);
+            border-top-color: var(--console-border-top-color);
+        }
+
+        .console-item {
+            border-top-color: var(--console-border-top-color) !important;
+        }
+
+        .console-session:first-of-type .console-session-header {
+            --console-text-color: hsl(0, 0%, 90%);
+            color: var(--console-text-color);
+        }
+
+        .console-other-filters-button > .glyph {
+            color: var(--console-text-color);
+        }
+
+        .console-item.selected::after {
+            background: var(--console-text-color);
+        }
+
+        .console-item.selected::before {
+            background: var(--console-text-color);
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -138,4 +139,12 @@
     display: inline-block;
     margin-inline-start: 2px;
     vertical-align: -4px;
+}
+
+@media (prefers-color-scheme: dark) {
+    @media (prefers-contrast: more) {
+        .object-tree {
+            color: var(--text-color);
+        }
+    }
 }


### PR DESCRIPTION
#### 0836f2125bf438ab613a3b2381d92223199dd1c3
<pre>
Web Inspector: Dark Mode: Increase the contrast in the console tab in @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)
<a href="https://bugs.webkit.org/show_bug.cgi?id=271859">https://bugs.webkit.org/show_bug.cgi?id=271859</a>

Reviewed by NOBODY (OOPS!).

Increase the brightness of the error level, the user command, the warning level, and console message in ConsoleMessageView.css.
Increase the brightness of the glyph, the header, and the console.item in LogContentView.css.
Create variables --console-border-top-color and  --console-text-color in LogContentView.css.
Rename variables --background-color-selected, --border-color-selected, --border-color-error, and --border-color-warning to:
--console-background-color-selected, --console-border-color-selected, --console-border-color-error, and --console-border-color-warning in LogContentView.css.
Increase the brightness of the object tree in ObjectTreeView.css.

* Source/WebInspectorUI/UserInterface/Views/ConsoleMessageView.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-error-level .console-message-body):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-user-command &gt; .console-message-body):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-warning-level .console-message-body):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-message .repeat-count):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-saved-variable):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-messages):
* Source/WebInspectorUI/UserInterface/Views/LogContentView.css:
(.console-messages:focus .console-item.selected):
(.console-messages:focus .console-item.selected + .console-item):
(@media (prefers-color-scheme: dark) .console-messages):
(@media (prefers-color-scheme: dark) .console-messages:focus .console-item.selected):
(@media (prefers-color-scheme: dark) .console-messages:focus .console-item.selected + .console-item):
(@media (prefers-color-scheme: dark) .console-error-level):
(@media (prefers-color-scheme: dark) .console-error-level:not(.filtered-out, .filtered-out-by-search), .console-error-level:not(.filtered-out, .filtered-out-by-search) + .console-item):
(@media (prefers-color-scheme: dark) .console-warning-level):
(@media (prefers-color-scheme: dark) .console-warning-level:not(.filtered-out, .filtered-out-by-search), .console-warning-level:not(.filtered-out, .filtered-out-by-search) + .console-item):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-error-level:not(.filtered-out, .filtered-out-by-search),):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-item):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-session:first-of-type .console-session-header):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-other-filters-button &gt; .glyph):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-item.selected::after):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .console-item.selected::before):
* Source/WebInspectorUI/UserInterface/Views/ObjectTreeView.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .object-tree):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0836f2125bf438ab613a3b2381d92223199dd1c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50584 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43956 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24589 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38966 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20266 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42592 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5950 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44249 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43026 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52478 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22945 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46283 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24215 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45326 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25007 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->