### PR TITLE
REGRESSION(275943@main): WebKit apps can crash on launch in ApplicationStateTracker::setScene()

### DIFF
--- a/Source/WebKit/UIProcess/ApplicationStateTracker.mm
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.mm
@@ -98,8 +98,11 @@ void* WKUIWindowSceneObserverContext = &WKUIWindowSceneObserverContext;
         if (!_parent)
             return;
 
-        UIWindowScene *scene = (UIWindowScene *)[change valueForKey:NSKeyValueChangeNewKey];
-        _parent->setScene(scene);
+        id scene = [change valueForKey:NSKeyValueChangeNewKey];
+        if ([scene isKindOfClass:UIWindowScene.class])
+            _parent->setScene((UIWindowScene *)scene);
+        else
+            _parent->setScene(nil);
     });
 }
 @end


### PR DESCRIPTION
#### f756d5eafc4c301c3a4e7c41c3d1e4bb9b2bfde8
<pre>
REGRESSION(275943@main): WebKit apps can crash on launch in ApplicationStateTracker::setScene()
<a href="https://bugs.webkit.org/show_bug.cgi?id=272040">https://bugs.webkit.org/show_bug.cgi?id=272040</a>
<a href="https://rdar.apple.com/124983721">rdar://124983721</a>

Reviewed by Eric Carlson and Andy Estes.

KVO will use a NSNull object as the value of a change when the windowScene becomes nil. Detect this case
and call setScene() with nil rather than the NSNull object.

* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
(-[WKUIWindowSceneObserver observeValueForKeyPath:ofObject:change:context:]):

Canonical link: <a href="https://commits.webkit.org/276979@main">https://commits.webkit.org/276979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9da33f4c9790fe4b5d347333fca2392908f4f61c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46256 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48928 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42297 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37787 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46834 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19001 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4300 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50740 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17752 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22552 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43900 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10251 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->