### PR TITLE
REGRESSION (276787@main): [ MacOS WK1 ] http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html is a consistent failure

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2856,5 +2856,3 @@ imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context
 # webkit.org/b/271865 REGRESSION (276749@main): [ MacOS WK1 ] 2X backdrop-filter tests are consistent failures 
 [ Sonoma+ ] css3/filters/backdrop/backdrop-filter-uneven-corner-radii.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/backdrop-filter.html [ Failure ]
-
-webkit.org/b/271892 http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html [ Failure ]

--- a/LayoutTests/platform/mac-wk1/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe-expected.txt
+++ b/LayoutTests/platform/mac-wk1/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe-expected.txt
@@ -1,0 +1,29 @@
+frame "<!--frame1-->" - didStartProvisionalLoadForFrame
+main frame - didFinishDocumentLoadForFrame
+frame "<!--frame1-->" - didCommitLoadForFrame
+CONSOLE MESSAGE: Blocked mixed content http://127.0.0.1:8000/security/mixedContent/resources/script.js because 'block-all-mixed-content' appears in the Content Security Policy.
+CONSOLE MESSAGE: Blocked mixed content http://127.0.0.1:8000/security/mixedContent/resources/script.js because 'block-all-mixed-content' appears in the Content Security Policy.
+frame "<!--frame1-->" - didFinishDocumentLoadForFrame
+frame "<!--frame1-->" - didHandleOnloadEventsForFrame
+main frame - didHandleOnloadEventsForFrame
+frame "<!--frame1-->" - didFinishLoadForFrame
+main frame - didFinishLoadForFrame
+This test loads a secure iframe that loads an insecure external script. We should trigger a mixed content block because the child frame has CSP directive block-all-mixed-content.
+
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+documentURI: https://127.0.0.1:8443/security/contentSecurityPolicy/block-all-mixed-content/resources/frame-with-insecure-script.html
+referrer: http://127.0.0.1:8000/
+blockedURI: http://127.0.0.1:8000
+violatedDirective: block-all-mixed-content
+effectiveDirective: block-all-mixed-content
+originalPolicy: block-all-mixed-content
+sourceFile:
+lineNumber: 0
+columnNumber: 0
+statusCode: 0
+
+


### PR DESCRIPTION
#### 35fd5bdf2ea4638eedc536500aedcbd8dc72ecab
<pre>
REGRESSION (276787@main): [ MacOS WK1 ] http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html is a consistent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=271892">https://bugs.webkit.org/show_bug.cgi?id=271892</a>
<a href="https://rdar.apple.com/125615616">rdar://125615616</a>

Reviewed by Chris Dumez.

The HTML script tag triggers first a preload then an actual load.
Both are checked for CSP and in WK1, both will expose a console message, contrary to WK2 where only one console message appears.
Add a WK1 specific test expectation to handle this case.

* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/mac-wk1/http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/277006@main">https://commits.webkit.org/277006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3b95cd666b5d0478eadaf56743f6a5e529fe938

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46382 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49057 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42423 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29881 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/23034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37852 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19091 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41091 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4427 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50883 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17828 "Found 60 new test failures: accessibility/ARIA-reflection.html, accessibility/accessibility-crash-focused-element-change.html, accessibility/accessibility-crash-setattribute.html, accessibility/accessibility-crash-with-dynamic-inline-content.html, accessibility/combobox/aria-combobox-control-owns-elements.html, accessibility/combobox/aria-combobox-hierarchy.html, accessibility/combobox/aria-combobox-no-owns.html, accessibility/combobox/aria-combobox.html, accessibility/combobox/mac/aria-combobox-activedescendant.html, accessibility/combobox/mac/combobox-activedescendant-notifications.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45083 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22678 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44009 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10268 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->