### PR TITLE
[JSC] Start sharing megamorphic ById JIT code

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1950,6 +1950,7 @@
 		E339700523210E0B00B0AE21 /* JSInternalFieldObjectImplInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E339700423210E0A00B0AE21 /* JSInternalFieldObjectImplInlines.h */; };
 		E33A94962255323000D42B06 /* RandomizingFuzzerAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = E33A94942255322900D42B06 /* RandomizingFuzzerAgent.h */; };
 		E33A94972255323300D42B06 /* FuzzerAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = E33A94922255322900D42B06 /* FuzzerAgent.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E33B33362B9BA14E0011E80F /* SharedJITStubSet.h in Headers */ = {isa = PBXBuildFile; fileRef = E33B33342B9BA14E0011E80F /* SharedJITStubSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E33BBE0925BFA0410053690F /* WasmStreamingCompiler.h in Headers */ = {isa = PBXBuildFile; fileRef = E33BBE0825BFA03C0053690F /* WasmStreamingCompiler.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E33D203C277F304000A45FBB /* ZycoreDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = E33D1FEB277F303F00A45FBB /* ZycoreDefines.h */; };
 		E33D2049277F304000A45FBB /* ZycoreComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = E33D1FF8277F303F00A45FBB /* ZycoreComparison.h */; };
@@ -5543,6 +5544,8 @@
 		E33A94932255322900D42B06 /* RandomizingFuzzerAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RandomizingFuzzerAgent.cpp; sourceTree = "<group>"; };
 		E33A94942255322900D42B06 /* RandomizingFuzzerAgent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RandomizingFuzzerAgent.h; sourceTree = "<group>"; };
 		E33A94952255322A00D42B06 /* FuzzerAgent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FuzzerAgent.cpp; sourceTree = "<group>"; };
+		E33B33342B9BA14E0011E80F /* SharedJITStubSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SharedJITStubSet.h; sourceTree = "<group>"; };
+		E33B33352B9BA14E0011E80F /* SharedJITStubSet.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SharedJITStubSet.cpp; sourceTree = "<group>"; };
 		E33BBE0725BFA03C0053690F /* WasmStreamingCompiler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmStreamingCompiler.cpp; sourceTree = "<group>"; };
 		E33BBE0825BFA03C0053690F /* WasmStreamingCompiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmStreamingCompiler.h; sourceTree = "<group>"; };
 		E33D1FE8277F303F00A45FBB /* ZydisGeneratedEnumRegister.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZydisGeneratedEnumRegister.h; sourceTree = "<group>"; };
@@ -9581,6 +9584,8 @@
 				865DA0C725B8960C00875772 /* SetPrivateBrandStatus.h */,
 				865DA0C625B8959E00875772 /* SetPrivateBrandVariant.cpp */,
 				865DA0C425B8957400875772 /* SetPrivateBrandVariant.h */,
+				E33B33352B9BA14E0011E80F /* SharedJITStubSet.cpp */,
+				E33B33342B9BA14E0011E80F /* SharedJITStubSet.h */,
 				5350356427147E5900EC1A7E /* SourceID.h */,
 				0FD82E84141F3FDA00179C94 /* SpeculatedType.cpp */,
 				0FD82E4F141DAEA100179C94 /* SpeculatedType.h */,
@@ -11642,6 +11647,7 @@
 				276B389B2A71D1A900252F4E /* ShadowRealmObjectInlines.h in Headers */,
 				8602960526FB552D0078EB62 /* ShadowRealmPrototype.h in Headers */,
 				276B38922A71D18800252F4E /* ShadowRealmPrototypeInlines.h in Headers */,
