### PR TITLE
Use std::span more in WTFString

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -118,14 +118,13 @@ static inline unsigned computeCurrencySortKey(const String& currency)
     return (currency[0] << 16) + (currency[1] << 8) + currency[2];
 }
 
-static inline unsigned computeCurrencySortKey(const char* currency)
+static inline unsigned computeCurrencySortKey(const std::array<const char, 3>& currency)
 {
-    ASSERT(strlen(currency) == 3);
-    ASSERT(containsOnly<isASCIIUpper>(currency, 3));
+    ASSERT(containsOnly<isASCIIUpper>(std::span { currency }));
     return (currency[0] << 16) + (currency[1] << 8) + currency[2];
 }
 
-static unsigned extractCurrencySortKey(std::pair<const char*, unsigned>* currencyMinorUnit)
+static unsigned extractCurrencySortKey(std::pair<std::array<const char, 3>, unsigned>* currencyMinorUnit)
 {
     return computeCurrencySortKey(currencyMinorUnit->first);
 }
@@ -135,35 +134,35 @@ static unsigned computeCurrencyDigits(const String& currency)
     // 11.1.1 The abstract operation CurrencyDigits (currency)
     // "If the ISO 4217 currency and funds code list contains currency as an alphabetic code,
     // then return the minor unit value corresponding to the currency from the list; else return 2.
