### PR TITLE
[Remote Inspection] Add a way to immediately apply visibility adjustment based on CSS selectors when loading

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -332,6 +332,9 @@ public:
     bool allowsActiveContentRuleListActionsForURL(const String& contentRuleListIdentifier, const URL&) const;
     WEBCORE_EXPORT void setActiveContentRuleListActionPatterns(const HashMap<String, Vector<String>>&);
 
+    const HashSet<String>& visibilityAdjustmentSelectors() const { return m_visibilityAdjustmentSelectors; }
+    void setVisibilityAdjustmentSelectors(HashSet<String>&& selectors) { m_visibilityAdjustmentSelectors = WTFMove(selectors); }
+
 #if ENABLE(DEVICE_ORIENTATION)
     DeviceOrientationOrMotionPermissionState deviceOrientationAndMotionAccessState() const { return m_deviceOrientationAndMotionAccessState; }
     void setDeviceOrientationAndMotionAccessState(DeviceOrientationOrMotionPermissionState state) { m_deviceOrientationAndMotionAccessState = state; }
@@ -696,6 +699,8 @@ private:
     String m_customNavigatorPlatform;
     MemoryCompactRobinHoodHashMap<String, Vector<UserContentURLPattern>> m_activeContentRuleListActionPatterns;
     ContentExtensionEnablement m_contentExtensionEnablement { ContentExtensionDefaultEnablement::Enabled, { } };
+
+    HashSet<String> m_visibilityAdjustmentSelectors;
 
     ScriptExecutionContextIdentifier m_resultingClientId;
 

--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -31,6 +31,7 @@
 #include "IntRect.h"
 #include "Region.h"
 #include "ScriptExecutionContextIdentifier.h"
+#include <wtf/ApproximateTime.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/Ref.h>
@@ -53,14 +54,18 @@ public:
     WEBCORE_EXPORT bool adjustVisibility(const Vector<std::pair<ElementIdentifier, ScriptExecutionContextIdentifier>>&);
     void adjustVisibilityInRepeatedlyTargetedRegions(Document&);
 
-    void resetAdjustmentRegions();
+    void reset();
 
     WEBCORE_EXPORT uint64_t numberOfVisibilityAdjustmentRects() const;
     WEBCORE_EXPORT bool resetVisibilityAdjustments(const Vector<std::pair<ElementIdentifier, ScriptExecutionContextIdentifier>>&);
 
 private:
+    void applyVisibilityAdjustmentFromSelectors(Document&);
+
     SingleThreadWeakPtr<Page> m_page;
     HashMap<ElementIdentifier, IntRect> m_pendingAdjustmentClientRects;
+    std::optional<HashSet<String>> m_remainingVisibilityAdjustmentSelectors;
+    ApproximateTime m_startTimeForSelectorBasedVisibilityAdjustment;
     Region m_adjustmentClientRegion;
     Region m_repeatedAdjustmentClientRegion;
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_adjustedElements;

