### PR TITLE
REGRESSION: fix compilation if !ENABLE(VIDEO)

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -281,6 +281,7 @@ ExceptionOr<Ref<GPUSampler>> GPUDevice::createSampler(const std::optional<GPUSam
     return GPUSampler::create(sampler.releaseNonNull());
 }
 
+#if ENABLE(VIDEO)
 GPUExternalTexture* GPUDevice::externalTextureForDescriptor(const GPUExternalTextureDescriptor& descriptor)
 {
     m_videoElementToExternalTextureMap.removeNullReferences();
@@ -333,9 +334,11 @@ private:
     WeakPtr<HTMLVideoElement> m_videoElement;
     WeakPtr<GPUDevice, WeakPtrImplWithEventTargetData> m_gpuDevice;
 };
+#endif
 
 ExceptionOr<Ref<GPUExternalTexture>> GPUDevice::importExternalTexture(const GPUExternalTextureDescriptor& externalTextureDescriptor)
 {
+#if ENABLE(VIDEO)
     if (RefPtr externalTexture = externalTextureForDescriptor(externalTextureDescriptor)) {
         externalTexture->undestroy();
 #if ENABLE(WEB_CODECS)
@@ -346,6 +349,7 @@ ExceptionOr<Ref<GPUExternalTexture>> GPUDevice::importExternalTexture(const GPUE
         m_videoElementToExternalTextureMap.remove(*videoElement.get());
         return externalTexture.releaseNonNull();
     }
+#endif
     RefPtr texture = m_backing->importExternalTexture(externalTextureDescriptor.convertToBacking());
     if (!texture)
         return Exception { ExceptionCode::InvalidStateError, "GPUDevice.importExternalTexture: Unable to import texture."_s };

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -160,7 +160,10 @@ private:
     Ref<GPUQueue> m_queue;
     RefPtr<GPUPipelineLayout> m_autoPipelineLayout;
     WeakHashSet<GPUBuffer> m_buffersToUnmap;
+
+#if ENABLE(VIDEO)
     GPUExternalTexture* externalTextureForDescriptor(const GPUExternalTextureDescriptor&);
+#endif
 
     WeakHashMap<HTMLVideoElement, WeakPtr<GPUExternalTexture>> m_videoElementToExternalTextureMap;
     bool m_waitingForDeviceLostPromise { false };

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1075,8 +1075,10 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, const LocalCont
             return matchesAnimatingFullscreenTransitionPseudoClass(element);
         case CSSSelector::PseudoClass::InternalFullscreenDocument:
             return matchesFullscreenDocumentPseudoClass(element);
+#if ENABLE(VIDEO)
         case CSSSelector::PseudoClass::InternalInWindowFullScreen:
             return matchesInWindowFullScreenPseudoClass(element);
+#endif
 #endif
 #if ENABLE(PICTURE_IN_PICTURE_API)
         case CSSSelector::PseudoClass::PictureInPicture:

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -428,6 +428,7 @@ ALWAYS_INLINE bool matchesFullscreenDocumentPseudoClass(const Element& element)
     return fullscreenManager && fullscreenManager->fullscreenElement();
 }
 
+#if ENABLE(VIDEO)
 ALWAYS_INLINE bool matchesInWindowFullScreenPseudoClass(const Element& element)
 {
     if (&element != element.document().fullscreenManager().currentFullscreenElement())
@@ -436,6 +437,7 @@ ALWAYS_INLINE bool matchesInWindowFullScreenPseudoClass(const Element& element)
     auto* mediaElement = dynamicDowncast<HTMLMediaElement>(element);
     return mediaElement && mediaElement->fullscreenMode() == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
 }
+#endif
 
 #endif
 

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -257,7 +257,9 @@ static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesLangPseudo
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullscreenPseudoClass, bool, (const Element&));
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesFullscreenDocumentPseudoClass, bool, (const Element&));
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesAnimatingFullscreenTransitionPseudoClass, bool, (const Element&));
+#if ENABLE(VIDEO)
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesInWindowFullScreenPseudoClass, bool, (const Element&));
+#endif
 #endif
 #if ENABLE(PICTURE_IN_PICTURE_API)
 static JSC_DECLARE_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesPictureInPicturePseudoClass, bool, (const Element&));
