### PR TITLE
CrashTracer: com.apple.WebKit.WebContent at WebCore: WebCore::ValidatedFormListedElement::updateValidity

### DIFF
--- a/Source/WebCore/dom/RadioButtonGroups.cpp
+++ b/Source/WebCore/dom/RadioButtonGroups.cpp
@@ -31,7 +31,7 @@ namespace WebCore {
 class RadioButtonGroup {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    bool isEmpty() const { return m_members.isEmpty(); }
+    bool isEmpty() const { return m_members.isEmptyIgnoringNullReferences(); }
     bool isRequired() const { return m_requiredCount; }
     RefPtr<HTMLInputElement> checkedButton() const { return m_checkedButton.get(); }
     void add(HTMLInputElement&);
@@ -47,7 +47,7 @@ private:
     bool isValid() const;
     void setCheckedButton(HTMLInputElement*);
 
-    HashSet<WeakRef<HTMLInputElement, WeakPtrImplWithEventTargetData>> m_members;
+    WeakHashSet<HTMLInputElement, WeakPtrImplWithEventTargetData> m_members;
     WeakPtr<HTMLInputElement, WeakPtrImplWithEventTargetData> m_checkedButton;
     size_t m_requiredCount { 0 };
 };
@@ -60,7 +60,7 @@ inline bool RadioButtonGroup::isValid() const
 Vector<Ref<HTMLInputElement>> RadioButtonGroup::members() const
 {
     auto sortedMembers = WTF::map(m_members, [](auto& element) -> Ref<HTMLInputElement> {
-        return element.get();
+        return element;
     });
     std::sort(sortedMembers.begin(), sortedMembers.end(), [](auto& a, auto& b) {
         return is_lt(treeOrder<ComposedTree>(a, b));
@@ -155,7 +155,7 @@ void RadioButtonGroup::remove(HTMLInputElement& button)
         }
     }
 
-    if (m_members.isEmpty()) {
+    if (m_members.isEmptyIgnoringNullReferences()) {
         ASSERT(!m_requiredCount);
         ASSERT(!m_checkedButton);
     } else if (wasValid != isValid())
@@ -170,7 +170,7 @@ void RadioButtonGroup::remove(HTMLInputElement& button)
 void RadioButtonGroup::setNeedsStyleRecalcForAllButtons()
 {
     for (auto& checkedButton : m_members) {
-        Ref button = checkedButton.get();
+        Ref button = checkedButton;
         ASSERT(button->isRadioButton());
         button->invalidateStyleForSubtree();
     }
@@ -179,7 +179,7 @@ void RadioButtonGroup::setNeedsStyleRecalcForAllButtons()
 void RadioButtonGroup::updateValidityForAllButtons()
 {
     for (auto& checkedButton : m_members) {
-        Ref button = checkedButton.get();
+        Ref button = checkedButton;
         ASSERT(button->isRadioButton());
         button->updateValidity();
     }


### PR DESCRIPTION
#### 1870b119a45087666315f1a1627f8c4cd02ed9cd
<pre>
CrashTracer: com.apple.WebKit.WebContent at WebCore: WebCore::ValidatedFormListedElement::updateValidity
<a href="https://bugs.webkit.org/show_bug.cgi?id=272044">https://bugs.webkit.org/show_bug.cgi?id=272044</a>
<a href="https://rdar.apple.com/117727866">rdar://117727866</a>

Reviewed by Ryosuke Niwa.

It speculatively fixes a bug that RadioButtonGroup::m_members may contain a nullptr WeakRef.

* Source/WebCore/dom/RadioButtonGroups.cpp:
(WebCore::RadioButtonGroup::isEmpty const):
(WebCore::RadioButtonGroup::remove):
(WebCore::RadioButtonGroup::setNeedsStyleRecalcForAllButtons):
(WebCore::RadioButtonGroup::updateValidityForAllButtons):

Canonical link: <a href="https://commits.webkit.org/277007@main">https://commits.webkit.org/277007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52a85267671f6d257df4d21e5adf513df310a260

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48968 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42336 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37807 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46873 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22564 "Found 1 new test failure: editing/selection/ios/show-grammar-replacements-on-tap.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19027 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41013 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4339 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50781 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45011 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22591 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43925 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10269 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22958 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->