### PR TITLE
Enable QuickLook sandbox restrictions after navigation policy decision

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1108,12 +1108,12 @@
 
 
 #if ENABLE(QUICKLOOK_SANDBOX_RESTRICTIONS)
-(with-filter (require-not (state-flag "BlockQuickLookSandboxResources"))
-    (allow syscall-unix
+(with-filter (require-not (state-flag "EnableQuickLookSandboxResources"))
+    (allow syscall-unix (with report) (with telemetry-backtrace)
         (syscall-unix-rarely-in-use)
         (syscall-unix-rarely-in-use-blocked-in-lockdown-mode)))
-(with-filter (state-flag "BlockQuickLookSandboxResources")
-    (allow syscall-unix (with report) (with telemetry-backtrace)
+(with-filter (state-flag "EnableQuickLookSandboxResources")
+    (allow syscall-unix
         (syscall-unix-rarely-in-use)
         (syscall-unix-rarely-in-use-blocked-in-lockdown-mode)))
 #else

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -186,12 +186,11 @@ function webcontent_sandbox_entitlements()
     plistbuddy Add :com.apple.private.security.mutable-state-flags:0 string EnableExperimentalSandbox
     plistbuddy Add :com.apple.private.security.mutable-state-flags:1 string BlockIOKitInWebContentSandbox
     plistbuddy Add :com.apple.private.security.mutable-state-flags:2 string local:WebContentProcessLaunched
-    plistbuddy Add :com.apple.private.security.mutable-state-flags:3 string BlockQuickLookSandboxResources
+    plistbuddy Add :com.apple.private.security.mutable-state-flags:3 string EnableQuickLookSandboxResources
     plistbuddy Add :com.apple.private.security.enable-state-flags array
     plistbuddy Add :com.apple.private.security.enable-state-flags:0 string EnableExperimentalSandbox
     plistbuddy Add :com.apple.private.security.enable-state-flags:1 string BlockIOKitInWebContentSandbox
     plistbuddy Add :com.apple.private.security.enable-state-flags:2 string local:WebContentProcessLaunched
-    plistbuddy Add :com.apple.private.security.enable-state-flags:3 string BlockQuickLookSandboxResources
 }
 
 function mac_process_webcontent_shared_entitlements()

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -57,10 +57,6 @@
 #include <WebCore/SubstituteData.h>
 #include <wtf/CompletionHandler.h>
 
-#if ENABLE(QUICKLOOK_SANDBOX_RESTRICTIONS)
-#include <wtf/spi/darwin/SandboxSPI.h>
-#endif
-
 #define WEBRESOURCELOADER_RELEASE_LOG(fmt, ...) RELEASE_LOG(Network, "%p - [webPageID=%" PRIu64 ", frameID=%" PRIu64 ", resourceID=%" PRIu64 ", durationSeconds=%.3f] WebResourceLoader::" fmt, this, m_trackingParameters.pageID.toUInt64(), m_trackingParameters.frameID.object().toUInt64(), m_trackingParameters.resourceID.toUInt64(), timeSinceLoadStart().value(), ##__VA_ARGS__)
 
 namespace WebKit {
@@ -156,13 +152,6 @@ void WebResourceLoader::didReceiveResponse(ResourceResponse&& response, PrivateR
     WEBRESOURCELOADER_RELEASE_LOG("didReceiveResponse: (httpStatusCode=%d)", response.httpStatusCode());
 
     Ref<WebResourceLoader> protectedThis(*this);
-
-#if ENABLE(QUICKLOOK_SANDBOX_RESTRICTIONS)
-    if (!response.isQuickLook()) {
-        auto auditToken = WebProcess::singleton().auditTokenForSelf();
-        sandbox_enable_state_flag("BlockQuickLookSandboxResources", *auditToken);
-    }
-#endif
 
     if (metrics) {
         metrics->workerStart = m_workerStart;


### PR DESCRIPTION
#### c13924352606e452a28e14bfeda40f51c63d1da7
<pre>
Enable QuickLook sandbox restrictions after navigation policy decision
<a href="https://bugs.webkit.org/show_bug.cgi?id=271939">https://bugs.webkit.org/show_bug.cgi?id=271939</a>
<a href="https://rdar.apple.com/125663992">rdar://125663992</a>

Reviewed by Chris Dumez.

Enable QuickLook sandbox restrictions after navigation policy decision. This enablement
was previously done in WebResourceLoader::didReceiveResponse, but that is incorrect,
since it would block QuickLook specific sandbox resources when one or more iframes
contained documents that could be previewed with QuickLook.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::didReceiveResponse):

Canonical link: <a href="https://commits.webkit.org/276862@main">https://commits.webkit.org/276862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2086d2458083baa407a3815b9a2e1492740a478a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/45978 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48649 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42018 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37599 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39657 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18789 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/45843 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19588 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4022 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42284 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50429 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20974 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44754 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22274 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43646 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22633 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6405 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21968 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->