### PR TITLE
Web Inspector: Network Tab: Scope Bar Background Blue

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/NetworkDetailView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/NetworkDetailView.css
@@ -40,6 +40,19 @@
     z-index: 1;
 }
 
+.network-detail .item {
+    --scope-bar-margin: var(--scope-bar-margin-override, var(--scope-bar-margin-default));
+    --scope-bar-padding: var(--scope-bar-padding-override, var(--scope-bar-padding-default));
+    --scope-bar-text-color: var(--scope-bar-text-color-override, var(--scope-bar-text-color-default));
+    --scope-bar-background-color: var(--scope-bar-background-color-override, var(--scope-bar-background-color-default));
+    --scope-bar-background-opacity: var(--scope-bar-background-opacity-override, var(--scope-bar-background-opacity-default));
+    --scope-bar-border-color: var(--scope-bar-border-color-override, var(--scope-bar-border-color-default));
+}
+
+.network-detail .item.button {
+    color: var(--text-color-secondary);
+}
+
 .network-detail .item.close > .glyph {
     border-radius: 2px;
     padding: 2px;
@@ -63,8 +76,13 @@
     display: none;
 }
 
-.network .network-detail .navigation-bar .item.radio.button.text-only.selected {
-    color: var(--glyph-color-active);
+.network .network-detail .navigation-bar .item.radio.button.text-only:is(.selected, :hover) {
+    background-color: var(--glyph-color-active);
+    color: var(--selected-foreground-color);
+}
+
+.network .network-detail .navigation-bar .item.radio.button.text-only:not(.selected):is(:hover) {
+    opacity: .8;
 }
 
 .network-detail > .content-browser {


### PR DESCRIPTION
#### e326b40ec810016f5b589c7663c2b7d557ffdb86
<pre>
Web Inspector: Network Tab: Scope Bar Background Blue
<a href="https://bugs.webkit.org/show_bug.cgi?id=272016">https://bugs.webkit.org/show_bug.cgi?id=272016</a>

Reviewed by NOBODY (OOPS!).

The goal of the pr is to match the navigation tab bars in both light mode and dark mode with the rest of the Web Inspector scope bars:
Add a blue background when a navigation item radio button is selected or hovered.
Set the opacity to 0.8 when a navigation item radio button is hovered but not selected.

* Source/WebInspectorUI/UserInterface/Views/NetworkDetailView.css:
(.network-detail .item):
(.network-detail .item.button):
(.network .network-detail .navigation-bar .item.radio.button.text-only:is(.selected, :hover)):
(.network .network-detail .navigation-bar .item.radio.button.text-only:not(.selected):is(:hover)):
(.network .network-detail .navigation-bar .item.radio.button.text-only.selected): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e326b40ec810016f5b589c7663c2b7d557ffdb86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48955 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42323 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37800 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19017 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41009 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4326 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42590 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50768 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21283 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45004 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22578 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43918 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/22945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->