### PR TITLE
Build fix: Switch CoreTelephony.framework to use delay-init linking

### DIFF
--- a/Source/WebKit/Configurations/WebKit.xcconfig
+++ b/Source/WebKit/Configurations/WebKit.xcconfig
@@ -222,6 +222,9 @@ OTHER_LDFLAGS = $(inherited) -lsqlite3 -iframework $(SDK_DIR)$(SYSTEM_LIBRARY_DI
 
 OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*] = -Wl,-delay_framework,CoreTelephony;
 OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*17.*] = ;
+OTHER_LDFLAGS_DELAY_INIT[sdk=appletv*] = ;
+OTHER_LDFLAGS_DELAY_INIT[sdk=watch*] = ;
+OTHER_LDFLAGS_DELAY_INIT[sdk=xr*] = ;
 
 REEXPORTED_FRAMEWORK_NAMES = WebKitLegacy;
 // Needed for bincompat (rdar://117360317)

--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig
@@ -99,6 +99,9 @@ OTHER_LDFLAGS = $(inherited) -lgtest -force_load $(BUILT_PRODUCTS_DIR)/libTestWe
 
 OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*] = -Wl,-delay_framework,CoreTelephony;
 OTHER_LDFLAGS_DELAY_INIT[sdk=iphone*17.*] = ;
+OTHER_LDFLAGS_DELAY_INIT[sdk=appletv*] = ;
+OTHER_LDFLAGS_DELAY_INIT[sdk=watch*] = ;
+OTHER_LDFLAGS_DELAY_INIT[sdk=xr*] = ;
 
 OTHER_LDFLAGS_PLATFORM_ = -framework Cocoa -framework Carbon;
 // FIXME: This should not be built on iOS. Instead we should create and use a TestWebKitAPI application.


### PR DESCRIPTION
#### 7e4ae4b1abc75768b5b5cb44665b6007cb4ebe0a
<pre>
Build fix: Switch CoreTelephony.framework to use delay-init linking
<a href="https://bugs.webkit.org/show_bug.cgi?id=271936">https://bugs.webkit.org/show_bug.cgi?id=271936</a>
&lt;<a href="https://rdar.apple.com/125661316">rdar://125661316</a>&gt;

Unreviewed build fix.

* Source/WebKit/Configurations/WebKit.xcconfig:
(OTHER_LDFLAGS_DELAY_INIT):
* Tools/TestWebKitAPI/Configurations/TestWebKitAPI.xcconfig:
(OTHER_LDFLAGS_DELAY_INIT):
- Define empty OTHER_LDFLAGS_DELAY_INIT for tvOS, visionOS and watchOS.
  CoreTelephony.framework only needs to be linked on iOS/iPadOS.

Canonical link: <a href="https://commits.webkit.org/276996@main">https://commits.webkit.org/276996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/046ee0ff136393633a1c5257f8fbf56327c5e407

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42402 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37842 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46939 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19074 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41072 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4405 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50858 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17817 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45060 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22657 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/43980 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6471 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->