### PR TITLE
[visionOS] Expose a _defaultSTSLabel SPI

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -4057,25 +4057,21 @@ void MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel()
         return;
     }
 
-    AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
-    if (!m_visible) {
-        // If the page is not visible, use the AudioSession's STS label.
-        [m_avPlayer _setSTSLabel:session.spatialTrackingLabel];
-        return;
-    }
-
     if (m_videoLayer) {
         // Let AVPlayer manage setting the spatial tracking label in its AVPlayerLayer itself;
         [m_avPlayer _setSTSLabel:nil];
         return;
     }
 
-    // If there is no AVPlayerLayer, use the default spatial tracking label if available, or
-    // the session's spatial tracking label if not.
-    if (!m_defaultSpatialTrackingLabel.isNull())
+    if (!m_defaultSpatialTrackingLabel.isNull()) {
+        // If a default spatial tracking label was explicitly set, use it.
         [m_avPlayer _setSTSLabel:m_defaultSpatialTrackingLabel];
-    else
-        [m_avPlayer _setSTSLabel:session.spatialTrackingLabel];
+        return;
+    }
+
+    // If there is no AVPlayerLayer, and no default spatial tracking label is available, use the session's spatial tracking label.
+    AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
+    [m_avPlayer _setSTSLabel:session.spatialTrackingLabel];
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1715,13 +1715,6 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel()
         return;
     }
 
-    AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
-    if (!m_visible) {
-        // If the page is not visible, use the AudioSession's STS label.
-        renderer.STSLabel = session.spatialTrackingLabel;
-        return;
-    }
-
     if (renderer) {
         // Let AVSBRS manage setting the spatial tracking label in its video renderer itself.
         renderer.STSLabel = nil;
@@ -1736,6 +1729,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel()
     // If there is no video renderer, use the default spatial tracking label if available, or
     // the session's spatial tracking label if not, and set the label directly on each audio
     // renderer.
+    AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];
     auto *defaultLabel = !m_defaultSpatialTrackingLabel.isNull() ? (NSString *)m_defaultSpatialTrackingLabel : session.spatialTrackingLabel;
     for (const auto &key : m_sampleBufferAudioRendererMap.keys())
         [(__bridge AVSampleBufferAudioRenderer *)key.get() setSTSLabel:defaultLabel];

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7417,4 +7417,16 @@ void Internals::registerPDFTest(Ref<VoidCallback>&& callback, Element& element)
         pluginViewBase->registerPDFTestCallback(WTFMove(callback));
 }
 
+const String& Internals::defaultSpatialTrackingLabel() const
+{
+#if HAVE(SPATIAL_TRACKING_LABEL)
+    auto* document = contextDocument();
+    if (!document)
+        return nullString();
+    if (RefPtr page = document->page())
+        return page->defaultSpatialTrackingLabel();
+#endif
+    return nullString();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1459,6 +1459,8 @@ public:
     Vector<PDFAnnotationRect> pdfAnnotationRectsForTesting(Element& pluginElement) const;
     void registerPDFTest(Ref<VoidCallback>&&, Element&);
 
+    const String& defaultSpatialTrackingLabel() const;
+
 private:
     explicit Internals(Document&);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1345,4 +1345,6 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     sequence<PDFAnnotationRect> pdfAnnotationRectsForTesting(Element element);
     undefined registerPDFTest(VoidCallback callback, Element element);
+
+    readonly attribute DOMString defaultSpatialTrackingLabel;
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -355,6 +355,10 @@ struct PerWebProcessState {
 
     RetainPtr<NSArray<NSNumber *>> _scrollViewDefaultAllowedTouchTypes;
 #endif
+
+#if PLATFORM(VISION)
+    String _defaultSTSLabel;
+#endif
 }
 
 - (BOOL)_isValid;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -676,6 +676,12 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 
 @end
 
+#if TARGET_OS_VISION
+@interface WKWebView (WKPrivateVision)
+@property (copy, setter=_setDefaultSTSLabel:) NSString *_defaultSTSLabel;
+@end
+#endif
+
 @interface WKWebView () <UIResponderStandardEditActions>
 @end
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4752,6 +4752,21 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 @end
 
+
+#if PLATFORM(VISION)
+@implementation WKWebView(WKPrivateVision)
+- (NSString *)_defaultSTSLabel
+{
+    return nsStringNilIfNull(_page->defaultSpatialTrackingLabel());
+}
+
+- (void)_setDefaultSTSLabel:(NSString *)defaultSTSLabel
+{
+    _page->setDefaultSpatialTrackingLabel(defaultSTSLabel);
+}
+@end
+#endif
+
 #endif // ENABLE(FULLSCREEN_API)
 
 @implementation WKWebView (_WKWebViewPrintFormatter)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2426,8 +2426,9 @@ public:
     template<typename M> void sendToProcessContainingFrame(std::optional<WebCore::FrameIdentifier>, M&&);
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
-    void setSpatialTrackingLabel(const String&);
-    const String& spatialTrackingLabel() const;
+    void setDefaultSpatialTrackingLabel(const String&);
+    const String& defaultSpatialTrackingLabel() const;
+    void updateDefaultSpatialTrackingLabel();
 #endif
 
 private:
@@ -3547,6 +3548,10 @@ private:
 #endif
 
     std::unique_ptr<WebsitePoliciesData> m_mainFrameWebsitePoliciesData;
+
+#if HAVE(SPATIAL_TRACKING_LABEL)
+    String m_defaultSpatialTrackingLabel;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -277,7 +277,6 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
     [_spatialTrackingView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
     [_spatialTrackingView setFrame:self.bounds];
     [self addSubview:_spatialTrackingView.get()];
-    _page->setSpatialTrackingLabel(_spatialTrackingLabel);
 #endif
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_applicationWillResignActive:) name:UIApplicationWillResignActiveNotification object:[UIApplication sharedApplication]];

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1027,6 +1027,7 @@
 		CD59F53519E9110D00CF1835 /* test-mse.mp4 in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD59F53319E910BC00CF1835 /* test-mse.mp4 */; };
 		CD5FF49F2162E943004BD86F /* ISOBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD5FF4962162E27E004BD86F /* ISOBox.cpp */; };
 		CD758A6F20572EA00071834A /* video-with-paused-audio-and-playing-muted.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD758A6E20572D540071834A /* video-with-paused-audio-and-playing-muted.html */; };
