### PR TITLE
Drop String::fromUTF8() overloads taking in a raw pointer and a size

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCContext.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCContext.cpp
@@ -873,7 +873,7 @@ JSCValue* jsc_context_evaluate_with_source_uri(JSCContext* context, const char* 
     g_return_val_if_fail(code, nullptr);
 
     JSValueRef exception = nullptr;
-    JSValueRef result = evaluateScriptInContext(context->priv->jsContext.get(), String::fromUTF8(code, length < 0 ? strlen(code) : length), uri, lineNumber, &exception);
+    JSValueRef result = evaluateScriptInContext(context->priv->jsContext.get(), String::fromUTF8(std::span(code, length < 0 ? strlen(code) : length)), uri, lineNumber, &exception);
     if (jscContextHandleExceptionIfNeeded(context, exception))
         return jsc_value_new_undefined(context);
 
@@ -913,7 +913,7 @@ JSCValue* jsc_context_evaluate_in_object(JSCContext* context, const char* code, 
     JSC::JSLockHolder locker(globalObject);
     globalObject->setGlobalScopeExtension(JSC::JSWithScope::create(vm, globalObject, globalObject->globalScope(), toJS(JSContextGetGlobalObject(context->priv->jsContext.get()))));
     JSValueRef exception = nullptr;
-    JSValueRef result = evaluateScriptInContext(objectContext.get(), String::fromUTF8(code, length < 0 ? strlen(code) : length), uri, lineNumber, &exception);
+    JSValueRef result = evaluateScriptInContext(objectContext.get(), String::fromUTF8(std::span(code, length < 0 ? strlen(code) : length)), uri, lineNumber, &exception);
     if (jscContextHandleExceptionIfNeeded(context, exception))
         return jsc_value_new_undefined(context);
 
@@ -973,7 +973,7 @@ JSCCheckSyntaxResult jsc_context_check_syntax(JSCContext* context, const char* c
     JSC::JSLockHolder locker(vm);
 
     URL sourceURL = uri ? URL(String::fromLatin1(uri)) : URL();
-    JSC::SourceCode source = JSC::makeSource(String::fromUTF8(code, length < 0 ? strlen(code) : length), JSC::SourceOrigin { sourceURL }, JSC::SourceTaintedOrigin::Untainted,
+    JSC::SourceCode source = JSC::makeSource(String::fromUTF8(std::span(code, length < 0 ? strlen(code) : length)), JSC::SourceOrigin { sourceURL }, JSC::SourceTaintedOrigin::Untainted,
         sourceURL.string() , TextPosition(OrdinalNumber::fromOneBasedInt(lineNumber), OrdinalNumber()));
     bool success = false;
     JSC::ParserError error;

--- a/Source/JavaScriptCore/API/glib/JSCValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCValue.cpp
@@ -370,7 +370,7 @@ JSCValue* jsc_value_new_string_from_bytes(JSCContext* context, GBytes* bytes)
 
     gsize dataSize;
     const auto* data = static_cast<const char*>(g_bytes_get_data(bytes, &dataSize));
-    auto string = String::fromUTF8(data, dataSize);
+    auto string = String::fromUTF8(std::span(data, dataSize));
     JSRetainPtr<JSStringRef> jsString(Adopt, OpaqueJSString::tryCreate(WTFMove(string)).leakRef());
     return jscContextGetOrCreateValue(context, JSValueMakeString(jscContextGetJSContext(context), jsString.get())).leakRef();
 }

--- a/Source/JavaScriptCore/debugger/DebuggerScope.cpp
+++ b/Source/JavaScriptCore/debugger/DebuggerScope.cpp
@@ -207,7 +207,7 @@ String DebuggerScope::name() const
     if (!codeBlock)
         return String();
 
-    return String::fromUTF8(codeBlock->inferredName());
+    return String::fromUTF8(codeBlock->inferredName().span());
 }
 
 DebuggerLocation DebuggerScope::location() const

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -521,7 +521,7 @@ long StopWatch::getElapsedMS()
 template<typename Vector>
 static inline String stringFromUTF(const Vector& utf8)
 {
-    return String::fromUTF8WithLatin1Fallback(utf8.data(), utf8.size());
+    return String::fromUTF8WithLatin1Fallback(utf8.span());
 }
 
 static JSC_DECLARE_CUSTOM_GETTER(accessorMakeMasquerader);
@@ -1995,7 +1995,7 @@ JSC_DEFINE_HOST_FUNCTION(functionReadFile, (JSGlobalObject* globalObject, CallFr
         return throwVMError(globalObject, scope, "Could not open file."_s);
 
     if (!isBinary)
-        return JSValue::encode(jsString(vm, String::fromUTF8WithLatin1Fallback(content->data(), content->length())));
+        return JSValue::encode(jsString(vm, String::fromUTF8WithLatin1Fallback(content->span())));
 
     Structure* structure = globalObject->typedArrayStructure(TypeUint8, content->isResizableOrGrowableShared());
     JSObject* result = JSUint8Array::create(vm, structure, WTFMove(content));

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -1848,7 +1848,7 @@ template<typename CharacterType> ALWAYS_INLINE String Lexer<CharacterType>::pars
             mergedCharacterBits |= m_current;
         shift();
     }
-    unsigned length = currentSourcePtr() - stringStart;
+    std::span commentDirective { stringStart, currentSourcePtr() };
 
     skipWhitespace();
     if (!isLineTerminator(m_current) && !atEnd())
@@ -1856,9 +1856,9 @@ template<typename CharacterType> ALWAYS_INLINE String Lexer<CharacterType>::pars
 
     if constexpr (std::is_same_v<CharacterType, UChar>) {
         if (isLatin1(mergedCharacterBits))
-            return String::make8Bit(stringStart, length);
+            return String::make8Bit(commentDirective);
     }
-    return std::span { stringStart, length };
+    return commentDirective;
 }
 IGNORE_WARNINGS_END
 

--- a/Source/JavaScriptCore/profiler/ProfilerBytecode.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecode.cpp
@@ -38,7 +38,7 @@ Ref<JSON::Value> Bytecode::toJSON(Dumper& dumper) const
     auto result = JSON::Object::create();
     result->setDouble(dumper.keys().m_bytecodeIndex, m_bytecodeIndex);
     result->setString(dumper.keys().m_opcode, String::fromUTF8(opcodeNames[m_opcodeID]));
-    result->setString(dumper.keys().m_description, String::fromUTF8(m_description));
+    result->setString(dumper.keys().m_description, String::fromUTF8(m_description.span()));
     return result;
 }
 

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp
@@ -76,15 +76,15 @@ const Bytecode& BytecodeSequence::forBytecodeIndex(unsigned bytecodeIndex) const
 
 void BytecodeSequence::addSequenceProperties(Dumper& dumper, JSON::Object& result) const
 {
-    auto header = JSON::Array::create();
-    for (unsigned i = 0; i < m_header.size(); ++i)
-        header->pushString(String::fromUTF8(m_header[i]));
-    result.setValue(dumper.keys().m_header, WTFMove(header));
+    Ref jsonHeader = JSON::Array::create();
+    for (auto& header : m_header)
+        jsonHeader->pushString(String::fromUTF8(header.span()));
+    result.setValue(dumper.keys().m_header, WTFMove(jsonHeader));
 
-    auto sequence = JSON::Array::create();
-    for (unsigned i = 0; i < m_sequence.size(); ++i)
-        sequence->pushValue(m_sequence[i].toJSON(dumper));
-    result.setValue(dumper.keys().m_bytecode, WTFMove(sequence));
+    Ref jsonSequence = JSON::Array::create();
+    for (auto& sequence : m_sequence)
+        jsonSequence->pushValue(sequence.toJSON(dumper));
+    result.setValue(dumper.keys().m_bytecode, WTFMove(jsonSequence));
 }
 
 } } // namespace JSC::Profiler

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp
@@ -57,15 +57,15 @@ Ref<JSON::Value> Bytecodes::toJSON(Dumper& dumper) const
     auto result = JSON::Object::create();
 
     result->setDouble(dumper.keys().m_bytecodesID, m_id);
-    result->setString(dumper.keys().m_inferredName, String::fromUTF8(m_inferredName));
-    String sourceCode = String::fromUTF8(m_sourceCode);
+    result->setString(dumper.keys().m_inferredName, String::fromUTF8(m_inferredName.span()));
+    String sourceCode = String::fromUTF8(m_sourceCode.span());
     if (Options::abbreviateSourceCodeForProfiler()) {
         unsigned size = Options::abbreviateSourceCodeForProfiler();
         if (sourceCode.length() > size)
             sourceCode = makeString(StringView(sourceCode).left(size - 1), horizontalEllipsis);
     }
     result->setString(dumper.keys().m_sourceCode, WTFMove(sourceCode));
