### PR TITLE
Use sandbox state flag to enable syscall telemetry

### DIFF
--- a/Source/WTF/wtf/cocoa/Entitlements.h
+++ b/Source/WTF/wtf/cocoa/Entitlements.h
@@ -39,6 +39,7 @@ WTF_EXPORT_PRIVATE bool hasEntitlement(xpc_connection_t, StringView entitlement)
 WTF_EXPORT_PRIVATE bool hasEntitlement(xpc_connection_t, ASCIILiteral entitlement);
 WTF_EXPORT_PRIVATE bool processHasEntitlement(ASCIILiteral entitlement);
 WTF_EXPORT_PRIVATE bool hasEntitlementValue(audit_token_t, ASCIILiteral entitlement, ASCIILiteral value);
+WTF_EXPORT_PRIVATE bool hasEntitlementValueInArray(audit_token_t, ASCIILiteral entitlement, ASCIILiteral value);
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/cocoa/Entitlements.mm
+++ b/Source/WTF/wtf/cocoa/Entitlements.mm
@@ -68,11 +68,36 @@ bool hasEntitlementValue(audit_token_t token, ASCIILiteral entitlement, ASCIILit
 {
     auto secTaskForToken = adoptCF(SecTaskCreateWithAuditToken(kCFAllocatorDefault, token));
     if (!secTaskForToken)
-        return { };
+        return false;
 
     auto string = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, entitlement.characters(), kCFStringEncodingASCII, kCFAllocatorNull));
     String entitlementValue = dynamic_cf_cast<CFStringRef>(adoptCF(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)).get());
     return entitlementValue == value;
+}
+
+bool hasEntitlementValueInArray(audit_token_t token, ASCIILiteral entitlement, ASCIILiteral value)
+{
+    auto secTaskForToken = adoptCF(SecTaskCreateWithAuditToken(kCFAllocatorDefault, token));
+    if (!secTaskForToken)
+        return false;
+
+    auto string = adoptCF(CFStringCreateWithCStringNoCopy(kCFAllocatorDefault, entitlement.characters(), kCFStringEncodingASCII, kCFAllocatorNull));
+    auto entitlementValue = adoptCF(SecTaskCopyValueForEntitlement(secTaskForToken.get(), string.get(), nullptr)).get();
+    if (!entitlementValue || CFGetTypeID(entitlementValue) != CFArrayGetTypeID())
+        return false;
+
+    RetainPtr<CFArrayRef> array = static_cast<CFArrayRef>(entitlementValue);
+
+    for (CFIndex i = 0; i < CFArrayGetCount(array.get()); ++i) {
+        auto element = CFArrayGetValueAtIndex(array.get(), i);
+        if (CFGetTypeID(element) != CFStringGetTypeID())
+            continue;
+        CFStringRef stringElement = static_cast<CFStringRef>(element);
+        if (value == stringElement)
+            return true;
+    }
+
+    return false;
 }
 
 } // namespace WTF

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1103,12 +1103,14 @@
 
 
 #if ENABLE(QUICKLOOK_SANDBOX_RESTRICTIONS)