+		CD780E762BBE176D002A3DEC /* WKWebViewSpatialTrackingLabels.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD780E752BBE176D002A3DEC /* WKWebViewSpatialTrackingLabels.mm */; };
 		CD78E11E1DB7EE2A0014A2DE /* FullscreenDelegate.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD78E11B1DB7EA360014A2DE /* FullscreenDelegate.html */; };
 		CD8394DF232AF7C000149495 /* media-loading.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD8394DE232AF15E00149495 /* media-loading.html */; };
 		CD9E292E1C90C33F000BB800 /* audio-only.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = CD9E292D1C90C1BA000BB800 /* audio-only.html */; };
@@ -3340,6 +3341,7 @@
 		CD59F53319E910BC00CF1835 /* test-mse.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-mse.mp4"; sourceTree = "<group>"; };
 		CD5FF4962162E27E004BD86F /* ISOBox.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ISOBox.cpp; sourceTree = "<group>"; };
 		CD758A6E20572D540071834A /* video-with-paused-audio-and-playing-muted.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "video-with-paused-audio-and-playing-muted.html"; sourceTree = "<group>"; };
+		CD780E752BBE176D002A3DEC /* WKWebViewSpatialTrackingLabels.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewSpatialTrackingLabels.mm; sourceTree = "<group>"; };
 		CD78E11A1DB7EA360014A2DE /* FullscreenDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenDelegate.mm; sourceTree = "<group>"; };
 		CD78E11B1DB7EA360014A2DE /* FullscreenDelegate.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = FullscreenDelegate.html; sourceTree = "<group>"; };
 		CD7F89DB22A86CDA00D683AE /* WKWebViewSuspendAllMediaPlayback.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewSuspendAllMediaPlayback.mm; sourceTree = "<group>"; };
@@ -4362,6 +4364,7 @@
 				953DF77B27C6DE5D00FDF3A5 /* WKWebViewResize.mm */,
 				37A9DBE7213B4C9300D261A2 /* WKWebViewServerTrustKVC.mm */,
 				93F56DA81E5F9181003EDE84 /* WKWebViewSnapshot.mm */,
+				CD780E752BBE176D002A3DEC /* WKWebViewSpatialTrackingLabels.mm */,
 				CD7F89DB22A86CDA00D683AE /* WKWebViewSuspendAllMediaPlayback.mm */,
 				9984FACA1CFFAEEE008D198C /* WKWebViewTextInput.mm */,
 				95A524942581A10D00461FE9 /* WKWebViewThemeColor.mm */,
