### PR TITLE
[WGSL] Pointer rewriter should visit phony assignment

### DIFF
--- a/Source/WebGPU/WGSL/PointerRewriter.cpp
+++ b/Source/WebGPU/WGSL/PointerRewriter.cpp
@@ -114,8 +114,10 @@ void PointerRewriter::visit(AST::VariableStatement& statement)
 void PointerRewriter::visit(AST::PhonyAssignmentStatement& statement)
 {
     auto* pointerType = std::get_if<Types::Pointer>(statement.rhs().inferredType());
-    if (!pointerType)
+    if (!pointerType) {
+        AST::Visitor::visit(statement);
         return;
+    }
     m_indicesToDelete.append(m_currentStatementIndex);
 }
 

--- a/Source/WebGPU/WGSL/tests/valid/array-length.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/array-length.wgsl
@@ -30,6 +30,10 @@ fn f() -> u32 {
     let y2 = arrayLength(yptr);
     let z2 = arrayLength(zptr);
 
+    _ = arrayLength(xptr);
+    _ = arrayLength(yptr);
+    _ = arrayLength(zptr);
+
     return x1 + y1 + z1 + x2 + y2 + z2;
 }
 

--- a/Source/WebGPU/WGSL/wgslc.cpp
+++ b/Source/WebGPU/WGSL/wgslc.cpp
@@ -118,7 +118,7 @@ static int runWGSL(const CommandLine& options)
     FileSystem::closeFile(handle);
     auto source = emptyString();
     if (readResult.has_value())
-        source = String::fromUTF8WithLatin1Fallback(readResult->data(), readResult->size());
+        source = String::fromUTF8WithLatin1Fallback(std::span(readResult->data(), readResult->size()));
     auto checkResult = WGSL::staticCheck(source, std::nullopt, configuration);
     if (auto* failedCheck = std::get_if<WGSL::FailedCheck>(&checkResult)) {
         for (const auto& error : failedCheck->errors)


### PR DESCRIPTION
#### 9c6ee0f8bb9311052934ad81e2e5f5f044d42fed
<pre>
[WGSL] Pointer rewriter should visit phony assignment
<a href="https://bugs.webkit.org/show_bug.cgi?id=272035">https://bugs.webkit.org/show_bug.cgi?id=272035</a>
<a href="https://rdar.apple.com/125618287">rdar://125618287</a>

Reviewed by Mike Wyrzykowski.

The pointer rewriter needs to delete phony assignments when the right-hand side
is a pointer, but it fails to visit the assignment when it&apos;s not a pointer. I also
fixed a compilation error in wgslc due to some recent refactoring to use std::span.

* Source/WebGPU/WGSL/PointerRewriter.cpp:
(WGSL::PointerRewriter::visit):
* Source/WebGPU/WGSL/tests/valid/array-length.wgsl:
* Source/WebGPU/WGSL/wgslc.cpp:
(runWGSL):

Canonical link: <a href="https://commits.webkit.org/277005@main">https://commits.webkit.org/277005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cadf15bd203d066dd9e5d3a2d61c576c83fea525

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48915 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42284 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37781 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39878 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/18994 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19849 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4287 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50725 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17744 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/44979 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22539 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43892 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10267 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22906 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->