### PR TITLE
Implement trusted types integration with SVG.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/resolve-spv.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/resolve-spv.js
@@ -1,0 +1,9 @@
+// Returns a promise that resolves with a Security Policy Violation (spv)
+    // even when it is received.
+function promise_spv() {
+  return new Promise((resolve, reject) => {
+    window.addEventListener("securitypolicyviolation", e => {
+      resolve(e);
+    }, { once: true });
+  });
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-expected.txt
@@ -6,15 +6,4 @@ PASS Assign String to SVGScriptElement.innerHTML.
 PASS Assign TrustedHTML to SVGScriptElement.innerHTML.
 TIMEOUT Assign TrustedHTML to SVGScriptElement.innerHTML and execute it. Test timed out
 NOTRUN Modify SVGScriptElement via DOM manipulation.
-NOTRUN Assign string to SVGScriptElement.href.baseVal.
-NOTRUN Assign TrustedScriptURL to SVGScriptElement.href.baseVal.
-NOTRUN Assign string to non-attached SVGScriptElement.href via setAttribute.
-NOTRUN Assign TrustedScriptURL to non-attached SVGScriptElement.href via setAttribute.
-NOTRUN Assign string to attached SVGScriptElement.href via setAttribute.
-NOTRUN Assign TrustedScriptURL to attached SVGScriptElement.href via setAttribute.
-NOTRUN Setup default policy
-NOTRUN Assign String to SVGScriptElement.innerHTML w/ default policy.
-NOTRUN Assign string to SVGScriptElement.href.baseVal  w/ default policy.
-NOTRUN Assign string to non-attached SVGScriptElement.href via setAttribute w/ default policy.
-NOTRUN Assign string to attached SVGScriptElement.href via setAttribute w/ default policy.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-set-href-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-set-href-expected.txt
@@ -1,0 +1,18 @@
+CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+
+PASS Assign string to SVGScriptElement.href.baseVal.
+PASS Assign TrustedScriptURL to SVGScriptElement.href.baseVal.
+FAIL Assign string to non-attached SVGScriptElement.href via setAttribute. assert_throws_js: function "_ => {
+        elem.setAttribute("href", "about:blank");
+      }" did not throw
+PASS Assign TrustedScriptURL to non-attached SVGScriptElement.href via setAttribute.
+FAIL Assign string to attached SVGScriptElement.href via setAttribute. assert_throws_js: function "_ => {
+        elem.setAttribute("href", "about:blank");
+      }" did not throw
+PASS Assign TrustedScriptURL to attached SVGScriptElement.href via setAttribute.
+PASS Setup default policy
+PASS Assign String to SVGScriptElement.innerHTML w/ default policy.
+PASS Assign string to SVGScriptElement.href.baseVal  w/ default policy.
+PASS Assign string to non-attached SVGScriptElement.href via setAttribute w/ default policy.
+PASS Assign string to attached SVGScriptElement.href via setAttribute w/ default policy.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-set-href.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-set-href.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="./support/resolve-spv.js"></script>	
+  <meta http-equiv="Content-Security-Policy"
+        content="require-trusted-types-for 'script'">
+</head>
+<body>
+  <div id="log"></div>
+  <svg id="svg"><script id="script">"some script text";</script></svg>
+  <script>
+    const policy = trustedTypes.createPolicy("policy", {
+        createScript: x => x, createHTML: x => x, createScriptURL: x => x });
+
+    promise_test(t => {
+      const elem = document.createElementNS(
+          "http://www.w3.org/2000/svg", "script");
+      assert_throws_js(TypeError, _ => {
+        elem.href.baseVal = "about:blank";
+      });
+      document.getElementById("svg").appendChild(elem);
+      return promise_spv();
+    }, "Assign string to SVGScriptElement.href.baseVal.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(
+          "http://www.w3.org/2000/svg", "script");
+      elem.href.baseVal = policy.createScriptURL("about:blank");
+      document.getElementById("svg").appendChild(elem);
+      return Promise.resolve();
+    }, "Assign TrustedScriptURL to SVGScriptElement.href.baseVal.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(
+          "http://www.w3.org/2000/svg", "script");
+      assert_throws_js(TypeError, _ => {
+        elem.setAttribute("href", "about:blank");
+      });
+      document.getElementById("svg").appendChild(elem);
+      return promise_spv();
+    }, "Assign string to non-attached SVGScriptElement.href via setAttribute.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(
+          "http://www.w3.org/2000/svg", "script");
+      elem.setAttribute("href", policy.createScriptURL("about:blank"));
+      document.getElementById("svg").appendChild(elem);
+      return Promise.resolve();
+    }, "Assign TrustedScriptURL to non-attached SVGScriptElement.href via setAttribute.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(
+          "http://www.w3.org/2000/svg", "script");
+      document.getElementById("svg").appendChild(elem);
+      assert_throws_js(TypeError, _ => {
+        elem.setAttribute("href", "about:blank");
+      });
+      return promise_spv();
+    }, "Assign string to attached SVGScriptElement.href via setAttribute.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(
+          "http://www.w3.org/2000/svg", "script");
+      document.getElementById("svg").appendChild(elem);
+      elem.setAttribute("href", policy.createScriptURL("about:blank"));
+      return Promise.resolve();
+    }, "Assign TrustedScriptURL to attached SVGScriptElement.href via setAttribute.");
+
+    // Default policy test: We repate the string assignment tests above,
+    // but now expect all of them to pass.
+    promise_test(t => {
+      trustedTypes.createPolicy("default", {
+        createScript: x => x, createHTML: x => x, createScriptURL: x => x });
+      return Promise.resolve();
+    }, "Setup default policy");
+
+    promise_test(t => {
+      document.getElementById("script").innerHTML = "'modified via innerHTML';";
+      return Promise.resolve();
+    }, "Assign String to SVGScriptElement.innerHTML w/ default policy.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(
+          "http://www.w3.org/2000/svg", "script");
+      elem.href.baseVal = "about:blank";
+      document.getElementById("svg").appendChild(elem);
+      return Promise.resolve();
+    }, "Assign string to SVGScriptElement.href.baseVal  w/ default policy.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(
+          "http://www.w3.org/2000/svg", "script");
+      elem.setAttribute("href", "about:blank");
+      document.getElementById("svg").appendChild(elem);
+      return Promise.resolve();
+    }, "Assign string to non-attached SVGScriptElement.href via setAttribute w/ default policy.");
+
+    promise_test(t => {
+      const elem = document.createElementNS(
+          "http://www.w3.org/2000/svg", "script");
+      document.getElementById("svg").appendChild(elem);
+      elem.setAttribute("href", "about:blank");
+      return Promise.resolve();
+    }, "Assign string to attached SVGScriptElement.href via setAttribute w/ default policy.");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script.html
@@ -2,6 +2,7 @@
 <head>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
