### PR TITLE
CheckedPtr should require FastMalloc, Part 2

### DIFF
--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -417,8 +417,21 @@ void CanMakeCheckedPtrBase<StorageType, PtrCounterType>::registerCheckedPtr(cons
 }
 #endif
 
-using CanMakeCheckedPtr = CanMakeCheckedPtrBase<SingleThreadIntegralWrapper<uint32_t>, uint32_t>;
-using CanMakeThreadSafeCheckedPtr = CanMakeCheckedPtrBase<std::atomic<uint32_t>, uint32_t>;
+template<typename T> class CanMakeCheckedPtr : public CanMakeCheckedPtrBase<SingleThreadIntegralWrapper<uint32_t>, uint32_t> {
+public:
+    ~CanMakeCheckedPtr()
+    {
+        static_assert(std::is_same<typename T::WTFIsFastAllocated, int>::value, "Objects that use CanMakeCheckedPtr must use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
+    }
+};
+
+template<typename T> class CanMakeThreadSafeCheckedPtr : public CanMakeCheckedPtrBase<std::atomic<uint32_t>, uint32_t> {
+public:
+    ~CanMakeThreadSafeCheckedPtr()
+    {
+        static_assert(std::is_same<typename T::WTFIsFastAllocated, int>::value, "Objects that use CanMakeCheckedPtr must use FastMalloc (WTF_MAKE_FAST_ALLOCATED)");
+    }
+};
 
 } // namespace WTF
 

--- a/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
@@ -48,7 +48,8 @@ enum class SpeechRecognitionUpdateType : uint8_t;
 
 class SpeechRecognitionCaptureSourceImpl
     : public RealtimeMediaSource::Observer
-    , public RealtimeMediaSource::AudioSampleObserver {
+    , public RealtimeMediaSource::AudioSampleObserver
+    , public CanMakeCheckedPtr<SpeechRecognitionCaptureSourceImpl> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using DataCallback = Function<void(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t)>;
@@ -58,6 +59,11 @@ public:
     void mute();
 
 private:
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+
     // RealtimeMediaSource::AudioSampleObserver
     void audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
 

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -251,7 +251,7 @@ enum AXTextChange { AXTextInserted, AXTextDeleted, AXTextAttributesChanged };
 enum class PostTarget { Element, ObservableParent };
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AXObjectCache);
-class AXObjectCache final : public CanMakeWeakPtr<AXObjectCache>, public CanMakeCheckedPtr
+class AXObjectCache final : public CanMakeWeakPtr<AXObjectCache>, public CanMakeCheckedPtr<AXObjectCache>
     , public AXTreeStore<AXObjectCache> {
     WTF_MAKE_NONCOPYABLE(AXObjectCache);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AXObjectCache);

--- a/Source/WebCore/animation/DocumentTimelinesController.h
+++ b/Source/WebCore/animation/DocumentTimelinesController.h
@@ -42,7 +42,7 @@ class DocumentTimeline;
 class WebAnimation;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DocumentTimelinesController);
