### PR TITLE
[resultsdbpy] Add dashboard on landing page

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/css/search.css
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/css/search.css
@@ -57,6 +57,12 @@
     -webkit-backdrop-filter: blur(5px);
     backdrop-filter: blur(5px);
 }
+.table>thead>tr>th {
+    padding: 0px;
+}
+.table>tbody>tr>td {
+    padding: 0px;
+}
 
 @media (prefers-color-scheme: dark) {
     .next-regress-bar button{

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/commit.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/commit.js
@@ -170,13 +170,24 @@ class Commit {
 };
 
 const COOKIE_NAME = 'commitRepresentation';
+let _banks = {};
 
 class _CommitBank {
+    forBranch(branch) {
+        let key = branch ? branch : 'main';
+        if (!_banks[key]) {
+            _banks[key] = new _CommitBank();
+            _banks[key]._branches = new Set([branch]);
+            _banks[key]._branchOverride = true;
+        }
+        return _banks[key];
+    }
     constructor() {
         this.commits = [];
 
         const params = queryToParams(document.URL.split('?')[1]);
 
+        this._branchOverride = false;
         this._branches = new Set(params.branch);
         this._repositories = new Set(params.repository_id);
         this._beginUuid = null;
@@ -223,7 +234,8 @@ class _CommitBank {
         document.cookie = `${COOKIE_NAME}=${JSON.stringify(this._representationCache)}`;
     }
     latest(params) {
-        this._branches = new Set(params.branch);
+        if (!this._branchOverride)
+            this._branches = new Set(params.branch);
         this._repositories = new Set(params.repository_id);
         this._beginUuid = null;
         this._endUuid = null;

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/common.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/common.js
@@ -28,6 +28,10 @@ function ErrorDisplay(json) {
     </div>`;
 }
 
+function intersection(listA, listB) {
+    return listA.filter(value => listB.includes(value));
+}
+
 function queryToParams(query) {
     if (!query)
         return {};
@@ -59,6 +63,17 @@ function paramsToQuery(json) {
                 return;
             result += (result ? '&' : '') + encodeURIComponent(parameter) + '=' + encodeURIComponent(value);
         });
+    }
+    return result;
+}
+
+function mergeQueries(queryA, queryB) {
+    let result = {...queryA};
+    for (const key in queryB) {
+        if (!Object.hasOwn(result, key))
+            result[key] = queryB[key];
+        else
+            result[key] = intersection(result[key], queryB[key]);
     }
     return result;
 }
@@ -218,4 +233,4 @@ function elapsedTime(startTimestamp, endTimestamp)
     return result;
 }
 
-export {deepCompare, ErrorDisplay, queryToParams, paramsToQuery, QueryModifier, escapeHTML, escapeEndpoint, linkify, percentage, elapsedTime};
+export {deepCompare, ErrorDisplay, intersection, queryToParams, paramsToQuery, mergeQueries, QueryModifier, escapeHTML, escapeEndpoint, linkify, percentage, elapsedTime};

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js
@@ -1,0 +1,479 @@
+// Copyright (C) 2024 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+import {intersection, paramsToQuery, queryToParams, mergeQueries, ErrorDisplay} from '/assets/js/common.js';
+import {CommitBank} from '/assets/js/commit.js'
+import {Configuration} from '/assets/js/configuration.js';
+import {Expectations} from '/assets/js/expectations.js';
+import {DOM, REF} from '/library/js/Ref.js';
+import {TypeForSuite} from '/assets/js/suites.js';
+
+let dashboards = new Set();
+
+class Dashboard {
+    static setWillFilterExpected(value) {
+        dashboards.forEach(dashboard => {
+            if (dashboard.willFilterExpected != value) {
+                dashboard.willFilterExpected = value;
+                dashboard.setTilesFromData();
+            }
+        });
+    }
+
+    static refreshCommits() {
+        dashboards.forEach(dashboard => {
+            dashboard.setTilesFromData();
+        });
+    }
+
+    constructor(title, suite, parameters, warnAfter=null, expireAfter=null) {
+        this.title = title;
+        this.suite = suite;
+        this.parameters = parameters;
+
+        this.warnAfter = warnAfter ? warnAfter : 12;
+        this.expireAfter = expireAfter ? expireAfter : 7*24;
+
+        this.willFilterExpected = false;
+
+        this.requestData = null;
+        this.redundentParameters = null;
+
+        this.commit_bank = null;
+
+        this.ref = REF.createRef({
+            state: {displayed: this.canEnable()},
+            onStateUpdate: (element, state) => {
+                element.style.display = state.displayed ? null : 'none';
+            },
+        });
+        this.title_ref = REF.createRef({
+            state: {status: null},
+            onStateUpdate: (element, state) => {
+                if (state.status)
+                    element.innerHTML = `<div class="dot ${state.status} small">
+                        <div class="tiny text" style="font-weight: normal;margin-top: 0px">
+                            ${Expectations.symbolMap[state.status]}
+                        </div>
+                    </div>
+                    ${this.title}`;
+                else
+                    element.innerHTML = `<div class="spinner tiny"></div> ${this.title}`;
+            },
+        });
+
+        this.showPassing = false;
+        this.showPassingSwitch = REF.createRef({
+            onElementMount: (element) => {
+                element.onchange = () => {
+                    this.showPassing = element.checked;
+                    this.setTilesFromData();
+                };
+            },
+        });
+
+        const typ = TypeForSuite(this.suite);
+        this.content = REF.createRef({
+            state: {tiles: null},
+            onStateUpdate: (element, state) => {
+                if (state.error)
+                    DOM.inject(element, ErrorDisplay(state));
+                else if (state.tiles) {
+                    let parameters = {...this.parameters};
+                    parameters.suite = [this.suite];
+                    DOM.inject(element, `<div style="display: grid; gap: 10px; grid-template-columns: repeat(auto-fill, minmax(265px, 1fr)); grid-template-rows: masonry;">
+                        ${state.tiles.map(tile => {
+                            let queueParameters = {...parameters};
+                            const configParameters = tile.configuration.toParams();
+                            for (const key in configParameters)
+                                queueParameters[key] = configParameters[key];
+
+                            return `<div class="badge">
+                                <table class="table">
+                                    <thead>
+                                        <tr>
+                                            <th>
+                                                <div class="dot ${tile.status} small">
+                                                    <div class="small text" style="font-weight: normal;margin-top: 0px">
+                                                        ${Expectations.symbolMap[tile.status]}
+                                                    </div>
+                                                </div>
+                                            </th>
+                                            <th>
+                                                <a class="text small clickable" href="suites?recent=False&${paramsToQuery(queueParameters)}" target="_blank">
+                                                    ${tile.configuration.toString()}
+                                                </a>
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td></td>
+                                            <td>
+                                                <a class="text tiny clickable" href="urls/build?${paramsToQuery(mergeQueries(queueParameters, {uuid: [tile.builds[0].uuid], after_time: [tile.builds[0].start_time], before_time: [tile.builds[0].start_time]}))}" target="_blank">
+                                                    ${typ.runDescription} @ ${new Date(tile.builds[0].start_time * 1000).toLocaleString()}
+                                                </a>
+                                            </td>
+                                        </tr>
+                                        ${tile.builds.map(build => {
+                                            if (build.sdks)
+                                                return `<tr>
+                                                        <td></td>
+                                                        <td>
+                                                            <a class="text tiny clickable" href="suites?recent=False&${paramsToQuery(mergeQueries(queueParameters, {sdk: build.sdks}))}" target="_blank">
+                                                                ${build.sdks[0]} -> ${build.sdks[1]}
+                                                            </a>
+                                                        </td>
+                                                    </tr>`;
+
+                                            if (build.range)
+                                                return `<tr>
+                                                        <td></td>
+                                                        <td>
+                                                            <a class="text tiny clickable" href="suites?recent=False&${paramsToQuery(mergeQueries(queueParameters, {after_uuid: [build.range[0]], before_uuid: [build.range[1]]}))}" target="_blank">
+                                                                ${build.count} ${typ.runDescription}${build.count > 1 ? 's' : ''}...
+                                                            </a>
+                                                        </td>
+                                                    </tr>`;
+
+                                            if (!build.status)
+                                                return `<tr>
+                                                        <td></td>
+                                                        <td>${Object.keys(build).sort().map(key => {
+                                                            // FIXME: We should link these commit ranges directly to the SCM providers
+                                                            return `<a class="text tiny clickable" href="commits?${paramsToQuery({repository_id: [build[key][0].repository_id], branch: this.parameters.branch ? this.parameters.branch : [], after_ref: [build[key][0].label()], before_ref: [build[key][build[key].length - 1].label()]})}" target="_blank">
+                                                                    ${build[key].length} ${key} change${build[key].length > 1 ? 's' : ''}
+                                                                </a>`;
+                                                        }).join(', ')}</td>
+                                                    </tr>`;
+
+                                            return `<tr>
+                                                    <td>
+                                                        <a class="clickable dot ${build.status} tiny" style="color: var(--white)" href="urls/build?${paramsToQuery(mergeQueries(queueParameters, {uuid: [build.uuid], after_time: [build.start_time], before_time: [build.start_time]}))}" target="_blank">
+                                                            ${Expectations.symbolMap[build.status]}
+                                                        </a>
+                                                    </td>
+                                                    <td>
+                                                        ${(build.commits.length ? build.commits : ['?']).map(commit => {
+                                                            if (typeof commit === 'string')
+                                                                return `<a class="clickable text tiny" href="commit?${paramsToQuery({branch: this.parameters.branch ? this.parameters.branch : [], uuid: [build.uuid]})}" target="_blank">${commit}</a>`;
+                                                            return `<a class="clickable text tiny" href="commit/info?${paramsToQuery({branch: this.parameters.branch ? this.parameters.branch : [], repository_id: [commit.repository_id], ref: [commit.label()]})}" target="_blank">${commit.label()}</a>`;
+                                                        }).join(', ')}
+                                                    </td>
+                                                </tr>`;
+                                        }).join('')}
+                                    </tbody>
+                                </table>
+                            </div>`;
+                        }).join('')}
+                    </div>`);
+                } else
+                    DOM.inject(element, '<div class="loader"><div class="spinner"></div></div>');
+            },
+        });
+
+        dashboards.add(this);
+        this.reload();
+    }
+    documentParams() {
+        let result = queryToParams(document.URL.split('?')[1]);
+        delete result.suite;
+        delete result.test;
+        return result;
+    }
+    canEnable() {
+        const globalParams = this.documentParams();
+
+        // Specific check for suite
+        if (Object.hasOwn(globalParams, 'suite') && !globalParams.suite.includes(this.suite))
+            return false;
+
+        // Specific check for branch
+        if (Object.hasOwn(globalParams, 'branch')) {
+            if (!Object.hasOwn(this.parameters, 'branch'))
+                return false;
+        }
+        for (const key in globalParams) {
+            if (!Object.hasOwn(this.parameters, key))
+                continue;
+            if (!intersection(this.parameters[key], globalParams[key]).length)
+                return false;
+        }
+        return true;
+    }
+    setEnabled(enabled) {
+        const wasEnabled = this.ref.state.displayed;
+        enabled = enabled && this.canEnable();
+
+        this.ref.setState({displayed: enabled})
+        if (!wasEnabled && enabled)
+            this.reload();
+    }
+    reload() {
+        this.setEnabled(this.ref.state.displayed);
+        if (!this.ref.state.displayed)
+            return;
+
+        this.title_ref.setState({status: null});
+
+        let parameters = mergeQueries(this.parameters, this.documentParams());
+        if (!Object.hasOwn(parameters, 'limit'))
+            parameters.limit = ['30'];
+
+        if (Object.hasOwn(this.parameters, 'branch'))
+            this.commit_bank = CommitBank.forBranch(this.parameters.branch);
+        else
+            this.commit_bank = CommitBank;
+        if (this.commit_bank.callbacks.indexOf(Dashboard.refreshCommits) < 0)
+            this.commit_bank.callbacks.push(Dashboard.refreshCommits)
+
+        fetch(`/api/results/${this.suite}?${paramsToQuery(parameters)}`).then(response => {
+            response.json().then(json => {
+                let results = {};
+                let uniqueParameters = {};
+                Configuration.members().forEach(member => {
+                    uniqueParameters[member] = new Set();
+                });
+
+                json.forEach(node => {
+                    let strippedConfig = new Configuration(node.configuration);
+                    strippedConfig.sdk = null;
+
+                    Configuration.members().forEach(member => {
+                        if (strippedConfig[member])
+                            uniqueParameters[member].add(strippedConfig[member]);
+                    });
+
+                    if (!results.hasOwnProperty(strippedConfig.toKey())) {
+                        results[strippedConfig.toKey()] = [];
+                    }
+                    const config = new Configuration(node.configuration);
+                    let index = Math.max(results[strippedConfig.toKey()].length - 1, 0);
+                    node.results.forEach(result => {
+                        let direction = 0;
+                        while (index < results[strippedConfig.toKey()].length) {
+                            let aKey = results[strippedConfig.toKey()][index][1].uuid;
+                            let bKey = result.uuid;
+                            if (aKey == bKey) {
+                                aKey = results[strippedConfig.toKey()][index][1].start_time;
+                                bKey = result.start_time;
+                            }
+
+                            if (aKey < bKey) {
+                                if (direction < 0)
+                                    break;
+                                direction = 1;
+                                index += 1;
+                            }
+                            else if (index && aKey > bKey) {
+                                if (direction > 0)
+                                    break;
+                                direction = -1;
+                                index -= 1;
+                            }
+                            else
+                                break;
+                        }
+                        results[strippedConfig.toKey()].splice(index, 0, [config, result]);
+                    });
+                });
+
+                this.redundentParameters = new Set();
+                for (const member in uniqueParameters) {
+                    // Never declare version or version_name redundent
+                    if (member == 'version' || member == 'version_name')
+                        continue
+                    if (uniqueParameters[member].size <= 1)
+                        this.redundentParameters.add(member);
+                }
+
+                this.requestData = results;
+                this.setTilesFromData();
+            }).catch(error => {
+                this.title_ref.setState({status: 'crashed'});
+                this.content.setState({
+                    error: 'Failed to Decode',
+                    description: `Failed to decode history of '${this.title}', and cannot construct dashboard`,
+                });
+            });
+        }).catch(error => {
+            this.title_ref.setState({status: 'crashed'});
+            this.content.setState({
+                error: 'Failed to Fetach',
+                description: `Failed to fetch history of '${this.title}', and cannot construct dashboard`,
+            });
+        });
+    }
+    failureForBuild(build) {
+        let result = Expectations.stringToStateId('PASS');
+        Expectations.failureTypes.forEach(type => {
+            const idForType = Expectations.stringToStateId(Expectations.failureTypeMap[type]);
+            const key = this.willFilterExpected ? `tests_unexpected_${type}` : `tests_${type}`;
+            if (build.stats[key])
+                result = Math.min(result, idForType);
+        });
+        return result;
+    }
+    tileLineForBuild(build) {
+        return {
+            status: Expectations.typeForId(this.failureForBuild(build)),
+            start_time: build.start_time,
+            uuid: build.uuid,
+            commits: this.commit_bank.commitsDuring(build.uuid).sort((a, b) => {
+                return a.repository_id.localeCompare(b.repository_id);
+            }),
+        };
+    }
+    setTilesFromData() {
+        if (!this.ref.state.displayed || !this.requestData)
+            return;
+
+        const now = Math.floor(Date.now() / 1000);
+        let oldestUuid = now * 100;
+        let totalStatus = Expectations.stringToStateId('PASS');
+        let tiles = [];
+        for (const key in this.requestData) {
+            if (!this.requestData[key] || !this.requestData[key].length)
+                continue;
+
+            const latestResult = this.requestData[key][this.requestData[key].length - 1][1];
+            if (latestResult.uuid / 100 < now - this.expireAfter * 60 * 60)
+                continue;
+
+            // For now, do the easy thing and only consider the latest run
+            // In the future, we can consider more sophisticated algorithms
+            const latestStatus = this.failureForBuild(latestResult);
+            let configStatus = latestStatus;
+            
+            if (latestResult.uuid / 100 < now - this.warnAfter * 60 * 60)
+                configStatus = Math.min(configStatus, Expectations.stringToStateId('WARNING'));;
+            if (!this.showPassing && configStatus >= Expectations.stringToStateId('PASS'))
+                continue
+
+            totalStatus = Math.min(totalStatus, configStatus);
+            let strippedConfig = new Configuration(this.requestData[key][this.requestData[key].length - 1][0]);
+            this.redundentParameters.forEach(member => {
+                strippedConfig[member] = null;
+            });
+            let tile = {
+                configuration: strippedConfig,
+                status: Expectations.typeForId(configStatus),
+                status_id: configStatus,
+                builds: [this.tileLineForBuild(latestResult)],
+            };
+
+            let count = this.requestData[key].length - 2;
+            let previous = null;
+            let previousSdk = this.requestData[key][this.requestData[key].length - 1][0];
+            while (count >= 0) {
+                const sdk = this.requestData[key][count][0];
+                const build = this.requestData[key][count][1];
+                if (this.failureForBuild(build) >= Expectations.stringToStateId('WARNING')) {
+                    if (previous) {
+                        if (count < this.requestData[key].length - 3)
+                            tile.builds.push({
+                                count: this.requestData[key].length - 3 - count,
+                                range: [build.uuid, latestResult.uuid],
+                            });
+                        tile.builds.push(this.tileLineForBuild(previous));
+                    }
+
+                    if (previousSdk && sdk.sdk != previousSdk.sdk)
+                        tile.builds.push({sdks: [sdk.sdk, previousSdk.sdk]});
+
+                    let candidateCommits = this.commit_bank.commitsDuring(build.uuid, (previous ? previous : latestResult).uuid);
+                    let startAt = 0;
+                    let repositories = new Set();
+                    while (startAt < candidateCommits.length) {
+                        if (repositories.has(candidateCommits[startAt].repository_id))
+                            break;
+                        repositories.add(candidateCommits[startAt].repository_id);
+                        startAt += 1;
+                    }
+                    if (candidateCommits.length > startAt + 1) {
+                        let regressionCommits = {};
+                        while (startAt < candidateCommits.length) {
+                            if (!regressionCommits[candidateCommits[startAt].repository_id])
+                                regressionCommits[candidateCommits[startAt].repository_id] = [];
+                            regressionCommits[candidateCommits[startAt].repository_id].push(candidateCommits[startAt]);
+                            startAt += 1;
+                        }
+                        tile.builds.push(regressionCommits);
+                    }
+
+                    tile.builds.push(this.tileLineForBuild(build));
+                    break;
+                }
+                previous = build;
+                previousSdk = sdk;
+                count -= 1;
+            }
+            oldestUuid = Math.min(oldestUuid, this.requestData[key][count < 0 ? 0 : count][1].uuid);
+
+            tiles.push(tile);
+        }
+
+        this.commit_bank.add(oldestUuid, now * 100);
+
+        tiles.sort((a, b) => {
+            if (a.status_id != b.status_id)
+                return a.status_id - b.status_id;
+            return a.configuration.compare(b.configuration);
+        });
+
+        if (Object.keys(this.requestData).length) {
+            this.title_ref.setState({status: Expectations.typeForId(totalStatus)});
+            this.content.setState({tiles: tiles});
+        } else {
+            this.title_ref.setState({status: 'warning'});
+            this.content.setState({
+                error: 'No History',
+                description: `Provided parameters for '${this.title}' yield no history`,
+            });
+        }
+    }
+    toString() {
+        let parameters = mergeQueries(this.parameters, this.documentParams());
+        parameters.suite = [this.suite];
+
+        return `<div class="section" ref="${this.ref}">
+            <div class="header row">
+                <a class="title" ref="${this.title_ref}" href="suites?${paramsToQuery(parameters)}">
+                    ${this.title}
+                </a>
+            </div>
+            <div class="content">
+                <div class="input" style="width: 180px">
+                    <label>Show passing</label>
+                    <label class="switch">
+                        <input type="checkbox" ref="${this.showPassingSwitch}">
+                        <span class="slider"></span>
+                    </label>
+                </div>
+                <div ref="${this.content}"> </div>
+            </div>
+        </div>`;
+    }
+}
+
+export {Dashboard};

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js
@@ -35,7 +35,7 @@ class Expectations
     }
 
     static stringToStateId(string) {
-        return Expectations.stateToIdMap[string];
+        return string in Expectations.stateToIdMap ? Expectations.stateToIdMap[string] : string;
     }
     static typeForId(string) {
         const id = Expectations.stringToStateId(string);

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
@@ -25,6 +25,7 @@ import {ArchiveRouter} from '/assets/js/archiveRouter.js';
 import {CommitBank} from '/assets/js/commit.js';
 import {Configuration} from '/assets/js/configuration.js';
 import {deepCompare, ErrorDisplay, escapeHTML, paramsToQuery, queryToParams, linkify, escapeEndpoint} from '/assets/js/common.js';
+import {Dashboard} from '/assets/js/dashboard.js';
 import {Expectations} from '/assets/js/expectations.js';
 import {InvestigateDrawer} from '/assets/js/investigate.js';
 import {TypeForSuite} from '/assets/js/suites.js';
@@ -1341,6 +1342,7 @@ function Legend(callback=null, plural=false, defaultWillFilterExpected=false, fl
                     InvestigateDrawer.dispatch();
                     InvestigateDrawer.select(InvestigateDrawer.selected);
                     callback(willFilterExpected);
+                    Dashboard.setWillFilterExpected(willFilterExpected);
                 };
             },
         });

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/constants.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/constants.js
@@ -28,5 +28,6 @@ const DEFAULT_ARCHITECTURE = {{ default_architecture }};
 const TESTS_LIMITS = JSON.parse('{{ tests_limits|safe }}');
 const SUITES_LIMITS = JSON.parse('{{ suites_limits|safe }}');
 const COMMITS_LIMITS = JSON.parse('{{ commits_limits|safe }}');
+const DASHBOARD_QUERY = JSON.parse('{{ dashboard_queries|safe }}');
 
-export {XCODE_CLOUD_SUITES, DEFAULT_ARCHITECTURE, TESTS_LIMITS, SUITES_LIMITS, COMMITS_LIMITS}
+export {XCODE_CLOUD_SUITES, DEFAULT_ARCHITECTURE, TESTS_LIMITS, SUITES_LIMITS, COMMITS_LIMITS, DASHBOARD_QUERY}

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html
@@ -33,7 +33,8 @@
 import {CommitBank} from '/assets/js/commit.js';
 import {deepCompare, ErrorDisplay, queryToParams, paramsToQuery, escapeHTML} from '/assets/js/common.js';
 import {Configuration} from '/assets/js/configuration.js';
-import {TESTS_LIMITS} from '/assets/js/constants.js';
+import {TESTS_LIMITS, DASHBOARD_QUERY} from '/assets/js/constants.js'
+import {Dashboard} from '/assets/js/dashboard.js';
 import {Drawer, BranchSelector, ConfigurationSelectors, LimitSlider, CommitRepresentation, CommitSearchBar} from '/assets/js/drawer.js';
 import {InvestigateDrawer} from '/assets/js/investigate.js';
 import {SearchBar} from '/assets/js/search.js';
@@ -44,6 +45,22 @@ import {DOM, REF, EventStream} from '/library/js/Ref.js';
 const DEFAULT_LIMIT = 100;
 const SUITES = JSON.parse('{{ suites|safe }}');
 const onCommitSearch = new EventStream();
+
+let dashboards = [];
+DASHBOARD_QUERY.forEach(query => {
+    let parameters = {...query};
+    delete parameters.title;
+    delete parameters.suite;
+    delete parameters.warnAfter;
+    delete parameters.expireAfter;
+    dashboards.push(new Dashboard(
+        query.title ? query.title : '?',
+        query.suite,
+        parameters,
+        query.warnAfter,
+        query.expireAfter,
+    ));
+});
 
 class SearchView {
     constructor() {    
@@ -109,8 +126,12 @@ class SearchView {
                                 }
                                 if (params.suite.length === 0)
                                     delete params.suite;
-                                if (params.test.length === 0)
+                                if (params.test.length === 0) {
                                     delete params.test;
+                                    dashboards.forEach(dashboard => {
+                                        dashboard.setEnabled(true);
+                                    });
+                                }
 
                                 const queryString = paramsToQuery(params);
                                 window.history.pushState(queryString, '', splitURL[0] + '?' + queryString);
@@ -154,10 +175,18 @@ class SearchView {
                         this.ref.state.children.push(child);
                     });
                 }
+
+                if (this.ref.state.children.length)
+                    dashboards.forEach(dashboard => {
+                        dashboard.setEnabled(false);
+                    });
             }
         });
     }
     reload() {
+        dashboards.forEach(dashboard => {
+            dashboard.reload();
+        });
         let params = queryToParams(document.URL.split('?')[1]);
         let limit = params.limit ? parseInt(params.limit[params.limit.length - 1]) : DEFAULT_LIMIT;
 
@@ -311,6 +340,7 @@ DOM.inject(
                 const queryString = paramsToQuery(params);
                 window.history.pushState(queryString, '', splitURL[0] + '?' + queryString);
             }, SUITES)}
+            ${dashboards.map(dashboard=>{return dashboard.toString();})}
             ${view}
         </div>
     </div>`

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes.py
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019, 2020 Apple Inc. All rights reserved.
+# Copyright (C) 2019-2024 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -48,6 +48,7 @@ class ViewRoutes(AuthedBlueprint):
         tests_limits=None,
         suites_limits=None,
         commits_limits=None,
+        dashboard_queries=None,
     ):
         super(ViewRoutes, self).__init__('view', import_name, url_prefix=None, auth_decorator=auth_decorator)
         self._cache = {}
@@ -63,6 +64,7 @@ class ViewRoutes(AuthedBlueprint):
         self.tests_limits = tests_limits or dict(max=50000, default=5000)
         self.suites_limits = suites_limits or dict(max=10000, default=1000)
         self.commits_limits = commits_limits or dict(max=10000, default=1000)
+        self.dashboard_queries = dashboard_queries or {}
 
         # Protecting js and css with auth doesn't make sense
         self.add_url_rule('/library/<path:path>', 'library', self.library, authed=False, methods=('GET',))
@@ -183,5 +185,6 @@ class ViewRoutes(AuthedBlueprint):
                 tests_limits=json.dumps(self.tests_limits),
                 suites_limits=json.dumps(self.suites_limits),
                 commits_limits=json.dumps(self.commits_limits),
+                dashboard_queries=json.dumps(self.dashboard_queries),
             ), mimetype='application/javascript',
         )


### PR DESCRIPTION
#### 532c42da7266c3d93a56ddf6a9c051996be83dd2
<pre>
[resultsdbpy] Add dashboard on landing page
<a href="https://bugs.webkit.org/show_bug.cgi?id=272034">https://bugs.webkit.org/show_bug.cgi?id=272034</a>
<a href="https://rdar.apple.com/125787240">rdar://125787240</a>

Reviewed by Elliott Williams.

Add a configurable dashboard to the results.webkit.org landing page. This dashboard
should surface current failures and attempt to pinpoint recent regression points.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/css/search.css:
(.table&gt;thead&gt;tr&gt;th): Disable padding in tables.
(.table&gt;tbody&gt;tr&gt;td): Ditto.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/commit.js:
(_CommitBank.prototype.forBranch): Return a CommitBank object for a specific branch.
(_CommitBank.prototype.latest): Only re-define branch arguments if object is global.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/common.js:
(intersection): Return a new list which is the intersection of two lists.
(mergeQueries): Combine two queries together.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js: Added.
(Dashboard.setWillFilterExpected): Set if all dashboards will display actual or expected results.
(Dashboard.refreshCommits): Force all dashboards to re-render without reloading data.
(Dashboard.prototype.constructor): Construct a single dashboard panel.
(Dashboard.prototype.documentParams): Return arguments for the current document, with data not valid
for suite endpoints stripped.
(Dashboard.prototype.canEnable): Check if this dashboard conforms to the current query. If it doesn&apos;t,
we need to hide this dashboard.
(Dashboard.prototype.setEnabled): Set if this dashboard should be displayed or hidden, fetching suite
data for this dashboard if it should be displayed.
(Dashboard.prototype.reload): Fetch suite endpoint to populate dashboard data and re-draw dashboard
with fetched data.
(Dashboard.prototype.failureForBuild): Determine the result ID for a provided build.
(Dashboard.prototype.tileLineForBuild): Return an object to be displayed in a dashboard tile given
a build.
(Dashboard.prototype.setTilesFromData): Take the current data for this dashboard and construct tiles
from it, passing those tiles to the UI to be displayed.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/expectations.js:
(Expectations.stringToStateId): Give an expectation string, convert to an integer ID.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js:
(Legend): Propigate willFilterExpected to dashboards.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/constants.js: Add DASHBOARD_QUERY.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/search.html: If no tests are being
searched for, display the set of dashboard queries which match the current query.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/view_routes.py:
(ViewRoutes.__init__): Allow caller to define a set of dashboard queries.
(ViewRoutes.constants): Configure constants.js with the set dashboard query.

Canonical link: <a href="https://commits.webkit.org/276963@main">https://commits.webkit.org/276963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f3b2dd68313105dc3a23bbeabc087e1e1b03fb4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46277 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/25416 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/48865 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48950 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42318 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48584 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/29769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/22869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46855 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/29769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/48865 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19015 "Passed tests") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/46142 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/29769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/48865 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4321 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/29769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/48865 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50763 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/22869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/46316 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/48865 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/43915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6454 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/22269 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->