### PR TITLE
QuickLook sometimes shows broken images for image sources when loading web archives

### DIFF
--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -302,7 +302,10 @@ ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()
 
         auto sourceSize = sizesParser.length();
 
-        candidate = bestFitSourceForImageAttributes(document().deviceScaleFactor(), nullAtom(), srcset, sourceSize);
+        candidate = bestFitSourceForImageAttributes(document().deviceScaleFactor(), nullAtom(), srcset, sourceSize, [&](auto& candidate) {
+            return m_imageLoader->shouldIgnoreCandidateWhenLoadingFromArchive(candidate);
+        });
+
         if (!candidate.isEmpty()) {
             setSourceElement(source);
             break;
@@ -353,7 +356,9 @@ void HTMLImageElement::selectImageSource(RelevantMutation relevantMutation)
             SizesAttributeParser sizesParser(attributeWithoutSynchronization(sizesAttr).string(), document());
             m_dynamicMediaQueryResults.appendVector(sizesParser.dynamicMediaQueryResults());
             auto sourceSize = sizesParser.length();
-            candidate = bestFitSourceForImageAttributes(document().deviceScaleFactor(), srcAttribute, srcsetAttribute, sourceSize);
+            candidate = bestFitSourceForImageAttributes(document().deviceScaleFactor(), srcAttribute, srcsetAttribute, sourceSize, [&](auto& candidate) {
+                return m_imageLoader->shouldIgnoreCandidateWhenLoadingFromArchive(candidate);
+            });
         }
     }
     setBestFitURLAndDPRFromImageCandidate(candidate);

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -301,7 +301,7 @@ static ImageCandidate pickBestImageCandidate(float deviceScaleFactor, Vector<Ima
     return imageCandidates[winner];
 }
 
-ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const AtomString& srcAttribute, StringView srcsetAttribute, float sourceSize)
+ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const AtomString& srcAttribute, StringView srcsetAttribute, float sourceSize, Function<bool(const ImageCandidate&)>&& shouldIgnoreCandidateCallback)
 {
     if (srcsetAttribute.isNull()) {
         if (srcAttribute.isNull())
@@ -313,6 +313,9 @@ ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const At
 
     if (!srcAttribute.isEmpty())
         imageCandidates.append(ImageCandidate(StringViewWithUnderlyingString(srcAttribute, srcAttribute), DescriptorParsingResult(), ImageCandidate::SrcOrigin));
+
+    if (shouldIgnoreCandidateCallback)
+        imageCandidates.removeAllMatching(shouldIgnoreCandidateCallback);
 
     return pickBestImageCandidate(deviceScaleFactor, imageCandidates, sourceSize);
 }

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.h
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.h
@@ -104,7 +104,7 @@ struct ImageCandidate {
     OriginAttribute originAttribute;
 };
 
-ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const AtomString& srcAttribute, StringView srcsetAttribute, float sourceSize);
+ImageCandidate bestFitSourceForImageAttributes(float deviceScaleFactor, const AtomString& srcAttribute, StringView srcsetAttribute, float sourceSize, Function<bool(const ImageCandidate&)>&& shouldIgnoreCandidateCallback = { });
 
 Vector<ImageCandidate> parseImageCandidatesFromSrcsetAttribute(StringView attribute);
 void getURLsFromSrcsetAttribute(const Element&, StringView attribute, ListHashSet<URL>&);

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -254,6 +254,7 @@ public:
     RefPtr<Archive> popArchiveForSubframe(const String& frameName, const URL&);
     WEBCORE_EXPORT SharedBuffer* parsedArchiveData() const;
 
+    bool hasArchiveResourceCollection() const { return !!m_archiveResourceCollection; }
     WEBCORE_EXPORT bool scheduleArchiveLoad(ResourceLoader&, const ResourceRequest&);
 #endif
 

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -37,6 +37,7 @@ class Document;
 class ImageLoader;
 class Page;
 class RenderImageResource;
+struct ImageCandidate;
 
 template<typename T, typename Counter> class EventSender;
 using ImageEventSender = EventSender<ImageLoader, SingleThreadWeakPtrImpl>;
@@ -64,6 +65,8 @@ public:
     Element& element() { return m_element.get(); }
     const Element& element() const { return m_element.get(); }
     Ref<Element> protectedElement() const { return m_element.get(); }
