### PR TITLE
[Navigation] Detect hasUAVisualTransition for NavigateEvent

### DIFF
--- a/LayoutTests/swipe/navigate-event-back-swipe-verify-ua-transition-expected.txt
+++ b/LayoutTests/swipe/navigate-event-back-swipe-verify-ua-transition-expected.txt
@@ -1,0 +1,8 @@
+startSwipeGesture
+didBeginSwipe
+completeSwipeGesture
+willEndSwipe
+hasUAVisualTransition true
+didEndSwipe
+didRemoveSwipeSnapshot
+

--- a/LayoutTests/swipe/navigate-event-back-swipe-verify-ua-transition.html
+++ b/LayoutTests/swipe/navigate-event-back-swipe-verify-ua-transition.html
@@ -1,0 +1,87 @@
+<!-- webkit-test-runner [ NavigationAPIEnabled=true ] -->
+<head>
+<style>
+html {
+    font-size: 32pt;
+}
+</style>
+<script src="resources/swipe-test.js"></script>
+<script src="../resources/ui-helper.js"></script>
+
+<script>
+
+function didBeginSwipeCallback()
+{
+    log("didBeginSwipe");
+
+    completeSwipeGesture();
+}
+
+function willEndSwipeCallback()
+{
+    log("willEndSwipe");
+
+    shouldBe(false, isFirstPage(), "The swipe should not yet have navigated away from the second page.");
+}
+
+function didEndSwipeCallback()
+{
+    log("didEndSwipe");
+
+    startMeasuringDuration("snapshotRemoval");
+}
+
+function didRemoveSwipeSnapshotCallback()
+{
+    log("didRemoveSwipeSnapshot");
+
+    shouldBe(true, isFirstPage(), "The swipe should have navigated back to the first page.");
+
+    testComplete();
+}
+
+function isFirstPage()
+{
+    return window.location.href.indexOf("second") == -1;
+}
+
+function updateContent()
+{
+    document.body.innerHTML = isFirstPage() ? "first" : "second";
+}
+
+window.onload = async function () {
+    if (!window.eventSender || !window.testRunner) {
+        document.body.innerHTML = "This test must be run in WebKitTestRunner.";
+        return;
+    }
+
+    updateContent();
+
+    initializeSwipeTest();
+
+    testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+    testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+    testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+    testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    navigation.onnavigate = function(e) {
+        log("hasUAVisualTransition " + e.hasUAVisualTransition);
+        updateContent();
+    };
+
+    await UIHelper.delayFor(0);
+
+    history.pushState(null, null, "#second");
+    updateContent();
+
+    await UIHelper.delayFor(0);
+    await startSwipeGesture();
+};
+</script>
+</head>
+<body>
+</body>

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -426,7 +426,7 @@ bool Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationT
         canIntercept,
         false, // FIXME: userInitiated
         hashChange,
-        false, // FIXME: hasUAVisualTransition
+        document->page() && document->page()->isInSwipeAnimation(),
     };
 
     // Free up no longer needed info.


### PR DESCRIPTION
#### d55a9c43bd6e450433aef6841e21b532c1c5db4b
<pre>
[Navigation] Detect hasUAVisualTransition for NavigateEvent
<a href="https://bugs.webkit.org/show_bug.cgi?id=272019">https://bugs.webkit.org/show_bug.cgi?id=272019</a>

Reviewed by Simon Fraser.

Detect hasUAVisualTransition for NavigateEvent as specified:
<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigate-event-firing">https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigate-event-firing</a>:dom-navigateevent-hasuavisualtransition

* LayoutTests/swipe/navigate-event-back-swipe-verify-ua-transition-expected.txt: Added.
* LayoutTests/swipe/navigate-event-back-swipe-verify-ua-transition.html: Added.
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/277129@main">https://commits.webkit.org/277129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c2ead7a057b9287d0bebd88dac39a0ed6629038

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46233 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48905 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42274 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37774 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18986 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40974 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4277 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50714 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17742 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44968 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22529 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43882 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10336 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22896 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->