### PR TITLE
Add SPI for creating _WKApplicationManifest with data

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h
@@ -63,6 +63,9 @@ typedef NS_ENUM(NSInteger, _WKApplicationManifestIconPurpose) {
 WK_CLASS_AVAILABLE(macos(10.13.4), ios(11.3))
 @interface _WKApplicationManifest : NSObject <NSSecureCoding>
 
+- (instancetype)init NS_UNAVAILABLE;
+- (nullable instancetype)initWithJSONData:(NSData *)jsonData manifestURL:(NSURL *)manifestURL documentURL:(NSURL *)documentURL WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 @property (nonatomic, readonly, nullable, copy) NSString *rawJSON;
 @property (nonatomic, readonly, nullable, copy) NSString *name;
 @property (nonatomic, readonly, nullable, copy) NSString *shortName;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -243,6 +243,22 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
 
 #if ENABLE(APPLICATION_MANIFEST)
 
+- (instancetype)initWithJSONData:(NSData *)jsonData manifestURL:(NSURL *)manifestURL documentURL:(NSURL *)documentURL
+{
+    if (!(self = [super init]))
+        return nil;
+
+    RetainPtr jsonString = adoptNS([[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding]);
+    if (!jsonString)
+        return nil;
+
+    // FIXME: Return nil if jsonString cannot be deserialized into JSON object.
+    auto manifest = WebCore::ApplicationManifestParser::parse(jsonString.get(), URL(manifestURL), URL(documentURL));
+    API::Object::constructInWrapper<API::ApplicationManifest>(self, manifest);
+
+    return self;
+}
+
 + (BOOL)supportsSecureCoding
 {
     return YES;
@@ -464,6 +480,15 @@ static NSString *nullableNSString(const WTF::String& string)
 }
 
 #else // ENABLE(APPLICATION_MANIFEST)
+
+- (instancetype)initWithJSONData:(NSData *)jsonData manifestURL:(NSURL *)manifestURL documentURL:(NSURL *)documentURL
+{
+    UNUSED_PARAM(jsonData);
+    UNUSED_PARAM(manifestURL);
+    UNUSED_PARAM(documentURL);
+
+    return nil;
+}
 
 + (_WKApplicationManifest *)applicationManifestFromJSON:(NSString *)json manifestURL:(NSURL *)manifestURL documentURL:(NSURL *)documentURL
 {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
@@ -399,6 +399,34 @@ TEST(ApplicationManifest, IconCoding)
     EXPECT_EQ(decodedIcon.purposes[1].unsignedLongValue, 4ul);
 }
 
+TEST(WKApplicationManifest, EmptyJSONData)
+{
+    RetainPtr<NSURL> manifestURL = [NSURL URLWithString:@"https://test.com/manifest.json"];
+    RetainPtr<NSURL> documentURL = [NSURL URLWithString:@"https://test.com"];
+
+    NSDictionary *emptyJSONObject = @{ };
+    RetainPtr emptyJSONData = [NSJSONSerialization dataWithJSONObject:emptyJSONObject options:0 error:nil];
+    RetainPtr manifest = adoptNS([[_WKApplicationManifest alloc] initWithJSONData:emptyJSONData.get() manifestURL:manifestURL.get() documentURL:documentURL.get()]);
+    EXPECT_NOT_NULL(manifest);
+}
+
+TEST(WKApplicationManifest, JSONDataEncoding)
+{
+    RetainPtr<NSURL> manifestURL = [NSURL URLWithString:@"https://test.com/manifest.json"];
+    RetainPtr<NSURL> documentURL = [NSURL URLWithString:@"https://test.com"];
+
+    NSString *jsonString = @"{ \"name\": \"TestName\" }";
+    RetainPtr jsonDataUTF8 = [jsonString dataUsingEncoding:NSUTF8StringEncoding];
+    RetainPtr jsonDataUTF16 = [jsonString dataUsingEncoding:NSUTF32StringEncoding];
+    RetainPtr manifest = adoptNS([[_WKApplicationManifest alloc] initWithJSONData:jsonDataUTF8.get() manifestURL:manifestURL.get() documentURL:documentURL.get()]);
+    EXPECT_NOT_NULL(manifest);
+    EXPECT_WK_STREQ("TestName", manifest.get().name);
+
+    manifest = adoptNS([[_WKApplicationManifest alloc] initWithJSONData:jsonDataUTF16.get() manifestURL:manifestURL.get() documentURL:documentURL.get()]);
+    EXPECT_NULL(manifest);
+}
+
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(APPLICATION_MANIFEST)


### PR DESCRIPTION
#### 0e6ba3e0f23c4e003355f497be46b7cf7cd613f8
<pre>
Add SPI for creating _WKApplicationManifest with data
<a href="https://bugs.webkit.org/show_bug.cgi?id=272075">https://bugs.webkit.org/show_bug.cgi?id=272075</a>
<a href="https://rdar.apple.com/125791668">rdar://125791668</a>

Reviewed by Chris Dumez.

Test: WKApplicationManifest.EmptyJSONData
      WKApplicationManifest.JSONDataEncoding

* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifest initWithJSONData:manifestURL:documentURL:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm:
(TestWebKitAPI::TEST(WKApplicationManifest, EmptyJSONData)):
(TestWebKitAPI::TEST(WKApplicationManifest, JSONDataEncoding)):

Canonical link: <a href="https://commits.webkit.org/277014@main">https://commits.webkit.org/277014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74c982a83e9a8e16414e8b5978a9f6b8fdf299b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49049 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23035 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37849 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46952 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19085 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41079 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4419 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50875 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45077 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22670 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44001 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10273 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22369 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->