### PR TITLE
A clonable ShadowRoot is always cloned

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/shadow-root-clonable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/shadow-root-clonable-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL attachShadow with clonable: true null is not an object (evaluating 'shallowClonedRoot.clonable')
+PASS attachShadow with clonable: true
 PASS attachShadow with clonable: false
 PASS attachShadow with clonable: undefined
 PASS declarative shadow roots do *not* get clonable: true automatically

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -579,7 +579,6 @@ Ref<Node> Element::cloneNodeInternal(Document& targetDocument, CloningOperation 
 {
     switch (type) {
     case CloningOperation::OnlySelf:
-        return cloneElementWithoutChildren(targetDocument);
     case CloningOperation::SelfWithTemplateContent: {
         Ref clone = cloneElementWithoutChildren(targetDocument);
         ScriptDisallowedScope::EventAllowedScope eventAllowedScope { clone };

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -236,10 +236,11 @@ bool ShadowRoot::childTypeAllowed(NodeType type) const
 Ref<Node> ShadowRoot::cloneNodeInternal(Document& targetDocument, CloningOperation type)
 {
     RELEASE_ASSERT(m_mode != ShadowRootMode::UserAgent);
+    ASSERT(m_isClonable);
     switch (type) {
     case CloningOperation::SelfWithTemplateContent:
         return create(targetDocument, m_mode, m_slotAssignmentMode, m_delegatesFocus ? DelegatesFocus::Yes : DelegatesFocus::No,
-            m_isClonable ? Clonable::Yes : Clonable::No, m_availableToElementInternals ? AvailableToElementInternals::Yes : AvailableToElementInternals::No);
+            Clonable::Yes, m_availableToElementInternals ? AvailableToElementInternals::Yes : AvailableToElementInternals::No);
     case CloningOperation::OnlySelf:
     case CloningOperation::Everything:
         break;


### PR DESCRIPTION
#### 4e262b07baa1b55186d79a67b35f326cfdea48b2
<pre>
A clonable ShadowRoot is always cloned
<a href="https://bugs.webkit.org/show_bug.cgi?id=272089">https://bugs.webkit.org/show_bug.cgi?id=272089</a>

Reviewed by Ryosuke Niwa.

This aligns us with other browsers and this change to the DOM standard:
<a href="https://github.com/whatwg/dom/pull/1272">https://github.com/whatwg/dom/pull/1272</a>

* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/shadow-root-clonable-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::cloneNodeInternal): This is the change that makes the test pass.
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::cloneNodeInternal): This cleans up a conditional that is always true.

Canonical link: <a href="https://commits.webkit.org/277066@main">https://commits.webkit.org/277066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9685a8a65dd162173b3cbeb53d8e8c90bd829648

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49121 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42486 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37905 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19149 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41152 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4490 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50955 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45144 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22742 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44080 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10299 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->