### PR TITLE
Update charactersToDouble() / charactersToFloat() to take in a std::span

### DIFF
--- a/Source/WTF/wtf/JSONValues.cpp
+++ b/Source/WTF/wtf/JSONValues.cpp
@@ -369,7 +369,7 @@ RefPtr<JSON::Value> buildValue(const CodeUnit* start, const CodeUnit* end, const
         break;
     case Token::Number: {
         bool ok;
-        double value = charactersToDouble(tokenStart, tokenEnd - tokenStart, &ok);
+        double value = charactersToDouble({ tokenStart, tokenEnd }, &ok);
         if (!ok)
             return nullptr;
         result = JSON::Value::create(value);

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -811,15 +811,15 @@ Ref<StringImpl> StringImpl::simplifyWhiteSpace(CodeUnitMatchFunction isWhiteSpac
 double StringImpl::toDouble(bool* ok)
 {
     if (is8Bit())
-        return charactersToDouble(characters8(), m_length, ok);
-    return charactersToDouble(characters16(), m_length, ok);
+        return charactersToDouble(span8(), ok);
+    return charactersToDouble(span16(), ok);
 }
 
 float StringImpl::toFloat(bool* ok)
 {
     if (is8Bit())
-        return charactersToFloat(characters8(), m_length, ok);
-    return charactersToFloat(characters16(), m_length, ok);
+        return charactersToFloat(span8(), ok);
+    return charactersToFloat(span16(), ok);
 }
 
 size_t StringImpl::find(const LChar* matchString, unsigned matchLength, unsigned start)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -673,15 +673,15 @@ inline AtomString StringView::toExistingAtomString() const
 inline float StringView::toFloat(bool& isValid) const
 {
     if (is8Bit())
-        return charactersToFloat(characters8(), m_length, &isValid);
-    return charactersToFloat(characters16(), m_length, &isValid);
+        return charactersToFloat(span8(), &isValid);
+    return charactersToFloat(span16(), &isValid);
 }
 
 inline double StringView::toDouble(bool& isValid) const
 {
     if (is8Bit())
-        return charactersToDouble(characters8(), m_length, &isValid);
-    return charactersToDouble(characters16(), m_length, &isValid);
+        return charactersToDouble(span8(), &isValid);
+    return charactersToDouble(span16(), &isValid);
 }
 
 inline String StringView::toStringWithoutCopying() const

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -546,13 +546,13 @@ String String::fromCodePoint(char32_t codePoint)
 // String Operations
 
 template<typename CharacterType, TrailingJunkPolicy policy>
-static inline double toDoubleType(const CharacterType* data, size_t length, bool* ok, size_t& parsedLength)
+static inline double toDoubleType(std::span<const CharacterType> data, bool* ok, size_t& parsedLength)
 {
     size_t leadingSpacesLength = 0;
-    while (leadingSpacesLength < length && isUnicodeCompatibleASCIIWhitespace(data[leadingSpacesLength]))
+    while (leadingSpacesLength < data.size() && isUnicodeCompatibleASCIIWhitespace(data[leadingSpacesLength]))
         ++leadingSpacesLength;
 
-    double number = parseDouble(data + leadingSpacesLength, length - leadingSpacesLength, parsedLength);
+    double number = parseDouble(data.data() + leadingSpacesLength, data.size() - leadingSpacesLength, parsedLength);
     if (!parsedLength) {
         if (ok)
             *ok = false;
@@ -561,46 +561,46 @@ static inline double toDoubleType(const CharacterType* data, size_t length, bool
 
     parsedLength += leadingSpacesLength;
     if (ok)
-        *ok = policy == TrailingJunkPolicy::Allow || parsedLength == length;
+        *ok = policy == TrailingJunkPolicy::Allow || parsedLength == data.size();
     return number;
 }
 
-double charactersToDouble(const LChar* data, size_t length, bool* ok)
+double charactersToDouble(std::span<const LChar> data, bool* ok)
 {
     size_t parsedLength;
-    return toDoubleType<LChar, TrailingJunkPolicy::Disallow>(data, length, ok, parsedLength);
+    return toDoubleType<LChar, TrailingJunkPolicy::Disallow>(data, ok, parsedLength);
 }
 
-double charactersToDouble(const UChar* data, size_t length, bool* ok)
+double charactersToDouble(std::span<const UChar> data, bool* ok)
 {
     size_t parsedLength;
-    return toDoubleType<UChar, TrailingJunkPolicy::Disallow>(data, length, ok, parsedLength);
+    return toDoubleType<UChar, TrailingJunkPolicy::Disallow>(data, ok, parsedLength);
 }
 
-float charactersToFloat(const LChar* data, size_t length, bool* ok)
+float charactersToFloat(std::span<const LChar> data, bool* ok)
 {
     // FIXME: This will return ok even when the string fits into a double but not a float.
     size_t parsedLength;
-    return static_cast<float>(toDoubleType<LChar, TrailingJunkPolicy::Disallow>(data, length, ok, parsedLength));
+    return static_cast<float>(toDoubleType<LChar, TrailingJunkPolicy::Disallow>(data, ok, parsedLength));
 }
 
-float charactersToFloat(const UChar* data, size_t length, bool* ok)
+float charactersToFloat(std::span<const UChar> data, bool* ok)
 {
     // FIXME: This will return ok even when the string fits into a double but not a float.
     size_t parsedLength;
-    return static_cast<float>(toDoubleType<UChar, TrailingJunkPolicy::Disallow>(data, length, ok, parsedLength));
+    return static_cast<float>(toDoubleType<UChar, TrailingJunkPolicy::Disallow>(data, ok, parsedLength));
 }
 
-float charactersToFloat(const LChar* data, size_t length, size_t& parsedLength)
+float charactersToFloat(std::span<const LChar> data, size_t& parsedLength)
 {
     // FIXME: This will return ok even when the string fits into a double but not a float.
-    return static_cast<float>(toDoubleType<LChar, TrailingJunkPolicy::Allow>(data, length, nullptr, parsedLength));
+    return static_cast<float>(toDoubleType<LChar, TrailingJunkPolicy::Allow>(data, nullptr, parsedLength));
 }
 
-float charactersToFloat(const UChar* data, size_t length, size_t& parsedLength)
+float charactersToFloat(std::span<const UChar> data, size_t& parsedLength)
 {
     // FIXME: This will return ok even when the string fits into a double but not a float.
-    return static_cast<float>(toDoubleType<UChar, TrailingJunkPolicy::Allow>(data, length, nullptr, parsedLength));
+    return static_cast<float>(toDoubleType<UChar, TrailingJunkPolicy::Allow>(data, nullptr, parsedLength));
 }
 
 const StaticString nullStringData { nullptr };

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -39,12 +39,12 @@ namespace WTF {
 
 // Declarations of string operations
 
-WTF_EXPORT_PRIVATE double charactersToDouble(const LChar*, size_t, bool* ok = nullptr);
-WTF_EXPORT_PRIVATE double charactersToDouble(const UChar*, size_t, bool* ok = nullptr);
-WTF_EXPORT_PRIVATE float charactersToFloat(const LChar*, size_t, bool* ok = nullptr);
-WTF_EXPORT_PRIVATE float charactersToFloat(const UChar*, size_t, bool* ok = nullptr);
-WTF_EXPORT_PRIVATE float charactersToFloat(const LChar*, size_t, size_t& parsedLength);
-WTF_EXPORT_PRIVATE float charactersToFloat(const UChar*, size_t, size_t& parsedLength);
+WTF_EXPORT_PRIVATE double charactersToDouble(std::span<const LChar>, bool* ok = nullptr);
+WTF_EXPORT_PRIVATE double charactersToDouble(std::span<const UChar>, bool* ok = nullptr);
+WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const LChar>, bool* ok = nullptr);
+WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const UChar>, bool* ok = nullptr);
+WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const LChar>, size_t& parsedLength);
+WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const UChar>, size_t& parsedLength);
 
 template<bool isSpecialCharacter(UChar), typename CharacterType> bool containsOnly(const CharacterType*, size_t);
 

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -100,52 +100,52 @@ bool CSSParserFastPaths::isSimpleLengthPropertyID(CSSPropertyID propertyId, bool
     }
 }
 
-template<typename CharacterType> static inline std::optional<double> parseCSSNumber(const CharacterType* characters, unsigned length)
+template<typename CharacterType> static inline std::optional<double> parseCSSNumber(std::span<const CharacterType> characters)
 {
     // The charactersToDouble() function allows a trailing '.' but that is not allowed in CSS number values.
-    if (length && characters[length - 1] == '.')
+    if (!characters.empty() && characters.back() == '.')
         return std::nullopt;
     // FIXME: If we don't want to skip over leading spaces, we should use parseDouble, not charactersToDouble.
     bool ok;
-    auto number = charactersToDouble(characters, length, &ok);
+    auto number = charactersToDouble(characters, &ok);
     if (!ok)
         return std::nullopt;
     return number;
 }
 
 template <typename CharacterType>
-static inline bool parseSimpleLength(const CharacterType* characters, unsigned length, CSSUnitType& unit, double& number)
+static inline bool parseSimpleLength(std::span<const CharacterType> characters, CSSUnitType& unit, double& number)
 {
-    if (length > 2 && isASCIIAlphaCaselessEqual(characters[length - 2], 'p') && isASCIIAlphaCaselessEqual(characters[length - 1], 'x')) {
-        length -= 2;
+    if (characters.size() > 2 && isASCIIAlphaCaselessEqual(characters[characters.size() - 2], 'p') && isASCIIAlphaCaselessEqual(characters[characters.size() - 1], 'x')) {
+        characters = characters.first(characters.size() - 2);
         unit = CSSUnitType::CSS_PX;
-    } else if (length > 1 && characters[length - 1] == '%') {
-        length -= 1;
+    } else if (!characters.empty() && characters.back() == '%') {
+        characters = characters.first(characters.size() - 1);
         unit = CSSUnitType::CSS_PERCENTAGE;
     }
 
-    auto parsedNumber = parseCSSNumber(characters, length);
+    auto parsedNumber = parseCSSNumber(characters);
     number = parsedNumber.value_or(0);
     return parsedNumber.has_value();
 }
 
 template <typename CharacterType>
-static inline bool parseSimpleAngle(const CharacterType* characters, unsigned length, CSSUnitType& unit, double& number)
+static inline bool parseSimpleAngle(std::span<const CharacterType> characters, CSSUnitType& unit, double& number)
 {
     // Just support deg and rad for now.
-    if (length < 4)
+    if (characters.size() < 4)
         return false;
 
-    if (isASCIIAlphaCaselessEqual(characters[length - 3], 'd') && isASCIIAlphaCaselessEqual(characters[length - 2], 'e') && isASCIIAlphaCaselessEqual(characters[length - 1], 'g')) {
-        length -= 3;
+    if (isASCIIAlphaCaselessEqual(characters[characters.size() - 3], 'd') && isASCIIAlphaCaselessEqual(characters[characters.size() - 2], 'e') && isASCIIAlphaCaselessEqual(characters[characters.size() - 1], 'g')) {
+        characters = characters.first(characters.size() - 3);
         unit = CSSUnitType::CSS_DEG;
-    } else if (isASCIIAlphaCaselessEqual(characters[length - 3], 'r') && isASCIIAlphaCaselessEqual(characters[length - 2], 'a') && isASCIIAlphaCaselessEqual(characters[length - 1], 'd')) {
-        length -= 3;
+    } else if (isASCIIAlphaCaselessEqual(characters[characters.size() - 3], 'r') && isASCIIAlphaCaselessEqual(characters[characters.size() - 2], 'a') && isASCIIAlphaCaselessEqual(characters[characters.size() - 1], 'd')) {
+        characters = characters.first(characters.size() - 3);
         unit = CSSUnitType::CSS_RAD;
     } else
         return false;
 
-    auto parsedNumber = parseCSSNumber(characters, length);
+    auto parsedNumber = parseCSSNumber(characters);
     number = parsedNumber.value_or(0);
     return parsedNumber.has_value();
 }
@@ -159,15 +159,14 @@ static RefPtr<CSSValue> parseSimpleLengthValue(CSSPropertyID propertyId, StringV
     if (isCSSViewportParsingEnabledForMode(cssParserMode) || !CSSParserFastPaths::isSimpleLengthPropertyID(propertyId, acceptsNegativeNumbers))
         return nullptr;
 
-    unsigned length = string.length();
     double number;
     CSSUnitType unit = CSSUnitType::CSS_NUMBER;
 
     if (string.is8Bit()) {
-        if (!parseSimpleLength(string.characters8(), length, unit, number))
+        if (!parseSimpleLength(string.span8(), unit, number))
             return nullptr;
     } else {
-        if (!parseSimpleLength(string.characters16(), length, unit, number))
+        if (!parseSimpleLength(string.span16(), unit, number))
             return nullptr;
     }
 
@@ -649,7 +648,7 @@ static bool parseTransformTranslateArguments(CharType*& pos, CharType* end, unsi
         unsigned argumentLength = static_cast<unsigned>(delimiter);
         CSSUnitType unit = CSSUnitType::CSS_NUMBER;
         double number;
-        if (!parseSimpleLength(pos, argumentLength, unit, number))
+        if (!parseSimpleLength(std::span<const CharType> { pos, argumentLength }, unit, number))
             return false;
         if (!number && unit == CSSUnitType::CSS_NUMBER)
             unit = CSSUnitType::CSS_PX;
@@ -672,7 +671,7 @@ static RefPtr<CSSValue> parseTransformAngleArgument(CharType*& pos, CharType* en
     unsigned argumentLength = static_cast<unsigned>(delimiter);
     CSSUnitType unit = CSSUnitType::CSS_NUMBER;
     double number;
-    if (!parseSimpleAngle(pos, argumentLength, unit, number))
+    if (!parseSimpleAngle(std::span<const CharType> { pos, argumentLength }, unit, number))
         return nullptr;
     if (!number && unit == CSSUnitType::CSS_NUMBER)
         unit = CSSUnitType::CSS_DEG;
@@ -690,7 +689,7 @@ static bool parseTransformNumberArguments(CharType*& pos, CharType* end, unsigne
         if (delimiter == notFound)
             return false;
         unsigned argumentLength = static_cast<unsigned>(delimiter);
-        auto number = parseCSSNumber(pos, argumentLength);
+        auto number = parseCSSNumber(std::span<const CharType> { pos, argumentLength });
         if (!number)
             return false;
         arguments.append(CSSPrimitiveValue::create(*number, CSSUnitType::CSS_NUMBER));

--- a/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
@@ -61,9 +61,9 @@ double CSSTokenizerInputStream::getDouble(unsigned start, unsigned end) const
     double result = 0.0;
     if (start < end) {
         if (m_string->is8Bit())
-            result = charactersToDouble(m_string->characters8() + m_offset + start, end - start, &isResultOK);
+            result = charactersToDouble(m_string->span8().subspan(m_offset + start, end - start), &isResultOK);
         else
-            result = charactersToDouble(m_string->characters16() + m_offset + start, end - start, &isResultOK);
+            result = charactersToDouble(m_string->span16().subspan(m_offset + start, end - start), &isResultOK);
     }
     // FIXME: It looks like callers ensure we have a valid number
     return isResultOK ? result : 0.0;

--- a/Source/WebCore/dom/ViewportArguments.cpp
+++ b/Source/WebCore/dom/ViewportArguments.cpp
@@ -296,9 +296,9 @@ static float numericPrefix(StringView key, StringView value, const InternalViewp
     size_t parsedLength;
     float numericValue;
     if (value.is8Bit())
-        numericValue = charactersToFloat(value.characters8(), value.length(), parsedLength);
+        numericValue = charactersToFloat(value.span8(), parsedLength);
     else
-        numericValue = charactersToFloat(value.characters16(), value.length(), parsedLength);
+        numericValue = charactersToFloat(value.span16(), parsedLength);
     if (!parsedLength) {
         errorHandler(ViewportErrorCode::UnrecognizedViewportArgumentValue, value, key);
         if (ok)

--- a/Source/WebCore/html/track/VTTScanner.cpp
+++ b/Source/WebCore/html/track/VTTScanner.cpp
@@ -163,9 +163,9 @@ bool VTTScanner::scanFloat(float& number, bool* isNegative)
     size_t lengthOfFloat = Run(integerRun.start(), position(), m_is8Bit).length();
     bool validNumber;
     if (m_is8Bit)
-        number = charactersToFloat(integerRun.start(), lengthOfFloat, &validNumber);
+        number = charactersToFloat({ integerRun.start(), lengthOfFloat }, &validNumber);
     else
-        number = charactersToFloat(reinterpret_cast<const UChar*>(integerRun.start()), lengthOfFloat, &validNumber);
+        number = charactersToFloat({ reinterpret_cast<const UChar*>(integerRun.start()), lengthOfFloat }, &validNumber);
 
     if (!validNumber)
         number = std::numeric_limits<float>::max();


### PR DESCRIPTION
#### ea31739e586c9c1c1cde13fbf0e7ff97cfea1b64
<pre>
Update charactersToDouble() / charactersToFloat() to take in a std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=272012">https://bugs.webkit.org/show_bug.cgi?id=272012</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/JSONValues.cpp:
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::toDouble):
(WTF::StringImpl::toFloat):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::toFloat const):
(WTF::StringView::toDouble const):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::toDoubleType):
(WTF::charactersToDouble):
(WTF::charactersToFloat):
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseCSSNumber):
(WebCore::parseSimpleLength):
(WebCore::parseSimpleAngle):
(WebCore::parseSimpleLengthValue):
(WebCore::parseTransformTranslateArguments):
(WebCore::parseTransformAngleArgument):
(WebCore::parseTransformNumberArguments):
* Source/WebCore/css/parser/CSSTokenizerInputStream.cpp:
(WebCore::CSSTokenizerInputStream::getDouble const):
* Source/WebCore/dom/ViewportArguments.cpp:
(WebCore::numericPrefix):
* Source/WebCore/html/track/VTTScanner.cpp:
(WebCore::VTTScanner::scanFloat):
* Source/WebCore/platform/Length.cpp:
(WebCore::parseLength):
(WebCore::newLengthArray):

Canonical link: <a href="https://commits.webkit.org/276933@main">https://commits.webkit.org/276933@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/586949b59596fb6e82bde6db0844490e27ded3a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42232 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37741 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18949 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40930 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4235 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39424 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50663 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45665 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44923 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22487 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43838 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22846 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52816 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6437 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22181 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10812 "Passed tests") | 
<!--EWS-Status-Bubble-End-->