@@ -6949,6 +6952,7 @@
 				CDE4E4F42B7F278600B3AE35 /* MediaLoading.mm in Sources */,
 				5797FE311EB15A6800B2F4A0 /* NavigationClientDefaultCrypto.cpp in Sources */,
 				7AD3FE8E1D76131200B169A4 /* TransformationMatrix.cpp in Sources */,
+				CD780E762BBE176D002A3DEC /* WKWebViewSpatialTrackingLabels.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSpatialTrackingLabels.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSpatialTrackingLabels.mm
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestWKWebView.h"
+#import "WKWebViewConfigurationExtras.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <wtf/BlockPtr.h>
+#import <wtf/RetainPtr.h>
+
+#if HAVE(SPATIAL_TRACKING_LABEL)
+TEST(WKWebView, DefaultSTSLabel)
+{
+    auto *configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 300, 300) configuration:configuration addToWindow:YES]);
+
+    [webView synchronouslyLoadHTMLString:@"<body></body>"];
+
+    auto getDefaultSTSLabel = [&] {
+        return [webView stringByEvaluatingJavaScript:@"internals.defaultSpatialTrackingLabel"];
+    };
+
+    auto testDefaultSTSLabelEventually = [&](auto test) {
+        int tries = 0;
+        do {
+            if (test(getDefaultSTSLabel()))
+                break;
+
+            TestWebKitAPI::Util::runFor(0.1_s);
+        } while (++tries <= 100);
+    };
+
+    testDefaultSTSLabelEventually([](auto* label) { return ![label isEqualToString:@""]; });
+    ASSERT_STRNE(getDefaultSTSLabel().UTF8String, "");
+
+    [webView removeFromSuperview];
+
+    testDefaultSTSLabelEventually([](auto* label) { return [label isEqualToString:@""]; });
+    ASSERT_STREQ(getDefaultSTSLabel().UTF8String, "");
+
+    [webView addToTestWindow];
+    [webView _setDefaultSTSLabel:@"default-sts-label"];
+
+    testDefaultSTSLabelEventually([](auto* label) { return [label isEqualToString:@"default-sts-label"]; });
+    ASSERT_STREQ(getDefaultSTSLabel().UTF8String, "default-sts-label");
+
+    [webView removeFromSuperview];
+
+    testDefaultSTSLabelEventually([](auto* label) { return [label isEqualToString:@"default-sts-label"]; });
+    ASSERT_STREQ(getDefaultSTSLabel().UTF8String, "default-sts-label");
+}
+#endif


### PR DESCRIPTION
#### 7c97c209930082bfc693e7a65269200f6a48efac
<pre>
[visionOS] Expose a _defaultSTSLabel SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=272093">https://bugs.webkit.org/show_bug.cgi?id=272093</a>
<a href="https://rdar.apple.com/120018549">rdar://120018549</a>

Reviewed by Eric Carlson.

When an application allows users to switch between WKWebViews within a single UIWindow
(e.g., via tabs in a web browser app), the unparented WKWebView may still be generating
audio and that audio still needs to be located spatially. Add a SPI for a client
application to provide a &quot;default&quot; spatial tracking label which can be used for the
fallback scenario where the WKWebView itself is not visible. Clients can use this SPI
to ensure that a background tab continues to have its audio playback spatialized to
the UIWindow that previously hosted it.

In adding this SPI, also move the responsibility for tracking whether the WKWebView is
parented or not up from MediaPlayerPrivate implementations into WebPageProxy. When the
web view is unparented, pass the defaultSTSLabel provided by the client down to the
WebContent and GPU processes for use by MediaPlayerPrivate and other internal clients.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _defaultSTSLabel]):
(-[WKWebView _setDefaultSTSLabel:]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::viewDidLeaveWindow):
(WebKit::WebPageProxy::viewDidEnterWindow):
(WebKit::WebPageProxy::setDefaultSpatialTrackingLabel):
(WebKit::WebPageProxy::defaultSpatialTrackingLabel const):
(WebKit::WebPageProxy::updateDefaultSpatialTrackingLabel):
(WebKit::WebPageProxy::setSpatialTrackingLabel): Deleted.
(WebKit::WebPageProxy::spatialTrackingLabel const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _commonInitializationWithProcessPool:configuration:]):

Canonical link: <a href="https://commits.webkit.org/277218@main">https://commits.webkit.org/277218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05f6ae9d8f1ef1bb426c3b33c390e024837a5a76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46675 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49352 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42722 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38044 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40208 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19315 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41338 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4720 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51209 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45309 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22972 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44279 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10385 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23432 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22676 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->