-    result->setString(dumper.keys().m_hash, String::fromUTF8(toCString(m_hash)));
+    result->setString(dumper.keys().m_hash, String::fromUTF8(toCString(m_hash).span()));
     result->setDouble(dumper.keys().m_instructionCount, m_instructionCount);
     addSequenceProperties(dumper, result.get());
 

--- a/Source/JavaScriptCore/profiler/ProfilerCompilation.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerCompilation.cpp
@@ -115,7 +115,7 @@ Ref<JSON::Value> Compilation::toJSON(Dumper& dumper) const
 {
     auto result = JSON::Object::create();
     result->setDouble(dumper.keys().m_bytecodesID, m_bytecodes->id());
-    result->setString(dumper.keys().m_compilationKind, String::fromUTF8(toCString(m_kind)));
+    result->setString(dumper.keys().m_compilationKind, String::fromUTF8(toCString(m_kind).span()));
 
     auto profiledBytecodes = JSON::Array::create();
     for (const auto& bytecode : m_profiledBytecodes)
@@ -149,9 +149,9 @@ Ref<JSON::Value> Compilation::toJSON(Dumper& dumper) const
     result->setDouble(dumper.keys().m_numInlinedGetByIds, m_numInlinedGetByIds);
     result->setDouble(dumper.keys().m_numInlinedPutByIds, m_numInlinedPutByIds);
     result->setDouble(dumper.keys().m_numInlinedCalls, m_numInlinedCalls);
-    result->setString(dumper.keys().m_jettisonReason, String::fromUTF8(toCString(m_jettisonReason)));
+    result->setString(dumper.keys().m_jettisonReason, String::fromUTF8(toCString(m_jettisonReason).span()));
     if (!m_additionalJettisonReason.isNull())
-        result->setString(dumper.keys().m_additionalJettisonReason, String::fromUTF8(m_additionalJettisonReason));
+        result->setString(dumper.keys().m_additionalJettisonReason, String::fromUTF8(m_additionalJettisonReason.span()));
 
     result->setValue(dumper.keys().m_uid, m_uid.toJSON(dumper));
 

--- a/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.cpp
@@ -47,7 +47,7 @@ Ref<JSON::Value> CompiledBytecode::toJSON(Dumper& dumper) const
     auto result = JSON::Object::create();
 
     result->setValue(dumper.keys().m_origin, m_origin.toJSON(dumper));
-    result->setString(dumper.keys().m_description, String::fromUTF8(m_description));
+    result->setString(dumper.keys().m_description, String::fromUTF8(m_description.span()));
 
     return result;
 }

--- a/Source/JavaScriptCore/profiler/ProfilerEvent.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerEvent.cpp
@@ -55,7 +55,7 @@ Ref<JSON::Value> Event::toJSON(Dumper& dumper) const
         result->setValue(dumper.keys().m_compilationUID, m_compilation->uid().toJSON(dumper));
     result->setString(dumper.keys().m_summary, String::fromUTF8(m_summary));
     if (m_detail.length())
-        result->setString(dumper.keys().m_detail, String::fromUTF8(m_detail));
+        result->setString(dumper.keys().m_detail, String::fromUTF8(m_detail.span()));
 
     return result;
 }

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1094,7 +1094,7 @@ Ref<JSON::Value> SamplingProfiler::stackTracesAsJSON()
         result->setString("category"_s, tierName(stackFrame));
         if (std::optional<std::pair<StackFrame::CodeLocation, CodeBlock*>> machineLocation = stackFrame.machineLocation) {
             auto inliner = JSON::Object::create();
-            inliner->setString("name"_s, String::fromUTF8(machineLocation->second->inferredName()));
+            inliner->setString("name"_s, String::fromUTF8(machineLocation->second->inferredName().span()));
             inliner->setString("location"_s, descriptionForLocation(machineLocation->first, std::nullopt, BytecodeIndex()));
             inliner->setString("category"_s, tierName(stackFrame));
             result->setValue("inliner"_s, WTFMove(inliner));

--- a/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
+++ b/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
@@ -85,11 +85,11 @@ bool FunctionAllowlist::contains(CodeBlock* codeBlock) const
     if (m_entries.isEmpty())
         return false;
 
-    String name = String::fromUTF8(codeBlock->inferredName());
+    String name = String::fromUTF8(codeBlock->inferredName().span());
     if (m_entries.contains(name))
         return true;
 
-    String hash = String::fromUTF8(codeBlock->hashAsStringIfPossible());
+    String hash = String::fromUTF8(codeBlock->hashAsStringIfPossible().span());
     if (m_entries.contains(hash))
         return true;
 

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -464,6 +464,8 @@ auto SectionParser::parseExport() -> PartialResult
         WASM_PARSER_FAIL_IF(!parseVarUInt32(fieldLen), "can't get ", exportNumber, "th Export's field name length");
         WASM_PARSER_FAIL_IF(!consumeUTF8String(fieldString, fieldLen), "can't get ", exportNumber, "th Export's field name of length ", fieldLen);
         String fieldName = String::fromUTF8(fieldString);
+        if (fieldName.isNull())
+            fieldName = emptyString();
         WASM_PARSER_FAIL_IF(exportNames.contains(fieldName), "duplicate export: '", fieldString, "'");
         exportNames.add(fieldName);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -188,12 +188,17 @@ JSWebAssemblyInstance* JSWebAssemblyInstance::tryCreate(VM& vm, JSGlobalObject* 
             return exception(createTypeError(globalObject, "can't make WebAssembly.Instance because there is no imports Object and the WebAssembly.Module requires imports"_s));
     }
 
+    auto stringFromUTF8 = [](auto& span) {
+        auto string = String::fromUTF8(span);
+        return string.isNull() ? emptyString() : string;
+    };
+
     // For each import i in module.imports:
     {
         IdentifierSet specifiers;
         for (auto& import : moduleInformation.imports) {
-            Identifier moduleName = Identifier::fromString(vm, String::fromUTF8(import.module));
-            Identifier fieldName = Identifier::fromString(vm, String::fromUTF8(import.field));
+            Identifier moduleName = Identifier::fromString(vm, stringFromUTF8(import.module));
+            Identifier fieldName = Identifier::fromString(vm, stringFromUTF8(import.field));
             auto result = specifiers.add(moduleName.impl());
             if (result.isNewEntry)
                 moduleRecord->appendRequestedModule(moduleName, nullptr);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyModule.cpp
@@ -93,6 +93,8 @@ void JSWebAssemblyModule::finishCreation(VM& vm)
     for (auto& exp : moduleInformation.exports) {
         auto offset = exportSymbolTable->takeNextScopeOffset(NoLockingNecessary);
         String field = String::fromUTF8(exp.field);
+        if (field.isNull())
+            field = emptyString();
         exportSymbolTable->set(NoLockingNecessary, AtomString(field).impl(), SymbolTableEntry(VarOffset(offset)));
     }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -76,7 +76,8 @@ void WebAssemblyModuleRecord::finishCreation(JSGlobalObject* globalObject, VM& v
     Base::finishCreation(globalObject, vm);
     ASSERT(inherits(info()));
     for (const auto& exp : moduleInformation.exports) {
-        Identifier field = Identifier::fromString(vm, String::fromUTF8(exp.field));
+        auto fieldString = String::fromUTF8(exp.field);
+        Identifier field = Identifier::fromString(vm, fieldString.isNull() ? emptyString() : fieldString);
         addExportEntry(ExportEntry::createLocal(field, field));
     }
 }
@@ -134,9 +135,14 @@ void WebAssemblyModuleRecord::initializeImports(JSGlobalObject* globalObject, JS
         return makeString(before, ' ', String::fromUTF8(import.module), ':', String::fromUTF8(import.field), ' ', after);
     };
 
+    auto stringFromUTF8 = [](auto& span) {
+        auto string = String::fromUTF8(span);
+        return string.isNull() ? emptyString() : string;
+    };
+
     for (const auto& import : moduleInformation.imports) {
-        Identifier moduleName = Identifier::fromString(vm, String::fromUTF8(import.module));
-        Identifier fieldName = Identifier::fromString(vm, String::fromUTF8(import.field));
+        Identifier moduleName = Identifier::fromString(vm, stringFromUTF8(import.module));
+        Identifier fieldName = Identifier::fromString(vm, stringFromUTF8(import.field));
         JSValue value;
         if (creationMode == Wasm::CreationMode::FromJS) {
             // 1. Let o be the resultant value of performing Get(importObject, i.module_name).
@@ -728,7 +734,8 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
         }
         }
 
-        Identifier propertyName = Identifier::fromString(vm, String::fromUTF8(exp.field));
+        String fieldString = String::fromUTF8(exp.field);
+        Identifier propertyName = Identifier::fromString(vm, fieldString.isNull() ? emptyString() : fieldString);
 
         bool shouldThrowReadOnlyError = false;
         bool ignoreReadOnlyErrors = true;

--- a/Source/WTF/wtf/StringPrintStream.cpp
+++ b/Source/WTF/wtf/StringPrintStream.cpp
@@ -100,19 +100,19 @@ Expected<String, UTF8ConversionError> StringPrintStream::tryToString()
     ASSERT(m_next == strlen(m_buffer));
     if (m_next > String::MaxLength)
         return makeUnexpected(UTF8ConversionError::OutOfMemory);
-    return String::fromUTF8(m_buffer, m_next);
+    return String::fromUTF8({ m_buffer, m_next });
 }
 
 String StringPrintStream::toString()
 {
     ASSERT(m_next == strlen(m_buffer));
-    return String::fromUTF8(m_buffer, m_next);
+    return String::fromUTF8({ m_buffer, m_next });
 }
 
 String StringPrintStream::toStringWithLatin1Fallback()
 {
     ASSERT(m_next == strlen(m_buffer));
-    return String::fromUTF8WithLatin1Fallback(m_buffer, m_next);
+    return String::fromUTF8WithLatin1Fallback({ m_buffer, m_next });
 }
 
 void StringPrintStream::increaseSize(size_t newSize)

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -212,7 +212,7 @@ static String decodeEscapeSequencesFromParsedURL(StringView input)
 
     // FIXME: Is UTF-8 always the correct encoding?
     // FIXME: This returns a null string when we encounter an invalid UTF-8 sequence. Is that OK?
-    return String::fromUTF8(percentDecoded.data(), percentDecoded.size());
+    return String::fromUTF8(percentDecoded.span());
 }
 
 String URL::user() const

--- a/Source/WTF/wtf/URLParser.h
+++ b/Source/WTF/wtf/URLParser.h
@@ -119,8 +119,8 @@ private:
     template<bool(*isInCodeSet)(char32_t), typename CharacterType> void utf8PercentEncode(const CodePointIterator<CharacterType>&);
     template<typename CharacterType> void utf8QueryEncode(const CodePointIterator<CharacterType>&);
     template<typename CharacterType> std::optional<LCharBuffer> domainToASCII(StringImpl&, const CodePointIterator<CharacterType>& iteratorForSyntaxViolationPosition);
-    template<typename CharacterType> LCharBuffer percentDecode(const LChar*, size_t, const CodePointIterator<CharacterType>& iteratorForSyntaxViolationPosition);
-    static LCharBuffer percentDecode(const LChar*, size_t);
+    template<typename CharacterType> LCharBuffer percentDecode(std::span<const LChar>, const CodePointIterator<CharacterType>& iteratorForSyntaxViolationPosition);
+    static LCharBuffer percentDecode(std::span<const LChar>);
     bool hasForbiddenHostCodePoint(const LCharBuffer&);
     void percentEncodeByte(uint8_t);
     void appendToASCIIBuffer(char32_t);

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -86,7 +86,7 @@ String createTemporaryZipArchive(const String& path)
         
         BOMCopier copier = BOMCopierNew();
         if (!BOMCopierCopyWithOptions(copier, newURL.path.fileSystemRepresentation, archivePath.data(), (__bridge CFDictionaryRef)options))
-            temporaryFile = String::fromUTF8(archivePath);
+            temporaryFile = String::fromUTF8(archivePath.span());
         BOMCopierFree(copier);
     }];
     

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -260,25 +260,19 @@ public:
     WTF_EXPORT_PRIVATE Vector<wchar_t> wideCharacters() const;
 #endif
 
