### PR TITLE
Web Inspector: Dark Mode: Increase the contrast in the search bar tab for @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.css
@@ -76,3 +76,22 @@ body[dir=rtl] .sidebar > .panel.navigation.search .item.source-code-match {
 .sidebar > .panel.navigation.search.changed > :is(.content, .message-text-view) {
     top: calc(var(--navigation-bar-height) + 40px - 1px);
 }
+
+@media (prefers-color-scheme: dark) {
+    .sidebar > .panel.details.css-style > .content ~ .options-container > .new-rule {
+        filter: var(--filter-invert);
+    }
+
+    @media (prefers-contrast: more) {
+        .sidebar > .panel.navigation.search > .search-bar > input[type="search"] {
+            color: hsl(0, 0%, 85%);
+        }
+
+        .sidebar > .panel.navigation.search.changed > .banner {
+            color: hsl(50, 100%, 95%);
+            background-color:  hsl(13, 20%, 15%);
+            border-top: 1px solid hsl(0, 0%, 70%, 0.8);
+            border-bottom: 1px solid hsl(0, 0%, 70%, 0.8);
+        }
+    }
+}


### PR DESCRIPTION
#### 9b04459c941a5b57d15cfb9e5e0e5184d3d9f562
<pre>
Web Inspector: Dark Mode: Increase the contrast in the search bar tab for @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)
<a href="https://bugs.webkit.org/show_bug.cgi?id=271930">https://bugs.webkit.org/show_bug.cgi?id=271930</a>

Reviewed by NOBODY (OOPS!).

Invert filter on the new rule and whiten the search in SearchSidebarPanel.css.
Increase darkness of background and lightness of text in search changed banner in SearchSidebarPanel.css.
Increase the lightness of the borders in search changed banner in SearchSidebarPanel.css.

* Source/WebInspectorUI/UserInterface/Views/SearchSidebarPanel.css:
(@media (prefers-color-scheme: dark) .sidebar &gt; .panel.details.css-style &gt; .content ~ .options-container &gt; .new-rule):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .sidebar &gt; .panel.navigation.search &gt; .search-bar &gt; input[type=&quot;search&quot;]):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .sidebar &gt; .panel.navigation.search.changed &gt; .banner):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af20e43cfaed84bd680e7261ac9b696886b1e194

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51839 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45170 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40115 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21229 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43484 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7299 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45319 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53753 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47434 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46403 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->