-class DocumentTimelinesController : public CanMakeCheckedPtr {
+class DocumentTimelinesController : public CanMakeCheckedPtr<DocumentTimelinesController> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(DocumentTimelinesController);
 public:
     explicit DocumentTimelinesController(Document&);

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -78,7 +78,7 @@ enum class ReasonForCallingCanExecuteScripts : uint8_t {
 
 using ValueOrException = Expected<JSC::JSValue, ExceptionDetails>;
 
-class ScriptController : public CanMakeWeakPtr<ScriptController>, public CanMakeCheckedPtr {
+class ScriptController : public CanMakeWeakPtr<ScriptController>, public CanMakeCheckedPtr<ScriptController> {
     WTF_MAKE_FAST_ALLOCATED;
 
     using RootObjectMap = HashMap<void*, Ref<JSC::Bindings::RootObject>>;

--- a/Source/WebCore/dom/CustomElementDefaultARIA.h
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.h
@@ -38,7 +38,7 @@ namespace WebCore {
 class Element;
 class WeakPtrImplWithEventTargetData;
 
-class CustomElementDefaultARIA : public CanMakeCheckedPtr {
+class CustomElementDefaultARIA : public CanMakeCheckedPtr<CustomElementDefaultARIA> {
     WTF_MAKE_ISO_ALLOCATED(CustomElementDefaultARIA);
 public:
     CustomElementDefaultARIA();

--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -116,7 +116,7 @@ private:
     bool m_invoking { false };
 };
 
-class CustomElementReactionQueue : public CanMakeCheckedPtr {
+class CustomElementReactionQueue : public CanMakeCheckedPtr<CustomElementReactionQueue> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(CustomElementReactionQueue);
 public:

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -46,7 +46,7 @@ struct SimpleRange;
 enum class RemovePartiallyOverlappingMarker : bool { No, Yes };
 enum class FilterMarkerResult : bool { Keep, Remove };
 
-class DocumentMarkerController : public CanMakeCheckedPtr {
+class DocumentMarkerController : public CanMakeCheckedPtr<DocumentMarkerController> {
     WTF_MAKE_NONCOPYABLE(DocumentMarkerController); WTF_MAKE_FAST_ALLOCATED;
 public:
     DocumentMarkerController(Document&);

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -153,10 +153,9 @@ private:
     mutable Markable<MonotonicTime> m_nextTimerFireTimeCache;
 };
 
-class EventLoopTaskGroup : public CanMakeWeakPtr<EventLoopTaskGroup>, public CanMakeCheckedPtr {
+class EventLoopTaskGroup : public CanMakeWeakPtr<EventLoopTaskGroup>, public CanMakeCheckedPtr<EventLoopTaskGroup> {
     WTF_MAKE_NONCOPYABLE(EventLoopTaskGroup);
     WTF_MAKE_FAST_ALLOCATED;
-
 public:
     EventLoopTaskGroup(EventLoop& eventLoop)
         : m_eventLoop(eventLoop)

--- a/Source/WebCore/dom/ExtensionStyleSheets.h
+++ b/Source/WebCore/dom/ExtensionStyleSheets.h
@@ -51,7 +51,7 @@ class StyleSheetContents;
 class StyleSheetList;
 class WeakPtrImplWithEventTargetData;
 
-class ExtensionStyleSheets : public CanMakeCheckedPtr {
+class ExtensionStyleSheets : public CanMakeCheckedPtr<ExtensionStyleSheets> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit ExtensionStyleSheets(Document&);

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -42,7 +42,7 @@ namespace WebCore {
 class DeferredPromise;
 class RenderStyle;
 
-class FullscreenManager final : public CanMakeWeakPtr<FullscreenManager>, public CanMakeCheckedPtr {
+class FullscreenManager final : public CanMakeWeakPtr<FullscreenManager>, public CanMakeCheckedPtr<FullscreenManager> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     FullscreenManager(Document&);

--- a/Source/WebCore/dom/IdTargetObserver.h
+++ b/Source/WebCore/dom/IdTargetObserver.h
@@ -26,13 +26,15 @@
 #pragma once
 
 #include <wtf/CheckedPtr.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
 class IdTargetObserverRegistry;
 
-class IdTargetObserver : public CanMakeCheckedPtr {
+class IdTargetObserver : public CanMakeCheckedPtr<IdTargetObserver> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~IdTargetObserver();
     virtual void idTargetChanged() = 0;

--- a/Source/WebCore/dom/IdTargetObserverRegistry.h
+++ b/Source/WebCore/dom/IdTargetObserverRegistry.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class IdTargetObserver;
 
-class IdTargetObserverRegistry : public CanMakeCheckedPtr {
+class IdTargetObserverRegistry : public CanMakeCheckedPtr<IdTargetObserverRegistry> {
     WTF_MAKE_FAST_ALLOCATED;
     friend class IdTargetObserver;
 public:
@@ -51,7 +51,7 @@ private:
     void removeObserver(const AtomString& id, IdTargetObserver&);
     void notifyObserversInternal(const AtomString& id);
 
-    struct ObserverSet : public CanMakeCheckedPtr {
+    struct ObserverSet : public CanMakeCheckedPtr<ObserverSet> {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
         HashSet<CheckedRef<IdTargetObserver>> observers;
     };

--- a/Source/WebCore/dom/PendingScriptClient.h
+++ b/Source/WebCore/dom/PendingScriptClient.h
@@ -31,9 +31,14 @@ namespace WebCore {
 
 class PendingScript;
 
-class PendingScriptClient : public CanMakeCheckedPtr {
+class PendingScriptClient {
 public:
     virtual ~PendingScriptClient() = default;
+
+    // CheckedPtr interface
+    virtual uint32_t ptrCount() const = 0;
+    virtual void incrementPtrCount() const = 0;
+    virtual void decrementPtrCount() const = 0;
 
     virtual void notifyFinished(PendingScript&) = 0;
 };

--- a/Source/WebCore/dom/RejectedPromiseTracker.h
+++ b/Source/WebCore/dom/RejectedPromiseTracker.h
@@ -45,7 +45,7 @@ class JSDOMGlobalObject;
 class ScriptExecutionContext;
 class UnhandledPromise;
 
-class RejectedPromiseTracker : public CanMakeCheckedPtr {
+class RejectedPromiseTracker : public CanMakeCheckedPtr<RejectedPromiseTracker> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(RejectedPromiseTracker);
 public:

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -28,6 +28,7 @@
 
 #include "PendingScriptClient.h"
 #include "Timer.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakRef.h>
@@ -39,11 +40,16 @@ class ScriptElement;
 class LoadableScript;
 class WeakPtrImplWithEventTargetData;
 
-class ScriptRunner : public PendingScriptClient {
+class ScriptRunner : public PendingScriptClient, public CanMakeCheckedPtr<ScriptRunner> {
     WTF_MAKE_NONCOPYABLE(ScriptRunner); WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit ScriptRunner(Document&);
     ~ScriptRunner();
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     enum ExecutionType { ASYNC_EXECUTION, IN_ORDER_EXECUTION };
     void queueScriptForExecution(ScriptElement&, LoadableScript&, ExecutionType);

--- a/Source/WebCore/dom/VisitedLinkState.h
+++ b/Source/WebCore/dom/VisitedLinkState.h
@@ -39,7 +39,7 @@ namespace WebCore {
 
 class Document;
 
-class VisitedLinkState : public CanMakeCheckedPtr {
+class VisitedLinkState : public CanMakeCheckedPtr<VisitedLinkState> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit VisitedLinkState(Document&);

--- a/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
@@ -30,12 +30,14 @@
 #include "MessagePortIdentifier.h"
 #include "ProcessIdentifier.h"
 #include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 
 namespace WebCore {
 
-class MessagePortChannelRegistry : public CanMakeWeakPtr<MessagePortChannelRegistry>, public CanMakeCheckedPtr {
+class MessagePortChannelRegistry : public CanMakeWeakPtr<MessagePortChannelRegistry>, public CanMakeCheckedPtr<MessagePortChannelRegistry> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT MessagePortChannelRegistry();
 

--- a/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class WorkerOrWorkletGlobalScope;
 
-class WorkerMessagePortChannelProvider final : public MessagePortChannelProvider, public CanMakeCheckedPtr {
+class WorkerMessagePortChannelProvider final : public MessagePortChannelProvider, public CanMakeCheckedPtr<WorkerMessagePortChannelProvider> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit WorkerMessagePortChannelProvider(WorkerOrWorkletGlobalScope&);

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -172,7 +172,7 @@ private:
     TemporarySelectionChange m_selectionChange;
 };
 
-class Editor : public CanMakeCheckedPtr {
+class Editor : public CanMakeCheckedPtr<Editor> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit Editor(Document&);

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -112,7 +112,7 @@ private:
     VisiblePosition m_position;
 };
 
-class FrameSelection final : private CaretBase, public CaretAnimationClient, public CanMakeCheckedPtr {
+class FrameSelection final : private CaretBase, public CaretAnimationClient, public CanMakeCheckedPtr<FrameSelection> {
     WTF_MAKE_NONCOPYABLE(FrameSelection);
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WebCore/editing/TextManipulationController.h
+++ b/Source/WebCore/editing/TextManipulationController.h
@@ -43,7 +43,7 @@ class Document;
 class Element;
 class VisiblePosition;
 
-class TextManipulationController : public CanMakeWeakPtr<TextManipulationController>, public CanMakeCheckedPtr {
+class TextManipulationController : public CanMakeWeakPtr<TextManipulationController>, public CanMakeCheckedPtr<TextManipulationController> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     TextManipulationController(Document&);

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -37,7 +37,7 @@ class BackForwardClient;
 class HistoryItem;
 class Page;
 
-class BackForwardController : public CanMakeCheckedPtr {
+class BackForwardController : public CanMakeCheckedPtr<BackForwardController> {
     WTF_MAKE_NONCOPYABLE(BackForwardController); WTF_MAKE_FAST_ALLOCATED;
 public:
     BackForwardController(Page&, Ref<BackForwardClient>&&);

--- a/Source/WebCore/history/CachedPage.h
+++ b/Source/WebCore/history/CachedPage.h
@@ -36,7 +36,7 @@ class Document;
 class DocumentLoader;
 class Page;
 
-class CachedPage : public CanMakeCheckedPtr {
+class CachedPage : public CanMakeCheckedPtr<CachedPage> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit CachedPage(Page&);

--- a/Source/WebCore/html/parser/HTMLDocumentParser.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.h
@@ -31,6 +31,7 @@
 #include "HTMLTokenizer.h"
 #include "PendingScriptClient.h"
 #include "ScriptableDocumentParser.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -45,11 +46,16 @@ class HTMLResourcePreloader;
 class PumpSession;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HTMLDocumentParser);
-class HTMLDocumentParser : public ScriptableDocumentParser, private HTMLScriptRunnerHost, private PendingScriptClient {
+class HTMLDocumentParser : public ScriptableDocumentParser, private HTMLScriptRunnerHost, private PendingScriptClient, public CanMakeCheckedPtr<HTMLDocumentParser> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(HTMLDocumentParser);
 public:
     static Ref<HTMLDocumentParser> create(HTMLDocument&, OptionSet<ParserContentPolicy> = DefaultParserContentPolicy);
     virtual ~HTMLDocumentParser();
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     static void parseDocumentFragment(const String&, DocumentFragment&, Element& contextElement, OptionSet<ParserContentPolicy> = { ParserContentPolicy::AllowScriptingContent });
 

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
@@ -42,7 +42,7 @@ struct PaintInfo;
 
 namespace LayoutIntegration {
 
-class FlexLayout : public CanMakeCheckedPtr {
+class FlexLayout : public CanMakeCheckedPtr<FlexLayout> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     FlexLayout(RenderFlexibleBox&);

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -61,7 +61,7 @@ struct LineAdjustment;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(LayoutIntegration_LineLayout);
 
-class LineLayout : public CanMakeCheckedPtr {
+class LineLayout : public CanMakeCheckedPtr<LineLayout> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LayoutIntegration_LineLayout);
 public:
     LineLayout(RenderBlockFlow&);

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -43,7 +43,7 @@ class InitialContainingBlock;
 class LayoutState;
 class TreeBuilder;
 
-class Box : public CanMakeCheckedPtr {
+class Box : public CanMakeCheckedPtr<Box> {
     WTF_MAKE_ISO_ALLOCATED(Box);
 public:
     enum class NodeType : uint8_t {
@@ -194,9 +194,6 @@ public:
     void setCachedGeometryForLayoutState(LayoutState&, std::unique_ptr<BoxGeometry>) const;
 
     UniqueRef<Box> removeFromParent();
-
-    void incrementPtrCount() const { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const { CanMakeCheckedPtr::decrementPtrCount(); }
 
 protected:
     Box(ElementAttributes&&, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle, OptionSet<BaseTypeFlag>);

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -311,7 +311,7 @@ private:
 };
 
 
-class FrameLoader::FrameProgressTracker : public CanMakeCheckedPtr {
+class FrameLoader::FrameProgressTracker : public CanMakeCheckedPtr<FrameLoader::FrameProgressTracker> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     explicit FrameProgressTracker(LocalFrame& frame)

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -101,7 +101,7 @@ WEBCORE_EXPORT bool isReload(FrameLoadType);
 
 using ContentPolicyDecisionFunction = CompletionHandler<void(PolicyAction)>;
 
-class FrameLoader final : public CanMakeCheckedPtr {
+class FrameLoader final : public CanMakeCheckedPtr<FrameLoader> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
     WTF_MAKE_NONCOPYABLE(FrameLoader);
 public:

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -43,7 +43,7 @@ enum class ShouldTreatAsContinuingLoad : uint8_t;
 
 struct StringWithDirection;
 
-class HistoryController : public CanMakeCheckedPtr {
+class HistoryController : public CanMakeCheckedPtr<HistoryController> {
     WTF_MAKE_NONCOPYABLE(HistoryController);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -50,7 +50,7 @@ class SecurityOrigin;
 enum class NewLoadInProgress : bool { No, Yes };
 enum class ScheduleLocationChangeResult : uint8_t { Stopped, Completed, Started };
 
-class NavigationScheduler : public CanMakeCheckedPtr {
+class NavigationScheduler : public CanMakeCheckedPtr<NavigationScheduler> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     explicit NavigationScheduler(Frame&);

--- a/Source/WebCore/loader/ProgressTracker.h
+++ b/Source/WebCore/loader/ProgressTracker.h
@@ -43,7 +43,7 @@ class ResourceResponse;
 class ProgressTrackerClient;
 struct ProgressItem;
 
-class ProgressTracker : public CanMakeCheckedPtr {
+class ProgressTracker : public CanMakeCheckedPtr<ProgressTracker> {
     WTF_MAKE_NONCOPYABLE(ProgressTracker);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:

--- a/Source/WebCore/loader/ThreadableLoaderClient.h
+++ b/Source/WebCore/loader/ThreadableLoaderClient.h
@@ -43,7 +43,7 @@ class ResourceResponse;
 class ResourceTiming;
 class SharedBuffer;
 
-class ThreadableLoaderClient : public CanMakeWeakPtr<ThreadableLoaderClient>, public CanMakeThreadSafeCheckedPtr {
+class ThreadableLoaderClient : public CanMakeWeakPtr<ThreadableLoaderClient>, public CanMakeThreadSafeCheckedPtr<ThreadableLoaderClient> {
     WTF_MAKE_NONCOPYABLE(ThreadableLoaderClient); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
 public:
     virtual void didSendData(unsigned long long /*bytesSent*/, unsigned long long /*totalBytesToBeSent*/) { }

--- a/Source/WebCore/page/AlternativeTextClient.h
+++ b/Source/WebCore/page/AlternativeTextClient.h
@@ -28,6 +28,7 @@
 #include "DictationContext.h"
 #include "FloatRect.h"
 #include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 
@@ -53,7 +54,8 @@ enum class AutocorrectionResponse : uint8_t {
     Accepted
 };
 
-class AlternativeTextClient : public CanMakeCheckedPtr {
+class AlternativeTextClient : public CanMakeCheckedPtr<AlternativeTextClient> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~AlternativeTextClient() = default;
 #if USE(AUTOCORRECTION_PANEL)

--- a/Source/WebCore/page/DeviceController.h
+++ b/Source/WebCore/page/DeviceController.h
@@ -38,7 +38,7 @@ namespace WebCore {
 class DeviceClient;
 class Page;
 
-class DeviceController : public Supplement<Page>, public CanMakeCheckedPtr {
+class DeviceController : public Supplement<Page>, public CanMakeCheckedPtr<DeviceController> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit DeviceController(DeviceClient&);

--- a/Source/WebCore/page/DiagnosticLoggingClient.h
+++ b/Source/WebCore/page/DiagnosticLoggingClient.h
@@ -45,7 +45,7 @@ struct DiagnosticLoggingDictionary {
     void set(String key, Payload value) { dictionary.set(WTFMove(key), WTFMove(value)); }
 };
 
-class DiagnosticLoggingClient : public CanMakeCheckedPtr {
+class DiagnosticLoggingClient : public CanMakeCheckedPtr<DiagnosticLoggingClient> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual void logDiagnosticMessage(const String& message, const String& description, ShouldSample) = 0;

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -32,6 +32,7 @@
 #include "TextChecking.h"
 #include "UndoStep.h"
 #include <wtf/CheckedPtr.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
@@ -61,7 +62,8 @@ struct GapRects;
 struct GrammarDetail;
 struct SimpleRange;
 
-class EditorClient : public CanMakeWeakPtr<EditorClient>, public CanMakeCheckedPtr {
+class EditorClient : public CanMakeWeakPtr<EditorClient>, public CanMakeCheckedPtr<EditorClient> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~EditorClient() = default;
 

--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -44,7 +44,7 @@ namespace WebCore {
 class Document;
 class Page;
 
-class ElementTargetingController : public CanMakeCheckedPtr {
+class ElementTargetingController : public CanMakeCheckedPtr<ElementTargetingController> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     ElementTargetingController(Page&);

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -133,7 +133,7 @@ enum class ImmediateActionStage : uint8_t {
     ActionCompleted
 };
 
-class EventHandler : public CanMakeCheckedPtr {
+class EventHandler : public CanMakeCheckedPtr<EventHandler> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit EventHandler(LocalFrame&);

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -49,7 +49,7 @@ class TreeScope;
 
 struct FocusCandidate;
 
-class FocusController : public CanMakeCheckedPtr {
+class FocusController : public CanMakeCheckedPtr<FocusController> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit FocusController(Page&, OptionSet<ActivityState>);

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -61,7 +61,8 @@ struct UpdateScrollInfoAfterLayoutTransaction {
     SingleThreadWeakHashSet<RenderBlock> blocks;
 };
 
-class LocalFrameViewLayoutContext : public CanMakeCheckedPtr {
+class LocalFrameViewLayoutContext : public CanMakeCheckedPtr<LocalFrameViewLayoutContext> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     LocalFrameViewLayoutContext(LocalFrameView&);
     ~LocalFrameViewLayoutContext();

--- a/Source/WebCore/page/PageConsoleClient.h
+++ b/Source/WebCore/page/PageConsoleClient.h
@@ -48,7 +48,7 @@ namespace WebCore {
 class Document;
 class Page;
 
-class WEBCORE_EXPORT PageConsoleClient final : public JSC::ConsoleClient, public CanMakeCheckedPtr {
+class WEBCORE_EXPORT PageConsoleClient final : public JSC::ConsoleClient, public CanMakeCheckedPtr<PageConsoleClient> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit PageConsoleClient(Page&);

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -86,7 +86,7 @@ enum class AllowTrustedTypePolicy : uint8_t {
     DisallowedDuplicateName,
 };
 
-class ContentSecurityPolicy : public CanMakeThreadSafeCheckedPtr {
+class ContentSecurityPolicy : public CanMakeThreadSafeCheckedPtr<ContentSecurityPolicy> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit ContentSecurityPolicy(URL&&, ScriptExecutionContext&);

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -41,7 +41,7 @@ class ScrollingStateFrameScrollingNode;
 // will be informed and will schedule a timer that will clone the new state tree and send it over to
 // the scrolling thread, avoiding locking. 
 
-class ScrollingStateTree : public CanMakeCheckedPtr {
+class ScrollingStateTree : public CanMakeCheckedPtr<ScrollingStateTree> {
     WTF_MAKE_FAST_ALLOCATED;
     friend class ScrollingStateNode;
 public:

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.h
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.h
@@ -51,9 +51,9 @@ const std::optional<KeyboardScrollingKey> keyboardScrollingKeyForKeyboardEvent(c
 const std::optional<ScrollDirection> scrollDirectionForKeyboardEvent(const KeyboardEvent&);
 const std::optional<ScrollGranularity> scrollGranularityForKeyboardEvent(const KeyboardEvent&);
 
-class KeyboardScrollingAnimator : public CanMakeWeakPtr<KeyboardScrollingAnimator>, public CanMakeCheckedPtr {
-    WTF_MAKE_NONCOPYABLE(KeyboardScrollingAnimator);
+class KeyboardScrollingAnimator : public CanMakeWeakPtr<KeyboardScrollingAnimator>, public CanMakeCheckedPtr<KeyboardScrollingAnimator> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(KeyboardScrollingAnimator);
 public:
     KeyboardScrollingAnimator(ScrollableArea&);
 

--- a/Source/WebCore/platform/OrientationNotifier.h
+++ b/Source/WebCore/platform/OrientationNotifier.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-class OrientationNotifier : public CanMakeCheckedPtr {
+class OrientationNotifier : public CanMakeCheckedPtr<OrientationNotifier> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit OrientationNotifier(IntDegrees orientation) { m_orientation = orientation; }

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -70,6 +70,7 @@ enum class DelegatedScrollingMode : uint8_t {
 };
 
 class ScrollView : public Widget, public ScrollableArea {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~ScrollView();
 

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -49,7 +49,7 @@
 
 namespace WebCore {
 
-struct SameSizeAsScrollableArea : public CanMakeWeakPtr<SameSizeAsScrollableArea>, public CanMakeCheckedPtr {
+struct SameSizeAsScrollableArea : public CanMakeWeakPtr<SameSizeAsScrollableArea>, public CanMakeCheckedPtr<SameSizeAsScrollableArea> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     ~SameSizeAsScrollableArea() { }

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -34,6 +34,7 @@
 #include "Scrollbar.h"
 #include "ScrollbarColor.h"
 #include <wtf/CheckedPtr.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/WeakPtr.h>
 
@@ -70,7 +71,8 @@ inline int offsetForOrientation(ScrollOffset offset, ScrollbarOrientation orient
     return 0;
 }
 
-class ScrollableArea : public CanMakeWeakPtr<ScrollableArea>, public CanMakeCheckedPtr {
+class ScrollableArea : public CanMakeWeakPtr<ScrollableArea>, public CanMakeCheckedPtr<ScrollableArea> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual bool isScrollView() const { return false; }
     virtual bool isRenderLayer() const { return false; }

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -126,9 +126,15 @@ public:
 #endif
 };
 
-class PlaybackSessionModelClient : public CanMakeWeakPtr<PlaybackSessionModelClient>, public CanMakeCheckedPtr {
+class PlaybackSessionModelClient : public CanMakeWeakPtr<PlaybackSessionModelClient> {
 public:
     virtual ~PlaybackSessionModelClient() { };
+
+    // CheckedPtr interface
+    virtual uint32_t ptrCount() const = 0;
+    virtual void incrementPtrCount() const = 0;
+    virtual void decrementPtrCount() const = 0;
+
     virtual void durationChanged(double) { }
     virtual void currentTimeChanged(double /* currentTime */, double /* anchorTime */) { }
     virtual void bufferedTimeChanged(double) { }

--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -98,9 +98,15 @@ public:
 #endif
 };
 
-class VideoPresentationModelClient : public CanMakeWeakPtr<VideoPresentationModelClient>, public CanMakeCheckedPtr {
+class VideoPresentationModelClient : public CanMakeWeakPtr<VideoPresentationModelClient> {
 public:
     virtual ~VideoPresentationModelClient() = default;
+
+    // CheckedPtr interface
+    virtual uint32_t ptrCount() const = 0;
+    virtual void incrementPtrCount() const = 0;
+    virtual void decrementPtrCount() const = 0;
+
     virtual void hasVideoChanged(bool) { }
     virtual void videoDimensionsChanged(const FloatSize&) { }
     virtual void willEnterPictureInPicture() { }

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -57,7 +57,7 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, __AVPlayerLayerView)
 #endif
 
 namespace WebCore {
-class WebAVPlayerLayerPresentationModelClient : public VideoPresentationModelClient {
+class WebAVPlayerLayerPresentationModelClient : public VideoPresentationModelClient, public CanMakeCheckedPtr<WebAVPlayerLayerPresentationModelClient> {
     WTF_MAKE_FAST_ALLOCATED(WebAVPlayerLayerPresentationModelClient);
 public:
     WebAVPlayerLayerPresentationModelClient(WebAVPlayerLayer* playerLayer)
@@ -65,6 +65,11 @@ public:
     {
     }
 private:
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+
     void videoDimensionsChanged(const FloatSize& videoDimensions)
     {
         [m_playerLayer.get() setVideoDimensions:videoDimensions];

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorClient.h
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorClient.h
@@ -29,6 +29,7 @@
 #include "PlatformScreen.h"
 #include <optional>
 #include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
 
 namespace WebCore {
 
@@ -37,7 +38,8 @@ class DisplayRefreshMonitorFactory;
 
 struct DisplayUpdate;
 
-class DisplayRefreshMonitorClient : public CanMakeCheckedPtr {
+class DisplayRefreshMonitorClient : public CanMakeCheckedPtr<DisplayRefreshMonitorClient> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     DisplayRefreshMonitorClient();
     virtual ~DisplayRefreshMonitorClient();

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -80,7 +80,7 @@ FontCascade::FontCascade(FontCascadeDescription&& description, const FontCascade
 
 FontCascade::FontCascade(const FontCascade& other)
     : CanMakeWeakPtr<FontCascade>()
-    , CanMakeCheckedPtr()
+    , CanMakeCheckedPtr<FontCascade>()
     , m_fontDescription(other.m_fontDescription)
     , m_spacing(other.m_spacing)
     , m_fonts(other.m_fonts)
@@ -1750,7 +1750,7 @@ public:
 #endif
     }
 
-    bool containsMorePaths() { return m_index != m_glyphBuffer->size(); }
+    bool containsMorePaths() { return m_index != m_glyphBuffer.size(); }
     Path path();
     std::pair<float, float> extents();
     GlyphUnderlineType underlineType();
@@ -1759,14 +1759,14 @@ public:
 private:
     unsigned m_index { 0 };
     CheckedRef<const TextRun> m_textRun;
-    CheckedRef<const GlyphBuffer> m_glyphBuffer;
+    const GlyphBuffer& m_glyphBuffer;
     Ref<const Font> m_fontData;
     AffineTransform m_translation;
 };
 
 Path GlyphToPathTranslator::path()
 {
-    Path path = Ref { m_fontData }->pathForGlyph(m_glyphBuffer->glyphAt(m_index));
+    Path path = Ref { m_fontData }->pathForGlyph(m_glyphBuffer.glyphAt(m_index));
     path.transform(m_translation);
     return path;
 }
@@ -1774,7 +1774,7 @@ Path GlyphToPathTranslator::path()
 std::pair<float, float> GlyphToPathTranslator::extents()
 {
     auto beginning = m_translation.mapPoint(FloatPoint(0, 0));
-    auto advance = m_glyphBuffer->advanceAt(m_index);
+    auto advance = m_glyphBuffer.advanceAt(m_index);
     auto end = m_translation.mapSize(size(advance));
     return std::make_pair(beginning.x(), beginning.x() + end.width());
 }
@@ -1786,11 +1786,11 @@ auto GlyphToPathTranslator::underlineType() -> GlyphUnderlineType
 
 void GlyphToPathTranslator::advance()
 {
-    GlyphBufferAdvance advance = m_glyphBuffer->advanceAt(m_index);
+    GlyphBufferAdvance advance = m_glyphBuffer.advanceAt(m_index);
     m_translation.translate(size(advance));
     ++m_index;
-    if (m_index < m_glyphBuffer->size())
-        m_fontData = m_glyphBuffer->fontAt(m_index);
+    if (m_index < m_glyphBuffer.size())
+        m_fontData = m_glyphBuffer.fontAt(m_index);
 }
 
 RefPtr<FontCascadeFonts> FontCascade::protectedFonts() const

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -33,6 +33,7 @@
 #include "TextSpacing.h"
 #include <optional>
 #include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/HashSet.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/CharacterProperties.h>
@@ -107,7 +108,8 @@ public:
     void operator()(TextLayout*) const;
 };
 
-class FontCascade : public CanMakeWeakPtr<FontCascade>, public CanMakeCheckedPtr {
+class FontCascade : public CanMakeWeakPtr<FontCascade>, public CanMakeCheckedPtr<FontCascade> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT FontCascade();
     WEBCORE_EXPORT FontCascade(FontCascadeDescription&&);

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -36,6 +36,7 @@
 #include <climits>
 #include <limits>
 #include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -44,7 +45,7 @@ static const constexpr GlyphBufferGlyph deletedGlyph = 0xFFFF;
 
 class Font;
 
-class GlyphBuffer : public CanMakeCheckedPtr {
+class GlyphBuffer {
 public:
     bool isEmpty() const { return m_fonts.isEmpty(); }
     unsigned size() const { return m_fonts.size(); }

--- a/Source/WebCore/platform/graphics/TextRun.cpp
+++ b/Source/WebCore/platform/graphics/TextRun.cpp
@@ -28,7 +28,7 @@
 
 namespace WebCore {
 
-struct ExpectedTextRunSize : public CanMakeCheckedPtr {
+struct ExpectedTextRunSize : public CanMakeCheckedPtr<ExpectedTextRunSize> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     String text;

--- a/Source/WebCore/platform/graphics/TextRun.h
+++ b/Source/WebCore/platform/graphics/TextRun.h
@@ -40,7 +40,7 @@ class Font;
 
 struct GlyphData;
 
-class TextRun : public CanMakeCheckedPtr {
+class TextRun : public CanMakeCheckedPtr<TextRun> {
     WTF_MAKE_FAST_ALLOCATED;
     friend void add(Hasher&, const TextRun&);
 public:

--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -27,6 +27,7 @@
 
 #include "IntPoint.h"
 #include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/WeakPtr.h>
 
@@ -75,7 +76,8 @@ public:
 };
 
 
-class TiledBacking : public CanMakeCheckedPtr {
+class TiledBacking : public CanMakeCheckedPtr<TiledBacking> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~TiledBacking() = default;
 

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -261,7 +261,7 @@ struct AdvanceInternalState {
     // rangeFont and font are not necessarily the same, since small-caps might change the range fot for a synthesized font, or a small-caps-synthesized font.
     RefPtr<const Font> rangeFont;
     RefPtr<const Font> nextRangeFont;
-    CheckedRef<GlyphBuffer> glyphBuffer;
+    GlyphBuffer& glyphBuffer;
     unsigned lastGlyphCount { 0 };
     Ref<const Font> primaryFont;
     float widthOfCurrentFontRange { 0 };
@@ -297,8 +297,8 @@ void WidthIterator::commitCurrentFontRange(AdvanceInternalState& advanceInternal
 {
 #if ASSERT_ENABLED
     ASSERT(advanceInternalState.rangeFont);
-    for (unsigned i = advanceInternalState.lastGlyphCount; i < advanceInternalState.glyphBuffer->size(); ++i)
-        ASSERT(&advanceInternalState.glyphBuffer->fontAt(i) == advanceInternalState.rangeFont);
+    for (unsigned i = advanceInternalState.lastGlyphCount; i < advanceInternalState.glyphBuffer.size(); ++i)
+        ASSERT(&advanceInternalState.glyphBuffer.fontAt(i) == advanceInternalState.rangeFont);
 #endif
 
     auto applyFontTransformsResult = applyFontTransforms(advanceInternalState.glyphBuffer, advanceInternalState.lastGlyphCount, *advanceInternalState.rangeFont, advanceInternalState.charactersTreatedAsSpace);
@@ -310,7 +310,7 @@ void WidthIterator::commitCurrentFontRange(AdvanceInternalState& advanceInternal
         m_fallbackFonts->add(*advanceInternalState.rangeFont);
 
     advanceInternalState.widthOfCurrentFontRange = 0;
-    advanceInternalState.lastGlyphCount = advanceInternalState.glyphBuffer->size();
+    advanceInternalState.lastGlyphCount = advanceInternalState.glyphBuffer.size();
 }
 
 static const Font* fontForRange(const Font* font, const SmallCapsState& smallCapsData, bool isSmallCaps)

--- a/Source/WebCore/platform/graphics/ca/LayerPool.h
+++ b/Source/WebCore/platform/graphics/ca/LayerPool.h
@@ -32,13 +32,15 @@
 #include "Timer.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Deque.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
     
-class LayerPool : public CanMakeCheckedPtr {
+class LayerPool : public CanMakeCheckedPtr<LayerPool> {
+    WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(LayerPool);
 public:
     WEBCORE_EXPORT LayerPool();

--- a/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
@@ -29,6 +29,7 @@
 
 #include "HTMLMediaElementEnums.h"
 #include "PlaybackSessionModel.h"
+#include <wtf/CheckedRef.h>
 
 OBJC_CLASS AVPlayerViewController;
 OBJC_CLASS UIView;
@@ -40,7 +41,8 @@ class FloatSize;
 
 class NullPlaybackSessionInterface final
     : public PlaybackSessionModelClient
-    , public RefCounted<NullPlaybackSessionInterface> {
+    , public RefCounted<NullPlaybackSessionInterface>
+    , public CanMakeCheckedPtr<NullPlaybackSessionInterface> {
 public:
     static Ref<NullPlaybackSessionInterface> create(PlaybackSessionModel& model)
     {
@@ -71,6 +73,11 @@ private:
         : m_model(model)
     {
     }
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     void durationChanged(double) final { }
     void currentTimeChanged(double, double) final { }

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
@@ -37,7 +37,8 @@ class NullVideoPresentationInterface final
     : public VideoPresentationModelClient
     , public PlaybackSessionModelClient
     , public VideoFullscreenCaptions
-    , public RefCounted<NullVideoPresentationInterface> {
+    , public RefCounted<NullVideoPresentationInterface>
+    , public CanMakeCheckedPtr<NullVideoPresentationInterface> {
 public:
     static Ref<NullVideoPresentationInterface> create(NullPlaybackSessionInterface& playbackSessionInterface)
     {
@@ -86,6 +87,11 @@ private:
         : m_playbackSessionInterface(playbackSessionInterface)
     {
     }
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     Ref<NullPlaybackSessionInterface> m_playbackSessionInterface;
     ThreadSafeWeakPtr<VideoPresentationModel> m_videoPresentationModel;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -34,6 +34,8 @@
 #include "Timer.h"
 #include <functional>
 #include <objc/objc.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
@@ -51,7 +53,9 @@ class WebPlaybackSessionChangeObserver;
 
 class WEBCORE_EXPORT PlaybackSessionInterfaceIOS
     : public PlaybackSessionModelClient
-    , public RefCounted<PlaybackSessionInterfaceIOS> {
+    , public RefCounted<PlaybackSessionInterfaceIOS>
+    , public CanMakeCheckedPtr<PlaybackSessionInterfaceIOS> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     void initialize();
     virtual void invalidate();
@@ -93,6 +97,11 @@ protected:
     PlaybackSessionModel* m_playbackSessionModel { nullptr };
 
 private:
+    // CheckedPtr interface
+    uint32_t ptrCount() const final;
+    void incrementPtrCount() const final;
+    void decrementPtrCount() const final;
+
     std::optional<MediaPlayerIdentifier> m_playerIdentifier;
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String m_spatialTrackingLabel;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
@@ -120,6 +120,22 @@ WTFLogChannel& PlaybackSessionInterfaceIOS::logChannel() const
 {
     return LogMedia;
 }
+
+uint32_t PlaybackSessionInterfaceIOS::ptrCount() const
+{
+    return CanMakeCheckedPtr::ptrCount();
+}
+
+void PlaybackSessionInterfaceIOS::incrementPtrCount() const
+{
+    CanMakeCheckedPtr::incrementPtrCount();
+}
+
+void PlaybackSessionInterfaceIOS::decrementPtrCount() const
+{
+    CanMakeCheckedPtr::decrementPtrCount();
+}
+
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -62,7 +62,8 @@ class VideoPresentationInterfaceIOS
     : public VideoPresentationModelClient
     , public PlaybackSessionModelClient
     , public VideoFullscreenCaptions
-    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoPresentationInterfaceIOS, WTF::DestructionThread::MainRunLoop> {
+    , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoPresentationInterfaceIOS, WTF::DestructionThread::MainRunLoop>
+    , public CanMakeCheckedPtr<VideoPresentationInterfaceIOS> {
 public:
     WEBCORE_EXPORT ~VideoPresentationInterfaceIOS();
     WEBCORE_EXPORT void setVideoPresentationModel(VideoPresentationModel*);
@@ -229,6 +230,11 @@ protected:
     bool m_waitingForPreparedToExit { false };
 #endif
 private:
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+
     void returnToStandby();
     void watchdogTimerFired();
 

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -42,6 +42,7 @@
 #import <QuartzCore/CoreAnimation.h>
 #import <UIKit/UIView.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/CheckedRef.h>
 #import <wtf/CrossThreadCopier.h>
 #import <wtf/WorkQueue.h>
 
@@ -100,8 +101,9 @@ class VideoFullscreenControllerContext final
     : public VideoPresentationModel
     , private VideoPresentationModelClient
     , private PlaybackSessionModel
-    , private PlaybackSessionModelClient {
-
+    , private PlaybackSessionModelClient
+    , public CanMakeCheckedPtr<VideoFullscreenControllerContext> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<VideoFullscreenControllerContext> create()
     {
@@ -118,6 +120,11 @@ public:
 
 private:
     VideoFullscreenControllerContext() { }
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     // VideoPresentationModelClient
     void hasVideoChanged(bool) override;

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -43,7 +43,8 @@ class PlaybackSessionModel;
 
 class WEBCORE_EXPORT PlaybackSessionInterfaceMac final
     : public PlaybackSessionModelClient
-    , public RefCounted<PlaybackSessionInterfaceMac> {
+    , public RefCounted<PlaybackSessionInterfaceMac>
+    , public CanMakeCheckedPtr<PlaybackSessionInterfaceMac> {
 public:
     static Ref<PlaybackSessionInterfaceMac> create(PlaybackSessionModel&);
     virtual ~PlaybackSessionInterfaceMac();
@@ -86,6 +87,12 @@ public:
 
 private:
     PlaybackSessionInterfaceMac(PlaybackSessionModel&);
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final;
+    void incrementPtrCount() const final;
+    void decrementPtrCount() const final;
+
     WeakPtr<PlaybackSessionModel> m_playbackSessionModel;
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
     WeakObjCPtr<WebPlaybackControlsManager> m_playbackControlsManager;

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -294,6 +294,21 @@ void PlaybackSessionInterfaceMac::updatePlaybackControlsManagerTiming(double cur
     manager.timing = [getAVValueTimingClass() valueTimingWithAnchorValue:currentTime anchorTimeStamp:effectiveAnchorTime rate:effectivePlaybackRate];
 }
 
+uint32_t PlaybackSessionInterfaceMac::ptrCount() const
+{
+    return CanMakeCheckedPtr::ptrCount();
+}
+
+void PlaybackSessionInterfaceMac::incrementPtrCount() const
+{
+    CanMakeCheckedPtr::incrementPtrCount();
+}
+
+void PlaybackSessionInterfaceMac::decrementPtrCount() const
+{
+    CanMakeCheckedPtr::decrementPtrCount();
+}
+
 #endif // ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
 
 #if !RELEASE_LOG_DISABLED
@@ -311,6 +326,7 @@ WTFLogChannel& PlaybackSessionInterfaceMac::logChannel() const
 {
     return LogMedia;
 }
+
 #endif
 
 }

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -33,6 +33,8 @@
 #include "PlaybackSessionModel.h"
 #include "VideoFullscreenCaptions.h"
 #include "VideoPresentationModel.h"
+#include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
@@ -51,8 +53,9 @@ class VideoPresentationInterfaceMac
     : public VideoPresentationModelClient
     , private PlaybackSessionModelClient
     , public VideoFullscreenCaptions
-    , public RefCounted<VideoPresentationInterfaceMac> {
-
+    , public RefCounted<VideoPresentationInterfaceMac>
+    , public CanMakeCheckedPtr<VideoPresentationInterfaceMac> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<VideoPresentationInterfaceMac> create(PlaybackSessionInterfaceMac& playbackSessionInterface)
     {
@@ -110,6 +113,12 @@ public:
 
 private:
     WEBCORE_EXPORT VideoPresentationInterfaceMac(PlaybackSessionInterfaceMac&);
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+
     Ref<PlaybackSessionInterfaceMac> m_playbackSessionInterface;
     std::optional<MediaPlayerIdentifier> m_playerIdentifier;
     ThreadSafeWeakPtr<VideoPresentationModel> m_videoPresentationModel;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h
@@ -27,6 +27,7 @@
 #include "ExceptionOr.h"
 #include "MediaRecorderPrivateOptions.h"
 #include "RealtimeMediaSource.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 
@@ -49,7 +50,9 @@ struct MediaRecorderPrivateOptions;
 
 class MediaRecorderPrivate
     : public RealtimeMediaSource::AudioSampleObserver
-    , public RealtimeMediaSource::VideoFrameObserver {
+    , public RealtimeMediaSource::VideoFrameObserver
+    , public CanMakeCheckedPtr<MediaRecorderPrivate> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     ~MediaRecorderPrivate();
 
@@ -89,6 +92,11 @@ protected:
     bool shouldMuteVideo() const { return m_shouldMuteVideo; }
 
 private:
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+
     virtual void stopRecording(CompletionHandler<void()>&&) = 0;
     virtual void pauseRecording(CompletionHandler<void()>&&) = 0;
     virtual void resumeRecording(CompletionHandler<void()>&&) = 0;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
@@ -29,6 +29,7 @@
 #include "CAAudioStreamDescription.h"
 #include "MediaRecorderPrivate.h"
 #include "MediaRecorderPrivateWriterCocoa.h"
+#include <wtf/CheckedRef.h>
 
 using CVPixelBufferRef = struct __CVBuffer*;
 typedef const struct opaqueCMFormatDescription* CMFormatDescriptionRef;

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h
@@ -27,6 +27,8 @@
 #if ENABLE(MEDIA_RECORDER)
 
 #include "MediaRecorderPrivate.h"
+#include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Lock.h>
 #include <wtf/MediaTime.h>
 #include <wtf/text/StringBuilder.h>
@@ -37,6 +39,7 @@ class MediaStreamTrackPrivate;
 
 class WEBCORE_EXPORT MediaRecorderPrivateMock final
     : public MediaRecorderPrivate {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit MediaRecorderPrivateMock(MediaStreamPrivate&);
     ~MediaRecorderPrivateMock();

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
@@ -29,6 +29,7 @@
 
 #include "AudioTrackPrivate.h"
 #include "MediaStreamTrackPrivate.h"
+#include <wtf/CheckedRef.h>
 
 namespace WebCore {
 
@@ -37,7 +38,8 @@ class AudioMediaStreamTrackRenderer;
 class AudioTrackPrivateMediaStream final
     : public AudioTrackPrivate
     , public MediaStreamTrackPrivate::Observer
-    , private RealtimeMediaSource::AudioSampleObserver {
+    , private RealtimeMediaSource::AudioSampleObserver
+    , public CanMakeCheckedPtr<AudioTrackPrivateMediaStream> {
     WTF_MAKE_NONCOPYABLE(AudioTrackPrivateMediaStream)
 public:
     static Ref<AudioTrackPrivateMediaStream> create(MediaStreamTrackPrivate& streamTrack)
@@ -70,6 +72,11 @@ public:
 
 private:
     explicit AudioTrackPrivateMediaStream(MediaStreamTrackPrivate&);
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     static std::unique_ptr<AudioMediaStreamTrackRenderer> createRenderer(AudioTrackPrivateMediaStream&);
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -107,9 +107,14 @@ public:
 
         virtual void hasStartedProducingData() { }
     };
-    class AudioSampleObserver : public CanMakeCheckedPtr {
+    class AudioSampleObserver {
     public:
         virtual ~AudioSampleObserver() = default;
+
+        // CheckedPtr interface
+        virtual uint32_t ptrCount() const = 0;
+        virtual void incrementPtrCount() const = 0;
+        virtual void decrementPtrCount() const = 0;
 
         // May be called on a background thread.
         virtual void audioSamplesAvailable(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t /*numberOfFrames*/) = 0;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -33,6 +33,7 @@
 #include "VideoFrameGStreamer.h"
 #include "VideoFrameMetadataGStreamer.h"
 #include "VideoTrackPrivateMediaStream.h"
+#include <wtf/CheckedRef.h>
 
 #if USE(GSTREAMER_WEBRTC)
 #include "RealtimeIncomingAudioSourceGStreamer.h"
@@ -135,7 +136,8 @@ WEBKIT_DEFINE_ASYNC_DATA_STRUCT(InternalSourcePadProbeData)
 class InternalSource final : public MediaStreamTrackPrivate::Observer,
     public RealtimeMediaSource::Observer,
     public RealtimeMediaSource::AudioSampleObserver,
-    public RealtimeMediaSource::VideoFrameObserver {
+    public RealtimeMediaSource::VideoFrameObserver,
+    public CanMakeCheckedPtr<InternalSource> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     InternalSource(GstElement* parent, MediaStreamTrackPrivate& track, const String& padName, bool consumerIsVideoPlayer)
@@ -522,6 +524,11 @@ public:
     GstStream* stream() const { return m_stream.get(); }
 
 private:
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+
     void flush()
     {
         GST_DEBUG_OBJECT(m_src.get(), "Flushing");

--- a/Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h
@@ -30,6 +30,7 @@
 #include "MediaStreamTrackPrivate.h"
 #include "RealtimeMediaSource.h"
 #include "WebAudioSourceProviderCocoa.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/MediaTime.h>
 
 namespace WebCore {
@@ -37,13 +38,19 @@ namespace WebCore {
 class MediaStreamTrackAudioSourceProviderCocoa final
     : public WebAudioSourceProviderCocoa
     , MediaStreamTrackPrivate::Observer
-    , RealtimeMediaSource::AudioSampleObserver {
+    , RealtimeMediaSource::AudioSampleObserver
+    , public CanMakeCheckedPtr<MediaStreamTrackAudioSourceProviderCocoa> {
 public:
     static Ref<MediaStreamTrackAudioSourceProviderCocoa> create(MediaStreamTrackPrivate&);
     ~MediaStreamTrackAudioSourceProviderCocoa();
 
 private:
     explicit MediaStreamTrackAudioSourceProviderCocoa(MediaStreamTrackPrivate&);
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     // WebAudioSourceProviderCocoa
     void hasNewClient(AudioSourceProviderClient*) final;

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h
@@ -29,6 +29,7 @@
 
 #include "AudioSampleDataSource.h"
 #include "RealtimeOutgoingAudioSource.h"
+#include <wtf/CheckedRef.h>
 
 namespace webrtc {
 class AudioTrackInterface;
@@ -37,13 +38,18 @@ class AudioTrackSinkInterface;
 
 namespace WebCore {
 
-class RealtimeOutgoingAudioSourceCocoa final : public RealtimeOutgoingAudioSource {
+class RealtimeOutgoingAudioSourceCocoa final : public RealtimeOutgoingAudioSource, public CanMakeCheckedPtr<RealtimeOutgoingAudioSourceCocoa> {
 public:
     static Ref<RealtimeOutgoingAudioSourceCocoa> create(Ref<MediaStreamTrackPrivate>&& audioSource) { return adoptRef(*new RealtimeOutgoingAudioSourceCocoa(WTFMove(audioSource))); }
 
 private:
     explicit RealtimeOutgoingAudioSourceCocoa(Ref<MediaStreamTrackPrivate>&&);
     ~RealtimeOutgoingAudioSourceCocoa();
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     void audioSamplesAvailable(const MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t) final;
 

--- a/Source/WebCore/platform/network/curl/CurlMultipartHandleClient.h
+++ b/Source/WebCore/platform/network/curl/CurlMultipartHandleClient.h
@@ -29,8 +29,13 @@
 
 namespace WebCore {
 
-class CurlMultipartHandleClient : public CanMakeThreadSafeCheckedPtr {
+class CurlMultipartHandleClient {
 public:
+    // CheckedPtr interface
+    virtual uint32_t ptrCount() const = 0;
+    virtual void incrementPtrCount() const = 0;
+    virtual void decrementPtrCount() const = 0;
+
     virtual void didReceiveHeaderFromMultipart(Vector<String>&&) = 0;
     virtual void didReceiveDataFromMultipart(std::span<const uint8_t>) = 0;
     virtual void didCompleteFromMultipart() = 0;

--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -42,9 +42,9 @@ class NetworkLoadMetrics;
 class ResourceError;
 class FragmentedSharedBuffer;
 
-class CurlRequest : public ThreadSafeRefCounted<CurlRequest>, public CurlRequestSchedulerClient, public CurlMultipartHandleClient {
+class CurlRequest : public ThreadSafeRefCounted<CurlRequest>, public CurlRequestSchedulerClient, public CurlMultipartHandleClient, public CanMakeThreadSafeCheckedPtr<CurlRequest> {
     WTF_MAKE_NONCOPYABLE(CurlRequest);
-
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class CaptureNetworkLoadMetrics : uint8_t {
         Basic,
@@ -81,6 +81,11 @@ public:
 
 private:
     WEBCORE_EXPORT CurlRequest(const ResourceRequest&, CurlRequestClient*, CaptureNetworkLoadMetrics);
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeThreadSafeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeThreadSafeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeThreadSafeCheckedPtr::decrementPtrCount(); }
 
     void retain() override { ref(); }
     void release() override { deref(); }

--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -49,7 +49,7 @@ class DatabaseAuthorizer;
 class SQLiteStatement;
 class SQLiteTransaction;
 
-class SQLiteDatabase : public CanMakeThreadSafeCheckedPtr {
+class SQLiteDatabase : public CanMakeThreadSafeCheckedPtr<SQLiteDatabase> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(SQLiteDatabase);
     friend class SQLiteTransaction;

--- a/Source/WebCore/rendering/LegacyRootInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRootInlineBox);
 
-struct SameSizeAsLegacyRootInlineBox : LegacyInlineFlowBox, CanMakeWeakPtr<LegacyRootInlineBox>, CanMakeCheckedPtr {
+struct SameSizeAsLegacyRootInlineBox : LegacyInlineFlowBox, CanMakeWeakPtr<LegacyRootInlineBox>, CanMakeCheckedPtr<SameSizeAsLegacyRootInlineBox> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     int layoutUnits[4];

--- a/Source/WebCore/rendering/LegacyRootInlineBox.h
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.h
@@ -23,6 +23,7 @@
 #include "BidiContext.h"
 #include "LegacyInlineFlowBox.h"
 #include "RenderBox.h"
+#include <wtf/FastMalloc.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -34,7 +35,7 @@ class RenderBlockFlow;
 struct BidiStatus;
 struct GapRects;
 
-class LegacyRootInlineBox : public LegacyInlineFlowBox, public CanMakeWeakPtr<LegacyRootInlineBox>, public CanMakeCheckedPtr {
+class LegacyRootInlineBox : public LegacyInlineFlowBox, public CanMakeWeakPtr<LegacyRootInlineBox>, public CanMakeCheckedPtr<LegacyRootInlineBox> {
     WTF_MAKE_ISO_ALLOCATED(LegacyRootInlineBox);
 public:
     explicit LegacyRootInlineBox(RenderBlockFlow&);

--- a/Source/WebCore/rendering/MarkedText.h
+++ b/Source/WebCore/rendering/MarkedText.h
@@ -37,7 +37,7 @@ class RenderText;
 class RenderedDocumentMarker;
 struct TextBoxSelectableRange;
 
-struct MarkedText : public CanMakeCheckedPtr {
+struct MarkedText : public CanMakeCheckedPtr<MarkedText> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     // Sorted by paint order

--- a/Source/WebCore/rendering/RegionContext.h
+++ b/Source/WebCore/rendering/RegionContext.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class Path;
 
-class RegionContext : public CanMakeCheckedPtr {
+class RegionContext : public CanMakeCheckedPtr<RegionContext> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~RegionContext() = default;

--- a/Source/WebCore/rendering/RenderImageResource.h
+++ b/Source/WebCore/rendering/RenderImageResource.h
@@ -29,6 +29,7 @@
 #include "CachedResourceHandle.h"
 #include "StyleImage.h"
 #include <wtf/CheckedPtr.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/IsoMalloc.h>
 #include <wtf/WeakPtr.h>
 
@@ -37,7 +38,7 @@ namespace WebCore {
 class CachedImage;
 class RenderElement;
 
-class RenderImageResource : public CanMakeCheckedPtr {
+class RenderImageResource : public CanMakeCheckedPtr<RenderImageResource> {
     WTF_MAKE_NONCOPYABLE(RenderImageResource); WTF_MAKE_ISO_ALLOCATED(RenderImageResource);
 public:
     RenderImageResource();

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -151,7 +151,7 @@ struct ScrollRectToVisibleOptions {
 
 using ScrollingScope = uint64_t;
 
-class RenderLayer : public CanMakeSingleThreadWeakPtr<RenderLayer>, public CanMakeCheckedPtr {
+class RenderLayer : public CanMakeSingleThreadWeakPtr<RenderLayer>, public CanMakeCheckedPtr<RenderLayer> {
     WTF_MAKE_ISO_ALLOCATED(RenderLayer);
 public:
     friend class RenderReplica;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -110,7 +110,7 @@ RenderObject::SetLayoutNeededForbiddenScope::~SetLayoutNeededForbiddenScope()
 
 #endif
 
-struct SameSizeAsRenderObject : public CachedImageClient, public CanMakeCheckedPtr {
+struct SameSizeAsRenderObject : public CachedImageClient, public CanMakeCheckedPtr<SameSizeAsRenderObject> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     virtual ~SameSizeAsRenderObject() = default; // Allocate vtable pointer.

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -101,7 +101,7 @@ enum class RepaintOutlineBounds : bool { No, Yes };
 enum class RequiresFullRepaint : bool { No, Yes };
 
 // Base class for all rendering tree objects.
-class RenderObject : public CachedImageClient, public CanMakeCheckedPtr {
+class RenderObject : public CachedImageClient, public CanMakeCheckedPtr<RenderObject> {
     WTF_MAKE_COMPACT_ISO_ALLOCATED(RenderObject);
     friend class RenderBlock;
     friend class RenderBlockFlow;

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -67,7 +67,7 @@ class CustomPropertyRegistry;
 class Resolver;
 class RuleSet;
 
-class Scope : public CanMakeWeakPtr<Scope>, public CanMakeCheckedPtr {
+class Scope : public CanMakeWeakPtr<Scope>, public CanMakeCheckedPtr<Scope> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit Scope(Document&);

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -54,7 +54,7 @@ struct TextUpdate {
     std::optional<std::unique_ptr<RenderStyle>> inheritedDisplayContentsStyle;
 };
 
-class Update : public CanMakeCheckedPtr {
+class Update : public CanMakeCheckedPtr<Update> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     Update(Document&);

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -38,7 +38,7 @@ class SVGSVGElement;
 class SVGUseElement;
 class WeakPtrImplWithEventTargetData;
 
-class SVGDocumentExtensions : public CanMakeCheckedPtr {
+class SVGDocumentExtensions : public CanMakeCheckedPtr<SVGDocumentExtensions> {
     WTF_MAKE_NONCOPYABLE(SVGDocumentExtensions); WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit SVGDocumentExtensions(Document&);

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -44,6 +44,7 @@
 #include "TextIndicator.h"
 #include "VP9Utilities.h"
 #include <JavaScriptCore/Forward.h>
+#include <wtf/CheckedRef.h>
 
 #if ENABLE(VIDEO)
 #include "MediaElementSession.h"
@@ -185,6 +186,7 @@ class Internals final : public RefCounted<Internals>, private ContextDestruction
     , public RealtimeMediaSource::Observer
     , private RealtimeMediaSource::AudioSampleObserver
     , private RealtimeMediaSource::VideoFrameObserver
+    , public CanMakeCheckedPtr<Internals>
 #endif
     {
 public:
@@ -1459,6 +1461,14 @@ public:
 
 private:
     explicit Internals(Document&);
+
+#if ENABLE(MEDIA_STREAM)
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+#endif
+
     Document* contextDocument() const;
     LocalFrame* frame() const;
 

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.h
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.h
@@ -53,7 +53,7 @@ class WorkerConsoleClient;
 class WorkerOrWorkletGlobalScope;
 class WorkerScriptFetcher;
 
-class WorkerOrWorkletScriptController : public CanMakeCheckedPtr {
+class WorkerOrWorkletScriptController : public CanMakeCheckedPtr<WorkerOrWorkletScriptController> {
     WTF_MAKE_NONCOPYABLE(WorkerOrWorkletScriptController);
     WTF_MAKE_FAST_ALLOCATED;
 public:

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -83,7 +83,7 @@ struct WorkerFetchResult;
 class SWServer : public RefCounted<SWServer>, public CanMakeWeakPtr<SWServer> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    class Connection : public CanMakeWeakPtr<Connection>, public CanMakeCheckedPtr {
+    class Connection : public CanMakeWeakPtr<Connection>, public CanMakeCheckedPtr<Connection> {
         WTF_MAKE_FAST_ALLOCATED;
         friend class SWServer;
     public:

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.h
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.h
@@ -38,7 +38,7 @@ class SWServerWorker;
 class ServiceWorkerJob;
 struct WorkerFetchResult;
 
-class SWServerJobQueue : public CanMakeCheckedPtr {
+class SWServerJobQueue : public CanMakeCheckedPtr<SWServerJobQueue> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit SWServerJobQueue(SWServer&, const ServiceWorkerRegistrationKey&);

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -51,7 +51,7 @@ struct ServiceWorkerContextData;
 struct ServiceWorkerJobDataIdentifier;
 enum class WorkerThreadMode : bool;
 
-class SWServerToContextConnection: public CanMakeWeakPtr<SWServerToContextConnection>, public CanMakeCheckedPtr, public Identified<SWServerToContextConnectionIdentifier> {
+class SWServerToContextConnection: public CanMakeWeakPtr<SWServerToContextConnection>, public CanMakeCheckedPtr<SWServerToContextConnection>, public Identified<SWServerToContextConnectionIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT virtual ~SWServerToContextConnection();

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -31,6 +31,7 @@
 #include "XMLErrors.h"
 #include <libxml/tree.h>
 #include <libxml/xmlstring.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/text/AtomStringHash.h>
 #include <wtf/text/CString.h>
@@ -60,7 +61,7 @@ private:
     xmlParserCtxtPtr m_context;
 };
 
-class XMLDocumentParser final : public ScriptableDocumentParser, public PendingScriptClient {
+class XMLDocumentParser final : public ScriptableDocumentParser, public PendingScriptClient, public CanMakeCheckedPtr<XMLDocumentParser> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<XMLDocumentParser> create(Document& document, LocalFrameView* view, OptionSet<ParserContentPolicy> policy = DefaultParserContentPolicy)
@@ -90,6 +91,11 @@ public:
 private:
     explicit XMLDocumentParser(Document&, LocalFrameView*, OptionSet<ParserContentPolicy>);
     XMLDocumentParser(DocumentFragment&, HashMap<AtomString, AtomString>&&, const AtomString&, OptionSet<ParserContentPolicy>);
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     void insert(SegmentedString&&) final;
     void append(RefPtr<StringImpl>&&) final;

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
@@ -65,9 +65,14 @@ class DownloadManager {
     WTF_MAKE_NONCOPYABLE(DownloadManager);
 
 public:
-    class Client : public CanMakeCheckedPtr {
+    class Client {
     public:
         virtual ~Client() { }
+
+        // CheckedPtr interface
+        virtual uint32_t ptrCount() const = 0;
+        virtual void incrementPtrCount() const = 0;
+        virtual void decrementPtrCount() const = 0;
 
         virtual void didCreateDownload() = 0;
         virtual void didDestroyDownload() = 0;
@@ -75,6 +80,8 @@ public:
         virtual IPC::Connection* parentProcessConnectionForDownloads() = 0;
         virtual AuthenticationManager& downloadsAuthenticationManager() = 0;
         virtual NetworkSession* networkSession(PAL::SessionID) const = 0;
+
+        // RefPtr interface
         virtual void ref() const = 0;
         virtual void deref() const = 0;
     };

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -131,9 +131,10 @@ class Cache;
 enum class CacheOption : uint8_t;
 }
 
-class NetworkProcess : public AuxiliaryProcess, private DownloadManager::Client, public ThreadSafeRefCounted<NetworkProcess>
+class NetworkProcess : public AuxiliaryProcess, private DownloadManager::Client, public ThreadSafeRefCounted<NetworkProcess>, public CanMakeCheckedPtr<NetworkProcess>
 {
     WTF_MAKE_NONCOPYABLE(NetworkProcess);
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     using RegistrableDomain = WebCore::RegistrableDomain;
     using TopFrameDomain = WebCore::RegistrableDomain;
@@ -426,6 +427,11 @@ public:
     void setInspectionForServiceWorkersAllowed(PAL::SessionID, bool);
 
 private:
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+
     void platformInitializeNetworkProcess(const NetworkProcessCreationParameters&);
 
     void didReceiveNetworkProcessMessage(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -101,7 +101,7 @@ namespace NetworkCache {
 class Cache;
 }
 
-class NetworkSession : public WebCore::SWServerDelegate, public CanMakeCheckedPtr {
+class NetworkSession : public WebCore::SWServerDelegate, public CanMakeCheckedPtr<NetworkSession> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static std::unique_ptr<NetworkSession> create(NetworkProcess&, const NetworkSessionCreationParameters&);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
@@ -44,7 +44,7 @@ class DownloadManager;
 class NetworkLoad;
 class NetworkSession;
 
-class ServiceWorkerNavigationPreloader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerNavigationPreloader>, public CanMakeCheckedPtr {
+class ServiceWorkerNavigationPreloader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerNavigationPreloader>, public CanMakeCheckedPtr<ServiceWorkerNavigationPreloader> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     ServiceWorkerNavigationPreloader(NetworkSession&, NetworkLoadParameters&&, const WebCore::NavigationPreloadState&, bool shouldCaptureExtraNetworkLoadMetrics);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h
@@ -46,7 +46,7 @@ namespace WebKit {
 class NetworkLoad;
 class NetworkSession;
 
-class ServiceWorkerSoftUpdateLoader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerSoftUpdateLoader>, public CanMakeCheckedPtr {
+class ServiceWorkerSoftUpdateLoader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerSoftUpdateLoader>, public CanMakeCheckedPtr<ServiceWorkerSoftUpdateLoader> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     using Handler = CompletionHandler<void(WebCore::WorkerFetchResult&&)>;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -46,6 +46,7 @@
 #include <WebCore/ServiceWorkerTypes.h>
 #include <pal/SessionID.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/ThreadSafeWeakHashSet.h>
 
@@ -89,7 +90,8 @@ class ServiceWorkerStorageManager;
 class StorageAreaBase;
 class StorageAreaRegistry;
 
-class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver, public CanMakeCheckedPtr {
+class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver, public CanMakeCheckedPtr<NetworkStorageManager> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
     static bool canHandleTypes(OptionSet<WebsiteDataType>);

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -54,11 +54,6 @@ header: <wtf/text/AtomString.h>
     String string()
 }
 
-header: <wtf/CheckedRef.h>
-[CustomHeader, Nested] class WTF::CanMakeCheckedPtr {
-    [NotSerialized] uint32_t ptrCount();
-}
-
 [WebKitPlatform] class WTF::UUID {
     uint64_t high();
     [Validator='((static_cast<UInt128>(*high) << 64) | *low) != WTF::UUID::deletedValue'] uint64_t low();

--- a/Source/WebKit/Shared/WebPreferencesStore.h
+++ b/Source/WebKit/Shared/WebPreferencesStore.h
@@ -35,9 +35,9 @@
 
 namespace WebKit {
 
-struct WebPreferencesStore : public CanMakeCheckedPtr {
-    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+// FIXME: WebPreferencesStore should be RefCounted. See usage in WebProcessPool.cpp.
 
+struct WebPreferencesStore {
     using Value = std::variant<String, bool, uint32_t, double>;
     using ValueMap = MemoryCompactRobinHoodHashMap<String, Value>;
 
@@ -69,8 +69,8 @@ struct WebPreferencesStore : public CanMakeCheckedPtr {
     ValueMap m_values { };
     ValueMap m_overriddenDefaults { };
 
-    WebPreferencesStore isolatedCopy() const & { return { CanMakeCheckedPtr { }, crossThreadCopy(m_values), crossThreadCopy(m_overriddenDefaults) }; }
-    WebPreferencesStore isolatedCopy() && { return { CanMakeCheckedPtr { }, crossThreadCopy(WTFMove(m_values)), crossThreadCopy(WTFMove(m_overriddenDefaults)) }; }
+    WebPreferencesStore isolatedCopy() const & { return { crossThreadCopy(m_values), crossThreadCopy(m_overriddenDefaults) }; }
+    WebPreferencesStore isolatedCopy() && { return { crossThreadCopy(WTFMove(m_values)), crossThreadCopy(WTFMove(m_overriddenDefaults)) }; }
 
     static ValueMap& defaults();
 };

--- a/Source/WebKit/Shared/WebPreferencesStore.serialization.in
+++ b/Source/WebKit/Shared/WebPreferencesStore.serialization.in
@@ -20,7 +20,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-struct WebKit::WebPreferencesStore : WTF::CanMakeCheckedPtr {
+struct WebKit::WebPreferencesStore {
     WebKit::WebPreferencesStore::ValueMap m_values;
     WebKit::WebPreferencesStore::ValueMap m_overriddenDefaults;
 };

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -66,7 +66,7 @@ class AuxiliaryProcessProxy
     , public ResponsivenessTimer::Client
     , private ProcessLauncher::Client
     , public IPC::Connection::Client
-    , public CanMakeThreadSafeCheckedPtr {
+    , public CanMakeThreadSafeCheckedPtr<AuxiliaryProcessProxy> {
     WTF_MAKE_NONCOPYABLE(AuxiliaryProcessProxy);
 
 protected:

--- a/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h
+++ b/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h
@@ -47,8 +47,9 @@ class ExtensionCapabilityGranter : public CanMakeWeakPtr<ExtensionCapabilityGran
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(ExtensionCapabilityGranter);
 public:
-    struct Client : public CanMakeCheckedPtr {
+    struct Client : public CanMakeWeakPtr<Client> {
         virtual ~Client() = default;
+
         virtual RefPtr<GPUProcessProxy> gpuProcessForCapabilityGranter(const ExtensionCapabilityGranter&) = 0;
         virtual RefPtr<WebProcessProxy> webProcessForCapabilityGranter(const ExtensionCapabilityGranter&, const String& environmentIdentifier) = 0;
     };
@@ -65,7 +66,7 @@ private:
     friend UniqueRef<ExtensionCapabilityGranter> WTF::makeUniqueRefWithoutFastMallocCheck(Client&);
     explicit ExtensionCapabilityGranter(Client&);
 
-    CheckedPtr<Client> m_client;
+    WeakRef<Client> m_client;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -46,6 +46,7 @@
 #include <WebCore/WebAudioBufferList.h>
 #include <wtf/NativePromise.h>
 #include <wtf/UniqueRef.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/cocoa/Entitlements.h>
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, &m_connectionProxy->connection())
@@ -56,7 +57,8 @@ using namespace WebCore;
 class UserMediaCaptureManagerProxy::SourceProxy
     : public RealtimeMediaSource::Observer
     , private RealtimeMediaSource::AudioSampleObserver
-    , private RealtimeMediaSource::VideoFrameObserver {
+    , private RealtimeMediaSource::VideoFrameObserver
+    , public CanMakeCheckedPtr<UserMediaCaptureManagerProxy::SourceProxy> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     SourceProxy(RealtimeMediaSourceIdentifier id, Ref<IPC::Connection>&& connection, ProcessIdentity&& resourceOwner, Ref<RealtimeMediaSource>&& source, RefPtr<RemoteVideoFrameObjectHeap>&& videoFrameObjectHeap)
@@ -271,6 +273,12 @@ public:
     }
 
 private:
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+
     void sourceStopped() final {
         m_connection->send(Messages::UserMediaCaptureManager::SourceStopped(m_id, m_source->captureDidFail()), 0);
     }

--- a/Source/WebKit/UIProcess/DisplayLink.h
+++ b/Source/WebKit/UIProcess/DisplayLink.h
@@ -32,6 +32,7 @@
 #include <WebCore/DisplayUpdate.h>
 #include <WebCore/PlatformScreen.h>
 #include <wtf/CheckedPtr.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 
@@ -48,7 +49,8 @@ namespace WebKit {
 class DisplayLink {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    class Client : public CanMakeThreadSafeCheckedPtr {
+    class Client : public CanMakeThreadSafeCheckedPtr<Client> {
+        WTF_MAKE_FAST_ALLOCATED;
     friend class DisplayLink;
     public:
         virtual ~Client() = default;

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -30,6 +30,7 @@
 #include <WebCore/Color.h>
 #include <WebCore/FloatRect.h>
 #include <WebCore/InspectorFrontendClient.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
@@ -64,7 +65,8 @@ class WebView;
 class WebInspectorUIExtensionControllerProxy;
 #endif
 
-class RemoteWebInspectorUIProxyClient : public CanMakeWeakPtr<RemoteWebInspectorUIProxyClient>, public CanMakeCheckedPtr {
+class RemoteWebInspectorUIProxyClient : public CanMakeWeakPtr<RemoteWebInspectorUIProxyClient>, public CanMakeCheckedPtr<RemoteWebInspectorUIProxyClient> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     virtual ~RemoteWebInspectorUIProxyClient() { }
     virtual void sendMessageToBackend(const String& message) = 0;

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -47,7 +47,7 @@ static constexpr Seconds processSuspensionTimeout { 20_s };
 static constexpr Seconds removeAllAssertionsTimeout { 8_min };
 static constexpr Seconds processAssertionCacheLifetime { 1_s };
 
-class ProcessThrottler::ProcessAssertionCache : public CanMakeCheckedPtr {
+class ProcessThrottler::ProcessAssertionCache : public CanMakeCheckedPtr<ProcessThrottler::ProcessAssertionCache> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     void add(Ref<ProcessAssertion>&& assertion)

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -53,7 +53,7 @@ using LayerHostingContextID = uint32_t;
 
 enum class ShouldDelayClosingUntilFirstLayerFlush : bool { No, Yes };
 
-class SuspendedPageProxy final: public IPC::MessageReceiver, public CanMakeCheckedPtr {
+class SuspendedPageProxy final: public IPC::MessageReceiver, public CanMakeCheckedPtr<SuspendedPageProxy> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     SuspendedPageProxy(WebPageProxy&, Ref<WebProcessProxy>&&, Ref<WebFrameProxy>&& mainFrame, Ref<BrowsingContextGroup>&&, ShouldDelayClosingUntilFirstLayerFlush);

--- a/Source/WebKit/UIProcess/WebBackForwardCache.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.h
@@ -40,7 +40,7 @@ class WebPageProxy;
 class WebProcessPool;
 class WebProcessProxy;
 
-class WebBackForwardCache : public CanMakeCheckedPtr {
+class WebBackForwardCache : public CanMakeCheckedPtr<WebBackForwardCache> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit WebBackForwardCache(WebProcessPool&);

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -40,7 +40,7 @@ class ProcessThrottlerActivity;
 class WebProcessPool;
 class WebsiteDataStore;
 
-class WebProcessCache : public CanMakeCheckedPtr {
+class WebProcessCache : public CanMakeCheckedPtr<WebProcessCache> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit WebProcessCache(WebProcessPool&);

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -683,19 +683,20 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
         }
     }
 
-    CheckedPtr<const WebPreferencesStore> preferencesStore;
-    if (workerType == RemoteWorkerType::ServiceWorker) {
-        if (RefPtr preferences = websiteDataStore->serviceWorkerOverridePreferences())
-            preferencesStore = &preferences->store();
-    }
+    struct WebPreferencesStoreRef {
+        RefPtr<WebPreferences> webPreferences;
+        RefPtr<WebProcessPool> processPool;
+        RefPtr<WebPageGroup> webPageGroup;
+        const WebPreferencesStore& store;
+    } preferencesStore = [&] {
+        if (workerType == RemoteWorkerType::ServiceWorker && websiteDataStore->serviceWorkerOverridePreferences())
+            return WebPreferencesStoreRef { websiteDataStore->serviceWorkerOverridePreferences(), nullptr, nullptr, websiteDataStore->serviceWorkerOverridePreferences()->store() };
 
-    if (!preferencesStore && processPool->m_remoteWorkerPreferences)
-        preferencesStore = &processPool->m_remoteWorkerPreferences.value();
+        if (processPool->m_remoteWorkerPreferences)
+            return WebPreferencesStoreRef { nullptr, processPool.copyRef(), nullptr, *processPool->m_remoteWorkerPreferences };
 
-    if (!preferencesStore)
-        preferencesStore = &processPool->m_defaultPageGroup->preferences().store();
-
-    ASSERT(preferencesStore);
+        return WebPreferencesStoreRef { nullptr, nullptr, processPool->m_defaultPageGroup.copyRef(), processPool->m_defaultPageGroup->preferences().store() };
+    }();
 
     if (!remoteWorkerProcessProxy) {
         Ref newProcessProxy = WebProcessProxy::createForRemoteWorkers(workerType, processPool, RegistrableDomain  { registrableDomain }, *websiteDataStore, lockdownMode);
@@ -705,7 +706,7 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
 
         processPool->initializeNewWebProcess(newProcessProxy, websiteDataStore.get());
         processPool->m_processes.append(WTFMove(newProcessProxy));
-        remoteWorkerProcessProxy->initializePreferencesForNetworkProcess(*preferencesStore);
+        remoteWorkerProcessProxy->initializePreferencesForNetworkProcess(preferencesStore.store);
     }
 
     remoteWorkerProcessProxy->addAllowedFirstPartyForCookies(registrableDomain);
@@ -715,7 +716,7 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
 
     websiteDataStore->networkProcess().sendWithAsyncReply(Messages::NetworkProcess::AddAllowedFirstPartyForCookies(remoteWorkerProcessProxy->coreProcessIdentifier(), registrableDomain, LoadedWebArchive::No), [aggregator] { });
 
-    remoteWorkerProcessProxy->establishRemoteWorkerContext(workerType, *preferencesStore, registrableDomain, serviceWorkerPageIdentifier, [aggregator] { });
+    remoteWorkerProcessProxy->establishRemoteWorkerContext(workerType, preferencesStore.store, registrableDomain, serviceWorkerPageIdentifier, [aggregator] { });
 
     if (!processPool->m_remoteWorkerUserAgent.isNull())
         remoteWorkerProcessProxy->setRemoteWorkerUserAgent(processPool->m_remoteWorkerUserAgent);

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -156,6 +156,10 @@ class WebProcessPool final
 #endif
 {
 public:
+    using IPC::MessageReceiver::weakPtrFactory;
+    using IPC::MessageReceiver::WeakValueType;
+    using IPC::MessageReceiver::WeakPtrImplType;
+
     static Ref<WebProcessPool> create(API::ProcessPoolConfiguration&);
 
     explicit WebProcessPool(API::ProcessPoolConfiguration&);        

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -43,6 +43,8 @@
 #import <WebCore/PlaybackSessionInterfaceAVKit.h>
 #import <WebCore/VideoPresentationInterfaceAVKit.h>
 #import <pal/spi/cocoa/AVKitSPI.h>
+#import <wtf/CheckedRef.h>
+#import <wtf/FastMalloc.h>
 #import <wtf/MonotonicTime.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>
@@ -61,7 +63,8 @@ static const Seconds bannerMinimumHideDelay = 1_s;
 
 @class WKFullscreenStackView;
 
-class WKFullScreenViewControllerPlaybackSessionModelClient : WebCore::PlaybackSessionModelClient {
+class WKFullScreenViewControllerPlaybackSessionModelClient : WebCore::PlaybackSessionModelClient, public CanMakeCheckedPtr<WKFullScreenViewControllerPlaybackSessionModelClient> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     void setParent(WKFullScreenViewController *parent) { m_parent = parent; }
 
@@ -94,6 +97,11 @@ public:
     }
 
 private:
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+
     WeakObjCPtr<WKFullScreenViewController> m_parent;
     RefPtr<WebCore::PlaybackSessionInterfaceIOS> m_interface;
 };

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -182,7 +182,7 @@ typedef id <NSValidatedUserInterfaceItem> ValidationItem;
 typedef Vector<RetainPtr<ValidationItem>> ValidationVector;
 typedef HashMap<String, ValidationVector> ValidationMap;
 
-class WebViewImpl : public CanMakeWeakPtr<WebViewImpl>, public CanMakeCheckedPtr {
+class WebViewImpl : public CanMakeWeakPtr<WebViewImpl>, public CanMakeCheckedPtr<WebViewImpl> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(WebViewImpl);
 public:

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
@@ -38,6 +38,7 @@ namespace WebKit {
 class WebView;
 
 class WebPopupMenuProxyWin : public WebPopupMenuProxy, private WebCore::ScrollableArea {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     static Ref<WebPopupMenuProxyWin> create(WebView* webView, WebPopupMenuProxy::Client& client)
     {

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -35,6 +35,7 @@
 #include "WebProcess.h"
 #include <WebCore/RealtimeMediaSource.h>
 #include <WebCore/SpeechRecognitionCaptureSource.h>
+#include <wtf/CheckedRef.h>
 
 #if PLATFORM(COCOA)
 #include "SharedCARingBuffer.h"
@@ -56,6 +57,7 @@ using namespace WebCore;
 class SpeechRecognitionRealtimeMediaSourceManager::Source
     : private RealtimeMediaSource::Observer
     , private RealtimeMediaSource::AudioSampleObserver
+    , public CanMakeCheckedPtr<SpeechRecognitionRealtimeMediaSourceManager::Source>
 {
     WTF_MAKE_FAST_ALLOCATED;
 public:
@@ -85,6 +87,11 @@ public:
     }
 
 private:
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+
     void sourceStopped() final
     {
         if (m_source->captureDidFail()) {

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -34,6 +34,7 @@
 #include <WebCore/PlatformCALayer.h>
 #include <WebCore/PlatformMediaSession.h>
 #include <WebCore/PlaybackSessionModelMediaElement.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
@@ -57,7 +58,8 @@ class PlaybackSessionManager;
 
 class PlaybackSessionInterfaceContext final
     : public RefCounted<PlaybackSessionInterfaceContext>
-    , public WebCore::PlaybackSessionModelClient {
+    , public WebCore::PlaybackSessionModelClient
+    , public CanMakeCheckedPtr<PlaybackSessionInterfaceContext> {
 public:
     static Ref<PlaybackSessionInterfaceContext> create(PlaybackSessionManager& manager, PlaybackSessionContextIdentifier contextId)
     {
@@ -69,6 +71,11 @@ public:
 
 private:
     friend class VideoPresentationInterfaceContext;
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     // PlaybackSessionModelClient
     void durationChanged(double) final;

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -34,6 +34,7 @@
 #include <WebCore/HTMLMediaElementEnums.h>
 #include <WebCore/PlatformCALayer.h>
 #include <WebCore/VideoPresentationModelVideoElement.h>
+#include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
@@ -68,7 +69,8 @@ class VideoPresentationManager;
 
 class VideoPresentationInterfaceContext
     : public RefCounted<VideoPresentationInterfaceContext>
-    , public WebCore::VideoPresentationModelClient {
+    , public WebCore::VideoPresentationModelClient
+    , public CanMakeCheckedPtr<VideoPresentationInterfaceContext> {
 public:
     static Ref<VideoPresentationInterfaceContext> create(VideoPresentationManager& manager, PlaybackSessionContextIdentifier contextId)
     {
@@ -101,6 +103,12 @@ public:
 private:
     // VideoPresentationModelClient
     void hasVideoChanged(bool) override;
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+
     void videoDimensionsChanged(const WebCore::FloatSize&) override;
     void setPlayerIdentifier(std::optional<WebCore::MediaPlayerIdentifier>) final;
 

--- a/Source/WebKitLegacy/Storage/StorageThread.h
+++ b/Source/WebKitLegacy/Storage/StorageThread.h
@@ -37,7 +37,7 @@ namespace WebCore {
 class StorageAreaSync;
 class StorageTask;
 
-class StorageThread : public CanMakeCheckedPtr {
+class StorageThread : public CanMakeCheckedPtr<StorageThread> {
     WTF_MAKE_NONCOPYABLE(StorageThread); WTF_MAKE_FAST_ALLOCATED;
 public:
     enum class Type { LocalStorage, IndexedDB };

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
@@ -83,7 +83,7 @@ private:
     bool isSuspendingPendingRequests() const { return !!m_suspendPendingRequestsCount; }
     void isResourceLoadFinished(WebCore::CachedResource&, CompletionHandler<void(bool)>&&) final;
 
-    class HostInformation : public CanMakeWeakPtr<HostInformation>, public CanMakeCheckedPtr {
+    class HostInformation : public CanMakeWeakPtr<HostInformation>, public CanMakeCheckedPtr<HostInformation> {
         WTF_MAKE_NONCOPYABLE(HostInformation); WTF_MAKE_FAST_ALLOCATED;
     public:
         HostInformation(const String&, unsigned);

--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
@@ -27,6 +27,7 @@
 
 #include "Utilities.h"
 #include <wtf/CheckedPtr.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/Threading.h>
@@ -35,7 +36,8 @@
 
 namespace TestWebKitAPI {
 
-class CheckedObject : public CanMakeCheckedPtr {
+class CheckedObject : public CanMakeCheckedPtr<CheckedObject> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     int someFunction() const { return -7; }
 };
@@ -348,7 +350,8 @@ TEST(WTF_CheckedPtr, ReferenceCountLimit)
     EXPECT_EQ(object.ptrCount(), count);
 }
 
-class ThreadSafeCheckedPtrObject : public CanMakeThreadSafeCheckedPtr {
+class ThreadSafeCheckedPtrObject : public CanMakeThreadSafeCheckedPtr<ThreadSafeCheckedPtrObject> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     std::atomic<unsigned> value { 0 };
 };

--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedRef.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedRef.cpp
@@ -27,6 +27,7 @@
 
 #include "Utilities.h"
 #include <wtf/CheckedRef.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
 
@@ -34,8 +35,9 @@ namespace TestWebKitAPI {
 
 namespace {
 
-class CheckedObject : public CanMakeCheckedPtr {
+class CheckedObject : public CanMakeCheckedPtr<CheckedObject> {
     WTF_MAKE_NONCOPYABLE(CheckedObject);
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     CheckedObject(int value = -7)
         : m_value(value)

--- a/Tools/TestWebKitAPI/Tests/WTF/Hasher.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Hasher.cpp
@@ -27,7 +27,9 @@
 
 #include <array>
 #include <limits>
-#include <wtf/CheckedPtr.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/Compiler.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/Hasher.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
@@ -229,30 +231,35 @@ TEST(WTF, Hasher_RefPtr)
     EXPECT_EQ(computeHash(refPtrVector), computeHash(ptrVector));
 }
 
+namespace {
+
+struct CheckedObject : public CanMakeCheckedPtr<CheckedObject> {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    CheckedObject() = default;
+};
+
+}
+
 TEST(WTF, Hasher_CheckedPtr)
 {
-    struct Test : public CanMakeCheckedPtr {
-        Test() = default;
-    };
+    CheckedObject test;
+    CheckedObject test2;
 
-    Test test;
-    Test test2;
-
-    CheckedPtr<Test> nullCheckedPtr;
-    CheckedPtr<Test> nonNullCheckedPtr = &test;
+    CheckedPtr<CheckedObject> nullCheckedPtr;
+    CheckedPtr<CheckedObject> nonNullCheckedPtr = &test;
 
     EXPECT_EQ(computeHash(nullCheckedPtr), computeHash(nullCheckedPtr.get()));
     EXPECT_EQ(computeHash(nonNullCheckedPtr), computeHash(nonNullCheckedPtr.get()));
 
-    Vector<CheckedPtr<Test>> checkedPtrVector;
-    Vector<Test*> ptrVector;
+    Vector<CheckedPtr<CheckedObject>> checkedPtrVector;
+    Vector<CheckedObject*> ptrVector;
     EXPECT_EQ(computeHash(checkedPtrVector), computeHash(ptrVector));
 
     checkedPtrVector.append(nonNullCheckedPtr);
     ptrVector.append(nonNullCheckedPtr.get());
     EXPECT_EQ(computeHash(checkedPtrVector), computeHash(ptrVector));
 
-    CheckedPtr<Test> nonNullCheckedPtr2 = &test2;
+    CheckedPtr<CheckedObject> nonNullCheckedPtr2 = &test2;
 
     checkedPtrVector.append(nonNullCheckedPtr2);
     ptrVector.append(nonNullCheckedPtr2.get());

--- a/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
@@ -59,7 +59,8 @@ static CurlResponse createCurlResponse(std::optional<String> contentType = "mult
     return response;
 }
 
-class MultipartHandleClient : public CurlMultipartHandleClient {
+class MultipartHandleClient : public CurlMultipartHandleClient, public CanMakeCheckedPtr<MultipartHandleClient> {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     void setMultipartHandle();
 
@@ -91,6 +92,11 @@ public:
     bool complete() { return m_didComplete; }
 
 private:
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr<MultipartHandleClient>::ptrCount(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr<MultipartHandleClient>::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr<MultipartHandleClient>::decrementPtrCount(); }
+
     Vector<String> m_headers;
     Vector<uint8_t> m_data;
     bool m_didComplete { false };


### PR DESCRIPTION
#### 8b7d41505065a3dacb612e0dc4112df118590c05
<pre>
CheckedPtr should require FastMalloc, Part 2
<a href="https://bugs.webkit.org/show_bug.cgi?id=271993">https://bugs.webkit.org/show_bug.cgi?id=271993</a>
<a href="https://rdar.apple.com/125737157">rdar://125737157</a>

Reviewed by Ryosuke Niwa.

This will enable zombie-mode CheckedPtr.

It&apos;s also just good performance hygiene.

The two major changes in this patch are:

(1) Declare your type when you inherit from CanMakeCheckedPtr, like we do for
RefCounted and CanMakeWeakPtr. We use this to do our FastMalloc static_assert.
(In future, I also plan to use this type to share our implementation with other
lifetime schemes.) Fixed any classes that violated the FastMalloc static_assert.

(2) Moved CanMakeCheckedPtr down from abstract base classes into concrete
subclasses. It&apos;s not possible for abstract base classes to require or
demonstrate that a class uses FastMalloc, or has any other concrete allocation
or destruction behavior. Abstract base classes that require a CheckedPtr
interface now make that part of their abstract API. (In future we need to do
this for CanMakeWeakPtr too. We&apos;ve already done it for RefCounted.) It&apos;s a bit
more obvious now which classes have overlapping / wasteful lifetime
implementations. We can clean that up soon.

* Source/WTF/wtf/CheckedRef.h:

(WTF::CanMakeCheckedPtrBase::~CanMakeCheckedPtrBase): Moved the FastMalloc
assertion here because CheckedPtr needs to support abstract base classes that
don&apos;t know how they&apos;re allocated. This is logically clearer: CheckedPtr just
invokes your checking API and doesn&apos;t care how you check; only CanMakeCheckedPtr
will depend on FastMalloc.

* Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h: (2)

* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/animation/DocumentTimelinesController.h:
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/dom/CustomElementDefaultARIA.h:
* Source/WebCore/dom/CustomElementReactionQueue.h:
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/dom/ExtensionStyleSheets.h:
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/dom/IdTargetObserver.h:
* Source/WebCore/dom/IdTargetObserverRegistry.h: (1)

* Source/WebCore/dom/PendingScriptClient.h: (2)
* Source/WebCore/dom/RejectedPromiseTracker.h: (1)
* Source/WebCore/dom/ScriptRunner.h: (2)

* Source/WebCore/dom/VisitedLinkState.h:
* Source/WebCore/dom/messageports/MessagePortChannelRegistry.h:
* Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h:
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/editing/TextManipulationController.h:
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/history/CachedPage.h: (1)

* Source/WebCore/html/parser/HTMLDocumentParser.h: (2)

* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
* Source/WebCore/layout/layouttree/LayoutBox.h:
(WebCore::Layout::Box::incrementPtrCount const): Deleted.
(WebCore::Layout::Box::decrementPtrCount const): Deleted.
* Source/WebCore/loader/FrameLoader.cpp:
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/loader/NavigationScheduler.h:
* Source/WebCore/loader/ProgressTracker.h:
* Source/WebCore/loader/ThreadableLoaderClient.h:
* Source/WebCore/page/AlternativeTextClient.h:
* Source/WebCore/page/DeviceController.h:
* Source/WebCore/page/DiagnosticLoggingClient.h:
* Source/WebCore/page/EditorClient.h:
* Source/WebCore/page/ElementTargetingController.h:
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/FocusController.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/PageConsoleClient.h:
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
* Source/WebCore/platform/KeyboardScrollingAnimator.h:
* Source/WebCore/platform/OrientationNotifier.h:
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/platform/ScrollableArea.cpp:
* Source/WebCore/platform/ScrollableArea.h: (1)

* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
* Source/WebCore/platform/cocoa/VideoPresentationModel.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm: (2)

* Source/WebCore/platform/graphics/DisplayRefreshMonitorClient.h: (1)

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::FontCascade):
(WebCore::GlyphToPathTranslator::containsMorePaths):
(WebCore::GlyphToPathTranslator::path):
(WebCore::GlyphToPathTranslator::extents):
(WebCore::GlyphToPathTranslator::advance):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/GlyphBuffer.h: Removed the recently added ability to
use CheckedPtr&lt;GlyphBuffer&gt;. GlyphBuffer is stack-allocated so it can&apos;t
participate in a zombie-mode lifetime scheme. We&apos;ll have to solve GlyphBuffer
another way later. (Chris said he&apos;s OK with this.)

* Source/WebCore/platform/graphics/TextRun.cpp:
* Source/WebCore/platform/graphics/TextRun.h:
* Source/WebCore/platform/graphics/TiledBacking.h: (1)

* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::commitCurrentFontRange): See GlyphBuffer.h

* Source/WebCore/platform/graphics/ca/LayerPool.h: (1)
* Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h:
* Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h:
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h:
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h:
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h: (2)

* Source/WebCore/platform/network/curl/CurlMultipartHandleClient.h:
* Source/WebCore/platform/sql/SQLiteDatabase.h:
* Source/WebCore/rendering/LegacyRootInlineBox.cpp:
* Source/WebCore/rendering/LegacyRootInlineBox.h:
* Source/WebCore/rendering/MarkedText.h:
* Source/WebCore/rendering/RegionContext.h:
* Source/WebCore/rendering/RenderImageResource.h:
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleUpdate.h:
* Source/WebCore/svg/SVGDocumentExtensions.h: (1)

* Source/WebCore/testing/Internals.h: (2)
* Source/WebCore/workers/WorkerOrWorkletScriptController.h:
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/service/server/SWServerJobQueue.h:
* Source/WebCore/workers/service/server/SWServerToContextConnection.h: (1)

* Source/WebCore/xml/parser/XMLDocumentParser.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadManager.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h: (2)

* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPreferencesStore.h:
(WebKit::WebPreferencesStore::isolatedCopy const):
(WebKit::WebPreferencesStore::isolatedCopy):
* Source/WebKit/Shared/WebPreferencesStore.serialization.in:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.h: (1)

* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp: (2)

* Source/WebKit/UIProcess/DisplayLink.h:
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
* Source/WebKit/UIProcess/WebBackForwardCache.h:
* Source/WebKit/UIProcess/WebProcessCache.h: (1)

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess):
WebPreferencesStore&amp; can&apos;t use zombie-mode CheckedPtr because it&apos;s an interior
object pointer. For now, we can accuratrely represent lifetime by explicitly
ref&apos;ing its owner. Later, we should just change it to be refcounted.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h: (2)

* Source/WebKitLegacy/Storage/StorageThread.h:
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h:
* Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp:
* Tools/TestWebKitAPI/Tests/WTF/CheckedRef.cpp:
* Tools/TestWebKitAPI/Tests/WTF/Hasher.cpp:
(TestWebKitAPI::TEST(WTF, Hasher_CheckedPtr)): (1)

Canonical link: <a href="https://commits.webkit.org/277020@main">https://commits.webkit.org/277020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57356d21c37f6e0f6249b177c21ca08135fd5cc1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49087 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42453 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48719 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37884 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19125 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41127 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4457 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/39654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50918 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45889 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45121 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22708 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44052 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53037 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6479 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22407 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10870 "Passed tests") | 
<!--EWS-Status-Bubble-End-->