-    WTF_EXPORT_PRIVATE static String make8Bit(const UChar*, unsigned);
+    WTF_EXPORT_PRIVATE static String make8Bit(std::span<const UChar>);
     WTF_EXPORT_PRIVATE void convertTo16Bit();
 
     // String::fromUTF8 will return a null string if the input data contains invalid UTF-8 sequences.
-    WTF_EXPORT_PRIVATE static String fromUTF8(const LChar*, size_t);
+    WTF_EXPORT_PRIVATE static String fromUTF8(std::span<const LChar>);
     WTF_EXPORT_PRIVATE static String fromUTF8(const LChar*);
-    static String fromUTF8(const char* characters, size_t length) { return fromUTF8(reinterpret_cast<const LChar*>(characters), length); }
+    static String fromUTF8(std::span<const char> characters) { return fromUTF8(std::span { reinterpret_cast<const LChar*>(characters.data()), characters.size() }); }
     static String fromUTF8(const char* string) { return fromUTF8(reinterpret_cast<const LChar*>(string)); }
-    WTF_EXPORT_PRIVATE static String fromUTF8(const CString&);
-    static String fromUTF8(const std::span<const LChar>& characters);
-    static String fromUTF8(const Vector<LChar>& characters) { return fromUTF8(characters.span()); }
-    static String fromUTF8ReplacingInvalidSequences(const LChar*, size_t);
+    static String fromUTF8ReplacingInvalidSequences(std::span<const LChar>);
 
     // Tries to convert the passed in string to UTF-8, but will fall back to Latin-1 if the string is not valid UTF-8.
     WTF_EXPORT_PRIVATE static String fromUTF8WithLatin1Fallback(std::span<const LChar>);
-
-    // FIXME: Update all call sites to pass a span and remove these 2 overloads.
-    static String fromUTF8WithLatin1Fallback(const LChar* characters, size_t length) { return fromUTF8WithLatin1Fallback(std::span { characters, length }); }
-    static String fromUTF8WithLatin1Fallback(const char* characters, size_t length) { return fromUTF8WithLatin1Fallback(std::span { reinterpret_cast<const LChar*>(characters), length }); }
+    static String fromUTF8WithLatin1Fallback(std::span<const char> characters) { return fromUTF8WithLatin1Fallback({ reinterpret_cast<const LChar*>(characters.data()), characters.size() }); }
 
     WTF_EXPORT_PRIVATE static String fromCodePoint(char32_t codePoint);
 
@@ -534,13 +528,6 @@ inline NSString * nsStringNilIfNull(const String& string)
 inline bool codePointCompareLessThan(const String& a, const String& b)
 {
     return codePointCompare(a.impl(), b.impl()) < 0;
-}
-
-inline String String::fromUTF8(const std::span<const LChar>& characters)
-{
-    if (characters.empty())
-        return emptyString();
-    return fromUTF8(characters.data(), characters.size());
 }
 
 template<typename Predicate>

--- a/Source/WebCore/Modules/applepay/cocoa/PaymentCocoa.mm
+++ b/Source/WebCore/Modules/applepay/cocoa/PaymentCocoa.mm
@@ -32,6 +32,7 @@
 #import "PaymentContact.h"
 #import "PaymentMethod.h"
 #import <pal/spi/cocoa/PassKitSPI.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 namespace WebCore {
 
@@ -57,7 +58,7 @@ static ApplePayPayment::Token convert(PKPaymentToken *paymentToken)
     if (NSString *transactionIdentifier = paymentToken.transactionIdentifier)
         result.transactionIdentifier = transactionIdentifier;
     if (NSData *paymentData = paymentToken.paymentData)
