### PR TITLE
Add mechanism to automatically convert Enums to Strings for printing

### DIFF
--- a/JSTests/wasm/wabt-wrapper.js
+++ b/JSTests/wasm/wabt-wrapper.js
@@ -1,4 +1,4 @@
-load("../libwabt.js");
+load("libwabt.js", "caller relative");
 
 export async function compile(wat, options = {}) {
     const wabtModule = await WabtModule();

--- a/Source/JavaScriptCore/bytecode/ExitKind.cpp
+++ b/Source/JavaScriptCore/bytecode/ExitKind.cpp
@@ -32,74 +32,6 @@
 
 namespace JSC {
 
-ASCIILiteral exitKindToString(ExitKind kind)
-{
-    switch (kind) {
-    case ExitKindUnset:
-        return "Unset"_s;
-    case BadType:
-        return "BadType"_s;
-    case BadConstantValue:
-        return "BadConstantValue"_s;
-    case BadIdent:
-        return "BadIdent"_s;
-    case BadExecutable:
-        return "BadExecutable"_s;
-    case BadCache:
-        return "BadCache"_s;
-    case BadConstantCache:
-        return "BadConstantCache"_s;
-    case BadIndexingType:
-        return "BadIndexingType"_s;
-    case BadTypeInfoFlags:
-        return "BadTypeInfoFlags"_s;
-    case Overflow:
-        return "Overflow"_s;
-    case NegativeZero:
-        return "NegativeZero"_s;
-    case NegativeIndex:
-        return "NegativeIndex"_s;
-    case Int52Overflow:
-        return "Int52Overflow"_s;
-    case StoreToHole:
-        return "StoreToHole"_s;
-    case LoadFromHole:
-        return "LoadFromHole"_s;
-    case OutOfBounds:
-        return "OutOfBounds"_s;
-    case InadequateCoverage:
-        return "InadequateCoverage"_s;
-    case ArgumentsEscaped:
-        return "ArgumentsEscaped"_s;
-    case ExoticObjectMode:
-        return "ExoticObjectMode"_s;
-    case VarargsOverflow:
-        return "VarargsOverflow"_s;
-    case TDZFailure:
-        return "TDZFailure"_s;
-    case HoistingFailed:
-        return "HoistingFailed"_s;
-    case Uncountable:
-        return "Uncountable"_s;
-    case UncountableInvalidation:
-        return "UncountableInvalidation"_s;
-    case WatchdogTimerFired:
-        return "WatchdogTimerFired"_s;
-    case DebuggerEvent:
-        return "DebuggerEvent"_s;
-    case ExceptionCheck:
-        return "ExceptionCheck"_s;
-    case GenericUnwind:
-        return "GenericUnwind"_s;
-    case BigInt32Overflow:
-        return "BigInt32Overflow"_s;
-    case UnexpectedResizableArrayBufferView:
-        return "UnexpectedResizableArrayBufferView"_s;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-    return "Unknown"_s;
-}
-
 bool exitKindMayJettison(ExitKind kind)
 {
     switch (kind) {
@@ -112,13 +44,3 @@ bool exitKindMayJettison(ExitKind kind)
 }
 
 } // namespace JSC
-
-namespace WTF {
-
-void printInternal(PrintStream& out, JSC::ExitKind kind)
-{
-    out.print(exitKindToString(kind));
-}
-
-} // namespace WTF
-

--- a/Source/JavaScriptCore/bytecode/ExitKind.h
+++ b/Source/JavaScriptCore/bytecode/ExitKind.h
@@ -62,14 +62,6 @@ enum ExitKind : uint8_t {
     UnexpectedResizableArrayBufferView, // We exited because we made an incorrect assumption about what type of ArrayBufferView we would see.
 };
 
-ASCIILiteral exitKindToString(ExitKind);
 bool exitKindMayJettison(ExitKind);
 
 } // namespace JSC
-
-namespace WTF {
-
-class PrintStream;
-void printInternal(PrintStream&, JSC::ExitKind);
-
-} // namespace WTF

--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.cpp
@@ -1059,23 +1059,3 @@ void ExpressionInfo::dumpEncodedInfo(ExpressionInfo::EncodedInfo* start, Express
 }
 
 } // namespace JSC
-
-namespace WTF {
-
-void printInternal(PrintStream& out, JSC::ExpressionInfo::FieldID fieldID)
-{
-    auto name = [] (auto fieldID) {
-        switch (fieldID) {
-        case JSC::ExpressionInfo::FieldID::InstPC: return "Inst";
-        case JSC::ExpressionInfo::FieldID::Divot: return "Divot";
-        case JSC::ExpressionInfo::FieldID::Start: return "Start";
-        case JSC::ExpressionInfo::FieldID::End: return "End";
-        case JSC::ExpressionInfo::FieldID::Line: return "Line";
-        case JSC::ExpressionInfo::FieldID::Column: return "Column";
-        }
-        return ""; // placate GCC.
-    };
-    out.print(name(fieldID));
-}
-
-} // namespace WTF

--- a/Source/JavaScriptCore/bytecode/ExpressionInfo.h
+++ b/Source/JavaScriptCore/bytecode/ExpressionInfo.h
@@ -332,9 +332,3 @@ private:
 static_assert(roundUpToMultipleOf<sizeof(unsigned)>(sizeof(ExpressionInfo)) == sizeof(ExpressionInfo), "CachedExpressionInfo relies on this invariant");
 
 } // namespace JSC
