### PR TITLE
airbnb.com: When trying to select days for checkin checkout, the date widget is empty

### DIFF
--- a/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache-with-pending-task.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-in-page-cache-with-pending-task.html
@@ -2,6 +2,28 @@
 <html>
 <body>
 <script src="../resources/js-test.js"></script>
+<style>
+@-webkit-keyframes bounce {
+    from {
+        -webkit-transform: translate3d(0,0,0);
+    }
+    to {
+        -webkit-transform: translate3d(200px,0,0);
+    }
+}
+
+#animator {
+    position: relative;
+    top: 0px;
+    width: 100px;
+    height: 100px;
+    background-color: blue;
+    -webkit-animation-name: bounce;
+    -webkit-animation-duration: 80ms;
+    -webkit-animation-iteration-count: infinite;
+}
+</style>
+<div id="animator"></div>
 <script>
 
 description('This tests that requestIdleCallback will execute the function even when there is a pending task for a suspended document');

--- a/LayoutTests/requestidlecallback/requestidlecallback-is-called-even-when-event-loop-is-busy-expected.txt
+++ b/LayoutTests/requestidlecallback/requestidlecallback-is-called-even-when-event-loop-is-busy-expected.txt
@@ -1,0 +1,25 @@
+This tests scheduling idle callbacks while there is a constant work in the event loop
+WebKit should eventually invoke all idle callbacks.
+
+idle1
+idle2
+idle3
+idle4
+idle5
+idle6
+idle7
+idle8
+idle9
+idle10
+idle11
+idle12
+idle13
+idle14
+idle15
+idle16
+idle17
+idle18
+idle19
+idle20
+PASS
+

