### PR TITLE
Figure out how to tell if a Web Extension has been updated in WebKit.

### DIFF
--- a/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
+++ b/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
@@ -29,10 +29,12 @@
 
 #include <Security/SecAccessControlPriv.h>
 #include <Security/SecCertificatePriv.h>
+#include <Security/SecCode.h>
 #include <Security/SecCodePriv.h>
 #include <Security/SecIdentityPriv.h>
 #include <Security/SecItemPriv.h>
 #include <Security/SecKeyPriv.h>
+#include <Security/SecStaticCode.h>
 #include <Security/SecTask.h>
 #include <Security/SecTrustPriv.h>
 
@@ -43,6 +45,10 @@
 #else
 
 #include <Security/SecBase.h>
+
+#if __has_include(<Security/CSCommon.h>)
+#include <Security/CSCommon.h>
+#endif
 
 typedef uint32_t SecSignatureHashAlgorithm;
 enum {
@@ -58,6 +64,22 @@ enum {
 };
 
 WTF_EXTERN_C_BEGIN
+
+#if !__has_include(<Security/CSCommon.h>)
+typedef struct __SecCode const *SecStaticCodeRef;
+
+typedef uint32_t SecCSFlags;
+enum {
+    kSecCSDefaultFlags = 0,
+};
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+extern const CFStringRef kSecCodeInfoUnique;
+
+OSStatus SecStaticCodeCreateWithPath(CFURLRef, SecCSFlags, SecStaticCodeRef * CF_RETURNS_RETAINED);
+OSStatus SecCodeCopySigningInformation(SecStaticCodeRef, SecCSFlags, CFDictionaryRef * CF_RETURNS_RETAINED);
+#endif
 
 #if PLATFORM(MAC)
 OSStatus SecTrustedApplicationCreateFromPath(const char* path, SecTrustedApplicationRef*);
@@ -85,6 +107,8 @@ SecAccessControlRef SecAccessControlCreateFromData(CFAllocatorRef, CFDataRef, CF
 CFDataRef SecAccessControlCopyData(SecAccessControlRef);
 
 CFDataRef SecKeyCopySubjectPublicKeyInfo(SecKeyRef);
+
+OSStatus SecCodeValidateFileResource(SecStaticCodeRef, CFStringRef, CFDataRef, SecCSFlags);
 
 #if PLATFORM(MAC)
 #include <Security/SecAsn1Types.h>

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -326,6 +326,16 @@ void WebExtensionContext::loadRegisteredContentScripts()
     }).get()];
 }
 
