### PR TITLE
Some API tests started crashing in CFRelease after macOS update

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm
@@ -85,28 +85,28 @@ TEST(IndexedDB, IndexUpgradeToV2)
 
 static void runMultipleIndicesTestWithDatabase(NSString* databaseName)
 {
-    auto handler = adoptNS([[IDBIndexUpgradeToV2MessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[IDBIndexUpgradeToV2MessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
     [configuration.get().websiteDataStore _terminateNetworkProcess];
 
-    NSURL *url = [[NSBundle mainBundle] URLForResource:databaseName withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
-    NSString *hash = WebCore::SQLiteFileSystem::computeHashForFileName("index-upgrade-test"_s);
-    NSURL *originURL = [NSURL URLWithString:@"file://"];
-    __block NSString *originDirectoryString = nil;
-    [configuration.get().websiteDataStore _originDirectoryForTesting:originURL topOrigin:originURL type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
+    RetainPtr url = [[NSBundle mainBundle] URLForResource:databaseName withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
+    String hash = WebCore::SQLiteFileSystem::computeHashForFileName("index-upgrade-test"_s);
+    RetainPtr originURL = [NSURL URLWithString:@"file://"];
+    __block RetainPtr<NSString> originDirectoryString;
+    [configuration.get().websiteDataStore _originDirectoryForTesting:originURL.get() topOrigin:originURL.get() type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
         originDirectoryString = result;
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
-    NSURL *databaseDirectory = [[NSURL fileURLWithPath:originDirectoryString isDirectory:YES] URLByAppendingPathComponent:hash];
-    [[NSFileManager defaultManager] removeItemAtURL:databaseDirectory error:nil];
-    [[NSFileManager defaultManager] createDirectoryAtURL:databaseDirectory withIntermediateDirectories:YES attributes:nil error:nil];
-    [[NSFileManager defaultManager] copyItemAtURL:url toURL:[databaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"] error:nil];
+    RetainPtr databaseDirectory = [[NSURL fileURLWithPath:originDirectoryString.get() isDirectory:YES] URLByAppendingPathComponent:hash];
+    [[NSFileManager defaultManager] removeItemAtURL:databaseDirectory.get() error:nil];
+    [[NSFileManager defaultManager] createDirectoryAtURL:databaseDirectory.get() withIntermediateDirectories:YES attributes:nil error:nil];
+    [[NSFileManager defaultManager] copyItemAtURL:url.get() toURL:[databaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"] error:nil];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IDBIndexUpgradeToV2WithMultipleIndices" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
-    [webView loadRequest:request];
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"IDBIndexUpgradeToV2WithMultipleIndices" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    [webView loadRequest:request.get()];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
 
     EXPECT_WK_STREQ(@"Get object: {\"name\":\"apple\",\"color\":\"red\"}", [lastScriptMessage body]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
@@ -328,38 +328,38 @@ TEST(IndexedDB, IndexedDBThirdPartyDataRemoval)
 
 TEST(IndexedDB, IndexedDBThirdPartyStorageLayout)
 {
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    NSString *databaseHash = WebCore::SQLiteFileSystem::computeHashForFileName("IndexedDBThirdPartyFrameHasAccess"_s);
-    NSURL *webkitURL = [NSURL URLWithString:@"http://webkit.org"];
-    NSURL *iframeURL = [NSURL URLWithString:@"iframe://"];
-    __block NSString *directoryString = nil;
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    String databaseHash = WebCore::SQLiteFileSystem::computeHashForFileName("IndexedDBThirdPartyFrameHasAccess"_s);
+    RetainPtr webkitURL = [NSURL URLWithString:@"http://webkit.org"];
+    RetainPtr iframeURL = [NSURL URLWithString:@"iframe://"];
+    __block RetainPtr<NSString> directoryString = nil;
     done = false;
-    [configuration.get().websiteDataStore _originDirectoryForTesting:iframeURL topOrigin:webkitURL type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
+    [configuration.get().websiteDataStore _originDirectoryForTesting:iframeURL.get() topOrigin:webkitURL.get() type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
         directoryString = result;
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
-    NSURL *webkitIframeRootDirectory = [NSURL fileURLWithPath:directoryString isDirectory:YES];
-    NSURL *webkitIframeDatabaseDirectory = [webkitIframeRootDirectory URLByAppendingPathComponent:databaseHash];
-    NSURL *webkitIframeDatabaseFile = [webkitIframeDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];
+    RetainPtr webkitIframeRootDirectory = [NSURL fileURLWithPath:directoryString.get() isDirectory:YES];
+    RetainPtr webkitIframeDatabaseDirectory = [webkitIframeRootDirectory URLByAppendingPathComponent:databaseHash];
+    RetainPtr webkitIframeDatabaseFile = [webkitIframeDatabaseDirectory URLByAppendingPathComponent:@"IndexedDB.sqlite3"];
 
     done = false;
-    [configuration.get().websiteDataStore _originDirectoryForTesting:webkitURL topOrigin:iframeURL type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
+    [configuration.get().websiteDataStore _originDirectoryForTesting:webkitURL.get() topOrigin:iframeURL.get() type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
         directoryString = result;
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
-    NSURL *iframeWebKitRootDirectory = [NSURL fileURLWithPath:directoryString isDirectory:YES];
+    RetainPtr iframeWebKitRootDirectory = [NSURL fileURLWithPath:directoryString.get() isDirectory:YES];
 
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-    [fileManager removeItemAtURL:webkitIframeRootDirectory error:nil];
-    [fileManager removeItemAtURL:iframeWebKitRootDirectory error:nil];
+    RetainPtr fileManager = [NSFileManager defaultManager];
+    [fileManager removeItemAtURL:webkitIframeRootDirectory.get() error:nil];
+    [fileManager removeItemAtURL:iframeWebKitRootDirectory.get() error:nil];
 
-    auto handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
+    RetainPtr handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:iframeBytesPersistence length:strlen(iframeBytesPersistence)]];
         [task didFinish];
@@ -368,11 +368,11 @@ TEST(IndexedDB, IndexedDBThirdPartyStorageLayout)
     // Allowing third-party frame to store data on disk.
     [[configuration preferences] _setStorageBlockingPolicy:_WKStorageBlockingPolicyAllowAll];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     loadThirdPartyPageInWebView(webView.get(), @"database is created - put item success");
-    EXPECT_TRUE([fileManager fileExistsAtPath:webkitIframeRootDirectory.path]);
-    EXPECT_TRUE([fileManager fileExistsAtPath:webkitIframeDatabaseFile.path]);
-    EXPECT_FALSE([fileManager fileExistsAtPath:iframeWebKitRootDirectory.path]);
+    EXPECT_TRUE([fileManager fileExistsAtPath:webkitIframeRootDirectory.get().path]);
+    EXPECT_TRUE([fileManager fileExistsAtPath:webkitIframeDatabaseFile.get().path]);
+    EXPECT_FALSE([fileManager fileExistsAtPath:iframeWebKitRootDirectory.get().path]);
 }
 
 TEST(IndexedDB, MigrateThirdPartyDataToGeneralStorageDirectory)
@@ -561,19 +561,19 @@ TEST(IndexedDB, IndexedDBGetDatabases)
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
 
-    auto handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
-    auto schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+    RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
     [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
-        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
+        RetainPtr response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:@"text/html" expectedContentLength:0 textEncodingName:nil]);
         [task didReceiveResponse:response.get()];
         [task didReceiveData:[NSData dataWithBytes:getDatabasesBytes length:strlen(getDatabasesBytes)]];
         [task didFinish];
     }];
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"webkit"];
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView loadHTMLString:getDatabasesString baseURL:[NSURL URLWithString:@"http://apple.com"]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     receivedScriptMessage = false;
@@ -584,44 +584,44 @@ TEST(IndexedDB, IndexedDBGetDatabases)
     receivedScriptMessage = false;
     EXPECT_WK_STREQ(@"child frame databases: []", [getNextMessage() body]);
 
-    auto secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr secondWebView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [secondWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"webkit://"]]];
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     receivedScriptMessage = false;
     EXPECT_WK_STREQ(@"main frame databases: []", [getNextMessage() body]);
 
     // Getting databases should not create files on disk.
-    NSURL *appleURL = [NSURL URLWithString:@"http://apple.com"];
-    NSURL *webkitURL = [NSURL URLWithString:@"webkit://"];
-    __block NSString *appleDirectoryString = nil;
+    RetainPtr appleURL = [NSURL URLWithString:@"http://apple.com"];
+    RetainPtr webkitURL = [NSURL URLWithString:@"webkit://"];
+    __block RetainPtr<NSString> appleDirectoryString;
     readyToContinue = false;
-    [[WKWebsiteDataStore defaultDataStore] _originDirectoryForTesting:appleURL topOrigin:appleURL type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
+    [[WKWebsiteDataStore defaultDataStore] _originDirectoryForTesting:appleURL.get() topOrigin:appleURL.get() type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
         appleDirectoryString = result;
         readyToContinue = true;
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
-    NSURL *appleDirectoryURL = [NSURL fileURLWithPath:appleDirectoryString isDirectory:YES];
+    RetainPtr appleDirectoryURL = [NSURL fileURLWithPath:appleDirectoryString.get() isDirectory:YES];
 
     readyToContinue = false;
-    __block NSString *webkitDirectoryString = nil;
-    [[WKWebsiteDataStore defaultDataStore] _originDirectoryForTesting:webkitURL topOrigin:webkitURL type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
+    __block RetainPtr<NSString> webkitDirectoryString;
+    [[WKWebsiteDataStore defaultDataStore] _originDirectoryForTesting:webkitURL.get() topOrigin:webkitURL.get() type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
         webkitDirectoryString = result;
         readyToContinue = true;
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
-    NSURL *webkitDirectoryURL = [NSURL fileURLWithPath:webkitDirectoryString isDirectory:YES];
+    RetainPtr webkitDirectoryURL = [NSURL fileURLWithPath:webkitDirectoryString.get() isDirectory:YES];
 
-    __block NSString *appleWebkitDirectoryString = nil;
+    __block RetainPtr<NSString> appleWebkitDirectoryString;
     readyToContinue = false;
-    [[WKWebsiteDataStore defaultDataStore] _originDirectoryForTesting:webkitURL topOrigin:appleURL type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
+    [[WKWebsiteDataStore defaultDataStore] _originDirectoryForTesting:webkitURL.get() topOrigin:appleURL.get() type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
         appleWebkitDirectoryString = result;
         readyToContinue = true;
     }];
     TestWebKitAPI::Util::run(&readyToContinue);
-    NSURL *appleWebkitDirectoryURL = [NSURL fileURLWithPath:appleWebkitDirectoryString isDirectory:YES];
+    RetainPtr appleWebkitDirectoryURL = [NSURL fileURLWithPath:appleWebkitDirectoryString.get() isDirectory:YES];
 
-    auto defaultFileManager = [NSFileManager defaultManager];
-    EXPECT_TRUE([defaultFileManager fileExistsAtPath:appleDirectoryURL.path]);
-    EXPECT_FALSE([defaultFileManager fileExistsAtPath:appleWebkitDirectoryURL.path]);
-    EXPECT_FALSE([defaultFileManager fileExistsAtPath:webkitDirectoryURL.path]);
+    RetainPtr defaultFileManager = [NSFileManager defaultManager];
+    EXPECT_TRUE([defaultFileManager fileExistsAtPath:appleDirectoryURL.get().path]);
+    EXPECT_FALSE([defaultFileManager fileExistsAtPath:appleWebkitDirectoryURL.get().path]);
+    EXPECT_FALSE([defaultFileManager fileExistsAtPath:webkitDirectoryURL.get().path]);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -77,53 +77,53 @@ enum class ShouldEnableProcessPrewarming : bool { No, Yes };
 
 static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldEnableProcessPrewarming)
 {
-    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().prewarmsProcessesAutomatically = shouldEnableProcessPrewarming == ShouldEnableProcessPrewarming::Yes ? YES : NO;
-    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
 
-    auto handler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    RetainPtr handler = adoptNS([[WebsiteDataStoreCustomPathsMessageHandler alloc] init]);
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
 
-    NSURL *idbPath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/IndexedDB/" stringByExpandingTildeInPath] isDirectory:YES];
-    NSURL *localStoragePath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/LocalStorage/" stringByExpandingTildeInPath] isDirectory:YES];
-    NSURL *cookieStorageFile = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/CookieStorage/Cookie.File" stringByExpandingTildeInPath] isDirectory:NO];
-    NSURL *resourceLoadStatisticsPath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/ResourceLoadStatistics/" stringByExpandingTildeInPath] isDirectory:YES];
-    NSURL *defaultIDBPath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/IndexedDB/" stringByExpandingTildeInPath] isDirectory:YES];
-    NSURL *defaultLocalStoragePath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/LocalStorage/" stringByExpandingTildeInPath] isDirectory:YES];
-    NSURL *defaultResourceLoadStatisticsPath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/ResourceLoadStatistics/" stringByExpandingTildeInPath] isDirectory:YES];
+    RetainPtr idbPath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/IndexedDB/" stringByExpandingTildeInPath] isDirectory:YES];
+    RetainPtr localStoragePath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/LocalStorage/" stringByExpandingTildeInPath] isDirectory:YES];
+    RetainPtr cookieStorageFile = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/CookieStorage/Cookie.File" stringByExpandingTildeInPath] isDirectory:NO];
+    RetainPtr resourceLoadStatisticsPath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/CustomWebsiteData/ResourceLoadStatistics/" stringByExpandingTildeInPath] isDirectory:YES];
+    RetainPtr defaultIDBPath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/IndexedDB/" stringByExpandingTildeInPath] isDirectory:YES];
+    RetainPtr defaultLocalStoragePath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/LocalStorage/" stringByExpandingTildeInPath] isDirectory:YES];
+    RetainPtr defaultResourceLoadStatisticsPath = [NSURL fileURLWithPath:[@"~/Library/WebKit/com.apple.WebKit.TestWebKitAPI/WebsiteData/ResourceLoadStatistics/" stringByExpandingTildeInPath] isDirectory:YES];
 
-    [[NSFileManager defaultManager] removeItemAtURL:idbPath error:nil];
-    [[NSFileManager defaultManager] removeItemAtURL:localStoragePath error:nil];
-    [[NSFileManager defaultManager] removeItemAtURL:cookieStorageFile error:nil];
-    [[NSFileManager defaultManager] removeItemAtURL:resourceLoadStatisticsPath error:nil];
-    [[NSFileManager defaultManager] removeItemAtURL:defaultIDBPath error:nil];
-    [[NSFileManager defaultManager] removeItemAtURL:defaultLocalStoragePath error:nil];
-    [[NSFileManager defaultManager] removeItemAtURL:defaultResourceLoadStatisticsPath error:nil];
+    [[NSFileManager defaultManager] removeItemAtURL:idbPath.get() error:nil];
+    [[NSFileManager defaultManager] removeItemAtURL:localStoragePath.get() error:nil];
+    [[NSFileManager defaultManager] removeItemAtURL:cookieStorageFile.get() error:nil];
+    [[NSFileManager defaultManager] removeItemAtURL:resourceLoadStatisticsPath.get() error:nil];
+    [[NSFileManager defaultManager] removeItemAtURL:defaultIDBPath.get() error:nil];
+    [[NSFileManager defaultManager] removeItemAtURL:defaultLocalStoragePath.get() error:nil];
+    [[NSFileManager defaultManager] removeItemAtURL:defaultResourceLoadStatisticsPath.get() error:nil];
 
-    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:idbPath.path]);
-    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:localStoragePath.path]);
-    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:cookieStorageFile.path]);
-    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:resourceLoadStatisticsPath.path]);
-    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:defaultIDBPath.path]);
-    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:defaultLocalStoragePath.path]);
-    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:defaultResourceLoadStatisticsPath.path]);
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:idbPath.get().path]);
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:localStoragePath.get().path]);
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:cookieStorageFile.get().path]);
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:resourceLoadStatisticsPath.get().path]);
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:defaultIDBPath.get().path]);
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:defaultLocalStoragePath.get().path]);
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:defaultResourceLoadStatisticsPath.get().path]);
 