--- a/LayoutTests/requestidlecallback/requestidlecallback-is-called-even-when-event-loop-is-busy.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-is-called-even-when-event-loop-is-busy.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests scheduling idle callbacks while there is a constant work in the event loop<br>
+WebKit should eventually invoke all idle callbacks.</p>
+<pre id="result"></pre>
+<details><summary>hello</summary>world</details>
+<script>
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+let busyWorkCounter = 0;
+function busyWork() {
+    let start = performance.now();
+    while (performance.now() - start < 2);
+    ++busyWorkCounter;
+}
+
+let shouldStopBusyWork = false;
+function scheduleBusyWork() {
+    if (shouldStopBusyWork)
+        return;
+
+    let timer = 0;
+    function doWork() {
+        if (shouldStopBusyWork)
+            return;
+        clearTimeout(timer);
+        document.querySelector('details').toggleAttribute('open');
+        setTimeout(scheduleBusyWork, 0);
+        setTimeout(() => busyWork(), 5);
+        setTimeout(() => busyWork(), 10);
+        busyWork();
+    }
+
+    requestAnimationFrame(doWork);
+    timer = setTimeout(doWork, 18);
+}
+
+scheduleBusyWork();
+
+let idleCounter = 0;
+function scheduleIdleWork(remaining) {
+    if (!remaining)
+        return;
+    requestIdleCallback((deadline) => {
+        ++idleCounter;
+        result.textContent += `idle${idleCounter}\n`;
+        busyWork();
+        if (idleCounter == 20) {
+            result.textContent += 'PASS\n';
+            document.querySelector('details').remove();
+            shouldStopBusyWork = true;
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+    });
+    setTimeout(() => {
+        scheduleIdleWork(remaining - 1);
+    }, 100);
+}
+
+scheduleIdleWork(20);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/requestidlecallback/requestidlecallback-is-called-when-idle-expected.txt
+++ b/LayoutTests/requestidlecallback/requestidlecallback-is-called-when-idle-expected.txt
@@ -1,0 +1,8 @@
+This tests scheduling requestIdleCallback when the browser is idle. WebKit should fire idle callbacks.
+You should see idle1, idle2, and idle3 below:
+
+idle1
+idle2
+idle3
+PASS
+

--- a/LayoutTests/requestidlecallback/requestidlecallback-is-called-when-idle.html
+++ b/LayoutTests/requestidlecallback/requestidlecallback-is-called-when-idle.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests scheduling requestIdleCallback when the browser is idle. WebKit should fire idle callbacks.<br>
+You should see idle1, idle2, and idle3 below:</p>
+<pre id="result"></pre>
+<script>
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+idle1 = requestIdleCallback(() => result.textContent += 'idle1\n');
+setTimeout(() => {
+  idle2 = requestIdleCallback(() => result.textContent += 'idle2\n');
+  setTimeout(() => {
+    idle3 = requestIdleCallback(() => result.textContent += 'idle3\n');
+  }, 1000);
+}, 1000);
+
+setTimeout(() => {
+    cancelIdleCallback(idle1);
+    cancelIdleCallback(idle2);
+    cancelIdleCallback(idle3);
+    result.textContent += (result.textContent.includes('idle3') ? 'PASS' : 'FAIL') + '\n';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, 3000);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7765,6 +7765,11 @@ WindowEventLoop& Document::windowEventLoop()
     return *m_eventLoop;
 }
 
+Ref<WindowEventLoop> Document::protectedWindowEventLoop()
+{
+    return windowEventLoop();
+}
+
 void Document::suspendScheduledTasks(ReasonForSuspension reason)
 {
     if (m_scheduledTasksAreSuspended) {
@@ -8070,8 +8075,6 @@ int Document::requestIdleCallback(Ref<IdleRequestCallback>&& callback, Seconds t
 {
     if (!m_idleCallbackController)
         m_idleCallbackController = makeUnique<IdleCallbackController>(*this);
-    if (RefPtr page = this->page())
-        page->opportunisticTaskScheduler().willQueueIdleCallback();
     return m_idleCallbackController->queueIdleCallback(WTFMove(callback), timeout);
 }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1271,6 +1271,7 @@ public:
     WEBCORE_EXPORT EventLoopTaskGroup& eventLoop() final;
     CheckedRef<EventLoopTaskGroup> checkedEventLoop() { return eventLoop(); }
     WindowEventLoop& windowEventLoop();
+    Ref<WindowEventLoop> protectedWindowEventLoop();
 
     ScriptedAnimationController* scriptedAnimationController() { return m_scriptedAnimationController.get(); }
     void suspendScriptedAnimationControllerCallbacks();

--- a/Source/WebCore/dom/IdleCallbackController.cpp
+++ b/Source/WebCore/dom/IdleCallbackController.cpp
@@ -60,7 +60,8 @@ int IdleCallbackController::queueIdleCallback(Ref<IdleRequestCallback>&& callbac
                 weakThis->invokeIdleCallbackTimeout(handle);
             });
         });
-    }
+    } else if (RefPtr page = m_document ? m_document->page() : nullptr)
+        m_document->protectedWindowEventLoop()->scheduleIdlePeriod(*page);
 
     return handle;
 }

--- a/Source/WebCore/dom/Microtasks.cpp
+++ b/Source/WebCore/dom/Microtasks.cpp
@@ -115,4 +115,12 @@ void MicrotaskQueue::addCheckpointTask(std::unique_ptr<EventLoopTask>&& task)
     m_checkpointTasks.append(WTFMove(task));
 }
 
+bool MicrotaskQueue::hasMicrotasksForFullyActiveDocument() const
+{
+    return m_microtaskQueue.containsIf([](auto& task) {
+        auto group = task->group();
+        return group && !group->isStoppedPermanently() && !group->isSuspended();
+    });
+}
+
 } // namespace WebCore

--- a/Source/WebCore/dom/Microtasks.h
+++ b/Source/WebCore/dom/Microtasks.h
@@ -46,6 +46,7 @@ public:
     WEBCORE_EXPORT void addCheckpointTask(std::unique_ptr<EventLoopTask>&&);
 
     bool isEmpty() const { return m_microtaskQueue.isEmpty(); }
+    bool hasMicrotasksForFullyActiveDocument() const;
 
 private:
     JSC::VM& vm() const { return m_vm.get(); }

--- a/Source/WebCore/dom/WindowEventLoop.cpp
+++ b/Source/WebCore/dom/WindowEventLoop.cpp
@@ -33,6 +33,7 @@
 #include "IdleCallbackController.h"
 #include "Microtasks.h"
 #include "MutationObserver.h"