--- a/Source/WebCore/page/ElementTargetingTypes.h
+++ b/Source/WebCore/page/ElementTargetingTypes.h
@@ -49,6 +49,7 @@ struct TargetedElementInfo {
     String renderedText;
     Vector<String> selectors;
     FloatRect boundsInRootView;
+    FloatRect boundsInClientCoordinates;
     PositionType positionType { PositionType::Static };
     Vector<FrameIdentifier> childFrameIdentifiers;
     bool isUnderPoint { true };

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1552,7 +1552,7 @@ void Page::didCommitLoad()
         geolocationController->didNavigatePage();
 #endif
 
-    m_elementTargetingController->resetAdjustmentRegions();
+    m_elementTargetingController->reset();
 
     m_isWaitingForLoadToFinish = true;
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -897,6 +897,7 @@ header: <WebCore/ElementTargetingTypes.h>
     String renderedText
     Vector<String> selectors
     WebCore::FloatRect boundsInRootView
+    WebCore::FloatRect boundsInClientCoordinates
     WebCore::PositionType positionType
     Vector<WebCore::FrameIdentifier> childFrameIdentifiers
     bool isUnderPoint

--- a/Source/WebKit/Shared/WebsitePoliciesData.cpp
+++ b/Source/WebKit/Shared/WebsitePoliciesData.cpp
@@ -52,6 +52,7 @@ void WebsitePoliciesData::applyToDocumentLoader(WebsitePoliciesData&& websitePol
         documentLoader.setContentExtensionEnablement(WTFMove(websitePolicies.contentExtensionEnablement));
 
     documentLoader.setActiveContentRuleListActionPatterns(websitePolicies.activeContentRuleListActionPatterns);
+    documentLoader.setVisibilityAdjustmentSelectors(WTFMove(websitePolicies.visibilityAdjustmentSelectors));
 
     OptionSet<WebCore::AutoplayQuirk> quirks;
     const auto& allowedQuirks = websitePolicies.allowedAutoplayQuirks;

--- a/Source/WebKit/Shared/WebsitePoliciesData.h
+++ b/Source/WebKit/Shared/WebsitePoliciesData.h
@@ -38,6 +38,7 @@
 #include <WebCore/DeviceOrientationOrMotionPermissionState.h>
 #include <WebCore/DocumentLoader.h>
 #include <WebCore/FrameLoaderTypes.h>
+#include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
 
 namespace IPC {
@@ -58,6 +59,7 @@ public:
 
     HashMap<String, Vector<String>> activeContentRuleListActionPatterns;
     Vector<WebCore::CustomHeaderFields> customHeaderFields;
+    HashSet<String> visibilityAdjustmentSelectors;
     String customUserAgent;
     String customUserAgentAsSiteSpecificQuirks;
     String customNavigatorPlatform;

--- a/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
+++ b/Source/WebKit/Shared/WebsitePoliciesData.serialization.in
@@ -53,6 +53,7 @@ enum class WebKit::WebContentMode : uint8_t {
 struct WebKit::WebsitePoliciesData {
     HashMap<String, Vector<String>> activeContentRuleListActionPatterns;
     Vector<WebCore::CustomHeaderFields> customHeaderFields;
+    HashSet<String> visibilityAdjustmentSelectors;
     String customUserAgent;
     String customUserAgentAsSiteSpecificQuirks;
     String customNavigatorPlatform;

--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
@@ -55,6 +55,7 @@ public:
     WebCore::PositionType positionType() const { return m_info.positionType; }
     WebCore::FloatRect boundsInRootView() const { return m_info.boundsInRootView; }
     WebCore::FloatRect boundsInWebView() const;
+    WebCore::FloatRect boundsInClientCoordinates() const { return m_info.boundsInClientCoordinates; }
 
     bool isUnderPoint() const { return m_info.isUnderPoint; }
     bool isPseudoElement() const { return m_info.isPseudoElement; }

--- a/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
+++ b/Source/WebKit/UIProcess/API/APIWebsitePolicies.h
@@ -135,6 +135,9 @@ public:
     bool allowPrivacyProxy() const { return m_data.allowPrivacyProxy; }
     void setAllowPrivacyProxy(bool allow) { m_data.allowPrivacyProxy = allow; }
 
+    const HashSet<WTF::String>& visibilityAdjustmentSelectors() const { return m_data.visibilityAdjustmentSelectors; }
+    void setVisibilityAdjustmentSelectors(HashSet<WTF::String>&& selectors) { m_data.visibilityAdjustmentSelectors = WTFMove(selectors); }
+
 private:
     WebKit::WebsitePoliciesData m_data;
     RefPtr<WebKit::WebsiteDataStore> m_websiteDataStore;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -654,4 +654,21 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
     _websitePolicies->setAdvancedPrivacyProtections(webCorePolicy);
 }
 
+- (void)_setVisibilityAdjustmentSelectors:(NSSet<NSString *> *)nsSelectors
+{
+    HashSet<String> selectors;
+    selectors.reserveInitialCapacity(nsSelectors.count);
+    for (NSString *selector in nsSelectors)
+        selectors.add(selector);
+    _websitePolicies->setVisibilityAdjustmentSelectors(WTFMove(selectors));
+}
+
+- (NSSet<NSString *> *)_visibilityAdjustmentSelectors
+{
+    RetainPtr selectors = adoptNS([[NSMutableSet alloc] initWithCapacity:_websitePolicies->visibilityAdjustmentSelectors().size()]);
+    for (auto& selector : _websitePolicies->visibilityAdjustmentSelectors())
+        [selectors addObject:selector];
+    return selectors.autorelease();
+}
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h
@@ -120,6 +120,8 @@ typedef NS_OPTIONS(NSUInteger, _WKWebsiteNetworkConnectionIntegrityPolicy) {
 @property (nonatomic, setter=_setNetworkConnectionIntegrityEnabled:) BOOL _networkConnectionIntegrityEnabled WK_API_AVAILABLE(macos(13.3), ios(16.4));
 @property (nonatomic, setter=_setNetworkConnectionIntegrityPolicy:) _WKWebsiteNetworkConnectionIntegrityPolicy _networkConnectionIntegrityPolicy WK_API_AVAILABLE(macos(13.3), ios(16.4));
 
+@property (nonatomic, copy, setter=_setVisibilityAdjustmentSelectors:) NSSet<NSString *> *_visibilityAdjustmentSelectors WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 - (void)_setContentRuleListsEnabled:(BOOL)enabled exceptions:(NSSet<NSString *> *)exceptions WK_API_AVAILABLE(macos(14.0), ios(17.0));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
@@ -41,13 +41,17 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA))
 @interface _WKTargetedElementInfo : NSObject
 
 @property (nonatomic, readonly) _WKTargetedElementPosition positionType;
-@property (nonatomic, readonly) CGRect bounds;
+@property (nonatomic, readonly) CGRect boundsInWebView; // In WKWebView's coordinate space.
+@property (nonatomic, readonly) CGRect boundsInClientCoordinates;
 @property (nonatomic, readonly, getter=isUnderPoint) BOOL underPoint;
 @property (nonatomic, readonly, getter=isPseudoElement) BOOL pseudoElement;
 
 @property (nonatomic, readonly, copy) NSArray<NSString *> *selectors;
 @property (nonatomic, readonly, copy) NSString *renderedText;
 @property (nonatomic, readonly) _WKRectEdge offsetEdges;
+
+// In root view coordinates. To be deprecated and removed, once clients adopt the more explicit bounds properties above.
+@property (nonatomic, readonly) CGRect bounds;
 
 - (BOOL)isSameElement:(_WKTargetedElementInfo *)other;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -71,6 +71,16 @@
     return _info->boundsInRootView();
 }
 
+- (CGRect)boundsInWebView
+{
+    return _info->boundsInWebView();
+}
+
+- (CGRect)boundsInClientCoordinates
+{
+    return _info->boundsInClientCoordinates();
+}
+
 - (NSArray<NSString *> *)selectors
 {
     return createNSArray(_info->selectors()).autorelease();

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1160,6 +1160,7 @@
 		F41AB9A81EF4696B0083FA08 /* prevent-operation.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9941EF4692C0083FA08 /* prevent-operation.html */; };
 		F41AB9A91EF4696B0083FA08 /* prevent-start.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB99A1EF4692C0083FA08 /* prevent-start.html */; };
 		F41AB9AA1EF4696B0083FA08 /* textarea-to-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41AB9951EF4692C0083FA08 /* textarea-to-input.html */; };
