### PR TITLE
[UnifiedPDF] Maintain scroll position when zooming and resizing the window

### DIFF
--- a/LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html
+++ b/LayoutTests/http/tests/pdf/linearized-pdf-in-iframe.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ UnifiedPDFEnabled=true PDFPluginHUDEnabled=false ] -->
 <html>
 <head>
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-40">
     <style>
         iframe {
             width: 700px;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -58,7 +58,8 @@ public:
     ~PDFDocumentLayout();
 
     void setPDFDocument(PDFDocument *document) { m_pdfDocument = document; }
-    bool havePDFDocument() const { return !!m_pdfDocument; }
+    bool hasPDFDocument() const { return !!m_pdfDocument; }
+    bool hasLaidOutPDFDocument() const { return !m_pageGeometry.isEmpty(); }
 
     size_t pageCount() const;
 
@@ -72,6 +73,10 @@ public:
     RetainPtr<PDFPage> pageAtIndex(PageIndex) const;
     std::optional<unsigned> indexForPage(RetainPtr<PDFPage>) const;
     PDFDocumentLayout::PageIndex nearestPageIndexForDocumentPoint(WebCore::FloatPoint) const;
+    // For the given Y offset, return a page index and page point for the page at this offset. Returns the leftmost
+    // page if two-up and both pages intersect that offset, otherwise the right page if only it intersects the offset.
+    // The point is centered horizontally in the given page.
+    std::pair<PDFDocumentLayout::PageIndex, WebCore::FloatPoint> pageIndexAndPagePointForDocumentYOffset(float) const;
 
     // This is not scaled by scale().
     WebCore::FloatRect layoutBoundsForPageAtIndex(PageIndex) const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm
@@ -164,6 +164,62 @@ PDFDocumentLayout::PageIndex PDFDocumentLayout::nearestPageIndexForDocumentPoint
     return pageCount - 1;
 }
 
+std::pair<PDFDocumentLayout::PageIndex, WebCore::FloatPoint> PDFDocumentLayout::pageIndexAndPagePointForDocumentYOffset(float documentYOffset) const
+{
+    auto pageCount = this->pageCount();
+
+    auto resultWithPageHorizontalCenterPoint = [&](PDFDocumentLayout::PageIndex pageIndex, float documentYOffset) {
+        auto pageBounds = layoutBoundsForPageAtIndex(pageIndex);
+        auto pagePoint = documentToPDFPage(FloatPoint { pageBounds.center().x(), documentYOffset }, pageIndex);
+        return std::make_pair(pageIndex, pagePoint);
+    };
+
+    switch (displayMode()) {
+    case PDFDocumentLayout::DisplayMode::TwoUpDiscrete:
+    case PDFDocumentLayout::DisplayMode::TwoUpContinuous:
+        for (PDFDocumentLayout::PageIndex index = 0; index < pageCount; ++index) {
+            if (index == pageCount - 1)
+                return resultWithPageHorizontalCenterPoint(index, documentYOffset);
+
+            if (isRightPageIndex(index))
+                continue;
+
+            // Handle side by side pages with different sizes.
+            std::optional<PDFDocumentLayout::PageIndex> targetPageIndex = [&](PDFDocumentLayout::PageIndex index) -> std::optional<PDFDocumentLayout::PageIndex> {
+                auto leftPageBounds = layoutBoundsForPageAtIndex(index);
+                if (documentYOffset >= leftPageBounds.y() && documentYOffset < leftPageBounds.maxY())
+                    return index;
+
+                auto rightPageIndex = index + 1;
+                if (rightPageIndex == pageCount)
+                    return { };
+
+                auto rightPageBounds = layoutBoundsForPageAtIndex(rightPageIndex);
+                if (documentYOffset >= rightPageBounds.y() && documentYOffset < rightPageBounds.maxY())
+                    return rightPageIndex;
+
+                return { };
+            }(index);
+
+            if (!targetPageIndex)
+                continue;
+
+            return resultWithPageHorizontalCenterPoint(*targetPageIndex, documentYOffset);
+        }
+        break;
+    case PDFDocumentLayout::DisplayMode::SinglePageDiscrete:
+    case PDFDocumentLayout::DisplayMode::SinglePageContinuous: {
+        for (PDFDocumentLayout::PageIndex index = 0; index < pageCount; ++index) {
+            auto pageBounds = layoutBoundsForPageAtIndex(index);
+            if (documentYOffset <= pageBounds.maxY() || index == pageCount - 1)
+                return resultWithPageHorizontalCenterPoint(index, documentYOffset);
+        }
+    }
+    }
+    ASSERT_NOT_REACHED();
+    return { pageCount - 1, { } };
+}
+
 void PDFDocumentLayout::updateLayout(IntSize pluginSize, ShouldUpdateAutoSizeScale shouldUpdateScale)
 {
     auto pageCount = this->pageCount();

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -436,6 +436,14 @@ private:
 
     WebCore::FloatSize centeringOffset() const;
 
+    struct ScrollAnchoringInfo {
+        PDFDocumentLayout::PageIndex pageIndex { 0 };
+        WebCore::FloatPoint pagePoint;
+    };
+
+    std::optional<ScrollAnchoringInfo> scrollAnchoringForCurrentScrollPosition(bool preserveScrollPosition) const;
+    void restoreScrollPositionWithInfo(const ScrollAnchoringInfo&);
+
     // HUD Actions.
 #if ENABLE(PDF_HUD)
     void zoomIn() final;


### PR DESCRIPTION
#### 56edd4201d2fee53ba3f72c3d4618bd587c097ae
<pre>
[UnifiedPDF] Maintain scroll position when zooming and resizing the window
<a href="https://bugs.webkit.org/show_bug.cgi?id=271938">https://bugs.webkit.org/show_bug.cgi?id=271938</a>
<a href="https://rdar.apple.com/119632576">rdar://119632576</a>

Reviewed by Tim Horton.

Do a better job of preserving the page that is in the viewport (&quot;restoring the scroll position&quot;)
under two circumstances:
1. We&apos;re in &quot;Automatically Resize&quot; mode and the user is resizing the window
2. Switching between Single Page and Two Page modes.

We do this by computing a point in the PDF page that is closest to the top of the viewport,
arbitrarily picking a point horizontally centered in that page.
`PDFDocumentLayout::pageIndexAndPagePointForDocumentYOffset()` has logic to pick the right page
if it is closer to the top (e.g. when page sizes are uneven).

After layout, we compute a new scroll position based on this page/point pair, and scroll to
it.

We avoid doing this when not in &quot;Automatically Resize&quot; mode because we don&apos;t want to clobber
the horizontal scroll position. We also need to ensure that we&apos;ve laid out the PDF pages
at least once.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.mm:
(WebKit::PDFDocumentLayout::pageIndexAndPagePointForDocumentYOffset const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updateLayout):
(WebKit::UnifiedPDFPlugin::scrollAnchoringForCurrentScrollPosition const):
(WebKit::UnifiedPDFPlugin::restoreScrollPositionWithInfo):

Canonical link: <a href="https://commits.webkit.org/276946@main">https://commits.webkit.org/276946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f2c9894b4e31890532c4bfc6b511f0d3e45d0f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48860 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42210 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37738 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18945 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40918 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4213 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42487 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41267 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50636 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44906 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22465 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43814 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10236 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22824 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->