### PR TITLE
REGRESSION (273461@main): The value attribute is not displayed in an input field with type="email" and multiple attributes

### DIFF
--- a/LayoutTests/fast/forms/email-input-type-value-and-multiple-attributes-set-expected.html
+++ b/LayoutTests/fast/forms/email-input-type-value-and-multiple-attributes-set-expected.html
@@ -1,0 +1,1 @@
+<input type="email" value="test@example.com">

--- a/LayoutTests/fast/forms/email-input-type-value-and-multiple-attributes-set.html
+++ b/LayoutTests/fast/forms/email-input-type-value-and-multiple-attributes-set.html
@@ -1,0 +1,1 @@
+<input type="email" value="test@example.com" multiple>

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -94,7 +94,7 @@ bool EmailInputType::supportsSelectionAPI() const
 void EmailInputType::attributeChanged(const QualifiedName& name)
 {
     if (name == multipleAttr)
-        element()->setValueFromRenderer(sanitizeValue(element()->value()));
+        element()->setValueInternal(sanitizeValue(element()->value()), TextFieldEventBehavior::DispatchNoEvent);
 
     BaseTextInputType::attributeChanged(name);
 }


### PR DESCRIPTION
#### b52f2b8abac2656e9e7e1c3ca3748e4f4650bded
<pre>
REGRESSION (273461@main): The value attribute is not displayed in an input field with type=&quot;email&quot; and multiple attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=271043">https://bugs.webkit.org/show_bug.cgi?id=271043</a>
<a href="https://rdar.apple.com/125221858">rdar://125221858</a>

Reviewed by Ryosuke Niwa.

273461@main deferred input element shadow tree construction outside of attribute
parsing. However, when combined with an earlier change to sanitize the value of
email inputs when the multiple attribute is set (263555@main), the deferral of
shadow tree construction results in the value not being displayed at all.

The root cause of the issue is the use of `setValueFromRenderer` introduced by
263555@main. The use of that method in `EmailInputType::attributeChanged` has
always been inappropriate, as it is specifically meant for user modifications.
However, in this case, the problem arises from the fact that `setValueFromRenderer`
calls `setFormControlValueMatchesRenderer(true)`. This results in the elision
of shadow tree construction in `TextFieldInputType::updateInnerTextValue`, as
`HTMLTextFormControlElement::setInnerTextValue` is only called if
`formControlValueMatchesRenderer()` returns false. Before 273461@main, this elision
was benign, as the shadow tree was constructed at attribute parse time.

Fix by using a more appropriate method to update the email input&apos;s value when
the multiple attribute is changed.

A new regression test is added. The coverage for the issue fixed by 263555@main
continues to be provided by the WPT: html/semantics/forms/the-input-element/email.html.

* LayoutTests/fast/forms/email-input-type-value-and-multiple-attributes-set-expected.html: Added.
* LayoutTests/fast/forms/email-input-type-value-and-multiple-attributes-set.html: Added.
* Source/WebCore/html/EmailInputType.cpp:
(WebCore::EmailInputType::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/276895@main">https://commits.webkit.org/276895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01cb27c9b423811ba1865e887277d10a8e63220c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46001 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48672 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48308 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37620 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18811 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40777 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4045 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50455 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/20997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44777 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43668 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10207 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22656 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/21991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->