### PR TITLE
[@starting-style] Style adjuster wrongly invoked with null element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-adjustment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-adjustment-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS The display property in <legend> @starting-style should be blockified so no transition should start
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-adjustment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-adjustment.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<title>CSS Transitions Test: Style adjustments for @starting-style</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/#defining-before-change-style-the-starting-style-rule">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/css-transitions/support/helper.js"></script>
+<style>
+legend {
+  transition: display 1s step-end allow-discrete;
+}
+@starting-style {
+  legend { display:inline; }
+}
+</style>
+<body>
+<legend></legend>
+<script>
+promise_test(async t => {
+  await waitForAnimationFrames(1);
+  assert_equals(document.getAnimations().length, 0, "No transitions");
+}, "The display property in <legend> @starting-style should be blockified so no transition should start");
+</script>
+</body>

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -815,10 +815,7 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveStartingStyle(const ResolvedSt
     if (startingStyle->display() == DisplayType::None)
         return nullptr;
 
-    // FIXME: This logic seems wrong, because passing a non-null Element to Adjuster corresponds
-    // to the absence (not presence) of a pseudo ID. We should instead refactor this code to
-    // pass a non-null element, along with an optional pseudo element identifier.
-    Adjuster adjuster(m_document, parentAfterChangeStyle, resolutionContext.parentBoxStyle, styleable.pseudoElementIdentifier ? &styleable.element : nullptr);
+    Adjuster adjuster(m_document, parentAfterChangeStyle, resolutionContext.parentBoxStyle, !styleable.pseudoElementIdentifier ? &styleable.element : nullptr);
     adjuster.adjust(*startingStyle, nullptr);
 
     return startingStyle;


### PR DESCRIPTION
#### b78e11bab3e30ab21cd2847a963341825126c1ee
<pre>
[@starting-style] Style adjuster wrongly invoked with null element
<a href="https://bugs.webkit.org/show_bug.cgi?id=272076">https://bugs.webkit.org/show_bug.cgi?id=272076</a>
<a href="https://rdar.apple.com/125837628">rdar://125837628</a>

Reviewed by Antoine Quint.

We may compute wrong starting style for elements that require style adjustments. This may have observable effects.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-adjustment-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/starting-style-adjustment.html: Added.

&lt;legend&gt; is always blockified per HTML spec. Test we don&apos;t trigger a transition based on before-adjustment value.

* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveStartingStyle const):

The pseudo-element logic was reversed.

Canonical link: <a href="https://commits.webkit.org/276993@main">https://commits.webkit.org/276993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/539c95eae46eae852cccb52fd4b2b229a85a8dbb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49062 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42428 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22984 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46965 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22563 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/39994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19095 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41099 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4432 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50889 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45088 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44018 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10262 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->