### PR TITLE
Web Inspector: Generating JS builtins for createInspectorInjectedScript is very slow

### DIFF
--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py
@@ -124,16 +124,18 @@ class BuiltinFunction:
         function_source = multilineCommentRegExp.sub("", function_string)
 
         intrinsic = "NoIntrinsic"
-        intrinsicMatch = functionIntrinsicRegExp.search(function_source)
-        if intrinsicMatch:
-            intrinsic = intrinsicMatch.group(1)
-            function_source = functionIntrinsicRegExp.sub("", function_source)
+        if "@intrinsic=" in function_source:
+            intrinsicMatch = functionIntrinsicRegExp.search(function_source)
+            if intrinsicMatch:
+                intrinsic = intrinsicMatch.group(1)
+                function_source = function_source.replace(intrinsicMatch.group(0), "")
 
         overridden_name = None
-        overriddenNameMatch = functionOverriddenNameRegExp.search(function_source)
-        if overriddenNameMatch:
-            overridden_name = overriddenNameMatch.group(1)
-            function_source = functionOverriddenNameRegExp.sub("", function_source)
+        if "@overriddenName=" in function_source:
+            overriddenNameMatch = functionOverriddenNameRegExp.search(function_source)
+            if overriddenNameMatch:
+                overridden_name = overriddenNameMatch.group(1)
+                function_source = function_source.replace(overriddenNameMatch.group(0), "")
 
         if not os.getenv("CONFIGURATION", "Debug").startswith("Debug"):
             function_source = lineWithOnlySingleLineCommentRegExp.sub("", function_source)
@@ -153,10 +155,11 @@ class BuiltinFunction:
             is_constructor = True
 
         visibility = "Public"
-        visibilityMatch = functionVisibilityRegExp.search(function_source)
-        if visibilityMatch:
-            visibility = visibilityMatch.group(1)
-            function_source = functionVisibilityRegExp.sub("", function_source)
+        if "@visibility=" in function_source:
+            visibilityMatch = functionVisibilityRegExp.search(function_source)
+            if visibilityMatch:
+                visibility = visibilityMatch.group(1)
+                function_source = function_source.replace(visibilityMatch.group(1), "")
         elif is_link_time_constant:
             visibility = "Private"
 


### PR DESCRIPTION
#### 2a64b0eff0e3cfa58863523af72f27a902fad7e4
<pre>
Web Inspector: Generating JS builtins for createInspectorInjectedScript is very slow
<a href="https://bugs.webkit.org/show_bug.cgi?id=271610">https://bugs.webkit.org/show_bug.cgi?id=271610</a>
<a href="https://rdar.apple.com/125703146">rdar://125703146</a>

Reviewed by Justin Michaud.

This patch puts guard to run certain regex.search() commands
to execute them only when necessary.
It also get rid of RegexPattern.sub() which is very costly on long
files, and replaces it by str.replace(pattern, &apos;&apos;)

I checked that the same files where generated without diff with the
current main code.
JSCBuiltins.cpp
JSCBuiltins.h

This patch reduces the execution time of
python Source/JavaScriptCore/Scripts/generate-js-builtins.py --framework JavaScriptCore --output-directory /tmp/ --combined Source/JavaScriptCore/builtins/*.js Source/JavaScriptCore/inspector/InjectedScriptSource.js
from ~21s to 0.1s
That should make the build bots happier.

* Source/JavaScriptCore/Scripts/wkbuiltins/builtins_model.py:
(BuiltinFunction.fromString):

Canonical link: <a href="https://commits.webkit.org/277085@main">https://commits.webkit.org/277085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/975575b313cefab6f3ddc1d872f216603745c67b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49058 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42424 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37853 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22559 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39989 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41094 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4428 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39627 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50884 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45860 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45084 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22679 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44011 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10309 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23049 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53008 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22378 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10863 "Passed tests") | 
<!--EWS-Status-Bubble-End-->