### PR TITLE
[view-transitions] Suppress rendering while a view-transition is being setup.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/input-targets-root-while-render-blocked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/input-targets-root-while-render-blocked-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Input when rendering suppressed targets root assert_equals: Events must target the transition root while render blocked expected Element node <html><head><title>View transitions: ensure input targets... but got Element node <div id="clicktarget"></div>
+PASS Input when rendering suppressed targets root
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-css-animation-while-render-blocked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-css-animation-while-render-blocked-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL CSS animation is blocked until prepare callback promise_test: Unhandled rejection with value: undefined
+PASS CSS animation is blocked until prepare callback
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>View transitions: Rendering suppression prevents painting (ref)</title>
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+<style>
+#target {
+  width: 200px;
+  height: 200px;
+  background: green;
+}
+</style>
+
+<div id=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>View transitions: Rendering suppression prevents painting (ref)</title>
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+<style>
+#target {
+  width: 200px;
+  height: 200px;
+  background: green;
+}
+</style>
+
+<div id=target></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html class=reftest-wait>
+<title>View transitions: Rendering suppression prevents painting</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/#document-rendering-suppression-for-view-transitions">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="no-painting-while-render-blocked-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+#target {
+  width: 200px;
+  height: 200px;
+  background: green;
+}
+</style>
+
+<div id=target></div>
+
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+async function runTest() {
+  let transition = document.startViewTransition(async () => {
+    document.getElementById('target').style.backgroundColor = "red";
+    takeScreenshot();
+    await new Promise(resolve => setTimeout(resolve, 5000));
+  });
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-raf-while-render-blocked-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-raf-while-render-blocked-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL rAF is blocked until prepare callback promise_test: Unhandled rejection with value: undefined
+PASS rAF is blocked until prepare callback
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3944,6 +3944,11 @@ imported/w3c/web-platform-tests/css/css-view-transitions/element-is-grouping-dur
 imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-name-removed-mid-transition.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/modify-style-via-cssom.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/names-are-tree-scoped.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/no-white-flash-before-activation.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/input-targets-root-while-render-blocked.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/no-css-animation-while-render-blocked.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-view-transitions/no-raf-while-render-blocked.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/svg/text/reftests/transform-dynamic-change.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1725,6 +1725,8 @@ webkit.org/b/264001 [ Debug ] imported/w3c/web-platform-tests/requestidlecallbac
 webkit.org/b/268398 [ Sonoma+ ] compositing/plugins/pdf/pdf-in-iframe-scrolling-tree-after-back.html [ Pass Failure ]
 
 imported/w3c/web-platform-tests/css/css-view-transitions/inline-element-size.html [ ImageOnlyFailure ]
+webkit.org/b/274852 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor.html [ ImageOnlyFailure ]
+webkit.org/b/273613 [ Ventura ] imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked.html [ Skip ]
 
 # webkit.org/b/270092  (REGRESSION (275274@main): [ Sonoma+ wk2 ] Multiple compositing/plugins/pdf/pdf are constant failures)
 [ Sonoma+ ] compositing/plugins/pdf/pdf-in-embed.html [ Failure ]
@@ -1761,8 +1763,6 @@ webkit.org/b/274709 imported/w3c/web-platform-tests/pointerevents/pointer-events
 webkit.org/b/274766 http/wpt/webauthn/public-key-credential-get-success-u2f.https.html [ Failure ]
 
 webkit.org/b/258228 [ Sonoma+ Debug ] accessibility/mac/text-input-session-notifications.html [ Skip ]
-
-webkit.org/b/274852 imported/w3c/web-platform-tests/css/css-view-transitions/new-content-flat-transform-ancestor.html [ ImageOnlyFailure ]
 
 # rdar://129424261 (REGRESSION (279443@main): [ Sonoma Release ] WindowServer watchdog timeout on Intel machine)
 [ Release x86_64 ] http/tests/webgpu/webgpu/idl/constructable.html [ Skip ]

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10547,6 +10547,7 @@ bool Document::activeViewTransitionCapturedDocumentElement() const
 
 void Document::setActiveViewTransition(RefPtr<ViewTransition>&& viewTransition)
 {
+    clearRenderingIsSuppressedForViewTransition();
     m_activeViewTransition = WTFMove(viewTransition);
 }
 
@@ -10558,6 +10559,34 @@ bool Document::hasViewTransitionPseudoElementTree() const
 void Document::setHasViewTransitionPseudoElementTree(bool value)
 {
     m_hasViewTransitionPseudoElementTree = value;
+}
+
+bool Document::renderingIsSuppressedForViewTransition() const
+{
+    return m_renderingIsSuppressedForViewTransition;
+}
+
+void Document::setRenderingIsSuppressedForViewTransitionAfterUpdateRendering()
+{
+    m_enableRenderingIsSuppressedForViewTransitionAfterUpdateRendering = true;
+}
+
+void Document::clearRenderingIsSuppressedForViewTransition()
+{
+    m_enableRenderingIsSuppressedForViewTransitionAfterUpdateRendering = false;
+    if (std::exchange(m_renderingIsSuppressedForViewTransition, false)) {
+        if (CheckedPtr view = renderView())
+            view->compositor().setRenderingIsSuppressed(false);
+    }
+}
+
+void Document::flushDeferredRenderingIsSuppressedForViewTransitionChanges()
+{
+    if (std::exchange(m_enableRenderingIsSuppressedForViewTransitionAfterUpdateRendering, false)) {
+        m_renderingIsSuppressedForViewTransition = true;
+        if (CheckedPtr view = renderView())
+            view->compositor().setRenderingIsSuppressed(true);
+    }
 }
 
 RefPtr<ViewTransition> Document::startViewTransition(RefPtr<ViewTransitionUpdateCallback>&& updateCallback)
@@ -10577,8 +10606,13 @@ RefPtr<ViewTransition> Document::startViewTransition(RefPtr<ViewTransitionUpdate
 
 void Document::performPendingViewTransitions()
 {
-    if (!m_activeViewTransition)
+    if (!m_activeViewTransition) {
+        if (renderingIsSuppressedForViewTransition()) {
+            clearRenderingIsSuppressedForViewTransition();
+            DOCUMENT_RELEASE_LOG_ERROR(ViewTransitions, "Rendering suppressed enabled without active view transition");
+        }
         return;
+    }
     Ref activeViewTransition = *m_activeViewTransition;
     if (activeViewTransition->phase() == ViewTransitionPhase::PendingCapture)
         activeViewTransition->setupViewTransition();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1687,6 +1687,11 @@ public:
 
     void performPendingViewTransitions();
 
+    bool renderingIsSuppressedForViewTransition() const;
+    void setRenderingIsSuppressedForViewTransitionAfterUpdateRendering();
+    void clearRenderingIsSuppressedForViewTransition();
+    void flushDeferredRenderingIsSuppressedForViewTransitionChanges();
+
 #if ENABLE(MEDIA_STREAM)
     void setHasCaptureMediaStreamTrack() { m_hasHadCaptureMediaStreamTrack = true; }
     bool hasHadCaptureMediaStreamTrack() const { return m_hasHadCaptureMediaStreamTrack; }
@@ -2580,6 +2585,8 @@ private:
 #endif
 
     bool m_hasViewTransitionPseudoElementTree { false };
+    bool m_renderingIsSuppressedForViewTransition { false };
+    bool m_enableRenderingIsSuppressedForViewTransitionAfterUpdateRendering { false };
 
 #if ENABLE(TOUCH_ACTION_REGIONS)
     bool m_mayHaveElementsWithNonAutoTouchAction { false };

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -110,7 +110,7 @@ void ViewTransition::skipViewTransition(ExceptionOr<JSC::JSValue>&& reason)
         });
     }
 
