### PR TITLE
[Skia] Use gtk_widget_queue_draw_region() for PageClientImpl::setViewNeedsDisplay in GTK3

### DIFF
--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp
@@ -37,7 +37,6 @@
 #include "IntRect.h"
 #include "Path.h"
 #include "RefPtrCairo.h"
-#include "Region.h"
 #include <wtf/Assertions.h>
 #include <wtf/Atomics.h>
 #include <wtf/NeverDestroyed.h>
@@ -370,16 +369,6 @@ void flipImageSurfaceVertically(cairo_surface_t* surface)
         memcpy(top, bottom, stride);
         memcpy(bottom, tmp.get(), stride);
     }
-}
-
-RefPtr<cairo_region_t> toCairoRegion(const Region& region)
-{
-    RefPtr<cairo_region_t> cairoRegion = adoptRef(cairo_region_create());
-    for (const auto& rect : region.rects()) {
-        cairo_rectangle_int_t cairoRect = rect;
-        cairo_region_union_rectangle(cairoRegion.get(), &cairoRect);
-    }
-    return cairoRegion;
 }
 
 cairo_matrix_t toCairoMatrix(const AffineTransform& transform)

--- a/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
+++ b/Source/WebCore/platform/graphics/cairo/CairoUtilities.h
@@ -94,8 +94,6 @@ WEBCORE_EXPORT void copyRectFromOneSurfaceToAnother(cairo_surface_t* from, cairo
 IntSize cairoSurfaceSize(cairo_surface_t*);
 void flipImageSurfaceVertically(cairo_surface_t*);
 
-RefPtr<cairo_region_t> toCairoRegion(const Region&);
-
 cairo_matrix_t toCairoMatrix(const AffineTransform&);
 
 void attachSurfaceUniqueID(cairo_surface_t*);


### PR DESCRIPTION
#### f088b437f4e1a06b18f09812f2662e93f090c9f7
<pre>
[Skia] Use gtk_widget_queue_draw_region() for PageClientImpl::setViewNeedsDisplay in GTK3
<a href="https://bugs.webkit.org/show_bug.cgi?id=271955">https://bugs.webkit.org/show_bug.cgi?id=271955</a>

Reviewed by Carlos Garcia Campos.

Just moves around the helper function that was only used in this location.

* Source/WebCore/platform/graphics/cairo/CairoUtilities.cpp:
(WebCore::toCairoRegion): Deleted.
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::toCairoRegion):
(WebKit::PageClientImpl::setViewNeedsDisplay):

Canonical link: <a href="https://commits.webkit.org/276887@main">https://commits.webkit.org/276887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9ae296d41952f5eadb007ace6db6df5fb5bea7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48724 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48360 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22619 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37659 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18849 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40831 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4097 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50517 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44823 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22349 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43720 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10201 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22708 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22043 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->