### PR TITLE
_WKWebExtensionDataRecord.errors shouldn't return a nil array

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
@@ -258,8 +258,10 @@ using namespace WebKit;
 
     NSString *databaseCloseErrorMessage;
     if ([self _isDatabaseOpen]) {
-        if ([_database close] != SQLITE_OK)
+        if ([_database close] != SQLITE_OK) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to close storage database for extension %{private}@", _uniqueIdentifier);
             databaseCloseErrorMessage = @"Failed to close extension storage database.";
+        }
         _database = nil;
     }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataRecord.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataRecord.h
@@ -30,7 +30,28 @@
 
 #import <WebKit/_WKWebExtensionDataType.h>
 
+#define HAVE_UPDATED_WEB_EXTENSION_DATA_RECORD_ERROR_PROPERTIES 1
+
 NS_ASSUME_NONNULL_BEGIN
+
+/*! @abstract Indicates a `_WKWebExtensionDataRecord` error. */
+WK_EXTERN NSErrorDomain const _WKWebExtensionDataRecordErrorDomain WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
+/*!
+ @abstract Constants used by NSError to indicate errors in the `_WKWebExtensionDataRecord` domain.
+ @constant WKWebExtensionDataRecordErrorUnknown  Indicates that an unknown error occurred.
+
+ @constant WKWebExtensionDataRecordErrorLocalStorageFailed  Indicates a failure occurred when either deleting or calculating local storage.
+ @constant WKWebExtensionDataRecordErrorSessionStorageFailed  Indicates a failure occurred when either deleting or calculating session storage.
+ @constant WKWebExtensionDataRecordErrorSyncStorageFailed  Indicates a failure occurred when either deleting or calculating sync storage.
+
+ */
+typedef NS_ERROR_ENUM(_WKWebExtensionDataRecordErrorDomain, _WKWebExtensionDataRecordError) {
+    _WKWebExtensionDataRecordErrorUnknown,
+    _WKWebExtensionDataRecordErrorLocalStorageFailed,
+    _WKWebExtensionDataRecordErrorSessionStorageFailed,
+    _WKWebExtensionDataRecordErrorSyncStorageFailed,
+} NS_SWIFT_NAME(_WKWebExtensionDataRecord.Error) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 /*!
  @abstract A `_WKWebExtensionDataRecord` object represents a record of stored data for a specific web extension context.
@@ -54,6 +75,9 @@ NS_SWIFT_NAME(_WKWebExtension.DataRecord)
 
 /*! @abstract The total size of all data types contained in this data record. */
 @property (nonatomic, readonly) unsigned long long totalSize;
