### PR TITLE
ComplexTextController: Control characters should be rendered as visible glyphs

### DIFF
--- a/LayoutTests/fast/text/control-characters/complex-1-expected.txt
+++ b/LayoutTests/fast/text/control-characters/complex-1-expected.txt
@@ -1,0 +1,12 @@
+A control character should be rendered as a visible glyph. "ਅ\u0001ਆ" should be longer than "ਅਆ"
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS target.clientWidth is > ref.clientWidth
+PASS successfullyParsed is true
+
+TEST COMPLETE
+ਅਆ
+ਅਆ
+

--- a/LayoutTests/fast/text/control-characters/complex-1.html
+++ b/LayoutTests/fast/text/control-characters/complex-1.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../../../resources/js-test.js"></script>
+<style>
+  #ref, #target {
+      background: lightblue;
+      display: inline-block;
+      font-size: 100px;
+  }
+</style>
+<body>
+  <span id="target"></span><br>
+  <span id="ref"></span><br>
+  <script>
+    description('A control character should be rendered as a visible glyph. "\u0A05\\u0001\u0A06" should be longer than "\u0A05\u0A06"');
+    document.getElementById("target").textContent = '\u0A05\u0001\u0A06';
+    document.getElementById("ref").textContent = '\u0A05\u0A06';
+    shouldBeGreaterThan("target.clientWidth", "ref.clientWidth");
+  </script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -285,9 +285,17 @@ public:
     static bool treatAsSpace(char32_t c) { return c == space || c == tabCharacter || c == newlineCharacter || c == noBreakSpace; }
     static bool isCharacterWhoseGlyphsShouldBeDeletedForTextRendering(char32_t character)
     {
-        // https://drafts.csswg.org/css-text-3/#white-space-processing
+        // https://www.w3.org/TR/css-text-3/#white-space-processing
+        // "Control characters (Unicode category Cc)—other than tabs (U+0009), line feeds (U+000A), carriage returns (U+000D) and sequences that form a segment break—must be rendered as a visible glyph"
+        if (character == tabCharacter || character == newlineCharacter || character == carriageReturn)
+            return true;
+        // Also, we're omitting Null (U+0000) from this set because Chrome and Firefox do so and it's needed for compat. See https://github.com/w3c/csswg-drafts/pull/6983.
+        if (character == nullCharacter)
+            return true;
+        if (isControlCharacter(character))
+            return false;
         // "Unsupported Default_ignorable characters must be ignored for text rendering."
-        return isControlCharacter(character) || isDefaultIgnorableCodePoint(character) || isInvisibleReplacementObjectCharacter(character);
+        return isDefaultIgnorableCodePoint(character) || isInvisibleReplacementObjectCharacter(character);
     }
     // FIXME: Callers of treatAsZeroWidthSpace() and treatAsZeroWidthSpaceInComplexScript() should probably be calling isCharacterWhoseGlyphsShouldBeDeletedForTextRendering() instead.
     static bool treatAsZeroWidthSpace(char32_t c) { return treatAsZeroWidthSpaceInComplexScript(c) || c == zeroWidthNonJoiner || c == zeroWidthJoiner; }

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -756,9 +756,13 @@ void WidthIterator::applyCSSVisibilityRules(GlyphBuffer& glyphBuffer, unsigned g
         }
 
         // https://www.w3.org/TR/css-text-3/#white-space-processing
+        // "Unsupported Default_ignorable characters must be ignored for text rendering."
+        if (FontCascade::isCharacterWhoseGlyphsShouldBeDeletedForTextRendering(characterResponsibleForThisGlyph)) {
+            deleteGlyph(i);
+            continue;
+        }
         // "Control characters (Unicode category Cc)—other than tabs (U+0009), line feeds (U+000A), carriage returns (U+000D) and sequences that form a segment break—must be rendered as a visible glyph"
-        // Also, we're omitting Null (U+0000) from this set because Chrome and Firefox do so and it's needed for compat. See https://github.com/w3c/csswg-drafts/pull/6983.
-        if (characterResponsibleForThisGlyph != nullCharacter && isControlCharacter(characterResponsibleForThisGlyph)) {
+        if (isControlCharacter(characterResponsibleForThisGlyph)) {
             // Let's assume that .notdef is visible.
             GlyphBufferGlyph visibleGlyph = 0;
             clobberGlyph(i, visibleGlyph);
@@ -767,13 +771,6 @@ void WidthIterator::applyCSSVisibilityRules(GlyphBuffer& glyphBuffer, unsigned g
         }
 
         adjustForSyntheticBold(i);
-
-        // https://drafts.csswg.org/css-text-3/#white-space-processing
-        // "Unsupported Default_ignorable characters must be ignored for text rendering."
-        if (FontCascade::isCharacterWhoseGlyphsShouldBeDeletedForTextRendering(characterResponsibleForThisGlyph)) {
-            deleteGlyph(i);
-            continue;
-        }
     }
 }
 


### PR DESCRIPTION
#### 3baa72dbb8d513476b27bcfae8d2dd02c6514541
<pre>
ComplexTextController: Control characters should be rendered as visible glyphs
<a href="https://bugs.webkit.org/show_bug.cgi?id=271869">https://bugs.webkit.org/show_bug.cgi?id=271869</a>

Reviewed by Vitor Roriz.

Control characters weren&apos;t rendered as visible glyphs in the complex
text code path in some condition.

The spec &lt;<a href="https://www.w3.org/TR/css-text-3/#white-space-processing">https://www.w3.org/TR/css-text-3/#white-space-processing</a>&gt; says:

&gt; Control characters (Unicode category Cc)—other than tabs (U+0009),
&gt; line feeds (U+000A), carriage returns (U+000D) and sequences that form
&gt; a segment break—must be rendered as a visible glyph

<a href="https://webkit.org/b/149128">https://webkit.org/b/149128</a> fixed the simple text code path.
<a href="https://webkit.org/b/153941">https://webkit.org/b/153941</a> fixed a part of the complex text code
path. We need one more fix.

ComplexTextController constructor is using
FontCascade::isCharacterWhoseGlyphsShouldBeDeletedForTextRendering to
determine a character is visible. It returned false for control
characters.

Changed isCharacterWhoseGlyphsShouldBeDeletedForTextRendering to
return false for control characters other than tabs, line feeds, and
carriage returns.

WidthIterator::applyCSSVisibilityRules is also using
isCharacterWhoseGlyphsShouldBeDeletedForTextRendering. Changed it to
keep the original behavior.

* LayoutTests/fast/text/control-characters/complex-1-expected.txt: Added.
* LayoutTests/fast/text/control-characters/complex-1.html: Added.
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::isCharacterWhoseGlyphsShouldBeDeletedForTextRendering):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::applyCSSVisibilityRules):

Canonical link: <a href="https://commits.webkit.org/277574@main">https://commits.webkit.org/277574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ee1c464dcf42fe7b5fbb21d03a54654e68143fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50598 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43970 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50223 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38983 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20281 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22261 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42615 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5964 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43053 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52492 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19311 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46292 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24229 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45336 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10593 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->