+		F41E446D2BBCDD81002A856F /* element-targeting-3.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41E44652BBCDC74002A856F /* element-targeting-3.html */; };
 		F422A3EB235BB16200CF00CA /* clipboard.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F422A3EA235BB14500CF00CA /* clipboard.html */; };
 		F425831624F07CA5006B985D /* WKWebViewCoders.mm in Sources */ = {isa = PBXBuildFile; fileRef = F425831524F07CA5006B985D /* WKWebViewCoders.mm */; };
 		F42BD7D9245CC508001E207A /* attributedStringNewlineAtEndOfDocument.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F42BD7D8245CC4E6001E207A /* attributedStringNewlineAtEndOfDocument.html */; };
@@ -1625,6 +1626,7 @@
 				F4BDA43027F8D19C00F9647D /* element-fullscreen.html in Copy Resources */,
 				F4DADD072BABAD0F008B398F /* element-targeting-1.html in Copy Resources */,
 				F4365E2B2BB11829005E8C1A /* element-targeting-2.html in Copy Resources */,
+				F41E446D2BBCDD81002A856F /* element-targeting-3.html in Copy Resources */,
 				51C8E1A91F27F49600BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist in Copy Resources */,
 				49D902B328209B3300E2C3B8 /* emptyTable.html in Copy Resources */,
 				A14AAB651E78DC5400C1ADC2 /* encrypted.pdf in Copy Resources */,
