### PR TITLE
Prevent locked files assertion from taking a power assertion

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -2975,25 +2975,15 @@ void NetworkProcess::setIsHoldingLockedFiles(bool isHoldingLockedFiles)
 #else
     if (!isHoldingLockedFiles) {
         m_holdingLockedFileAssertion = nullptr;
-#if USE(EXTENSIONKIT)
-        invalidateFileActivity();
-#endif
         return;
     }
 
     if (m_holdingLockedFileAssertion && m_holdingLockedFileAssertion->isValid())
         return;
 
-#if USE(EXTENSIONKIT)
-    if (hasAcquiredFileActivity())
-        return;
-    if (acquireLockedFileActivity())
-        return;
-#endif
-
     // We synchronously take a process assertion when beginning a SQLite transaction so that we don't get suspended
     // while holding a locked file. We would get killed if suspended while holding locked files.
-    m_holdingLockedFileAssertion = ProcessAssertion::create(getCurrentProcessID(), "Network Process is holding locked files"_s, ProcessAssertionType::FinishTaskInterruptable, ProcessAssertion::Mode::Sync);
+    m_holdingLockedFileAssertion = ProcessAssertion::create(getCurrentProcessID(), "Network Process is holding locked files"_s, ProcessAssertionType::FinishTaskCanSleep, ProcessAssertion::Mode::Sync);
 #endif
 }
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -72,10 +72,6 @@
 typedef struct OpaqueCFHTTPCookieStorage*  CFHTTPCookieStorageRef;
 #endif
 
-#if USE(EXTENSIONKIT)
-OBJC_CLASS WKGrant;
-#endif
-
 namespace IPC {
 class FormDataReference;
 }
@@ -523,11 +519,6 @@ private:
 
 #if USE(RUNNINGBOARD)
     void setIsHoldingLockedFiles(bool);
-#if USE(EXTENSIONKIT)
-    bool acquireLockedFileActivity();
-    void invalidateFileActivity();
-    bool hasAcquiredFileActivity() const;
-#endif
 #endif
     void stopRunLoopIfNecessary();
 
@@ -564,9 +555,6 @@ private:
 
 #if USE(RUNNINGBOARD)
     WebSQLiteDatabaseTracker m_webSQLiteDatabaseTracker;
-#if USE(EXTENSIONKIT)
-    OSObjectPtr<dispatch_semaphore_t> m_holdingLockedFileSemaphore;
-#endif
     RefPtr<ProcessAssertion> m_holdingLockedFileAssertion;
 #endif
     

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -258,42 +258,4 @@ void NetworkProcess::setProxyConfigData(PAL::SessionID sessionID, Vector<std::pa
 }
 #endif // HAVE(NW_PROXY_CONFIG)
 