+#include "OpportunisticTaskScheduler.h"
 #include "Page.h"
 #include "SecurityOrigin.h"
 #include "ThreadGlobalData.h"
@@ -120,6 +121,13 @@ MicrotaskQueue& WindowEventLoop::microtaskQueue()
     return *m_microtaskQueue;
 }
 
+void WindowEventLoop::scheduleIdlePeriod(Page& page)
+{
+    if (m_pagesWithRenderingOpportunity.contains(page) && page.opportunisticTaskScheduler().isScheduled())
+        page.opportunisticTaskScheduler().willQueueIdleCallback();
+    scheduleToRunIfNeeded();
+}
+
 void WindowEventLoop::didScheduleRenderingUpdate(Page& page, MonotonicTime nextRenderingUpdate)
 {
     m_pagesWithRenderingOpportunity.set(page, nextRenderingUpdate);
@@ -133,8 +141,10 @@ void WindowEventLoop::didStartRenderingUpdate(Page& page)
 void WindowEventLoop::opportunisticallyRunIdleCallbacks()
 {
     auto now = MonotonicTime::now();
-    if (shouldEndIdlePeriod(now))
+    if (shouldEndIdlePeriod(now)) {
+        decayIdleCallbackDuration();
         return;
+    }
 
     m_lastIdlePeriodStartTime = now;
 
@@ -147,16 +157,23 @@ void WindowEventLoop::opportunisticallyRunIdleCallbacks()
             return;
         idleCallbackController->startIdlePeriod();
     });
+
+    auto duration = MonotonicTime::now() - m_lastIdlePeriodStartTime;
+    m_expectedIdleCallbackDuration = (m_expectedIdleCallbackDuration + duration) / 2;
 }
 
 bool WindowEventLoop::shouldEndIdlePeriod(MonotonicTime now)
 {
     if (hasTasksForFullyActiveDocument())
         return true;
-    if (!microtaskQueue().isEmpty())
+    if (microtaskQueue().hasMicrotasksForFullyActiveDocument())
         return true;
+    auto expectedFinishTime = now + m_expectedIdleCallbackDuration;
     auto renderingTime = nextRenderingTime();
-    if (renderingTime && *renderingTime < now + IdleCallbackDurationExpectation)
+    if (renderingTime && *renderingTime < expectedFinishTime)
+        return true;
+    auto timerTime = nextTimerFireTime();
+    if (timerTime && *timerTime < expectedFinishTime)
         return true;
     return false;
 }
@@ -192,9 +209,6 @@ void WindowEventLoop::didReachTimeToRun()
     auto deadline = ApproximateTime::now() + ThreadTimers::maxDurationOfFiringTimers;
     run(deadline);
 
