### PR TITLE
[GTK] Implement printing using the Print portal

### DIFF
--- a/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.h.in
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.h.in
@@ -83,7 +83,7 @@ WEBKIT_API WebKitPrintOperationResponse
 webkit_print_operation_run_dialog         (WebKitPrintOperation *print_operation,
                                            GtkWindow            *parent);
 
-WEBKIT_API void
+WEBKIT_DEPRECATED void
 webkit_print_operation_print              (WebKitPrintOperation *print_operation);
 
 G_END_DECLS

--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestPrinting.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestPrinting.cpp
@@ -141,7 +141,9 @@ static void testPrintOperationPrint(PrintTest* test, gconstpointer)
     gtk_print_settings_set(printSettings.get(), GTK_PRINT_SETTINGS_OUTPUT_URI, outputURI.get());
 
     webkit_print_operation_set_print_settings(test->m_printOperation.get(), printSettings.get());
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     webkit_print_operation_print(test->m_printOperation.get());
+    ALLOW_DEPRECATED_DECLARATIONS_END
     test->waitUntilPrintFinished();
 
     GRefPtr<GFileInfo> fileInfo = adoptGRef(g_file_query_info(outputFile.get(),
@@ -171,14 +173,18 @@ static void testPrintOperationErrors(PrintTest* test, gconstpointer)
     gtk_print_settings_set_printer(printSettings.get(), gtk_printer_get_name(printer.get()));
     gtk_print_settings_set(printSettings.get(), GTK_PRINT_SETTINGS_OUTPUT_URI, "file:///foo/bar");
     webkit_print_operation_set_print_settings(test->m_printOperation.get(), printSettings.get());
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     webkit_print_operation_print(test->m_printOperation.get());
+    ALLOW_DEPRECATED_DECLARATIONS_END
     if (test->m_expectedError == WEBKIT_PRINT_ERROR_GENERAL)
         test->waitUntilPrintFinished();
 
     // Printer not found error.
     test->m_expectedError = WEBKIT_PRINT_ERROR_PRINTER_NOT_FOUND;
     gtk_print_settings_set_printer(printSettings.get(), "The fake WebKit printer");
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     webkit_print_operation_print(test->m_printOperation.get());
+    ALLOW_DEPRECATED_DECLARATIONS_END
     if (test->m_expectedError == WEBKIT_PRINT_ERROR_PRINTER_NOT_FOUND)
         test->waitUntilPrintFinished();
 
@@ -186,7 +192,9 @@ static void testPrintOperationErrors(PrintTest* test, gconstpointer)
     test->m_expectedError = WEBKIT_PRINT_ERROR_INVALID_PAGE_RANGE;
     gtk_print_settings_set_printer(printSettings.get(), gtk_printer_get_name(printer.get()));
     gtk_print_settings_set_page_set(printSettings.get(), GTK_PAGE_SET_EVEN);
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     webkit_print_operation_print(test->m_printOperation.get());
+    ALLOW_DEPRECATED_DECLARATIONS_END
     if (test->m_expectedError == WEBKIT_PRINT_ERROR_INVALID_PAGE_RANGE)
         test->waitUntilPrintFinished();
 }
@@ -253,7 +261,9 @@ public:
 
         m_printOperation = printOperation;
         g_signal_connect(m_printOperation.get(), "finished", G_CALLBACK(printOperationFinished), this);
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         webkit_print_operation_print(m_printOperation.get());
+        ALLOW_DEPRECATED_DECLARATIONS_END
     }
 
     void printFinished()


### PR DESCRIPTION
#### fd47d132791d1978fac5b3c2e39ed36486f9a0a6
<pre>
[GTK] Implement printing using the Print portal
<a href="https://bugs.webkit.org/show_bug.cgi?id=192748">https://bugs.webkit.org/show_bug.cgi?id=192748</a>

Reviewed by Michael Catanzaro.

When running inside a sandboxed environment - which is fairly common
nowadays - printing is severely limited due to using the legacy GTK
print API (GtkPrintUnixDialog &amp; family).

Due to WebKit&apos;s multi-process architecture, using the modern alternative,
GtkPrintOperation, is not really possible, because GtkPrintOperation has
the enconded assumption that the rendering of the document pages happens
in the same process as of printing.

Implement manual support for the Print portal. The portal has two well
defined steps:

 1. PreparePrint() is where WebKit sends the settings and page setup
    that are stored in WebKitPrintOperation to the portal. The portal
    presents a dialog to let users choose their print preferences. This
    step returns WebKit a token, which is the &quot;authentication&quot; mechanism
    for the next step.

 2. Print() takes a token, and a file descriptor pointing to the file
    that will be send to the printer. The file descriptor can and often
    does point to an in-memory buffer! In WebKit&apos;s case, it&apos;s a tmpfile.

This effectively means that webkit_print_operation_print(), which assumes
that step 1 can be skipped - cannot work under a sandbox. Deprecate this
function, and adjust the tests to ignore this deprecation, as the tests
should be adapted separately.

* Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.cpp:
(webkitPrintOperationFinished):
(webkitPrintOperationFailed):
(webkitPrintOperationPrintPagesForFrame):
(findFilePrinter):
(webkitPrintOperationSendPagesToPrintPortal):
(webkitPrintOperationPreparePrint):
(webkitPrintOperationRunPortalDialog):
(webkitPrintOperationRunDialogForFrame):
* Source/WebKit/UIProcess/API/gtk/WebKitPrintOperation.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGtk/TestPrinting.cpp:
(testPrintOperationPrint):
(testPrintOperationErrors):

Canonical link: <a href="https://commits.webkit.org/277671@main">https://commits.webkit.org/277671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10a3cdb002158cfd4701780927de9dbc5efd1b12

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50497 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43869 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38916 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20208 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22163 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42516 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5863 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52391 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22852 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46225 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24123 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45278 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24913 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6856 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->