-#if USE(RUNNINGBOARD) && USE(EXTENSIONKIT)
-bool NetworkProcess::acquireLockedFileActivity()
-{
-    RELEASE_LOG(Process, "NetworkProcess::acquireLockedFileActivity hasAcquiredFileActivity = %d", hasAcquiredFileActivity());
-
-    invalidateFileActivity();
-
-    m_holdingLockedFileSemaphore = adoptOSObject(dispatch_semaphore_create(0));
-    [[NSProcessInfo processInfo] performExpiringActivityWithReason:@"Expiring activity for locked file" usingBlock:[holdingLockedFileSemaphore = m_holdingLockedFileSemaphore] (BOOL expired) {
-        RELEASE_LOG(Process, "Starting expiring activity, expired = %d", expired);
-        if (!expired) {
-            auto timeout = dispatch_time(DISPATCH_TIME_NOW, 30 * NSEC_PER_SEC);
-            dispatch_semaphore_wait(holdingLockedFileSemaphore.get(), timeout);
-        }
-    }];
-
-    return true;
-}
-
-void NetworkProcess::invalidateFileActivity()
-{
-    RELEASE_LOG(Process, "NetworkProcess::invalidateActivity hasAcquiredFileActivity = %d", hasAcquiredFileActivity());
-
-    if (!hasAcquiredFileActivity())
-        return;
-
-    if (m_holdingLockedFileSemaphore) {
-        dispatch_semaphore_signal(m_holdingLockedFileSemaphore.get());
-        m_holdingLockedFileSemaphore = nullptr;
-    }
-}
-
-bool NetworkProcess::hasAcquiredFileActivity() const
-{
-    return !!m_holdingLockedFileSemaphore;
-}
-#endif
-
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -342,6 +342,8 @@ static ASCIILiteral runningBoardNameForAssertionType(ProcessAssertionType assert
         return "Foreground"_s;
     case ProcessAssertionType::MediaPlayback:
         return "MediaPlayback"_s;
+    case ProcessAssertionType::FinishTaskCanSleep:
+        return "FinishTaskCanSleep"_s;
     case ProcessAssertionType::FinishTaskInterruptable:
         return "FinishTaskInterruptable"_s;
     case ProcessAssertionType::BoostedJetsam:
@@ -359,6 +361,7 @@ static ASCIILiteral runningBoardDomainForAssertionType(ProcessAssertionType asse
     case ProcessAssertionType::MediaPlayback:
     case ProcessAssertionType::BoostedJetsam:
         return "com.apple.webkit"_s;
+    case ProcessAssertionType::FinishTaskCanSleep:
     case ProcessAssertionType::FinishTaskInterruptable:
         return "com.apple.common"_s;
     }

--- a/Source/WebKit/UIProcess/ProcessAssertion.cpp
+++ b/Source/WebKit/UIProcess/ProcessAssertion.cpp
@@ -45,6 +45,8 @@ ASCIILiteral processAssertionTypeDescription(ProcessAssertionType type)
         return "foreground"_s;
     case ProcessAssertionType::MediaPlayback:
         return "media-playback"_s;
+    case ProcessAssertionType::FinishTaskCanSleep:
+        return "finish-task-can-sleep"_s;
     case ProcessAssertionType::FinishTaskInterruptable:
         return "finish-task-interruptible"_s;
     case ProcessAssertionType::BoostedJetsam:

--- a/Source/WebKit/UIProcess/ProcessAssertion.h
+++ b/Source/WebKit/UIProcess/ProcessAssertion.h
@@ -65,6 +65,7 @@ enum class ProcessAssertionType : uint8_t {
     UnboundedNetworking,
     Foreground,
     MediaPlayback,
+    FinishTaskCanSleep,
     FinishTaskInterruptable,
     BoostedJetsam,
 };

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -216,6 +216,7 @@ String ProcessThrottler::assertionName(ProcessAssertionType type) const
             return "NearSuspended"_s;
         case ProcessAssertionType::UnboundedNetworking:
         case ProcessAssertionType::MediaPlayback:
+        case ProcessAssertionType::FinishTaskCanSleep:
         case ProcessAssertionType::FinishTaskInterruptable:
         case ProcessAssertionType::BoostedJetsam:
             ASSERT_NOT_REACHED(); // These other assertion types are not used by the ProcessThrottler.


### PR DESCRIPTION
#### b77155f9e2ec8a25d434d9c35b9ce0b3df779484
<pre>
Prevent locked files assertion from taking a power assertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=272009">https://bugs.webkit.org/show_bug.cgi?id=272009</a>
<a href="https://rdar.apple.com/125037124">rdar://125037124</a>

Reviewed by Per Arne Vollan and Chris Dumez.

The locked files assertion in NetworkProcess can sometimes take a power assertion, because
FinishTaskInterruptable assertions take power assertions. (There are cases where the system allows
you to create a FinishTaskInterruptable but doesn&apos;t actually immediately activate it, so it doesn&apos;t
*always* take a power assertion, but it can and does create a power assertion in various
circumstances.) This is bad because even taking and then immediately releasing a power assertion can
reset the idle timer for the whole device for several seconds.

To fix this, take a FinishTaskCanSleep assertion instead.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::setIsHoldingLockedFiles):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::acquireLockedFileActivity): Deleted.
(WebKit::NetworkProcess::invalidateFileActivity): Deleted.
(WebKit::NetworkProcess::hasAcquiredFileActivity const): Deleted.
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(WebKit::runningBoardNameForAssertionType):
(WebKit::runningBoardDomainForAssertionType):
* Source/WebKit/UIProcess/ProcessAssertion.cpp:
(WebKit::processAssertionTypeDescription):
* Source/WebKit/UIProcess/ProcessAssertion.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::assertionName const):

Canonical link: <a href="https://commits.webkit.org/276985@main">https://commits.webkit.org/276985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7f250c6b30d263b77dc5d1019d3d343b79ca85d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48846 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42216 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37730 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18936 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4219 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41261 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50642 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17661 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44904 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22471 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43812 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10255 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->