### PR TITLE
Linker error when logging ViewportConfiguration to TextStream in Release configuration

### DIFF
--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -674,8 +674,6 @@ bool ViewportConfiguration::setIsKnownToLayOutWiderThanViewport(bool value)
     return true;
 }
 
-#if !LOG_DISABLED
-
 TextStream& operator<<(TextStream& ts, const ViewportConfiguration::Parameters& parameters)
 {
     ts.startGroup();
@@ -746,6 +744,8 @@ String ViewportConfiguration::description() const
 
     return ts.release();
 }
+
+#if !LOG_DISABLED
 
 void ViewportConfiguration::dump() const
 {

--- a/Source/WebCore/page/ViewportConfiguration.h
+++ b/Source/WebCore/page/ViewportConfiguration.h
@@ -148,9 +148,9 @@ public:
     WEBCORE_EXPORT static Parameters imageDocumentParameters();
     WEBCORE_EXPORT static Parameters xhtmlMobileParameters();
     WEBCORE_EXPORT static Parameters testingParameters();
-    
-#if !LOG_DISABLED
+
     String description() const;
+#if !LOG_DISABLED
     WEBCORE_EXPORT void dump() const;
 #endif
 


### PR DESCRIPTION
#### 59cedf7135bc81ea30a89477356dfd5951764d2d
<pre>
Linker error when logging ViewportConfiguration to TextStream in Release configuration
<a href="https://bugs.webkit.org/show_bug.cgi?id=271962">https://bugs.webkit.org/show_bug.cgi?id=271962</a>
<a href="https://rdar.apple.com/125713559">rdar://125713559</a>

Reviewed by Sihui Liu.

WebCore::operator&lt;&lt;(WTF::TextStream&amp;, WebCore::ViewConfiguration const&amp;)
is defined behind !LOG_DISABLED, which means in Release configuration,
the linker cannot find this definition.

This patch fixes the linker error by removing the relevant !LOG_DISABLED
checks around both the operator&lt;&lt; overload definition and the
description()/dump() declarations, since said methods are referenced by
the operator&lt;&lt; overload.

* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::ViewportConfiguration::setIsKnownToLayOutWiderThanViewport):
(WebCore::ViewportConfiguration::dump const):
* Source/WebCore/page/ViewportConfiguration.h:

Canonical link: <a href="https://commits.webkit.org/276925@main">https://commits.webkit.org/276925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d6be03cabc8089fde54db68df858ffd3be1a44e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46155 "Failed to checkout and rebase branch from PR 26672") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42195 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37719 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18923 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19751 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40901 "Found 1 new test failure: fullscreen/element-clear-during-fullscreen-crash.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4199 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42453 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50622 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44895 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22451 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43831 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10223 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22145 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->