### PR TITLE
_WKWebExtensionDataRecord.errors shouldn't return a nil array

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDataRecordCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDataRecordCocoa.mm
@@ -36,6 +36,11 @@
 
 namespace WebKit {
 
+NSArray *WebExtensionDataRecord::errors()
+{
+    return [m_errors copy] ?: @[ ];
+}
+
 void WebExtensionDataRecord::addError(NSString *debugDescription, WebExtensionDataType type)
 {
     if (!m_errors)

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
@@ -62,7 +62,7 @@ public:
     size_t sizeOfType(Type type) const { return m_typeSizes.get(type); }
     void setSizeOfType(Type type, size_t size) { m_typeSizes.set(type, size); }
 
-    NSMutableArray *errors() { return m_errors.get(); };
+    NSArray *errors();
     void addError(NSString *debugDescription, Type);
 
 #ifdef __OBJC__


### PR DESCRIPTION
#### 5180add1072b2fa2b4007c230cab8327563a3ae7
<pre>
_WKWebExtensionDataRecord.errors shouldn&apos;t return a nil array
<a href="https://bugs.webkit.org/show_bug.cgi?id=272102">https://bugs.webkit.org/show_bug.cgi?id=272102</a>
<a href="https://rdar.apple.com/125862003">rdar://125862003</a>

Reviewed by Brian Weinstein and Timothy Hatcher.

Return an empty array if there are no errors for the WebExtensionDataRecord.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDataRecordCocoa.mm:
(WebKit::WebExtensionDataRecord::errors):
* Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h:
(WebKit::WebExtensionDataRecord::errors): Deleted.

Canonical link: <a href="https://commits.webkit.org/277027@main">https://commits.webkit.org/277027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38edd1a9ae9519e79161a89ecadc1754d9727a2f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49146 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42511 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23089 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47048 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19170 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4515 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50982 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6485 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/22470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->