+void WebExtensionContext::clearRegisteredContentScripts()
+{
+    m_registeredScriptsMap.clear();
+
+    [registeredContentScriptsStore() deleteDatabaseWithCompletionHandler:^(NSString *errorMessage) {
+        if (errorMessage)
+            RELEASE_LOG_ERROR(Extensions, "Failed to delete registered content scripts database. Error: %{public}@", errorMessage);
+    }];
+}
+
 bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtensionRegisteredScriptParameters>& scripts, FirstTimeRegistration firstTimeRegistration, DynamicInjectedContentsMap& injectedContentsMap, NSString *callingAPIName, NSString **errorMessage)
 {
     Vector<String> idsToAdd;

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -36,6 +36,7 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/spi/cocoa/SecuritySPI.h>
 
 OBJC_CLASS NSArray;
 OBJC_CLASS NSBundle;
@@ -51,10 +52,6 @@ OBJC_CLASS UTType;
 OBJC_CLASS _WKWebExtension;
 OBJC_CLASS _WKWebExtensionLocalization;
 OBJC_CLASS _WKWebExtensionMatchPattern;
-
-#if PLATFORM(MAC)
-#include <Security/CSCommon.h>
-#endif
 
 #ifdef __OBJC__
 #include "_WKWebExtensionPermission.h"
@@ -197,8 +194,10 @@ public:
 
     Ref<API::Data> serializeLocalization();
 
+    SecStaticCodeRef bundleStaticCode() const;
+    NSData *bundleHash() const;
+
 #if PLATFORM(MAC)
-    SecStaticCodeRef bundleStaticCode();
     bool validateResourceData(NSURL *, NSData *, NSError **);
 #endif
 
@@ -328,11 +327,8 @@ private:
 
     MatchPatternSet m_externallyConnectableMatchPatterns;
 
-#if PLATFORM(MAC)
-    RetainPtr<SecStaticCodeRef> m_bundleStaticCode;
-#endif
-
     RetainPtr<NSBundle> m_bundle;
+    mutable RetainPtr<SecStaticCodeRef> m_bundleStaticCode;
     RetainPtr<NSURL> m_resourceBaseURL;
     RetainPtr<NSDictionary> m_manifest;
     RetainPtr<NSMutableDictionary> m_resources;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -543,6 +543,7 @@ private:
     NSDictionary *readStateFromStorage();
     void writeStateToStorage() const;
 
+    void determineInstallReasonDuringLoad();
     void moveLocalStorageIfNeeded(const URL& previousBaseURL, CompletionHandler<void()>&&);
 
     void permissionsDidChange(const PermissionsSet&);
@@ -565,7 +566,6 @@ private:
     void loadBackgroundWebViewIfNeeded();
     void loadBackgroundWebView();
     void unloadBackgroundWebView();
-    void queueStartupAndInstallEventsForExtensionIfNecessary();
     void scheduleBackgroundContentToUnload();
     void unloadBackgroundContentIfPossible();
 
@@ -639,6 +639,7 @@ private:
 
     // Registered content scripts methods.
     void loadRegisteredContentScripts();
+    void clearRegisteredContentScripts();
     _WKWebExtensionRegisteredScriptsSQLiteStore *registeredContentScriptsStore();
 
     // Storage


### PR DESCRIPTION
#### adf9728dc4e18d23d5393998b76018b74154b910
<pre>
Figure out how to tell if a Web Extension has been updated in WebKit.
<a href="https://webkit.org/b/249266">https://webkit.org/b/249266</a>
<a href="https://rdar.apple.com/problem/103573769">rdar://problem/103573769</a>

Reviewed by Brian Weinstein.

Use the code signing hash from the app extension bundle to tell if an extension
has updated. This will change after building in Xcode or via App Store updates.
There is no quick way to do this for non-bundle code paths, so we still consider
an extension updated if the version in the manifest changes.

Unfortunately, there is no way to test this with TestWebKitAPI currently since it requires
an extension to be loaded from a bundle, code signed, updated, and reloaded. I was able
to manually test this against extensions loaded in Safari.

* Source/WTF/wtf/spi/cocoa/SecuritySPI.h: Added functions and types for iOS and macOS.
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::clearRegisteredContentScripts): Added.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::bundleStaticCode const): Made const, use bridge_cast().
(WebKit::WebExtension::bundleHash const): Added.
(WebKit::WebExtension::validateResourceData): Store staticCode in variable. Use bridge_cast().
(WebKit::WebExtension::imageForPath): Use bridge_cast().
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::load): Call determineInstallReasonDuringLoad().
(WebKit::WebExtensionContext::loadBackgroundWebViewDuringLoad):
(WebKit::WebExtensionContext::determineInstallReasonDuringLoad): Renamed. Drop writeStateToStorage()
since it is already done by the caller in load(). Save and compare the bundleHash() to determine updates.
Always set LastSeenVersion. Call clearRegisteredContentScripts() when extension updates.
(WebKit::WebExtensionContext::queueStartupAndInstallEventsForExtensionIfNecessary): Deleted.
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:

Canonical link: <a href="https://commits.webkit.org/277022@main">https://commits.webkit.org/277022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceda76a71da439bf13b4533a59c1e5ae3461a17d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46456 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49132 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42497 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23075 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47034 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19160 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41165 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4501 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/39699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50966 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45934 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45151 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44087 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53081 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6481 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22456 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->