-        result.paymentData = String::fromUTF8((const char*)paymentData.bytes, paymentData.length);
+        result.paymentData = String::fromUTF8(span(paymentData));
 
     return result;
 }

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -276,7 +276,7 @@ String ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::dataAsString() 
 {
     if (std::holds_alternative<Ref<SharedBuffer>>(m_data)) {
         auto& buffer = std::get<Ref<SharedBuffer>>(m_data);
-        return String::fromUTF8(buffer->data(), buffer->size());
+        return String::fromUTF8(buffer->span());
     }
 
     if (std::holds_alternative<String>(m_data))

--- a/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp
@@ -82,7 +82,7 @@ bool CDMSessionClearKey::update(JSC::Uint8Array* rawKeysData, RefPtr<JSC::Uint8A
     ASSERT(rawKeysData);
 
     do {
-        auto rawKeysString = String::fromUTF8(rawKeysData->data(), rawKeysData->length());
+        auto rawKeysString = String::fromUTF8(rawKeysData->span());
         if (rawKeysString.isEmpty())  {
             LOG(Media, "CDMSessionClearKey::update(%p) - failed: empty message", this);
             break;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -957,7 +957,7 @@ String GStreamerMediaEndpoint::trackIdFromSDPMedia(const GstSDPMedia& media)
     if (components.size() < 2)
         return emptyString();
 
-    return String::fromUTF8(components[1].utf8());
+    return String::fromUTF8(components[1].utf8().span());
 }
 
 void GStreamerMediaEndpoint::connectIncomingTrack(WebRTCTrackData& data)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
@@ -187,7 +187,7 @@ void LibWebRTCDataChannelHandler::OnMessage(const webrtc::DataBuffer& buffer)
         if (buffer.binary)
             m_bufferedMessages.append(SharedBuffer::create(std::span { data, buffer.size() }));
         else
-            m_bufferedMessages.append(String::fromUTF8(data, buffer.size()));
+            m_bufferedMessages.append(String::fromUTF8({ data, buffer.size() }));
         return;
     }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -269,7 +269,7 @@ void LibWebRTCPeerConnectionBackend::doAddIceCandidate(RTCIceCandidate& candidat
     std::unique_ptr<webrtc::IceCandidateInterface> rtcCandidate(webrtc::CreateIceCandidate(candidate.sdpMid().utf8().data(), sdpMLineIndex, candidate.candidate().utf8().data(), &error));
 
     if (!rtcCandidate) {
-        callback(Exception { ExceptionCode::OperationError, String::fromUTF8(error.description.data(), error.description.length()) });
+        callback(Exception { ExceptionCode::OperationError, String::fromUTF8(error.description) });
         return;
     }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.h
@@ -77,7 +77,7 @@ webrtc::Priority fromRTCPriorityType(RTCPriorityType);
 
 inline String fromStdString(const std::string& value)
 {
-    return String::fromUTF8(value.data(), value.length());
+    return String::fromUTF8(value);
 }
 
 RTCIceCandidateFields convertIceCandidate(const cricket::Candidate&);

--- a/Source/WebCore/Modules/webauthn/cbor/CBORReader.cpp
+++ b/Source/WebCore/Modules/webauthn/cbor/CBORReader.cpp
@@ -220,7 +220,7 @@ std::optional<CBORValue> CBORReader::readString(uint64_t numBytes)
     }
 
     ASSERT(numBytes <= std::numeric_limits<size_t>::max());
-    String cborString = String::fromUTF8(m_data.data() + std::distance(m_data.begin(), m_it), static_cast<size_t>(numBytes));
+    String cborString = String::fromUTF8(m_data.subspan(std::distance(m_data.begin(), m_it), numBytes));
     m_it += numBytes;
 
     // Invalid UTF8 bytes produce an empty WTFString.

--- a/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp
@@ -89,7 +89,7 @@ bool WebSocketExtensionParser::consumeQuotedString()
     }
     if (m_current >= m_end || *m_current != '"')
         return false;
-    m_currentToken = String::fromUTF8(buffer.data(), buffer.size());
+    m_currentToken = String::fromUTF8(buffer.span());
     if (m_currentToken.isNull())
         return false;
     ++m_current;

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -217,7 +217,7 @@ static CString trimToValidUTF8Length1024(CString&& string)
     while (true) {
         if (!string.length())
             return WTFMove(string);
-        auto decoded = String::fromUTF8(string.data(), string.length());
+        auto decoded = String::fromUTF8(string.span());
         if (!decoded)
             string = CString(string.data(), string.length() - 1);
         else

--- a/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
+++ b/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
@@ -187,7 +187,7 @@ String CryptoDigest::toHexString()
         snprintf(buffer, 3, "%02X", hash.at(i));
         buffer += 2;
     }
-    return String::fromUTF8(result);
+    return String::fromUTF8(result.span());
 }
 
 std::optional<Vector<uint8_t>> CryptoDigest::computeHash(CryptoDigest::Algorithm algo, const Vector<uint8_t>& data, bool useCryptoKit)