+
+    bool shouldIgnoreCandidateWhenLoadingFromArchive(const ImageCandidate&) const;
 
     bool imageComplete() const { return m_imageComplete; }
 

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -95,6 +95,7 @@ struct AutocorrectionContext {
 @property (nonatomic, readonly) CGImageRef snapshotAfterScreenUpdates;
 @property (nonatomic, readonly) NSUInteger gpuToWebProcessConnectionCount;
 @property (nonatomic, readonly) NSString *contentsAsString;
+@property (nonatomic, readonly) NSData *contentsAsWebArchive;
 @property (nonatomic, readonly) NSArray<NSString *> *tagsInBody;
 @property (nonatomic, readonly) NSString *selectedText;
 - (void)loadTestPageNamed:(NSString *)pageName;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -458,6 +458,18 @@ static WebEvent *unwrap(BEKeyEntry *event)
     return result.autorelease();
 }
 
+- (NSData *)contentsAsWebArchive
+{
+    __block bool done = false;
+    __block RetainPtr<NSData> result;
+    [self createWebArchiveDataWithCompletionHandler:^(NSData *contents, NSError *error) {
+        result = contents;
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    return result.autorelease();
+}
+
 - (NSArray<NSString *> *)tagsInBody
 {
     return [self objectByEvaluatingJavaScript:@"Array.from(document.body.getElementsByTagName('*')).map(e => e.tagName)"];


### PR DESCRIPTION
#### 408858f600d2b7aafb86848018a1b8858f8dfd17
<pre>
QuickLook sometimes shows broken images for image sources when loading web archives
<a href="https://bugs.webkit.org/show_bug.cgi?id=272005">https://bugs.webkit.org/show_bug.cgi?id=272005</a>
<a href="https://rdar.apple.com/123918480">rdar://123918480</a>

Reviewed by Sihui Liu.

When previewing web archives, QuickLook (more precisely, `QLPreviewController`) loads the archive
data in a `WKWebView` that is configured to have an empty set of `_allowedNetworkHosts` (thereby
preventing network access when loading the archive). While this is a perfectly reasonable behavior
for the purposes of loading web archives, it exposes an issue when rendering images with sources
specified via the `srcset` attribute — if the &quot;best fit&quot; chosen for the image in QuickLook&apos;s web
view isn&apos;t the same source as the one that was chosen when creating the web archive, we end up with
a broken image since the selected source isn&apos;t present in the web archive, and we also can&apos;t
download it over the network. Since everything from viewport/screen dimensions to the device scale
factor can influence this, we can end up with broken images when copying images with `srcset`s in
many cases.

To mitigate this, we add some logic to detect when image sources are unavailable when loading web
archives (*and* we&apos;re additionally not allowed to fetch them from over the internet), and avoid
surfacing these image sources as potential candidates when selecting the best fit. See below for
more details.

Test: LoadWebArchive.PreferCachedImageSourceOverBrokenImage

* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::bestFitSourceFromPictureElement):
(WebCore::HTMLImageElement::selectImageSource):

Pass the new filtering function (using `ImageLoader::shouldIgnoreCandidateWhenLoadingFromArchive`
below) into `bestFitSourceForImageAttributes`.

* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
(WebCore::bestFitSourceForImageAttributes):

Add a new optional filtering function that takes an `ImageCandidate` and returns whether or not we
can even attempt to load the candidate; for now, this is `false` only in the case where we&apos;re
loading archived resources, and we&apos;re not allowed to load the URL over the network.

* Source/WebCore/html/parser/HTMLSrcsetParser.h:
(WebCore::bestFitSourceForImageAttributes):
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::hasArchiveResourceCollection const):

Add a new helper function, which we can use to bail early in
`ImageLoader::shouldIgnoreCandidateWhenLoadingFromArchive`, to avoid eagerly parsing all URLs in the
`srcset`.

* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::shouldIgnoreCandidateWhenLoadingFromArchive const):
* Source/WebCore/loader/ImageLoader.h:
* Tools/TestWebKitAPI/Tests/mac/LoadWebArchive.mm:
(TestWebKitAPI::TEST(LoadWebArchive, PreferCachedImageSourceOverBrokenImage)):

Add a new API test to exercise the change, by loading a web archive from a web view at 1x device
pixel scale that contains an image with a `srcset`, and loading the archive in another web view at
2x scale. Before the changes in this patch, this results in a broken image.

* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[WKWebView contentsAsWebArchive]):

Canonical link: <a href="https://commits.webkit.org/276952@main">https://commits.webkit.org/276952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41aaf8e4c5e208821bb23341148da10e3f166252

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48868 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42237 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37744 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22394 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18953 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19783 "layout-tests (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40934 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4240 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50670 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44929 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22492 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43844 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10240 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22851 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22186 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->