-    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
     websiteDataStoreConfiguration.get().unifiedOriginStorageLevel = _WKUnifiedOriginStorageLevelNone;
-    websiteDataStoreConfiguration.get()._indexedDBDatabaseDirectory = idbPath;
-    websiteDataStoreConfiguration.get()._webStorageDirectory = localStoragePath;
-    websiteDataStoreConfiguration.get()._cookieStorageFile = cookieStorageFile;
-    websiteDataStoreConfiguration.get()._resourceLoadStatisticsDirectory = resourceLoadStatisticsPath;
+    websiteDataStoreConfiguration.get()._indexedDBDatabaseDirectory = idbPath.get();
+    websiteDataStoreConfiguration.get()._webStorageDirectory = localStoragePath.get();
+    websiteDataStoreConfiguration.get()._cookieStorageFile = cookieStorageFile.get();
+    websiteDataStoreConfiguration.get()._resourceLoadStatisticsDirectory = resourceLoadStatisticsPath.get();
 
     configuration.get().websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]).get();
     configuration.get().processPool = processPool.get();
 
-    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
     [webView setNavigationDelegate:handler.get()];
 
-    NSURLRequest *request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"WebsiteDataStoreCustomPaths" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
-    [webView loadRequest:request];
+    RetainPtr request = [NSURLRequest requestWithURL:[[NSBundle mainBundle] URLForResource:@"WebsiteDataStoreCustomPaths" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"]];
+    [webView loadRequest:request.get()];
 
     EXPECT_FALSE([WKWebsiteDataStore _defaultDataStoreExists]);
 
@@ -139,15 +139,15 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
     TestWebKitAPI::Util::run(&flushed);
 
     // Get the IndexedDB database path in use.
-    NSURL *fileURL = [NSURL URLWithString:@"file://"];
-    __block NSString *fileIDBPathString = nil;
+    RetainPtr fileURL = [NSURL URLWithString:@"file://"];
+    __block RetainPtr<NSString> fileIDBPathString;
     done = false;
-    [configuration.get().websiteDataStore _originDirectoryForTesting:fileURL topOrigin:fileURL type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
+    [configuration.get().websiteDataStore _originDirectoryForTesting:fileURL.get() topOrigin:fileURL.get() type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
         fileIDBPathString = result;
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
-    NSURL *fileIDBPath = [NSURL fileURLWithPath:fileIDBPathString isDirectory:YES];
+    RetainPtr fileIDBPath = [NSURL fileURLWithPath:fileIDBPathString.get() isDirectory:YES];
 
     // Forcibly shut down everything of WebKit that we can.
     auto pid = [webView _webProcessIdentifier];
@@ -158,70 +158,70 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
     handler = nil;
     configuration = nil;
 
-    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:localStoragePath.path]);
+    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:localStoragePath.get().path]);
 
 #if PLATFORM(IOS_FAMILY)
     int retryCount = 30;
     while (retryCount--) {
-        if ([[NSFileManager defaultManager] fileExistsAtPath:cookieStorageFile.path])
+        if ([[NSFileManager defaultManager] fileExistsAtPath:cookieStorageFile.get().path])
             break;
         TestWebKitAPI::Util::runFor(0.1_s);
     }