+  <script src="./support/resolve-spv.js"></script>	
   <meta http-equiv="Content-Security-Policy"
         content="require-trusted-types-for 'script'">
 </head>
@@ -9,16 +10,6 @@
   <div id="log"></div>
   <svg id="svg"><script id="script">"some script text";</script></svg>
   <script>
-    // Returns a promise that resolves with a Security Policy Violation (spv)
-    // even when it is received.
-    function promise_spv() {
-      return new Promise((resolve, reject) => {
-        window.addEventListener("securitypolicyviolation", e => {
-          resolve(e);
-        }, { once: true });
-      });
-    }
-
     const policy = trustedTypes.createPolicy("policy", {
         createScript: x => x, createHTML: x => x, createScriptURL: x => x });
 
@@ -49,96 +40,5 @@
       document.getElementById("svg").appendChild(elem);
       return promise_spv();
     }, "Modify SVGScriptElement via DOM manipulation.");
-
-    promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
-      assert_throws_js(TypeError, _ => {
-        elem.href.baseVal = "about:blank";
-      });
-      document.getElementById("svg").appendChild(elem);
-      return promise_spv();
-    }, "Assign string to SVGScriptElement.href.baseVal.");
-
-    promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
-      elem.href.baseVal = policy.createScriptURL("about:blank");
-      document.getElementById("svg").appendChild(elem);
-      return Promise.resolve();
-    }, "Assign TrustedScriptURL to SVGScriptElement.href.baseVal.");
-
-    promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
-      assert_throws_js(TypeError, _ => {
-        elem.setAttribute("href", "about:blank");
-      });
-      document.getElementById("svg").appendChild(elem);
-      return promise_spv();
-    }, "Assign string to non-attached SVGScriptElement.href via setAttribute.");
-
-    promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
-      elem.setAttribute("href", policy.createScriptURL("about:blank"));
-      document.getElementById("svg").appendChild(elem);
-      return Promise.resolve();
-    }, "Assign TrustedScriptURL to non-attached SVGScriptElement.href via setAttribute.");
-
-    promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
-      document.getElementById("svg").appendChild(elem);
-      assert_throws_js(TypeError, _ => {
-        elem.setAttribute("href", "about:blank");
-      });
-      return promise_spv();
-    }, "Assign string to attached SVGScriptElement.href via setAttribute.");
-
-    promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
-      document.getElementById("svg").appendChild(elem);
-      elem.setAttribute("href", policy.createScriptURL("about:blank"));
-      return Promise.resolve();
-    }, "Assign TrustedScriptURL to attached SVGScriptElement.href via setAttribute.");
-
-    // Default policy test: We repate the string assignment tests above,
-    // but now expect all of them to pass.
-    promise_test(t => {
-      trustedTypes.createPolicy("default", {
-        createScript: x => x, createHTML: x => x, createScriptURL: x => x });
-      return Promise.resolve();
-    }, "Setup default policy");
-
-    promise_test(t => {
-      document.getElementById("script").innerHTML = "'modified via innerHTML';";
-      return Promise.resolve();
-    }, "Assign String to SVGScriptElement.innerHTML w/ default policy.");
-
-    promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
-      elem.href.baseVal = "about:blank";
-      document.getElementById("svg").appendChild(elem);
-      return Promise.resolve();
-    }, "Assign string to SVGScriptElement.href.baseVal  w/ default policy.");
-
-    promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
-      elem.setAttribute("href", "about:blank");
-      document.getElementById("svg").appendChild(elem);
-      return Promise.resolve();
-    }, "Assign string to non-attached SVGScriptElement.href via setAttribute w/ default policy.");
-
-    promise_test(t => {
-      const elem = document.createElementNS(
-          "http://www.w3.org/2000/svg", "script");
-      document.getElementById("svg").appendChild(elem);
-      elem.setAttribute("href", "about:blank");
-      return Promise.resolve();
-    }, "Assign string to attached SVGScriptElement.href via setAttribute w/ default policy.");
   </script>
 </body>

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3071,6 +3071,7 @@ svg/graphics/SVGImageForContainer.cpp
 svg/graphics/SVGResourceImage.cpp
 svg/graphics/filters/SVGFilter.cpp
 svg/properties/SVGAnimatedProperty.cpp