-    // FIXME: Set rendering suppression for view transitions to false.
+    document()->clearRenderingIsSuppressedForViewTransition();
 
     if (document()->activeViewTransition() == this)
         clearViewTransition();
@@ -231,7 +231,7 @@ void ViewTransition::setupViewTransition()
         return;
     }
 
-    // FIXME: Set document’s rendering suppression for view transitions to true.
+    document()->setRenderingIsSuppressedForViewTransitionAfterUpdateRendering();
     protectedDocument()->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [this, weakThis = WeakPtr { *this }] {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
@@ -526,10 +526,11 @@ void ViewTransition::activateViewTransition()
     if (m_phase == ViewTransitionPhase::Done)
         return;
 
+    document()->clearRenderingIsSuppressedForViewTransition();
+
     // Ensure style & render tree are up-to-date.
     protectedDocument()->updateStyleIfNeeded();
 
-    // FIXME: Set rendering suppression for view transitions to false.
     if (!protectedDocument()->renderView() || protectedDocument()->renderView()->sizeForCSSLargeViewportUnits() != m_initialLargeViewportSize) {
         skipViewTransition(Exception { ExceptionCode::InvalidStateError, "Skipping view transition because viewport size changed."_s });
         return;

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -1008,7 +1008,7 @@ Vector<TargetedElementInfo> ElementTargetingController::extractTargets(Vector<Re
 
             return targetRenderer->isOutOfFlowPositioned()
                 && (!style.hasBackground() || !style.opacity())
-                && style.usedPointerEvents() == PointerEvents::None;
+                && targetRenderer->usedPointerEvents() == PointerEvents::None;
         }();
 
         if (shouldSkipTargetThatCoversViewport)

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -338,7 +338,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         return std::nullopt;
     auto& renderer = *matchedElement->renderer();
 
-    if (renderer.style().usedPointerEvents() == PointerEvents::None)
+    if (renderer.usedPointerEvents() == PointerEvents::None)
         return std::nullopt;
 
     bool isOriginalMatch = matchedElement == originalElement;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1020,6 +1020,7 @@ public:
 #endif
 
     WEBCORE_EXPORT void forEachDocument(const Function<void(Document&)>&) const;
+    void forEachRenderableDocument(const Function<void(Document&)>&) const;
     void forEachMediaElement(const Function<void(HTMLMediaElement&)>&);
     static void forEachDocumentFromMainFrame(const Frame&, const Function<void(Document&)>&);
     void forEachLocalFrame(const Function<void(LocalFrame&)>&);

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -135,6 +135,7 @@ namespace WebCore {
     M(Threading) \
     M(URLParser) \
     M(Viewports) \
+    M(ViewTransitions) \
     M(VirtualMemory) \
     M(WebAudio) \
     M(WebGL) \

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -674,6 +674,9 @@ public:
     bool shouldPaintUsingCompositeCopy() const { return m_shouldPaintUsingCompositeCopy; }
     void setShouldPaintUsingCompositeCopy(bool copy) { m_shouldPaintUsingCompositeCopy = copy; }
 
+    bool renderingIsSuppressedIncludingDescendants() const { return m_renderingIsSuppressedIncludingDescendants; }
+    void setRenderingIsSuppressedIncludingDescendants(bool suppressed) { m_renderingIsSuppressedIncludingDescendants = suppressed; }
+
     const std::optional<FloatRect>& animationExtent() const { return m_animationExtent; }
     void setAnimationExtent(std::optional<FloatRect> animationExtent) { m_animationExtent = animationExtent; }
 
@@ -793,6 +796,7 @@ protected:
     bool m_userInteractionEnabled : 1;
     bool m_canDetachBackingStore : 1;
     bool m_shouldPaintUsingCompositeCopy : 1;
+    bool m_renderingIsSuppressedIncludingDescendants : 1 { false };
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
     bool m_isSeparated : 1;
 #if HAVE(CORE_ANIMATION_SEPARATED_PORTALS)

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -1771,6 +1771,9 @@ void GraphicsLayerCA::setVisibleAndCoverageRects(const VisibleAndCoverageRects& 
 
 bool GraphicsLayerCA::needsCommit(const CommitState& commitState)
 {
+    if (renderingIsSuppressedIncludingDescendants())
+        return false;
+
     if (commitState.ancestorHadChanges)
         return true;
     if (m_uncommittedChanges)

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -234,6 +234,7 @@ private:
 
     bool platformCALayerContentsOpaque() const override { return contentsOpaque(); }
     bool platformCALayerDrawsContent() const override { return drawsContent(); }
+    bool platformCALayerRenderingIsSuppressedIncludingDescendants() const override { return renderingIsSuppressedIncludingDescendants(); }
     WEBCORE_EXPORT bool platformCALayerDelegatesDisplay(PlatformCALayer*) const override;
     WEBCORE_EXPORT void platformCALayerLayerDisplay(PlatformCALayer*) override;
     void platformCALayerLayerDidDisplay(PlatformCALayer* layer) override { return layerDidDisplay(layer); }

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h
@@ -57,6 +57,8 @@ public:
     virtual void platformCALayerLayerDisplay(PlatformCALayer*) { }
     virtual void platformCALayerLayerDidDisplay(PlatformCALayer*) { }
 
+    virtual bool platformCALayerRenderingIsSuppressedIncludingDescendants() const { return false; }
+
     virtual void platformCALayerSetNeedsToRevalidateTiles() { }
     virtual float platformCALayerDeviceScaleFactor() const = 0;
     virtual float platformCALayerContentsScaleMultiplierForNewTiles(PlatformCALayer*) const { return 1; }

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -62,7 +62,7 @@ void EventRegionContext::unite(const FloatRoundedRect& roundedRect, RenderObject
     auto region = transformAndClipIfNeeded(approximateAsRegion(roundedRect), [](auto affineTransform, auto region) {
         return affineTransform.mapRegion(region);
     });
-    m_eventRegion.unite(region, style, overrideUserModifyIsEditable);
+    m_eventRegion.unite(region, renderer, style, overrideUserModifyIsEditable);
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     auto rect = roundedRect.rect();
@@ -400,9 +400,9 @@ EventRegion::EventRegion(Region&& region
 {
 }
 
-void EventRegion::unite(const Region& region, const RenderStyle& style, bool overrideUserModifyIsEditable)
+void EventRegion::unite(const Region& region, RenderObject& renderer, const RenderStyle& style, bool overrideUserModifyIsEditable)
 {
-    if (style.usedPointerEvents() == PointerEvents::None)
+    if (renderer.usedPointerEvents() == PointerEvents::None)
         return;
 
     m_region.unite(region);

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -106,7 +106,7 @@ public:
 
     friend bool operator==(const EventRegion&, const EventRegion&) = default;
 
-    void unite(const Region&, const RenderStyle&, bool overrideUserModifyIsEditable = false);
+    void unite(const Region&, RenderObject&, const RenderStyle&, bool overrideUserModifyIsEditable = false);
     void translate(const IntSize&);
 
     bool contains(const IntPoint& point) const { return m_region.contains(point); }

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -124,7 +124,7 @@ inline bool RenderElement::visibleToHitTesting(const std::optional<HitTestReques
     auto visibility = !request || request->userTriggered() ? style().usedVisibility() : style().visibility();
     return visibility == Visibility::Visible
         && !isSkippedContent()
-        && ((request && request->ignoreCSSPointerEventsProperty()) || style().usedPointerEvents() != PointerEvents::None);
+        && ((request && request->ignoreCSSPointerEventsProperty()) || usedPointerEvents() != PointerEvents::None);
 }
 
 inline int adjustForAbsoluteZoom(int value, const RenderElement& renderer)

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -702,6 +702,12 @@ void RenderLayerCompositor::flushPendingLayerChanges(bool isFlushRoot)
     ++m_layerFlushCount;
 }
 
+void RenderLayerCompositor::setRenderingIsSuppressed(bool suppressed)
+{
+    if (auto* rootLayer = rootGraphicsLayer())
+        rootLayer->setRenderingIsSuppressedIncludingDescendants(suppressed);
+}
+
 #if PLATFORM(IOS_FAMILY)
 void RenderLayerCompositor::updateScrollCoordinatedLayersAfterFlushIncludingSubframes()
 {

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -184,6 +184,7 @@ public:
     void notifyFlushRequired(const GraphicsLayer*) override;
     void notifySubsequentFlushRequired(const GraphicsLayer*) override;
     void flushPendingLayerChanges(bool isFlushRoot = true);
+    void setRenderingIsSuppressed(bool);
 
     // Called when the GraphicsLayer for the given RenderLayer has flushed changes inside of flushPendingLayerChanges().
     void didChangePlatformLayerForLayer(RenderLayer&, const GraphicsLayer*);

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -2435,6 +2435,13 @@ bool RenderObject::effectiveCapturedInViewTransition() const
     return capturedInViewTransition();
 }
 
+PointerEvents RenderObject::usedPointerEvents() const
+{
+    if (document().renderingIsSuppressedForViewTransition() && !isDocumentElementRenderer())
+        return PointerEvents::None;
+    return style().usedPointerEvents();
+}
+
 #if PLATFORM(IOS_FAMILY)
 
 static bool intervalsSufficientlyOverlap(int startA, int endA, int startB, int endB)

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1137,6 +1137,8 @@ public:
     bool isSkippedContentRoot() const;
     bool isSkippedContentForLayout() const;
 
+    PointerEvents usedPointerEvents() const;
+
 protected:
     //////////////////////////////////////////
     // Helper functions. Dangerous to use!

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -221,7 +221,7 @@ static bool isGraphicsElement(const RenderElement& renderer)
 
 bool RenderSVGModelObject::checkIntersection(RenderElement* renderer, const FloatRect& rect)
 {
-    if (!renderer || renderer->style().usedPointerEvents() == PointerEvents::None)
+    if (!renderer || renderer->usedPointerEvents() == PointerEvents::None)
         return false;
     if (!isGraphicsElement(*renderer))
         return false;
@@ -234,7 +234,7 @@ bool RenderSVGModelObject::checkIntersection(RenderElement* renderer, const Floa
 
 bool RenderSVGModelObject::checkEnclosure(RenderElement* renderer, const FloatRect& rect)
 {
-    if (!renderer || renderer->style().usedPointerEvents() == PointerEvents::None)
+    if (!renderer || renderer->usedPointerEvents() == PointerEvents::None)
         return false;
     if (!isGraphicsElement(*renderer))
         return false;

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -303,7 +303,7 @@ bool RenderSVGShape::nodeAtPoint(const HitTestRequest& request, HitTestResult& r
     if (!pointInSVGClippingArea(localPoint))
         return false;
 
-    PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGPath, request, style().usedPointerEvents());
+    PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGPath, request, usedPointerEvents());
     if (isVisibleToHitTesting(style(), request) || !hitRules.requireVisible) {
         const SVGRenderStyle& svgStyle = style().svgStyle();
         WindRule fillRule = svgStyle.fillRule();

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -427,7 +427,7 @@ bool RenderSVGText::nodeAtFloatPoint(const HitTestRequest& request, HitTestResul
 {
     ASSERT(!document().settings().layerBasedSVGEngineEnabled());
 
-    PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGText, request, style().usedPointerEvents());
+    PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGText, request, usedPointerEvents());
     if (isVisibleToHitTesting(style(), request) || !hitRules.requireVisible) {
         if ((hitRules.canHitStroke && (style().svgStyle().hasStroke() || !hitRules.requireStroke))
             || (hitRules.canHitFill && (style().svgStyle().hasFill() || !hitRules.requireFill))) {

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.cpp
@@ -760,7 +760,7 @@ bool SVGInlineTextBox::nodeAtPoint(const HitTestRequest& request, HitTestResult&
     // FIXME: integrate with LegacyInlineTextBox::nodeAtPoint better.
     ASSERT(!isLineBreak());
 
-    PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGText, request, renderer().style().usedPointerEvents());
+    PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGText, request, renderer().usedPointerEvents());
     if (isVisibleToHitTesting(renderer().style(), request) || !hitRules.requireVisible) {
         if ((hitRules.canHitStroke && (renderer().style().svgStyle().hasStroke() || !hitRules.requireStroke))
             || (hitRules.canHitFill && (renderer().style().svgStyle().hasFill() || !hitRules.requireFill))) {

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -226,7 +226,7 @@ bool LegacyRenderSVGImage::nodeAtFloatPoint(const HitTestRequest& request, HitTe
     if (hitTestAction != HitTestForeground)
         return false;
 
-    PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGImage, request, style().usedPointerEvents());
+    PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGImage, request, usedPointerEvents());
     if (isVisibleToHitTesting(style(), request) || !hitRules.requireVisible) {
         static NeverDestroyed<SVGVisitedRendererTracking::VisitedSet> s_visitedSet;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -195,7 +195,7 @@ void LegacyRenderSVGModelObject::absoluteFocusRingQuads(Vector<FloatQuad>& quads
     
 bool LegacyRenderSVGModelObject::checkIntersection(RenderElement* renderer, const FloatRect& rect)
 {
-    if (!renderer || renderer->style().usedPointerEvents() == PointerEvents::None)
+    if (!renderer || renderer->usedPointerEvents() == PointerEvents::None)
         return false;
     if (!isGraphicsElement(*renderer))
         return false;
@@ -210,7 +210,7 @@ bool LegacyRenderSVGModelObject::checkIntersection(RenderElement* renderer, cons
 
 bool LegacyRenderSVGModelObject::checkEnclosure(RenderElement* renderer, const FloatRect& rect)
 {
-    if (!renderer || renderer->style().usedPointerEvents() == PointerEvents::None)
+    if (!renderer || renderer->usedPointerEvents() == PointerEvents::None)
         return false;
     if (!isGraphicsElement(*renderer))
         return false;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -352,7 +352,7 @@ bool LegacyRenderSVGShape::nodeAtFloatPoint(const HitTestRequest& request, HitTe
 
     SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
-    PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGPath, request, style().usedPointerEvents());
+    PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGPath, request, usedPointerEvents());
     if (isVisibleToHitTesting(style(), request) || !hitRules.requireVisible) {
         const SVGRenderStyle& svgStyle = style().svgStyle();
         WindRule fillRule = svgStyle.fillRule();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -71,6 +71,7 @@ public:
     PlatformLayer* platformLayer() const override { return nullptr; }
 
     void recursiveBuildTransaction(RemoteLayerTreeContext&, RemoteLayerTreeTransaction&);
+    void recursiveMarkWillBeDisplayed();
 
     void setNeedsDisplayInRect(const WebCore::FloatRect& dirtyRect) override;
     void setNeedsDisplay() override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -190,11 +190,31 @@ void PlatformCALayerRemote::updateClonedLayerProperties(PlatformCALayerRemote& c
     clone.updateCustomAppearance(customAppearance());
 }
 
+void PlatformCALayerRemote::recursiveMarkWillBeDisplayed()
+{
+    if (m_properties.backingStoreOrProperties.store && m_properties.backingStoreAttached)
+        m_properties.backingStoreOrProperties.store->layerWillBeDisplayed();
+
+    for (size_t i = 0; i < m_children.size(); ++i) {
+        PlatformCALayerRemote& child = downcast<PlatformCALayerRemote>(*m_children[i]);
+        ASSERT(child.superlayer() == this);
+        child.recursiveMarkWillBeDisplayed();
+    }
+}
+
 void PlatformCALayerRemote::recursiveBuildTransaction(RemoteLayerTreeContext& context, RemoteLayerTreeTransaction& transaction)
 {
     ASSERT(!m_properties.backingStoreOrProperties.store || owner());
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(&context == m_context);
-    
+
+    if (owner() && owner()->platformCALayerRenderingIsSuppressedIncludingDescendants()) {
+        // Rendering is suppressed, so don't include any mutations from this subtree
+        // in the transaction. We do still mark all existing layers as will be displayed though,
+        // to prevent the previous contents from being discarded.
+        recursiveMarkWillBeDisplayed();
+        return;
+    }
+
     bool usesBackingStore = owner() && (owner()->platformCALayerDrawsContent() || owner()->platformCALayerDelegatesDisplay(this));
     if (m_properties.backingStoreOrProperties.store && !usesBackingStore) {
         m_properties.backingStoreOrProperties.store = nullptr;


### PR DESCRIPTION
#### 365b5b3b07b0ccc3be56f0a7bcce3f912f5d5b27
<pre>
[view-transitions] Suppress rendering while a view-transition is being setup.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270672">https://bugs.webkit.org/show_bug.cgi?id=270672</a>
<a href="https://rdar.apple.com/124240939">rdar://124240939</a>

Reviewed by Simon Fraser.

This implements rendering suppression by adding a flag to GraphicsLayer that
prevents updates to the PlatformCALayer tree for it and its descendants until
the flag is cleared. This will currently only work on cocoa, with remote
layers enabled.

The flag gets set on the GraphicsLayer after the rendering update completes,
so that any mutations made before rendering suppression were enabled (including
layer tree changes needed for suppression) get flushed before blocking all
future changes.

It also moves all consumers of RenderStyle:::usedPointerEvents to go via the
renderer, where we can override them to none while suppression is in place.
The exceptions are the style change handlers, which can remain unchanged
since we invalidate style entirely when the VT starts.

This doesn&apos;t yet prevent async scrolling rendering updates - bug 273612.
It also doesn&apos;t work fully with in-process layers - bug 273613.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/input-targets-root-while-render-blocked-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-css-animation-while-render-blocked-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-painting-while-render-blocked.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/no-raf-while-render-blocked-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setActiveViewTransition):
(WebCore::Document::renderingIsSuppressedForViewTransition const):
(WebCore::Document::setRenderingIsSuppressedForViewTransitionAfterUpdateRendering):
(WebCore::Document::clearRenderingIsSuppressedForViewTransition):
(WebCore::Document::flushDeferredRenderingIsSuppressedForViewTransitionChanges):
(WebCore::Document::performPendingViewTransitions):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::skipViewTransition):
(WebCore::ViewTransition::setupViewTransition):
(WebCore::ViewTransition::activateViewTransition):
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::extractTargets):
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):
(WebCore::Page::doAfterUpdateRendering):
(WebCore::Page::didCompleteRenderingFrame):
(WebCore::Page::prioritizeVisibleResources):
(WebCore::Page::forEachRenderableDocument const):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/Logging.h:
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::renderingIsSuppressedIncludingDescendants const):
(WebCore::GraphicsLayer::setRenderingIsSuppressedIncludingDescendants):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::needsCommit):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h:
(WebCore::PlatformCALayerClient::platformCALayerRenderingIsSuppressedIncludingDescendants const):
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::unite):
(WebCore::EventRegion::unite):
* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/RenderElementInlines.h:
(WebCore::RenderElement::visibleToHitTesting const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::setRenderingIsSuppressed):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::usedPointerEvents const):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::checkIntersection):
(WebCore::RenderSVGModelObject::checkEnclosure):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::nodeAtPoint):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::nodeAtFloatPoint):
* Source/WebCore/rendering/svg/SVGInlineTextBox.cpp:
(WebCore::SVGInlineTextBox::nodeAtPoint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::nodeAtFloatPoint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::checkIntersection):
(WebCore::LegacyRenderSVGModelObject::checkEnclosure):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::nodeAtFloatPoint):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::recursiveMarkWillBeDisplayed):
(WebKit::PlatformCALayerRemote::recursiveBuildTransaction):

Canonical link: <a href="https://commits.webkit.org/279857@main">https://commits.webkit.org/279857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0abd9a2314a3b52459f33e2a0363d841b679fc0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5496 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44356 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3712 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4780 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3637 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59633 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30010 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51778 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51181 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12024 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32159 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->