### PR TITLE
Web Inspector: CSS Completion picks property with higher usage count instead of exact match

### DIFF
--- a/LayoutTests/inspector/css/css-property-expected.txt
+++ b/LayoutTests/inspector/css/css-property-expected.txt
@@ -33,6 +33,9 @@ Sorted by usage:
 Initially selected completion when ranked by `count % 2`: "Fake Property 101 Seen"
 Initially selected completion when ranked by `count % 3`: "Fake Property 200 Seen"
 
+-- Running test case: CSSProperty.ExactMatchCompletion
+PASS: Exact match outweighs most used property name
+
 -- Running test case: CSSProperty.prototype.get valid
 PASS: "background-repeat" is a valid property.
 PASS: "background-repeat-x" is an invalid property.

--- a/LayoutTests/inspector/css/css-property.html
+++ b/LayoutTests/inspector/css/css-property.html
@@ -56,6 +56,41 @@ function test() {
     });
 
     suite.addTestCase({
+        name: "CSSProperty.ExactMatchCompletion",
+        description: "Ensure that exact match completions outweigh higher-count completion candidates.",
+        async test() {
+            let fakeCSSProperties = [
+                {
+                    name: "fake-property-with-high-usage-count",
+                    count: 999,
+                    rank: 1,
+                },
+                {
+                    name: "fake-property",
+                    count: 0,
+                    rank: 1,
+                }
+            ];
+
+            let completions = [];
+            for ({name, count, rank} of fakeCSSProperties) {
+                WI.CSSProperty._cachedNameCounts[name] = count;
+
+                let completion = new WI.QueryResult(name, ["not reached"]);
+                completion.rankForTesting = rank;
+                completions.push(completion);
+            }
+
+
+            InspectorTest.expectEqual(1, WI.CSSProperty.indexOfCompletionForMostUsedPropertyName(completions, "fake-property"), "Exact match outweighs most used property name");
+
+            for ({name} of fakeCSSProperties) {
+                delete WI.CSSProperty._cachedNameCounts[name];
+            }
+        }
+    });
+
+    suite.addTestCase({
         name: "CSSProperty.prototype.get valid",
         description: "Ensure valid, invalid, and internal-only have correct valid state.",
         test(resolve, reject) {

--- a/Source/WebInspectorUI/UserInterface/Models/CSSProperty.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSProperty.js
@@ -129,12 +129,17 @@ WI.CSSProperty = class CSSProperty extends WI.Object
         return 0;
     }
 
-    static indexOfCompletionForMostUsedPropertyName(completions)
+    static indexOfCompletionForMostUsedPropertyName(completions, completionPrefix)
     {
         let highestRankCompletions = completions;
         if (highestRankCompletions.every((completion) => completion instanceof WI.QueryResult)) {
             let highestRankValue = -1;
-            for (let completion of completions) {
+            for (let i = 0; i < completions.length; i++) {
+                let completion = completions[i];
+                // Exact match overrides popularity by usage.
+                if (completionPrefix === completion.value)
+                    return i;
+
                 if (completion.rank > highestRankValue) {
                     highestRankValue = completion.rank;
                     highestRankCompletions = [];
@@ -144,6 +149,7 @@ WI.CSSProperty = class CSSProperty extends WI.Object
                     highestRankCompletions.push(completion);
             }
         }
+
         let mostUsedHighestRankCompletion = highestRankCompletions.min((a, b) => WI.CSSProperty.sortByPropertyNameUsageCount(WI.CSSCompletions.getCompletionText(a), WI.CSSCompletions.getCompletionText(b)));
         return completions.indexOf(mostUsedHighestRankCompletion);
     }

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js
@@ -368,10 +368,10 @@ WI.SpreadsheetStyleProperty = class SpreadsheetStyleProperty extends WI.Object
         textField.value = isEditingName ? this._property.name : this._property.rawValue;
     }
 
-    spreadsheetTextFieldInitialCompletionIndex(textField, completions)
+    spreadsheetTextFieldInitialCompletionIndex(textField, completions, completionPrefix)
     {
         if (textField === this._nameTextField && WI.settings.experimentalCSSSortPropertyNameAutocompletionByUsage.value)
-            return WI.CSSProperty.indexOfCompletionForMostUsedPropertyName(completions);
+            return WI.CSSProperty.indexOfCompletionForMostUsedPropertyName(completions, completionPrefix);
         return 0;
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/SpreadsheetTextField.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SpreadsheetTextField.js
@@ -463,7 +463,7 @@ WI.SpreadsheetTextField = class SpreadsheetTextField
         this._suggestionsView.selectedIndex = NaN;
         if (this._completionPrefix) {
             if (this._delegate?.spreadsheetTextFieldInitialCompletionIndex)
-                this._suggestionsView.selectedIndex = this._delegate.spreadsheetTextFieldInitialCompletionIndex(this, completions);
+                this._suggestionsView.selectedIndex = this._delegate.spreadsheetTextFieldInitialCompletionIndex(this, completions, this._completionPrefix);
             else
                 this._suggestionsView.selectNext();
         } else


### PR DESCRIPTION
#### 1d3b3b63a5765c4bad241e2fcec81e78f4ee1355
<pre>
Web Inspector: CSS Completion picks property with higher usage count instead of exact match
<a href="https://bugs.webkit.org/show_bug.cgi?id=272113">https://bugs.webkit.org/show_bug.cgi?id=272113</a>
<a href="https://rdar.apple.com/125866965">rdar://125866965</a>

Reviewed by NOBODY (OOPS!).

Ensure that an exact match CSS property is picked as the default selected completion,
regardless of other CSS properties with higher rank or usage count.

* LayoutTests/inspector/css/css-property-expected.txt:
* LayoutTests/inspector/css/css-property.html:
* Source/WebInspectorUI/UserInterface/Models/CSSProperty.js:
(WI.CSSProperty.indexOfCompletionForMostUsedPropertyName):
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetStyleProperty.js:
(WI.SpreadsheetStyleProperty.prototype.spreadsheetTextFieldInitialCompletionIndex):
* Source/WebInspectorUI/UserInterface/Views/SpreadsheetTextField.js:
(WI.SpreadsheetTextField.prototype._updateCompletions):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d3b3b63a5765c4bad241e2fcec81e78f4ee1355

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49288 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42656 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38005 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40170 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19272 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20143 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41287 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4656 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42918 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51139 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21618 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18027 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45266 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40329 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44217 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22611 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->