-
-namespace WTF {
-
-JS_EXPORT_PRIVATE void printInternal(PrintStream&, JSC::ExpressionInfo::FieldID);
-
-} // namespace WTF

--- a/Source/JavaScriptCore/bytecode/Watchpoint.h
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.h
@@ -48,7 +48,9 @@ class FireDetail {
 public:
     FireDetail() = default;
     virtual ~FireDetail() = default;
-    virtual void dump(PrintStream&) const = 0;
+    // This can't be pure virtual as it breaks our Dumpable concept.
+    // FIXME: Make this virtual after we stop suppporting the Montery Clang.
+    virtual void dump(PrintStream&) const { }
 };
 
 class StringFireDetail final : public FireDetail {

--- a/Source/JavaScriptCore/dfg/DFGArrayMode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArrayMode.cpp
@@ -662,134 +662,6 @@ bool ArrayMode::alreadyChecked(Graph& graph, Node* node, const AbstractValue& va
     return false;
 }
 
-const char* arrayActionToString(Array::Action action)
-{
-    switch (action) {
-    case Array::Read:
-        return "Read";
-    case Array::Write:
-        return "Write";
-    default:
-        return "Unknown!";
-    }
-}
-
-const char* arrayTypeToString(Array::Type type)
-{
-    switch (type) {
-    case Array::SelectUsingPredictions:
-        return "SelectUsingPredictions";
-    case Array::SelectUsingArguments:
-        return "SelectUsingArguments";
-    case Array::Unprofiled:
-        return "Unprofiled";
-    case Array::Generic:
-        return "Generic";
-    case Array::ForceExit:
-        return "ForceExit";
-    case Array::String:
-        return "String";
-    case Array::Undecided:
-        return "Undecided";
-    case Array::Int32:
-        return "Int32";
-    case Array::Double:
-        return "Double";
-    case Array::Contiguous:
-        return "Contiguous";
-    case Array::ArrayStorage:
-        return "ArrayStorage";
-    case Array::SlowPutArrayStorage:
-        return "SlowPutArrayStorage";
-    case Array::DirectArguments:
-        return "DirectArguments";
-    case Array::ScopedArguments:
-        return "ScopedArguments";
-    case Array::Int8Array:
-        return "Int8Array";
-    case Array::Int16Array:
-        return "Int16Array";
-    case Array::Int32Array:
-        return "Int32Array";
-    case Array::Uint8Array:
-        return "Uint8Array";
-    case Array::Uint8ClampedArray:
-        return "Uint8ClampedArray";
-    case Array::Uint16Array:
-        return "Uint16Array";
-    case Array::Uint32Array:
-        return "Uint32Array";
-    case Array::Float32Array:
-        return "Float32Array";
-    case Array::Float64Array:
-        return "Float64Array";
-    case Array::BigInt64Array:
-        return "BigInt64Array";
-    case Array::BigUint64Array:
-        return "BigUint64Array";
-    case Array::AnyTypedArray:
-        return "AnyTypedArray";
-    default:
-        // Better to return something then it is to crash. Remember, this method
-        // is being called from our main diagnostic tool, the IR dumper. It's like
-        // a stack trace. So if we get here then probably something has already
-        // gone wrong.
-        return "Unknown!";
-    }
-}
-
-const char* arrayClassToString(Array::Class arrayClass)
-{
-    switch (arrayClass) {
-    case Array::Array:
-        return "Array";
-    case Array::OriginalArray:
-        return "OriginalArray";
-    case Array::OriginalNonCopyOnWriteArray:
-        return "OriginalNonCopyOnWriteArray";
-    case Array::OriginalCopyOnWriteArray:
-        return "OriginalCopyOnWriteArray";
-    case Array::NonArray:
-        return "NonArray";
-    case Array::OriginalNonArray:
-        return "OriginalNonArray";
-    case Array::PossiblyArray:
-        return "PossiblyArray";
-    default:
-        return "Unknown!";
-    }
-}
-
-const char* arraySpeculationToString(Array::Speculation speculation)
-{
-    switch (speculation) {
-    case Array::InBoundsSaneChain:
-        return "InBoundsSaneChain";
-    case Array::InBounds:
-        return "InBounds";
-    case Array::ToHole:
-        return "ToHole";
-    case Array::OutOfBounds:
-        return "OutOfBounds";
-    case Array::OutOfBoundsSaneChain:
-        return "OutOfBoundsSaneChain";
-    default:
-        return "Unknown!";
-    }
-}
-
-const char* arrayConversionToString(Array::Conversion conversion)
-{
-    switch (conversion) {
-    case Array::AsIs:
-        return "AsIs";
-    case Array::Convert:
-        return "Convert";
-    default:
-        return "Unknown!";
-    }
-}
-
 IndexingType toIndexingShape(Array::Type type)
 {
     switch (type) {
@@ -933,29 +805,34 @@ void ArrayMode::dump(PrintStream& out) const
 
 namespace WTF {
 
+// Better to return something then it is to crash. Remember, these methods
+// are being called from our main diagnostic tool, the IR dumper. It's like
+// a stack trace. So if we get here then probably something has already
+// gone wrong.
+
 void printInternal(PrintStream& out, JSC::DFG::Array::Action action)
 {
-    out.print(JSC::DFG::arrayActionToString(action));
+    out.print(EnumDumpWithDefault(action, "Unknown!"));
 }
 
 void printInternal(PrintStream& out, JSC::DFG::Array::Type type)
 {
-    out.print(JSC::DFG::arrayTypeToString(type));
+    out.print(EnumDumpWithDefault(type, "Unknown!"));
 }
 
 void printInternal(PrintStream& out, JSC::DFG::Array::Class arrayClass)
 {
-    out.print(JSC::DFG::arrayClassToString(arrayClass));
+    out.print(EnumDumpWithDefault(arrayClass, "Unknown!"));
 }
 
 void printInternal(PrintStream& out, JSC::DFG::Array::Speculation speculation)
 {
-    out.print(JSC::DFG::arraySpeculationToString(speculation));
+    out.print(EnumDumpWithDefault(speculation, "Unknown!"));
 }
 
 void printInternal(PrintStream& out, JSC::DFG::Array::Conversion conversion)
 {
-    out.print(JSC::DFG::arrayConversionToString(conversion));
+    out.print(EnumDumpWithDefault(conversion, "Unknown!"));
 }
 
 } // namespace WTF

--- a/Source/JavaScriptCore/dfg/DFGArrayMode.h
+++ b/Source/JavaScriptCore/dfg/DFGArrayMode.h
@@ -106,12 +106,6 @@ enum Conversion : uint8_t {
 };
 } // namespace Array
 
-const char* arrayActionToString(Array::Action);
-const char* arrayTypeToString(Array::Type);
-const char* arrayClassToString(Array::Class);
-const char* arraySpeculationToString(Array::Speculation);
-const char* arrayConversionToString(Array::Conversion);
-
 IndexingType toIndexingShape(Array::Type);
 
 TypedArrayType toTypedArrayType(Array::Type);

--- a/Source/JavaScriptCore/dfg/DFGBranchDirection.h
+++ b/Source/JavaScriptCore/dfg/DFGBranchDirection.h
@@ -45,23 +45,6 @@ enum BranchDirection : uint8_t {
     TakeBoth
 };
     
-static inline const char* branchDirectionToString(BranchDirection branchDirection)
-{
-    switch (branchDirection) {
-    case InvalidBranchDirection:
-        return "InvalidBranchDirection";
-    case TakeTrue:
-        return "TakeTrue";
-    case TakeFalse:
-        return "TakeFalse";
-    case TakeBoth:
-        return "TakeBoth";
-    }
-
-    RELEASE_ASSERT_NOT_REACHED();
-    return "InvalidBranchDirection";
-}
-    
 static inline bool isKnownDirection(BranchDirection branchDirection)
 {
     switch (branchDirection) {
@@ -82,14 +65,5 @@ static inline bool branchCondition(BranchDirection branchDirection)
 }
 
 } } // namespace JSC::DFG
-
-namespace WTF {
-
-inline void printInternal(PrintStream& out, JSC::DFG::BranchDirection direction)
-{
-    out.print(JSC::DFG::branchDirectionToString(direction));
-}
-
-} // namespace WTF
 
 #endif // ENABLE(DFG_JIT)

--- a/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExit.cpp
@@ -207,7 +207,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompileOSRExit, void, (CallFrame* cal
             patchBuffer, OSRExitPtrTag, nullptr,
             "DFG OSR exit #%u (D@%u, %s, %s) from %s, with operands = %s",
                 exitIndex, exit.m_dfgNodeIndex, toCString(exit.m_codeOrigin).data(),
-                exitKindToString(exit.m_kind).characters(), toCString(*codeBlock).data(),
+                exit.m_kind, toCString(*codeBlock).data(),
                 toCString(ignoringContext<DumpContext>(operands)).data());
         codeBlock->dfgJITData()->setExitCode(exitIndex, exitCode);
     }
