### PR TITLE
[GTK4] Drop String::fromUTF8() overloads taking in a raw pointer and a size

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp
@@ -193,22 +193,22 @@ void DropTarget::accept(GdkDrop* drop, std::optional<WebCore::IntPoint> position
                     if (length >= 2 && reinterpret_cast<const UChar*>(markupData)[0] == 0xFEFF)
                         m_selectionData->setMarkup(String({ reinterpret_cast<const UChar*>(markupData) + 1, (length / 2) - 1 }));
                     else
-                        m_selectionData->setMarkup(String::fromUTF8(reinterpret_cast<const char*>(markupData), length));
+                        m_selectionData->setMarkup(String::fromUTF8(std::span(static_cast<const char*>(markupData), length)));
                 }
             } else if (mimeType == "_NETSCAPE_URL"_s) {
                 gsize length;
-                const auto* urlData = g_bytes_get_data(data.get(), &length);
+                const auto* urlData = static_cast<const char*>(g_bytes_get_data(data.get(), &length));
                 if (length) {
-                    Vector<String> tokens = String::fromUTF8(reinterpret_cast<const char*>(urlData), length).split('\n');
+                    Vector<String> tokens = String::fromUTF8(std::span(urlData, length)).split('\n');
                     URL url({ }, tokens[0]);
                     if (url.isValid())
                         m_selectionData->setURL(url, tokens.size() > 1 ? tokens[1] : String());
                 }
             } else if (mimeType == "text/uri-list"_s) {
                 gsize length;
-                const auto* uriListData = g_bytes_get_data(data.get(), &length);
+                const auto* uriListData = static_cast<const char*>(g_bytes_get_data(data.get(), &length));
                 if (length) {
-                    String uriListString(String::fromUTF8(reinterpret_cast<const char*>(uriListData), length));
+                    String uriListString(String::fromUTF8(std::span(uriListData, length)));
                     for (auto& line : uriListString.split('\n')) {
                         line = line.trim(deprecatedIsSpaceOrNewline);
                         if (line.isEmpty())


### PR DESCRIPTION
#### cd3cf3d5e2f23603d3ba5539feb166f427199246
<pre>
[GTK4] Drop String::fromUTF8() overloads taking in a raw pointer and a size
<a href="https://bugs.webkit.org/show_bug.cgi?id=272018">https://bugs.webkit.org/show_bug.cgi?id=272018</a>

Reviewed by Carlos Garcia Campos.

This was done already in 276889@main but GTK4 files missed it,
so fix the build.

* Source/WebKit/UIProcess/API/gtk/DropTargetGtk4.cpp:
(WebKit::DropTarget::accept):

Canonical link: <a href="https://commits.webkit.org/276931@main">https://commits.webkit.org/276931@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d214e30bf8cad5880b3be247f474c58ccb52f902

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42244 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22785 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/46781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/39844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/18962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4247 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/41292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50679 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21199 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22499 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/43855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22858 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6436 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22193 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->