@@ -3514,6 +3516,7 @@
 		F41AB99C1EF4692C0083FA08 /* contenteditable-and-textarea.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "contenteditable-and-textarea.html"; sourceTree = "<group>"; };
 		F41AB99D1EF4692C0083FA08 /* link-and-target-div.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "link-and-target-div.html"; sourceTree = "<group>"; };
 		F41AB99E1EF4692C0083FA08 /* div-and-large-image.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "div-and-large-image.html"; sourceTree = "<group>"; };
+		F41E44652BBCDC74002A856F /* element-targeting-3.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-targeting-3.html"; sourceTree = "<group>"; };
 		F422A3E8235ACA9B00CF00CA /* ClipboardTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ClipboardTests.mm; sourceTree = "<group>"; };
 		F422A3EA235BB14500CF00CA /* clipboard.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = clipboard.html; sourceTree = "<group>"; };
 		F425831524F07CA5006B985D /* WKWebViewCoders.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewCoders.mm; sourceTree = "<group>"; };
@@ -4827,6 +4830,7 @@
 				F4BDA42F27F8CF5600F9647D /* element-fullscreen.html */,
 				F4DADCFF2BABA80C008B398F /* element-targeting-1.html */,
 				F4365E232BB1181A005E8C1A /* element-targeting-2.html */,
+				F41E44652BBCDC74002A856F /* element-targeting-3.html */,
 				51C8E1A81F27F47300BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist */,
 				F4C2AB211DD6D94100E06D5B /* enormous-video-with-sound.html */,
 				F407FE381F1D0DE60017CF25 /* enormous.svg */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-3.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-3.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<style>
+body, html {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    font-size: 16px;
+    line-height: 200%;
+    -webkit-text-size-adjust: none;
+    color: white;
+}
+
+main::before {
+    width: 250px;
+    height: 250px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: tomato;
+    text-align: center;
+    opacity: 0.5;
+    content: " ";
+}
+
+html::after {
+    width: 200px;
+    height: 200px;
+    position: fixed;
+    top: 25px;
+    left: 25px;
+    background: green;
+    text-align: center;
+    opacity: 0.5;
+    content: " ";
+}
+</style>
+</head>
+<body>
+    <main>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</main>
+</body>
+</html>

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -108,6 +108,7 @@ struct AutocorrectionContext {
 - (void)synchronouslyLoadRequest:(NSURLRequest *)request preferences:(WKWebpagePreferences *)preferences;
 - (void)synchronouslyLoadRequestIgnoringSSLErrors:(NSURLRequest *)request;
 - (void)synchronouslyLoadTestPageNamed:(NSString *)pageName;
+- (void)synchronouslyLoadTestPageNamed:(NSString *)pageName preferences:(WKWebpagePreferences *)preferences;
 - (BOOL)_synchronouslyExecuteEditCommand:(NSString *)command argument:(NSString *)argument;
 - (void)expectElementTagsInOrder:(NSArray<NSString *> *)tagNames;
 - (void)expectElementCount:(NSInteger)count querySelector:(NSString *)querySelector;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -137,6 +137,12 @@ static NSString *overrideBundleIdentifier(id, SEL)
     [self _test_waitForDidFinishNavigation];
 }
 
