### PR TITLE
[resultsdbpy] Fix commit ranges on dashboard

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js
@@ -402,25 +402,18 @@ class Dashboard {
                         tile.builds.push({sdks: [sdk.sdk, previousSdk.sdk]});
 
                     let candidateCommits = this.commit_bank.commitsDuring(build.uuid, (previous ? previous : latestResult).uuid);
-                    let startAt = 0;
-                    let repositories = new Set();
-                    while (startAt < candidateCommits.length) {
-                        if (repositories.has(candidateCommits[startAt].repository_id))
-                            break;
-                        repositories.add(candidateCommits[startAt].repository_id);
-                        startAt += 1;
-                    }
-                    if (candidateCommits.length > startAt + 1) {
-                        let regressionCommits = {};
-                        while (startAt < candidateCommits.length) {
-                            if (!regressionCommits[candidateCommits[startAt].repository_id])
-                                regressionCommits[candidateCommits[startAt].repository_id] = [];
-                            regressionCommits[candidateCommits[startAt].repository_id].push(candidateCommits[startAt]);
-                            startAt += 1;
-                        }
+                    let regressionCommits = {};
+                    let maxFromRepo = 0;
+                    candidateCommits.forEach(commit => {
+                        if (commit.uuid <= build.uuid)
+                            return;
+                        if (!regressionCommits[commit.repository_id])
+                            regressionCommits[commit.repository_id] = [];
+                        regressionCommits[commit.repository_id].push(commit)
+                        maxFromRepo = Math.max(maxFromRepo, regressionCommits[commit.repository_id].length)
+                    });
+                    if (maxFromRepo > 1)
                         tile.builds.push(regressionCommits);
-                    }
-
                     tile.builds.push(this.tileLineForBuild(build));
                     break;
                 }


### PR DESCRIPTION
#### 267ba50c98e879439d9e144ac1732f66d089622b
<pre>
[resultsdbpy] Fix commit ranges on dashboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=272111">https://bugs.webkit.org/show_bug.cgi?id=272111</a>
<a href="https://rdar.apple.com/125865304">rdar://125865304</a>

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js:
(Dashboard.prototype.setTilesFromData): Compare commits in range to UUID of last passing
build instead of assuming the CommitBank will return a set of commits in a certain order.

Canonical link: <a href="https://commits.webkit.org/277122@main">https://commits.webkit.org/277122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97a80c42f46ec1d04df072ff867e578f20a9cfc0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49148 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48779 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/29988 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23091 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37919 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47050 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/29988 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40072 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/19169 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/46338 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/29988 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41175 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4517 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/29988 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/41551 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/50985 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21477 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17917 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45169 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/46511 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22769 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44107 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23173 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6545 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/22472 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->