+				E33B33362B9BA14E0011E80F /* SharedJITStubSet.h in Headers */,
 				FE2D0B382AE242B000A071A7 /* SideDataRepository.h in Headers */,
 				4BC18E5628FDE6C800ECD68D /* SIMDInfo.h in Headers */,
 				E379B59029834EC5007C4C0E /* SIMDShuffle.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -281,6 +281,7 @@ bytecode/ReduceWhitespace.cpp
 bytecode/Repatch.cpp
 bytecode/SetPrivateBrandStatus.cpp
 bytecode/SetPrivateBrandVariant.cpp
+bytecode/SharedJITStubSet.cpp
 bytecode/SpeculatedType.cpp
 bytecode/StructureSet.cpp
 bytecode/StructureStubClearingWatchpoint.cpp

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -323,6 +323,10 @@ public:
 
     UniquedStringImpl* uid() const { return m_identifier.uid(); }
     CacheableIdentifier identifier() const { return m_identifier; }
+    void updateIdentifier(CacheableIdentifier identifier)
+    {
+        m_identifier = identifier;
+    }
 
 #if ASSERT_ENABLED
     void checkConsistency(StructureStubInfo&);

--- a/Source/JavaScriptCore/bytecode/SharedJITStubSet.cpp
+++ b/Source/JavaScriptCore/bytecode/SharedJITStubSet.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SharedJITStubSet.h"
+
+#include "BaselineJITRegisters.h"
+#include "CacheableIdentifierInlines.h"
+#include "DFGJITCode.h"
+#include "InlineCacheCompiler.h"
+#include "Repatch.h"
+
+namespace JSC {
+
+#if ENABLE(JIT)
+
+RefPtr<PolymorphicAccessJITStubRoutine> SharedJITStubSet::getStatelessStub(StatelessCacheKey key) const
+{
+    return m_statelessStubs.get(key);
+}
+
+void SharedJITStubSet::setStatelessStub(StatelessCacheKey key, Ref<PolymorphicAccessJITStubRoutine> stub)
+{
+    m_statelessStubs.add(key, WTFMove(stub));
+}
+
+RefPtr<InlineCacheHandler> SharedJITStubSet::getSlowPathHandler(AccessType type) const
+{
+    return m_slowPathHandlers[static_cast<unsigned>(type)];
+}
+
+void SharedJITStubSet::setSlowPathHandler(AccessType type, Ref<InlineCacheHandler> handler)
+{
+    m_slowPathHandlers[static_cast<unsigned>(type)] = WTFMove(handler);
+}
+
+#endif // ENABLE(JIT)
+
+} // namespace JSC

--- a/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
+++ b/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "StructureStubInfo.h"
+
+namespace JSC {
+
+#if ENABLE(JIT)
+
+class SharedJITStubSet {
+    WTF_MAKE_FAST_ALLOCATED(SharedJITStubSet);
+public:
+    SharedJITStubSet() = default;
+
+    using StructureStubInfoKey = std::tuple<AccessType, bool, bool, bool, bool>;
+    using StatelessCacheKey = std::tuple<StructureStubInfoKey, AccessCase::AccessType>;
+
+    static StructureStubInfoKey stubInfoKey(const StructureStubInfo& stubInfo)
+    {
+        return std::tuple { stubInfo.accessType, static_cast<bool>(stubInfo.propertyIsInt32), static_cast<bool>(stubInfo.propertyIsString), static_cast<bool>(stubInfo.propertyIsSymbol), static_cast<bool>(stubInfo.prototypeIsKnownObject) };
+    }
+
+    struct Hash {
+        struct Key {
+            Key() = default;
+
+            Key(StructureStubInfoKey stubInfoKey, PolymorphicAccessJITStubRoutine* wrapped)
+                : m_wrapped(wrapped)
+                , m_stubInfoKey(stubInfoKey)
+            { }
+
+            Key(WTF::HashTableDeletedValueType)
+                : m_wrapped(bitwise_cast<PolymorphicAccessJITStubRoutine*>(static_cast<uintptr_t>(1)))
+            { }
+
+            bool isHashTableDeletedValue() const { return m_wrapped == bitwise_cast<PolymorphicAccessJITStubRoutine*>(static_cast<uintptr_t>(1)); }
+
+            friend bool operator==(const Key&, const Key&) = default;
+
+            PolymorphicAccessJITStubRoutine* m_wrapped { nullptr };
+            StructureStubInfoKey m_stubInfoKey { };
+        };
+
+        using KeyTraits = SimpleClassHashTraits<Key>;
+
+        static unsigned hash(const Key& p)
+        {
+            if (!p.m_wrapped)
+                return 1;
+            return p.m_wrapped->hash();
+        }
+
+        static bool equal(const Key& a, const Key& b)
+        {
+            return a == b;
+        }
+
+        static constexpr bool safeToCompareToEmptyOrDeleted = false;
+    };
+
+    struct Searcher {
+        struct Translator {
+            static unsigned hash(const Searcher& searcher)
+            {
+                return PolymorphicAccessJITStubRoutine::computeHash(searcher.m_cases);
+            }
+
+            static bool equal(const Hash::Key a, const Searcher& b)
+            {
+                if (a.m_stubInfoKey == b.m_stubInfoKey) {
+                    // FIXME: The ordering of cases does not matter for sharing capabilities.
+                    // We can potentially increase success rate by making this comparison / hashing non ordering sensitive.
+                    const auto& aCases = a.m_wrapped->cases();
+                    const auto& bCases = b.m_cases;
+                    if (aCases.size() != bCases.size())
+                        return false;
+                    for (unsigned index = 0; index < bCases.size(); ++index) {
+                        if (!AccessCase::canBeShared(*aCases[index], *bCases[index]))
+                            return false;
+                    }
+                    return true;
+                }
+                return false;
+            }
+        };
+
+        StructureStubInfoKey m_stubInfoKey;
+        const FixedVector<RefPtr<AccessCase>>& m_cases;
+    };
+
+    struct PointerTranslator {
+        static unsigned hash(const PolymorphicAccessJITStubRoutine* stub)
+        {
+            return stub->hash();
+        }
+
+        static bool equal(const Hash::Key& key, const PolymorphicAccessJITStubRoutine* stub)
+        {
+            return key.m_wrapped == stub;
+        }
+    };
+
+    void add(Hash::Key&& key)
+    {
+        m_stubs.add(WTFMove(key));
+    }
+
+    void remove(PolymorphicAccessJITStubRoutine* stub)
+    {
+        auto iter = m_stubs.find<PointerTranslator>(stub);
+        if (iter != m_stubs.end())
+            m_stubs.remove(iter);
+    }
+
+    RefPtr<PolymorphicAccessJITStubRoutine> find(const Searcher& searcher)
+    {
+        auto entry = m_stubs.find<SharedJITStubSet::Searcher::Translator>(searcher);
+        if (entry != m_stubs.end())
+            return entry->m_wrapped;
+        return nullptr;
+    }
+
+    RefPtr<PolymorphicAccessJITStubRoutine> getStatelessStub(StatelessCacheKey) const;
+    void setStatelessStub(StatelessCacheKey, Ref<PolymorphicAccessJITStubRoutine>);
+
+    RefPtr<InlineCacheHandler> getSlowPathHandler(AccessType) const;
+    void setSlowPathHandler(AccessType, Ref<InlineCacheHandler>);
+
+private:
+    HashSet<Hash::Key, Hash, Hash::KeyTraits> m_stubs;
+    HashMap<StatelessCacheKey, Ref<PolymorphicAccessJITStubRoutine>> m_statelessStubs;
+    std::array<RefPtr<InlineCacheHandler>, numberOfAccessTypes> m_fallbackHandlers { };
+    std::array<RefPtr<InlineCacheHandler>, numberOfAccessTypes> m_slowPathHandlers { };
+};
+
+#else
+
+class StructureStubInfo;
+
+#endif // ENABLE(JIT)
+
+} // namespace JSC

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -787,26 +787,6 @@ void StructureStubInfo::checkConsistency()
     }
 }
 #endif // ASSERT_ENABLED
-
-RefPtr<PolymorphicAccessJITStubRoutine> SharedJITStubSet::getStatelessStub(StatelessCacheKey key) const
-{
-    return m_statelessStubs.get(key);
-}
-
-void SharedJITStubSet::setStatelessStub(StatelessCacheKey key, Ref<PolymorphicAccessJITStubRoutine> stub)
-{
-    m_statelessStubs.add(key, WTFMove(stub));
-}
-
-RefPtr<InlineCacheHandler> SharedJITStubSet::getSlowPathHandler(AccessType type) const
-{
-    return m_slowPathHandlers[static_cast<unsigned>(type)];
-}
-
-void SharedJITStubSet::setSlowPathHandler(AccessType type, Ref<InlineCacheHandler> handler)
-{
-    m_slowPathHandlers[static_cast<unsigned>(type)] = WTFMove(handler);
-}
 
 #endif // ENABLE(JIT)
 

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1667,6 +1667,10 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
         finalizeUnconditionalFinalizers(); // We rely on these unconditional finalizers running before clearCurrentlyExecuting since CodeBlock's finalizer relies on querying currently executing.
         removeDeadCompilerWorklistEntries();
     }
+
+    // Keep in mind that we may use AtomStringTable, and this is totally OK since the main thread is suspended.
+    // End phase itself can run on main thread or concurrent collector thread. But whenever running this,
+    // mutator is suspended so there is no race condition.
     deleteUnmarkedCompiledCode();
 
     notifyIncrementalSweeper();

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
@@ -89,6 +89,7 @@ private:
 
 class PolymorphicCallStubRoutine final : public GCAwareJITStubRoutine, public ButterflyArray<PolymorphicCallStubRoutine, PolymorphicCallNode, CallSlot> {
 public:
+    using Base = GCAwareJITStubRoutine;
     friend class JITStubRoutine;
 
     CallVariantList variants() const;

--- a/Source/JavaScriptCore/runtime/CacheableIdentifier.h
+++ b/Source/JavaScriptCore/runtime/CacheableIdentifier.h
@@ -44,6 +44,7 @@ public:
     template <typename CodeBlockType>
     static inline CacheableIdentifier createFromIdentifierOwnedByCodeBlock(CodeBlockType*, UniquedStringImpl*);
     static inline CacheableIdentifier createFromImmortalIdentifier(UniquedStringImpl*);
+    static inline CacheableIdentifier createFromSharedStub(UniquedStringImpl*);
     static constexpr CacheableIdentifier createFromRawBits(uintptr_t rawBits) { return CacheableIdentifier(rawBits); }
 
     CacheableIdentifier(const CacheableIdentifier&) = default;

--- a/Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h
@@ -53,6 +53,11 @@ inline CacheableIdentifier CacheableIdentifier::createFromImmortalIdentifier(Uni
     return CacheableIdentifier(uid);
 }
 
+inline CacheableIdentifier CacheableIdentifier::createFromSharedStub(UniquedStringImpl* uid)
+{
+    return CacheableIdentifier(uid);
+}
+
 inline CacheableIdentifier CacheableIdentifier::createFromCell(JSCell* i)
 {
     return CacheableIdentifier(i);

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -104,6 +104,7 @@
 #include "SamplingProfiler.h"
 #include "ScopedArguments.h"
 #include "ShadowChicken.h"
+#include "SharedJITStubSet.h"
 #include "SideDataRepository.h"
 #include "SimpleTypedArrayController.h"
 #include "SourceProviderCache.h"


### PR DESCRIPTION
#### fca8004e23d3082e953e64a2af8246add3c9d20b
<pre>
[JSC] Start sharing megamorphic ById JIT code
<a href="https://bugs.webkit.org/show_bug.cgi?id=271942">https://bugs.webkit.org/show_bug.cgi?id=271942</a>
<a href="https://rdar.apple.com/125667161">rdar://125667161</a>

Reviewed by NOBODY (OOPS!).

This patch makes megamorphic ById JIT code shareable between multiple sites.
This is paving a way towards full handler IC, but for now, this is limited to megamorphic ById JIT code.
SharedJITStubSet can do hashing via AccessCase vector and can store JIT code for them. This is a key part
for Handler IC since we would like to use that later.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/bytecode/AccessCase.h:
(JSC::AccessCase::updateIdentifier):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::isMegamorphicById):
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/bytecode/SharedJITStubSet.cpp: Added.
(JSC::SharedJITStubSet::getStatelessStub const):
(JSC::SharedJITStubSet::setStatelessStub):
(JSC::SharedJITStubSet::getSlowPathHandler const):
(JSC::SharedJITStubSet::setSlowPathHandler):
* Source/JavaScriptCore/bytecode/SharedJITStubSet.h: Added.
(JSC::SharedJITStubSet::stubInfoKey):
(JSC::SharedJITStubSet::Hash::Key::Key):
(JSC::SharedJITStubSet::Hash::Key::isHashTableDeletedValue const):
(JSC::SharedJITStubSet::Hash::hash):
(JSC::SharedJITStubSet::Hash::equal):
(JSC::SharedJITStubSet::Searcher::Translator::hash):
(JSC::SharedJITStubSet::Searcher::Translator::equal):
(JSC::SharedJITStubSet::PointerTranslator::hash):
(JSC::SharedJITStubSet::PointerTranslator::equal):
(JSC::SharedJITStubSet::add):
(JSC::SharedJITStubSet::remove):
(JSC::SharedJITStubSet::find):
* Source/JavaScriptCore/bytecode/StructureStubInfo.cpp:
(JSC::SharedJITStubSet::getStatelessStub const): Deleted.
(JSC::SharedJITStubSet::setStatelessStub): Deleted.
(JSC::SharedJITStubSet::getSlowPathHandler const): Deleted.
(JSC::SharedJITStubSet::setSlowPathHandler): Deleted.
* Source/JavaScriptCore/bytecode/StructureStubInfo.h:
(JSC::SharedJITStubSet::Hash::Key::Key): Deleted.
(JSC::SharedJITStubSet::Hash::Key::isHashTableDeletedValue const): Deleted.
(JSC::SharedJITStubSet::Hash::hash): Deleted.
(JSC::SharedJITStubSet::Hash::equal): Deleted.
(JSC::SharedJITStubSet::Searcher::Translator::hash): Deleted.
(JSC::SharedJITStubSet::Searcher::Translator::equal): Deleted.
(JSC::SharedJITStubSet::PointerTranslator::hash): Deleted.
(JSC::SharedJITStubSet::PointerTranslator::equal): Deleted.
(JSC::SharedJITStubSet::add): Deleted.
(JSC::SharedJITStubSet::remove): Deleted.
(JSC::SharedJITStubSet::find): Deleted.
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::runEndPhase):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::PolymorphicAccessJITStubRoutine::observeZeroRefCountImpl):
(JSC::PolymorphicAccessJITStubRoutine::computeHash):
(JSC::PolymorphicAccessJITStubRoutine::addedToSharedJITStubSet):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
(JSC::PolymorphicAccessJITStubRoutine::hash const):
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h:
* Source/JavaScriptCore/runtime/CacheableIdentifier.h:
* Source/JavaScriptCore/runtime/CacheableIdentifierInlines.h:
(JSC::CacheableIdentifier::createFromSharedStub):
* Source/JavaScriptCore/runtime/VM.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fca8004e23d3082e953e64a2af8246add3c9d20b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48763 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/48849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/42219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22753 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/48849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46756 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/39822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/48849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/40920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4222 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/39411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/41269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50645 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/45652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/43815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52803 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6430 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22168 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->