### PR TITLE
[UnifiedPDF] Zoom out doesn't go out far enough with keyboard zoom

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -221,6 +221,12 @@ private:
     double scaleFactor() const override;
     double contentScaleFactor() const final;
 
+    // Scale normalization is used to map the internal "scale factor" to the exposed scaleFactor()/setPageScaleFactor()
+    // so that scale factor 1 shows at "Actual Size".
+    void computeNormalizationFactor();
+    double fromNormalizedScaleFactor(double) const;
+    double toNormalizedScaleFactor(double) const;
+
     void didBeginMagnificationGesture() override;
     void didEndMagnificationGesture() override;
     void setPageScaleFactor(double scale, std::optional<WebCore::IntPoint> origin) final;
@@ -367,7 +373,7 @@ private:
     // GraphicsLayerClient
     void notifyFlushRequired(const WebCore::GraphicsLayer*) override;
     void paintContents(const WebCore::GraphicsLayer*, WebCore::GraphicsContext&, const WebCore::FloatRect&, OptionSet<WebCore::GraphicsLayerPaintBehavior>) override;
-    float pageScaleFactor() const override { return scaleFactor(); }
+    float pageScaleFactor() const override;
     bool layerNeedsPlatformContext(const WebCore::GraphicsLayer*) const override { return true; }
     void tiledBackingUsageChanged(const WebCore::GraphicsLayer*, bool /*usingTiledBacking*/) override;
     std::optional<float> customContentsScale(const WebCore::GraphicsLayer*) const override;
@@ -503,10 +509,12 @@ private:
     WebCore::ScrollingNodeID m_scrollingNodeID;
 
     double m_scaleFactor { 1 };
-    bool m_inMagnificationGesture { false };
+    double m_scaleNormalizationFactor { 1 };
+
     std::optional<WebCore::IntPoint> m_magnificationOriginInContentCoordinates;
     std::optional<WebCore::IntPoint> m_magnificationOriginInPluginCoordinates;
 
+    bool m_inMagnificationGesture { false };
     bool m_didAttachScrollingTreeNode { false };
     bool m_didScrollToFragment { false };
     bool m_didLayoutWithValidDocument { false };


### PR DESCRIPTION
#### ed9218bd94b98544ebaa74c34f2810a73dafd012
<pre>
[UnifiedPDF] Zoom out doesn&apos;t go out far enough with keyboard zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=271937">https://bugs.webkit.org/show_bug.cgi?id=271937</a>
<a href="https://rdar.apple.com/125386166">rdar://125386166</a>

Reviewed by Tim Horton.

Internally, UnifiedPDFPlugin would adjust m_scaleFactor based on window-fitting
and other behaviors for the correct layout. However, the value exposed to
clients was somewhat arbitrary; m_scaleFactor==1 meant &quot;fit to window&quot;, not
&quot;actual size&quot;. This meant that the behavior of &quot;Actual Size&quot; from the PDF context
menu was different to &quot;Actual Size&quot; in the Safari menus, which just called
`setPageScaleFactor(1)`, and Command-+ and Command-- wouldn&apos;t work as expected.

Fix by computing a normalization factor so that the exposed scale factor is `1`
for actual size.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::computeNormalizationFactor):
(WebKit::UnifiedPDFPlugin::fromNormalizedScaleFactor const):
(WebKit::UnifiedPDFPlugin::toNormalizedScaleFactor const):
(WebKit::UnifiedPDFPlugin::scaleFactor const):
(WebKit::UnifiedPDFPlugin::setScaleFactor):
(WebKit::UnifiedPDFPlugin::setPageScaleFactor):
(WebKit::UnifiedPDFPlugin::updateLayout):

Canonical link: <a href="https://commits.webkit.org/276890@main">https://commits.webkit.org/276890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79aaef270171235a3fe1142e666a542850d800b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48755 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42124 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22655 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22307 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39758 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18873 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4128 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50546 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21080 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44847 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43744 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10203 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22074 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->