+svg/properties/SVGAnimatedString.cpp
 svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
 svg/properties/SVGAttributeAnimator.cpp
 svg/properties/SVGPropertyTraits.cpp

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyImpl.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyImpl.h
@@ -29,6 +29,7 @@
 #include "SVGAnimatedDecoratedProperty.h"
 #include "SVGAnimatedPrimitiveProperty.h"
 #include "SVGAnimatedPropertyList.h"
+#include "SVGAnimatedString.h"
 #include "SVGAnimatedValueProperty.h"
 #include "SVGDecoratedEnumeration.h"
 #include "SVGLength.h"
@@ -46,7 +47,6 @@ namespace WebCore {
 using SVGAnimatedBoolean = SVGAnimatedPrimitiveProperty<bool>;
 using SVGAnimatedInteger = SVGAnimatedPrimitiveProperty<int>;
 using SVGAnimatedNumber = SVGAnimatedPrimitiveProperty<float>;
-using SVGAnimatedString = SVGAnimatedPrimitiveProperty<String>;
 
 using SVGAnimatedEnumeration = SVGAnimatedDecoratedProperty<SVGDecoratedEnumeration, unsigned>;
 

--- a/Source/WebCore/svg/properties/SVGAnimatedString.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimatedString.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,14 +20,34 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    SkipVTableValidation,
-    Exposed=Window
-] interface SVGAnimatedString {
-    attribute (DOMString or TrustedScriptURL) baseVal;
-    readonly attribute DOMString animVal;
-};
+#include "config.h"
+#include "SVGAnimatedString.h"
 