-    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:cookieStorageFile.path]);
+    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:cookieStorageFile.get().path]);
 
     // Note: The format of the cookie file on disk is proprietary and opaque, so this is fragile to future changes.
     // But right now, it is reliable to scan the file for the ASCII string of the cookie name we set.
     // This helps verify that the cookie file was actually written to as we'd expect.
-    auto data = adoptNS([[NSData alloc] initWithContentsOfURL:cookieStorageFile]);
+    RetainPtr data = adoptNS([[NSData alloc] initWithContentsOfURL:cookieStorageFile.get()]);
     char bytes[] = "testkey";
-    auto cookieKeyData = adoptNS([[NSData alloc] initWithBytes:(void *)bytes length:strlen(bytes)]);
+    RetainPtr cookieKeyData = adoptNS([[NSData alloc] initWithBytes:(void *)bytes length:strlen(bytes)]);
     auto result = [data rangeOfData:cookieKeyData.get() options:0 range:NSMakeRange(0, data.get().length)];
     EXPECT_NE((const long)result.location, NSNotFound);
 #endif
 
 #if PLATFORM(MAC)
     // FIXME: The default LocalStorage path is being used for something, but they shouldn't be. (theses should be false, not true)
-    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:defaultLocalStoragePath.path]);
+    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:defaultLocalStoragePath.get().path]);
 #endif
 
