### PR TITLE
Expose correct enum values to IPC test API for negative values

### DIFF
--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -1358,6 +1358,11 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, u
     result.append('')
     result.append('namespace WebKit {')
     result.append('')
+    result.append('template<typename E> uint64_t enumValueForIPCTestAPI(E e)')
+    result.append('{')
+    result.append('    return static_cast<std::make_unsigned_t<std::underlying_type_t<E>>>(e);')
+    result.append('}')
+    result.append('')
     result.append('Vector<SerializedTypeInfo> allSerializedTypes()')
     result.append('{')
     result.append('    return {')
@@ -1396,7 +1401,7 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, u
             for valid_value in enum.valid_values:
                 if valid_value.condition is not None:
                     result.append('#if ' + valid_value.condition)
-                result.append('            static_cast<uint64_t>(' + enum.namespace_and_name() + '::' + valid_value.name + '),')
+                result.append('            enumValueForIPCTestAPI(' + enum.namespace_and_name() + '::' + valid_value.name + '),')
                 if valid_value.condition is not None:
                     result.append('#endif')
         result.append('        } },')

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -93,6 +93,11 @@ static_assert(std::is_same_v<WTF::ProcessID, pid_t>);
 
 namespace WebKit {
 
+template<typename E> uint64_t enumValueForIPCTestAPI(E e)
+{
+    return static_cast<std::make_unsigned_t<std::underlying_type_t<E>>>(e);
+}
+
 Vector<SerializedTypeInfo> allSerializedTypes()
 {
     return {
@@ -520,61 +525,61 @@ Vector<SerializedEnumInfo> allSerializedEnums()
         } },
 #endif
         { "EnumWithoutNamespace"_s, sizeof(EnumWithoutNamespace), false, {
-            static_cast<uint64_t>(EnumWithoutNamespace::Value1),
-            static_cast<uint64_t>(EnumWithoutNamespace::Value2),
-            static_cast<uint64_t>(EnumWithoutNamespace::Value3),
+            enumValueForIPCTestAPI(EnumWithoutNamespace::Value1),
+            enumValueForIPCTestAPI(EnumWithoutNamespace::Value2),
+            enumValueForIPCTestAPI(EnumWithoutNamespace::Value3),
         } },
 #if ENABLE(UINT16_ENUM)
         { "EnumNamespace::EnumType"_s, sizeof(EnumNamespace::EnumType), false, {
-            static_cast<uint64_t>(EnumNamespace::EnumType::FirstValue),
+            enumValueForIPCTestAPI(EnumNamespace::EnumType::FirstValue),
 #if ENABLE(ENUM_VALUE_CONDITION)
-            static_cast<uint64_t>(EnumNamespace::EnumType::SecondValue),
+            enumValueForIPCTestAPI(EnumNamespace::EnumType::SecondValue),
 #endif
         } },
 #endif
         { "EnumNamespace2::OptionSetEnumType"_s, sizeof(EnumNamespace2::OptionSetEnumType), true, {
-            static_cast<uint64_t>(EnumNamespace2::OptionSetEnumType::OptionSetFirstValue),
+            enumValueForIPCTestAPI(EnumNamespace2::OptionSetEnumType::OptionSetFirstValue),
 #if ENABLE(OPTION_SET_SECOND_VALUE)
-            static_cast<uint64_t>(EnumNamespace2::OptionSetEnumType::OptionSetSecondValue),
+            enumValueForIPCTestAPI(EnumNamespace2::OptionSetEnumType::OptionSetSecondValue),
 #endif
 #if !(ENABLE(OPTION_SET_SECOND_VALUE))
-            static_cast<uint64_t>(EnumNamespace2::OptionSetEnumType::OptionSetSecondValueElse),
+            enumValueForIPCTestAPI(EnumNamespace2::OptionSetEnumType::OptionSetSecondValueElse),
 #endif
-            static_cast<uint64_t>(EnumNamespace2::OptionSetEnumType::OptionSetThirdValue),
+            enumValueForIPCTestAPI(EnumNamespace2::OptionSetEnumType::OptionSetThirdValue),
         } },
         { "OptionSetEnumFirstCondition"_s, sizeof(OptionSetEnumFirstCondition), true, {
 #if ENABLE(OPTION_SET_FIRST_VALUE)
-            static_cast<uint64_t>(OptionSetEnumFirstCondition::OptionSetFirstValue),
+            enumValueForIPCTestAPI(OptionSetEnumFirstCondition::OptionSetFirstValue),
 #endif
-            static_cast<uint64_t>(OptionSetEnumFirstCondition::OptionSetSecondValue),
-            static_cast<uint64_t>(OptionSetEnumFirstCondition::OptionSetThirdValue),
+            enumValueForIPCTestAPI(OptionSetEnumFirstCondition::OptionSetSecondValue),
+            enumValueForIPCTestAPI(OptionSetEnumFirstCondition::OptionSetThirdValue),
         } },
         { "OptionSetEnumLastCondition"_s, sizeof(OptionSetEnumLastCondition), true, {
-            static_cast<uint64_t>(OptionSetEnumLastCondition::OptionSetFirstValue),
-            static_cast<uint64_t>(OptionSetEnumLastCondition::OptionSetSecondValue),
+            enumValueForIPCTestAPI(OptionSetEnumLastCondition::OptionSetFirstValue),
+            enumValueForIPCTestAPI(OptionSetEnumLastCondition::OptionSetSecondValue),
 #if ENABLE(OPTION_SET_THIRD_VALUE)
-            static_cast<uint64_t>(OptionSetEnumLastCondition::OptionSetThirdValue),
+            enumValueForIPCTestAPI(OptionSetEnumLastCondition::OptionSetThirdValue),
 #endif
         } },
         { "OptionSetEnumAllCondition"_s, sizeof(OptionSetEnumAllCondition), true, {
 #if ENABLE(OPTION_SET_FIRST_VALUE)
-            static_cast<uint64_t>(OptionSetEnumAllCondition::OptionSetFirstValue),
+            enumValueForIPCTestAPI(OptionSetEnumAllCondition::OptionSetFirstValue),
 #endif
 #if ENABLE(OPTION_SET_SECOND_VALUE)
-            static_cast<uint64_t>(OptionSetEnumAllCondition::OptionSetSecondValue),
+            enumValueForIPCTestAPI(OptionSetEnumAllCondition::OptionSetSecondValue),
 #endif
 #if ENABLE(OPTION_SET_THIRD_VALUE)
-            static_cast<uint64_t>(OptionSetEnumAllCondition::OptionSetThirdValue),
+            enumValueForIPCTestAPI(OptionSetEnumAllCondition::OptionSetThirdValue),
 #endif
         } },
 #if (ENABLE(OUTER_CONDITION)) && (ENABLE(INNER_CONDITION))
         { "EnumNamespace::InnerEnumType"_s, sizeof(EnumNamespace::InnerEnumType), false, {
-            static_cast<uint64_t>(EnumNamespace::InnerEnumType::InnerValue),
+            enumValueForIPCTestAPI(EnumNamespace::InnerEnumType::InnerValue),
 #if ENABLE(INNER_INNER_CONDITION)
-            static_cast<uint64_t>(EnumNamespace::InnerEnumType::InnerInnerValue),
+            enumValueForIPCTestAPI(EnumNamespace::InnerEnumType::InnerInnerValue),
 #endif
 #if !(ENABLE(INNER_INNER_CONDITION))
-            static_cast<uint64_t>(EnumNamespace::InnerEnumType::OtherInnerInnerValue),
+            enumValueForIPCTestAPI(EnumNamespace::InnerEnumType::OtherInnerInnerValue),
 #endif
         } },
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -593,14 +593,20 @@ TEST(IPCTestingAPI, SerializedTypeInfo)
         @"type": @"bool"
     }];
     EXPECT_TRUE([typeInfo[@"WebCore::CacheQueryOptions"] isEqualToArray:expectedArray]);