-    if (hasTasksForFullyActiveDocument() || !microtaskQueue().isEmpty())
-        return;
-
     auto hasIdleCallbacks = findMatchingAssociatedContext([&](ScriptExecutionContext& context) {
         RefPtr document = dynamicDowncast<Document>(context);
         if (!document || document->activeDOMObjectsAreSuspended() || document->activeDOMObjectsAreStopped())
@@ -207,10 +221,8 @@ void WindowEventLoop::didReachTimeToRun()
     if (!hasIdleCallbacks)
         return;
 
-    auto now = MonotonicTime::now();
-
-    auto timerTime = nextTimerFireTime();
-    if (timerTime && *timerTime < now + IdleCallbackDurationExpectation) {
+    if (shouldEndIdlePeriod(MonotonicTime::now())) {
+        decayIdleCallbackDuration();
         scheduleToRunIfNeeded();
         return;
     }

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -55,6 +55,7 @@ public:
 
     CustomElementQueue& backupElementQueue();
 
+    void scheduleIdlePeriod(Page&);
     void didScheduleRenderingUpdate(Page&, MonotonicTime);
     void didStartRenderingUpdate(Page&);
     void opportunisticallyRunIdleCallbacks();
@@ -73,6 +74,8 @@ private:
 
     std::optional<MonotonicTime> nextRenderingTime() const;
     void didReachTimeToRun();
+
+    void decayIdleCallbackDuration() { m_expectedIdleCallbackDuration /= 2; }
 
     String m_agentClusterKey;
     Timer m_timer;
@@ -95,6 +98,7 @@ private:
     bool m_processingBackupElementQueue { false };
 
     MonotonicTime m_lastIdlePeriodStartTime;
+    Seconds m_expectedIdleCallbackDuration { 4_ms };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/OpportunisticTaskScheduler.h
+++ b/Source/WebCore/page/OpportunisticTaskScheduler.h
@@ -65,6 +65,7 @@ public:
 
     void willQueueIdleCallback() { m_mayHavePendingIdleCallbacks = true; }
 
+    bool isScheduled() const { return m_runLoopObserver->isScheduled(); }
     void rescheduleIfNeeded(MonotonicTime deadline);
     bool hasImminentlyScheduledWork() const { return m_imminentlyScheduledWorkCount; }
 


### PR DESCRIPTION
#### ecd009129377e8b137d771313e82be843dadaa59
<pre>
airbnb.com: When trying to select days for checkin checkout, the date widget is empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=268058">https://bugs.webkit.org/show_bug.cgi?id=268058</a>

Reviewed by Chris Dumez and Wenson Hsieh.

This PR fixes a few bugs that caused idle callbacks to sometimes not get invoked.

1. Check for the existence of microtasks in shouldEndIdlePeriod and didReachTimeToRun were not taking
into account that there could be suspended microtasks (e.g. microtasks for a document in page cache).
Fixed this bug by introducing MicrotaskQueue::hasMicrotasksForFullyActiveDocument which checks for an
existence of a microtask for a fully active document.

2. When the event loop is sufficiently busy such that there is no idle period of at least 4ms,
opportunisticallyRunIdleCallbacks and didReachTimeToRun would perpetually defer idle callbacks.
Fixed this bug by decaying (shortening) the expected idle callback duration in each iteration using
exponential moving average with the weight of 50%. This will eventually shorten the expected idle
callback duration enough to start the idle period even when the event loop is constantly scheduling
timers and rAF callbacks.

3. opportunisticallyRunIdleCallbacks and didReachTimeToRun can sometimes exit without processing
pending idle callbacks and never schedule itself again when the initial check for idleness had failed.
Fixed this bug by always scheduling the event loop to run via scheduleToRunIfNeeded and in addition to
signaling OpportunisticTaskScheduler in IdleCallbackController::queueIdleCallback. This PR also moves
the code to signal OpportunisticTaskScheduler from Document to WindowEventLoop.

* LayoutTests/requestidlecallback/requestidlecallback-in-page-cache-with-pending-task.html: Added web
animation so that a microtask to stop the animation is queued as the document moves into the page cache.
* LayoutTests/requestidlecallback/requestidlecallback-is-called-even-when-event-loop-is-busy-expected.txt: Added.
* LayoutTests/requestidlecallback/requestidlecallback-is-called-even-when-event-loop-is-busy.html: Added.
* LayoutTests/requestidlecallback/requestidlecallback-is-called-when-idle-expected.txt: Added.
* LayoutTests/requestidlecallback/requestidlecallback-is-called-when-idle.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::protectedWindowEventLoop): Added.
(WebCore::Document::requestIdleCallback):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/IdleCallbackController.cpp:
(WebCore::IdleCallbackController::queueIdleCallback):
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::MicrotaskQueue::hasMicrotasksForFullyActiveDocument const): Added.
* Source/WebCore/dom/Microtasks.h:
* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::scheduleIdlePeriod): Signal OpportunisticTaskScheduler and schedule the event
loop to run again.
(WebCore::WindowEventLoop::opportunisticallyRunIdleCallbacks):
(WebCore::WindowEventLoop::shouldEndIdlePeriod):
(WebCore::WindowEventLoop::didReachTimeToRun): Call shouldEndIdlePeriod instead of duplicating the code.
* Source/WebCore/dom/WindowEventLoop.h:
* Source/WebCore/page/OpportunisticTaskScheduler.h:

Canonical link: <a href="https://commits.webkit.org/276866@main">https://commits.webkit.org/276866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f465b64911feecb6392635285b44cf6b169df5c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45991 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48662 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42031 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37613 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18803 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40768 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4035 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42296 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50443 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17464 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44768 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22287 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39830 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43660 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22646 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6406 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->