-    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:idbPath.path]);
-    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:defaultIDBPath.path]);
-    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:fileIDBPath.path]);
+    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:idbPath.get().path]);
+    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:defaultIDBPath.get().path]);
+    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:fileIDBPath.get().path]);
 
     @autoreleasepool {
-        auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
-        auto types = adoptNS([[NSSet alloc] initWithObjects:WKWebsiteDataTypeIndexedDBDatabases, nil]);
+        RetainPtr dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr types = adoptNS([[NSSet alloc] initWithObjects:WKWebsiteDataTypeIndexedDBDatabases, nil]);
         
-        NSURL *appleURL = [NSURL URLWithString:@"https://apple.com"];
-        __block NSString *idbPathString = nil;
+        RetainPtr appleURL = [NSURL URLWithString:@"https://apple.com"];
+        __block RetainPtr<NSString> idbPathString;
         done = false;
-        [dataStore _originDirectoryForTesting:appleURL topOrigin:fileURL type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
+        [dataStore _originDirectoryForTesting:appleURL.get() topOrigin:fileURL.get() type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
             idbPathString = result;
             done = true;
         }];
         TestWebKitAPI::Util::run(&done);
-        NSURL *fileAppleIDBPath = [NSURL fileURLWithPath:idbPathString isDirectory:YES];
+        RetainPtr fileAppleIDBPath = [NSURL fileURLWithPath:idbPathString.get() isDirectory:YES];
 
-        NSURL *webkitURL = [NSURL URLWithString:@"https://webkit.org"];
+        RetainPtr webkitURL = [NSURL URLWithString:@"https://webkit.org"];
         done = false;
-        [dataStore _originDirectoryForTesting:webkitURL topOrigin:fileURL type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
+        [dataStore _originDirectoryForTesting:webkitURL.get() topOrigin:fileURL.get() type:WKWebsiteDataTypeIndexedDBDatabases completionHandler:^(NSString *result) {
             idbPathString = result;
             done = true;
         }];
         TestWebKitAPI::Util::run(&done);
-        NSURL *fileWebKitIDBPath = [NSURL fileURLWithPath:idbPathString isDirectory:YES];
+        RetainPtr fileWebKitIDBPath = [NSURL fileURLWithPath:idbPathString.get() isDirectory:YES];
 
         // Subframe of different origins may also create IndexedDB files.
         RetainPtr<NSURL> url1 = [[NSBundle mainBundle] URLForResource:@"IndexedDB" withExtension:@"sqlite3" subdirectory:@"TestWebKitAPI.resources"];
         RetainPtr<NSURL> url2 = [[NSBundle mainBundle] URLForResource:@"IndexedDB" withExtension:@"sqlite3-shm" subdirectory:@"TestWebKitAPI.resources"];
         RetainPtr<NSURL> url3 = [[NSBundle mainBundle] URLForResource:@"IndexedDB" withExtension:@"sqlite3-wal" subdirectory:@"TestWebKitAPI.resources"];
 
-        [[NSFileManager defaultManager] createDirectoryAtURL:fileAppleIDBPath withIntermediateDirectories:YES attributes:nil error:nil];
+        [[NSFileManager defaultManager] createDirectoryAtURL:fileAppleIDBPath.get() withIntermediateDirectories:YES attributes:nil error:nil];
         [[NSFileManager defaultManager] copyItemAtURL:url1.get() toURL:[fileAppleIDBPath URLByAppendingPathComponent:@"IndexedDB.sqlite3"] error:nil];
         [[NSFileManager defaultManager] copyItemAtURL:url2.get() toURL:[fileAppleIDBPath URLByAppendingPathComponent:@"IndexedDB.sqlite3-shm"] error:nil];
         [[NSFileManager defaultManager] copyItemAtURL:url3.get() toURL:[fileAppleIDBPath URLByAppendingPathComponent:@"IndexedDB.sqlite3-wal"] error:nil];
 
-        [[NSFileManager defaultManager] createDirectoryAtURL:fileWebKitIDBPath withIntermediateDirectories:YES attributes:nil error:nil];
+        [[NSFileManager defaultManager] createDirectoryAtURL:fileWebKitIDBPath.get() withIntermediateDirectories:YES attributes:nil error:nil];
         [[NSFileManager defaultManager] copyItemAtURL:url1.get() toURL:[fileWebKitIDBPath URLByAppendingPathComponent:@"IndexedDB.sqlite3"] error:nil];
         [[NSFileManager defaultManager] copyItemAtURL:url2.get() toURL:[fileWebKitIDBPath URLByAppendingPathComponent:@"IndexedDB.sqlite3-shm"] error:nil];
         [[NSFileManager defaultManager] copyItemAtURL:url3.get() toURL:[fileWebKitIDBPath URLByAppendingPathComponent:@"IndexedDB.sqlite3-wal"] error:nil];
@@ -232,7 +232,7 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
                 if ([[record displayName] isEqual: @"apple.com"]) {
                     [dataStore removeDataOfTypes:types.get() forDataRecords:@[record] completionHandler:^() {
                         receivedScriptMessage = true;
-                        EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:fileAppleIDBPath.path]);
+                        EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:fileAppleIDBPath.get().path]);
                     }];
                 }
             }