@@ -881,7 +881,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationDebugPrintSpeculationFailure, void, (
     NativeCallFrameTracer tracer(vm, callFrame);
 
     dataLog("Speculation failure in ", *codeBlock);
-    dataLog(" @ exit #", debugInfo->exitIndex, " (", debugInfo->bytecodeIndex, ", ", exitKindToString(debugInfo->kind), ") with ");
+    dataLog(" @ exit #", debugInfo->exitIndex, " (", debugInfo->bytecodeIndex, ", ", debugInfo->kind, ") with ");
     if (alternative) {
         dataLog(
             "executeCounter = ", alternative->jitExecuteCounter(),

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -624,7 +624,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
         patchBuffer, OSRExitPtrTag, nullptr,
         "FTL OSR exit #%u (D@%u, %s, %s) from %s, with operands = %s",
             exitID, exit.m_dfgNodeIndex, toCString(exit.m_codeOrigin).data(),
-            exitKindToString(exit.m_kind).characters(), toCString(*codeBlock).data(),
+            exit.m_kind, toCString(*codeBlock).data(),
             toCString(ignoringContext<DumpContext>(exit.m_descriptor->m_values)).data()
         );
 }

--- a/Source/JavaScriptCore/heap/AbstractSlotVisitor.h
+++ b/Source/JavaScriptCore/heap/AbstractSlotVisitor.h
@@ -196,7 +196,9 @@ public:
     virtual void reportExternalMemoryVisited(size_t) = 0;
 #endif
 
-    virtual void dump(PrintStream&) const = 0;
+    // This can't be pure virtual as it breaks our Dumpable concept.
+    // FIXME: Make this virtual after we stop suppporting the Montery Clang.
+    virtual void dump(PrintStream&) const { }
 
     RootMarkReason rootMarkReason() const { return m_rootMarkReason; }
     void setRootMarkReason(RootMarkReason reason) { m_rootMarkReason = reason; }

--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
@@ -44,7 +44,9 @@ public:
     virtual void* tryAllocateAlignedMemory(size_t alignment, size_t size) = 0;
     virtual void freeAlignedMemory(void*) = 0;
     
-    virtual void dump(PrintStream&) const = 0;
+    // This can't be pure virtual as it breaks our Dumpable concept.
+    // FIXME: Make this virtual after we stop suppporting the Montery Clang.
+    virtual void dump(PrintStream&) const { }
 
     void registerDirectory(Heap&, BlockDirectory*);
     BlockDirectory* firstDirectory() const { return m_directories.first(); }

--- a/Source/JavaScriptCore/heap/GCLogging.cpp
+++ b/Source/JavaScriptCore/heap/GCLogging.cpp
@@ -28,24 +28,6 @@
 
 #include <wtf/PrintStream.h>
 
-namespace JSC {
-
-ASCIILiteral GCLogging::levelAsString(Level level)
-{
-    switch (level) {
-    case None:
-        return "None"_s;
-    case Basic:
-        return "Basic"_s;
-    case Verbose:
-        return "Verbose"_s;
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-        return ""_s;
-    }
-}
-
-} // namespace JSC
 
 namespace WTF {
 

--- a/Source/JavaScriptCore/heap/GCLogging.h
+++ b/Source/JavaScriptCore/heap/GCLogging.h
@@ -40,7 +40,6 @@ public:
         Verbose
     };
 
-    static ASCIILiteral levelAsString(Level);
     static void dumpObjectGraph(Heap*);
 };
 