+#include "SVGScriptElement.h"
+#include "ScriptExecutionContext.h"
+#include "TrustedType.h"
+
+namespace WebCore {
+
+ExceptionOr<void> SVGAnimatedString::setBaseVal(const StringOrTrustedScriptURL& baseVal)
+{
+    auto stringValueHolder = WTF::switchOn(baseVal,
+        [&](const String& str) -> ExceptionOr<String> {
+            SVGElement* el = contextElement();
+            if (isScriptElement(*el))
+                return trustedTypeCompliantString(TrustedType::TrustedScriptURL, *(contextElement()->document().scriptExecutionContext()), str, "SVGScriptElement href"_s);
+            return String(str);
+        },
+        [](const RefPtr<TrustedScriptURL>& trustedScriptURL) -> ExceptionOr<String> {
+            return trustedScriptURL->toString();
+        }
+    );
+    if (stringValueHolder.hasException())
+        return stringValueHolder.releaseException();
+
+    return SVGAnimatedPrimitiveProperty<String>::setBaseVal(stringValueHolder.releaseReturnValue());
+}
+}

--- a/Source/WebCore/svg/properties/SVGAnimatedString.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedString.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,14 +20,35 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[
-    SkipVTableValidation,
-    Exposed=Window
-] interface SVGAnimatedString {
-    attribute (DOMString or TrustedScriptURL) baseVal;
-    readonly attribute DOMString animVal;
+#pragma once
+
+#include "SVGAnimatedProperty.h"
+#include "TrustedScriptURL.h"
+
+namespace WebCore {
+
+using StringOrTrustedScriptURL = std::variant<String, RefPtr<TrustedScriptURL>>;
+
+class SVGAnimatedString : public SVGAnimatedPrimitiveProperty<String> {
+    public:
+
+    static Ref<SVGAnimatedString> create(SVGElement* contextElement)
+    {
+        return adoptRef(*new SVGAnimatedString(contextElement));
+    }
+
+    virtual ExceptionOr<void> setBaseVal(const StringOrTrustedScriptURL&);
+
+    protected:
+
+    SVGAnimatedString(SVGElement* contextElement)
+        : SVGAnimatedPrimitiveProperty<String>(contextElement)
+    {
+
+    }
 };
 
+}


### PR DESCRIPTION
#### 068145c5b797fe9690f476678deb681dbe855808
<pre>
Implement trusted types integration with SVG.
<a href="https://bugs.webkit.org/show_bug.cgi?id=267693">https://bugs.webkit.org/show_bug.cgi?id=267693</a>

Reviewed by NOBODY (OOPS!).

Modify the SVGAnimatedString interface to enforce Trusted Types.
It also split the tests of assignment of SVGScriptElement.href out to a separate test.

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/support/resolve-spv.js: Added.
(promise_spv):
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-set-href-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script-set-href.html: Copied from LayoutTests/imported/w3c&gt;
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-svg-script.html:
* Source/WebCore/Sources.txt:
* Source/WebCore/svg/SVGAnimatedString.idl:
* Source/WebCore/svg/properties/SVGAnimatedPropertyImpl.h:
* Source/WebCore/svg/properties/SVGAnimatedString.cpp: Copied from Source/WebCore/svg/SVGAnimatedString.idl.
(WebCore::SVGAnimatedString::setBaseVal):
* Source/WebCore/svg/properties/SVGAnimatedString.h: Copied from Source/WebCore/svg/SVGAnimatedString.idl.
(WebCore::SVGAnimatedString::create):
(WebCore::SVGAnimatedString::SVGAnimatedString):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/068145c5b797fe9690f476678deb681dbe855808

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/48993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49073 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48705 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/22995 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46976 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22579 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40006 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/19108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/19946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41108 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4443 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/41473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50902 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21403 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22694 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/40155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23076 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/22393 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->