### PR TITLE
[CSS] Fix link invalidation when color depends on the visited style

### DIFF
--- a/LayoutTests/fast/css/link-style-color-invalidation-expected.html
+++ b/LayoutTests/fast/css/link-style-color-invalidation-expected.html
@@ -1,0 +1,5 @@
+<style>
+    a, a:visited { color:green; }
+</style>
+
+<a href="">Should be green when hovered</a>

--- a/LayoutTests/fast/css/link-style-color-invalidation.html
+++ b/LayoutTests/fast/css/link-style-color-invalidation.html
@@ -1,0 +1,12 @@
+<style>
+    a:link { color: green; }
+    a:hover { color: green; }
+</style>
+
+<a href="">Should be green when hovered</a>
+
+<script>
+if (window.eventSender) {
+    eventSender.mouseMoveTo(10, 10);
+}
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3365,6 +3365,7 @@ webkit.org/b/250767 imported/w3c/web-platform-tests/html/user-activation/activat
 # :hover simulation not working on iOS
 imported/w3c/web-platform-tests/css/selectors/hover-002.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-text-decor/invalidation/text-decoration-thickness.html [ Skip ]
+fast/css/link-style-color-invalidation.html [ Skip ]
 
 # Certain versions of iOS use different text security characters.
 webkit.org/b/209692 platform/ios/fast/text/text-security-disc-bullet-pua-ios-new.html [ Pass ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1244,6 +1244,7 @@ fast/forms/caps-lock-indicator-width.html [ Skip ]
 
 # WK1 and WK2 mousemove events are subtly different in ways that break this test on WK1.
 fast/events/ghostly-mousemoves-in-subframe.html [ Skip ]
+fast/css/link-style-color-invalidation.html [ Skip ]
 
 # WK1 does not filter response headers.
 http/wpt/loading/redirect-headers.html [ Skip ]


### PR DESCRIPTION
#### e451a390febd89df0938e9b125ebff43adbf100b
<pre>
[CSS] Fix link invalidation when color depends on the visited style
<a href="https://bugs.webkit.org/show_bug.cgi?id=61697">https://bugs.webkit.org/show_bug.cgi?id=61697</a>
<a href="https://rdar.apple.com/97529381">rdar://97529381</a>

Reviewed by Simon Fraser.

This patch fixes the comparison for the &quot;color&quot; property,
by comparing the used value used for rendering
(taking into account the duality color/visitedLinkColor).

We should ideally do that for each color property
(backgroundColor/visitedLinkBackgroundColor...etc) in a followup patch.

Also, this doesn&apos;t change the current algorithm which requires repaint
whenever the color value changes without looking at its actual usage
in other properties (like what is done in the SVGRenderStyle diff).

* LayoutTests/fast/css/link-style-color-invalidation-expected.html: Added.
* LayoutTests/fast/css/link-style-color-invalidation.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::currentColorWithVisitedDiffers):
(WebCore::RenderStyle::changeRequiresRepaint const):
(WebCore::RenderStyle::changeRequiresRepaintIfText const):

Canonical link: <a href="https://commits.webkit.org/279411@main">https://commits.webkit.org/279411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e003d62f5136f80138d87c0ec799bcb8af71e20e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32775 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56700 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4146 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40212 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3917 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43309 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2715 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24442 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3474 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2302 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58295 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3643 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50707 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46350 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50047 "Found 1 new API test failure: /WebKitGTK/TestUIClient:/webkit/WebKitWebView/display-usermedia-permission-request (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11645 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30712 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->