### PR TITLE
[GTK][WPE] Add a content type property to TextureMapperPlatformLayerProxy

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -155,7 +155,7 @@ MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(MediaPlayer* player)
     , m_drawTimer(RunLoop::main(), this, &MediaPlayerPrivateGStreamer::repaint)
     , m_pausedTimerHandler(RunLoop::main(), this, &MediaPlayerPrivateGStreamer::pausedTimerFired)
 #if USE(TEXTURE_MAPPER) && !USE(NICOSIA)
-    , m_platformLayerProxy(adoptRef(new TextureMapperPlatformLayerProxyGL))
+    , m_platformLayerProxy(adoptRef(new TextureMapperPlatformLayerProxyGL(TextureMapperPlatformLayerProxy::ContentType::Video)))
 #endif
 #if !RELEASE_LOG_DISABLED
     , m_logger(player->mediaPlayerLogger())
@@ -180,13 +180,13 @@ MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer(MediaPlayer* player)
     m_nicosiaLayer = Nicosia::ContentLayer::create(*this,
         [&]() -> Ref<TextureMapperPlatformLayerProxy> {
             if (isHolePunchRenderingEnabled())
-                return adoptRef(*new TextureMapperPlatformLayerProxyGL(true));
+                return adoptRef(*new TextureMapperPlatformLayerProxyGL(TextureMapperPlatformLayerProxy::ContentType::HolePunch));
 
 #if USE(TEXTURE_MAPPER_DMABUF)
             if (webKitDMABufVideoSinkIsEnabled() && webKitDMABufVideoSinkProbePlatform())
-                return adoptRef(*new TextureMapperPlatformLayerProxyDMABuf);
+                return adoptRef(*new TextureMapperPlatformLayerProxyDMABuf(TextureMapperPlatformLayerProxy::ContentType::Video));
 #endif
-            return adoptRef(*new TextureMapperPlatformLayerProxyGL(false));
+            return adoptRef(*new TextureMapperPlatformLayerProxyGL(TextureMapperPlatformLayerProxy::ContentType::Video));
         }());
 #endif
 

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp
@@ -36,9 +36,9 @@ MediaPlayerPrivateHolePunch::MediaPlayerPrivateHolePunch(MediaPlayer* player)
     , m_readyTimer(RunLoop::main(), this, &MediaPlayerPrivateHolePunch::notifyReadyState)
     , m_networkState(MediaPlayer::NetworkState::Empty)
 #if USE(NICOSIA)
-    , m_nicosiaLayer(Nicosia::ContentLayer::create(*this, adoptRef(*new WebCore::TextureMapperPlatformLayerProxyGL(true))))
+    , m_nicosiaLayer(Nicosia::ContentLayer::create(*this, adoptRef(*new WebCore::TextureMapperPlatformLayerProxyGL(WebCore::TextureMapperPlatformLayerProxy::ContentType::HolePunch))))
 #else