+
+/*! @abstract An array containing all errors that may have occurred when either calculating or deleting storage. */
+@property (nonatomic, readonly, copy) NSArray<NSError *> *errors;
 
 /*!
  @abstract Retrieves the size of the specific data types in this data record.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataRecord.mm
@@ -32,6 +32,8 @@
 
 #import "_WKWebExtensionDataTypeInternal.h"
 
+NSErrorDomain const _WKWebExtensionDataRecordErrorDomain = @"_WKWebExtensionDataRecordErrorDomain";
+
 @implementation _WKWebExtensionDataRecord
 
 #if ENABLE(WK_WEB_EXTENSIONS)
@@ -75,6 +77,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionDataRecord, WebExtensionDat
     return _webExtensionDataRecord->sizeOfTypes(WebKit::toWebExtensionDataTypes(dataTypes));
 }
 
+- (NSArray<NSError *> *)errors
+{
+    return _webExtensionDataRecord->errors();
+}
+
 #pragma mark WKObject protocol implementation
 
 - (API::Object&)_apiObject
@@ -114,6 +121,11 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionDataRecord, WebExtensionDat
     return 0;
 }
 
+- (NSArray<NSError *> *)errors
+{
+    return nil;
+}
+
 #endif // ENABLE(WK_WEB_EXTENSIONS)
 
 @end
@@ -142,6 +154,12 @@ Vector<Ref<WebExtensionDataRecord>> toWebExtensionDataRecords(NSArray *records)
 NSArray *toAPI(const Vector<Ref<WebExtensionDataRecord>>& records)
 {
     return createNSArray(records).get();
+}
+
+NSError *createDataRecordError(_WKWebExtensionDataRecordError error, NSString *debugDescription)
+{
+    NSDictionary *userInfo = debugDescription ? @{ NSDebugDescriptionErrorKey: debugDescription } : @{ };
+    return [NSError errorWithDomain:_WKWebExtensionDataRecordErrorDomain code:error userInfo:userInfo];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -121,9 +121,9 @@ String WebExtensionController::storageDirectory(WebExtensionContext& extensionCo
     return nullString();
 }
 
-void WebExtensionController::getDataRecords(OptionSet<WebExtensionDataType> types, CompletionHandler<void(Vector<Ref<WebExtensionDataRecord>>)>&& completionHandler)
+void WebExtensionController::getDataRecords(OptionSet<WebExtensionDataType> dataTypes, CompletionHandler<void(Vector<Ref<WebExtensionDataRecord>>)>&& completionHandler)
 {
-    if (!m_configuration->storageIsPersistent() || types.isEmpty()) {
+    if (!m_configuration->storageIsPersistent() || dataTypes.isEmpty()) {
         completionHandler({ });
         return;
     }
@@ -140,27 +140,36 @@ void WebExtensionController::getDataRecords(OptionSet<WebExtensionDataType> type
     auto uniqueIdentifiers = FileSystem::listDirectory(m_configuration->storageDirectory());
     for (auto& uniqueIdentifier : uniqueIdentifiers) {
         String displayName;
-        if (!WebExtensionContext::readDisplayNameFromState(stateFilePath(uniqueIdentifier), displayName))
+        if (!WebExtensionContext::readDisplayNameFromState(stateFilePath(uniqueIdentifier), displayName)) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to read extension display name from State.plist for extension: %{private}@", (NSString *)uniqueIdentifier);
             continue;
+        }
 
-        for (auto type : types) {
-            auto *storage = sqliteStore(storageDirectory(uniqueIdentifier), type, this->extensionContext(uniqueIdentifier));
-            if (!storage)
+        for (auto dataType : dataTypes) {
+            Ref record = recordHolder->recordsMap.ensure(uniqueIdentifier, [&] {
+                return WebExtensionDataRecord::create(displayName, uniqueIdentifier);
+            }).iterator->value;
+
+            auto *storage = sqliteStore(storageDirectory(uniqueIdentifier), dataType, this->extensionContext(uniqueIdentifier));
+            if (!storage) {
+                RELEASE_LOG_ERROR(Extensions, "Failed to create sqlite store for extension: %{private}@", (NSString *)uniqueIdentifier);
+                record->addError(@"Unable to calculate extension storage", dataType);
                 continue;
+            }
 
-            calculateStorageSize(storage, type, makeBlockPtr([recordHolder, aggregator, uniqueIdentifier, displayName, type](size_t size) mutable {
-                Ref record = recordHolder->recordsMap.ensure(uniqueIdentifier, [&] {
-                    return WebExtensionDataRecord::create(displayName, uniqueIdentifier);
-                }).iterator->value;
-                record->setSizeOfType(type, size);
+            calculateStorageSize(storage, dataType, makeBlockPtr([recordHolder, aggregator, uniqueIdentifier, displayName, dataType, record = Ref { record }](Expected<size_t, WebExtensionError>&& result) mutable {
+                if (!result)
+                    record->addError(result.error(), dataType);
+                else
+                    record->setSizeOfType(dataType, result.value());
             }));
         }
     }
 }
 
-void WebExtensionController::getDataRecord(OptionSet<WebExtensionDataType> types, WebExtensionContext& extensionContext, CompletionHandler<void(RefPtr<WebExtensionDataRecord>)>&& completionHandler)
+void WebExtensionController::getDataRecord(OptionSet<WebExtensionDataType> dataTypes, WebExtensionContext& extensionContext, CompletionHandler<void(RefPtr<WebExtensionDataRecord>)>&& completionHandler)
 {
-    if (!m_configuration->storageIsPersistent() || types.isEmpty()) {
+    if (!m_configuration->storageIsPersistent() || dataTypes.isEmpty()) {
         completionHandler(nullptr);
         return;
     }
@@ -186,23 +195,30 @@ void WebExtensionController::getDataRecord(OptionSet<WebExtensionDataType> types
         completionHandler(recordHolder->recordsMap.takeFirst());
     });
 
-    for (auto type : types) {
-        auto *storage = sqliteStore(storageDirectory(matchingUniqueIdentifier), type, this->extensionContext(matchingUniqueIdentifier));
-        if (!storage)
-            continue;
+    for (auto dataType : dataTypes) {
+        Ref record = recordHolder->recordsMap.ensure(matchingUniqueIdentifier, [&] {
+            return WebExtensionDataRecord::create(displayName, matchingUniqueIdentifier);
+        }).iterator->value;
 
-        calculateStorageSize(storage, type, makeBlockPtr([recordHolder, aggregator, matchingUniqueIdentifier, displayName, type](size_t size) mutable {
-            Ref record = recordHolder->recordsMap.ensure(matchingUniqueIdentifier, [&] {
-                return WebExtensionDataRecord::create(displayName, matchingUniqueIdentifier);
-            }).iterator->value;
-            record->setSizeOfType(type, size);
+        auto *storage = sqliteStore(storageDirectory(matchingUniqueIdentifier), dataType, this->extensionContext(matchingUniqueIdentifier));
+        if (!storage) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to create sqlite store for extension: %{private}@", (NSString *)matchingUniqueIdentifier);
+            record->addError(@"Unable to calculcate extension storage", dataType);
+            continue;
+        }
+
+        calculateStorageSize(storage, dataType, makeBlockPtr([recordHolder, aggregator, matchingUniqueIdentifier, displayName, dataType, record = Ref { record }](Expected<size_t, WebExtensionError>&& result) mutable {
+            if (!result)
+                record->addError(result.error(), dataType);
+            else
+                record->setSizeOfType(dataType, result.value());
         }));
     }
 }
 
-void WebExtensionController::removeData(OptionSet<WebExtensionDataType> types, const Vector<Ref<WebExtensionDataRecord>>& records, CompletionHandler<void()>&& completionHandler)
+void WebExtensionController::removeData(OptionSet<WebExtensionDataType> dataTypes, const Vector<Ref<WebExtensionDataRecord>>& records, CompletionHandler<void()>&& completionHandler)
 {
-    if (!m_configuration->storageIsPersistent() || types.isEmpty() || records.isEmpty()) {
+    if (!m_configuration->storageIsPersistent() || dataTypes.isEmpty() || records.isEmpty()) {
         completionHandler();
         return;
     }
@@ -211,34 +227,46 @@ void WebExtensionController::removeData(OptionSet<WebExtensionDataType> types, c
         completionHandler();
     });
 
-    for (auto& record : records) {
+    for (Ref record : records) {
         auto uniqueIdentifier = record.get().uniqueIdentifier();
-        for (auto type : types) {
+        for (auto dataType : dataTypes) {
             RefPtr extensionContext = this->extensionContext(uniqueIdentifier);
-            auto *storage = sqliteStore(storageDirectory(uniqueIdentifier), type, extensionContext);
-            if (!storage)
+            auto *storage = sqliteStore(storageDirectory(uniqueIdentifier), dataType, extensionContext);
+            if (!storage) {
+                RELEASE_LOG_ERROR(Extensions, "Failed to create sqlite store for extension: %{private}@", (NSString *)uniqueIdentifier);
+                record->addError(@"Unable to delete extension storage", dataType);
                 continue;
+            }
 
-            removeStorage(storage, type, makeBlockPtr([aggregator, uniqueIdentifier, extensionContext = RefPtr { extensionContext }]() mutable {
-                [NSDistributedNotificationCenter.defaultCenter postNotificationName:WebExtensionLocalStorageWasDeletedNotification object:nil userInfo:@{ WebExtensionUniqueIdentifierKey: uniqueIdentifier }];
+            removeStorage(storage, dataType, makeBlockPtr([aggregator, uniqueIdentifier, dataType, record = Ref { record }](Expected<void, WebExtensionError>&& result) mutable {
+                if (!result)
+                    record->addError(result.error(), dataType);
+                else
+                    [NSDistributedNotificationCenter.defaultCenter postNotificationName:WebExtensionLocalStorageWasDeletedNotification object:nil userInfo:@{ WebExtensionUniqueIdentifierKey: uniqueIdentifier }];
             }));
         }
     }
 }
 
-void WebExtensionController::calculateStorageSize(_WKWebExtensionStorageSQLiteStore *storage, WebExtensionDataType type, CompletionHandler<void(size_t)>&& completionHandler)
+void WebExtensionController::calculateStorageSize(_WKWebExtensionStorageSQLiteStore *storage, WebExtensionDataType type, CompletionHandler<void(Expected<size_t, WebExtensionError>&&)>&& completionHandler)
 {
     [storage getStorageSizeForKeys:@[ ] completionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](size_t storageSize, NSString *errorMessage) mutable {
         // FIXME: <https://webkit.org/b/269100> Add storage size of window.localStorage, window.sessionStorage and indexedDB.
-        completionHandler(storageSize);
+        if (errorMessage)
+            completionHandler(makeUnexpected(errorMessage));
+        else
+            completionHandler(storageSize);
     }).get()];
 }
 
-void WebExtensionController::removeStorage(_WKWebExtensionStorageSQLiteStore *storage, WebExtensionDataType type, CompletionHandler<void()>&& completionHandler)
+void WebExtensionController::removeStorage(_WKWebExtensionStorageSQLiteStore *storage, WebExtensionDataType type, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& completionHandler)
 {
-    [storage deleteDatabaseWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSString *) mutable {
+    [storage deleteDatabaseWithCompletionHandler:makeBlockPtr([completionHandler = WTFMove(completionHandler)](NSString *errorMessage) mutable {
         // FIXME: <https://webkit.org/b/269100> Remove window.localStorage, window.sessionStorage, indexedDB.
-        completionHandler();
+        if (errorMessage)
+            completionHandler(makeUnexpected(errorMessage));
+        else
+            completionHandler({ });
     }).get()];
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDataRecordCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDataRecordCocoa.mm
@@ -36,6 +36,11 @@
 
 namespace WebKit {
 
+NSArray *WebExtensionDataRecord::errors()
+{
+    return [m_errors copy] ?: @[ ];
+}
+
 void WebExtensionDataRecord::addError(NSString *debugDescription, WebExtensionDataType type)
 {
     if (!m_errors)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDataRecordCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDataRecordCocoa.mm
@@ -23,34 +23,38 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "_WKWebExtensionDataRecordPrivate.h"
+#if !__has_feature(objc_arc)
+#error This file requires ARC. Add the "-fobjc-arc" compiler flag for this file.
+#endif
+
+#import "config.h"
+#import "WebExtensionDataRecord.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
-#import "WKObject.h"
-#import "WebExtensionDataRecord.h"
-#import <wtf/cocoa/VectorCocoa.h>
-
-namespace WebKit {
-template<> struct WrapperTraits<WebExtensionDataRecord> {
-    using WrapperClass = _WKWebExtensionDataRecord;
-};
-}
-
-@interface _WKWebExtensionDataRecord () <WKObject> {
-@package
-    API::ObjectStorage<WebKit::WebExtensionDataRecord> _webExtensionDataRecord;
-}
-
-@property (nonatomic, readonly) WebKit::WebExtensionDataRecord& _webExtensionDataRecord;
-
-@end
+#import "_WKWebExtensionDataRecordInternal.h"
 
 namespace WebKit {
 
-Vector<Ref<WebExtensionDataRecord>> toWebExtensionDataRecords(NSArray *);
-NSArray *toAPI(const Vector<Ref<WebExtensionDataRecord>>&);
-NSError *createDataRecordError(_WKWebExtensionDataRecordError, NSString *underlyingErrorMessage);
+void WebExtensionDataRecord::addError(NSString *debugDescription, WebExtensionDataType type)
+{
+    if (!m_errors)
+        m_errors = [[NSMutableArray alloc] init];
+
+    switch (type) {
+    case WebExtensionDataType::Local:
+        [m_errors.get() addObject:createDataRecordError(_WKWebExtensionDataRecordErrorLocalStorageFailed, debugDescription)];
+        break;
+    case WebExtensionDataType::Session:
+        [m_errors.get() addObject:createDataRecordError(_WKWebExtensionDataRecordErrorSessionStorageFailed, debugDescription)];
+        break;
+    case WebExtensionDataType::Sync:
+        [m_errors.get() addObject:createDataRecordError(_WKWebExtensionDataRecordErrorSyncStorageFailed, debugDescription)];
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+    }
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm
@@ -77,6 +77,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
     dispatch_async(_databaseQueue, ^{
         auto strongSelf = weakSelf.get();
         if (!strongSelf) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to retrieve keys: %{private}@ for extension %{private}@.", keys, self->_uniqueIdentifier);
             completionHandler(nil, [NSString stringWithFormat:@"Failed to retrieve keys %@", keys]);
             return;
         }
@@ -96,6 +97,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
     dispatch_async(_databaseQueue, ^{
         auto strongSelf = weakSelf.get();
         if (!strongSelf) {
+            RELEASE_LOG_ERROR(Extensions, "Failed to calculate storage size for keys: %{private}@ for extension %{private}@.", keys, self->_uniqueIdentifier);
             completionHandler(0, [NSString stringWithFormat:@"Failed to caluclate storage size for keys: %@", keys]);
             return;
         }
@@ -126,8 +128,10 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
         dispatch_async(dispatch_get_main_queue(), ^{
             if (success)
                 completionHandler(result, nil);
-            else
+            else {
+                RELEASE_LOG_ERROR(Extensions, "Failed to calculate storage size for keys: %{private}@ for extension %{private}@. %{private}@", keys, self->_uniqueIdentifier, error.localizedDescription);
                 completionHandler(0, error.localizedDescription);
+            }
         });
     });
 }
@@ -144,6 +148,7 @@ static NSString *rowFilterStringFromRowKeys(NSArray<NSString *> *keys)
         dispatch_async(self->_databaseQueue, ^{
             auto strongSelf = weakSelf.get();
             if (!strongSelf) {
+                RELEASE_LOG_ERROR(Extensions, "Failed to calculate storage size for extension %{private}@.", self->_uniqueIdentifier);
                 completionHandler(0.0, 0, @{ }, @"Failed to calculate storage size");
                 return;
             }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -36,6 +36,7 @@
 #include "WebExtensionControllerConfiguration.h"
 #include "WebExtensionControllerIdentifier.h"
 #include "WebExtensionDataType.h"
+#include "WebExtensionError.h"
 #include "WebExtensionFrameIdentifier.h"
 #include "WebExtensionURLSchemeHandler.h"
 #include "WebProcessProxy.h"
@@ -108,10 +109,9 @@ public:
     void getDataRecords(OptionSet<WebExtensionDataType>, CompletionHandler<void(Vector<Ref<WebExtensionDataRecord>>)>&&);
     void getDataRecord(OptionSet<WebExtensionDataType>, WebExtensionContext&, CompletionHandler<void(RefPtr<WebExtensionDataRecord>)>&&);
     void removeData(OptionSet<WebExtensionDataType>, const Vector<Ref<WebExtensionDataRecord>>&, CompletionHandler<void()>&&);
-    void removeData(OptionSet<WebExtensionDataType>, const WebExtensionContextSet&, CompletionHandler<void()>&&);
 
-    void calculateStorageSize(_WKWebExtensionStorageSQLiteStore *, WebExtensionDataType, CompletionHandler<void(size_t)>&&);
-    void removeStorage(_WKWebExtensionStorageSQLiteStore *, WebExtensionDataType, CompletionHandler<void()>&&);
+    void calculateStorageSize(_WKWebExtensionStorageSQLiteStore *, WebExtensionDataType, CompletionHandler<void(Expected<size_t, WebExtensionError>&&)>&&);
+    void removeStorage(_WKWebExtensionStorageSQLiteStore *, WebExtensionDataType, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
     bool hasLoadedContexts() const { return !m_extensionContexts.isEmpty(); }
     bool isFreshlyCreated() const { return m_freshlyCreated; }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
@@ -62,7 +62,7 @@ public:
     size_t sizeOfType(Type type) const { return m_typeSizes.get(type); }
     void setSizeOfType(Type type, size_t size) { m_typeSizes.set(type, size); }
 
-    NSMutableArray *errors() { return m_errors.get(); };
+    NSArray *errors();
     void addError(NSString *debugDescription, Type);
 
 #ifdef __OBJC__

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
@@ -62,6 +62,9 @@ public:
     size_t sizeOfType(Type type) const { return m_typeSizes.get(type); }
     void setSizeOfType(Type type, size_t size) { m_typeSizes.set(type, size); }
 
+    NSMutableArray *errors() { return m_errors.get(); };
+    void addError(NSString *debugDescription, Type);
+
 #ifdef __OBJC__
     _WKWebExtensionDataRecord *wrapper() const { return (_WKWebExtensionDataRecord *)API::ObjectImpl<API::Object::Type::WebExtensionDataRecord>::wrapper(); }
 #endif
@@ -72,6 +75,7 @@ private:
     String m_displayName;
     String m_uniqueIdentifier;
     HashMap<Type, size_t> m_typeSizes;
+    RetainPtr<NSMutableArray> m_errors;
 };
 
 class WebExtensionDataRecordHolder : public RefCounted<WebExtensionDataRecordHolder> {

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2034,6 +2034,7 @@
 		B66F88BD2B6C3EF900FB1734 /* FullScreenMediaDetails.h in Headers */ = {isa = PBXBuildFile; fileRef = B66F88B92B6C312400FB1734 /* FullScreenMediaDetails.h */; };
 		B66F88C02B6D1F2300FB1734 /* PreviewWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B66F88BF2B6D1F1200FB1734 /* PreviewWindowController.swift */; };
 		B66F88C22B6D202600FB1734 /* WKSPreviewWindowController.h in Headers */ = {isa = PBXBuildFile; fileRef = B66F88C12B6D202600FB1734 /* WKSPreviewWindowController.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B67DA51B2BBC89D20056A855 /* WebExtensionDataRecordCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = B67DA51A2BBC89D10056A855 /* WebExtensionDataRecordCocoa.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		B68437B329A3E2F500472D1B /* _WKWebExtensionLocalization.h in Headers */ = {isa = PBXBuildFile; fileRef = B6217BB0299C39F000498BF8 /* _WKWebExtensionLocalization.h */; };
 		B69E1A682AFF5F0C000FB98E /* WebExtensionRegisteredScriptParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = B69E1A672AFF5F0B000FB98E /* WebExtensionRegisteredScriptParameters.h */; };
 		B6A292352B18FCF30061930E /* _WKWebExtensionSQLiteStore.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6A292332B18FCF20061930E /* _WKWebExtensionSQLiteStore.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -7222,6 +7223,7 @@
 		B66F88BF2B6D1F1200FB1734 /* PreviewWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewWindowController.swift; sourceTree = "<group>"; };
 		B66F88C12B6D202600FB1734 /* WKSPreviewWindowController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKSPreviewWindowController.h; sourceTree = "<group>"; };
 		B6746A9C2AA8CC79002B244A /* WebExtensionAPIScripting.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebExtensionAPIScripting.idl; sourceTree = "<group>"; };
+		B67DA51A2BBC89D10056A855 /* WebExtensionDataRecordCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionDataRecordCocoa.mm; sourceTree = "<group>"; };
 		B69E1A672AFF5F0B000FB98E /* WebExtensionRegisteredScriptParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionRegisteredScriptParameters.h; sourceTree = "<group>"; };
 		B6A292332B18FCF20061930E /* _WKWebExtensionSQLiteStore.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKWebExtensionSQLiteStore.mm; sourceTree = "<group>"; };
 		B6A292342B18FCF20061930E /* _WKWebExtensionSQLiteStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _WKWebExtensionSQLiteStore.h; sourceTree = "<group>"; };
@@ -9806,6 +9808,7 @@
 				1C0234DB28A0268B00AC1E5B /* WebExtensionContextCocoa.mm */,
 				1CBEE26F28F4DDA0006D1A02 /* WebExtensionControllerCocoa.mm */,
 				1C1549D129381B9F001B9E5B /* WebExtensionControllerConfigurationCocoa.mm */,
