### PR TITLE
Github api should not assume the current user as the fork owner.

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -139,7 +139,9 @@ class GitHub(Scm):
                 if not value:
                     raise ValueError("Must define '{}' when creating pull-request".format(key))
 
-            user, _ = self.repository.credentials(required=True)
+            if ':' not in head:
+                user, _ = self.repository.credentials(required=True)
+                head = '{}:{}'.format(user, head)
             url = '{api_url}/repos/{owner}/{name}/pulls'.format(
                 api_url=self.repository.api_url,
                 owner=self.repository.owner,
@@ -152,7 +154,7 @@ class GitHub(Scm):
                     title=title,
                     body=PullRequest.create_body(body, commits),
                     base=base or self.repository.default_branch,
-                    head='{}:{}'.format(user, head),
+                    head=head,
                     draft=draft,
                 ),
             )


### PR DESCRIPTION
#### a1f01fd352d03d3ed4965b126e20665f7a6c6c45
<pre>
Github api should not assume the current user as the fork owner.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272054">https://bugs.webkit.org/show_bug.cgi?id=272054</a>
<a href="https://rdar.apple.com/125792901">rdar://125792901</a> (Github api should not assume the current user as the fork owner)

Reviewed by Jonathan Bedard.

Canonical link: <a href="https://commits.webkit.org/277008@main">https://commits.webkit.org/277008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adb45bf0f6a1bb190ae52ea8fe6a78300a04d6fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48962 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42330 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29781 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37804 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19024 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/46199 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41012 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4333 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42598 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41367 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50775 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45007 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/46328 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22585 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43921 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:afterAll (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22952 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6473 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->