-    , m_platformLayerProxy(adoptRef(new TextureMapperPlatformLayerProxyGL))
+    , m_platformLayerProxy(adoptRef(new TextureMapperPlatformLayerProxyGL(TextureMapperPlatformLayerProxy::ContentType::HolePunch)))
 #endif
 {
     pushNextHolePunchBuffer();

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaContentLayer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaContentLayer.cpp
@@ -33,11 +33,6 @@
 
 namespace Nicosia {
 
-Ref<ContentLayer> ContentLayer::create(Client& client)
-{
-    return adoptRef(*new ContentLayer(client, adoptRef(*new WebCore::TextureMapperPlatformLayerProxyGL)));
-}
-
 Ref<ContentLayer> ContentLayer::create(Client& client, Ref<WebCore::TextureMapperPlatformLayerProxy>&& proxy)
 {
     return adoptRef(*new ContentLayer(client, WTFMove(proxy)));

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaContentLayer.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaContentLayer.h
@@ -45,7 +45,6 @@ public:
         virtual void swapBuffersIfNeeded() = 0;
     };
 
-    static Ref<ContentLayer> create(Client&);
     static Ref<ContentLayer> create(Client&, Ref<WebCore::TextureMapperPlatformLayerProxy>&&);
 
     virtual ~ContentLayer();

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp
@@ -88,14 +88,14 @@ void GCGLANGLELayer::swapBuffersIfNeeded()
 
 GCGLANGLELayer::GCGLANGLELayer(GraphicsContextGLTextureMapperANGLE& context)
     : m_context(context)
-    , m_contentLayer(Nicosia::ContentLayer::create(*this, adoptRef(*new TextureMapperPlatformLayerProxyGL)))
+    , m_contentLayer(Nicosia::ContentLayer::create(*this, adoptRef(*new TextureMapperPlatformLayerProxyGL(TextureMapperPlatformLayerProxy::ContentType::WebGL))))
 {
 }
 
 #if USE(ANGLE_GBM)
 GCGLANGLELayer::GCGLANGLELayer(GraphicsContextGLGBM& context)
     : m_context(context)
-    , m_contentLayer(Nicosia::ContentLayer::create(*this, adoptRef(*new TextureMapperPlatformLayerProxyDMABuf)))
+    , m_contentLayer(Nicosia::ContentLayer::create(*this, adoptRef(*new TextureMapperPlatformLayerProxyDMABuf(TextureMapperPlatformLayerProxy::ContentType::WebGL))))
 {
 }
 #endif

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
@@ -47,7 +47,7 @@ using namespace WebCore;
 
 NicosiaImageBufferPipeSource::NicosiaImageBufferPipeSource()
 {
-    m_nicosiaLayer = Nicosia::ContentLayer::create(*this);
+    m_nicosiaLayer = Nicosia::ContentLayer::create(*this, adoptRef(*new TextureMapperPlatformLayerProxyGL(TextureMapperPlatformLayerProxy::ContentType::OffscreenCanvas)));
 }
 
 NicosiaImageBufferPipeSource::~NicosiaImageBufferPipeSource()

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.cpp
@@ -30,7 +30,11 @@
 
 namespace WebCore {
 
-TextureMapperPlatformLayerProxy::TextureMapperPlatformLayerProxy() = default;
+TextureMapperPlatformLayerProxy::TextureMapperPlatformLayerProxy(ContentType contentType)
+    : m_contentType(contentType)
+{
+}
+
 TextureMapperPlatformLayerProxy::~TextureMapperPlatformLayerProxy() = default;
 
 bool TextureMapperPlatformLayerProxy::isActive()

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.h
@@ -39,12 +39,19 @@ class TextureMapperPlatformLayerBuffer;
 class TextureMapperPlatformLayerProxy : public ThreadSafeRefCounted<TextureMapperPlatformLayerProxy> {
     WTF_MAKE_FAST_ALLOCATED();
 public:
+    enum class ContentType : uint8_t {
+        WebGL,
+        Video,
+        OffscreenCanvas,
+        HolePunch
+    };
+
     class Compositor {
     public:
         virtual void onNewBufferAvailable() = 0;
     };
 
-    TextureMapperPlatformLayerProxy();
+    explicit TextureMapperPlatformLayerProxy(ContentType);
     virtual ~TextureMapperPlatformLayerProxy();
 
     virtual bool isGLBased() const { return false; }
@@ -52,6 +59,8 @@ public:
 
     Lock& lock() WTF_RETURNS_LOCK(m_lock) { return m_lock; }
     bool isActive();
+
+    ContentType contentType() const { return m_contentType; }
 
     virtual void activateOnCompositingThread(Compositor*, TextureMapperLayer*) = 0;
     virtual void invalidate() = 0;
@@ -61,6 +70,7 @@ protected:
     Lock m_lock;
     Compositor* m_compositor { nullptr };
     TextureMapperLayer* m_targetLayer { nullptr };
+    ContentType m_contentType;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
@@ -71,7 +71,11 @@ struct TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::EGLImageData {
     std::array<EGLImageKHR, DMABufFormat::c_maxPlanes> image { EGL_NO_IMAGE_KHR, EGL_NO_IMAGE_KHR, EGL_NO_IMAGE_KHR, EGL_NO_IMAGE_KHR };
 };
 
-TextureMapperPlatformLayerProxyDMABuf::TextureMapperPlatformLayerProxyDMABuf() = default;
+TextureMapperPlatformLayerProxyDMABuf::TextureMapperPlatformLayerProxyDMABuf(ContentType contentType)
+    : TextureMapperPlatformLayerProxy(contentType)
+{
+}
+
 TextureMapperPlatformLayerProxyDMABuf::~TextureMapperPlatformLayerProxyDMABuf() = default;
 
 void TextureMapperPlatformLayerProxyDMABuf::activateOnCompositingThread(Compositor* compositor, TextureMapperLayer* targetLayer)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.h
@@ -45,7 +45,7 @@ class TextureMapper;
 class TextureMapperPlatformLayerProxyDMABuf final : public TextureMapperPlatformLayerProxy {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    TextureMapperPlatformLayerProxyDMABuf();
+    explicit TextureMapperPlatformLayerProxyDMABuf(ContentType);
     virtual ~TextureMapperPlatformLayerProxyDMABuf();
 
     bool isDMABufBased() const override { return true; }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp
@@ -42,8 +42,8 @@ static const Seconds releaseUnusedBuffersTimerInterval = { 500_ms };
 
 namespace WebCore {
 
-TextureMapperPlatformLayerProxyGL::TextureMapperPlatformLayerProxyGL(bool disableBufferInvalidation)
-    : m_disableBufferInvalidation(disableBufferInvalidation)
+TextureMapperPlatformLayerProxyGL::TextureMapperPlatformLayerProxyGL(ContentType contentType)
+    : TextureMapperPlatformLayerProxy(contentType)
 {
 }
 
@@ -104,7 +104,7 @@ void TextureMapperPlatformLayerProxyGL::invalidate()
             m_targetLayer = nullptr;
         }
 
-        if (!m_disableBufferInvalidation) {
+        if (contentType() != ContentType::HolePunch) {
             m_currentBuffer = nullptr;
             m_pendingBuffer = nullptr;
             m_releaseUnusedBuffersTimer = nullptr;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.h
@@ -44,7 +44,7 @@ namespace WebCore {
 class TextureMapperPlatformLayerProxyGL final : public TextureMapperPlatformLayerProxy {
     WTF_MAKE_FAST_ALLOCATED();
 public:
-    TextureMapperPlatformLayerProxyGL(bool disableBufferInvalidation = false);
+    explicit TextureMapperPlatformLayerProxyGL(ContentType);
     virtual ~TextureMapperPlatformLayerProxyGL();
 
     bool isGLBased() const override { return true; }

--- a/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
@@ -70,7 +70,7 @@ private:
 NicosiaDisplayDelegate::NicosiaDisplayDelegate(bool isOpaque)
     : m_isOpaque(isOpaque)
 {
-    m_contentLayer = Nicosia::ContentLayer::create(*this, adoptRef(*new WebCore::TextureMapperPlatformLayerProxyDMABuf));
+    m_contentLayer = Nicosia::ContentLayer::create(*this, adoptRef(*new WebCore::TextureMapperPlatformLayerProxyDMABuf(WebCore::TextureMapperPlatformLayerProxy::ContentType::WebGL)));
 }
 
 NicosiaDisplayDelegate::~NicosiaDisplayDelegate()


### PR DESCRIPTION
#### ba0578f34b1d565deb05a1db81902a9a0d925080
<pre>
[GTK][WPE] Add a content type property to TextureMapperPlatformLayerProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=272112">https://bugs.webkit.org/show_bug.cgi?id=272112</a>

Reviewed by Carlos Garcia Campos.

Add a property to TextureMapperPlatformLayerProxy to indicate the type of
frames that are passing through it. The type can be WebGL, Video,
OffscreenCanvas or HolePuch.

We don&apos;t want to have proxies without a defined content type, so this patch
removes the method to create a Nicosia::ContentLayer that doesn&apos;t receive
a proxy and creates one whose content type is not known. This way, the code
that creates the Nicosia::ContentLayer has to specifically create a proxy
with a defined content type for it.

This change removes the need of the of the disableBufferInvalidation parameter
in the TextureMapperPlatformLayerProxyGL constructor, as this is only used for
the HolePunch case. Now that the proxy knows when it&apos;s handling HolePunch
buffers, the previous condition can be reworked.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::MediaPlayerPrivateGStreamer):
* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.cpp:
(WebCore::MediaPlayerPrivateHolePunch::MediaPlayerPrivateHolePunch):
* Source/WebCore/platform/graphics/nicosia/NicosiaContentLayer.cpp:
* Source/WebCore/platform/graphics/nicosia/NicosiaContentLayer.h:
* Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp:
(Nicosia::GCGLANGLELayer::GCGLANGLELayer):
* Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp:
(Nicosia::NicosiaImageBufferPipeSource::NicosiaImageBufferPipeSource):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.cpp:
(WebCore::TextureMapperPlatformLayerProxy::TextureMapperPlatformLayerProxy):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxy.h:
(WebCore::TextureMapperPlatformLayerProxy::contentType const):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp:
(WebCore::TextureMapperPlatformLayerProxyDMABuf::TextureMapperPlatformLayerProxyDMABuf):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp:
(WebCore::TextureMapperPlatformLayerProxyGL::TextureMapperPlatformLayerProxyGL):
(WebCore::TextureMapperPlatformLayerProxyGL::invalidate):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.h:
* Source/WebKit/WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp:
(WebKit::NicosiaDisplayDelegate::NicosiaDisplayDelegate):

Canonical link: <a href="https://commits.webkit.org/277110@main">https://commits.webkit.org/277110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e69cfbfad47793baa760a0eee7c24f341a58214

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49401 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42771 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23347 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40241 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19354 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41377 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4770 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41744 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51278 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18093 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23021 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44308 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10322 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->