### PR TITLE
[cmake] Fix recompilation on rebuild without changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(WebKit)
 
 # Remove this cmake_policy() after upgrading cmake_minimum_required() to 3.20.
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.20")
-    cmake_policy(SET CMP0116 OLD)
+    cmake_policy(SET CMP0116 NEW)
 endif ()
 
 # -----------------------------------------------------------------------------

--- a/Source/WebKit/InspectorGResources.cmake
+++ b/Source/WebKit/InspectorGResources.cmake
@@ -8,11 +8,9 @@ macro(WEBKIT_BUILD_INSPECTOR_GRESOURCES _derived_sources_dir)
         VERBATIM
     )
 
-    add_custom_command(
-        OUTPUT ${_derived_sources_dir}/InspectorGResourceBundle.c ${_derived_sources_dir}/InspectorGResourceBundle.deps
-        DEPENDS ${_derived_sources_dir}/InspectorGResourceBundle.xml
-        DEPFILE ${_derived_sources_dir}/InspectorGResourceBundle.deps
-        COMMAND glib-compile-resources --generate --sourcedir=${_derived_sources_dir}/InspectorResources/WebInspectorUI --target=${_derived_sources_dir}/InspectorGResourceBundle.c --dependency-file=${_derived_sources_dir}/InspectorGResourceBundle.deps ${_derived_sources_dir}/InspectorGResourceBundle.xml
-        VERBATIM
+    GLIB_COMPILE_RESOURCES(
+        OUTPUT        ${_derived_sources_dir}/InspectorGResourceBundle.c
+        SOURCE_XML    ${_derived_sources_dir}/InspectorGResourceBundle.xml
+        RESOURCE_DIRS ${_derived_sources_dir}/InspectorResources/WebInspectorUI
     )
 endmacro()

--- a/Source/WebKit/ModernMediaControlsGResources.cmake
+++ b/Source/WebKit/ModernMediaControlsGResources.cmake
@@ -7,11 +7,9 @@ macro(WEBKIT_BUILD_MODERN_MEDIA_CONTROLS_GRESOURCES _derived_sources_dir)
         VERBATIM
     )
 
-    add_custom_command(
-        OUTPUT ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.c ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.deps
-        DEPENDS ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.xml
-        DEPFILE ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.deps
-        COMMAND glib-compile-resources --generate --sourcedir=${WEBCORE_DIR}/Modules/modern-media-controls/images/adwaita --target=${_derived_sources_dir}/ModernMediaControlsGResourceBundle.c --dependency-file=${_derived_sources_dir}/ModernMediaControlsGResourceBundle.deps ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.xml
-        VERBATIM
+    GLIB_COMPILE_RESOURCES(
+        OUTPUT        ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.c
+        SOURCE_XML    ${_derived_sources_dir}/ModernMediaControlsGResourceBundle.xml
+        RESOURCE_DIRS ${WEBCORE_DIR}/Modules/modern-media-controls/images/adwaita
     )
 endmacro()

--- a/Source/WebKit/PdfJSGResources.cmake
+++ b/Source/WebKit/PdfJSGResources.cmake
@@ -10,12 +10,10 @@ macro(WEBKIT_BUILD_PDFJS_GRESOURCES _derived_sources_dir)
         VERBATIM
     )
 
