### PR TITLE
disable i386 swift module compilation for watch simulator

### DIFF
--- a/Source/WebCore/PAL/Configurations/PAL.xcconfig
+++ b/Source/WebCore/PAL/Configurations/PAL.xcconfig
@@ -110,3 +110,7 @@ EXCLUDED_SOURCE_FILE_NAMES[sdk=watchos10*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=watchsimulator10*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=xros1*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=xrsimulator1*] = ;
+
+// Only for watchsimulator. Other platforms don't trigger Swift module builds for i386.
+EXCLUDED_ARCHS = $(EXCLUDED_ARCHS_$(WK_PLATFORM_NAME));
+EXCLUDED_ARCHS_watchsimulator = i386;


### PR DESCRIPTION
#### ae2a0966fb718e40529940a5afb634e91d84e163
<pre>
disable i386 swift module compilation for watch simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=271926">https://bugs.webkit.org/show_bug.cgi?id=271926</a>
<a href="https://rdar.apple.com/125645416">rdar://125645416</a>

Reviewed by Elliott Williams.

WebKit does not support it and there is no need for PAL module to generate i386
swift modules. PAL don&apos;t expose the swift modules.
Xcode by default will generate swift modules for i386 for watch simulator only.
So this additional setting should disable it.

* Source/WebCore/PAL/Configurations/PAL.xcconfig:

Canonical link: <a href="https://commits.webkit.org/277039@main">https://commits.webkit.org/277039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47846b2597243abcba4bf67e00ce4d0405c9dba2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45948 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48619 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41988 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37574 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39630 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18760 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40726 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3992 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42248 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50395 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44720 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22244 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43607 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10283 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22603 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->