### PR TITLE
Switch CoreTelephony.framework to use delay-init linking

### DIFF
--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2007-2009 Torch Mobile, Inc.
  * Copyright (C) 2010, 2011 Research In Motion Limited. All rights reserved.
  *
@@ -1769,6 +1769,14 @@
     || (PLATFORM(WATCHOS) && __WATCH_OS_VERSION_MIN_REQUIRED >= 100000) \
     || PLATFORM(VISION))
 #define HAVE_COREGRAPHICS_WITH_PDF_AREA_OF_INTEREST_SUPPORT 1
+#endif
+
+#if ((PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 150000) \
+    || ((PLATFORM(IOS) || PLATFORM(MACCATALYST)) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 180000) \
+    || (PLATFORM(WATCHOS) && __WATCH_OS_VERSION_MIN_REQUIRED >= 110000) \
+    || (PLATFORM(APPLETV) && __TV_OS_VERSION_MIN_REQUIRED >= 180000) \
+    || (PLATFORM(VISION) && __VISION_OS_VERSION_MIN_REQUIRED >= 20000))
+#define HAVE_DELAY_INIT_LINKING 1
 #endif
 
 #if !defined(HAVE_ESIM_AUTOFILL_SYSTEM_SUPPORT) && \

--- a/Source/WebCore/PAL/pal/cocoa/CoreTelephonySoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/CoreTelephonySoftLink.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,12 +25,13 @@
 
 #pragma once
 
-#if HAVE(CORE_TELEPHONY)
-
 #import <pal/spi/cocoa/CoreTelephonySPI.h>
+
+#if HAVE(CORE_TELEPHONY) && !HAVE(DELAY_INIT_LINKING)
+
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, CoreTelephony)
 SOFT_LINK_CLASS_FOR_HEADER(PAL, CoreTelephonyClient)
 
-#endif // HAVE(CORE_TELEPHONY)
+#endif // HAVE(CORE_TELEPHONY) && !HAVE(DELAY_INIT_LINKING)

--- a/Source/WebCore/PAL/pal/cocoa/CoreTelephonySoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/CoreTelephonySoftLink.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,7 +25,7 @@
 
 #import "config.h"
 
-#if HAVE(CORE_TELEPHONY)
+#if HAVE(CORE_TELEPHONY) && !HAVE(DELAY_INIT_LINKING)
 
 #import <pal/spi/cocoa/CoreTelephonySPI.h>
 #import <wtf/SoftLinking.h>
@@ -33,4 +33,4 @@
 SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, CoreTelephony, PAL_EXPORT)
 SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT(PAL, CoreTelephony, CoreTelephonyClient, PAL_EXPORT)
 
-#endif // HAVE(CORE_TELEPHONY)
+#endif // HAVE(CORE_TELEPHONY) && !HAVE(DELAY_INIT_LINKING)

--- a/Source/WebKit/Configurations/WebKit.xcconfig
+++ b/Source/WebKit/Configurations/WebKit.xcconfig
@@ -1,4 +1,4 @@
-// Copyright (C) 2010-2023 Apple Inc. All rights reserved.
+// Copyright (C) 2010-2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -218,7 +218,10 @@ WK_NO_STATIC_INITIALIZERS_Release_NO_ = $(WK_ERROR_WHEN_LINKING_WITH_STATIC_INIT
 WK_NO_STATIC_INITIALIZERS_Production__ = $(WK_ERROR_WHEN_LINKING_WITH_STATIC_INITIALIZERS);
 WK_NO_STATIC_INITIALIZERS_Production_NO_ = $(WK_ERROR_WHEN_LINKING_WITH_STATIC_INITIALIZERS);
 
-OTHER_LDFLAGS = $(inherited) -lsqlite3 -iframework $(SDK_DIR)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks $(UNEXPORTED_SYMBOL_LDFLAGS) $(FRAMEWORK_AND_LIBRARY_LDFLAGS) $(OTHER_LDFLAGS_SHARED_CACHE) $(SOURCE_VERSION_LDFLAGS) $(PROFILE_GENERATE_OR_USE_LDFLAGS) $(WK_NO_STATIC_INITIALIZERS);
+OTHER_LDFLAGS = $(inherited) -lsqlite3 -iframework $(SDK_DIR)$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks $(UNEXPORTED_SYMBOL_LDFLAGS) $(FRAMEWORK_AND_LIBRARY_LDFLAGS) $(OTHER_LDFLAGS_DELAY_INIT) $(OTHER_LDFLAGS_SHARED_CACHE) $(SOURCE_VERSION_LDFLAGS) $(PROFILE_GENERATE_OR_USE_LDFLAGS) $(WK_NO_STATIC_INITIALIZERS);
+
+OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*] = -Wl,-delay_framework,CoreTelephony;
+OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*17.*] = ;
 
 REEXPORTED_FRAMEWORK_NAMES = WebKitLegacy;
 // Needed for bincompat (rdar://117360317)

