### PR TITLE
Thread safety warning: MediaFormatReader m_duration is unprotected by m_parseTracksLock

### DIFF
--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.cpp
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.cpp
@@ -112,6 +112,12 @@ void MediaFormatReader::startOnMainThread(MTPluginByteSourceRef byteSource)
     });
 }
 
+MediaTime MediaFormatReader::duration() const
+{
+    Locker locker { m_parseTracksLock };
+    return m_duration;
+}
+
 static ConcurrentWorkQueue& readerQueue()
 {
     static NeverDestroyed<Ref<ConcurrentWorkQueue>> queue = ConcurrentWorkQueue::create("WebKit::MediaFormatReader Queue");

--- a/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.h
+++ b/Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.h
@@ -56,7 +56,7 @@ public:
     static RefPtr<MediaFormatReader> create(Allocator&&);
 
     void startOnMainThread(MTPluginByteSourceRef);
-    const MediaTime& duration() const { return m_duration; }
+    MediaTime duration() const;
 
     const Logger& logger() const { ASSERT(m_logger); return *m_logger.get(); }
     const Logger* loggerPtr() const { return m_logger.get(); }
@@ -90,7 +90,7 @@ private:
 
     RetainPtr<MTPluginByteSourceRef> m_byteSource WTF_GUARDED_BY_LOCK(m_parseTracksLock);
     Condition m_parseTracksCondition;
-    Lock m_parseTracksLock;
+    mutable Lock m_parseTracksLock;
     MediaTime m_duration WTF_GUARDED_BY_LOCK(m_parseTracksLock);
     std::optional<OSStatus> m_parseTracksStatus WTF_GUARDED_BY_LOCK(m_parseTracksLock);
     Vector<Ref<MediaTrackReader>> m_trackReaders WTF_GUARDED_BY_LOCK(m_parseTracksLock);


### PR DESCRIPTION
#### fef30aefacf72c9c0cb3ce0a2d84fd3bd7fbf4b7
<pre>
Thread safety warning: MediaFormatReader m_duration is unprotected by m_parseTracksLock
<a href="https://rdar.apple.com/124551630">rdar://124551630</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=272048">https://bugs.webkit.org/show_bug.cgi?id=272048</a>

Reviewed by Eric Carlson.

In addition to holding the lock when accessing m_duration, we should also not be handing
a reference to an internal variable that can be modified off the calling thread.

* Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.cpp:
(WebKit::MediaFormatReader::duration const):
* Source/WebKit/Shared/mac/MediaFormatReader/MediaFormatReader.h:

Canonical link: <a href="https://commits.webkit.org/277035@main">https://commits.webkit.org/277035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a9f5ae9a4d3aa4f937189dc4c8996e10afca165

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49001 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42368 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37826 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19051 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19894 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4371 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42617 "Found 1 new API test failure: TestWebKitAPI.ScrollViewScrollabilityTests.ScrollableWithOverflowHiddenWhenZoomed (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50849 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45053 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22623 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43973 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10281 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22990 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22320 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->