--- a/Source/WebCore/bridge/IdentifierRep.cpp
+++ b/Source/WebCore/bridge/IdentifierRep.cpp
@@ -89,9 +89,9 @@ IdentifierRep* IdentifierRep::get(const char* name)
 {
     ASSERT(name);
     if (!name)
-        return 0;
+        return nullptr;
   
-    String string = String::fromUTF8WithLatin1Fallback(name, strlen(name));
+    String string = String::fromUTF8WithLatin1Fallback(span(name));
     StringIdentifierMap::AddResult result = stringIdentifierMap().add(string.impl(), nullptr);
     if (result.isNewEntry) {
         ASSERT(!result.iterator->value);

--- a/Source/WebCore/contentextensions/ContentExtensionActions.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionActions.cpp
@@ -60,7 +60,7 @@ static size_t deserializeLength(std::span<const uint8_t> span, size_t offset)
 static String deserializeUTF8String(std::span<const uint8_t> span, size_t offset, size_t length)
 {
     RELEASE_ASSERT(span.size() >= offset + length);
-    return String::fromUTF8(span.data() + offset, length);
+    return String::fromUTF8(span.subspan(offset, length));
 }
 
 static void writeLengthToVectorAtOffset(Vector<uint8_t>& vector, size_t offset)

--- a/Source/WebCore/contentextensions/ContentExtensionStringSerialization.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionStringSerialization.cpp
@@ -33,7 +33,7 @@ namespace WebCore::ContentExtensions {
 String deserializeString(std::span<const uint8_t> span)
 {
     auto serializedLength = *reinterpret_cast<const uint32_t*>(span.data());
-    return String::fromUTF8(span.data() + sizeof(uint32_t), serializedLength - sizeof(uint32_t));
+    return String::fromUTF8(span.subspan(sizeof(uint32_t), serializedLength - sizeof(uint32_t)));
 }
 
 void serializeString(Vector<uint8_t>& actions, const String& string)

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -229,7 +229,7 @@ namespace CSSPropertyParserHelpersWorkerSafe {
 static RefPtr<CSSFontFaceSrcResourceValue> consumeFontFaceSrcURI(CSSParserTokenRange& range, const CSSParserContext& context)
 {
     StringView parsedURL = CSSPropertyParserHelpers::consumeURLRaw(range);
-    String urlString = !parsedURL.is8Bit() && parsedURL.containsOnlyASCII() ? String::make8Bit(parsedURL.characters16(), parsedURL.length()) : parsedURL.toString();
+    String urlString = !parsedURL.is8Bit() && parsedURL.containsOnlyASCII() ? String::make8Bit(parsedURL.span16()) : parsedURL.toString();
     auto location = context.completeURL(urlString);
     if (location.resolvedURL.isNull())
         return nullptr;

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -468,7 +468,7 @@ static std::optional<MarkupAndArchive> extractMarkupAndArchive(SharedBuffer& buf
     if (!canShowMIMETypeAsHTML(type))
         return std::nullopt;
 
-    return MarkupAndArchive { String::fromUTF8(mainResource->data().makeContiguous()->data(), mainResource->data().size()), mainResource.releaseNonNull(), archive.releaseNonNull() };
+    return MarkupAndArchive { String::fromUTF8(mainResource->data().makeContiguous()->span()), mainResource.releaseNonNull(), archive.releaseNonNull() };
 }
 
 static String sanitizeMarkupWithArchive(LocalFrame& frame, Document& destinationDocument, MarkupAndArchive& markupAndArchive, MSOListQuirks msoListQuirks, const std::function<bool(const String)>& canShowMIMETypeAsHTML)
@@ -511,7 +511,7 @@ static String sanitizeMarkupWithArchive(LocalFrame& frame, Document& destination
         if (!shouldReplaceSubresourceURLWithBlobDuringSanitization(subframeURL))
             continue;
 
-        MarkupAndArchive subframeContent = { String::fromUTF8(subframeMainResource->data().makeContiguous()->data(), subframeMainResource->data().size()),
+        MarkupAndArchive subframeContent = { String::fromUTF8(subframeMainResource->data().makeContiguous()->span()),
             subframeMainResource.releaseNonNull(), subframeArchive.copyRef() };
         auto subframeMarkup = sanitizeMarkupWithArchive(frame, destinationDocument, subframeContent, MSOListQuirks::Disabled, canShowMIMETypeAsHTML);
 

--- a/Source/WebCore/html/parser/AtomHTMLToken.h
+++ b/Source/WebCore/html/parser/AtomHTMLToken.h
@@ -268,7 +268,7 @@ inline AtomHTMLToken::AtomHTMLToken(HTMLToken& token)
         return;
     case Type::Comment: {
         if (token.commentIsAll8BitData())
-            m_data = String::make8Bit(token.comment().data(), token.comment().size());
+            m_data = String::make8Bit(token.comment().span());
         else
             m_data = token.comment().span();
         return;

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -233,7 +233,7 @@ private:
     {
         if (stringView.is8Bit() || !isAll8BitData())
             return stringView.toString();
-        return String::make8Bit(stringView.characters16(), stringView.length());
+        return String::make8Bit(stringView.span16());
     }
 
     StringView m_text;

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -338,7 +338,7 @@ static Ref<Inspector::Protocol::Network::Request> buildObjectForResourceRequest(
 
     if (request.httpBody() && !request.httpBody()->isEmpty()) {
         auto bytes = request.httpBody()->flatten();
-        requestObject->setPostData(String::fromUTF8WithLatin1Fallback(bytes.data(), bytes.size()));
+        requestObject->setPostData(String::fromUTF8WithLatin1Fallback(bytes.span()));
     }
 
     if (resourceLoader) {

--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -171,7 +171,7 @@ static bool threadCPUUsage(pid_t id, float period, ThreadInfo& info)
         if (!name)
             return false;
         name++;
-        info.name = String::fromUTF8(name, position - name);
+        info.name = String::fromUTF8({ name, position });
     }
 
     // Move after state.

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -132,7 +132,7 @@ String localizedString(const wchar_t* key)
 #else
 String localizedString(const char* key)
 {
-    return String::fromUTF8(key, strlen(key));
+    return String::fromUTF8(key);
 }
 #endif
 

--- a/Source/WebCore/platform/SharedBufferChunkReader.cpp
+++ b/Source/WebCore/platform/SharedBufferChunkReader.cpp
@@ -112,7 +112,7 @@ String SharedBufferChunkReader::nextChunkAsUTF8StringWithLatin1Fallback(bool inc
     if (!nextChunk(data, includeSeparator))
         return String();
 
-    return data.size() ? String::fromUTF8WithLatin1Fallback(data.data(), data.size()) : emptyString();
+    return data.size() ? String::fromUTF8WithLatin1Fallback(data.span()) : emptyString();
 }
 
 size_t SharedBufferChunkReader::peek(Vector<uint8_t>& data, size_t requestedSize)

--- a/Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp
+++ b/Source/WebCore/platform/generic/KeyedDecoderGeneric.cpp
@@ -62,7 +62,7 @@ static std::optional<String> readString(WTF::Persistence::Decoder& decoder)
     Vector<uint8_t> buffer(size.value());
     if (!decoder.decodeFixedLengthData({ buffer.data(), size.value() }))
         return std::nullopt;
-    auto result = String::fromUTF8(buffer.data(), size.value());
+    auto result = String::fromUTF8(buffer.span());
     if (result.isNull())
         return std::nullopt;
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -264,7 +264,7 @@ Vector<String> extractGStreamerOptionsFromCommandLine()
         return { };
 
     Vector<String> options;
-    auto optionsString = String::fromUTF8(contents.get(), length);
+    auto optionsString = String::fromUTF8(std::span(contents.get(), length));
     optionsString.split('\0', [&options](StringView item) {
         if (item.startsWith("--gst"_s))
             options.append(item.toString());

--- a/Source/WebCore/platform/gtk/PasteboardGtk.cpp
+++ b/Source/WebCore/platform/gtk/PasteboardGtk.cpp
@@ -289,7 +289,7 @@ void Pasteboard::read(PasteboardWebContentReader& reader, WebContentReadingPolic
     auto types = platformStrategies()->pasteboardStrategy()->types(m_name);
     if (types.contains("text/html"_s)) {
         auto buffer = platformStrategies()->pasteboardStrategy()->readBufferFromClipboard(m_name, "text/html"_s);
-        if (buffer && reader.readHTML(String::fromUTF8(buffer->data(), buffer->size())))
+        if (buffer && reader.readHTML(String::fromUTF8(buffer->span())))
             return;
     }
 
@@ -417,7 +417,7 @@ String Pasteboard::readString(const String& type)
             return platformStrategies()->pasteboardStrategy()->readTextFromClipboard(m_name);
 
         auto buffer = platformStrategies()->pasteboardStrategy()->readBufferFromClipboard(m_name, type);
-        return buffer ? String::fromUTF8(buffer->data(), buffer->size()) : String();
+        return buffer ? String::fromUTF8(buffer->span()) : String();
     }
 
     switch (selectionDataTypeFromHTMLClipboardType(type)) {

--- a/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 
 static inline String toWTFString(const std::string& value)
 {
-    return String::fromUTF8(value.data(), value.length());
+    return String::fromUTF8(value);
 }
 
 LibWebRTCDTMFSenderBackend::LibWebRTCDTMFSenderBackend(rtc::scoped_refptr<webrtc::DtmfSenderInterface>&& sender)

--- a/Source/WebCore/platform/mock/RTCDataChannelHandlerMock.cpp
+++ b/Source/WebCore/platform/mock/RTCDataChannelHandlerMock.cpp
@@ -51,7 +51,7 @@ void RTCDataChannelHandlerMock::setClient(RTCDataChannelHandlerClient& client, S
 
 bool RTCDataChannelHandlerMock::sendStringData(const CString& string)
 {
-    m_client->didReceiveStringData(String::fromUTF8(string));
+    m_client->didReceiveStringData(String::fromUTF8(string.span()));
     return true;
 }
 

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -782,7 +782,7 @@ size_t parseHTTPHeader(std::span<const uint8_t> data, String& failureReason, Str
         failureReason = makeString("CR doesn't follow LF after header value at ", trimInputSample(std::span { p, end }));
         return 0;
     }
-    valueStr = String::fromUTF8(value.data(), value.size());
+    valueStr = String::fromUTF8(value.span());
     if (valueStr.isNull()) {
         failureReason = "Invalid UTF-8 sequence in header value"_s;
         return 0;

--- a/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
@@ -134,7 +134,7 @@ String ResourceResponse::platformSuggestedFilename() const
 {
     StringView contentDisposition = filenameFromHTTPContentDisposition(httpHeaderField(HTTPHeaderName::ContentDisposition));
     if (contentDisposition.is8Bit())
-        return String::fromUTF8WithLatin1Fallback(contentDisposition.characters8(), contentDisposition.length());
+        return String::fromUTF8WithLatin1Fallback(contentDisposition.span8());
     return contentDisposition.toString();
 }
 

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -203,7 +203,7 @@ void NetworkStorageSession::getCredentialFromPersistentStorage(const ProtectionS
             size_t length;
             GRefPtr<SecretValue> secretValue = adoptGRef(secret_item_get_secret(secretItem.get()));
             const char* passwordData = secret_value_get(secretValue.get(), &length);
-            data->completionHandler(Credential(user, String::fromUTF8(passwordData, length), CredentialPersistence::Permanent));
+            data->completionHandler(Credential(user, String::fromUTF8({ passwordData, length }), CredentialPersistence::Permanent));
         }, data.release());
 #else
     UNUSED_PARAM(protectionSpace);

--- a/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
@@ -139,7 +139,7 @@ String ResourceResponse::platformSuggestedFilename() const
         return { };
 
     if (contentDisposition.is8Bit())
-        contentDisposition = String::fromUTF8WithLatin1Fallback(contentDisposition.characters8(), contentDisposition.length());
+        contentDisposition = String::fromUTF8WithLatin1Fallback(contentDisposition.span8());
     GUniquePtr<SoupMessageHeaders> soupHeaders(soup_message_headers_new(SOUP_MESSAGE_HEADERS_RESPONSE));
     soup_message_headers_append(soupHeaders.get(), "Content-Disposition", contentDisposition.utf8().data());
     GRefPtr<GHashTable> params;

--- a/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
+++ b/Source/WebCore/platform/sql/SQLiteFileSystem.cpp
@@ -162,7 +162,7 @@ String SQLiteFileSystem::computeHashForFileName(StringView fileName)
         snprintf(buffer, 3, "%02X", digest.at(i));
         buffer += 2;
     }
-    return String::fromUTF8(result);
+    return String::fromUTF8(result.span());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/sql/SQLiteStatement.cpp
+++ b/Source/WebCore/platform/sql/SQLiteStatement.cpp
@@ -213,7 +213,7 @@ SQLValue SQLiteStatement::columnValue(int col)
         return sqlite3_value_double(value);
     case SQLITE_BLOB: // SQLValue and JS don't represent blobs, so use TEXT -case
     case SQLITE_TEXT:
-        return String::fromUTF8(sqlite3_value_text(value), sqlite3_value_bytes(value));
+        return String::fromUTF8(std::span(sqlite3_value_text(value), sqlite3_value_bytes(value)));
     case SQLITE_NULL:
         return nullptr;
     default:
@@ -231,7 +231,7 @@ String SQLiteStatement::columnText(int col)
         return String();
     if (columnCount() <= col)
         return String();
-    return String::fromUTF8(sqlite3_column_text(m_statement, col), sqlite3_column_bytes(m_statement, col));
+    return String::fromUTF8(std::span(sqlite3_column_text(m_statement, col), sqlite3_column_bytes(m_statement, col)));
 }
     
 double SQLiteStatement::columnDouble(int col)

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -159,7 +159,7 @@ bool XMLDocumentParser::updateLeafTextNode()
         return true;
 
     // This operation might fire mutation event, see below.
-    m_leafTextNode->appendData(String::fromUTF8(m_bufferedText.data(), m_bufferedText.size()));
+    m_leafTextNode->appendData(String::fromUTF8(m_bufferedText.span()));
     m_bufferedText = { };
 
     m_leafTextNode = nullptr;

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -689,7 +689,7 @@ void XMLDocumentParser::doWrite(const String& parseString)
 
 static inline String toString(const xmlChar* string, size_t size)
 {
-    return String::fromUTF8(reinterpret_cast<const char*>(string), size);
+    return String::fromUTF8({ reinterpret_cast<const char*>(string), size });
 }
 
 static inline String toString(const xmlChar* string)

--- a/Source/WebDriver/WebDriverService.cpp
+++ b/Source/WebDriver/WebDriverService.cpp
@@ -273,7 +273,7 @@ void WebDriverService::handleRequest(HTTPRequestHandler::Request&& request, Func
 
     RefPtr<JSON::Object> parametersObject;
     if (method.value() == HTTPMethod::Post) {
-        auto messageValue = JSON::Value::parseJSON(String::fromUTF8(request.data, request.dataLength));
+        auto messageValue = JSON::Value::parseJSON(String::fromUTF8({ request.data, request.dataLength }));
         if (!messageValue) {
             sendResponse(WTFMove(replyHandler), CommandResult::fail(CommandResult::ErrorCode::InvalidArgument));
             return;

--- a/Source/WebDriver/socket/HTTPParser.cpp
+++ b/Source/WebDriver/socket/HTTPParser.cpp
@@ -129,7 +129,7 @@ bool HTTPParser::readLine(String& line)
     if (position == notFound || position + 1 == length || m_buffer[position + 1] != 0x0a)
         return false;
 
-    line = String::fromUTF8(m_buffer.data(), position);
+    line = String::fromUTF8({ m_buffer.data(), position });
     if (line.isNull())
         LOG_ERROR("Client error: invalid encoding in HTTP header.");
 

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
@@ -33,6 +33,7 @@
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/NeverDestroyed.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 static RetainPtr<SecTrustRef>& allowedLocalTestServerTrust()
 {
@@ -130,7 +131,7 @@ void NetworkLoader::start(URL&& url, RefPtr<JSON::Object>&& jsonPayload, WebCore
         taskMap().remove(identifier);
         if (error)
             return callback(error.localizedDescription, { });
-        if (auto jsonValue = JSON::Value::parseJSON(String::fromUTF8(static_cast<const LChar*>(data.bytes), data.length)))
+        if (auto jsonValue = JSON::Value::parseJSON(String::fromUTF8(span(data))))
             return callback({ }, jsonValue->asObject());
         callback({ }, nullptr);
     }).get()];

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -1010,7 +1010,7 @@ void Storage::traverseWithinRootPath(const String& rootPath, const String& type,
                         static_cast<size_t>(metaData.bodySize),
                         worth,
                         bodyShareCount,
-                        String::fromUTF8(SHA1::hexDigest(metaData.bodyHash))
+                        String::fromUTF8(SHA1::hexDigest(metaData.bodyHash).span())
                     };
                     traverseOperation.handler(&record, info);
                 }

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp
@@ -207,7 +207,7 @@ void WebSocketTask::didReceiveData(WebCore::CurlStreamID, const WebCore::SharedB
                 }
             }
             if (data.size() >= 3)
-                m_closeEventReason = String::fromUTF8(&data[2], data.size() - 2);
+                m_closeEventReason = String::fromUTF8({ &data[2], data.size() - 2 });
             else
                 m_closeEventReason = emptyString();
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContentFilterStore.cpp
@@ -196,7 +196,7 @@ static void webkitUserContentFilterStoreSaveBytes(GRefPtr<GTask>&& task, String&
     }
 
     auto* store = WEBKIT_USER_CONTENT_FILTER_STORE(g_task_get_source_object(task.get()));
-    store->priv->store->compileContentRuleList(WTFMove(identifier), String::fromUTF8(sourceData, sourceSize), [task = WTFMove(task)](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
+    store->priv->store->compileContentRuleList(WTFMove(identifier), String::fromUTF8({ sourceData, sourceSize }), [task = WTFMove(task)](RefPtr<API::ContentRuleList> contentRuleList, std::error_code error) {
         if (g_task_return_error_if_cancelled(task.get()))
             return;
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -438,7 +438,7 @@ static void webkitWebContextConstructed(GObject* object)
         // Once the settings have been passed to the ProcessPoolConfiguration, we don't need them anymore so we can free them.
         g_clear_pointer(&priv->memoryPressureSettings, webkit_memory_pressure_settings_free);
     }
-    configuration.setTimeZoneOverride(String::fromUTF8(priv->timeZoneOverride.data(), priv->timeZoneOverride.length()));
+    configuration.setTimeZoneOverride(String::fromUTF8(priv->timeZoneOverride.span()));
 
 #if !ENABLE(2022_GLIB_API)
     if (!priv->websiteDataManager)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -2715,7 +2715,7 @@ String webkitWebViewGetCurrentScriptDialogMessage(WebKitWebView* webView)
     if (!webView->priv->currentScriptDialog)
         return { };
 
-    return String::fromUTF8(webView->priv->currentScriptDialog->message);
+    return String::fromUTF8(webView->priv->currentScriptDialog->message.span());
 }
 
 void webkitWebViewSetCurrentScriptDialogUserInput(WebKitWebView* webView, const String& userInput)
@@ -4133,7 +4133,7 @@ static void webkitWebViewEvaluateJavascriptInternal(WebKitWebView* webView, cons
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
     g_return_if_fail(script);
 
-    RunJavaScriptParameters params = { String::fromUTF8(script, length < 0 ? strlen(script) : length), JSC::SourceTaintedOrigin::Untainted, URL({ }, String::fromUTF8(sourceURI)), RunAsAsyncFunction::No, std::nullopt, ForceUserGesture::Yes, RemoveTransientActivation::Yes };
+    RunJavaScriptParameters params = { String::fromUTF8(std::span(script, length < 0 ? strlen(script) : length)), JSC::SourceTaintedOrigin::Untainted, URL({ }, String::fromUTF8(sourceURI)), RunAsAsyncFunction::No, std::nullopt, ForceUserGesture::Yes, RemoveTransientActivation::Yes };
     webkitWebViewRunJavaScriptWithParams(webView, WTFMove(params), worldName, returnType, adoptGRef(g_task_new(webView, cancellable, callback, userData)));
 }
 
@@ -4269,7 +4269,7 @@ static void webkitWebViewCallAsyncJavascriptFunctionInternal(WebKitWebView* webV
         return;
     }
 
-    RunJavaScriptParameters params = { String::fromUTF8(body, length < 0 ? strlen(body) : length), JSC::SourceTaintedOrigin::Untainted, URL({ }, String::fromUTF8(sourceURI)), RunAsAsyncFunction::Yes, WTFMove(argumentsMap), ForceUserGesture::Yes, RemoveTransientActivation::Yes };
+    RunJavaScriptParameters params = { String::fromUTF8(std::span(body, length < 0 ? strlen(body) : length)), JSC::SourceTaintedOrigin::Untainted, URL({ }, String::fromUTF8(sourceURI)), RunAsAsyncFunction::Yes, WTFMove(argumentsMap), ForceUserGesture::Yes, RemoveTransientActivation::Yes };
     webkitWebViewRunJavaScriptWithParams(webView, WTFMove(params), worldName, returnType, adoptGRef(g_task_new(webView, cancellable, callback, userData)));
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebsiteDataManager.cpp
@@ -534,7 +534,7 @@ WebKit::WebsiteDataStore& webkitWebsiteDataManagerGetDataStore(WebKitWebsiteData
 {
     WebKitWebsiteDataManagerPrivate* priv = manager->priv;
     if (!priv->websiteDataStore) {
-        auto configuration = WebsiteDataStoreConfiguration::createWithBaseDirectories(String::fromUTF8(priv->baseCacheDirectory), String::fromUTF8(priv->baseDataDirectory));
+        auto configuration = WebsiteDataStoreConfiguration::createWithBaseDirectories(String::fromUTF8(priv->baseCacheDirectory.span()), String::fromUTF8(priv->baseDataDirectory.span()));
 #if !ENABLE(2022_GLIB_API)
         if (priv->localStorageDirectory)
             configuration->setLocalStorageDirectory(FileSystem::stringFromFileSystemRepresentation(priv->localStorageDirectory.get()));

--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk3.cpp
@@ -183,7 +183,7 @@ void DropTarget::dataReceived(IntPoint&& position, GtkSelectionData* data, unsig
             if (length >= 2 && reinterpret_cast<const UChar*>(markupData)[0] == 0xFEFF)
                 m_selectionData->setMarkup(String({ reinterpret_cast<const UChar*>(markupData) + 1, static_cast<size_t>((length / 2) - 1) }));
             else
-                m_selectionData->setMarkup(String::fromUTF8(markupData, length));
+                m_selectionData->setMarkup(String::fromUTF8(std::span(markupData, length)));
         }
         break;
     }
@@ -191,14 +191,14 @@ void DropTarget::dataReceived(IntPoint&& position, GtkSelectionData* data, unsig
         gint length;
         const auto* uriListData = gtk_selection_data_get_data_with_length(data, &length);
         if (length > 0)
-            m_selectionData->setURIList(String::fromUTF8(uriListData, length));
+            m_selectionData->setURIList(String::fromUTF8(std::span(uriListData, length)));
         break;
     }
     case DropTargetType::NetscapeURL: {
         gint length;
         const auto* urlData = gtk_selection_data_get_data_with_length(data, &length);
         if (length > 0) {
-            Vector<String> tokens = String::fromUTF8(urlData, length).split('\n');
+            Vector<String> tokens = String::fromUTF8(std::span(urlData, length)).split('\n');
             URL url({ }, tokens[0]);
             if (url.isValid())
                 m_selectionData->setURL(url, tokens.size() > 1 ? tokens[1] : String());

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -4162,7 +4162,7 @@ static NSString *computeStringHashForContentBlockerRules(NSString *rules)
     sha1.computeHash(digest);
 
     auto hashAsCString = SHA1::hexDigest(digest);
-    auto hashAsString = String::fromUTF8(hashAsCString);
+    auto hashAsString = String::fromUTF8(hashAsCString.span());
     return [hashAsString stringByAppendingString:[NSString stringWithFormat:@"-%zu", currentDeclarativeNetRequestRuleTranslatorVersion]];
 }
 

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorHTTPServer.cpp
@@ -134,7 +134,7 @@ void RemoteInspectorHTTPServer::handleWebSocket(const char* path, SoupWebsocketC
         auto& httpServer = *static_cast<RemoteInspectorHTTPServer*>(userData);
         gsize dataSize;
         const auto* data = static_cast<const char*>(g_bytes_get_data(message, &dataSize));
-        httpServer.sendMessageToBackend(connection, String::fromUTF8(data, dataSize));
+        httpServer.sendMessageToBackend(connection, String::fromUTF8(std::span(data, dataSize)));
     }), this);
     g_signal_connect(connection, "closed", G_CALLBACK(+[](SoupWebsocketConnection* connection, gpointer userData) {
         auto& httpServer = *static_cast<RemoteInspectorHTTPServer*>(userData);

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -61,7 +61,7 @@ using namespace WebCore;
 static webrtc::WebKitVideoDecoder createVideoDecoder(const webrtc::SdpVideoFormat& format)
 {
     auto& codecs = WebProcess::singleton().libWebRTCCodecs();
-    auto codecString = String::fromUTF8(format.name.data(), format.name.length());
+    auto codecString = String::fromUTF8(format.name);
 
     if (equalIgnoringASCIICase(codecString, "H264"_s))
         return { codecs.createDecoder(VideoCodecType::H264), false };
@@ -589,7 +589,7 @@ LibWebRTCCodecs::Encoder* LibWebRTCCodecs::createEncoderInternal(VideoCodecType 
     encoder->scalabilityMode = scalabilityMode;
 
     auto parameters = WTF::map(formatParameters, [](auto& entry) {
-        return std::pair { String::fromUTF8(entry.first.data(), entry.first.length()), String::fromUTF8(entry.second.data(), entry.second.length()) };
+        return std::pair { String::fromUTF8(entry.first), String::fromUTF8(entry.second) };
     });
 
     ensureGPUProcessConnectionAndDispatchToThread([this, encoder = WTFMove(encoder), parameters = WTFMove(parameters), callback = WTFMove(callback)]() mutable {

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
@@ -147,7 +147,7 @@ void LibWebRTCNetworkManager::networksChanged(const Vector<RTCNetwork>& networks
         filteredNetworks = networks;
     else {
         for (auto& network : networks) {
-            if (WTF::anyOf(network.ips, [&](const auto& ip) { return ipv4.rtcAddress() == ip.rtcAddress() || ipv6.rtcAddress() == ip.rtcAddress(); }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name.data(), network.name.size()))))
+            if (WTF::anyOf(network.ips, [&](const auto& ip) { return ipv4.rtcAddress() == ip.rtcAddress() || ipv6.rtcAddress() == ip.rtcAddress(); }) || (!m_useMDNSCandidates && m_enableEnumeratingVisibleNetworkInterfaces && m_allowedInterfaces.contains(String::fromUTF8(network.name))))
                 filteredNetworks.append(network);
         }
     }

--- a/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
+++ b/Source/WebKit/WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
@@ -146,7 +146,7 @@ void RTCDataChannelRemoteManager::receiveData(WebCore::RTCDataChannelIdentifier 
     if (isRaw)
         buffer = Vector(data);
     else
-        text = String::fromUTF8(data.data(), data.size());
+        text = String::fromUTF8(data);
 
     postTaskToHandler(handlerIdentifier, [isRaw, text = WTFMove(text).isolatedCopy(), buffer = WTFMove(buffer)](auto& handler) mutable {
         if (isRaw)

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.cpp
@@ -618,7 +618,7 @@ bool WebSocketChannel::processFrame()
             if (m_continuousFrameOpCode == WebSocketFrame::OpCodeText) {
                 String message;
                 if (continuousFrameData.size())
-                    message = String::fromUTF8(continuousFrameData.data(), continuousFrameData.size());
+                    message = String::fromUTF8(continuousFrameData.span());
                 else
                     message = emptyString();
                 if (message.isNull())
@@ -681,7 +681,7 @@ bool WebSocketChannel::processFrame()
             }
         }
         if (frame.payload.size() >= 3)
-            m_closeEventReason = String::fromUTF8(&frame.payload[2], frame.payload.size() - 2);
+            m_closeEventReason = String::fromUTF8({ &frame.payload[2], frame.payload.size() - 2 });
         else
             m_closeEventReason = emptyString();
         skipBuffer(frameEnd - m_buffer.data());

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1443,7 +1443,7 @@ static RetainPtr<NSString> dumpFramesAsText(WebFrame *frame)
     // the result without any conversion.
     if (auto utf8Result = WTF::String(innerText).tryGetUTF8()) {
         auto string = WTFMove(utf8Result.value());
-        [result appendFormat:@"%@\n", String::fromUTF8WithLatin1Fallback(string.data(), string.length()).createCFString().get()];
+        [result appendFormat:@"%@\n", String::fromUTF8WithLatin1Fallback(string.span()).createCFString().get()];
     } else
         [result appendString:@"\n"];
 

--- a/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/URLParser.cpp
@@ -505,7 +505,7 @@ TEST_F(WTF_URLParser, Credentials)
     testUserPassword("%25"_s, "%"_s, "%25"_s);
     testUserPassword("%2525"_s, "%25"_s, "%2525"_s);
     testUserPassword("%FX"_s, "%FX"_s);
-    testUserPassword("%00"_s, String::fromUTF8("\0"_s, 1), "%00"_s);
+    testUserPassword("%00"_s, String::fromUTF8({ "\0", 1 }), "%00"_s);
     testUserPassword("%F%25"_s, "%F%"_s, "%F%25"_s);
     testUserPassword("%X%25"_s, "%X%"_s, "%X%25"_s);
     testUserPassword("%%25"_s, "%%"_s, "%%25"_s);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaLoading.mm
@@ -40,7 +40,7 @@ namespace TestWebKitAPI {
 
 static String parseUserAgent(const Vector<char>& request)
 {
-    auto headers = String::fromUTF8(request.data(), request.size()).split("\r\n"_s);
+    auto headers = String::fromUTF8(request.span()).split("\r\n"_s);
     auto index = headers.findIf([] (auto& header) { return header.startsWith("User-Agent:"_s); });
     if (index != notFound)
         return headers[index];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -2450,7 +2450,7 @@ TEST(SiteIsolation, ApplicationNameForUserAgent)
                 continue;
             }
             if (path == "/request_from_subframe"_s) {
-                auto headers = String::fromUTF8(request.data(), request.size()).split("\r\n"_s);
+                auto headers = String::fromUTF8(request.span()).split("\r\n"_s);
                 auto userAgentIndex = headers.findIf([](auto& header) {
                     return header.startsWith("User-Agent:"_s);
                 });
@@ -2506,7 +2506,7 @@ TEST(SiteIsolation, WebsitePoliciesCustomUserAgent)
                 continue;
             }
             if (path == "/request_from_subframe"_s) {
-                auto headers = String::fromUTF8(request.data(), request.size()).split("\r\n"_s);
+                auto headers = String::fromUTF8(request.span()).split("\r\n"_s);
                 auto userAgentIndex = headers.findIf([](auto& header) {
                     return header.startsWith("User-Agent:"_s);
                 });
@@ -2595,7 +2595,7 @@ TEST(SiteIsolation, WebsitePoliciesCustomUserAgentDuringCrossSiteProvisionalNavi
                 continue;
             }
             if (path == "/request_from_subframe"_s) {
-                auto headers = String::fromUTF8(request.data(), request.size()).split("\r\n"_s);
+                auto headers = String::fromUTF8(request.span()).split("\r\n"_s);
                 auto userAgentIndex = headers.findIf([](auto& header) {
                     return header.startsWith("User-Agent:"_s);
                 });
@@ -2681,7 +2681,7 @@ TEST(SiteIsolation, WebsitePoliciesCustomUserAgentDuringSameSiteProvisionalNavig
                 continue;
             }
             if (path == "/request_from_subframe"_s) {
-                auto headers = String::fromUTF8(request.data(), request.size()).split("\r\n"_s);
+                auto headers = String::fromUTF8(request.span()).split("\r\n"_s);
                 auto userAgentIndex = headers.findIf([](auto& header) {
                     return header.startsWith("User-Agent:"_s);
                 });

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -908,14 +908,14 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::computedRoleString()
 JSRetainPtr<JSStringRef> AccessibilityUIElement::title()
 {
     m_element->updateBackingStore();
-    auto titleValue = makeString("AXTitle: ", String::fromUTF8(m_element->name()));
+    auto titleValue = makeString("AXTitle: ", String::fromUTF8(m_element->name().span()));
     return OpaqueJSString::tryCreate(titleValue).leakRef();
 }
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::description()
 {
     m_element->updateBackingStore();
-    auto descriptionValue = makeString("AXDescription: ", String::fromUTF8(m_element->description()));
+    auto descriptionValue = makeString("AXDescription: ", String::fromUTF8(m_element->description().span()));
     return OpaqueJSString::tryCreate(descriptionValue).leakRef();
 }
 
@@ -956,7 +956,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::stringValue()
         // Tests expect the combo box to expose the selected element name as the string value.
         if (auto menu = childAtIndex(0)) {
             if (auto* selectedChild = menu->m_element->selectedChild(0))
-                return OpaqueJSString::tryCreate(makeString("AXValue: ", String::fromUTF8(selectedChild->name()))).leakRef();
+                return OpaqueJSString::tryCreate(makeString("AXValue: ", String::fromUTF8(selectedChild->name().span()))).leakRef();
         }
     }
 

--- a/Tools/WebKitTestRunner/StringFunctions.h
+++ b/Tools/WebKitTestRunner/StringFunctions.h
@@ -102,7 +102,7 @@ inline WTF::String toWTFString(WKStringRef string)
     size_t stringLength = WKStringGetUTF8CStringNonStrict(string, buffer.get(), bufferSize);
     if (!stringLength)
         return "(null)"_s;
-    return WTF::String::fromUTF8WithLatin1Fallback(buffer.get(), stringLength - 1);
+    return WTF::String::fromUTF8WithLatin1Fallback({ buffer.get(), stringLength - 1 });
 }
     
 inline WTF::String toWTFString(const WKRetainPtr<WKStringRef>& string)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -3263,7 +3263,7 @@ void getAllStorageAccessEntriesCallback(void* userData, WKArrayRef domainList)
         auto buffer = std::vector<char>(WKStringGetMaximumUTF8CStringSize(domain));
         auto stringLength = WKStringGetUTF8CString(domain, buffer.data(), buffer.size());
 
-        resultDomains.append(String::fromUTF8(buffer.data(), stringLength - 1));
+        resultDomains.append(String::fromUTF8({ buffer.data(), stringLength - 1 }));
     }
 
     if (context->completionHandler)


### PR DESCRIPTION
#### df2cc0871eec5de263ca9f20816ef2afcc7b359a
<pre>
Drop String::fromUTF8() overloads taking in a raw pointer and a size
<a href="https://bugs.webkit.org/show_bug.cgi?id=271945">https://bugs.webkit.org/show_bug.cgi?id=271945</a>

Reviewed by Darin Adler.

Drop String::fromUTF8() overloads taking in a raw pointer and a size, in favor
of the ones taking in spans.

* Source/JavaScriptCore/debugger/DebuggerScope.cpp:
(JSC::DebuggerScope::name const):
* Source/JavaScriptCore/jsc.cpp:
(stringFromUTF):
(JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;CharacterType&gt;::parseCommentDirectiveValue):
* Source/JavaScriptCore/profiler/ProfilerBytecode.cpp:
(JSC::Profiler::Bytecode::toJSON const):
* Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp:
(JSC::Profiler::BytecodeSequence::addSequenceProperties const):
* Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp:
(JSC::Profiler::Bytecodes::toJSON const):
* Source/JavaScriptCore/profiler/ProfilerCompilation.cpp:
(JSC::Profiler::Compilation::toJSON const):
* Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.cpp:
(JSC::Profiler::CompiledBytecode::toJSON const):
* Source/JavaScriptCore/profiler/ProfilerEvent.cpp:
(JSC::Profiler::Event::toJSON const):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::stackTracesAsJSON):
* Source/JavaScriptCore/tools/FunctionAllowlist.cpp:
(JSC::FunctionAllowlist::contains const):
* Source/WTF/wtf/StringPrintStream.cpp:
(WTF::StringPrintStream::tryToString):
(WTF::StringPrintStream::toString):
(WTF::StringPrintStream::toStringWithLatin1Fallback):
* Source/WTF/wtf/URL.cpp:
(WTF::decodeEscapeSequencesFromParsedURL):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::percentDecode):
(WTF::URLParser::parseHostAndPort):
(WTF::URLParser::formURLDecode):
* Source/WTF/wtf/URLParser.h:
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::createTemporaryZipArchive):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::make8Bit):
(WTF::fromUTF8Impl):
(WTF::String::fromUTF8):
(WTF::String::fromUTF8ReplacingInvalidSequences):
(WTF::String::fromUTF8WithLatin1Fallback):
* Source/WTF/wtf/text/WTFString.h:
(WTF::String::fromUTF8): Deleted.
* Source/WebCore/Modules/applepay/cocoa/PaymentCocoa.mm:
(WebCore::convert):
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemTypeLoader::dataAsString const):
* Source/WebCore/Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp:
(WebCore::CDMSessionClearKey::update):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp:
(WebCore::LibWebRTCDataChannelHandler::OnMessage):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp:
(WebCore::LibWebRTCPeerConnectionBackend::doAddIceCandidate):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.h:
(WebCore::fromStdString):
* Source/WebCore/Modules/webauthn/cbor/CBORReader.cpp:
(cbor::CBORReader::readString):
* Source/WebCore/Modules/websockets/WebSocketExtensionParser.cpp:
(WebCore::WebSocketExtensionParser::consumeQuotedString):
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::trimToValidUTF8Length1024):
* Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp:
(PAL::CryptoDigest::toHexString):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::extractMarkupAndArchive):
(WebCore::sanitizeMarkupWithArchive):
* Source/WebCore/html/parser/AtomHTMLToken.h:
(WebCore::AtomHTMLToken::AtomHTMLToken):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::ExternalCharacterTokenBuffer::makeString const):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::buildObjectForResourceRequest):
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCDTMFSenderBackend.cpp:
(WebCore::toWTFString):
* Source/WebCore/platform/mock/RTCDataChannelHandlerMock.cpp:
(WebCore::RTCDataChannelHandlerMock::sendStringData):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::parseHTTPHeader):
* Source/WebCore/platform/sql/SQLiteFileSystem.cpp:
(WebCore::SQLiteFileSystem::computeHashForFileName):
* Source/WebCore/platform/sql/SQLiteStatement.cpp:
(WebCore::SQLiteStatement::columnValue):
(WebCore::SQLiteStatement::columnText):
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::XMLDocumentParser::updateLeafTextNode):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::toString):

Canonical link: <a href="https://commits.webkit.org/276889@main">https://commits.webkit.org/276889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59c1ff69b8010ab5aa3984233f0097793cd9c285

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46061 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48732 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42101 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37669 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18859 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40840 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4105 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39294 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42382 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50523 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45535 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17577 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44843 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22357 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43727 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22716 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52686 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6415 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22051 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10777 "Passed tests") | 
<!--EWS-Status-Bubble-End-->