### PR TITLE
Make default safety of align-content on block containers that are scroll containers unsafe.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-overflow-000-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-overflow-000-expected.html
@@ -50,8 +50,8 @@
 </div>
 <div class="wrapper">
   <div class="test">
-    <div class="float">FLT</div>
-    <div style="padding-top: 0.5em; margin-bottom: -0.5em"></div>
+    <div class="float" style="margin-top: -0.6em">FLT</div>
+    <div style="margin-bottom: -0.6em"></div>
     <div class="in-flow">
       <div class="float">FLT</div>
       <span class="label">CENTER</span>
@@ -63,9 +63,9 @@
 </div>
 <div class="wrapper">
   <div class="test">
-    <div class="float">FLT</div>
-    <div style="padding-top: 0.5em; margin-bottom: -0.5em"></div>
+    <div style="margin-bottom: -1.2em"></div>
     <div class="in-flow">
+      <div class="float" style="margin-top: -1em">FLT</div>
       <div class="float">FLT</div>
       <span class="label">END</span>
       <span class="abspos">ABS</span>
@@ -89,9 +89,9 @@
 </div>
 <div class="wrapper">
   <div class="test">
-    <div class="float">FLT</div>
-    <div style="padding-top: 0.5em; margin-bottom: -0.5em"></div>
+    <div style="margin-bottom: -1.2em"></div>
     <div class="in-flow">
+      <div class="float" style="margin-top: -1em">FLT</div>
       <div class="float">FLT</div>
       <span class="label">LAST BASELINE</span>
       <span class="abspos">ABS</span>
@@ -115,9 +115,9 @@
 </div>
 <div class="wrapper">
   <div class="test">
-    <div class="float">FLT</div>
-    <div style="padding-top: 0.5em; margin-bottom: -0.5em"></div>
+    <div style="margin-bottom: -1.2em"></div>
     <div class="in-flow">
+      <div class="float" style="margin-top: -1em">FLT</div>
       <div class="float">FLT</div>
       <span class="label">FLEX-END</span>
       <span class="abspos">ABS</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-overflow-000-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-overflow-000-ref.html
@@ -50,8 +50,8 @@
 </div>
 <div class="wrapper">
   <div class="test">
-    <div class="float">FLT</div>
-    <div style="padding-top: 0.5em; margin-bottom: -0.5em"></div>
+    <div class="float" style="margin-top: -0.6em">FLT</div>
+    <div style="margin-bottom: -0.6em"></div>
     <div class="in-flow">
       <div class="float">FLT</div>
       <span class="label">CENTER</span>
@@ -63,9 +63,9 @@
 </div>
 <div class="wrapper">
   <div class="test">
-    <div class="float">FLT</div>
-    <div style="padding-top: 0.5em; margin-bottom: -0.5em"></div>
+    <div style="margin-bottom: -1.2em"></div>
     <div class="in-flow">
+      <div class="float" style="margin-top: -1em">FLT</div>
       <div class="float">FLT</div>
       <span class="label">END</span>
       <span class="abspos">ABS</span>
@@ -89,9 +89,9 @@
 </div>
 <div class="wrapper">
   <div class="test">
-    <div class="float">FLT</div>
-    <div style="padding-top: 0.5em; margin-bottom: -0.5em"></div>
+    <div style="margin-bottom: -1.2em"></div>
     <div class="in-flow">
+      <div class="float" style="margin-top: -1em">FLT</div>
       <div class="float">FLT</div>
       <span class="label">LAST BASELINE</span>
       <span class="abspos">ABS</span>
@@ -115,9 +115,9 @@
 </div>
 <div class="wrapper">
   <div class="test">
-    <div class="float">FLT</div>
-    <div style="padding-top: 0.5em; margin-bottom: -0.5em"></div>
+    <div style="margin-bottom: -1.2em"></div>
     <div class="in-flow">
+      <div class="float" style="margin-top: -1em">FLT</div>
       <div class="float">FLT</div>
       <span class="label">FLEX-END</span>
       <span class="abspos">ABS</span>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-alignment-block-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-alignment-block-001.html
@@ -158,7 +158,7 @@
     <th scope=row>
       safe end
 
-  <tr class="start align-center">
+  <tr class="center align-center">
     <td>
       <div class="test ltr htb no-scroll"><div class="indicator"><div class=tl></div><div class=tc></div><div class=tr></div><div class=cl></div><div class=cc></div><div class=cr></div><div class=bl></div><div class=bc></div><div class=br></div></div></div>
     <td>
@@ -175,7 +175,7 @@
       center
 
 
-  <tr class="start align-end">
+  <tr class="end align-end">
     <td>
       <div class="test ltr htb no-scroll"><div class="indicator"><div class=tl></div><div class=tc></div><div class=tr></div><div class=cl></div><div class=cc></div><div class=cr></div><div class=bl></div><div class=bc></div><div class=br></div></div></div>
     <td>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -672,8 +672,13 @@ inline LayoutUnit RenderBlockFlow::shiftForAlignContent(LayoutUnit intrinsicLogi
     // Calculate alignment shift.
     LayoutUnit computedLogicalHeight = logicalHeight();
     LayoutUnit space = computedLogicalHeight - intrinsicLogicalHeight;
-    if (space <= 0 && OverflowAlignment::Unsafe != alignment.overflow())
-        return 0_lu; // Floored at zero; we're done
+    if (space <= 0) {
+        bool overflowIsSafe = (alignment.overflow() == OverflowAlignment::Default && !isScrollContainerY())
+            || alignment.overflow() == OverflowAlignment::Safe
+            || alignment.position() == ContentPosition::Normal;
+        if (overflowIsSafe)
+            return 0_lu; // Floored at zero; we're done
+    }
     if (alignment.isCentered())
         space = space / 2;
 
@@ -4445,8 +4450,7 @@ LayoutOptionalOutsets RenderBlockFlow::allowedLayoutOverflow() const
 {
     LayoutOptionalOutsets allowance = RenderBox::allowedLayoutOverflow();
 
-    auto alignment = style().alignContent();
-    if (!alignment.isNormal() && OverflowAlignment::Unsafe == alignment.overflow()) {
+    if (style().alignContent().position() != ContentPosition::Normal) {
         if (hasRareBlockFlowData()) {
             if (isHorizontalWritingMode())
                 allowance.setTop(-rareBlockFlowData()->m_alignContentShift);


### PR DESCRIPTION
#### fd49ec9a304465a0e383ecd001823c9cc354cb38
<pre>
Make default safety of align-content on block containers that are scroll containers unsafe.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272002">https://bugs.webkit.org/show_bug.cgi?id=272002</a>
<a href="https://rdar.apple.com/problem/125742095">rdar://problem/125742095</a>

Reviewed by Simon Fraser.

Tweaks the align-content safety checks for RenderBlockFlow to assume
&quot;unsafe&quot; rather than &quot;safe&quot; alignment on scroll containers.

* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-overflow-000-expected.html: Adjust expectations.
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-overflow-000-ref.html: Adjust expectations.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-alignment-block-001.html: Adjust expectations.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::shiftForAlignContent): Check for &apos;safe&apos; and content distribution explicitly, limit default safety check to non-scroll-containers.
(WebCore::RenderBlockFlow::allowedLayoutOverflow const): Simplify short-circuit alignment check.

Canonical link: <a href="https://commits.webkit.org/276929@main">https://commits.webkit.org/276929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/620daaf73933ad9532210d36ec5d81a80f47722e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48855 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42225 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48491 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37736 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18943 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40923 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4228 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42478 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50653 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17667 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44913 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22480 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/39982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43822 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10226 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22839 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->