### PR TITLE
Make run-jsc-stress-tests handle expected crashes correctly.

### DIFF
--- a/JSTests/stress/ensure-crash.js
+++ b/JSTests/stress/ensure-crash.js
@@ -1,4 +1,4 @@
-//@ crashOK!
+//@ mustCrash!
 //@ skip if $hostOS == "windows"
 //@ runDefault
 

--- a/JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior-bad-transition-debug.js
+++ b/JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior-bad-transition-debug.js
@@ -1,5 +1,7 @@
-//@ crashOK!
-//@ $skipModes << :lockdown
+//@ mustCrash!
+//@ skip if $buildType != "debug" # crash relies on a Debug ASSERT
+//@ $skipModes << :lockdown # because signal handler not supported.
+
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior-bad-transition.js
+++ b/JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior-bad-transition.js
@@ -1,4 +1,7 @@
-//@ crashOK!
+//@ mustCrash!
+//@ skip if $buildType != "debug" # crash relies on a Debug ASSERT
+//@ $skipModes << :lockdown # because signal handler not supported.
+
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error('bad value: ' + actual);

--- a/JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior.js
+++ b/JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior.js
@@ -1,4 +1,6 @@
-//@ crashOK!
+//@ mustCrash!
+//@ skip if $buildType != "debug" # crash relies on a Debug ASSERT
+//@ $skipModes << :lockdown # because signal handler not supported.
 //@ runDefault("--useLLInt=1")
 
 function shouldBe(actual, expected) {

--- a/JSTests/stress/incorrect-put-could-generate-invalid-ic-involving-dictionary-flatten-debug.js
+++ b/JSTests/stress/incorrect-put-could-generate-invalid-ic-involving-dictionary-flatten-debug.js
@@ -1,4 +1,6 @@
-//@ crashOK!
+//@ mustCrash!
+//@ skip if $buildType != "debug" # crash relies on a Debug ASSERT
+//@ $skipModes << :lockdown # because signal handler not supported.
 //@ runDefault("--useLLInt=true")
 
 function shouldBe(actual, expected) {

--- a/Source/JavaScriptCore/Scripts/process-entitlements.sh
+++ b/Source/JavaScriptCore/Scripts/process-entitlements.sh
@@ -16,6 +16,8 @@ function mac_process_jsc_entitlements()
     plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
+        plistbuddy Add :com.apple.private.pac.exception bool YES
+
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
         then
             plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
@@ -36,6 +38,7 @@ function mac_process_testapi_entitlements()
     plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
+        plistbuddy Add :com.apple.private.pac.exception bool YES
         plistbuddy Add :com.apple.security.cs.allow-jit bool YES
         plistbuddy Add :com.apple.rootless.storage.JavaScriptCore bool YES
 
@@ -65,6 +68,7 @@ function maccatalyst_process_jsc_entitlements()
 
     if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
     then
+        plistbuddy Add :com.apple.private.pac.exception bool YES
         if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
         then
             plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
@@ -86,6 +90,11 @@ function maccatalyst_process_testapi_entitlements()
     plistbuddy Add :com.apple.security.fatal-exceptions array
     plistbuddy Add :com.apple.security.fatal-exceptions:0 string jit
 
+    if [[ "${WK_USE_RESTRICTED_ENTITLEMENTS}" == YES ]]
+    then
+        plistbuddy Add :com.apple.private.pac.exception bool YES
+    fi
+
     if (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 110000 ))
     then
         plistbuddy Add :com.apple.security.cs.jit-write-allowlist bool YES
@@ -105,6 +114,7 @@ function maccatalyst_process_testapi_entitlements()
 
 function ios_family_process_jsc_entitlements()
 {
+    plistbuddy Add :com.apple.private.pac.exception bool YES
     plistbuddy Add :com.apple.private.verified-jit bool YES
     plistbuddy Add :dynamic-codesigning bool YES
     plistbuddy Add :com.apple.developer.kernel.extended-virtual-addressing bool YES

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2023 Apple Inc.  All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc.  All rights reserved.
  * Copyright (C) 2007-2009 Torch Mobile, Inc.
  * Copyright (C) 2011 University of Szeged. All rights reserved.
  *
@@ -347,6 +347,9 @@ void WTFCrash()
     WTFReportBacktrace();
 #if ASAN_ENABLED
     __builtin_trap();
+#elif OS(DARWIN) && CPU(ARM64)
+    WTFBreakpointTrap();
+    __builtin_trap(); // Suppress NO_RETURN_DUE_TO_CRASH warning.
 #else
     *(int *)(uintptr_t)0xbbadbeef = 0;
     // More reliable, but doesn't say BBADBEEF.

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2013-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -668,13 +668,14 @@ class BasePlan
     attr_accessor :retryParameters
 
     @@index = 0
-    def initialize(directory, arguments, family, name, outputHandler, errorHandler, retryParameters)
+    def initialize(directory, arguments, family, name, outputHandler, errorHandler, retryParameters, expectCrash)
         @directory = directory
         @arguments = argumentsMapper(arguments)
         @family = family
         @name = name
         @outputHandler = outputHandler
         @errorHandler = errorHandler
+        @expectCrash = expectCrash
         # A plan for which @retryParameters is not nil is being
         # treated as potentially flaky.
         @retryParameters = retryParameters
@@ -683,13 +684,17 @@ class BasePlan
         @@index += 1
     end
     def self.mock(family, name, retryParameters=nil)
-        self.new("/none", [], family, name, nil, nil, retryParameters)
+        self.new("/none", [], family, name, nil, nil, retryParameters, false)
     end
     def self.create(directory, arguments, family, name, outputHandler, errorHandler)
-        if $runCommandOptions[:crashOK]
+        if $runCommandOptions[:mustCrash]
             outputHandler = noisyOutputHandler
         end
-        self.new(directory, arguments, family, name, outputHandler, errorHandler, $runCommandOptions[:flaky])
+        self.new(directory, arguments, family, name, outputHandler, errorHandler, $runCommandOptions[:flaky], $runCommandOptions[:mustCrash])
+    end
+
+    def expectCrash
+        @expectCrash
     end
     def argumentsMapper(args)
         args
@@ -910,9 +915,9 @@ def slow!
     skip() if ($mode == "quick")
 end
 
-def crashOK!
+def mustCrash!
     $testSpecificRequiredOptions += ["-s"]
-    $runCommandOptions[:crashOK] = true
+    $runCommandOptions[:mustCrash] = true
 end
 
 def serial!

--- a/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
+++ b/Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2013-2016 Apple Inc. All rights reserved.
+# Copyright (C) 2013-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,13 @@ def noisyOutputHandler
     }
 end
 
+def getFailCondition(plan)
+    # jsc shell's expected crashes are configured to return with an error > 130.
+    # So, if we're expecting a crash and the exitCode is less or equal to 130, the test
+    # is not exiting due to an expected crash, and it should be considered a test failure.
+    plan.expectCrash ? "-le 130" : "-ne 0"
+end
+
 def getAndTestExitCode(plan, condition)
     <<-EOF
     if test "$exitCode" #{condition}
@@ -60,7 +67,7 @@ end
 def simpleErrorHandler
     Proc.new {
         | outp, plan |
-        outp.puts getAndTestExitCode(plan, "-ne 0")
+        outp.puts getAndTestExitCode(plan, getFailCondition(plan))
         outp.puts "then"
         outp.puts "    (echo ERROR: Unexpected exit code: $exitCode) | " + redirectAndPrefixCommand(plan.name)
         outp.puts "    " + plan.failCommand
@@ -74,7 +81,7 @@ end
 def expectedFailErrorHandler
     Proc.new {
         | outp, plan |
-        outp.puts getAndTestExitCode(plan, "-ne 0")
+        outp.puts getAndTestExitCode(plan, getFailCondition(plan))
         outp.puts "then"
         outp.puts "    " + plan.successCommand
         outp.puts "else"
@@ -91,7 +98,7 @@ def noisyErrorHandler
         | outp, plan |
         outputFilename = Shellwords.shellescape((Pathname("..") + (plan.name + ".out")).to_s)
 
-        outp.puts getAndTestExitCode(plan, "-ne 0")
+        outp.puts getAndTestExitCode(plan, getFailCondition(plan))
         outp.puts "then"
         outp.puts "    (cat #{outputFilename} && echo ERROR: Unexpected exit code: $exitCode) | " + redirectAndPrefixCommand(plan.name)
         outp.puts "    " + plan.failCommand
@@ -108,7 +115,7 @@ def diffErrorHandler(expectedFilename)
         outputFilename = Shellwords.shellescape((Pathname("..") + (plan.name + ".out")).to_s)
         diffFilename = Shellwords.shellescape((Pathname("..") + (plan.name + ".diff")).to_s)
 
-        outp.puts getAndTestExitCode(plan, "-ne 0")
+        outp.puts getAndTestExitCode(plan, getFailCondition(plan))
         outp.puts "then"
         outp.puts "    (cat #{outputFilename} && echo ERROR: Unexpected exit code: $exitCode) | " + redirectAndPrefixCommand(plan.name)
         outp.puts "    " + plan.failCommand
@@ -136,7 +143,7 @@ def mozillaErrorHandler
         | outp, plan |
         outputFilename = Shellwords.shellescape((Pathname("..") + (plan.name + ".out")).to_s)
 
-        outp.puts getAndTestExitCode(plan, "-ne 0")
+        outp.puts getAndTestExitCode(plan, getFailCondition(plan))
         outp.puts "then"
         outp.puts "    (cat #{outputFilename} && echo ERROR: Unexpected exit code: $exitCode) | " + redirectAndPrefixCommand(plan.name)
         outp.puts "    " + plan.failCommand
@@ -157,7 +164,7 @@ def mozillaFailErrorHandler
         | outp, plan |
         outputFilename = Shellwords.shellescape((Pathname("..") + (plan.name + ".out")).to_s)
 
-        outp.puts getAndTestExitCode(plan, "-ne 0")
+        outp.puts getAndTestExitCode(plan, getFailCondition(plan))
         outp.puts "then"
         outp.puts "    " + plan.successCommand
         outp.puts "elif grep -i -q failed! #{outputFilename}"
@@ -177,7 +184,7 @@ def mozillaExit3ErrorHandler
         | outp, plan |
         outputFilename = Shellwords.shellescape((Pathname("..") + (plan.name + ".out")).to_s)
 
-        outp.puts getAndTestExitCode(plan, "-ne 0")
+        outp.puts getAndTestExitCode(plan, getFailCondition(plan))
         outp.puts "then"
         outp.puts "    if [ \"$exitCode\" -eq 3 ]"
         outp.puts "    then"
@@ -206,7 +213,7 @@ def chakraPassFailErrorHandler
         | outp, plan |
         outputFilename = Shellwords.shellescape((Pathname("..") + (plan.name + ".out")).to_s)
 
-        outp.puts getAndTestExitCode(plan, "-ne 0")
+        outp.puts getAndTestExitCode(plan, getFailCondition(plan))
         outp.puts "then"
         outp.puts "    (cat #{outputFilename} && echo ERROR: Unexpected exit code: $exitCode) | " + redirectAndPrefixCommand(plan.name)
         outp.puts "    " + plan.failCommand


### PR DESCRIPTION
#### 724f7173e04a9d448964e3094b0929d6ae29d551
<pre>
Make run-jsc-stress-tests handle expected crashes correctly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=271954">https://bugs.webkit.org/show_bug.cgi?id=271954</a>
<a href="https://rdar.apple.com/124471961">rdar://124471961</a>

Reviewed by Yusuke Suzuki.

It does not make sense to have a crashOK! test attribute, which imply that the test will be
flaky.  A test should be deterministic.  We should either expect a crash or no crash.  To enable
this, we&apos;ll make the following changes:

1. Change the jsc shell &quot;crash detector&quot; signal handler to exit with exitCode 137 (to indicate
   a fatal crash).
2. Fix the JSC stress test harness to actually be able to handle crashes (terminations with
   exitCode &gt; 130).
3. Rename the &quot;crashOK!&quot; test attribute to &quot;mustCrash!&quot;.  It now makes it clear that a test is
   expected to crash, instead of flakily crashing sometimes.
4. Add filter conditions to tests that &quot;mustCrash!&quot; so that they are only run with
   configurations where they are expected to crash.  Skip the rest.
5. Make WTFCrash() crash with WTFBreakpointTrap() on Darwin ARM64 platforms to be consistent
   with all other crashes.

6. Opportunistic quality of life improvement: make jsc shell timeouts crash below
   crashDueToJSCShellTimeout() to distinguish it from other crashes.

* JSTests/stress/ensure-crash.js:
* JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior-bad-transition-debug.js:
* JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior-bad-transition.js:
* JSTests/stress/incorrect-put-could-generate-invalid-ic-but-still-not-causing-bad-behavior.js:
* JSTests/stress/incorrect-put-could-generate-invalid-ic-involving-dictionary-flatten-debug.js:
* Source/JavaScriptCore/Scripts/process-entitlements.sh:
* Source/JavaScriptCore/jsc.cpp:
(crashDueToJSCShellTimeout):
(timeoutCheckCallback):
(CommandLine::parseArguments):
* Source/WTF/wtf/Assertions.cpp:
* Tools/Scripts/run-jsc-stress-tests:
* Tools/Scripts/webkitruby/jsc-stress-test-writer-default.rb:

Canonical link: <a href="https://commits.webkit.org/276881@main">https://commits.webkit.org/276881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/308c155358edf328435545dc2a85a7d737fd3e0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48707 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42076 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37642 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22253 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18833 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19649 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-transforms/transform3d-preserve3d-001.html, imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40812 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4080 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39269 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50494 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45510 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44801 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22332 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43697 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22691 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52661 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6411 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22026 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10774 "Passed tests") | 
<!--EWS-Status-Bubble-End-->