@@ -909,11 +911,15 @@ JSC_DEFINE_JIT_OPERATION(operationMatchesAnimatingFullscreenTransitionPseudoClas
     COUNT_SELECTOR_OPERATION(operationMatchesAnimatingFullscreenTransitionPseudoClass);
     return matchesAnimatingFullscreenTransitionPseudoClass(element);
 }
+
+#if ENABLE(VIDEO)
 JSC_DEFINE_JIT_OPERATION(operationMatchesInWindowFullScreenPseudoClass, bool, (const Element& element))
 {
     COUNT_SELECTOR_OPERATION(operationMatchesInWindowFullScreenPseudoClass);
     return matchesInWindowFullScreenPseudoClass(element);
 }
+#endif
+
 #endif
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
@@ -1112,9 +1118,11 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
     case CSSSelector::PseudoClass::InternalAnimatingFullscreenTransition:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesAnimatingFullscreenTransitionPseudoClass));
         return FunctionType::SimpleSelectorChecker;
+#if ENABLE(VIDEO)
     case CSSSelector::PseudoClass::InternalInWindowFullScreen:
         fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesInWindowFullScreenPseudoClass));
         return FunctionType::SimpleSelectorChecker;
+#endif
 #endif
 
 #if ENABLE(PICTURE_IN_PICTURE_API)

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -529,9 +529,11 @@ bool FullscreenManager::willEnterFullscreen(Element& element, HTMLMediaElementEn
     INFO_LOG(LOGIDENTIFIER);
     ASSERT(page()->settings().fullScreenEnabled());
 
+#if ENABLE(VIDEO)
     if (RefPtr mediaElement = dynamicDowncast<HTMLMediaElement>(element))
         mediaElement->willBecomeFullscreenElement(mode);
     else
+#endif
         element.willBecomeFullscreenElement();
 
     ASSERT(&element == m_pendingFullscreenElement);

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -31,6 +31,7 @@
 #include "FrameDestructionObserverInlines.h"
 #include "GCReachableRef.h"
 #include "HTMLMediaElement.h"
+#include "HTMLMediaElementEnums.h"
 #include "LayoutRect.h"
 #include "Page.h"
 #include <wtf/Deque.h>

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -3100,6 +3100,7 @@ Inspector::Protocol::ErrorStringOr<void> InspectorDOMAgent::setAllowEditingUserA
 
 Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::MediaStats>> InspectorDOMAgent::getMediaStats(Inspector::Protocol::DOM::NodeId nodeId)
 {
+#if ENABLE(VIDEO)
     Inspector::Protocol::ErrorString errorString;
 
     auto* element = assertElement(errorString, nodeId);
@@ -3176,6 +3177,10 @@ Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::DOM::MediaStats>> In
     }
 
     return stats;
+#else
+    UNUSED_PARAM(nodeId);
+    return makeUnexpected("no media support"_s);
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -171,7 +171,6 @@ void RemoteDevice::setSharedVideoFrameMemory(WebCore::SharedMemory::Handle&& han
 #if PLATFORM(COCOA) && ENABLE(VIDEO)
 void RemoteDevice::importExternalTextureFromVideoFrame(const WebGPU::ExternalTextureDescriptor& descriptor, WebGPUIdentifier identifier)
 {
-#if PLATFORM(COCOA) && ENABLE(VIDEO)
     std::optional<WebKit::SharedVideoFrame> sharedVideoFrame = descriptor.sharedFrame;
     RetainPtr<CVPixelBufferRef> pixelBuffer { nullptr };
     if (sharedVideoFrame) {
@@ -193,9 +192,6 @@ void RemoteDevice::importExternalTextureFromVideoFrame(const WebGPU::ExternalTex
     RELEASE_ASSERT(externalTexture);
     auto remoteExternalTexture = RemoteExternalTexture::create(*externalTexture, m_objectHeap, m_streamConnection.copyRef(), identifier);
     m_objectHeap->addObject(identifier, remoteExternalTexture);
-#else
-    UNUSED_PARAM(identifier);
-#endif
 }
 #endif // PLATFORM(COCOA) && ENABLE(VIDEO)
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7265,6 +7265,7 @@ header: <WebCore/Font.h>
 [Nested] enum class WebCore::FontVisibility : bool;
 [Nested] enum class WebCore::FontIsOrientationFallback : bool;
 
+#if ENABLE(VIDEO)
 header: <WebCore/CaptionUserPreferences.h>
 enum class WebCore::CaptionUserPreferencesDisplayMode : uint8_t {
     Automatic,
@@ -7272,6 +7273,7 @@ enum class WebCore::CaptionUserPreferencesDisplayMode : uint8_t {
     AlwaysOn,
     Manual,
 };
+#endif
 
 header: <WebCore/InspectorClient.h>
 enum class WebCore::InspectorClientDeveloperPreference : uint8_t {
@@ -7918,6 +7920,7 @@ header: <WebCore/FilterFunction.h>
     SourceGraphic
 };
 
+#if ENABLE(VIDEO)
 class WebCore::SerializedPlatformDataCueValue {
     std::optional<WebCore::SerializedPlatformDataCueValue::Data> data()
 }
@@ -7929,6 +7932,7 @@ class WebCore::SerializedPlatformDataCueValue {
     String key;
     RetainPtr<NSLocale> locale;
     std::variant<std::nullptr_t, RetainPtr<NSString>, RetainPtr<NSDate>, RetainPtr<NSNumber>, RetainPtr<NSData>> value;
+#endif
 #endif
 };
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -30,6 +30,7 @@
 #include "FullScreenMediaDetails.h"
 #include "MessageReceiver.h"
 #include <WebCore/HTMLMediaElement.h>
+#include <WebCore/HTMLMediaElementEnums.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -30,6 +30,7 @@
 #include "WebCoreArgumentCoders.h"
 #include <WebCore/EventListener.h>
 #include <WebCore/HTMLMediaElement.h>
+#include <WebCore/HTMLMediaElementEnums.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/LengthBox.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFullScreenClient.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundlePageFullScreenClient.h
@@ -32,6 +32,7 @@
 #include "FullScreenMediaDetails.h"
 #include "WKBundlePageFullScreenClient.h"
 #include <WebCore/HTMLMediaElement.h>
+#include <WebCore/HTMLMediaElementEnums.h>
 #include <WebCore/MediaPlayerEnums.h>
 #include <wtf/Forward.h>
 


### PR DESCRIPTION
#### ea2be408f27eb1009bbde7b0a2496018d4ca5e86
<pre>
REGRESSION: fix compilation if !ENABLE(VIDEO)

<a href="https://bugs.webkit.org/show_bug.cgi?id=271881">https://bugs.webkit.org/show_bug.cgi?id=271881</a>

Reviewed by Mike Wyrzykowski.

[WebCore]: FullscreenManager: add missing include

HTMLMediaElement normally includes HTMLMediaElementEnums,
but only if VIDEO is enabled.

[WebCore]: FullscreenManager: fix undefined reference to HTMLMediaElement

HTMLMediaElement is not compiled if VIDEO is not enabled.

[WebCore]: css: fix fix undefined reference to HTMLMediaElement

HTMLMediaElement is not compiled if VIDEO is not enabled.

[WebCore]: InspectorDOMAgent: fix fix undefined reference to HTMLMediaElement

HTMLMediaElement is not compiled if VIDEO is not enabled.

[WebKit]: WebGPU: drop duplicate directive in RemoteDevice

The #if PLATFORM(COCOA) &amp;&amp; ENABLE(VIDEO) directive is already defined
outside the function scope, so drop the inner ones.

[WebCore]: GPUDevice: fix undefined reference to HTMLMediaElement

HTMLMediaElement is not compiled if VIDEO is not enabled.

[WebKit]: WebFullScreenManagerProxy: add missing include

HTMLMediaElement normally includes HTMLMediaElementEnums,
but only if VIDEO is enabled.

[WebKit]: WebFullScreenManager: add missing include

HTMLMediaElement normally includes HTMLMediaElementEnums,
but only if VIDEO is enabled.

[WebKit]: InjectedBundlePageFullScreenClient: add missing include

HTMLMediaElement normally includes HTMLMediaElementEnums,
but only if VIDEO is enabled.

[WebKit]: WebCoreArgumentCoders.serialization.in: fix undefined reference

CaptionUserPreferencesDisplayMode and SerializedPlatformDataCueValue
are only compiled if VIDEO is enabled.

Signed-off-by: Thomas Devoogdt &lt;thomas@devoogdt.com&gt;
Canonical link: <a href="https://commits.webkit.org/276977@main">https://commits.webkit.org/276977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a10cd053fe7d9ddd2fd549672a6a45a965319a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46301 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48974 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48608 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/29793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/22894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46879 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/29793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/39921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19037 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/29793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41019 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4345 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/29793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50787 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/22894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/43929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10248 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22294 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->