@@ -246,14 +246,14 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
         receivedScriptMessage = false;
         TestWebKitAPI::Util::run(&receivedScriptMessage);
 
-        EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:fileWebKitIDBPath.path]);
+        EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:fileWebKitIDBPath.get().path]);
 
         // Now, with brand new WKWebsiteDataStores pointing at the same custom cookie storage location,
         // in newly fired up NetworkProcesses, verify that the fetch and delete APIs work as expected.
         [dataStore _terminateNetworkProcess];
     }
 
-    auto newCustomDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    RetainPtr newCustomDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
     [newCustomDataStore fetchDataRecordsOfTypes:[NSSet setWithObjects:WKWebsiteDataTypeCookies, nil] completionHandler:^(NSArray<WKWebsiteDataRecord *> * records) {
         EXPECT_GT([records count], (unsigned long)0);
         receivedScriptMessage = true;
@@ -1711,27 +1711,27 @@ TEST(WKWebsiteDataStore, RemoveServiceWorkerData)
         { "/migratetest/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
     });
 
-    auto websiteDataStore = createCustomWebsiteDataStoreForServiceWorker(&server);
-    __block NSString *serviceWorkerDirectoryString = nil;
-    auto url = [server.request() URL];
+    RetainPtr websiteDataStore = createCustomWebsiteDataStoreForServiceWorker(&server);
+    __block RetainPtr<NSString> serviceWorkerDirectoryString;
+    RetainPtr url = [server.request() URL];
     done = false;
-    [websiteDataStore.get() _originDirectoryForTesting:url topOrigin:url type:WKWebsiteDataTypeServiceWorkerRegistrations completionHandler:^(NSString *result) {
+    [websiteDataStore.get() _originDirectoryForTesting:url.get() topOrigin:url.get() type:WKWebsiteDataTypeServiceWorkerRegistrations completionHandler:^(NSString *result) {
         serviceWorkerDirectoryString = result;
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
-    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:serviceWorkerDirectoryString]);
+    EXPECT_TRUE([[NSFileManager defaultManager] fileExistsAtPath:serviceWorkerDirectoryString.get()]);
 
-    auto dataTypes = [NSSet setWithObjects:WKWebsiteDataTypeServiceWorkerRegistrations, nil];
+    RetainPtr dataTypes = [NSSet setWithObjects:WKWebsiteDataTypeServiceWorkerRegistrations, nil];
     done = false;
-    [websiteDataStore removeDataOfTypes:dataTypes modifiedSince:[NSDate distantPast] completionHandler:^() {
+    [websiteDataStore removeDataOfTypes:dataTypes.get() modifiedSince:[NSDate distantPast] completionHandler:^() {
         done = true;
     }];
     TestWebKitAPI::Util::run(&done);
-    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:serviceWorkerDirectoryString]);
+    EXPECT_FALSE([[NSFileManager defaultManager] fileExistsAtPath:serviceWorkerDirectoryString.get()]);
 
     done = false;
-    [websiteDataStore fetchDataRecordsOfTypes:dataTypes completionHandler:^(NSArray<WKWebsiteDataRecord *> * records) {
+    [websiteDataStore fetchDataRecordsOfTypes:dataTypes.get() completionHandler:^(NSArray<WKWebsiteDataRecord *> * records) {
         EXPECT_EQ([records count], 0u);
         done = true;
     }];


### PR DESCRIPTION
#### f3925d705c14b41a1722888fd11619e5ab1779ba
<pre>
Some API tests started crashing in CFRelease after macOS update
<a href="https://bugs.webkit.org/show_bug.cgi?id=272110">https://bugs.webkit.org/show_bug.cgi?id=272110</a>
<a href="https://rdar.apple.com/125807895">rdar://125807895</a>

Reviewed by Brady Eidson and Sihui Liu.

Our API test was unsafe as it was not ref&apos;ing autoreleased
NSStrings / NSURLs and expecting them to still be alive after
calling some async operations.

Update those tests to use RetainPtr more consistently.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm:
(TEST(IndexedDB, CheckpointsWALAutomatically)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm:
(runMultipleIndicesTestWithDatabase):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm:
(IndexedDBThirdPartyStorageLayout)):
((IndexedDB, IndexedDBGetDatabases)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm:
(TEST(IndexedDB, IndexedDBTempFileSize)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm:
(TEST(IndexedDB, StoreBlobThenRemoveData)):
(TEST(IndexedDB, StoreBlobThenDeleteDatabase)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(runWebsiteDataStoreCustomPaths):
((WKWebsiteDataStore, RemoveServiceWorkerData)):

Canonical link: <a href="https://commits.webkit.org/277042@main">https://commits.webkit.org/277042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/842bd60316d69fc34109a2963edeb510c38bf6e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49150 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/29990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23093 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37922 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47052 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19172 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41178 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4519 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51005 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21479 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45180 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44119 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6491 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22474 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->