### PR TITLE
[WASM-Function-References] Enable typed funcrefs by default

### DIFF
--- a/JSTests/wasm/references/element_active_mod.js
+++ b/JSTests/wasm/references/element_active_mod.js
@@ -1,3 +1,5 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=false", "--useWebAssemblyGC=false")
+
 import * as assert from '../assert.js';
 
 function module(bytes, valid = true) {

--- a/JSTests/wasm/references/func_ref.js
+++ b/JSTests/wasm/references/func_ref.js
@@ -1,3 +1,5 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=false", "--useWebAssemblyGC=false")
+
 import * as assert from '../assert.js';
 import Builder from '../Builder.js';
 

--- a/JSTests/wasm/references/is_null.js
+++ b/JSTests/wasm/references/is_null.js
@@ -1,3 +1,5 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=false", "--useWebAssemblyGC=false")
+
 import * as assert from '../assert.js';
 import Builder from '../Builder.js';
 

--- a/JSTests/wasm/references/multitable.js
+++ b/JSTests/wasm/references/multitable.js
@@ -372,7 +372,7 @@ assert.throws(() => new WebAssembly.Instance(new WebAssembly.Module((new Builder
               .RefNull("funcref")
               .TableGet(0)
             .End()
-          .End().WebAssembly().get())), Error, "WebAssembly.Module doesn't validate: table.get index to type Funcref expected I32, in function at index 0 (evaluating 'new WebAssembly.Module")
+            .End().WebAssembly().get())), Error, "WebAssembly.Module doesn't validate: table.get index to type (ref null func) expected I32, in function at index 0 (evaluating 'new WebAssembly.Module")
 
 
 assert.throws(() => new WebAssembly.Instance(new WebAssembly.Module((new Builder())
@@ -388,7 +388,7 @@ assert.throws(() => new WebAssembly.Instance(new WebAssembly.Module((new Builder
               .RefNull("funcref")
               .TableSet(0)
             .End()
-          .End().WebAssembly().get())), Error, "WebAssembly.Module doesn't validate: table.set index to type Funcref expected I32, in function at index 0 (evaluating 'new WebAssembly.Module")
+            .End().WebAssembly().get())), Error, "WebAssembly.Module doesn't validate: table.set index to type (ref null func) expected I32, in function at index 0 (evaluating 'new WebAssembly.Module")
 
 assert.throws(() => new WebAssembly.Instance(new WebAssembly.Module((new Builder())
           .Type().End()
@@ -403,7 +403,7 @@ assert.throws(() => new WebAssembly.Instance(new WebAssembly.Module((new Builder
               .GetLocal(0)
               .TableSet(1)
             .End()
-          .End().WebAssembly().get())), Error, "WebAssembly.Module doesn't validate: table.set value to type Externref expected Funcref, in function at index 0 (evaluating 'new WebAssembly.Module")
+            .End().WebAssembly().get())), Error, "WebAssembly.Module doesn't validate: table.set value to type (ref null extern) expected (ref null func), in function at index 0 (evaluating 'new WebAssembly.Module")
 
 if (!$vm.isMemoryLimited()) {
     function tableInsanity(num, b) {

--- a/JSTests/wasm/references/table_misc.js
+++ b/JSTests/wasm/references/table_misc.js
@@ -1,3 +1,5 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=false", "--useWebAssemblyGC=false")
+
 import * as assert from '../assert.js';
 import Builder from '../Builder.js';
 

--- a/JSTests/wasm/references/validation.js
+++ b/JSTests/wasm/references/validation.js
@@ -1,3 +1,5 @@
+//@ runWebAssemblySuite("--useWebAssemblyTypedFunctionReferences=false", "--useWebAssemblyGC=false")
+
 import * as assert from '../assert.js';
 import Builder from '../Builder.js';
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -598,7 +598,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useStringWellFormed, true, Normal, "Expose the String well-formed methods.") \
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object.") \
     v(Bool, useWebAssemblyThreading, true, Normal, "Allow instructions from the wasm threading spec.") \
-    v(Bool, useWebAssemblyTypedFunctionReferences, false, Normal, "Allow function types from the wasm typed function references spec.") \
+    v(Bool, useWebAssemblyTypedFunctionReferences, true, Normal, "Allow function types from the wasm typed function references spec.") \
     v(Bool, useWebAssemblyGC, false, Normal, "Allow gc types from the wasm gc proposal.") \
     v(Bool, useWebAssemblySIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec.") \
     v(Bool, useWebAssemblyRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec.") \

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp
@@ -72,9 +72,9 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyTag, (JSGlobalObject* globalObjec
         else if (valueString == "f64"_s)
             type = Wasm::Types::F64;
         else if (valueString == "funcref"_s || valueString == "anyfunc"_s)
-            type = Wasm::Types::Funcref;
+            type = Wasm::funcrefType();
         else if (valueString == "externref"_s)
-            type = Wasm::Types::Externref;
+            type = Wasm::externrefType();
         else {
             throwTypeError(globalObject, scope, "WebAssembly.Tag constructor expects the 'parameters' field of the first argument to be a sequence of WebAssembly value types."_s);
             return;


### PR DESCRIPTION
#### 23f72b45f4ed9f04fa7c64c846d850fce90f0732
<pre>
[WASM-Function-References] Enable typed funcrefs by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=272003">https://bugs.webkit.org/show_bug.cgi?id=272003</a>

Reviewed by Yusuke Suzuki.

Enables typed funcref flag by default, also fixes tests that were broken by
this:
  * Error messages are different for reference type tests. For most of them,
    disable typed funcrefs (so this path is actually tested) and change error
    messages in a few cases.
  * V8 exceptions tests found a bug in the tag constructor with typed funcref,
    fix that as well.

* JSTests/wasm/references/element_active_mod.js:
* JSTests/wasm/references/func_ref.js:
* JSTests/wasm/references/is_null.js:
* JSTests/wasm/references/multitable.js:
* JSTests/wasm/references/table_misc.js:
* JSTests/wasm/references/validation.js:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/277773@main">https://commits.webkit.org/277773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cda20a868c7fe6fe608493ca8a3db0a786828042

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49165 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42530 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37931 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22670 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19182 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20043 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41197 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4534 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39734 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42878 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51004 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/45968 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45181 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22786 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44120 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10700 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23198 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53114 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22489 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10892 "Passed tests") | 
<!--EWS-Status-Bubble-End-->