### PR TITLE
Do some more std::span adoption

### DIFF
--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -66,7 +66,6 @@ WTF_EXPORT_PRIVATE Vector<uint8_t> base64EncodeToVector(std::span<const std::byt
 Vector<uint8_t> base64EncodeToVector(std::span<const uint8_t>, Base64EncodeMode = Base64EncodeMode::Default);
 Vector<uint8_t> base64EncodeToVector(std::span<const char>, Base64EncodeMode = Base64EncodeMode::Default);
 Vector<uint8_t> base64EncodeToVector(const CString&, Base64EncodeMode = Base64EncodeMode::Default);
-Vector<uint8_t> base64EncodeToVector(const void*, unsigned, Base64EncodeMode = Base64EncodeMode::Default);
 
 WTF_EXPORT_PRIVATE String base64EncodeToString(std::span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
 String base64EncodeToString(std::span<const uint8_t>, Base64EncodeMode = Base64EncodeMode::Default);
@@ -135,11 +134,6 @@ inline Vector<uint8_t> base64EncodeToVector(const CString& input, Base64EncodeMo
     return base64EncodeToVector(input.span(), mode);
 }
 
-inline Vector<uint8_t> base64EncodeToVector(const void* input, unsigned length, Base64EncodeMode mode)
-{
-    return base64EncodeToVector({ static_cast<const std::byte*>(input), length }, mode);
-}
-
 inline String base64EncodeToString(std::span<const uint8_t> input, Base64EncodeMode mode)
 {
     return base64EncodeToString(std::as_bytes(input), mode);
@@ -203,11 +197,6 @@ inline Vector<uint8_t> base64URLEncodeToVector(std::span<const char> input)
 inline Vector<uint8_t> base64URLEncodeToVector(const CString& input)
 {
     return base64EncodeToVector(input, Base64EncodeMode::URL);
-}
-
-inline Vector<uint8_t> base64URLEncodeToVector(const void* input, unsigned length)
-{
-    return base64EncodeToVector(input, length, Base64EncodeMode::URL);
 }
 
 inline String base64URLEncodeToString(std::span<const std::byte> input)

--- a/Source/WebCore/Modules/webaudio/AsyncAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webaudio/AsyncAudioDecoder.cpp
@@ -43,7 +43,7 @@ AsyncAudioDecoder::AsyncAudioDecoder()
 Ref<DecodingTaskPromise> AsyncAudioDecoder::decodeAsync(Ref<ArrayBuffer>&& audioData, float sampleRate)
 {
     return WTF::invokeAsync(m_runLoop, [audioData = WTFMove(audioData), sampleRate] () mutable {
-        auto audioBuffer = AudioBuffer::createFromAudioFileData(audioData->data(), audioData->byteLength(), false, sampleRate);
+        auto audioBuffer = AudioBuffer::createFromAudioFileData(audioData->span(), false, sampleRate);
         // The ArrayBuffer must be deleted on the main thread, send it back there to be derefed.
         callOnMainThread([audioData = WTFMove(audioData)] { });
         if (!audioBuffer)

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -76,9 +76,9 @@ ExceptionOr<Ref<AudioBuffer>> AudioBuffer::create(const AudioBufferOptions& opti
     return buffer;
 }
 
-RefPtr<AudioBuffer> AudioBuffer::createFromAudioFileData(const void* data, size_t dataSize, bool mixToMono, float sampleRate)
+RefPtr<AudioBuffer> AudioBuffer::createFromAudioFileData(std::span<const uint8_t> data, bool mixToMono, float sampleRate)
 {
-    RefPtr<AudioBus> bus = createBusFromInMemoryAudioFile(data, dataSize, mixToMono, sampleRate);
+    RefPtr bus = createBusFromInMemoryAudioFile(data, mixToMono, sampleRate);
     if (!bus)
         return nullptr;
     return adoptRef(*new AudioBuffer(*bus));

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.h
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.h
@@ -48,7 +48,7 @@ public:
     static RefPtr<AudioBuffer> create(unsigned numberOfChannels, size_t numberOfFrames, float sampleRate, LegacyPreventDetaching = LegacyPreventDetaching::No);
     static ExceptionOr<Ref<AudioBuffer>> create(const AudioBufferOptions&);
     // Returns nullptr if data is not a valid audio file.
-    static RefPtr<AudioBuffer> createFromAudioFileData(const void* data, size_t dataSize, bool mixToMono, float sampleRate);
+    static RefPtr<AudioBuffer> createFromAudioFileData(std::span<const uint8_t> data, bool mixToMono, float sampleRate);
 
     // Format
     size_t originalLength() const { return m_originalLength; }

--- a/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp
@@ -186,16 +186,14 @@ Ref<FragmentedSharedBuffer> MHTMLArchive::generateMHTMLData(Page* page)
         mhtmlData.append(asciiString.span());
 
         // FIXME: ideally we would encode the content as a stream without having to fetch it all.
-        auto* data = resource.data->data();
-        size_t dataLength = resource.data->size();
         if (!strcmp(contentEncoding, quotedPrintable)) {
-            auto encodedData = quotedPrintableEncode(data, dataLength);
+            auto encodedData = quotedPrintableEncode(resource.data->span());
             mhtmlData.append(encodedData.span());
             mhtmlData.append("\r\n"_span);
         } else {
             ASSERT(!strcmp(contentEncoding, base64));
             // We are not specifying insertLFs = true below as it would cut the lines with LFs and MHTML requires CRLFs.
-            auto encodedData = base64EncodeToVector(data, dataLength);
+            auto encodedData = base64EncodeToVector(resource.data->span());
             const size_t maximumLineLength = 76;
             size_t index = 0;
             size_t encodedDataLength = encodedData.size();

--- a/Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp
+++ b/Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp
@@ -206,7 +206,7 @@ RefPtr<ArchiveResource> MHTMLParser::parseNextPart(const MIMEHeader& mimeHeader,
         break;
     }
     case MIMEHeader::QuotedPrintable:
-        data = quotedPrintableDecode(contiguousContent->data(), contiguousContent->size());
+        data = quotedPrintableDecode(contiguousContent->span());
         break;
     case MIMEHeader::SevenBit:
     case MIMEHeader::Binary:

--- a/Source/WebCore/platform/audio/AudioFileReader.h
+++ b/Source/WebCore/platform/audio/AudioFileReader.h
@@ -39,6 +39,6 @@ class AudioBus;
 // sampleRate will be made (if it doesn't already match the file's sample-rate).
 // The created buffer will have its sample-rate set correctly to the result.
 
-RefPtr<AudioBus> createBusFromInMemoryAudioFile(const void* data, size_t dataSize, bool mixToMono, float sampleRate);
+RefPtr<AudioBus> createBusFromInMemoryAudioFile(std::span<const uint8_t> data, bool mixToMono, float sampleRate);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h
@@ -54,13 +54,14 @@ class AudioFileReader
 #endif
 {
 public:
-    AudioFileReader(const void* data, size_t dataSize);
+    explicit AudioFileReader(std::span<const uint8_t> data);
     ~AudioFileReader();
 
     RefPtr<AudioBus> createBus(float sampleRate, bool mixToMono); // Returns nullptr on error
 
-    const void* data() const { return m_data; }
-    size_t dataSize() const { return m_dataSize; }
+    const uint8_t* data() const { return m_data.data(); }
+    size_t dataSize() const { return m_data.size(); }
+    std::span<const uint8_t> span() const { return m_data; }
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
@@ -71,7 +72,7 @@ public:
 
 private:
 #if ENABLE(MEDIA_SOURCE)
-    bool isMaybeWebM(const uint8_t* data, size_t dataSize) const;
+    bool isMaybeWebM(std::span<const uint8_t>) const;
     std::unique_ptr<AudioFileReaderWebMData> demuxWebMData(std::span<const uint8_t>) const;
     Vector<AudioStreamPacketDescription> getPacketDescriptions(CMSampleBufferRef) const;
     std::optional<size_t> decodeWebMData(AudioBufferList&, size_t numberOfFrames, const AudioStreamBasicDescription& inFormat, const AudioStreamBasicDescription& outFormat) const;
@@ -82,8 +83,7 @@ private:
     std::optional<AudioStreamBasicDescription> fileDataFormat() const;
     AudioStreamBasicDescription clientDataFormat(const AudioStreamBasicDescription& inFormat, float sampleRate) const;
 
-    const void* m_data = { nullptr };
-    size_t m_dataSize = { 0 };
+    std::span<const uint8_t> m_data;
 
     AudioFileID m_audioFileID = { nullptr };
     ExtAudioFileRef m_extAudioFileRef = { nullptr };

--- a/Source/WebCore/platform/audio/glib/AudioBusGLib.cpp
+++ b/Source/WebCore/platform/audio/glib/AudioBusGLib.cpp
@@ -40,7 +40,7 @@ RefPtr<AudioBus> AudioBus::loadPlatformResource(const char* name, float sampleRa
     GUniquePtr<char> path(g_strdup_printf(AUDIO_GRESOURCE_PATH "/%s", name));
     GRefPtr<GBytes> data = adoptGRef(g_resources_lookup_data(path.get(), G_RESOURCE_LOOKUP_FLAGS_NONE, nullptr));
     ASSERT(data);
-    return createBusFromInMemoryAudioFile(g_bytes_get_data(data.get(), nullptr), g_bytes_get_size(data.get()), false, sampleRate);
+    return createBusFromInMemoryAudioFile(std::span(static_cast<const uint8_t*>(g_bytes_get_data(data.get(), nullptr)), g_bytes_get_size(data.get())), false, sampleRate);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/mac/AudioBusMac.mm
+++ b/Source/WebCore/platform/audio/mac/AudioBusMac.mm
@@ -29,6 +29,7 @@
 #import "AudioBus.h"
 
 #import "AudioFileReader.h"
+#import <wtf/cocoa/SpanCocoa.h>
 
 @interface WebCoreAudioBundleClass : NSObject
 @end
@@ -44,7 +45,7 @@ RefPtr<AudioBus> AudioBus::loadPlatformResource(const char* name, float sampleRa
         NSBundle *bundle = [NSBundle bundleForClass:[WebCoreAudioBundleClass class]];
         NSURL *audioFileURL = [bundle URLForResource:[NSString stringWithUTF8String:name] withExtension:@"wav" subdirectory:@"audio"];
         if (NSData *audioData = [NSData dataWithContentsOfURL:audioFileURL options:NSDataReadingMappedIfSafe error:nil])
-            return createBusFromInMemoryAudioFile([audioData bytes], [audioData length], false, sampleRate);
+            return createBusFromInMemoryAudioFile(span(audioData), false, sampleRate);
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -1093,7 +1093,7 @@ webm::Status WebMParser::VideoTrackData::consumeFrameData(webm::Reader& reader, 
             setFormatDescription(createVideoInfoFromVP9HeaderParser(m_headerParser, track().video.value().colour));
         }
     } else if (codec() == CodecType::VP8) {
-        auto header = parseVP8FrameHeader(blockBufferData, segmentHeaderLength);
+        auto header = parseVP8FrameHeader({ blockBufferData, segmentHeaderLength });
         if (header && header->keyframe) {
             isKey = true;
             setFormatDescription(createVideoInfoFromVP8Header(*header, track().video.value().colour));

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
@@ -66,7 +66,7 @@ struct VP8FrameHeader {
     bool needsClamping { false };
 };
 
-std::optional<VP8FrameHeader> parseVP8FrameHeader(const uint8_t* frameData, size_t frameSize);
+std::optional<VP8FrameHeader> parseVP8FrameHeader(std::span<const uint8_t>);
 Ref<VideoInfo> createVideoInfoFromVP8Header(const VP8FrameHeader&, const webm::Element<webm::Colour>&);
 
 class WEBCORE_EXPORT VP9TestingOverrides {

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -712,18 +712,18 @@ Ref<VideoInfo> createVideoInfoFromVP9HeaderParser(const vp9_parser::Vp9HeaderPar
     return createVideoInfoFromVPCodecConfigurationRecord(record, parser.width(), parser.height());
 }
 
-std::optional<VP8FrameHeader> parseVP8FrameHeader(const uint8_t* frameData, size_t frameSize)
+std::optional<VP8FrameHeader> parseVP8FrameHeader(std::span<const uint8_t> frameData)
 {
     // VP8 frame headers are defined in RFC 6386: <https://tools.ietf.org/html/rfc6386>.
 
     // Bail if the header is below a minimum size
-    if (frameSize < 11)
+    if (frameData.size() < 11)
         return std::nullopt;
 
     VP8FrameHeader header;
     size_t headerSize = 11;
 
-    auto view = JSC::DataView::create(ArrayBuffer::create(frameData, headerSize), 0, headerSize);
+    auto view = JSC::DataView::create(ArrayBuffer::create(frameData.data(), headerSize), 0, headerSize);
     bool status = true;
 
     auto uncompressedChunk = view->get<uint32_t>(0, true, &status);

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -133,16 +133,16 @@ void BlobRegistryImpl::registerInternalFileBlobURL(const URL& url, Ref<BlobDataF
     addBlobData(url.string(), WTFMove(blobData));
 }
 
-static FileSystem::MappedFileData storeInMappedFileData(const String& path, const uint8_t* data, size_t size)
+static FileSystem::MappedFileData storeInMappedFileData(const String& path, std::span<const uint8_t> data)
 {
-    auto mappedFileData = FileSystem::createMappedFileData(path, size);
+    auto mappedFileData = FileSystem::createMappedFileData(path, data.size());
     if (!mappedFileData)
         return { };
     FileSystem::deleteFile(path);
 
-    memcpy(const_cast<void*>(mappedFileData.data()), data, size);
+    memcpy(const_cast<void*>(mappedFileData.data()), data.data(), data.size());
 
-    FileSystem::finalizeMappedFileData(mappedFileData, size);
+    FileSystem::finalizeMappedFileData(mappedFileData, data.size());
     return mappedFileData;
 }
 
@@ -158,7 +158,7 @@ Ref<DataSegment> BlobRegistryImpl::createDataSegment(Vector<uint8_t>&& movedData
     static NeverDestroyed<Ref<WorkQueue>> workQueue(WorkQueue::create("BlobRegistryImpl Data Queue"));
     auto filePath = FileSystem::pathByAppendingComponent(m_fileDirectory, makeString("mapping-file-", ++blobMappingFileCounter, ".blob"));
     workQueue.get()->dispatch([blobData = Ref { blobData }, data, filePath = WTFMove(filePath).isolatedCopy()]() mutable {
-        auto mappedFileData = storeInMappedFileData(filePath, data->data(), data->size());
+        auto mappedFileData = storeInMappedFileData(filePath, data->span());
         if (!mappedFileData)
             return;
         ASSERT(mappedFileData.size() == data->size());

--- a/Source/WebCore/platform/network/FormDataBuilder.cpp
+++ b/Source/WebCore/platform/network/FormDataBuilder.cpp
@@ -90,17 +90,17 @@ static void appendQuoted(Vector<uint8_t>& buffer, const Vector<uint8_t>& string)
 }
 
 // https://url.spec.whatwg.org/#concept-urlencoded-byte-serializer
-static void appendFormURLEncoded(Vector<uint8_t>& buffer, const uint8_t* string, size_t length)
+static void appendFormURLEncoded(Vector<uint8_t>& buffer, std::span<const uint8_t> string)
 {
     static const char safeCharacters[] = "-._*";
-    for (size_t i = 0; i < length; ++i) {
+    for (size_t i = 0; i < string.size(); ++i) {
         auto character = string[i];
         if (isASCIIAlphanumeric(character)
             || (character != '\0' && strchr(safeCharacters, character)))
             append(buffer, character);
         else if (character == ' ')
             append(buffer, '+');
-        else if (character == '\n' || (character == '\r' && (i + 1 >= length || string[i + 1] != '\n')))
+        else if (character == '\n' || (character == '\r' && (i + 1 >= string.size() || string[i + 1] != '\n')))
             append(buffer, "%0D%0A"); // FIXME: Unclear exactly where this rule about normalizing line endings to CRLF comes from.
         else if (character != '\r') {
             append(buffer, '%');
@@ -113,7 +113,7 @@ static void appendFormURLEncoded(Vector<uint8_t>& buffer, const uint8_t* string,
 
 static void appendFormURLEncoded(Vector<uint8_t>& buffer, const Vector<uint8_t>& string)
 {
-    appendFormURLEncoded(buffer, string.data(), string.size());
+    appendFormURLEncoded(buffer, string.span());
 }
 
 Vector<uint8_t> generateUniqueBoundaryString()
@@ -212,7 +212,7 @@ void addKeyValuePairAsFormData(Vector<uint8_t>& buffer, const Vector<uint8_t>& k
 
 void encodeStringAsFormData(Vector<uint8_t>& buffer, const CString& string)
 {
-    appendFormURLEncoded(buffer, string.dataAsUInt8Ptr(), string.length());
+    appendFormURLEncoded(buffer, string.span());
 }
 
 }

--- a/Source/WebCore/platform/text/QuotedPrintable.cpp
+++ b/Source/WebCore/platform/text/QuotedPrintable.cpp
@@ -41,14 +41,14 @@ static const size_t maximumLineLength = 76;
 
 static constexpr auto crlfLineEnding = "\r\n"_s;
 
-static size_t lengthOfLineEndingAtIndex(const uint8_t* input, size_t inputLength, size_t index)
+static size_t lengthOfLineEndingAtIndex(std::span<const uint8_t> input, size_t index)
 {
-    ASSERT_WITH_SECURITY_IMPLICATION(index < inputLength);
+    ASSERT_WITH_SECURITY_IMPLICATION(index < input.size());
     if (input[index] == '\n')
         return 1; // Single LF.
 
     if (input[index] == '\r') {
-        if ((index + 1) == inputLength || input[index + 1] != '\n')
+        if ((index + 1) == input.size() || input[index + 1] != '\n')
             return 1; // Single CR (Classic Mac OS).
         return 2; // CR-LF.
     }
@@ -58,16 +58,16 @@ static size_t lengthOfLineEndingAtIndex(const uint8_t* input, size_t inputLength
 
 Vector<uint8_t> quotedPrintableEncode(const Vector<uint8_t>& input)
 {
-    return quotedPrintableEncode(input.data(), input.size());
+    return quotedPrintableEncode(input.span());
 }
 
-Vector<uint8_t> quotedPrintableEncode(const uint8_t* input, size_t inputLength)
+Vector<uint8_t> quotedPrintableEncode(std::span<const uint8_t> input)
 {
     Vector<uint8_t> out;
-    out.reserveInitialCapacity(inputLength);
+    out.reserveInitialCapacity(input.size());
     size_t currentLineLength = 0;
-    for (size_t i = 0; i < inputLength; ++i) {
-        bool isLastCharacter = (i == inputLength - 1);
+    for (size_t i = 0; i < input.size(); ++i) {
+        bool isLastCharacter = (i == input.size() - 1);
         uint8_t currentCharacter = input[i];
         bool requiresEncoding = false;
         // All non-printable ASCII characters and = require encoding.
@@ -75,12 +75,12 @@ Vector<uint8_t> quotedPrintableEncode(const uint8_t* input, size_t inputLength)
             requiresEncoding = true;
 
         // Space and tab characters have to be encoded if they appear at the end of a line.
-        if (!requiresEncoding && (currentCharacter == '\t' || currentCharacter == ' ') && (isLastCharacter || lengthOfLineEndingAtIndex(input, inputLength, i + 1)))
+        if (!requiresEncoding && (currentCharacter == '\t' || currentCharacter == ' ') && (isLastCharacter || lengthOfLineEndingAtIndex(input, i + 1)))
             requiresEncoding = true;
 
         // End of line should be converted to CR-LF sequences.
         if (!isLastCharacter) {
-            size_t lengthOfLineEnding = lengthOfLineEndingAtIndex(input, inputLength, i);
+            size_t lengthOfLineEnding = lengthOfLineEndingAtIndex(input, i);
             if (lengthOfLineEnding) {
                 out.append(crlfLineEnding.span8());
                 currentLineLength = 0;
@@ -119,23 +119,20 @@ Vector<uint8_t> quotedPrintableEncode(const uint8_t* input, size_t inputLength)
 
 Vector<uint8_t> quotedPrintableDecode(const Vector<uint8_t>& input)
 {
-    return quotedPrintableDecode(input.data(), input.size());
+    return quotedPrintableDecode(input.span());
 }
 
-Vector<uint8_t> quotedPrintableDecode(const uint8_t* data, size_t dataLength)
+Vector<uint8_t> quotedPrintableDecode(std::span<const uint8_t> data)
 {
     Vector<uint8_t> out;
-    if (!dataLength)
-        return out;
-
-    for (size_t i = 0; i < dataLength; ++i) {
+    for (size_t i = 0; i < data.size(); ++i) {
         char currentCharacter = data[i];
         if (currentCharacter != '=') {
             out.append(currentCharacter);
             continue;
         }
         // We are dealing with a '=xx' sequence.
-        if (dataLength - i < 3) {
+        if (data.size() - i < 3) {
             // Unfinished = sequence, append as is.
             out.append(currentCharacter);
             continue;

--- a/Source/WebCore/platform/text/QuotedPrintable.h
+++ b/Source/WebCore/platform/text/QuotedPrintable.h
@@ -35,9 +35,9 @@
 namespace WebCore {
 
 Vector<uint8_t> quotedPrintableEncode(const Vector<uint8_t>&);
-Vector<uint8_t> quotedPrintableEncode(const uint8_t*, size_t);
+Vector<uint8_t> quotedPrintableEncode(std::span<const uint8_t>);
 
 Vector<uint8_t> quotedPrintableDecode(const Vector<uint8_t>&);
-Vector<uint8_t> quotedPrintableDecode(const uint8_t*, size_t);
+Vector<uint8_t> quotedPrintableDecode(std::span<const uint8_t>);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.h
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.h
@@ -47,8 +47,8 @@ public:
 #endif
 
     virtual void flush() = 0;
-    virtual void setFormat(const uint8_t*, size_t, uint16_t width, uint16_t height) = 0;
-    virtual int32_t decodeFrame(int64_t timeStamp, const uint8_t*, size_t) = 0;
+    virtual void setFormat(std::span<const uint8_t>, uint16_t width, uint16_t height) = 0;
+    virtual int32_t decodeFrame(int64_t timeStamp, std::span<const uint8_t>) = 0;
     virtual void setFrameSize(uint16_t width, uint16_t height) = 0;
 };
 

--- a/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.mm
+++ b/Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.mm
@@ -54,8 +54,8 @@ public:
 
 private:
     void flush() final { webrtc::flushLocalDecoder(m_decoder); }
-    void setFormat(const uint8_t* data, size_t size, uint16_t width, uint16_t height) final { webrtc::setDecodingFormat(m_decoder, data, size, width, height); }
-    int32_t decodeFrame(int64_t timeStamp, const uint8_t* data, size_t size) final { return webrtc::decodeFrame(m_decoder, timeStamp, data, size); }
+    void setFormat(std::span<const uint8_t> data, uint16_t width, uint16_t height) final { webrtc::setDecodingFormat(m_decoder, data.data(), data.size(), width, height); }
+    int32_t decodeFrame(int64_t timeStamp, std::span<const uint8_t> data) final { return webrtc::decodeFrame(m_decoder, timeStamp, data.data(), data.size()); }
     void setFrameSize(uint16_t width, uint16_t height) final { webrtc::setDecoderFrameSize(m_decoder, width, height); }
 
     webrtc::LocalDecoder m_decoder;
@@ -82,8 +82,8 @@ public:
 
 private:
     void flush() final { [m_decoder flush]; }
-    void setFormat(const uint8_t*, size_t, uint16_t width, uint16_t height) final { setFrameSize(width, height); }
-    int32_t decodeFrame(int64_t timeStamp, const uint8_t* data, size_t size) final { return [m_decoder decodeData:data size:size timeStamp:timeStamp]; }
+    void setFormat(std::span<const uint8_t>, uint16_t width, uint16_t height) final { setFrameSize(width, height); }
+    int32_t decodeFrame(int64_t timeStamp, std::span<const uint8_t> data) final { return [m_decoder decodeData:data.data() size:data.size() timeStamp:timeStamp]; }
     void setFrameSize(uint16_t width, uint16_t height) final { [m_decoder setWidth:width height:height];; }
 
     RetainPtr<RTCVideoDecoderVTBAV1> m_decoder;

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -185,14 +185,14 @@ HGLOBAL createGlobalData(const Vector<char>& vector)
     return vm;
 }
 
-HGLOBAL createGlobalData(const uint8_t* data, size_t length)
+HGLOBAL createGlobalData(std::span<const uint8_t> data)
 {
-    HGLOBAL vm = ::GlobalAlloc(GPTR, length + 1);
+    HGLOBAL vm = ::GlobalAlloc(GPTR, data.size() + 1);
     if (!vm)
         return 0;
     uint8_t* buffer = static_cast<uint8_t*>(GlobalLock(vm));
-    memcpy(buffer, data, length);
-    buffer[length] = 0;
+    memcpy(buffer, data.data(), data.size());
+    buffer[data.size()] = 0;
     GlobalUnlock(vm);
     return vm;
 }

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
@@ -38,7 +38,7 @@ class DocumentFragment;
 HGLOBAL createGlobalData(const String&);
 HGLOBAL createGlobalData(const Vector<char>&);
 HGLOBAL createGlobalData(const URL& url, const String& title);
-HGLOBAL createGlobalData(const uint8_t*, size_t);
+HGLOBAL createGlobalData(std::span<const uint8_t>);
 
 FORMATETC* urlWFormat();
 FORMATETC* urlFormat();

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -1156,7 +1156,7 @@ void Pasteboard::writeCustomData(const Vector<PasteboardCustomData>& data)
 
         if (customData.hasSameOriginCustomData() || !customData.origin().isEmpty()) {
             auto sharedBuffer = customData.createSharedBuffer();
-            HGLOBAL cbData = createGlobalData(reinterpret_cast<const uint8_t*>(sharedBuffer->data()), sharedBuffer->size());
+            HGLOBAL cbData = createGlobalData(sharedBuffer->span());
             if (cbData && !::SetClipboardData(CustomDataClipboardFormat, cbData))
                 ::GlobalFree(cbData);
         }

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm
@@ -234,7 +234,7 @@ void LibWebRTCCodecsProxy::flushDecoder(VideoDecoderIdentifier identifier)
 void LibWebRTCCodecsProxy::setDecoderFormatDescription(VideoDecoderIdentifier identifier, std::span<const uint8_t> data, uint16_t width, uint16_t height)
 {
     doDecoderTask(identifier, [&](auto& decoder) {
-        decoder.webrtcDecoder->setFormat(data.data(), data.size(), width, height);
+        decoder.webrtcDecoder->setFormat(data, width, height);
     });
 }
 
@@ -243,7 +243,7 @@ void LibWebRTCCodecsProxy::decodeFrame(VideoDecoderIdentifier identifier, int64_
     doDecoderTask(identifier, [&](auto& decoder) {
         if (decoder.frameRateMonitor)
             decoder.frameRateMonitor->update();
-        if (decoder.webrtcDecoder->decodeFrame(timeStamp, data.data(), data.size()))
+        if (decoder.webrtcDecoder->decodeFrame(timeStamp, data))
             m_connection->send(Messages::LibWebRTCCodecs::FailedDecoding { identifier }, 0);
     });
 }


### PR DESCRIPTION
#### e58d56a4c34dc437ec64187dc07b97627344a352
<pre>
Do some more std::span adoption
<a href="https://bugs.webkit.org/show_bug.cgi?id=271981">https://bugs.webkit.org/show_bug.cgi?id=271981</a>

Reviewed by Darin Adler and Sihui Liu.

* Source/WTF/wtf/text/Base64.h:
* Source/WebCore/Modules/webaudio/AsyncAudioDecoder.cpp:
(WebCore::AsyncAudioDecoder::decodeAsync):
* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::createFromAudioFileData):
* Source/WebCore/Modules/webaudio/AudioBuffer.h:
* Source/WebCore/loader/archive/mhtml/MHTMLArchive.cpp:
(WebCore::MHTMLArchive::generateMHTMLData):
* Source/WebCore/loader/archive/mhtml/MHTMLParser.cpp:
(WebCore::MHTMLParser::parseNextPart):
* Source/WebCore/platform/audio/AudioFileReader.h:
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::AudioFileReader::AudioFileReader):
(WebCore::AudioFileReader::isMaybeWebM const):
(WebCore::createBusFromInMemoryAudioFile):
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.h:
(WebCore::AudioFileReader::data const):
(WebCore::AudioFileReader::dataSize const):
(WebCore::AudioFileReader::span const):
* Source/WebCore/platform/audio/glib/AudioBusGLib.cpp:
(WebCore::AudioBus::loadPlatformResource):
* Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp:
(WebCore::AudioFileReader::AudioFileReader):
(WebCore::AudioFileReader::decodeAudioForBusCreation):
(WebCore::createBusFromInMemoryAudioFile):
* Source/WebCore/platform/audio/mac/AudioBusMac.mm:
(WebCore::AudioBus::loadPlatformResource):
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::VideoTrackData::consumeFrameData):
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
(WebCore::parseVP8FrameHeader):
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::storeInMappedFileData):
(WebCore::BlobRegistryImpl::createDataSegment):
* Source/WebCore/platform/network/FormDataBuilder.cpp:
(WebCore::FormDataBuilder::appendFormURLEncoded):
(WebCore::FormDataBuilder::encodeStringAsFormData):
* Source/WebCore/platform/text/QuotedPrintable.cpp:
(WebCore::lengthOfLineEndingAtIndex):
(WebCore::quotedPrintableEncode):
(WebCore::quotedPrintableDecode):
* Source/WebCore/platform/text/QuotedPrintable.h:
* Source/WebCore/platform/video-codecs/cocoa/RTCVideoDecoderVTBAV1.mm:
(computeAV1InputFormat):
(av1BufferToCMSampleBuffer):
(-[RTCVideoDecoderVTBAV1 decodeData:size:timeStamp:]):
* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.h:
* Source/WebCore/platform/video-codecs/cocoa/WebRTCVideoDecoder.mm:
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::createGlobalData):
* Source/WebCore/platform/win/ClipboardUtilitiesWin.h:
* Source/WebCore/platform/win/PasteboardWin.cpp:
(WebCore::Pasteboard::writeCustomData):
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.mm:
(WebKit::LibWebRTCCodecsProxy::setDecoderFormatDescription):

Canonical link: <a href="https://commits.webkit.org/276940@main">https://commits.webkit.org/276940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0a8ccead0360d939242fc776ddfbd8e930c3dc7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46226 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48811 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48898 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22813 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18980 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40960 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4270 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/39460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42537 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50706 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45700 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21222 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17728 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44962 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43875 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52851 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6442 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22216 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->