### PR TITLE
Try to fix the visionOS build

### DIFF
--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaKitExtras.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaKitExtras.swift
@@ -30,14 +30,14 @@ import UIKit
 @objc extension PlayableViewController {
     var wks_automaticallyDockOnFullScreenPresentation: Bool {
         get {
-#if canImport(LinearMediaKit, _version: 212)
+#if canImport(LinearMediaKit, _version: 211.0.2)
             self.automaticallyDockOnFullScreenPresentation
 #else
             false
 #endif
         }
         set {
-#if canImport(LinearMediaKit, _version: 212)
+#if canImport(LinearMediaKit, _version: 211.0.2)
             self.automaticallyDockOnFullScreenPresentation = newValue
 #endif
         }
@@ -45,21 +45,21 @@ import UIKit
 
     var wks_dismissFullScreenOnExitingDocking: Bool {
         get {
-#if canImport(LinearMediaKit, _version: 212)
+#if canImport(LinearMediaKit, _version: 211.0.2)
             self.dismissFullScreenOnExitingDocking
 #else
             false
 #endif
         }
         set {
-#if canImport(LinearMediaKit, _version: 212)
+#if canImport(LinearMediaKit, _version: 211.0.2)
             self.dismissFullScreenOnExitingDocking = newValue
 #endif
         }
     }
 
     var wks_environmentPickerButtonViewController: UIViewController? {
-#if canImport(LinearMediaKit, _version: 212)
+#if canImport(LinearMediaKit, _version: 211.0.2)
         self.environmentPickerButtonViewController
 #else
         nil


### PR DESCRIPTION
#### 122f2bd05db439925e762f681d12f4128f39e836
<pre>
Try to fix the visionOS build
<a href="https://bugs.webkit.org/show_bug.cgi?id=272007">https://bugs.webkit.org/show_bug.cgi?id=272007</a>
<a href="https://rdar.apple.com/125747739">rdar://125747739</a>

Unreviewed build fix after 276898@main.

* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaKitExtras.swift:
(PlayableViewController.wks_automaticallyDockOnFullScreenPresentation):
(PlayableViewController.wks_dismissFullScreenOnExitingDocking):
(PlayableViewController.wks_environmentPickerButtonViewController):

Canonical link: <a href="https://commits.webkit.org/276915@main">https://commits.webkit.org/276915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60c63ae2ef6f1162d66821240138ec7a03f72f5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46173 "Failed to checkout and rebase branch from PR 26706") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/25304 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/48758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/48844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/42214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/29633 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/22747 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/48844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46751 "Failed to checkout and rebase branch from PR 26706") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/29633 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/48758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/48844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/29633 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/48758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/4217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/29633 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/48758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/50640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/22747 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/50640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/48758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/50640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6429 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/22163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->