-    static constexpr std::pair<const char*, unsigned> currencyMinorUnits[] = {
-        { "BHD", 3 },
-        { "BIF", 0 },
-        { "BYR", 0 },
-        { "CLF", 4 },
-        { "CLP", 0 },
-        { "DJF", 0 },
-        { "GNF", 0 },
-        { "IQD", 3 },
-        { "ISK", 0 },
-        { "JOD", 3 },
-        { "JPY", 0 },
-        { "KMF", 0 },
-        { "KRW", 0 },
-        { "KWD", 3 },
-        { "LYD", 3 },
-        { "OMR", 3 },
-        { "PYG", 0 },
-        { "RWF", 0 },
-        { "TND", 3 },
-        { "UGX", 0 },
-        { "UYI", 0 },
-        { "VND", 0 },
-        { "VUV", 0 },
-        { "XAF", 0 },
-        { "XOF", 0 },
-        { "XPF", 0 }
+    static constexpr std::pair<std::array<const char, 3>, unsigned> currencyMinorUnits[] = {
+        { { 'B', 'H', 'D' }, 3 },
+        { { 'B', 'I', 'F' }, 0 },
+        { { 'B', 'Y', 'R' }, 0 },
+        { { 'C', 'L', 'F' }, 4 },
+        { { 'C', 'L', 'P' }, 0 },
+        { { 'D', 'J', 'F' }, 0 },
+        { { 'G', 'N', 'F' }, 0 },
+        { { 'I', 'Q', 'D' }, 3 },
+        { { 'I', 'S', 'K' }, 0 },
+        { { 'J', 'O', 'D' }, 3 },
+        { { 'J', 'P', 'Y' }, 0 },
+        { { 'K', 'M', 'F' }, 0 },
+        { { 'K', 'R', 'W' }, 0 },
+        { { 'K', 'W', 'D' }, 3 },
+        { { 'L', 'Y', 'D' }, 3 },
+        { { 'O', 'M', 'R' }, 3 },
+        { { 'P', 'Y', 'G' }, 0 },
+        { { 'R', 'W', 'F' }, 0 },
+        { { 'T', 'N', 'D' }, 3 },
+        { { 'U', 'G', 'X' }, 0 },
+        { { 'U', 'Y', 'I' }, 0 },
+        { { 'V', 'N', 'D' }, 0 },
+        { { 'V', 'U', 'V' }, 0 },
+        { { 'X', 'A', 'F' }, 0 },
+        { { 'X', 'O', 'F' }, 0 },
+        { { 'X', 'P', 'F' }, 0 }
     };
-    auto* currencyMinorUnit = tryBinarySearch<std::pair<const char*, unsigned>>(currencyMinorUnits, std::size(currencyMinorUnits), computeCurrencySortKey(currency), extractCurrencySortKey);
+    auto* currencyMinorUnit = tryBinarySearch<std::pair<std::array<const char, 3>, unsigned>>(currencyMinorUnits, std::size(currencyMinorUnits), computeCurrencySortKey(currency), extractCurrencySortKey);
     if (currencyMinorUnit)
         return currencyMinorUnit->second;
     return 2;

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -30,8 +30,12 @@ class AtomString final {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     AtomString();
-    AtomString(const LChar*, unsigned length);
-    AtomString(const UChar*, unsigned length);
+    AtomString(std::span<const LChar>);
+    AtomString(std::span<const UChar>);
+
+    // FIXME: Update call sites to pass in a std::span and drop these constructors.
+    AtomString(const LChar* characters, size_t length) : AtomString(std::span { characters, length }) { }
+    AtomString(const UChar* characters, size_t length) : AtomString(std::span { characters, length }) { }
 
     ALWAYS_INLINE static AtomString fromLatin1(const char* characters) { return AtomString(characters); }
 
@@ -176,13 +180,13 @@ inline AtomString::AtomString(const char* string)
 {
 }
 
-inline AtomString::AtomString(const LChar* string, unsigned length)
-    : m_string(AtomStringImpl::add(std::span { string, length }))
+inline AtomString::AtomString(std::span<const LChar> string)
+    : m_string(AtomStringImpl::add(string))
 {
 }
 
-inline AtomString::AtomString(const UChar* string, unsigned length)
-    : m_string(AtomStringImpl::add(std::span { string, length }))
+inline AtomString::AtomString(std::span<const UChar> string)
+    : m_string(AtomStringImpl::add(string))
 {
 }
 
@@ -343,7 +347,7 @@ ALWAYS_INLINE String WARN_UNUSED_RETURN makeStringByReplacingAll(const AtomStrin
 template<> struct IntegerToStringConversionTrait<AtomString> {
     using ReturnType = AtomString;
     using AdditionalArgumentType = void;
-    static AtomString flush(LChar* characters, unsigned length, void*) { return { characters, length }; }
+    static AtomString flush(std::span<const LChar> characters, void*) { return characters; }
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/IntegerToStringConversion.h
+++ b/Source/WTF/wtf/text/IntegerToStringConversion.h
@@ -48,7 +48,7 @@ static typename IntegerToStringConversionTrait<T>::ReturnType numberToStringImpl
     if (NumberType == NegativeNumber)
         *--p = '-';
 
-    return IntegerToStringConversionTrait<T>::flush(p, static_cast<unsigned>(end - p), additionalArgument);
+    return IntegerToStringConversionTrait<T>::flush({ p, end }, additionalArgument);
 }
 
 template<typename T, typename SignedIntegerType>
@@ -135,8 +135,7 @@ template<size_t N>
 struct IntegerToStringConversionTrait<Vector<LChar, N>> {
     using ReturnType = Vector<LChar, N>;
     using AdditionalArgumentType = void;
-    // FIXME: Should take in a std::span.
-    static ReturnType flush(LChar* characters, unsigned length, void*) { return { std::span { characters, length } }; }
+    static ReturnType flush(std::span<const LChar> characters, void*) { return characters; }
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringBuilder.cpp
+++ b/Source/WTF/wtf/text/StringBuilder.cpp
@@ -149,28 +149,30 @@ UChar* StringBuilder::extendBufferForAppendingWithUpconvert(unsigned requiredLen
     return extendBufferForAppending<UChar>(requiredLength);
 }
 
-void StringBuilder::appendCharacters(const UChar* characters, unsigned length)
+void StringBuilder::appendCharacters(std::span<const UChar> characters)
 {
-    if (!length || hasOverflowed())
+    if (characters.empty() || hasOverflowed())
         return;
-    if (length == 1 && isLatin1(characters[0]) && is8Bit()) {
+    if (characters.size() == 1 && isLatin1(characters[0]) && is8Bit()) {
         append(static_cast<LChar>(characters[0]));
         return;
     }
-    if (auto destination = extendBufferForAppendingWithUpconvert(saturatedSum<uint32_t>(m_length, length)))
-        StringImpl::copyCharacters(destination, characters, length);
+    RELEASE_ASSERT(characters.size() < std::numeric_limits<uint32_t>::max());
+    if (auto destination = extendBufferForAppendingWithUpconvert(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))))
+        StringImpl::copyCharacters(destination, characters.data(), characters.size());
 }
 
-void StringBuilder::appendCharacters(const LChar* characters, unsigned length)
+void StringBuilder::appendCharacters(std::span<const LChar> characters)
 {
-    if (!length || hasOverflowed())
+    if (characters.empty() || hasOverflowed())
         return;
+    RELEASE_ASSERT(characters.size() < std::numeric_limits<uint32_t>::max());
     if (is8Bit()) {
-        if (auto destination = extendBufferForAppending<LChar>(saturatedSum<uint32_t>(m_length, length)))
-            StringImpl::copyCharacters(destination, characters, length);
+        if (auto destination = extendBufferForAppending<LChar>(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))))
+            StringImpl::copyCharacters(destination, characters.data(), characters.size());
     } else {
-        if (auto destination = extendBufferForAppending<UChar>(saturatedSum<uint32_t>(m_length, length)))
-            StringImpl::copyCharacters(destination, characters, length);
+        if (auto destination = extendBufferForAppending<UChar>(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))))
+            StringImpl::copyCharacters(destination, characters.data(), characters.size());
     }
 }
 

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -51,9 +51,13 @@ public:
     bool hasOverflowed() const { return m_length > String::MaxLength; }
     bool crashesOnOverflow() const { return m_shouldCrashOnOverflow; }
 
