### PR TITLE
[Remote Inspection] Frequent targeted element requests can break automatic visibility adjustment

### DIFF
--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -31,6 +31,7 @@
 #include "IntRect.h"
 #include "Region.h"
 #include "ScriptExecutionContextIdentifier.h"
+#include "Timer.h"
 #include <wtf/ApproximateTime.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
@@ -60,10 +61,12 @@ public:
     WEBCORE_EXPORT bool resetVisibilityAdjustments(const Vector<std::pair<ElementIdentifier, ScriptExecutionContextIdentifier>>&);
 
 private:
+    void cleanUpAdjustmentClientRects();
     void applyVisibilityAdjustmentFromSelectors(Document&);
 
     SingleThreadWeakPtr<Page> m_page;
-    HashMap<ElementIdentifier, IntRect> m_pendingAdjustmentClientRects;
+    DeferrableOneShotTimer m_recentAdjustmentClientRectsCleanUpTimer;
+    HashMap<ElementIdentifier, IntRect> m_recentAdjustmentClientRects;
     std::optional<HashSet<String>> m_remainingVisibilityAdjustmentSelectors;
     ApproximateTime m_startTimeForSelectorBasedVisibilityAdjustment;
     Region m_adjustmentClientRegion;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -181,16 +181,19 @@ TEST(ElementTargeting, NearbyOutOfFlowElements)
     [webView synchronouslyLoadTestPageNamed:@"element-targeting-2"];
 
     RetainPtr elements = [webView targetedElementInfoAt:CGPointMake(100, 100)];
-    EXPECT_EQ([elements count], 4U);
+    EXPECT_EQ([elements count], 5U);
     EXPECT_TRUE([elements objectAtIndex:0].underPoint);
-    EXPECT_FALSE([elements objectAtIndex:1].underPoint);
+    EXPECT_TRUE([elements objectAtIndex:1].underPoint);
     EXPECT_FALSE([elements objectAtIndex:2].underPoint);
     EXPECT_FALSE([elements objectAtIndex:3].underPoint);
+    EXPECT_FALSE([elements objectAtIndex:4].underPoint);
+    // The two elements that are directly hit-tested should take precedence over nearby elements.
     EXPECT_WK_STREQ(".fixed.container", [elements firstObject].selectors.firstObject);
+    EXPECT_WK_STREQ(".box", [elements objectAtIndex:1].selectors.firstObject);
     __auto_type nextThreeSelectors = [NSSet setWithArray:@[
-        [elements objectAtIndex:1].selectors.firstObject,
         [elements objectAtIndex:2].selectors.firstObject,
         [elements objectAtIndex:3].selectors.firstObject,
+        [elements objectAtIndex:4].selectors.firstObject,
     ]];
     EXPECT_TRUE([nextThreeSelectors containsObject:@".absolute.top-right"]);
     EXPECT_TRUE([nextThreeSelectors containsObject:@".absolute.bottom-left"]);
@@ -231,11 +234,13 @@ TEST(ElementTargeting, AdjustVisibilityForUnparentedElement)
 
     RetainPtr elements = [webView targetedElementInfoAt:CGPointMake(100, 100)];
     setOverlaysParented(false);
+    [webView targetedElementInfoAt:CGPointMake(100, 100)];
     [webView adjustVisibilityForTargets:elements.get()];
     setOverlaysParented(true);
 
     elements = [webView targetedElementInfoAt:CGPointMake(100, 100)];
     setOverlaysParented(false);
+    [webView targetedElementInfoAt:CGPointMake(100, 100)];
     [webView adjustVisibilityForTargets:elements.get()];
     setOverlaysParented(true);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-2.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-2.html
@@ -18,12 +18,15 @@ body, html {
     width: 200px;
     height: 200px;
     position: fixed;
-    top: 0;
-    left: 0;
     background: tomato;
     color: white;
     text-align: center;
     opacity: 0.75;
+}
+
+.container {
+    top: 0;
+    left: 0;
 }
 
 .absolute {
@@ -49,9 +52,17 @@ body, html {
     top: 10px;
     left: 110px;
 }
+
+.box {
+    border: 1px solid black;
+    width: 250px;
+    height: 250px;
+    box-sizing: border-box;
+}
 </style>
 </head>
 <body>
+    <div class="box"></div>
     <div class="fixed container"></div>
     <div class="absolute bottom-right"></div>
     <div class="absolute bottom-left"></div>


### PR DESCRIPTION
#### 58a545029fd142c73099d59e6e3a601a6c034dc4
<pre>
[Remote Inspection] Frequent targeted element requests can break automatic visibility adjustment
<a href="https://bugs.webkit.org/show_bug.cgi?id=272068">https://bugs.webkit.org/show_bug.cgi?id=272068</a>

Reviewed by Tim Horton.

Currently, `m_pendingAdjustmentClientRects` cleared out and recomputed in
`ElementTargetingController` when the WebKit client requests targeted element information; this
cache is then consulted when the client goes to adjust visibility for these previously requested
elements, to update visibility adjustment coverage regions (in client coordinates). By clearing out
`m_pendingAdjustmentClientRects`, we avoid unbounded growth in this map, as the user targets
elements around the page.

However, this strategy has a subtle flaw — it&apos;s possible for the client to perform another targeted
element request in between the first targeting request, and visibility adjustment; in this case, if
the request finds different hit-tested elements (e.g. in the case where the targeted element has
already been unparented), we&apos;ll end up with no cached client rects at adjustent time, since the
second request would&apos;ve cleared out the cached rects.

Fix this race by not clearing out this client rect cache during each targeting request; instead, we
prevent unbounded growth by scheduling a timer to perform cache cleanup, once no more targeting
requests are received. This works well in practice, since the cache doesn&apos;t get very large to begin
with (in real use cases), so there&apos;s no need to aggressively clear out the map.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::findTargets):

Restart the client rect cleanup timer whenever we receive another request to target elements. After
a somewhat-arbitrary 15 seconds of inactivity, purge the client rect cache.

(WebCore::ElementTargetingController::adjustVisibility):
(WebCore::ElementTargetingController::reset):
(WebCore::ElementTargetingController::cleanUpAdjustmentClientRects):
* Source/WebCore/page/ElementTargetingController.h:

Add a timer that cleans up `m_recentAdjustmentClientRects` when fired. Additionally, rename what is
currently `m_pendingAdjustmentClientRects` to `m_recentAdjustmentClientRects`, now that this map no
longer tracks only the last set of targeted elements that are pending visibility adjustment.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(TestWebKitAPI::TEST(ElementTargeting, NearbyOutOfFlowElements)):
(TestWebKitAPI::TEST(ElementTargeting, AdjustVisibilityForUnparentedElement)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-2.html:

Augment an existing API test to cover this corner case.

Canonical link: <a href="https://commits.webkit.org/277038@main">https://commits.webkit.org/277038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ad8ef9a1a949d200afd3ea25b6af17b86b8588b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49083 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42449 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37876 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/46986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19117 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41120 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4453 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50914 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45113 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22704 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44043 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10284 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->