+- (void)synchronouslyLoadTestPageNamed:(NSString *)pageName preferences:(WKWebpagePreferences *)preferences
+{
+    [self loadTestPageNamed:pageName];
+    [self _test_waitForDidFinishNavigationWithPreferences:preferences];
+}
+
 - (BOOL)_synchronouslyExecuteEditCommand:(NSString *)command argument:(NSString *)argument
 {
     __block bool done = false;


### PR DESCRIPTION
#### 60ad4ce2c9dba49e168cb8048022d1e9baf67afc
<pre>
[Remote Inspection] Add a way to immediately apply visibility adjustment based on CSS selectors when loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=272060">https://bugs.webkit.org/show_bug.cgi?id=272060</a>

Reviewed by Aditya Keerthi.

Add a mechanism which allows WebKit clients to eagerly apply visibility adjustment to elements per
navigation, based on sets of CSS selectors. See below for more details.

* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::visibilityAdjustmentSelectors const):
(WebCore::DocumentLoader::setVisibilityAdjustmentSelectors):

Add plumbing from `WebsitePoliciesData` down into `DocumentLoader`, like all of the other per-load
website policies.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::computeClientRect):
(WebCore::targetedElementInfo):
(WebCore::ElementTargetingController::adjustVisibilityInRepeatedlyTargetedRegions):
(WebCore::ElementTargetingController::applyVisibilityAdjustmentFromSelectors):

If we haven&apos;t already done so yet, pull `visibilityAdjustmentSelectors` from the `DocumentLoader`
into `ElementTargetingController`. For up to 30 seconds after committing the load, continually look
for elements that correspond to these selectors, and immediately adjust visibility for them if
found.

(WebCore::ElementTargetingController::reset):
(WebCore::ElementTargetingController::resetAdjustmentRegions): Deleted.

Rename `resetAdjustmentRegions` to just `reset`, since it now clears out more state than just what&apos;s
necessary for tracking adjustment regions.

* Source/WebCore/page/ElementTargetingController.h:
* Source/WebCore/page/ElementTargetingTypes.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCommitLoad):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebsitePoliciesData.cpp:
(WebKit::WebsitePoliciesData::applyToDocumentLoader):
* Source/WebKit/Shared/WebsitePoliciesData.h:
* Source/WebKit/Shared/WebsitePoliciesData.serialization.in:

Add more plumbing for CSS selectors from the client down into WebCore.

* Source/WebKit/UIProcess/API/APITargetedElementInfo.h:
* Source/WebKit/UIProcess/API/APIWebsitePolicies.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setVisibilityAdjustmentSelectors:]):
(-[WKWebpagePreferences _visibilityAdjustmentSelectors]):

Add support for the new SPI. See above for more details.

* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo boundsInWebView]):
(-[_WKTargetedElementInfo boundsInClientCoordinates]):

Also, clean up this `bounds` SPI property — currently, the `-bounds` property returns the bounds of
the element in root view coordinates, while the targeted element request expects a point in the web
view&apos;s coordinate space. To address this inconsistency and clarify the behavior of the API, add
alternatives to `bounds`: `boundsInWebView` and `boundsInClientCoordinates` that explicitly indicate
which coordinate space the bounds are in. Depending on the purpose, the client can use either.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(TestWebKitAPI::setUpWebViewForSnapshotting):

Factor this setup code into a common helper to reduce code duplication.

(TestWebKitAPI::TEST(ElementTargeting, AdjustVisibilityForUnparentedElement)):
(TestWebKitAPI::TEST(ElementTargeting, AdjustVisibilityFromSelectors)):
(TestWebKitAPI::TEST(ElementTargeting, AdjustVisibilityFromPseudoSelectors)):

Add an API test to exercise the new SPI, and verify that it works well with the rest of the existing
SPI surface around visibility adjustment.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-3.html: Added.
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:

(-[WKWebView synchronouslyLoadTestPageNamed:preferences:]):

Canonical link: <a href="https://commits.webkit.org/276990@main">https://commits.webkit.org/276990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d018024830b8c48faec994bcb019a87cbc8d1268

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42399 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22954 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46936 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39966 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19070 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41070 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4402 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50860 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45064 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43984 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10259 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22353 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->