### PR TITLE
[iOS] 2 fast/viewport/viewport-legacy-xhtmlmp*.html layout tests are constantly failing.

### DIFF
--- a/LayoutTests/fast/viewport/viewport-legacy-xhtmlmp-remove-and-add.html
+++ b/LayoutTests/fast/viewport/viewport-legacy-xhtmlmp-remove-and-add.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.0//EN" "http://www.wapforum.org/DTD/xhtml-mobile10.dtd">
 <head>
     <!--
-    Related spec: http://www.w3.org/TR/css-device-adapt/
+    Related spec: https://www.w3.org/TR/css-viewport/
 
     XHTML-MP is used for mobile documents which are assumed to be designed for
     handheld devices, hence using the viewport size as the initial containing

--- a/LayoutTests/fast/viewport/viewport-legacy-xhtmlmp.html
+++ b/LayoutTests/fast/viewport/viewport-legacy-xhtmlmp.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.0//EN" "http://www.wapforum.org/DTD/xhtml-mobile10.dtd">
 <head>
     <!--
-    Related spec: http://www.w3.org/TR/css-device-adapt/
+    Related spec: https://www.w3.org/TR/css-viewport/
 
     XHTML-MP is used for mobile documents which are assumed to be designed for
     handheld devices, hence using the viewport size as the initial containing

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7018,9 +7018,6 @@ imported/w3c/web-platform-tests/svg/import/animate-elem-30-t-manual.svg [ Failur
 imported/w3c/web-platform-tests/svg/import/animate-elem-85-t-manual.svg [ Failure ]
 imported/w3c/web-platform-tests/svg/import/animate-pservers-grad-01-b-manual.svg [ Failure ]
 
-webkit.org/b/271784 fast/viewport/viewport-legacy-xhtmlmp.html [ Failure ]
-webkit.org/b/271784 fast/viewport/viewport-legacy-xhtmlmp-remove-and-add.html [ Failure ]
-
 webkit.org/b/271785 media/modern-media-controls/overflow-support/chapters.html [ Timeout ]
 webkit.org/b/271785 media/modern-media-controls/overflow-support/playback-speed.html [ Timeout ]
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4623,20 +4623,30 @@ ViewportArguments Document::viewportArguments() const
     return page->overrideViewportArguments().value_or(m_viewportArguments);
 }
 
+bool Document::isViewportDocument() const
+{
+    RefPtr page = this->page();
+    if (!page)
+        return false;
+
+#if ENABLE(FULLSCREEN_API)
+    if (RefPtr outermostFullscreenDocument = page->outermostFullscreenDocument())
+        return outermostFullscreenDocument == this;
+#endif
+
+    if (RefPtr frame = this->frame())
+        return frame->isMainFrame();
+
+    return false;
+}
+
 void Document::updateViewportArguments()
 {
     RefPtr page = this->page();
     if (!page)
         return;
 
-    bool isViewportDocument = [&] {
-#if ENABLE(FULLSCREEN_API)
-        if (auto* outermostFullscreenDocument = page->outermostFullscreenDocument())
-            return outermostFullscreenDocument == this;
-#endif
-        return frame()->isMainFrame();
-    }();
-    if (!isViewportDocument)
+    if (!isViewportDocument())
         return;
 
 #if ASSERT_ENABLED

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1079,8 +1079,8 @@ public:
     DOMTimerHoldingTank* domTimerHoldingTankIfExists() { return m_domTimerHoldingTank.get(); }
     DOMTimerHoldingTank& domTimerHoldingTank();
 #endif
-    
     void processViewport(const String& features, ViewportArguments::Type origin);
+    WEBCORE_EXPORT bool isViewportDocument() const;
     void processDisabledAdaptations(const String& adaptations);
     void updateViewportArguments();
     void processReferrerPolicy(const String& policy, ReferrerPolicySource);

--- a/Source/WebCore/dom/ViewportArguments.h
+++ b/Source/WebCore/dom/ViewportArguments.h
@@ -70,8 +70,8 @@ struct ViewportArguments {
         PluginDocument,
         ImageDocument,
 #endif
+        CSSDeviceAdaptation,
         ViewportMeta,
-        CSSDeviceAdaptation
     } type;
 
     static constexpr int ValueAuto = -1;


### PR DESCRIPTION
#### 1b57c1925dd6e75019a596962321846094c57544
<pre>
[iOS] 2 fast/viewport/viewport-legacy-xhtmlmp*.html layout tests are constantly failing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=271784">https://bugs.webkit.org/show_bug.cgi?id=271784</a>
<a href="https://rdar.apple.com/125504723">rdar://125504723</a>

Reviewed by Tim Horton.

This patch addresses the following failed tests:
- fast/viewport/viewport-legacy-xhtmlmp.html
- fast/viewport/viewport-legacy-xhtmlmp-remove-and-add.html

Both tests use the XHTML Mobile Profile (XHTML-MP) doctype, but this is
not reflected in the document&apos;s resolved viewport configuration. The
test output shows that the viewport&apos;s width is equivalent to the default
desktop width (980) and the minimum scale is equivalent to the ratio
between the XHTML mobile paramaters width (320) and the default desktop
width.

This patch updates the viewport configuration to XHTML-MP parameters and
provides the right viewport origin type (CSSDeviceAdaption) if the web
page&apos;s viewport configuration is being reset and the page has a mobile
doctype, like for the failing tests. This way, We make sure the document
throws away the stale viewport arguments with desktop values and instead
respects the mobile profile, but only if the exisitng viewport arguments
were not configured through a meta tag, since that takes priority over
XHTML-MP.

Lastly, we improve conformance to current smart pointer usage guidelines
with drive-by refactors in WebPage::resetViewportDefaultConfiguration
and in Document::updateViewportArguments.

* LayoutTests/fast/viewport/viewport-legacy-xhtmlmp-remove-and-add.html:
* LayoutTests/fast/viewport/viewport-legacy-xhtmlmp.html:

Update viewport spec link in the test comments.

* LayoutTests/platform/ios/TestExpectations:

Fix test expectations.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::isViewportDocument const):

Make the lambda function from Document::updateViewportArguments a member
function so we can call it in WebPage::resetViewportDefaultConfiguration
as well.

Also, slight smart pointer hygiene improvements.

(WebCore::Document::updateViewportArguments):
* Source/WebCore/dom/Document.h:

* Source/WebCore/dom/ViewportArguments.h:

Rearrange the ViewportArguments::Type cases to reflect that viewport
arguments obtained from a meta tag are prioritized over XHTML-MP.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::resetViewportDefaultConfiguration):

If we have received a mobile doctype, and we have a viewport document,
update the viewport configuration to reflect that of the XHTML-MP. Call
WebPage::viewportPropertiesDidChange to propagate these changes.

Also, slight smart pointer hygiene improvements.

Canonical link: <a href="https://commits.webkit.org/276992@main">https://commits.webkit.org/276992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5afe7e37da3d8b76a1f610f8a3b9749ab8fa42ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46293 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48966 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42334 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48600 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37809 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19029 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41014 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4337 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42606 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBSuspendImminently (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50779 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45014 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43928 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10260 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->