-    WTF_EXPORT_PRIVATE void appendCharacters(const UChar*, unsigned);
-    WTF_EXPORT_PRIVATE void appendCharacters(const LChar*, unsigned);
-    void appendCharacters(const char* characters, unsigned length) { appendCharacters(reinterpret_cast<const LChar*>(characters), length); }
+    WTF_EXPORT_PRIVATE void appendCharacters(std::span<const UChar>);
+    WTF_EXPORT_PRIVATE void appendCharacters(std::span<const LChar>);
+
+    // FIXME: Port callers to pass a span and remove these overloads.
+    void appendCharacters(const char* characters, size_t length) { appendCharacters({ reinterpret_cast<const LChar*>(characters), length }); }
+    void appendCharacters(const UChar* characters, size_t length) { appendCharacters({ characters, length }); }
+    void appendCharacters(const LChar* characters, size_t length) { appendCharacters({ characters, length }); }
 
     template<typename... StringTypes> void append(StringTypes...);
 
@@ -326,7 +330,7 @@ template<typename CharacterType> bool equal(const StringBuilder& builder, const 
 template<> struct IntegerToStringConversionTrait<StringBuilder> {
     using ReturnType = void;
     using AdditionalArgumentType = StringBuilder;
-    static void flush(const LChar* characters, unsigned length, StringBuilder* builder) { builder->appendCharacters(characters, length); }
+    static void flush(std::span<const LChar> characters, StringBuilder* builder) { builder->appendCharacters(characters); }
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -168,7 +168,7 @@ Ref<StringImpl> StringImpl::createWithoutCopyingNonEmpty(const LChar* characters
     return adoptRef(*new StringImpl(characters, length, ConstructWithoutCopying));
 }
 
-template<typename CharacterType> inline Ref<StringImpl> StringImpl::createUninitializedInternal(unsigned length, CharacterType*& data)
+template<typename CharacterType> inline Ref<StringImpl> StringImpl::createUninitializedInternal(size_t length, CharacterType*& data)
 {
     if (!length) {
         data = nullptr;
@@ -177,7 +177,7 @@ template<typename CharacterType> inline Ref<StringImpl> StringImpl::createUninit
     return createUninitializedInternalNonEmpty(length, data);
 }
 
-template<typename CharacterType> inline Ref<StringImpl> StringImpl::createUninitializedInternalNonEmpty(unsigned length, CharacterType*& data)
+template<typename CharacterType> inline Ref<StringImpl> StringImpl::createUninitializedInternalNonEmpty(size_t length, CharacterType*& data)
 {
     ASSERT(length);
 
@@ -191,15 +191,15 @@ template<typename CharacterType> inline Ref<StringImpl> StringImpl::createUninit
     return constructInternal<CharacterType>(*string, length);
 }
 
-template Ref<StringImpl> StringImpl::createUninitializedInternalNonEmpty(unsigned length, LChar*& data);
-template Ref<StringImpl> StringImpl::createUninitializedInternalNonEmpty(unsigned length, UChar*& data);
+template Ref<StringImpl> StringImpl::createUninitializedInternalNonEmpty(size_t length, LChar*& data);
+template Ref<StringImpl> StringImpl::createUninitializedInternalNonEmpty(size_t length, UChar*& data);
 
-Ref<StringImpl> StringImpl::createUninitialized(unsigned length, LChar*& data)
+Ref<StringImpl> StringImpl::createUninitialized(size_t length, LChar*& data)
 {
     return createUninitializedInternal(length, data);
 }
 
-Ref<StringImpl> StringImpl::createUninitialized(unsigned length, UChar*& data)
+Ref<StringImpl> StringImpl::createUninitialized(size_t length, UChar*& data)
 {
     return createUninitializedInternal(length, data);
 }

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -613,8 +613,8 @@ inline bool StringView::contains(CodeUnitMatchFunction&& function) const
 template<bool isSpecialCharacter(UChar)> inline bool StringView::containsOnly() const
 {
     if (is8Bit())
-        return WTF::containsOnly<isSpecialCharacter>(characters8(), length());
-    return WTF::containsOnly<isSpecialCharacter>(characters16(), length());
+        return WTF::containsOnly<isSpecialCharacter>(span8());
+    return WTF::containsOnly<isSpecialCharacter>(span16());
 }
 
 template<typename CharacterType> inline void StringView::getCharacters8(CharacterType* destination) const

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -46,7 +46,7 @@ WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const UChar>, bool* ok = nu
 WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const LChar>, size_t& parsedLength);
 WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const UChar>, size_t& parsedLength);
 
-template<bool isSpecialCharacter(UChar), typename CharacterType> bool containsOnly(const CharacterType*, size_t);
+template<bool isSpecialCharacter(UChar), typename CharacterType, std::size_t Extent> bool containsOnly(std::span<const CharacterType, Extent>);
 
 enum class TrailingZerosPolicy : bool { Keep, Truncate };
 
@@ -371,7 +371,7 @@ template<> struct VectorTraits<String> : VectorTraitsBase<false, void> {
 template<> struct IntegerToStringConversionTrait<String> {
     using ReturnType = String;
     using AdditionalArgumentType = void;
-    static String flush(const LChar* characters, unsigned length, void*) { return std::span { characters, length }; }
+    static String flush(std::span<const LChar> characters, void*) { return characters; }
 };
 
 #ifdef __OBJC__


### PR DESCRIPTION
#### 492d572f84caae7af7b09bc7b2d0da09cc6c4c1e
<pre>
Use std::span more in WTFString
<a href="https://bugs.webkit.org/show_bug.cgi?id=272067">https://bugs.webkit.org/show_bug.cgi?id=272067</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::computeCurrencySortKey):
(JSC::extractCurrencySortKey):
(JSC::computeCurrencyDigits):
* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::StringLiterals::operator _charspan):
* Source/WTF/wtf/text/AtomString.h:
(WTF::IntegerToStringConversionTrait&lt;AtomString&gt;::flush):
* Source/WTF/wtf/text/IntegerToStringConversion.h:
(WTF::numberToStringImpl):
* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::appendCharacters):
(WTF::IntegerToStringConversionTrait&lt;StringBuilder&gt;::flush):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::containsOnly):
(WTF::isSpecialCharacter const):
* Source/WTF/wtf/text/StringView.h:
(WTF::isSpecialCharacter const):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::ascii const):
(WTF::String::latin1 const):
* Source/WTF/wtf/text/WTFString.h:
(WTF::IntegerToStringConversionTrait&lt;String&gt;::flush):

Canonical link: <a href="https://commits.webkit.org/277043@main">https://commits.webkit.org/277043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dec3dbd30bd2a705c4a40b2f51758d8309a299f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46479 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49155 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42520 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23098 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47057 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19176 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41188 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4524 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/39724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50993 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45958 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21484 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45170 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44108 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53104 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6492 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22479 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10887 "Passed tests") | 
<!--EWS-Status-Bubble-End-->