### PR TITLE
[svn-apply-patch] Replace patch application with git

### DIFF
--- a/Tools/Scripts/webkitpy/common/checkout/checkout.py
+++ b/Tools/Scripts/webkitpy/common/checkout/checkout.py
@@ -171,21 +171,15 @@ for l in lines[1:]:
 
         encoded_patch = string_utils.encode(patch.contents())
         num_commits = len(self.COMMIT_SUBJECT_RE.findall(encoded_patch))
-        if isinstance(self._scm, Git) and num_commits:
-            self._executive.run_command(
-                ['git', 'am', '--keep-non-patch'],
-                input=self.filter_patch_content(encoded_patch, reviewer=patch.reviewer().full_name if patch.reviewer() else None),
-                cwd=self._scm.checkout_root,
-            )
-            self._executive.run_command(
-                ['git', 'filter-branch', '-f', '--msg-filter', '{} -c "{}"'.format(sys.executable, self.FILTER_BRANCH_PROGRAM), 'HEAD...HEAD~{}'.format(num_commits)],
-                cwd=self._scm.checkout_root,
-            )
-        else:
-            args = [self.script_path('svn-apply'), "--force"]
-            if patch.reviewer():
-                args += ['--reviewer', patch.reviewer().full_name]
-            self._executive.run_command(args, input=patch.contents(), cwd=self._scm.checkout_root)
+        self._executive.run_command(
+            ['git', 'am', '--keep-non-patch'],
+            input=self.filter_patch_content(encoded_patch, reviewer=patch.reviewer().full_name if patch.reviewer() else None),
+            cwd=self._scm.checkout_root,
+        )
+        self._executive.run_command(
+            ['git', 'filter-branch', '-f', '--msg-filter', '{} -c "{}"'.format(sys.executable, self.FILTER_BRANCH_PROGRAM), 'HEAD...HEAD~{}'.format(num_commits)],
+            cwd=self._scm.checkout_root,
+        )
 
     def apply_reverse_diff(self, revision):
         self._scm.apply_reverse_diff(revision)

--- a/Tools/Scripts/webkitpy/common/checkout/checkout_unittest.py
+++ b/Tools/Scripts/webkitpy/common/checkout/checkout_unittest.py
@@ -372,6 +372,6 @@ class CheckoutTest(unittest.TestCase):
         with OutputCapture(level=logging.INFO) as captured:
             checkout.apply_patch(mock_patch)
         self.assertEqual(
-            captured.root.log.getvalue(),
-            "MOCK run_command: ['svn-apply', '--force'], cwd=/mock-checkout, input=foo\n",
+            captured.root.log.getvalue().splitlines()[0],
+            "MOCK run_command: ['git', 'am', '--keep-non-patch'], cwd=/mock-checkout, input=foo",
         )


### PR DESCRIPTION
#### 1b32d05f1db0f73999a36ffd03ebfd63a8674d1b
<pre>
[svn-apply-patch] Replace patch application with git
<a href="https://bugs.webkit.org/show_bug.cgi?id=271975">https://bugs.webkit.org/show_bug.cgi?id=271975</a>
<a href="https://rdar.apple.com/125728253">rdar://125728253</a>

Reviewed by Ryan Haddad.

* Tools/Scripts/webkitpy/common/checkout/checkout.py:
(apply_patch): Always use &apos;git&apos; to apply patch.
* Tools/Scripts/webkitpy/common/checkout/checkout_unittest.py:
(CheckoutTest.test_apply_patch):

Canonical link: <a href="https://commits.webkit.org/276896@main">https://commits.webkit.org/276896@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16d766a8616fe57594f4e0817e1239542cde4649

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48758 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42127 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22659 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37687 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46665 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22309 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/39764 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18877 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/45952 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19708 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/40862 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4131 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42407 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/41212 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50550 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21083 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17601 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44852 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22383 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/43751 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6418 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->