### PR TITLE
Web Inspector: DOM tree view Cmd-F search unexpectedly changes text displayed

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -197,34 +197,30 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         if (!this._highlightResult)
             return;
 
-        function updateEntryShow(entry)
-        {
-            switch (entry.type) {
+        if (show) {
+            for (let entry of this._highlightResult) {
+                switch (entry.type) {
                 case "added":
                     entry.parent.insertBefore(entry.node, entry.nextSibling);
                     break;
                 case "changed":
                     entry.node.textContent = entry.newText;
                     break;
+                }
             }
-        }
-
-        function updateEntryHide(entry)
-        {
-            switch (entry.type) {
+        } else {
+            for (let i = this._highlightResult.length - 1; i >= 0; --i) {
+                let entry = this._highlightResult[i];
+                switch (entry.type) {
                 case "added":
                     entry.node.remove();
                     break;
                 case "changed":
                     entry.node.textContent = entry.oldText;
                     break;
+                }
             }
         }
-
-        var updater = show ? updateEntryShow : updateEntryHide;
-
-        for (var i = 0, size = this._highlightResult.length; i < size; ++i)
-            updater(this._highlightResult[i]);
     }
 
     get hovered()


### PR DESCRIPTION
#### 0e3b3412203ccd0a2671b5a3f88f156bc9b8a298
<pre>
Web Inspector: DOM tree view Cmd-F search unexpectedly changes text displayed
<a href="https://rdar.apple.com/125797803">rdar://125797803</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=272047">https://bugs.webkit.org/show_bug.cgi?id=272047</a>

Reviewed by Devin Rousso.

When doing a Cmd-F search in the DOM tree view, there is logic to first
convert the search matches into a change list, which is a list of
highlight elements to add or text to change, then execute the changes in
that list.

   - The source for generating change list (works fine) is in
     `WI.highlightRangesWithStyleClass`.
   - The source for executing the changes (problematic) is in
     `WI.DOMTreeElement._updateSearchHighlight`.

Executing a change list can be one of two opposite kinds: applying for
showing the search results, or reverting to hide the results. When
reverting the changes, the original code did it in the same order as
they&apos;re applied, which can cause problems when there are multiple
changes to the same node.

   - For instance, when the search query is &quot;a&quot; and some node&apos;s text is
     &quot;ab ac&quot;, the change list can be something like
     {&quot;ab ac&quot;-&gt;&quot;b ac&quot;, &quot;b ac&quot;-&gt;&quot;b c&quot;} (where the &quot;a&quot;s get put into newly
     generated highlight elements). When reverting, if it&apos;s still done
     in the same order, we&apos;d be setting the text to &quot;b ac&quot; rather than
     the expected &quot;ab ac&quot;.

This commit simply make it so that reverting a change list is done in
the reverse order, therefore preserving the original text when there
are more than one text changes applied to the same node.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype._updateSearchHighlight):
(WI.DOMTreeElement.prototype._updateSearchHighlight.updateEntryShow): Deleted.
(WI.DOMTreeElement.prototype._updateSearchHighlight.updateEntryHide): Deleted.
   - When reverting changes, do so in the reverse order.
   - Remove the helper functions as they don&apos;t improve readability
     anymore with the new logic.

Canonical link: <a href="https://commits.webkit.org/277073@main">https://commits.webkit.org/277073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/656012d3a5beb4ecc9448127435558661ee79e0a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49270 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42638 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23212 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47172 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40153 "Build is in progress. Recent messages:") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19259 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41269 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4638 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51119 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21600 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45254 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44202 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10302 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22593 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->