+				B67DA51A2BBC89D10056A855 /* WebExtensionDataRecordCocoa.mm */,
 				B6D031042AC1F241006C8E0B /* WebExtensionDynamicScriptsCocoa.mm */,
 				1C1CE96C288DF46C0098D3A1 /* WebExtensionMatchPatternCocoa.mm */,
 				1CC1A36D2B0DCEC900373759 /* WebExtensionMenuItemCocoa.mm */,
@@ -19644,6 +19647,7 @@
 				1C3BEB522887492F00E66E38 /* WebExtensionControllerMessageReceiver.cpp in Sources */,
 				1C3D0AC1291AE6210093F67E /* WebExtensionControllerProxyCocoa.mm in Sources */,
 				1C3BEB532887492F00E66E38 /* WebExtensionControllerProxyMessageReceiver.cpp in Sources */,
+				B67DA51B2BBC89D20056A855 /* WebExtensionDataRecordCocoa.mm in Sources */,
 				B6D031062AC1F241006C8E0B /* WebExtensionDynamicScriptsCocoa.mm in Sources */,
 				1C1CE96D288DF46D0098D3A1 /* WebExtensionMatchPatternCocoa.mm in Sources */,
 				1CC1A36C2B0D9A0900373759 /* WebExtensionMenuItem.cpp in Sources */,