--- a/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,7 +77,11 @@ bool shouldAllowAutoFillForCellularIdentifiers(const URL& topURL)
         return false;
     }
 
+#if HAVE(DELAY_INIT_LINKING)
+    static NeverDestroyed cachedClient = adoptNS([[CoreTelephonyClient alloc] initWithQueue:dispatch_get_main_queue()]);
+#else
     static NeverDestroyed cachedClient = adoptNS([PAL::allocCoreTelephonyClientInstance() initWithQueue:dispatch_get_main_queue()]);
+#endif
     auto client = cachedClient->get();
 
     static NeverDestroyed<String> lastQueriedHost;

--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPILibrary.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPILibrary.xcconfig
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2014 Apple Inc. All rights reserved.
+// Copyright (C) 2014-2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -28,3 +28,8 @@
 PRODUCT_NAME = TestWebKitAPI;
 SKIP_INSTALL = YES;
 GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+
+OTHER_LDFLAGS = $(inherited) $(OTHER_LDFLAGS_DELAY_INIT);
+
+OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*] = -Wl,-delay_framework,CoreTelephony;
+OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*17.*] = ;

--- a/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm
@@ -1274,7 +1274,11 @@ static BOOL allowESIMAutoFillForWebKit(id, SEL, NSString *host, NSError **)
 TEST(KeyboardInputTests, DeviceEIDAndIMEIAutoFill)
 {
     InstanceMethodSwizzler swizzler {
+#if HAVE(DELAY_INIT_LINKING)
+        CoreTelephonyClient.class,
+#else
         PAL::getCoreTelephonyClientClass(),
+#endif
         @selector(isAutofilleSIMIdAllowedForDomain:error:),
         reinterpret_cast<IMP>(allowESIMAutoFillForWebKit)
     };


### PR DESCRIPTION
#### 3e53dd942f96f2a13275beadcdcf0ea2f517b58f
<pre>
Switch CoreTelephony.framework to use delay-init linking
<a href="https://bugs.webkit.org/show_bug.cgi?id=271936">https://bugs.webkit.org/show_bug.cgi?id=271936</a>
&lt;<a href="https://rdar.apple.com/125661316">rdar://125661316</a>&gt;

Reviewed by Elliott Williams and Wenson Hsieh.

* Source/WTF/wtf/PlatformHave.h:
(HAVE_DELAY_INIT_LINKING): Add.
- Define macro for platforms that support delay-init linking.
* Source/WebCore/PAL/pal/cocoa/CoreTelephonySoftLink.h:
* Source/WebCore/PAL/pal/cocoa/CoreTelephonySoftLink.mm:
- Comment out soft-linking macros when using delay-init linking.
* Source/WebKit/Configurations/WebKit.xcconfig:
(OTHER_LDFLAGS):
(OTHER_LDFLAGS_DELAY_INIT): Add.
- Add linker flag for delay-init of CoreTelephony.framework.
* Source/WebKit/UIProcess/Cocoa/CoreTelephonyUtilities.mm:
(WebKit::shouldAllowAutoFillForCellularIdentifiers):
- Update source code for use with delay-init linking.
* Tools/TestWebKitAPI/Configurations/TestWebKitAPILibrary.xcconfig:
(OTHER_LDFLAGS): Add.
(OTHER_LDFLAGS_DELAY_INIT): Add.
- Add linker flag for delay-init of CoreTelephony.framework.
* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(TestWebKitAPI::TEST(KeyboardInputTests, DeviceEIDAndIMEIAutoFill)):
- Update source code for use with delay-init linking.

Canonical link: <a href="https://commits.webkit.org/276947@main">https://commits.webkit.org/276947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d8a20629c876bbe90aa0333834625b64aacdf6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42045 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37624 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18815 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19615 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40781 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4049 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39238 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42345 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50460 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45479 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44782 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22301 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43673 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22660 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52630 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6447 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21995 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10751 "Passed tests") | 
<!--EWS-Status-Bubble-End-->