### PR TITLE
Acquire locked file assertion from UIProcess

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -70,7 +70,7 @@ messages -> NetworkProcess LegacyReceiver {
     SetCacheModelSynchronouslyForTesting(enum:uint8_t WebKit::CacheModel cacheModel) -> () Synchronous
 
     ProcessWillSuspendImminentlyForTestingSync() -> () Synchronous
-    PrepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime) -> ()
+    PrepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime) -> (bool needsLockedFilesAssertion)
     ProcessDidResume(bool forForegroundActivity)
 
     NotifyMediaStreamingActivity(bool activity)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -258,42 +258,4 @@ void NetworkProcess::setProxyConfigData(PAL::SessionID sessionID, Vector<std::pa
 }
 #endif // HAVE(NW_PROXY_CONFIG)
 
-#if USE(RUNNINGBOARD) && USE(EXTENSIONKIT)
-bool NetworkProcess::acquireLockedFileActivity()
-{
-    RELEASE_LOG(Process, "NetworkProcess::acquireLockedFileActivity hasAcquiredFileActivity = %d", hasAcquiredFileActivity());
-
-    invalidateFileActivity();
-
-    m_holdingLockedFileSemaphore = adoptOSObject(dispatch_semaphore_create(0));
-    [[NSProcessInfo processInfo] performExpiringActivityWithReason:@"Expiring activity for locked file" usingBlock:[holdingLockedFileSemaphore = m_holdingLockedFileSemaphore] (BOOL expired) {
-        RELEASE_LOG(Process, "Starting expiring activity, expired = %d", expired);
-        if (!expired) {
-            auto timeout = dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC);
-            dispatch_semaphore_wait(holdingLockedFileSemaphore.get(), timeout);
-        }
-    }];
-
-    return true;
-}
-
-void NetworkProcess::invalidateFileActivity()
-{
-    RELEASE_LOG(Process, "NetworkProcess::invalidateActivity hasAcquiredFileActivity = %d", hasAcquiredFileActivity());
-
-    if (!hasAcquiredFileActivity())
-        return;
-
-    if (m_holdingLockedFileSemaphore) {
-        dispatch_semaphore_signal(m_holdingLockedFileSemaphore.get());
-        m_holdingLockedFileSemaphore = nullptr;
-    }
-}
-
-bool NetworkProcess::hasAcquiredFileActivity() const
-{
-    return !!m_holdingLockedFileSemaphore;
-}
-#endif
-
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -335,6 +335,8 @@ public:
 
     void notifyMediaStreamingActivity(bool);
 
+    void releaseLockedFileAssertion();
+
 private:
     explicit NetworkProcessProxy();
 
@@ -472,6 +474,8 @@ private:
     RetainPtr<id> m_backgroundObserver;
     RetainPtr<id> m_foregroundObserver;
 #endif
+
+    RefPtr<ProcessAssertion> m_holdingLockedFileAssertion;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in
@@ -112,6 +112,8 @@ messages -> NetworkProcessProxy LegacyReceiver {
 #if ENABLE(NETWORK_ISSUE_REPORTING)
     ReportNetworkIssue(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, URL requestURL)
 #endif
+
+    ReleaseLockedFileAssertion()
 }
 
 }


### PR DESCRIPTION
#### 7338c8f6f3460b13fc391e5df9c624176caa6853
<pre>
Acquire locked file assertion from UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=271989">https://bugs.webkit.org/show_bug.cgi?id=271989</a>
<a href="https://rdar.apple.com/125037124">rdar://125037124</a>

Reviewed by NOBODY (OOPS!).

We currently acquire a locked file assertion eagerly in the NetworkProcess when a SQLite transaction
starts. We would like to avoid doing this eagerly because that assertion (a FinishTaskInterruptible
assertion) prevents the system from sleeping, which is causing a power regression due to recent
changes in the OS surrounding the way background assertions are taken. We would also like to stop
taking the assertion from within NetworkProcess since we will likely not support taking assertions
directly from process extensions in the future.

To fix this, we defer taking any assertions unless we are about to suspend with an active SQLite
transaction (in `NetworkProcess::prepareToSuspend`). If there is an active transaction, then we
notify the UIProcess about that in the PrepareToSuspend IPC response and allow the UIProcess to
acquire the assertion synchronously. We add a `NetworkProcessProxy::releaseLockedFileAssertion` IPC
to drop the assertion when the last transaction completes.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::NetworkProcess):
(WebKit::NetworkProcess::processWillSuspendImminentlyForTestingSync):
(WebKit::NetworkProcess::prepareToSuspend):
(WebKit::NetworkProcess::didFinishLastTransaction):
(WebKit::NetworkProcess::setIsHoldingLockedFiles): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::acquireLockedFileActivity): Deleted.
(WebKit::NetworkProcess::invalidateFileActivity): Deleted.
(WebKit::NetworkProcess::hasAcquiredFileActivity const): Deleted.
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::releaseLockedFileAssertion):
(WebKit::NetworkProcessProxy::sendPrepareToSuspend):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7338c8f6f3460b13fc391e5df9c624176caa6853

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48784 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42153 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37702 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18895 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19845 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4157 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42464 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50578 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21109 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44870 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22409 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43771 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22768 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->