### PR TITLE
Web Extension objects should return the same JS wrapper (Bitwarden popup never loads).

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm
@@ -153,6 +153,33 @@ TEST(WKWebExtensionAPINamespace, NotificationsUnsupported)
     [manager loadAndRun];
 }
 
+
+TEST(WKWebExtensionAPINamespace, ObjectEquality)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"permissions": @[ @"storage", @"tabs" ],
+        @"background": @{
+            @"scripts": @[ @"background.js" ],
+            @"type": @"module",
+            @"persistent": @NO
+        }
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertEq(browser.storage, browser.storage)",
+        @"browser.test.assertEq(browser.storage.local, browser.storage.local)",
+        @"browser.test.assertEq(browser.storage.session, browser.storage.session)",
+        @"browser.test.assertEq(browser.storage.sync, browser.storage.sync)",
+        @"browser.test.assertEq(browser.tabs, browser.tabs)",
+        @"browser.test.assertEq(browser.windows, browser.windows)",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    Util::loadAndRunExtension(manifest, @{ @"background.js": backgroundScript });
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### fe7e1f64e14ecf2830f1a88c03276cbf25821cbf
<pre>
Web Extension objects should return the same JS wrapper (Bitwarden popup never loads).
<a href="https://webkit.org/b/272006">https://webkit.org/b/272006</a>
<a href="https://rdar.apple.com/125633239">rdar://125633239</a>

Reviewed by Brian Weinstein.

Make a cache per global context that we use to return the same wrapper for the JSWebExtensionWrappable
objects, that way equality checks in JavaScript will succeed.

This was breaking Bitwarden because they are doing a switch on the storage objects to get the
name, and since equality wasn&apos;t true, the switch would fail.

    switch (e) {
    case chrome.storage.local:
        return &quot;local&quot;;
    case chrome.storage.sync:
        return &quot;sync&quot;;
    case chrome.storage.session:
        return &quot;session&quot;;
    default:
        throw new Error(&quot;Unknown storage location&quot;)
    }

* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::wrapperCache): Added.
(WebKit::cacheMapDestroyed): Added.
(WebKit::wrapperCacheMap): Added.
(WebKit::getCachedWrapper): Added.
(WebKit::JSWebExtensionWrapper::wrap): Lookup and add the wrapper to the cache.
(WebKit::JSWebExtensionWrapper::finalize): Set private to nullptr.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPINamespace.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPINamespace, ObjectEquality)):

Canonical link: <a href="https://commits.webkit.org/276935@main">https://commits.webkit.org/276935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f85ac15a46d3911257fcc7db99311dd6b69af49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48845 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42215 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22748 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37729 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40908 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4218 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50652 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17659 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44916 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22470 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43836 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22829 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6438 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->