### PR TITLE
Fix build after drop of String constructor with raw pointer and length

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
+++ b/Source/JavaScriptCore/runtime/IntlPluralRules.cpp
@@ -263,7 +263,7 @@ JSValue IntlPluralRules::select(JSGlobalObject* globalObject, double value) cons
     if (U_FAILURE(status))
         return throwTypeError(globalObject, scope, "failed to select plural value"_s);
 
-    return jsString(vm, String(result.data(), length));
+    return jsString(vm, String({ result.data(), static_cast<size_t>(length) }));
 #endif
 }
 

--- a/Source/WebCore/rendering/svg/SVGTextMetrics.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetrics.cpp
@@ -54,7 +54,6 @@ SVGTextMetrics::SVGTextMetrics(RenderSVGInlineText& textRenderer, const TextRun&
     m_glyph.unicodeString = run.text().toString();
     m_glyph.isValid = true;
 
-    ASSERT(run.length() >= 0);
     m_length = static_cast<unsigned>(run.length());
 }
 


### PR DESCRIPTION
#### 34d037641b002c0f4da1f85499bf1304f9413d74
<pre>
Fix build after drop of String constructor with raw pointer and length
<a href="https://bugs.webkit.org/show_bug.cgi?id=272033">https://bugs.webkit.org/show_bug.cgi?id=272033</a>

Reviewed by Chris Dumez.

String constructors taking in a raw pointer and a length have been
dropped in 276859@main, some codepaths need updates.

* Source/JavaScriptCore/runtime/IntlPluralRules.cpp:
(JSC::IntlPluralRules::select const):
Use the std::span String constructor in the codepath without HAVE(ICU_U_NUMBER_FORMATTER).

* Source/WebCore/rendering/svg/SVGTextMetrics.cpp:
(WebCore::SVGTextMetrics::SVGTextMetrics):
Remove ASSERT() since TextRun length is always unsigned.

Canonical link: <a href="https://commits.webkit.org/276954@main">https://commits.webkit.org/276954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f97e4b375cc73273ea6ee7790f6b6e6c6d054dd2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48910 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42279 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22827 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37777 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22458 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/39873 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18990 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/40973 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4282 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/39472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42559 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41327 "Failed to checkout and rebase branch from PR 26727") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50719 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45714 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21237 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17743 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/44971 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43885 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10234 "Failed to push commit to Webkit repository") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/52863 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22229 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->