+
     NSDictionary *expectedDictionary = @{
         @"isOptionSet" : @1,
         @"size" : @1,
         @"validValues" : @[@1, @2]
     };
-
     NSDictionary *enumInfo = [webView objectByEvaluatingJavaScript:@"IPC.serializedEnumInfo"];
     EXPECT_TRUE([enumInfo[@"WebKit::WebsiteDataFetchOption"] isEqualToDictionary:expectedDictionary]);
+    NSDictionary *expectedMouseEventButtonDictionary = @{
+        @"isOptionSet" : @NO,
+        @"size" : @1,
+        @"validValues" : @[@1, @2, @254]
+    };
+    EXPECT_TRUE([enumInfo[@"WebKit::WebMouseEventButton"] isEqualToDictionary:expectedMouseEventButtonDictionary]);
 
     NSArray *objectIdentifiers = [webView objectByEvaluatingJavaScript:@"IPC.objectIdentifiers"];
     EXPECT_TRUE([objectIdentifiers containsObject:@"WebCore::PageIdentifier"]);


### PR DESCRIPTION
#### b7a0efc2c0d91301c4966c434aea9a28b29a5778
<pre>
Expose correct enum values to IPC test API for negative values
<a href="https://bugs.webkit.org/show_bug.cgi?id=272061">https://bugs.webkit.org/show_bug.cgi?id=272061</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebKit/Scripts/generate-serializers.py:
(generate_serialized_type_info):
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
(WebKit::enumValueForIPCTestAPI):
(WebKit::allSerializedTypes): Deleted.
(WebKit::allSerializedEnums): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
(SerializedTypeInfo)):

Canonical link: <a href="https://commits.webkit.org/276986@main">https://commits.webkit.org/276986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88efa9bdfd3d26385496615f964b1a89a9aa1758

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/48995 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42363 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22915 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37822 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19046 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/46187 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41029 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4366 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50808 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45029 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22618 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43948 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/22985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6468 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22315 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->