--- a/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
@@ -35,7 +35,7 @@ namespace JSC {
 GigacageAlignedMemoryAllocator::GigacageAlignedMemoryAllocator(Gigacage::Kind kind)
     : m_kind(kind)
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)
-    , m_heap(makeString("GigacageAlignedMemoryAllocator "_s, String::fromUTF8(Gigacage::name(m_kind))).utf8().data())
+    , m_heap(makeString("GigacageAlignedMemoryAllocator "_s, m_kind).utf8().data())
 #endif
 {
 }
@@ -62,7 +62,7 @@ void GigacageAlignedMemoryAllocator::freeAlignedMemory(void* basePtr)
 
 void GigacageAlignedMemoryAllocator::dump(PrintStream& out) const
 {
-    out.print(Gigacage::name(m_kind), "Gigacage");
+    out.print(m_kind, "Gigacage");
 }
 
 void* GigacageAlignedMemoryAllocator::tryAllocateMemory(size_t size)

--- a/Source/JavaScriptCore/jit/JITOpaqueByproduct.h
+++ b/Source/JavaScriptCore/jit/JITOpaqueByproduct.h
@@ -40,7 +40,9 @@ public:
     OpaqueByproduct() { }
     virtual ~OpaqueByproduct() { }
 
-    virtual void dump(PrintStream&) const = 0;
+    // This can't be pure virtual as it breaks our Dumpable concept.
+    // FIXME: Make this virtual after we stop suppporting the Montery Clang.
+    virtual void dump(PrintStream&) const { }
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4024,8 +4024,8 @@ void CommandLine::parseArguments(int argc, char** argv)
         }
         if (!strcmp(arg, "--signal-expected")) {
 #if OS(UNIX)
-            SignalAction (*exit)(Signal, SigInfo&, PlatformRegisters&) = [] (Signal, SigInfo&, PlatformRegisters&) {
-                dataLogLn("Signal handler hit. Exiting with status 137");
+            SignalAction (*exit)(Signal, SigInfo&, PlatformRegisters&) = [] (Signal signal, SigInfo&, PlatformRegisters&) {
+                dataLogLn("Signal handler for ", ScopedEnumDump(signal), " hit. Exiting with status 137");
                 // Deliberate exit with a SIGKILL code greater than 130.
                 terminateProcess(137);
                 return SignalAction::ForceDefault;

--- a/Source/JavaScriptCore/profiler/ProfilerOSRExit.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerOSRExit.cpp
@@ -48,7 +48,7 @@ Ref<JSON::Value> OSRExit::toJSON(Dumper& dumper) const
     auto result = JSON::Object::create();
     result->setDouble(dumper.keys().m_id, m_id);
     result->setValue(dumper.keys().m_origin, m_origin.toJSON(dumper));
-    result->setString(dumper.keys().m_exitKind, exitKindToString(m_exitKind));
+    result->setString(dumper.keys().m_exitKind, enumName(m_exitKind));
     result->setBoolean(dumper.keys().m_isWatchpoint, !!m_isWatchpoint);
     result->setDouble(dumper.keys().m_count, m_counter);
     return result;

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp
@@ -65,23 +65,9 @@ size_t BufferMemoryHandle::fastMappedBytes()
     return MAX_ARRAY_BUFFER_SIZE + fastMappedRedzoneBytes();
 }
 
-ASCIILiteral BufferMemoryResult::toString(Kind kind)
-{
-    switch (kind) {
-    case Success:
-        return "Success"_s;
-    case SuccessAndNotifyMemoryPressure:
-        return "SuccessAndNotifyMemoryPressure"_s;
-    case SyncTryToReclaimMemory:
-        return "SyncTryToReclaimMemory"_s;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-    return { };
-}
-
 void BufferMemoryResult::dump(PrintStream& out) const
 {
-    out.print("{basePtr = ", RawPointer(basePtr), ", kind = ", toString(kind), "}");
+    out.print("{basePtr = ", RawPointer(basePtr), ", kind = ", kind, "}");
 }
 
 BufferMemoryResult BufferMemoryManager::tryAllocateFastMemory()
@@ -186,7 +172,7 @@ BufferMemoryResult::Kind BufferMemoryManager::tryAllocatePhysicalBytes(size_t by
         return BufferMemoryResult::Success;
     }();
 
-    dataLogLnIf(Options::logWasmMemory(), "Allocated physical: ", bytes, ", ", BufferMemoryResult::toString(result), "; state: ", *this);
+    dataLogLnIf(Options::logWasmMemory(), "Allocated physical: ", bytes, ", ", result, "; state: ", *this);
 
     return result;
 }

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -63,8 +63,6 @@ struct BufferMemoryResult {
         SyncTryToReclaimMemory
     };
 
-    static ASCIILiteral toString(Kind);
-
     BufferMemoryResult() { }
 
     BufferMemoryResult(void* basePtr, Kind kind)

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -1365,7 +1365,7 @@ void Option::dump(StringBuilder& builder) const
         builder.append('"', m_optionString ? span8(m_optionString) : ""_span, '"');
         break;
     case Options::Type::GCLogLevel:
-        builder.append(GCLogging::levelAsString(m_gcLogLevel));
+        builder.append(m_gcLogLevel);
         break;
     case Options::Type::OSLogType:
         builder.append(asString(m_osLogType));

--- a/Source/JavaScriptCore/wasm/WasmWorklist.cpp
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.cpp
@@ -41,17 +41,6 @@ namespace WasmWorklistInternal {
 static constexpr bool verbose = false;
 }
 
-const char* Worklist::priorityString(Priority priority)
-{
-    switch (priority) {
-    case Priority::Preparation: return "Preparation";
-    case Priority::Shutdown: return "Shutdown";
-    case Priority::Compilation: return "Compilation";
-    case Priority::Synchronous: return "Synchronous";
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
 void Worklist::dump(PrintStream& out) const
 {
     out.print("Queue Size = ", m_queue.size());

--- a/Source/JavaScriptCore/wasm/WasmWorklist.h
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.h
@@ -60,7 +60,6 @@ public:
         Compilation,
         Preparation
     };
-    const char* priorityString(Priority);
 
     void dump(PrintStream&) const;
 

--- a/Source/WTF/wtf/EnumTraits.h
+++ b/Source/WTF/wtf/EnumTraits.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,9 +23,41 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.5
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2024 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 #pragma once
 
 #include <algorithm>
+#include <span>
 #include <type_traits>
 
 namespace WTF {
@@ -123,8 +155,118 @@ constexpr bool isZeroBasedContiguousEnum()
     return ZeroBasedContiguousEnumChecker<std::underlying_type_t<E>, typename EnumTraits<E>::values>::isZeroBasedContiguousEnum();
 }
 
+#if COMPILER(CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-warning-option"
+#pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
+#endif
+
+template<typename E>
+constexpr std::span<const char> enumTypeNameImpl()
+{
+    static_assert(std::is_enum_v<E>, "enumTypeName requires an enum type.");
+
+#if COMPILER(CLANG)
+    const size_t prefix = sizeof("std::span<const char> WTF::enumTypeNameImpl() [E = ") - 1;
+    const size_t suffix = sizeof("]") - 1;
+    std::span<const char> name { __PRETTY_FUNCTION__ + prefix, sizeof(__PRETTY_FUNCTION__) - prefix - suffix - 1 };
+#elif COMPILER(GCC)
+    const size_t prefix = sizeof("constexpr std::span<const char> WTF::enumTypeNameImpl() [with auto V = ") - 1;
+    const size_t suffix = sizeof("]") - 1;
+    std::span<const char> name { __PRETTY_FUNCTION__ + prefix, sizeof(__PRETTY_FUNCTION__) - prefix - suffix - 1 };
+#else
+#error "Unsupported compiler"
+#endif
+    for (size_t i = name.size(); i--;) {
+        if (name[i] == ':')
+            return name.subspan(i + 1);
+    }
+    return name;
+}
+template<typename E>
+constexpr std::span<const char> enumTypeName()
+{
+    constexpr auto result = enumTypeNameImpl<std::decay_t<E>>(); // Force the span to be generated at compile time.
+    return result;
+}
+
+template<auto V>
+constexpr std::span<const char> enumNameImpl()
+{
+    static_assert(std::is_enum_v<decltype(V)>, "enumName requires an enum type.");
+
+#if COMPILER(CLANG)
+    const size_t prefix = sizeof("std::span<const char> WTF::enumNameImpl() [V = ") - 1;
+    const size_t suffix = sizeof("]") - 1;
+    std::span<const char> name { __PRETTY_FUNCTION__ + prefix, sizeof(__PRETTY_FUNCTION__) - prefix - suffix - 1 };
+    if (name[0] == '(' || name[0] == '-' || ('0' <= name[0] && name[0] <= '9'))
+        return { };
+#elif COMPILER(GCC)
+    const size_t prefix = sizeof("constexpr std::span<const char> WTF::enumNameImpl() [with auto V = ") - 1;
+    const size_t suffix = sizeof("]") - 1;
+    std::span<const char> name { __PRETTY_FUNCTION__ + prefix, sizeof(__PRETTY_FUNCTION__) - prefix - suffix - 1 };
+    if (name[0] == '(')
+        name = { };
+#else
+#error "Unsupported compiler"
+#endif
+    for (std::size_t i = name.size(); i--;) {
+        if (name[i] == ':')
+            return name.subspan(i + 1);
+    }
+    return name;
+}
+
+template<auto V>
+constexpr std::span<const char> enumName()
+{
+    constexpr auto result = enumNameImpl<V>(); // Force the span to be generated at compile time.
+    return result;
+}
+
+namespace detail {
+
+template<size_t i, size_t end>
+constexpr void forConstexpr(const auto& func)
+{
+    if constexpr (i < end) {
+        func(std::integral_constant<size_t, i>());
+        forConstexpr<i + 1, end>(func);
+    }
+}
+
+}
+
+template<typename E, size_t limit = 256>
+constexpr std::array<std::span<const char>, limit> enumNames()
+{
+    std::array<std::span<const char>, limit> names;
+
+    detail::forConstexpr<0, limit>([&] (auto i) {
+        names[i] = enumName<static_cast<E>(static_cast<unsigned>(i))>();
+    });
+    return names;
+}
+
+
+template<typename T>
+constexpr std::span<const char> enumName(T v)
+{
+    constexpr auto names = enumNames<std::decay_t<T>>();
+    if (static_cast<size_t>(v) >= names.size())
+        return { "enum out of range" };
+    return names[static_cast<uint8_t>(v)];
+}
+
+#if COMPILER(CLANG)
+#pragma clang diagnostic pop
+#endif
+
 } // namespace WTF
 
 using WTF::enumToUnderlyingType;
 using WTF::isValidEnum;
 using WTF::isZeroBasedContiguousEnum;
+using WTF::enumTypeName;
+using WTF::enumNames;
+using WTF::enumName;

--- a/Source/WTF/wtf/Gigacage.h
+++ b/Source/WTF/wtf/Gigacage.h
@@ -52,18 +52,6 @@ inline void removePrimitiveDisableCallback(void (*)(void*), void*) { }
 
 inline void forbidDisablingPrimitiveGigacage() { }
 
-ALWAYS_INLINE ASCIILiteral name(Kind kind)
-{
-    switch (kind) {
-    case Primitive:
-        return "Primitive"_s;
-    case NumberOfKinds:
-        break;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-    return { };
-}
-
 ALWAYS_INLINE bool contains(const void*) { return false; }
 ALWAYS_INLINE bool disablingPrimitiveGigacageIsForbidden() { return false; }
 ALWAYS_INLINE bool isEnabled() { return false; }

--- a/Tools/TestWebKitAPI/Configurations/DebugRelease.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/DebugRelease.xcconfig
@@ -1,4 +1,4 @@
-// Copyright (C) 2010, 2013 Apple Inc. All rights reserved.
+// Copyright (C) 2010-2024 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -32,8 +32,6 @@ ONLY_ACTIVE_ARCH = YES;
 SDKROOT = $(SDKROOT_$(USE_INTERNAL_SDK));
 SDKROOT_ = macosx;
 SDKROOT_YES = macosx.internal;
-
-OTHER_CPLUSPLUSFLAGS = $(inherited) -ftemplate-depth=256;
 
 VALIDATE_DEPENDENCIES = $(VALIDATE_DEPENDENCIES_INTERNAL_$(USE_INTERNAL_SDK));
 VALIDATE_DEPENDENCIES_INTERNAL_ = $(VALIDATE_DEPENDENCIES_NATIVE_TARGET_$(WK_NOT_$(WK_EMPTY_$(PRODUCT_TYPE))));

--- a/Tools/TestWebKitAPI/Tests/WTF/EnumTraits.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/EnumTraits.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 
 #include <wtf/Deque.h>
 #include <wtf/EnumTraits.h>
+#include <wtf/text/ASCIILiteral.h>
 
 enum class TestEnum {
     A,
@@ -91,6 +92,59 @@ TEST(WTF_EnumTraits, ZeroBasedContiguousEnum)
     EXPECT_FALSE(isZeroBasedContiguousEnum<TestNonContiguousEnum>());
     static_assert(!isZeroBasedContiguousEnum<TestNonZeroBasedEnum>());
     EXPECT_FALSE(isZeroBasedContiguousEnum<TestNonZeroBasedEnum>());
+}
+
+static bool isExpectedEnumString(const ASCIILiteral& expected, const std::span<const char>& result)
+{
+    // result won't have a null terminator.
+    bool equal = true;
+    for (size_t i = 0; i < result.size(); ++i)
+        equal &= expected[i] == result[i];
+    return equal;
+}
+
+enum NonClassMultiWord {
+    FooBar,
+    BazBloop,
+    WordW1thNumb3rs,
+    Hole = WordW1thNumb3rs + 2,
+    Duplicate = Hole,
+};
+
+enum class ClassMultiWord {
+    FooBar,
+    BazBloop,
+    WordW1thNumb3rs,
+    Hole = WordW1thNumb3rs + 2,
+    Duplicate = Hole,
+};
+
+TEST(WTF_EnumTraits, EnumNameTemplate)
+{
+    EXPECT_TRUE(isExpectedEnumString("NonClassMultiWord"_s, enumTypeName<NonClassMultiWord>()));
+    EXPECT_TRUE(isExpectedEnumString("FooBar"_s, enumName<FooBar>()));
+    EXPECT_TRUE(isExpectedEnumString("WordW1thNumb3rs"_s, enumName<WordW1thNumb3rs>()));
+    EXPECT_TRUE(isExpectedEnumString("Hole"_s, enumName<Hole>()));
+    EXPECT_TRUE(isExpectedEnumString("Hole"_s, enumName<Duplicate>()));
+
+    EXPECT_TRUE(isExpectedEnumString("ClassMultiWord"_s, enumTypeName<ClassMultiWord>()));
+    EXPECT_TRUE(isExpectedEnumString("FooBar"_s, enumName<ClassMultiWord::FooBar>()));
+    EXPECT_TRUE(isExpectedEnumString("WordW1thNumb3rs"_s, enumName<ClassMultiWord::WordW1thNumb3rs>()));
+    EXPECT_TRUE(isExpectedEnumString("Hole"_s, enumName<ClassMultiWord::Hole>()));
+    EXPECT_TRUE(isExpectedEnumString("Hole"_s, enumName<ClassMultiWord::Duplicate>()));
+}
+
+TEST(WTF_EnumTraits, EnumNameArgument)
+{
+    EXPECT_TRUE(isExpectedEnumString("FooBar"_s, enumName(FooBar)));
+    EXPECT_TRUE(isExpectedEnumString("WordW1thNumb3rs"_s, enumName(WordW1thNumb3rs)));
+    EXPECT_TRUE(isExpectedEnumString("Hole"_s, enumName(Hole)));
+    EXPECT_TRUE(isExpectedEnumString("Hole"_s, enumName(Duplicate)));
+
+    EXPECT_TRUE(isExpectedEnumString("FooBar"_s, enumName(ClassMultiWord::FooBar)));
+    EXPECT_TRUE(isExpectedEnumString("WordW1thNumb3rs"_s, enumName(ClassMultiWord::WordW1thNumb3rs)));
+    EXPECT_TRUE(isExpectedEnumString("Hole"_s, enumName(ClassMultiWord::Hole)));
+    EXPECT_TRUE(isExpectedEnumString("Hole"_s, enumName(ClassMultiWord::Duplicate)));
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### f5716c3f9c9a8b19d82c02df456588ea62767c1e
<pre>
Add mechanism to automatically convert Enums to Strings for printing
<a href="https://bugs.webkit.org/show_bug.cgi?id=271967">https://bugs.webkit.org/show_bug.cgi?id=271967</a>
<a href="https://rdar.apple.com/125723369">rdar://125723369</a>

Reviewed by Yusuke Suzuki.

This patch adds support a set of new functions that return a `std::span&lt;const char&gt;`
with the stringification of an enum&apos;s type or members. Members are determined by
reflecting on the compiler&apos;s result for `__PRETTY_FUNCTION__`. This doesn&apos;t seem to
significantly increase compile times as a Debug build of JSC was 272.5s with this
change vs 268.8s without (~1% compile time increase).

In order to limit compile time overhead, the number of enum values stringified is
limited to 256 by default.

This patch also integrates this new name reflection into `dataLog` so it will
automatically print the enum&apos;s value strigified into the log. There&apos;s also a
`ScopedEnumDump` that includes the enum&apos;s name and `EnumDumpWithDefault` that
takes a default string if a stringification for the enum value can&apos;t be deduced.

* JSTests/wasm/wabt-wrapper.js:
* Source/JavaScriptCore/bytecode/ExitKind.cpp:
(JSC::exitKindToString): Deleted.
(WTF::printInternal): Deleted.
* Source/JavaScriptCore/bytecode/ExitKind.h:
* Source/JavaScriptCore/bytecode/ExpressionInfo.cpp:
(WTF::printInternal): Deleted.
* Source/JavaScriptCore/bytecode/ExpressionInfo.h:
* Source/JavaScriptCore/dfg/DFGArrayMode.cpp:
(WTF::printInternal):
(JSC::DFG::arrayActionToString): Deleted.
(JSC::DFG::arrayTypeToString): Deleted.
(JSC::DFG::arrayClassToString): Deleted.
(JSC::DFG::arraySpeculationToString): Deleted.
(JSC::DFG::arrayConversionToString): Deleted.
* Source/JavaScriptCore/dfg/DFGArrayMode.h:
* Source/JavaScriptCore/dfg/DFGBranchDirection.h:
(JSC::DFG::branchDirectionToString): Deleted.
(WTF::printInternal): Deleted.
* Source/JavaScriptCore/dfg/DFGOSRExit.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp:
(JSC::FTL::compileStub):
* Source/JavaScriptCore/heap/GCLogging.cpp:
(JSC::GCLogging::levelAsString): Deleted.
* Source/JavaScriptCore/heap/GCLogging.h:
* Source/JavaScriptCore/jsc.cpp:
(CommandLine::parseArguments):
* Source/JavaScriptCore/profiler/ProfilerOSRExit.cpp:
(JSC::Profiler::OSRExit::toJSON const):
* Source/JavaScriptCore/runtime/BufferMemoryHandle.cpp:
(JSC::BufferMemoryResult::dump const):
(JSC::BufferMemoryManager::tryAllocatePhysicalBytes):
(JSC::BufferMemoryResult::toString): Deleted.
* Source/JavaScriptCore/runtime/BufferMemoryHandle.h:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::OptionsHelper::Option::dump const):
* Source/JavaScriptCore/wasm/WasmWorklist.cpp:
(JSC::Wasm::Worklist::priorityString): Deleted.
* Source/JavaScriptCore/wasm/WasmWorklist.h:
* Source/WTF/wtf/EnumTraits.h:
(WTF::enumTypeNameImpl):
(WTF::enumTypeName):
(WTF::enumNameImpl):
(WTF::enumName):
(WTF::detail::for_constexpr):
(WTF::enumNames):
* Source/WTF/wtf/Gigacage.h:
(Gigacage::name): Deleted.
* Source/WTF/wtf/PrintStream.h:
(WTF::printInternal):
(WTF::ScopedEnumDump::ScopedEnumDump):
(WTF::ScopedEnumDump::dump const):
(WTF::EnumDumpMayBeUnknown::EnumDumpMayBeUnknown):
(WTF::EnumDumpMayBeUnknown::dump const):
(WTF::requires):

Canonical link: <a href="https://commits.webkit.org/281831@main">https://commits.webkit.org/281831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea2baf00950dcdc5a3a3600199bba4303a11d0eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61160 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65110 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11709 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63290 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49451 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8153 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52988 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30281 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10213 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10638 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/54264 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66841 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/60408 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10321 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56823 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5129 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57017 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4228 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/82163 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9198 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36325 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/14335 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37408 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38502 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->