### PR TITLE
[WebGPU] Attribute locations should be validated prior to invoking metal compiler

### DIFF
--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -516,11 +516,14 @@ static ShaderModule::VertexOutputs parseVertexReturnType(const WGSL::Type& type)
     return vertexOutputs;
 }
 
-static void populateStageInMap(const WGSL::Type& type, ShaderModule::VertexStageIn& vertexStageIn)
+static void populateStageInMap(const WGSL::Type& type, ShaderModule::VertexStageIn& vertexStageIn, const std::optional<unsigned>& optionalLocation)
 {
     auto* inputStruct = std::get_if<WGSL::Types::Struct>(&type);
-    if (!inputStruct)
+    if (!inputStruct) {
+        if (optionalLocation)
+            vertexStageIn.add(*optionalLocation, vertexFormatTypeForStructMember(&type));
         return;
+    }
 
     for (auto& member : inputStruct->structure.members()) {
         if (!member.location())
@@ -639,7 +642,7 @@ static ShaderModule::VertexStageIn parseStageIn(const WGSL::AST::Function& funct
             continue;
 
         if (auto* inferredType = parameter.typeName().inferredType())
-            populateStageInMap(*inferredType, result);
+            populateStageInMap(*inferredType, result, parameter.location());
     }
 
     return result;


### PR DESCRIPTION
#### 4ab8a909f6b54dd3ab4c2f34b5caf8c839922779
<pre>
[WebGPU] Attribute locations should be validated prior to invoking metal compiler
<a href="https://bugs.webkit.org/show_bug.cgi?id=272091">https://bugs.webkit.org/show_bug.cgi?id=272091</a>
&lt;radar://125721108&gt;

Reviewed by Tadeu Zagallo.

Before calling the Metal compiler with attributes which exceed the maximum allowed
value for vertex_stage_in, we should validate these values in createRenderPipeline.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::errorValidatingVertexStageIn):
(WebGPU::Device::createRenderPipeline):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::populateStageInMap):
(WebGPU::parseStageIn):

Canonical link: <a href="https://commits.webkit.org/277065@main">https://commits.webkit.org/277065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fda5b4b586ab509ee0e89db314e5ffa07e6ef72

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49106 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42472 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37892 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40036 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19134 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/19987 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4476 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42745 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50940 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21436 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45129 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22728 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44061 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10300 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22430 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->