### PR TITLE
[JSC] Handle OutOfBounds GetByVal of TypedArray

### DIFF
--- a/JSTests/microbenchmarks/uint8-clamped-array-out-of-bounds.js
+++ b/JSTests/microbenchmarks/uint8-clamped-array-out-of-bounds.js
@@ -1,0 +1,16 @@
+function test(array, length)
+{
+    var result = 0;
+    for (var i = 0; i < length; ++i) {
+        result += array[i] | 0;
+    }
+    return result;
+}
+noInline(test);
+
+var array = new Uint8ClampedArray(1024);
+for (var i = 0; i < array.length; ++i)
+    array[i] = i & 0xff;
+
+for (var i = 0; i < 1e2; ++i)
+    test(array, 10000);

--- a/JSTests/stress/typed-array-out-of-bounds.js
+++ b/JSTests/stress/typed-array-out-of-bounds.js
@@ -1,0 +1,22 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+
+function test(array, i) {
+    return array[i];
+}
+noInline(test);
+
+Uint8Array.prototype[-1] = 42;
+Uint8Array.prototype[1000000000] = 42;
+
+var array = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+
+for (var i = 0; i < 1e4; ++i) {
+    shouldBe(test(array, -1), undefined);
+    shouldBe(test(array, 1000000000), undefined);
+    shouldBe(test(array, 0), 1);
+    shouldBe(test(array, 1), 2);
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2339,6 +2339,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case AtomicsStore:
     case AtomicsSub:
     case AtomicsXor: {
+        ArrayMode arrayMode = node->arrayMode();
         if (node->op() == GetByVal || node->op() == GetByValMegamorphic) {
             auto foldGetByValOnConstantProperty = [&] (Edge& arrayEdge, Edge& indexEdge) {
                 // FIXME: We can expand this for non x86 environments.
@@ -2374,7 +2375,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 if (structureIDEarly.isNuked())
                     return false;
 
-                if (node->arrayMode().arrayClass() == Array::OriginalCopyOnWriteArray) {
+                if (arrayMode.arrayClass() == Array::OriginalCopyOnWriteArray) {
 
                     WTF::loadLoadFence();
                     Butterfly* butterfly = array->butterfly();
@@ -2386,11 +2387,11 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                         return false;
 
                     Structure* structure = structureIDLate.decode();
-                    switch (node->arrayMode().type()) {
+                    switch (arrayMode.type()) {
                     case Array::Int32:
                     case Array::Contiguous:
                     case Array::Double:
-                        if (structure->indexingMode() != (toIndexingShape(node->arrayMode().type()) | CopyOnWrite | IsArray))
+                        if (structure->indexingMode() != (toIndexingShape(arrayMode.type()) | CopyOnWrite | IsArray))
                             return false;
                         break;
                     default:
@@ -2409,9 +2410,9 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                         return true;
                     }
 
-                    if (node->arrayMode().isOutOfBounds()) {
+                    if (arrayMode.isOutOfBounds()) {
                         if (m_graph.isWatchingArrayPrototypeChainIsSaneWatchpoint(node)) {
-                            if (node->arrayMode().type() == Array::Double && node->arrayMode().isOutOfBoundsSaneChain() && !(node->flags() & NodeBytecodeUsesAsOther))
+                            if (arrayMode.type() == Array::Double && arrayMode.isOutOfBoundsSaneChain() && !(node->flags() & NodeBytecodeUsesAsOther))
                                 setConstant(node, jsNumber(PNaN));
                             else
                                 setConstant(node, jsUndefined());
@@ -2421,7 +2422,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                     return false;
                 }
 
-                if (node->arrayMode().type() == Array::ArrayStorage || node->arrayMode().type() == Array::SlowPutArrayStorage) {
+                if (arrayMode.type() == Array::ArrayStorage || arrayMode.type() == Array::SlowPutArrayStorage) {
                     JSValue value;
                     {
                         // ArrayStorage's Butterfly can be half-broken state.
@@ -2470,7 +2471,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             };
 
             bool didFold = false;
-            switch (node->arrayMode().type()) {
+            switch (arrayMode.type()) {
             case Array::Generic:
             case Array::Int32:
             case Array::Double:
@@ -2478,7 +2479,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             case Array::ArrayStorage:
             case Array::SlowPutArrayStorage:
                 if (foldGetByValOnConstantProperty(m_graph.child(node, 0), m_graph.child(node, 1))) {
-                    if (node->arrayMode().isEffectfulOutOfBounds())
+                    if (arrayMode.isEffectfulOutOfBounds())
                         didFoldClobberWorld();
                     didFold = true;
                 }
@@ -2490,7 +2491,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             if (didFold)
                 break;
 
-            if (m_graph.child(node, 0).useKind() == ObjectUse && node->arrayMode().type() == Array::Generic) {
+            if (m_graph.child(node, 0).useKind() == ObjectUse && arrayMode.type() == Array::Generic) {
                 AbstractValue& property = forNode(m_graph.child(node, 1));
                 if (JSValue constant = property.value()) {
                     if (constant.isString()) {
@@ -2521,7 +2522,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             // the returned values rely on the typed array types. On the other hand, Atomics.store's
             // returned value is input value. This means that Atomics.store + Uint8Array can return doubles
             // while the typed array is Uint8Array (the above one is the example).
-            switch (node->arrayMode().type()) {
+            switch (arrayMode.type()) {
             case Array::Generic:
                 clobberWorld();
                 makeHeapTopForNode(node);
@@ -2548,7 +2549,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             break;
         }
 
-        switch (node->arrayMode().type()) {
+        switch (arrayMode.type()) {
         case Array::SelectUsingPredictions:
         case Array::Unprofiled:
         case Array::SelectUsingArguments:
@@ -2571,7 +2572,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             makeHeapTopForNode(node);
             break;
         case Array::String:
-            if (node->arrayMode().isOutOfBounds()) {
+            if (arrayMode.isOutOfBounds()) {
                 // If the watchpoint was still valid we could totally set this to be
                 // SpecString | SpecOther. Except that we'd have to be careful. If we
                 // tested the watchpoint state here then it could change by the time
@@ -2589,26 +2590,26 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             break;
         case Array::DirectArguments:
         case Array::ScopedArguments:
-            if (node->arrayMode().isOutOfBounds())
+            if (arrayMode.isOutOfBounds())
                 clobberWorld();
             makeHeapTopForNode(node);
             break;
         case Array::Int32:
-            if (node->arrayMode().isEffectfulOutOfBounds()) {
+            if (arrayMode.isEffectfulOutOfBounds()) {
                 clobberWorld();
                 makeHeapTopForNode(node);
-            } else if (node->arrayMode().isOutOfBoundsSaneChain())
+            } else if (arrayMode.isOutOfBoundsSaneChain())
                 setNonCellTypeForNode(node, SpecInt32Only | SpecOther);
             else
                 setNonCellTypeForNode(node, SpecInt32Only);
             break;
         case Array::Double:
-            if (node->arrayMode().isEffectfulOutOfBounds()) {
+            if (arrayMode.isEffectfulOutOfBounds()) {
                 clobberWorld();
                 makeHeapTopForNode(node);
-            } else if (node->arrayMode().isInBoundsSaneChain())
+            } else if (arrayMode.isInBoundsSaneChain())
                 setNonCellTypeForNode(node, SpecBytecodeDouble);
-            else if (node->arrayMode().isOutOfBoundsSaneChain()) {
+            else if (arrayMode.isOutOfBoundsSaneChain()) {
                 if (!!(node->flags() & NodeBytecodeUsesAsOther))
                     setNonCellTypeForNode(node, SpecBytecodeDouble | SpecOther);
                 else
@@ -2619,41 +2620,73 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         case Array::Contiguous:
         case Array::ArrayStorage:
         case Array::SlowPutArrayStorage:
-            if (node->arrayMode().isEffectfulOutOfBounds())
+            if (arrayMode.isEffectfulOutOfBounds())
                 clobberWorld();
             makeHeapTopForNode(node);
             break;
         case Array::Int8Array:
-            setNonCellTypeForNode(node, SpecInt32Only);
+            if (node->op() == GetByVal && arrayMode.isOutOfBounds())
+                setNonCellTypeForNode(node, SpecInt32Only | SpecOther);
+            else
+                setNonCellTypeForNode(node, SpecInt32Only);
             break;
         case Array::Int16Array:
-            setNonCellTypeForNode(node, SpecInt32Only);
+            if (node->op() == GetByVal && arrayMode.isOutOfBounds())
+                setNonCellTypeForNode(node, SpecInt32Only | SpecOther);
+            else
+                setNonCellTypeForNode(node, SpecInt32Only);
             break;
         case Array::Int32Array:
-            setNonCellTypeForNode(node, SpecInt32Only);
+            if (node->op() == GetByVal && arrayMode.isOutOfBounds())
+                setNonCellTypeForNode(node, SpecInt32Only | SpecOther);
+            else
+                setNonCellTypeForNode(node, SpecInt32Only);
             break;
         case Array::Uint8Array:
-            setNonCellTypeForNode(node, SpecInt32Only);
+            if (node->op() == GetByVal && arrayMode.isOutOfBounds())
+                setNonCellTypeForNode(node, SpecInt32Only | SpecOther);
+            else
+                setNonCellTypeForNode(node, SpecInt32Only);
             break;
         case Array::Uint8ClampedArray:
-            setNonCellTypeForNode(node, SpecInt32Only);
+            if (node->op() == GetByVal && arrayMode.isOutOfBounds())
+                setNonCellTypeForNode(node, SpecInt32Only | SpecOther);
+            else
+                setNonCellTypeForNode(node, SpecInt32Only);
             break;
         case Array::Uint16Array:
-            setNonCellTypeForNode(node, SpecInt32Only);
-            break;
-        case Array::Uint32Array:
-            if (node->shouldSpeculateInt32())
-                setNonCellTypeForNode(node, SpecInt32Only);
-            else if (node->shouldSpeculateInt52())
-                setNonCellTypeForNode(node, SpecInt52Any);
+            if (node->op() == GetByVal && arrayMode.isOutOfBounds())
+                setNonCellTypeForNode(node, SpecInt32Only | SpecOther);
             else
-                setNonCellTypeForNode(node, SpecAnyIntAsDouble);
+                setNonCellTypeForNode(node, SpecInt32Only);
             break;
+        case Array::Uint32Array: {
+            if (node->shouldSpeculateInt32()) {
+                if (node->op() == GetByVal && arrayMode.isOutOfBounds())
+                    setNonCellTypeForNode(node, SpecInt32Only | SpecOther);
+                else
+                    setNonCellTypeForNode(node, SpecInt32Only);
+            } else if (!(node->op() == GetByVal && arrayMode.isOutOfBounds()) && node->shouldSpeculateInt52())
+                setNonCellTypeForNode(node, SpecInt52Any);
+            else {
+                if (node->op() == GetByVal && arrayMode.isOutOfBounds())
+                    setNonCellTypeForNode(node, SpecAnyIntAsDouble | SpecOther);
+                else
+                    setNonCellTypeForNode(node, SpecAnyIntAsDouble);
+            }
+            break;
+        }
         case Array::Float32Array:
-            setNonCellTypeForNode(node, SpecFullDouble);
+            if (node->op() == GetByVal && arrayMode.isOutOfBounds())
+                setNonCellTypeForNode(node, SpecBytecodeDouble | SpecOther);
+            else
+                setNonCellTypeForNode(node, SpecFullDouble);
             break;
         case Array::Float64Array:
-            setNonCellTypeForNode(node, SpecFullDouble);
+            if (node->op() == GetByVal && arrayMode.isOutOfBounds())
+                setNonCellTypeForNode(node, SpecBytecodeDouble | SpecOther);
+            else
+                setNonCellTypeForNode(node, SpecFullDouble);
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -1099,6 +1099,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         case Array::Uint32Array:
         case Array::Float32Array:
         case Array::Float64Array:
+            // Even if we hit out-of-bounds, this is fine. TypedArray does not propagate access to its [[Prototype]] when out-of-bounds access happens.
             read(TypedArrayProperties);
             read(MiscFields);
             if (mode.mayBeResizableOrGrowableSharedTypedArray()) {

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1190,7 +1190,7 @@ private:
                 break;
             }
             
-            arrayMode = node->arrayMode();
+            arrayMode = node->arrayMode(); // Reload
             switch (arrayMode.type()) {
             case Array::SelectUsingPredictions:
             case Array::Unprofiled:
@@ -1253,16 +1253,19 @@ private:
                 
             case Array::Float32Array:
             case Array::Float64Array:
-                node->setResult(NodeResultDouble);
+                if (!(node->op() == GetByVal && arrayMode.isOutOfBounds()))
+                    node->setResult(NodeResultDouble);
                 break;
                 
             case Array::Uint32Array:
                 if (node->shouldSpeculateInt32())
                     break;
-                if (node->shouldSpeculateInt52())
+                if (!(node->op() == GetByVal && arrayMode.isOutOfBounds()) && node->shouldSpeculateInt52())
                     node->setResult(NodeResultInt52);
-                else
-                    node->setResult(NodeResultDouble);
+                else {
+                    if (!(node->op() == GetByVal && arrayMode.isOutOfBounds()))
+                        node->setResult(NodeResultDouble);
+                }
                 break;
                 
             default:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1470,7 +1470,6 @@ public:
     void compileResolveRope(Node*);
     JITCompiler::Jump jumpForTypedArrayOutOfBounds(Node*, GPRReg baseGPR, GPRReg indexGPR, GPRReg scratchGPR, GPRReg scratch2GPR);
     JITCompiler::Jump jumpForTypedArrayIsDetachedIfOutOfBounds(Node*, GPRReg baseGPR, JITCompiler::Jump outOfBounds);
-    void emitTypedArrayBoundsCheck(Node*, GPRReg baseGPR, GPRReg indexGPR, GPRReg scratchGPR, GPRReg scratch2GPR);
     void compileGetTypedArrayByteOffset(Node*);
 #if USE(LARGE_TYPED_ARRAYS)
     void compileGetTypedArrayByteOffsetAsInt52(Node*);
@@ -1510,7 +1509,7 @@ public:
 #endif
         Edge valueUse);
     void loadFromIntTypedArray(GPRReg storageReg, GPRReg propertyReg, GPRReg resultReg, TypedArrayType);
-    void setIntTypedArrayLoadResult(Node*, JSValueRegs resultRegs, TypedArrayType, bool canSpeculate, bool shouldBox, FPRReg);
+    void setIntTypedArrayLoadResult(Node*, JSValueRegs resultRegs, TypedArrayType, bool canSpeculate, bool shouldBox, FPRReg, Jump);
     template <typename ClassType> void compileNewFunctionCommon(GPRReg, RegisteredStructure, GPRReg, GPRReg, GPRReg, JumpList&, size_t, FunctionExecutable*);
     void compileNewFunction(Node*);
     void compileSetFunctionName(Node*);


### PR DESCRIPTION
#### de77ddb828e1bb4c9ccd13bf96819e1268f28deb
<pre>
[JSC] Handle OutOfBounds GetByVal of TypedArray
<a href="https://bugs.webkit.org/show_bug.cgi?id=272107">https://bugs.webkit.org/show_bug.cgi?id=272107</a>
<a href="https://rdar.apple.com/problem/125863449">rdar://problem/125863449</a>

Reviewed by Justin Michaud.

Previously, DFG / FTL are not tolerant against OutOfBounds access of TypedArray: whenever we encounter this, we did OSR exit.
But this is not so great, and we should make it work well since there are legit cases which does OutOfBounds access to TypedArray.

This patch integrates OutOfBounds GetByVal access to TypedArray, which is similar to what we have for the other arrays.
Based on ArrayProfile information, we annotate DFG::ArrayMode with OutOfBounds. And then DFG / FTL handle this case gracefully.
InBounds case is still fastest since we can put strong type prediction / invariant on the returned value too. But still, OutOfBounds
handling is better than just doing OSR exit repeatedly.
One of the interesting aspect is that TypedArray does not propagate access of OutOfBounds to [[Prototype]], which is specified in the spec.
As a result, we can say that the result is `undefined` when OutOfBounds access happens, which makes slow path case significantly simpler.

                                                  ToT                     Patched

    uint8-clamped-array-out-of-bounds       18.8348+-0.0251     ^      1.3021+-0.0190        ^ definitely 14.4654x faster

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGArrayMode.cpp:
(JSC::DFG::ArrayMode::refine const):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::setIntTypedArrayLoadResult):
(JSC::DFG::SpeculativeJIT::compileGetByValOnIntTypedArray):
(JSC::DFG::SpeculativeJIT::emitTypedArrayBoundsCheck): Deleted.
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileGetByValImpl):

Canonical link: <a href="https://commits.webkit.org/277050@main">https://commits.webkit.org/277050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca314b1dba8e0962d98a4f57643f1937343fb362

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49206 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42570 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23148 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47108 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19209 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41225 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4574 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/39776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51047 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46008 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21535 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45202 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44143 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53154 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6498 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22529 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->