### PR TITLE
Web Inspector: Dark Mode: Increase contrast in the timeline tab in @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -226,5 +227,11 @@ body.mac-platform.legacy .timeline-overview > .graphs-container {
 @media (prefers-color-scheme: dark) {
     .timeline-overview:not(.frames) > .graphs-container > .timeline-overview-graph:nth-child(even) {
         background: var(--background-color-alternate);
+    }
+
+    @media (prefers-contrast: more) {
+        .navigation-bar.timelines .item.text.enabled-timelines {
+            color: var(--timeline-text-color);
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +29,7 @@
     pointer-events: none;
 
     --timeline-ruler-marker-translateX: -1px;
+    --timeline-text-color: hsl(0, 0%, 50%);
 }
 
 .timeline-ruler.allows-time-range-selection:not(.disabled) {
@@ -84,7 +86,7 @@ body.window-inactive .timeline-ruler > .header > .divider {
     inset-inline-end: var(--timeline-ruler-header-divider-label-offset-end);
     font-size: 9px;
     font-weight: normal;
-    color: hsl(0, 0%, 50%);
+    color: var(--timeline-text-color);
     white-space: nowrap;
 
     --timeline-ruler-header-divider-label-offset-end: 5px;
@@ -160,7 +162,7 @@ body.window-inactive .timeline-ruler > .header > .divider {
 }
 
 .timeline-ruler > .markers > .marker.load-event {
-    color: hsl(0, 100%, 50%);
+    color: var(--timeline-text-color);
 }
 
 .timeline-ruler > .markers > .marker.dom-content-event {
@@ -261,5 +263,27 @@ body[dir=rtl] .timeline-ruler > .selection-handle.left {
 @media (prefers-color-scheme: dark) {
     .timeline-ruler > .markers > .marker.dom-content-event {
         color: hsl(240, 100%, 70%);
+    }
+
+    @media (prefers-contrast: more) {
+        .timeline-ruler {
+            --timeline-text-color: hsl(0, 0%, 90%);
+        }
+
+        .timeline-ruler > .markers > .marker.load-event {
+            color: var(--timeline-text-color);
+        }
+
+        .timeline-ruler > .markers > .marker.dom-content-event {
+            color: hsl(240, 100%, 95%);
+        }
+
+        .timeline-ruler > .markers > .marker.timestamp {
+            color: hsl(119, 100%, 95%);
+        }
+
+        .timeline-ruler > .header > .divider > .label {
+            color: var(--timeline-text-color);
+        }
     }
 }


### PR DESCRIPTION
#### 00086ecf5c3a6830bf40b39701e94703c9d541d0
<pre>
Web Inspector: Dark Mode: Increase contrast in the timeline tab in @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)
<a href="https://bugs.webkit.org/show_bug.cgi?id=271927">https://bugs.webkit.org/show_bug.cgi?id=271927</a>

Reviewed by NOBODY (OOPS!).

Increase lightness of enabled timelines in TimelineOverview.css.
Creatе --timeline-text-color in TimelineRuler.css.
Lighten markers, labels, and dividers in TimelineRuler.css.

* Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .navigation-bar.timelines .item.text.enabled-timelines):
* Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css:
(.timeline-ruler):
(.timeline-ruler &gt; .header &gt; .divider &gt; .label):
(.timeline-ruler &gt; .markers &gt; .marker.load-event):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .timeline-ruler):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .timeline-ruler &gt; .markers &gt; .marker.load-event):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .timeline-ruler &gt; .markers &gt; .marker.dom-content-event):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .timeline-ruler &gt; .markers &gt; .marker.timestamp):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .timeline-ruler &gt; .header &gt; .divider &gt; .label):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00086ecf5c3a6830bf40b39701e94703c9d541d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47371 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50055 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43420 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38569 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24086 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19889 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41997 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5415 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51931 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45866 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23677 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44911 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24462 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23396 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->