### PR TITLE
Web Inspector: Dark Mode: Increase contrast in the

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -392,5 +393,11 @@ body:not(.window-inactive, .window-docked-inactive) .data-grid:focus tr.editable
 
     .data-grid th:is(.sort-ascending, .sort-descending) > .header-cell-content:first-child::after {
         filter: invert();
+    }
+
+    @media (prefers-contrast: more) {
+        .data-grid tr.filler td {
+            background: hsl(0, 0%, 15%);
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
- * Copyright (C) 2024 Frances Cornwall.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -393,11 +392,5 @@ body:not(.window-inactive, .window-docked-inactive) .data-grid:focus tr.editable
 
     .data-grid th:is(.sort-ascending, .sort-descending) > .header-cell-content:first-child::after {
         filter: invert();
-    }
-
-    @media (prefers-contrast: more) {
-        .data-grid tr.filler td {
-            background: hsl(0, 0%, 15%);
-        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -202,7 +203,8 @@ body.mac-platform.legacy .timeline-overview > .graphs-container {
 }
 
 .timeline-overview:not(.frames) > .graphs-container > .timeline-overview-graph:nth-child(even) {
-    background-color: hsl(0, 0%, 96%);
+    --timeline-color: hsl(0, 0%, 95%);
+    color: var(--timeline-color);
     background-clip: padding-box;
 }
 
@@ -226,5 +228,12 @@ body.mac-platform.legacy .timeline-overview > .graphs-container {
 @media (prefers-color-scheme: dark) {
     .timeline-overview:not(.frames) > .graphs-container > .timeline-overview-graph:nth-child(even) {
         background: var(--background-color-alternate);
+    }
+
+    @media (prefers-contrast: more) {
+        .timeline-overview.edit-instruments > .tree-outline.timelines .item:nth-child(even),
+        .timeline-overview > .tree-outline.timelines .item:not(.selected):nth-child(even) {
+            background-color: hsla(0, 0%, 15%);
+        }
     }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -261,5 +262,23 @@ body[dir=rtl] .timeline-ruler > .selection-handle.left {
 @media (prefers-color-scheme: dark) {
     .timeline-ruler > .markers > .marker.dom-content-event {
         color: hsl(240, 100%, 70%);
+    }
+
+    @media (prefers-contrast: more) {
+        .timeline-ruler > .markers > .marker.load-event {
+            color: hsl(0, 100%, 95%);
+        }
+
+        .timeline-ruler > .markers > .marker.dom-content-event {
+            color: hsl(240, 100%, 95%);
+        }
+
+        .timeline-ruler > .markers > .marker.timestamp {
+            color: hsl(119, 100%, 95%);
+        }
+
+        .timeline-ruler > .header > .divider > .label {
+            color: hsl(0, 0%, 95%);
+        }
     }
 }


### PR DESCRIPTION
#### 89c35760232a91467ab8ebc404e323f17a40df80
<pre>
Web Inspector: Dark Mode: Increase contrast in the storage tab for @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)
<a href="https://bugs.webkit.org/show_bug.cgi?id=271929">https://bugs.webkit.org/show_bug.cgi?id=271929</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).
</pre>
----------------------------------------------------------------------
#### e09a281cb84688b2464c9af7db414eebcd8ea5d4
<pre>
Web Inspector: Dark Mode: Increase contrast in the storage tab for @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)
<a href="https://bugs.webkit.org/show_bug.cgi?id=271929">https://bugs.webkit.org/show_bug.cgi?id=271929</a>

Reviewed by NOBODY (OOPS!).

Darken the data grid filler background in DataGrid.css.

* Source/WebInspectorUI/UserInterface/Views/DataGrid.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .data-grid tr.filler td):
</pre>
----------------------------------------------------------------------
#### ec5eae2cc86ceb4e11922cc17a0dbdb54677f560
<pre>
Web Inspector: Dark Mode: Increase contrast in the timeline tab in @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)
<a href="https://bugs.webkit.org/show_bug.cgi?id=271927">https://bugs.webkit.org/show_bug.cgi?id=271927</a>

Reviewed by NOBODY (OOPS!).

Darken backgrounds in TimelineOverView.css.
Lighten markers and dividers in TimelineRuler.css.

* Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css:
(.timeline-overview:not(.frames) &gt; .graphs-container &gt; .timeline-overview-graph:nth-child(even)):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .timeline-overview.edit-instruments &gt; .tree-outline.timelines .item:nth-child(even),):
* Source/WebInspectorUI/UserInterface/Views/TimelineRuler.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .timeline-ruler &gt; .markers &gt; .marker.load-event):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .timeline-ruler &gt; .markers &gt; .marker.dom-content-event):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .timeline-ruler &gt; .markers &gt; .marker.timestamp):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .timeline-ruler &gt; .header &gt; .divider &gt; .label):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89c35760232a91467ab8ebc404e323f17a40df80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48541 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/41996 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37579 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18769 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19558 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40733 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4000 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42255 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50405 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44732 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22252 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43619 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22611 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->