### PR TITLE
[WebXR] WebXR should base its foveation on the app's setting

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
@@ -2654,7 +2654,7 @@ angle::Result ContextMtl::setupDrawImpl(const gl::Context *context,
                     mState.getBlendColor().blue, mState.getBlendColor().alpha);
                 break;
             case DIRTY_BIT_VIEWPORT:
-                mRenderEncoder.setViewport(mViewport);
+                mRenderEncoder.setViewport(mViewport, mRenderEncoder.rasterizationRateMapForPass(mRasterizationRateMap, mRasterizationRateMapTexture));
                 break;
             case DIRTY_BIT_SCISSOR:
                 mRenderEncoder.setScissorRect(mScissorRect, mRenderEncoder.rasterizationRateMapForPass(mRasterizationRateMap, mRasterizationRateMapTexture));
@@ -2683,7 +2683,7 @@ angle::Result ContextMtl::setupDrawImpl(const gl::Context *context,
                 // Already handled.
                 break;
             case DIRTY_BIT_VARIABLE_RASTERIZATION_RATE:
-                if (getState().privateState().isVariableRasterizationRateEnabled())
+                if (getState().privateState().isVariableRasterizationRateEnabled() && mRasterizationRateMap)
                 {
                     mRenderEncoder.setRasterizationRateMap(mRenderEncoder.rasterizationRateMapForPass(mRasterizationRateMap, mRasterizationRateMapTexture));
                 }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.h
@@ -416,7 +416,8 @@ class RenderCommandEncoder final : public CommandEncoder
     RenderCommandEncoder &setStencilRefVals(uint32_t frontRef, uint32_t backRef);
     RenderCommandEncoder &setStencilRefVal(uint32_t ref);
 
-    RenderCommandEncoder &setViewport(const MTLViewport &viewport);
+    RenderCommandEncoder &setViewport(const MTLViewport &viewport,
+                                      id<MTLRasterizationRateMap> map);
     RenderCommandEncoder &setScissorRect(const MTLScissorRect &rect,
                                          id<MTLRasterizationRateMap> map);
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
@@ -689,7 +689,7 @@ void SetupCommonBlitWithDrawStates(const gl::Context *context,
     MTLScissorRect scissorRectMtl =
         GetScissorRect(params.dstScissorRect, params.dstTextureSize.height, params.dstFlipY);
 
-    cmdEncoder->setViewport(viewportMtl);
+    cmdEncoder->setViewport(viewportMtl, nil);
     cmdEncoder->setScissorRect(scissorRectMtl, nil);
 
     if (params.src)
@@ -1224,7 +1224,7 @@ angle::Result ClearUtils::setupClearWithDraw(const gl::Context *context,
 
     scissorRect = GetScissorRect(params.clearArea, params.dstTextureSize.height, params.flipY);
 
-    cmdEncoder->setViewport(viewport);
+    cmdEncoder->setViewport(viewport, nil);
     cmdEncoder->setScissorRect(scissorRect, nil);
 
     // uniform

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -94,6 +94,7 @@ public:
 
     void startFrame(const PlatformXR::FrameData::LayerData&);
     void endFrame();
+    bool usesLayeredMode() const;
 
 private:
     WebXROpaqueFramebuffer(PlatformXR::LayerHandle, Ref<WebGLFramebuffer>&&, WebGLRenderingContextBase&, Attributes&&, IntSize);

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -311,16 +311,31 @@ void WebXRWebGLLayer::computeViewports()
         return size;
     };
 
-    if (m_session->mode() == XRSessionMode::ImmersiveVr && m_session->views().size() > 1) {
-        auto scale = m_leftViewportData.currentScale;
-        auto viewport = m_framebuffer->drawViewport(PlatformXR::Eye::Left);
-        viewport.setSize(roundDown(viewport.size(), scale));
-        m_leftViewportData.viewport->updateViewport(viewport);
+    auto roundDownShared = [](double value) -> int {
+        return std::max(1, static_cast<int>(std::floor(value)));
+    };
 
-        scale = m_rightViewportData.currentScale;
-        viewport = m_framebuffer->drawViewport(PlatformXR::Eye::Right);
-        viewport.setSize(roundDown(viewport.size(), scale));
-        m_rightViewportData.viewport->updateViewport(viewport);
+    auto width = framebufferWidth();
+    auto height = framebufferHeight();
+
+    if (m_session->mode() == XRSessionMode::ImmersiveVr && m_session->views().size() > 1) {
+        if (m_framebuffer && m_framebuffer->usesLayeredMode()) {
+            auto scale = m_leftViewportData.currentScale;
+            auto viewport = m_framebuffer->drawViewport(PlatformXR::Eye::Left);
+            viewport.setSize(roundDown(viewport.size(), scale));
+            m_leftViewportData.viewport->updateViewport(viewport);
+
+            scale = m_rightViewportData.currentScale;
+            viewport = m_framebuffer->drawViewport(PlatformXR::Eye::Right);
+            viewport.setSize(roundDown(viewport.size(), scale));
+            m_rightViewportData.viewport->updateViewport(viewport);
+            return;
+        }
+
+        auto leftScale = m_leftViewportData.currentScale;
+        m_leftViewportData.viewport->updateViewport(IntRect(0, 0, roundDownShared(width * 0.5 * leftScale), roundDownShared(height * leftScale)));
+        auto rightScale = m_rightViewportData.currentScale;
+        m_rightViewportData.viewport->updateViewport(IntRect(width * 0.5, 0, roundDownShared(width * 0.5 * rightScale), roundDownShared(height * rightScale)));
     } else {
         auto viewport = m_framebuffer ? m_framebuffer->drawViewport(PlatformXR::Eye::None) : IntRect(0, 0, framebufferWidth(), framebufferHeight());
         m_leftViewportData.viewport->updateViewport(viewport);


### PR DESCRIPTION
#### 4d12bc5c1a01933bbd3edd6ecef280e2bc58afac
<pre>
[WebXR] WebXR should base its foveation on the app&apos;s setting
<a href="https://bugs.webkit.org/show_bug.cgi?id=272069">https://bugs.webkit.org/show_bug.cgi?id=272069</a>
&lt;radar://125824522&gt;

Reviewed by Tim Horton.

Respect the app&apos;s foveation setting.

Also fixup the viewport transformation.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm:
(rx::ContextMtl::setupDrawImpl):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.mm:
(rx::mtl::RenderCommandEncoder::setViewport):
(rx::mtl::RenderCommandEncoder::rasterizationRateMapForPass const):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm:
(rx::mtl::ClearUtils::setupClearWithDraw):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::usesLayeredMode const):
(WebCore::WebXROpaqueFramebuffer::blitSharedToLayered):
(WebCore::convertViewportToPhysicalCoordinates):
(WebCore::WebXROpaqueFramebuffer::drawViewport const):
(WebCore::displayLayout):
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp:
(WebCore::WebXRWebGLLayer::computeViewports):

Canonical link: <a href="https://commits.webkit.org/277037@main">https://commits.webkit.org/277037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df713a5b9e40298a4808564ffe6eeec866906c5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49084 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42450 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37877 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40018 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19118 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19967 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41119 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4454 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50915 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45115 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22705 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44045 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10282 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->