### PR TITLE
Adopt std::span in more places

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -103,7 +103,7 @@ ExceptionOr<void> GPUQueue::writeBuffer(
     if (dataOffset > dataSize || dataOffset + contentSize > dataSize || (contentSize % 4))
         return Exception { ExceptionCode::OperationError };
 
-    m_backing->writeBuffer(buffer.backing(), bufferOffset, data.data(), dataSize, dataOffset, contentSize);
+    m_backing->writeBuffer(buffer.backing(), bufferOffset, data.span(), dataOffset, contentSize);
     return { };
 }
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
@@ -72,8 +72,7 @@ void QueueImpl::onSubmittedWorkDone(CompletionHandler<void()>&& callback)
 void QueueImpl::writeBuffer(
     const Buffer&,
     Size64,
-    const void*,
-    size_t,
+    std::span<const uint8_t>,
     Size64,
     std::optional<Size64>)
 {
@@ -93,13 +92,12 @@ void QueueImpl::writeTexture(
 void QueueImpl::writeBuffer(
     const Buffer& buffer,
     Size64 bufferOffset,
-    void* source,
-    size_t byteLength,
+    std::span<uint8_t> source,
     Size64 dataOffset,
     std::optional<Size64> size)
 {
     // FIXME: Use checked arithmetic and check the cast
-    wgpuQueueWriteBuffer(m_backing.get(), m_convertToBackingContext->convertToBacking(buffer), bufferOffset, static_cast<uint8_t*>(source) + dataOffset, static_cast<size_t>(size.value_or(byteLength - dataOffset)));
+    wgpuQueueWriteBuffer(m_backing.get(), m_convertToBackingContext->convertToBacking(buffer), bufferOffset, static_cast<uint8_t*>(source.data()) + dataOffset, static_cast<size_t>(size.value_or(source.size() - dataOffset)));
 }
 
 void QueueImpl::writeTexture(

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
@@ -65,8 +65,7 @@ private:
     void writeBuffer(
         const Buffer&,
         Size64 bufferOffset,
-        const void* source,
-        size_t byteLength,
+        std::span<const uint8_t> source,
         Size64 dataOffset,
         std::optional<Size64>) final;
 
@@ -80,8 +79,7 @@ private:
     void writeBuffer(
         const Buffer&,
         Size64 bufferOffset,
-        void* source,
-        size_t byteLength,
+        std::span<uint8_t> source,
         Size64 dataOffset,
         std::optional<Size64>) final;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
@@ -64,8 +64,7 @@ public:
     virtual void writeBuffer(
         const Buffer&,
         Size64 bufferOffset,
-        const void* source,
-        size_t byteLength,
+        std::span<const uint8_t> source,
         Size64 dataOffset = 0,
         std::optional<Size64> = std::nullopt) = 0;
 
@@ -79,8 +78,7 @@ public:
     virtual void writeBuffer(
         const Buffer&,
         Size64 bufferOffset,
-        void* source,
-        size_t byteLength,
+        std::span<uint8_t> source,
         Size64 dataOffset = 0,
         std::optional<Size64> = std::nullopt) = 0;
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp
@@ -35,16 +35,12 @@ namespace WebCore {
 
 ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeSaltKey(const Vector<uint8_t>& rawKey)
 {
-    uint8_t usage[] = "SFrame10";
-    uint8_t info[] = "salt";
-    return deriveHDKFSHA256Bits(rawKey.data(), 16, usage, sizeof(usage) - 1, info, sizeof(info) - 1, 96);
+    return deriveHDKFSHA256Bits(rawKey.subspan(0, 16), "SFrame10"_span, "salt"_span, 96);
 }
 
 static ExceptionOr<Vector<uint8_t>> createBaseSFrameKey(const Vector<uint8_t>& rawKey)
 {
-    uint8_t usage[] = "SFrame10";
-    uint8_t info[] = "key";
-    return deriveHDKFSHA256Bits(rawKey.data(), 16, usage, sizeof(usage) - 1, info, sizeof(info) - 1, 128);
+    return deriveHDKFSHA256Bits(rawKey.subspan(0, 16), "SFrame10"_span, "key"_span, 128);
 }
 
 ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeAuthenticationKey(const Vector<uint8_t>& rawKey)
@@ -53,9 +49,7 @@ ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeAuthenticationKey(c
     if (key.hasException())
         return key;
 
-    uint8_t usage[] = "SFrame10 AES CM AEAD";
-    uint8_t info[] = "auth";
-    return deriveHDKFSHA256Bits(key.returnValue().data(), 16, usage, sizeof(usage) - 1, info, sizeof(info) - 1, 256);
+    return deriveHDKFSHA256Bits(key.returnValue().subspan(0, 16), "SFrame10 AES CM AEAD"_span, "auth"_span, 256);
 }
 
 ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeEncryptionKey(const Vector<uint8_t>& rawKey)
@@ -64,9 +58,7 @@ ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::computeEncryptionKey(const
     if (key.hasException())
         return key;
 
-    uint8_t usage[] = "SFrame10 AES CM AEAD";
-    uint8_t info[] = "enc";
-    return deriveHDKFSHA256Bits(key.returnValue().data(), 16, usage, sizeof(usage) - 1, info, sizeof(info) - 1, 128);
+    return deriveHDKFSHA256Bits(key.returnValue().subspan(0, 16), "SFrame10 AES CM AEAD"_span, "enc"_span, 128);
 }
 
 ExceptionOr<Vector<uint8_t>> RTCRtpSFrameTransformer::decryptData(std::span<const uint8_t> data, const Vector<uint8_t>& iv, const Vector<uint8_t>& key)

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFMac.cpp
@@ -38,7 +38,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHKDF::platformDeriveBits(const Crypt
     CCDigestAlgorithm digestAlgorithm;
     getCommonCryptoDigestAlgorithm(parameters.hashIdentifier, digestAlgorithm);
 
-    return deriveHDKFBits(digestAlgorithm, key.key().data(), key.key().size(), parameters.saltVector().data(), parameters.saltVector().size(), parameters.infoVector().data(), parameters.infoVector().size(), length);
+    return deriveHDKFBits(digestAlgorithm, key.key().span(), parameters.saltVector().span(), parameters.infoVector().span(), length);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp
@@ -57,7 +57,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmHMAC::platformSign(const CryptoKeyHM
     if (!algorithm)
         return Exception { ExceptionCode::OperationError };
 
-    return calculateHMACSignature(*algorithm, key.key(), data.data(), data.size());
+    return calculateHMACSignature(*algorithm, key.key(), data.span());
 }
 
 ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
@@ -66,7 +66,7 @@ ExceptionOr<bool> CryptoAlgorithmHMAC::platformVerify(const CryptoKeyHMAC& key, 
     if (!algorithm)
         return Exception { ExceptionCode::OperationError };
 
-    auto expectedSignature = calculateHMACSignature(*algorithm, key.key(), data.data(), data.size());
+    auto expectedSignature = calculateHMACSignature(*algorithm, key.key(), data.span());
     // Using a constant time comparison to prevent timing attacks.
     return signature.size() == expectedSignature.size() && !constantTimeMemcmp(expectedSignature.data(), signature.data(), expectedSignature.size());
 }

--- a/Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.h
+++ b/Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.h
@@ -36,10 +36,10 @@ typedef uint32_t CCOperation;
 namespace WebCore {
 
 ExceptionOr<Vector<uint8_t>> transformAESCTR(CCOperation, const Vector<uint8_t>& counter, size_t counterLength, const Vector<uint8_t>& key, std::span<const uint8_t> data);
-CCStatus keyDerivationHMAC(CCDigestAlgorithm, const void *, size_t, const void *, size_t, const void *, size_t, void *, size_t);
-ExceptionOr<Vector<uint8_t>> deriveHDKFBits(CCDigestAlgorithm, const uint8_t* key, size_t keySize, const uint8_t* salt, size_t saltSize, const uint8_t* info, size_t infoSize, size_t length);
-ExceptionOr<Vector<uint8_t>> deriveHDKFSHA256Bits(const uint8_t* key, size_t keySize, const uint8_t* salt, size_t saltSize, const uint8_t* info, size_t infoSize, size_t length);
-Vector<uint8_t> calculateHMACSignature(CCHmacAlgorithm, const Vector<uint8_t>& key, const uint8_t* data, size_t);
-Vector<uint8_t> calculateSHA256Signature(const Vector<uint8_t>& key, const uint8_t* data, size_t);
+CCStatus keyDerivationHMAC(CCDigestAlgorithm, std::span<const uint8_t> keyDerivationKey, std::span<const uint8_t> context, std::span<const uint8_t> salt, Vector<uint8_t>& derivedKey);
+ExceptionOr<Vector<uint8_t>> deriveHDKFBits(CCDigestAlgorithm, std::span<const uint8_t> key, std::span<const uint8_t> salt, std::span<const uint8_t> info, size_t length);
+ExceptionOr<Vector<uint8_t>> deriveHDKFSHA256Bits(std::span<const uint8_t> key, std::span<const uint8_t> salt, std::span<const uint8_t> info, size_t length);
+Vector<uint8_t> calculateHMACSignature(CCHmacAlgorithm, const Vector<uint8_t>& key, std::span<const uint8_t> data);
+Vector<uint8_t> calculateSHA256Signature(const Vector<uint8_t>& key, std::span<const uint8_t> data);
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
@@ -87,7 +87,7 @@ void RemoteQueue::writeBuffer(
     if (!convertedBuffer)
         return;
 
-    m_backing->writeBuffer(*convertedBuffer, bufferOffset, data.data(), data.size(), 0, std::nullopt);
+    m_backing->writeBuffer(*convertedBuffer, bufferOffset, data.span(), 0, std::nullopt);
 }
 
 void RemoteQueue::writeTexture(

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
@@ -55,7 +55,7 @@ namespace NetworkCache {
 class Data {
 public:
     Data() { }
-    Data(const uint8_t*, size_t);
+    Data(std::span<const uint8_t>);
 
     ~Data() { }
 
@@ -70,6 +70,7 @@ public:
     Data(GRefPtr<GBytes>&&, FileSystem::PlatformFileHandle fd = FileSystem::invalidPlatformFileHandle);
 #elif USE(CURL)
     Data(std::variant<Vector<uint8_t>, FileSystem::MappedFileData>&&);
+    Data(Vector<uint8_t>&& data) : Data(std::variant<Vector<uint8_t>, FileSystem::MappedFileData> { WTFMove(data) }) { }
 #endif
     bool isNull() const;
     bool isEmpty() const { return !m_size; }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
@@ -34,9 +34,9 @@
 namespace WebKit {
 namespace NetworkCache {
 
-Data::Data(const uint8_t* data, size_t size)
-    : m_dispatchData(adoptOSObject(dispatch_data_create(data, size, nullptr, DISPATCH_DATA_DESTRUCTOR_DEFAULT)))
-    , m_size(size)
+Data::Data(std::span<const uint8_t> data)
+    : m_dispatchData(adoptOSObject(dispatch_data_create(data.data(), data.size(), nullptr, DISPATCH_DATA_DESTRUCTOR_DEFAULT)))
+    , m_size(data.size())
 {
 }
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
@@ -31,11 +31,11 @@
 namespace WebKit {
 namespace NetworkCache {
 
-Data::Data(const uint8_t* data, size_t size)
-    : m_buffer(Box<std::variant<Vector<uint8_t>, FileSystem::MappedFileData>>::create(Vector<uint8_t>(size)))
-    , m_size(size)
+Data::Data(std::span<const uint8_t> data)
+    : m_buffer(Box<std::variant<Vector<uint8_t>, FileSystem::MappedFileData>>::create(Vector<uint8_t>(data.size())))
+    , m_size(data.size())
 {
-    memcpy(std::get<Vector<uint8_t>>(*m_buffer).data(), data, size);
+    memcpy(std::get<Vector<uint8_t>>(*m_buffer).data(), data.data(), data.size());
 }
 
 Data::Data(std::variant<Vector<uint8_t>, FileSystem::MappedFileData>&& data)
@@ -83,7 +83,7 @@ Data Data::subrange(size_t offset, size_t size) const
     if (!m_buffer)
         return { };
 
-    return { data() + offset, size };
+    return span().subspan(offset, size);
 }
 
 Data concatenate(const Data& a, const Data& b)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
@@ -42,12 +42,12 @@
 namespace WebKit {
 namespace NetworkCache {
 
-Data::Data(const uint8_t* data, size_t size)
-    : m_size(size)
+Data::Data(std::span<const uint8_t> data)
+    : m_size(data.size())
 {
-    uint8_t* copiedData = static_cast<uint8_t*>(fastMalloc(size));
-    memcpy(copiedData, data, size);
-    m_buffer = adoptGRef(g_bytes_new_with_free_func(copiedData, size, fastFree, copiedData));
+    uint8_t* copiedData = static_cast<uint8_t*>(fastMalloc(data.size()));
+    memcpy(copiedData, data.data(), data.size());
+    m_buffer = adoptGRef(g_bytes_new_with_free_func(copiedData, data.size(), fastFree, copiedData));
 }
 
 Data::Data(GRefPtr<GBytes>&& buffer, FileSystem::PlatformFileHandle fd)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
@@ -102,11 +102,11 @@ Storage::Record Entry::encodeAsStorageRecord() const
     
     encoder.encodeChecksum();
 
-    Data header(encoder.buffer(), encoder.bufferSize());
+    Data header(encoder.span());
     Data body;
     if (m_buffer) {
         m_buffer = m_buffer->makeContiguous();
-        body = { static_cast<WebCore::SharedBuffer*>(m_buffer.get())->data(), m_buffer->size() };
+        body = { downcast<WebCore::SharedBuffer>(*m_buffer).span() };
     }
 
     return { m_key, m_timeStamp, header, body, { } };

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp
@@ -597,7 +597,7 @@ static Data encodeRecordMetaData(const RecordMetaData& metaData)
 
     encoder.encodeChecksum();
 
-    return Data(encoder.buffer(), encoder.bufferSize());
+    return Data(encoder.span());
 }
 
 std::optional<BlobStorage::Blob> Storage::storeBodyAsBlob(WriteOperation& writeOperation)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp
@@ -49,7 +49,7 @@ Storage::Record SubresourcesEntry::encodeAsStorageRecord() const
 
     encoder.encodeChecksum();
 
-    return { m_key, m_timeStamp, { encoder.buffer(), encoder.bufferSize() }, { }, { }};
+    return { m_key, m_timeStamp, encoder.span(), { }, { } };
 }
 
 std::unique_ptr<SubresourcesEntry> SubresourcesEntry::decodeStorageRecord(const Storage::Record& storageEntry)

--- a/Source/WebKit/Platform/IPC/DaemonCoders.h
+++ b/Source/WebKit/Platform/IPC/DaemonCoders.h
@@ -184,7 +184,7 @@ template<> struct Coder<WTF::String> {
         encoder << length << is8Bit;
 
         if (is8Bit)
-            encoder.encodeFixedLengthData({ string.characters8(), length * sizeof(LChar) });
+            encoder.encodeFixedLengthData(string.span8());
         else
             encoder.encodeFixedLengthData({ reinterpret_cast<const uint8_t*>(string.characters16()), length * sizeof(UChar) });
     }

--- a/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm
@@ -86,7 +86,7 @@ std::span<const uint8_t> SandboxExtensionImpl::getSerializedFormat()
 {
     ASSERT(m_token);
     ASSERT(strlen(m_token));
-    return { reinterpret_cast<const uint8_t*>(m_token), strlen(m_token) };
+    return span8(m_token);
 }
 
 char* SandboxExtensionImpl::sandboxExtensionForType(const char* path, SandboxExtension::Type type, std::optional<audit_token_t> auditToken, OptionSet<SandboxExtension::Flags> flags)

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -137,7 +137,7 @@ static WebKit::NetworkCache::Data encodeContentRuleListMetaData(const ContentRul
     encoder << metaData.unused64bits2;
 
     ASSERT(encoder.bufferSize() == CurrentVersionFileHeaderSize);
-    return WebKit::NetworkCache::Data(encoder.buffer(), encoder.bufferSize());
+    return WebKit::NetworkCache::Data(encoder.span());
 }
 
 template<typename T> void getData(const T&, const Function<bool(std::span<const uint8_t>)>&);
@@ -277,12 +277,11 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
             writeToFile(sourceJSON.is8Bit());
             m_sourceWritten += sizeof(bool);
             if (sourceJSON.is8Bit()) {
-                size_t serializedLength = sourceJSON.length() * sizeof(LChar);
-                writeToFile(WebKit::NetworkCache::Data(sourceJSON.characters8(), serializedLength));
-                m_sourceWritten += serializedLength;
+                writeToFile(WebKit::NetworkCache::Data(sourceJSON.span8()));
+                m_sourceWritten += sourceJSON.length();
             } else {
                 size_t serializedLength = sourceJSON.length() * sizeof(UChar);
-                writeToFile(WebKit::NetworkCache::Data(reinterpret_cast<const uint8_t*>(sourceJSON.characters16()), serializedLength));
+                writeToFile(WebKit::NetworkCache::Data({ reinterpret_cast<const uint8_t*>(sourceJSON.characters16()), serializedLength }));
                 m_sourceWritten += serializedLength;
             }
         }
@@ -294,7 +293,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
             ASSERT(!m_topURLFiltersBytecodeWritten);
             ASSERT(!m_frameURLFiltersBytecodeWritten);
             m_actionsWritten += actions.size();
-            writeToFile(WebKit::NetworkCache::Data(actions.data(), actions.size()));
+            writeToFile(WebKit::NetworkCache::Data(actions.span()));
         }
 
         void writeURLFiltersBytecode(Vector<DFABytecode>&& bytecode) final
@@ -302,20 +301,20 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
             ASSERT(!m_topURLFiltersBytecodeWritten);
             ASSERT(!m_frameURLFiltersBytecodeWritten);
             m_urlFiltersBytecodeWritten += bytecode.size();
-            writeToFile(WebKit::NetworkCache::Data(bytecode.data(), bytecode.size()));
+            writeToFile(WebKit::NetworkCache::Data(bytecode.span()));
         }
         
         void writeTopURLFiltersBytecode(Vector<DFABytecode>&& bytecode) final
         {
             ASSERT(!m_frameURLFiltersBytecodeWritten);
             m_topURLFiltersBytecodeWritten += bytecode.size();
-            writeToFile(WebKit::NetworkCache::Data(bytecode.data(), bytecode.size()));
+            writeToFile(WebKit::NetworkCache::Data(bytecode.span()));
         }
 
         void writeFrameURLFiltersBytecode(Vector<DFABytecode>&& bytecode) final
         {
             m_frameURLFiltersBytecodeWritten += bytecode.size();
-            writeToFile(WebKit::NetworkCache::Data(bytecode.data(), bytecode.size()));
+            writeToFile(WebKit::NetworkCache::Data(bytecode.span()));
         }
         
         void finalize() final
@@ -339,7 +338,7 @@ static Expected<MappedData, std::error_code> compiledToFile(WTF::String&& json, 
     private:
         void writeToFile(bool value)
         {
-            writeToFile(WebKit::NetworkCache::Data(reinterpret_cast<const uint8_t*>(&value), sizeof(value)));
+            writeToFile(WebKit::NetworkCache::Data({ reinterpret_cast<const uint8_t*>(&value), sizeof(value) }));
         }
         void writeToFile(const WebKit::NetworkCache::Data& data)
         {

--- a/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
@@ -33,6 +33,7 @@
 #include "GPUProcessMessages.h"
 #include "MediaPermissionUtilities.h"
 #include "WebProcessProxy.h"
+#include <wtf/cocoa/SpanCocoa.h>
 
 #if HAVE(POWERLOG_TASK_MODE_QUERY)
 #include <pal/spi/mac/PowerLogSPI.h>
@@ -97,8 +98,7 @@ void GPUProcessProxy::sendBookmarkDataForCacheDirectory()
     auto url = adoptNS([[NSURL alloc] initFileURLWithPath:@"Caches/com.apple.WebKit.GPU/" relativeToURL:directoryURL]);
     error = nil;
     NSData* bookmark = [url bookmarkDataWithOptions:NSURLBookmarkCreationMinimalBookmark includingResourceValuesForKeys:nil relativeToURL:nil error:&error];
-    std::span<const uint8_t> bookmarkData(reinterpret_cast<const uint8_t*>([bookmark bytes]), [bookmark length]);
-    send(Messages::GPUProcess::ResolveBookmarkDataForCacheDirectory(WTFMove(bookmarkData)), 0);
+    send(Messages::GPUProcess::ResolveBookmarkDataForCacheDirectory(span(bookmark)), 0);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -71,8 +71,7 @@ void RemoteQueueProxy::onSubmittedWorkDone(CompletionHandler<void()>&& callback)
 void RemoteQueueProxy::writeBuffer(
     const WebCore::WebGPU::Buffer& buffer,
     WebCore::WebGPU::Size64 bufferOffset,
-    const void* source,
-    size_t byteLength,
+    std::span<const uint8_t> source,
     WebCore::WebGPU::Size64 dataOffset,
     std::optional<WebCore::WebGPU::Size64> size)
 {
@@ -81,7 +80,7 @@ void RemoteQueueProxy::writeBuffer(
     if (!convertedBuffer)
         return;
 
-    auto sendResult = send(Messages::RemoteQueue::WriteBuffer(convertedBuffer, bufferOffset, std::span { static_cast<const uint8_t*>(source) + dataOffset, static_cast<size_t>(size.value_or(byteLength - dataOffset)) }));
+    auto sendResult = send(Messages::RemoteQueue::WriteBuffer(convertedBuffer, bufferOffset, source.subspan(dataOffset, static_cast<size_t>(size.value_or(source.size() - dataOffset)))));
     UNUSED_VARIABLE(sendResult);
 }
 
@@ -108,8 +107,7 @@ void RemoteQueueProxy::writeTexture(
 void RemoteQueueProxy::writeBuffer(
     const WebCore::WebGPU::Buffer&,
     WebCore::WebGPU::Size64,
-    void*,
-    size_t,
+    std::span<uint8_t>,
     WebCore::WebGPU::Size64,
     std::optional<WebCore::WebGPU::Size64>)
 {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -80,8 +80,7 @@ private:
     void writeBuffer(
         const WebCore::WebGPU::Buffer&,
         WebCore::WebGPU::Size64 bufferOffset,
-        const void* source,
-        size_t byteLength,
+        std::span<const uint8_t> source,
         WebCore::WebGPU::Size64 dataOffset = 0,
         std::optional<WebCore::WebGPU::Size64> = std::nullopt) final;
 
@@ -95,8 +94,7 @@ private:
     void writeBuffer(
         const WebCore::WebGPU::Buffer&,
         WebCore::WebGPU::Size64 bufferOffset,
-        void* source,
-        size_t byteLength,
+        std::span<uint8_t> source,
         WebCore::WebGPU::Size64 dataOffset = 0,
         std::optional<WebCore::WebGPU::Size64> = std::nullopt) final;
 


### PR DESCRIPTION
#### 841e14710a42738a5f3d202e572058a8953ffca1
<pre>
Adopt std::span in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=272070">https://bugs.webkit.org/show_bug.cgi?id=272070</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::GPUQueue::writeBuffer):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::writeBuffer):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransformerCocoa.cpp:
(WebCore::RTCRtpSFrameTransformer::computeSaltKey):
(WebCore::createBaseSFrameKey):
(WebCore::RTCRtpSFrameTransformer::computeAuthenticationKey):
(WebCore::RTCRtpSFrameTransformer::computeEncryptionKey):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFMac.cpp:
(WebCore::CryptoAlgorithmHKDF::platformDeriveBits):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHMACMac.cpp:
(WebCore::CryptoAlgorithmHMAC::platformSign):
(WebCore::CryptoAlgorithmHMAC::platformVerify):
* Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.cpp:
(WebCore::keyDerivationHMAC):
(WebCore::deriveHDKFBits):
(WebCore::deriveHDKFSHA256Bits):
(WebCore::calculateHMACSignature):
(WebCore::calculateSHA256Signature):
* Source/WebCore/crypto/cocoa/CryptoUtilitiesCocoa.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp:
(WebKit::RemoteQueue::writeBuffer):
* Source/WebKit/NetworkProcess/cache/NetworkCacheData.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm:
(WebKit::NetworkCache::Data::Data):
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp:
(WebKit::NetworkCache::Data::Data):
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp:
(WebKit::NetworkCache::Data::Data):
* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp:
(WebKit::NetworkCache::Entry::encodeAsStorageRecord const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.cpp:
(WebKit::NetworkCache::encodeRecordMetaData):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSubresourcesEntry.cpp:
(WebKit::NetworkCache::SubresourcesEntry::encodeAsStorageRecord const):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::processUDPData):
(WebKit::NetworkRTCUDPSocketCocoaConnections::setupNWConnection):
* Source/WebKit/Platform/IPC/DaemonCoders.h:
(WebKit::Daemon::Coder&lt;WTF::String&gt;::encode):
* Source/WebKit/Shared/Cocoa/SandboxExtensionCocoa.mm:
(WebKit::SandboxExtensionImpl::getSerializedFormat):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::encodeContentRuleListMetaData):
(API::compiledToFile):
* Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm:
(WebKit::GPUProcessProxy::sendBookmarkDataForCacheDirectory):
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::HistoryEntryDataEncoder::operator&lt;&lt;):
(WebKit::HistoryEntryDataEncoder::encodeArithmeticType):
(WebKit::HistoryEntryDataEncoder::encodeFixedLengthData):
(WebKit::HistoryEntryDataDecoder::HistoryEntryDataDecoder):
(WebKit::decodeSessionHistoryEntryData):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::writeBuffer):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:

Canonical link: <a href="https://commits.webkit.org/277025@main">https://commits.webkit.org/277025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fabcb90fd7b94f0ebd424b8c289f9a0e5850b5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46418 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49118 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42459 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23052 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37904 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22613 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19148 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41124 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4463 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50924 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45120 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44050 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6483 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22413 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->