-    add_custom_command(
-        OUTPUT ${_derived_sources_dir}/PdfJSGResourceBundle.c ${_derived_sources_dir}/PdfJSGResourceBundle.deps
-        DEPENDS ${_derived_sources_dir}/PdfJSGResourceBundle.xml
-        DEPFILE ${_derived_sources_dir}/PdfJSGResourceBundle.deps
-        COMMAND glib-compile-resources --generate --sourcedir=${THIRDPARTY_DIR}/pdfjs --target=${_derived_sources_dir}/PdfJSGResourceBundle.c --dependency-file=${_derived_sources_dir}/PdfJSGResourceBundle.deps ${_derived_sources_dir}/PdfJSGResourceBundle.xml
-        VERBATIM
+    GLIB_COMPILE_RESOURCES(
+        OUTPUT        ${_derived_sources_dir}/PdfJSGResourceBundle.c
+        SOURCE_XML    ${_derived_sources_dir}/PdfJSGResourceBundle.xml
+        RESOURCE_DIRS ${THIRDPARTY_DIR}/pdfjs
     )
 
     add_custom_command(
@@ -26,11 +24,9 @@ macro(WEBKIT_BUILD_PDFJS_GRESOURCES _derived_sources_dir)
         VERBATIM
     )
 
-    add_custom_command(
-        OUTPUT ${_derived_sources_dir}/PdfJSGResourceBundleExtras.c ${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps
-        DEPENDS ${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml
-        DEPFILE ${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps
-        COMMAND glib-compile-resources --generate --sourcedir=${WEBCORE_DIR}/Modules/pdfjs-extras --target=${_derived_sources_dir}/PdfJSGResourceBundleExtras.c --dependency-file=${_derived_sources_dir}/PdfJSGResourceBundleExtras.deps ${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml
-        VERBATIM
+    GLIB_COMPILE_RESOURCES(
+        OUTPUT        ${_derived_sources_dir}/PdfJSGResourceBundleExtras.c
+        SOURCE_XML    ${_derived_sources_dir}/PdfJSGResourceBundleExtras.xml
+        RESOURCE_DIRS ${WEBCORE_DIR}/Modules/pdfjs-extras
     )
 endmacro()

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -458,12 +458,12 @@ file(WRITE ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
     "</gresources>\n"
 )
 
-add_custom_command(
-    OUTPUT ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.c ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.deps
-    DEPENDS ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
-    DEPFILE ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.deps
-    COMMAND glib-compile-resources --generate --sourcedir=${CMAKE_SOURCE_DIR}/Source/WebCore/Resources --sourcedir=${CMAKE_SOURCE_DIR}/Source/WebCore/platform/audio/resources --sourcedir=${CMAKE_SOURCE_DIR}/Source/WebKit/Resources/gtk --target=${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.c --dependency-file=${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.deps ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
-    VERBATIM
+GLIB_COMPILE_RESOURCES(
+    OUTPUT        ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.c
+    SOURCE_XML    ${WebKitGTK_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
+    RESOURCE_DIRS ${CMAKE_SOURCE_DIR}/Source/WebCore/Resources
+                  ${CMAKE_SOURCE_DIR}/Source/WebCore/platform/audio/resources
+                  ${CMAKE_SOURCE_DIR}/Source/WebKit/Resources/gtk
 )
 
 if (ENABLE_WAYLAND_TARGET)

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -357,12 +357,11 @@ file(WRITE ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
     "</gresources>\n"
 )
 
-add_custom_command(
-    OUTPUT ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.c ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.deps
-    DEPENDS ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
-    DEPFILE ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.deps
-    COMMAND glib-compile-resources --generate --sourcedir=${CMAKE_SOURCE_DIR}/Source/WebCore/Resources --sourcedir=${CMAKE_SOURCE_DIR}/Source/WebCore/platform/audio/resources --target=${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.c --dependency-file=${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.deps ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
-    VERBATIM
+GLIB_COMPILE_RESOURCES(
+    OUTPUT        ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.c
+    SOURCE_XML    ${WebKit_DERIVED_SOURCES_DIR}/WebKitResourcesGResourceBundle.xml
+    RESOURCE_DIRS ${CMAKE_SOURCE_DIR}/Source/WebCore/Resources
+                  ${CMAKE_SOURCE_DIR}/Source/WebCore/platform/audio/resources
 )
 
 list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES

--- a/Source/cmake/FindGLibCompileResources.cmake
+++ b/Source/cmake/FindGLibCompileResources.cmake
@@ -1,0 +1,65 @@
+pkg_get_variable(GLIB2_PREFIX glib-2.0 prefix)
+find_program(
+    GLIB_COMPILE_RESOURCES_EXECUTABLE
+    NAMES glib-compile-resources
+    HINTS ${GLIB2_PREFIX}
+    REQUIRED
+)
+execute_process(
+    COMMAND ${GLIB_COMPILE_RESOURCES_EXECUTABLE} --version
+    OUTPUT_VARIABLE glib_compile_resources_version
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+message(STATUS "Found glib-compile-resources (required): "
+    ${GLIB_COMPILE_RESOURCES_EXECUTABLE}
+    " (${glib_compile_resources_version})"
+)
+
+set(glib_compile_resources_has_depfile_bug FALSE)
+if ("${glib_compile_resources_version}" VERSION_LESS 2.77)
+    set(glib_compile_resources_has_depfile_bug TRUE)
+endif ()
+
+function(GLIB_COMPILE_RESOURCES)
+    set(zeroArgKeywords "")
+    set(oneArgKeywords OUTPUT SOURCE_XML)
+    set(manyArgsKeywords RESOURCE_DIRS)
+    cmake_parse_arguments(
+        PARSE_ARGV 0 ARG
+        "${zeroArgKeywords}" "${oneArgKeywords}" "${manyArgsKeywords}"
+    )
+
+    set(resource_dir_args "")
+    foreach (resource_dir IN LISTS ARG_RESOURCE_DIRS)
+        list(APPEND resource_dir_args --sourcedir=${resource_dir})
+    endforeach ()
+
+    set(additional_cmd_line)
+    if (${glib_compile_resources_has_depfile_bug})
+        # Workaround for older versions of glib-compile-resources lacking this fix:
+        # https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3460
+        #
+        # Affected versions produce broken depfiles that look like this:
+        #   foo.xml: resource1 resource2
+        # But depfiles should look like this:
+        #   foo.c: foo.xml resource1 resource2
+        set(additional_cmd_line &&
+            ${PERL_EXECUTABLE} -pi ${CMAKE_SOURCE_DIR}/Tools/glib/fix-glib-resources-depfile.pl
+            ${ARG_SOURCE_XML} ${ARG_OUTPUT} ${ARG_OUTPUT}.deps)
+    endif ()
+
+    add_custom_command(
+        OUTPUT  ${ARG_OUTPUT} ${ARG_OUTPUT}.deps
+        DEPENDS ${ARG_SOURCE_XML}
+        DEPFILE ${ARG_OUTPUT}.deps
+        COMMAND ${GLIB_COMPILE_RESOURCES_EXECUTABLE}
+                --generate
+                --target=${ARG_OUTPUT}
+                --dependency-file=${ARG_OUTPUT}.deps
+                ${resource_dir_args}
+                ${ARG_SOURCE_XML}
+                ${additional_cmd_line}
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        VERBATIM
+    )
+endfunction()

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -30,6 +30,7 @@ find_package(WebP REQUIRED COMPONENTS demux)
 find_package(ATSPI 2.5.3)
 
 include(GStreamerDefinitions)
+include(FindGLibCompileResources)
 
 SET_AND_EXPOSE_TO_BUILD(USE_GCRYPT TRUE)
 SET_AND_EXPOSE_TO_BUILD(USE_LIBEPOXY TRUE)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -32,6 +32,7 @@ WEBKIT_OPTION_BEGIN()
 SET_AND_EXPOSE_TO_BUILD(ENABLE_DEVELOPER_MODE ${DEVELOPER_MODE})
 
 include(GStreamerDefinitions)
+include(FindGLibCompileResources)
 
 # Public options shared with other WebKit ports. Do not add any options here
 # without approval from a WPE reviewer. There must be strong reason to support

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -123,17 +123,10 @@ if (COMPILER_IS_GCC_OR_CLANG)
     WEBKIT_ADD_TARGET_CXX_FLAGS(WebKitGLibAPITestsCore -Wno-unused-parameter)
 endif ()
 
-add_custom_command(
-    OUTPUT ${TEST_RESOURCES_DIR}/webkitglib-tests-resources.gresource ${TEST_RESOURCES_DIR}/webkitglib-tests-resources.deps
-    DEPENDS ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/resources/webkitglib-tests.gresource.xml
-            ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/resources/link-title.js
-    DEPFILE ${TEST_RESOURCES_DIR}/webkitglib-tests-resources.deps
-    COMMAND glib-compile-resources
-            --target=${TEST_RESOURCES_DIR}/webkitglib-tests-resources.gresource
-            --sourcedir=${CMAKE_SOURCE_DIR}
-            --dependency-file=${TEST_RESOURCES_DIR}/webkitglib-tests-resources.deps
-            ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/resources/webkitglib-tests.gresource.xml
-    VERBATIM
+GLIB_COMPILE_RESOURCES(
+    OUTPUT        ${TEST_RESOURCES_DIR}/webkitglib-tests-resources.gresource
+    RESOURCE_DIRS ${CMAKE_SOURCE_DIR}
+    SOURCE_XML    ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/resources/webkitglib-tests.gresource.xml
 )
 
 add_custom_target(test-gresource-bundle

--- a/Tools/glib/fix-glib-resources-depfile.pl
+++ b/Tools/glib/fix-glib-resources-depfile.pl
@@ -1,0 +1,6 @@
+# Workaround for https://gitlab.gnome.org/GNOME/glib/-/merge_requests/3460
+# Used by FindGLibCompileResources.cmake for glib-compile-commands < 2.77
+BEGIN {
+    ($old_xml, $new_target) = splice(@ARGV, 0, 2);
+}
+s{\Q$old_xml:}{$new_target: $old_xml}


### PR DESCRIPTION
#### 18c724980da23899f80a0271c0cbb70c0769e662
<pre>
[cmake] Fix recompilation on rebuild without changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=257516">https://bugs.webkit.org/show_bug.cgi?id=257516</a>

Reviewed by Adrian Perez de Castro.

Running build-webkit twice in a row made the second run still take
somewhere in the order of a minute to complete, despite there being no
changes in any code.

This patch fixes the bugs in the build system causing that deficiency,
at least for users of CMake &gt;=3.20.

Namely:

* Amends 250761@main, which added a cmake_policy() command for CMP0116
  without any effect. This patch sets it to NEW, which tells CMake to
  rewrite depfiles to use paths relative to the sub-build directory if
  the user CMake version is recent enough (&gt;=3.20). Previous versions of
  CMake will remain affected.

* Refactors all usages of glib-compile-commands into a new CMake
  function, GLIB_COMPILE_COMMANDS(), provided by a new
  FindGLibCompileResources.cmake file.

* Detects versions of the glib-compile-commands older than 2.77 as
  potentially affected by this bug in depfile generation:
  <a href="https://gitlab.gnome.org/GNOME/glib/-/issues/2829">https://gitlab.gnome.org/GNOME/glib/-/issues/2829</a>
  If building with an affected version, a Perl post processing script is
  added automatically that corrects the depfiles. The Perl script is
  meant to be harmless in the case of false positives (older but patched
  versions).

* Modifies apply-build-revision-to-files.py, which is responsible for
  generating BuildRevision.h, to not write to the file if the resulting
  contents would remain unchanged. This avoids touching the modification
  time of the file which build systems like Ninja use to test whether
  files are dirty and therefore need to be recompiled along with all
  their dependents. A similar check already exists for many other
  generators that run on every build.

* CMakeLists.txt:
* Source/WebKit/InspectorGResources.cmake:
* Source/WebKit/ModernMediaControlsGResources.cmake:
* Source/WebKit/PdfJSGResources.cmake:
* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/cmake/FindGLibCompileResources.cmake: Added.
* Source/cmake/OptionsGTK.cmake:
* Source/cmake/OptionsWPE.cmake:
* Tools/TestWebKitAPI/glib/CMakeLists.txt:
* Tools/glib/apply-build-revision-to-files.py:
(main):
* Tools/glib/fix-glib-resources-depfile.pl: Added.

Canonical link: <a href="https://commits.webkit.org/277059@main">https://commits.webkit.org/277059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d872866fb32d15c512ed30a6fdf30ebced496fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49249 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23191 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47151 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19242 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41249 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4617 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/39819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51097 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46053 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21579 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10291 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53197 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22572 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->