-(with-filter (require-not (state-flag "EnableQuickLookSandboxResources"))
+(allow syscall-unix
+    (syscall-unix-rarely-in-use)
+    (syscall-unix-rarely-in-use-blocked-in-lockdown-mode))
+(with-filter
+    (require-all
+        (state-flag "ParentProcessCanEnableQuickLookStateFlag")
+        (require-not (state-flag "EnableQuickLookSandboxResources")))
     (allow syscall-unix (with report) (with telemetry-backtrace)
-        (syscall-unix-rarely-in-use)
-        (syscall-unix-rarely-in-use-blocked-in-lockdown-mode)))
-(with-filter (state-flag "EnableQuickLookSandboxResources")
-    (allow syscall-unix
         (syscall-unix-rarely-in-use)
         (syscall-unix-rarely-in-use-blocked-in-lockdown-mode)))
 #else

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -187,10 +187,12 @@ function webcontent_sandbox_entitlements()
     plistbuddy Add :com.apple.private.security.mutable-state-flags:1 string BlockIOKitInWebContentSandbox
     plistbuddy Add :com.apple.private.security.mutable-state-flags:2 string local:WebContentProcessLaunched
     plistbuddy Add :com.apple.private.security.mutable-state-flags:3 string EnableQuickLookSandboxResources
+    plistbuddy Add :com.apple.private.security.mutable-state-flags:4 string ParentProcessCanEnableQuickLookStateFlag
     plistbuddy Add :com.apple.private.security.enable-state-flags array
     plistbuddy Add :com.apple.private.security.enable-state-flags:0 string EnableExperimentalSandbox
     plistbuddy Add :com.apple.private.security.enable-state-flags:1 string BlockIOKitInWebContentSandbox
     plistbuddy Add :com.apple.private.security.enable-state-flags:2 string local:WebContentProcessLaunched
+    plistbuddy Add :com.apple.private.security.enable-state-flags:3 string ParentProcessCanEnableQuickLookStateFlag
 }
 
 function notify_entitlements()

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7222,7 +7222,8 @@ void WebPageProxy::decidePolicyForResponseShared(Ref<WebProcessProxy>&& process,
 #if ENABLE(QUICKLOOK_SANDBOX_RESTRICTIONS)
         if (policyAction == PolicyAction::Use && PreviewConverter::supportsMIMEType(navigationResponse->response().mimeType())) {
             auto auditToken = m_process->connection()->getAuditToken();
-            sandbox_enable_state_flag("EnableQuickLookSandboxResources", *auditToken);
+            bool status = sandbox_enable_state_flag("EnableQuickLookSandboxResources", *auditToken);
+            WEBPAGEPROXY_RELEASE_LOG(Sandbox, "Enabling EnableQuickLookSandboxResources state flag, status = %d", status);
         }
 #endif // ENABLE(QUICKLOOK_SANDBOX_RESTRICTIONS)
 #endif // USE(QUICK_LOOK)

--- a/Tools/MobileMiniBrowser/Configurations/MobileMiniBrowser.xcconfig
+++ b/Tools/MobileMiniBrowser/Configurations/MobileMiniBrowser.xcconfig
@@ -24,3 +24,5 @@
 PRODUCT_NAME = MiniBrowser
 STRIP_STYLE=debugging
 SUPPORTED_PLATFORMS = iphoneos iphonesimulator xros xrsimulator;
+CODE_SIGN_ENTITLEMENTS[sdk=*simulator] = MobileMiniBrowser/MobileMiniBrowser.entitlements;
+OTHER_CODE_SIGN_FLAGS[sdk=*simulator] = ;

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		CDC279282935417100151088 /* test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = test.mp4; sourceTree = "<group>"; };
 		CDC279292935417100151088 /* looping2s.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = looping2s.html; sourceTree = "<group>"; };
 		DD954C942A90280800C6843C /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		E3C8BD852BBF286D00181A2E /* MobileMiniBrowser.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = MobileMiniBrowser.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -177,6 +178,7 @@
 				CD1DAFA61D709E3600017CF0 /* Info.plist */,
 				CD1DAFA31D709E3600017CF0 /* LaunchScreen.storyboard */,
 				CD1DAF961D709E3600017CF0 /* main.m */,
+				E3C8BD852BBF286D00181A2E /* MobileMiniBrowser.entitlements */,
 			);
 			name = "MobileMiniBrowser App";
 			path = MobileMiniBrowser;

--- a/Tools/MobileMiniBrowser/MobileMiniBrowser/MobileMiniBrowser.entitlements
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser/MobileMiniBrowser.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.runningboard.assertions.webkit</key>
+	<true/>
+	<key>com.apple.private.security.enable-state-flags</key>
+	<array>
+		<string>EnableQuickLookSandboxResources</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
#### 9167490750e5180cf2ec4b9e1ba82881b6979da4
<pre>
Use sandbox state flag to enable syscall telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=272046">https://bugs.webkit.org/show_bug.cgi?id=272046</a>
<a href="https://rdar.apple.com/125796089">rdar://125796089</a>

Reviewed by Sihui Liu.

Use sandbox state flag to enable syscall telemetry related to QuickLook. If the parent process
is able to set the state flag EnableQuickLookSandboxResources in the WebContent process, and
this state flag is not set, telemetry is enabled. This will enable us to determine which
rarely used syscalls are being used when not loading QuickLook documents. This will give us
information on which syscalls can be blocked in that scenario.

* Source/WTF/wtf/cocoa/Entitlements.h:
* Source/WTF/wtf/cocoa/Entitlements.mm:
(WTF::hasEntitlementValue):
(WTF::hasEntitlementValueInArray):
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForResponseShared):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):
* Tools/MobileMiniBrowser/Configurations/MobileMiniBrowser.xcconfig:
* Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj:
* Tools/MobileMiniBrowser/MobileMiniBrowser/MobileMiniBrowser.entitlements: Added.

Canonical link: <a href="https://commits.webkit.org/277118@main">https://commits.webkit.org/277118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b57a263dd2b06530621047143fa9c6d20b5c8cc8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49316 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42684 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38027 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19293 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/46505 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41310 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4684 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39886 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51225 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46121 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21646 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45319 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22936 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44275 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23385 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53264 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6543 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22639 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10929 "Passed tests") | 
<!--EWS-Status-Bubble-End-->