### PR TITLE
[WebGL] remove workaround for multisampled blits to blitFramebuffer

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7445,6 +7445,3 @@ imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html 
 
 # re-import css/css-align WPT failure
 webkit.org/b/271692 imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-break-overflow-020.html [ ImageOnlyFailure ]
-
-# https://bugs.webkit.org/show_bug.cgi?id=271874
-webkit.org/b/271874 webgl/2.0.0/conformance2/rendering/blitframebuffer-test.html [ Skip ]

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -437,8 +437,7 @@ webkit.org/b/251107 webgl/2.0.0/conformance2/rendering/blitframebuffer-filter-sr
 webkit.org/b/251107 webgl/2.0.0/conformance2/rendering/blitframebuffer-multisampled-readbuffer.html [ Pass Failure ]
 webkit.org/b/251107 webgl/2.0.0/conformance2/rendering/blitframebuffer-outside-readbuffer.html [ Pass Failure ]
 webkit.org/b/251107 webgl/2.0.0/conformance2/rendering/blitframebuffer-stencil-only.html [ Pass Failure ]
-# https://bugs.webkit.org/show_bug.cgi?id=271874
-webkit.org/b/251107 webgl/2.0.0/conformance2/rendering/blitframebuffer-test.html [ Skip ]
+webkit.org/b/251107 webgl/2.0.0/conformance2/rendering/blitframebuffer-test.html [ Pass Failure ]
 webkit.org/b/251107 webgl/2.0.0/conformance2/rendering/clear-srgb-color-buffer.html [ Pass Failure ]
 webkit.org/b/251107 webgl/2.0.0/conformance2/rendering/draw-buffers.html [ Pass Failure ]
 webkit.org/b/251107 webgl/2.0.0/conformance2/rendering/element-index-uint.html [ Pass Failure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1274,7 +1274,7 @@ webkit.org/b/251107 webgl/2.0.0/conformance2/extensions/ext-color-buffer-float.h
 webkit.org/b/251107 webgl/2.0.0/conformance2/extensions/ext-color-buffer-half-float.html [ Pass Failure ]
 webkit.org/b/251107 webgl/2.0.0/conformance2/renderbuffers/invalidate-framebuffer.html [ Pass Failure ]
 webkit.org/b/251107 webgl/2.0.0/conformance2/renderbuffers/multisample-with-full-sample-counts.html [ Pass Failure ]
-webkit.org/b/251107 webgl/2.0.0/conformance2/rendering/blitframebuffer-test.html [ Skip ]
+webkit.org/b/251107 webgl/2.0.0/conformance2/rendering/blitframebuffer-test.html [ Pass Failure ]
 webkit.org/b/251107 webgl/2.0.0/conformance2/rendering/rgb-format-support.html [ Pass Failure ]
 webkit.org/b/251107 webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-2d-r32f-red-float.html [ Pass Timeout ]
 webkit.org/b/251107 webgl/2.0.0/conformance2/textures/canvas_sub_rectangle/tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html [ Pass Timeout ]

--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationES.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationES.cpp
@@ -1673,7 +1673,7 @@ bool ValidateBlitFramebufferParameters(const Context *context,
         return false;
     }
 
-    bool sameBounds = (srcX1 - srcX0) == (dstX1 - dstX0) && (srcY1 - srcY0) == (dstY1 - dstY0);
+    bool sameBounds = srcX0 == dstX0 && srcY0 == dstY0 && srcX1 == dstX1 && srcY1 == dstY1;
 
     if (mask & GL_COLOR_BUFFER_BIT)
     {

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -407,7 +407,7 @@ bool WebXROpaqueFramebuffer::setupFramebuffer(GraphicsContextGL& gl, const Platf
     m_leftViewport = calculateViewportShared(PlatformXR::Eye::Left, foveationChange, data.viewports[0], data.viewports[1]);
     m_rightViewport = calculateViewportShared(PlatformXR::Eye::Right, foveationChange, data.viewports[0], data.viewports[1]);
     // Intermediate resolve target
-    if (framebufferResize && needsIntermediateResolve) {
+    if ((!m_resolvedFBO || framebufferResize) && needsIntermediateResolve) {
         allocateAttachments(gl, m_resolveAttachments, 0, size);
 
         ensure(gl, m_resolvedFBO);
@@ -416,8 +416,7 @@ bool WebXROpaqueFramebuffer::setupFramebuffer(GraphicsContextGL& gl, const Platf
         ASSERT(gl.checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
         if (gl.checkFramebufferStatus(GL::FRAMEBUFFER) != GL::FRAMEBUFFER_COMPLETE)
             return false;
-    } else
-        m_resolvedFBO.release(gl);
+    }
 
     // Drawing target
     if (framebufferResize) {


### PR DESCRIPTION
#### 70d8c3cd9ea07ff568521b3ca58b488c681e1c22
<pre>
[WebGL] remove workaround for multisampled blits to blitFramebuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=271874">https://bugs.webkit.org/show_bug.cgi?id=271874</a>
&lt;radar://125593588&gt;

Reviewed by Tim Horton.

Root cause here is we were ping-ponging between the resolve
buffer and the main display buffer for copying from the shared
to layered render targets.

The resolve buffer is not multisample, so that copy was fine.

But the display buffer is multisampled, so we would fail Angle
validation and no blit would occur.

Fix this by not destroying the resolve buffer in setupFramebuffer,
revert the Angle change, and also revert skipping blit-framebuffer tests.

* LayoutTests/TestExpectations:
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/ThirdParty/ANGLE/src/libANGLE/validationES.cpp:
(gl::ValidateBlitFramebufferParameters):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):

Canonical link: <a href="https://commits.webkit.org/276860@main">https://commits.webkit.org/276860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b54cbbaee148194d457e77ab3d7ab6c635bbc04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41984 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37572 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18757 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40723 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/3988 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50391 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44717 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22240 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43603 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10188 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22599 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21934 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->