### PR DESCRIPTION
#### 035147f17c13bdf6520c0b8f73070d13f12457ee
<pre>
_WKWebExtensionDataRecord.errors shouldn&apos;t return a nil array
<a href="https://bugs.webkit.org/show_bug.cgi?id=272102">https://bugs.webkit.org/show_bug.cgi?id=272102</a>
<a href="https://rdar.apple.com/125862003">rdar://125862003</a>

Reviewed by NOBODY (OOPS!).

Return an empty array if there are no errors for the WebExtensionDataRecord.

* Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h:
(WebKit::WebExtensionDataRecord::errors):
</pre>
----------------------------------------------------------------------
#### 818ddb2140e8154aa82daa5db2f7518da20598ba
<pre>
Update methods used to fetch web extension data records to set an error if an issue occurred.
<a href="https://bugs.webkit.org/show_bug.cgi?id=271998">https://bugs.webkit.org/show_bug.cgi?id=271998</a>
<a href="https://rdar.apple.com/124625910">rdar://124625910</a>

Reviewed by NOBODY (OOPS!).

We should notify apps if there was an issue in deleting or calculating extension storage.
If an error occurs, apps can decide to show an alert to their users. We add a test for this
unfortunately because I tested manually by forcing an error (e.g. result = makeUnexpected(&quot;error&quot;))
and I verified _WKWebExtensionDataRecord.errors was populated in Safari.

* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
(-[_WKWebExtensionSQLiteStore _deleteDatabase]):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataRecord.h:
(NS_ERROR_ENUM):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataRecord.mm:
(WebKit::createDataRecordError):
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataRecordInternal.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::getDataRecords):
(WebKit::WebExtensionController::getDataRecord):
(WebKit::WebExtensionController::removeData):
(WebKit::WebExtensionController::calculateStorageSize):
(WebKit::WebExtensionController::removeStorage):

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDataRecordCocoa.mm:
Copied from Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionDataRecordInternal.h.
(WebKit::WebExtensionDataRecord::setError):
Sets an error on the corresponding _WKWebExtensionDataRecord.

* Source/WebKit/UIProcess/Extensions/Cocoa/_WKWebExtensionStorageSQLiteStore.mm:
(-[_WKWebExtensionStorageSQLiteStore getValuesForKeys:completionHandler:]):
(-[_WKWebExtensionStorageSQLiteStore getStorageSizeForKeys:completionHandler:]):
(-[_WKWebExtensionStorageSQLiteStore getStorageSizeForAllKeysIncludingKeyedData:withCompletionHandler:]):
Add additional logging when an error occurs.

* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/035147f17c13bdf6520c0b8f73070d13f12457ee

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46467 "Failed to checkout and rebase branch from PR 26802") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/25623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/49069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49143 "Failed to checkout and rebase branch from PR 26802") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/42508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/29983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/23086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/49143 "Failed to checkout and rebase branch from PR 26802") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47045 "Failed to checkout and rebase branch from PR 26802") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/29983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/49069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/49143 "Failed to checkout and rebase branch from PR 26802") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/29983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/49069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4512 "Failed to checkout and rebase branch from PR 26802") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/29983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/49069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50979 "Failed to checkout and rebase branch from PR 26802") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/23086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/50979 "Failed to checkout and rebase branch from PR 26802") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/49069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/50979 "Failed to checkout and rebase branch from PR 26802") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/22467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->