### PR TITLE
Web Inspector: Dark Mode: Scope bars hovered and selected to match light mode

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.css
@@ -195,6 +195,10 @@
     .sidebar > .panel.details.css-style > .content ~ .options-container > .new-rule {
         filter: var(--filter-invert);
     }
+
+    .sidebar > .panel.details.css-style > .content ~ .options-container > .toggle:is(.selected,:hover) {
+        color: var(--scope-bar-text-color-active);
+    }
 }
 
 .multi-sidebar.showing-multiple > .sidebar > .panel.details:not(.style-rules) > .options-container > .toggle,

--- a/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ScopeBar.css
@@ -119,3 +119,9 @@
     margin-bottom: -1px;
     margin-inline: 6px 2px;
 }
+
+@media (prefers-color-scheme: dark) {
+    .scope-bar > li:is(.selected, :hover) {
+        color: var(--scope-bar-text-color-active);
+    }
+}

--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -365,6 +365,8 @@
         --slider-track-background: hsl(0, 0%, 35%);
         --slider-track-box-shadow: inset 0 0 3px hsl(0, 0%, 20%);
         --slider-track-tick-background: hsl(0, 0%, 55%);
+
+        --scope-bar-text-color-active: hsl(0, 0%, 15%);
     }
 }
 


### PR DESCRIPTION
#### fb1051954daf2cdd76cca1b4ad58546792fc9b2a
<pre>
Web Inspector: Dark Mode: Scope bars hovered and selected to match light mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=271988">https://bugs.webkit.org/show_bug.cgi?id=271988</a>

Reviewed by NOBODY (OOPS!).

Purpose of pr is to darken text color when a scope bar is selected or hovered in dark mode (@media (prefers-color-scheme: dark)) to match when light mode is selected or hovered.
Create a variable --scope-bar-text-color-active and set to hsl(0, 0%, 15%) in ScopeBar.css.
When navigation bar is selected or hovered, set color to --scope-bar-text-color-active in RadioNavigationItem.css.
When sidebar is selected or hovered, set color to --scope-bar-text-color-active in GeneralStyleDetailsSidebarPanel.css.
When scope bar is selected or hovered, set color to --scope-bar-text-color-active in ScopeBar.css.

* Source/WebInspectorUI/UserInterface/Views/GeneralStyleDetailsSidebarPanel.css:
(@media (prefers-color-scheme: dark) .sidebar &gt; .panel.details.css-style &gt; .content ~ .options-container &gt; .toggle:is(.selected,:hover)):
* Source/WebInspectorUI/UserInterface/Views/ScopeBar.css:
(@media (prefers-color-scheme: dark) .scope-bar &gt; li:is(.selected, :hover)):
* Source/WebInspectorUI/UserInterface/Views/Variables.css:
(:root):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb1051954daf2cdd76cca1b4ad58546792fc9b2a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25250 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/48704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48790 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/42159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22692 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46697 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/48704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18900 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/48704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4163 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/48704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50584 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/48704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/43780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/22109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->