### PR TITLE
[ANGLE]: fix is_always_lock_free assertion on 32 bit arch

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/serial_utils.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/serial_utils.h
@@ -116,7 +116,7 @@ class Serial final
 };
 
 // Defines class to track the queue serial that can be load/store from multiple threads atomically.
-class AtomicQueueSerial final
+class alignas(8) AtomicQueueSerial final
 {
   public:
     AtomicQueueSerial &operator=(const Serial &other)
@@ -129,7 +129,6 @@ class AtomicQueueSerial final
   private:
     static constexpr uint64_t kInvalid = 0;
     std::atomic<uint64_t> mValue       = kInvalid;
-    static_assert(decltype(mValue)::is_always_lock_free, "Must always be lock free");
 };
 
 // Used as default/initial serial


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=252670

Reviewed by NOBODY (OOPS!).

Remove is_always_lock_free assertion from AtomicQueueSerial

Build will fail when compiled on 32 bit architecture. The code will still function on 32 bit architecture but with performance penalty due to lock. But we are not really expecting it actually run on 32 bit platform with vulkan backend (the atomic queue serial is only used by vulkan backend). We could move AtomicQueueSerial into vulkan backend, but that will be a much larger change that I try to avoid. This CL removes the static_assertion and make it 8 bytes aligned as well.

Bug: angleproject:7989
Change-Id: I3c0bd9877c4171485ca1aa9af0cf4621c1c23f56
Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5407870
Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
Commit-Queue: Charlie Lao <cclao@google.com>

Upstream: https://chromium.googlesource.com/angle/angle/+/321c6b63bebce3f31414d8a53fb2f94b5561b818<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4399714e71df34ac53e830ae1f7b2eab93716fa7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48635 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42004 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37586 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18776 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40741 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4008 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50414 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20960 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44740 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22260 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43632 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22619 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21954 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->