### PR TITLE
When exiting from pip to in-window fullscreen, the video content becomes small

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7147,8 +7147,12 @@ void HTMLMediaElement::willBecomeFullscreenElement(VideoFullscreenMode mode)
 
 #if PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)
     if (oldVideoFullscreenMode == VideoFullscreenModePictureInPicture) {
-        if (auto* video = dynamicDowncast<HTMLVideoElement>(*this))
-            video->exitToFullscreenModeWithoutAnimationIfPossible(oldVideoFullscreenMode, VideoFullscreenModeStandard);
+        if (RefPtr video = dynamicDowncast<HTMLVideoElement>(*this)) {
+            if (RefPtr page = document().page(); page && mode == VideoFullscreenModeInWindow)
+                page->chrome().client().exitVideoFullscreenForVideoElement(*video);
+            else
+                video->exitToFullscreenModeWithoutAnimationIfPossible(oldVideoFullscreenMode, mode);
+        }
     }
 #endif
 

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -91,7 +91,7 @@ public:
     bool hasMode(HTMLMediaElementEnums::VideoFullscreenMode mode) const { return m_mode & mode; }
     bool isMode(HTMLMediaElementEnums::VideoFullscreenMode mode) const { return m_mode == mode; }
     WEBCORE_EXPORT void setMode(HTMLMediaElementEnums::VideoFullscreenMode, bool);
-    void clearMode(HTMLMediaElementEnums::VideoFullscreenMode);
+    WEBCORE_EXPORT void clearMode(HTMLMediaElementEnums::VideoFullscreenMode);
 
     WEBCORE_EXPORT bool isPlayingVideoInEnhancedFullscreen() const;
 

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -448,7 +448,7 @@ void VideoPresentationInterfaceMac::setupFullscreen(NSView& layerHostedView, con
     UNUSED_PARAM(allowsPictureInPicturePlayback);
     ASSERT(mode == HTMLMediaElementEnums::VideoFullscreenModePictureInPicture);
 
-    m_mode = mode;
+    m_mode |= mode;
 
     [videoPresentationInterfaceObjC() setUpPIPForVideoView:&layerHostedView withFrame:(NSRect)initialRect inWindow:parentWindow];
 
@@ -462,7 +462,7 @@ void VideoPresentationInterfaceMac::enterFullscreen()
 {
     LOG(Fullscreen, "VideoPresentationInterfaceMac::enterFullscreen(%p)", this);
 
-    if (mode() == HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) {
+    if (hasMode(HTMLMediaElementEnums::VideoFullscreenModePictureInPicture)) {
         if (auto model = videoPresentationModel())
             model->willEnterPictureInPicture();
         [m_webVideoPresentationInterfaceObjC enterPIP];

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -232,6 +232,8 @@ private:
     void preparedToReturnToInline(PlaybackSessionContextIdentifier, bool visible, WebCore::FloatRect inlineRect);
     void preparedToExitFullscreen(PlaybackSessionContextIdentifier);
     void exitFullscreenWithoutAnimationToMode(PlaybackSessionContextIdentifier, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
+    void setVideoFullscreenMode(PlaybackSessionContextIdentifier, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
+    void clearVideoFullscreenMode(PlaybackSessionContextIdentifier, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
     void setPlayerIdentifier(PlaybackSessionContextIdentifier, std::optional<WebCore::MediaPlayerIdentifier>);
     void textTrackRepresentationUpdate(PlaybackSessionContextIdentifier, WebCore::ShareableBitmap::Handle&& textTrack);
     void textTrackRepresentationSetContentsScale(PlaybackSessionContextIdentifier, float scale);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
@@ -36,7 +36,8 @@ messages -> VideoPresentationManagerProxy {
     PreparedToReturnToInline(WebKit::PlaybackSessionContextIdentifier contextId, bool visible, WebCore::FloatRect inlineRect)
     PreparedToExitFullscreen(WebKit::PlaybackSessionContextIdentifier contextId)
     ExitFullscreenWithoutAnimationToMode(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::MediaPlayerEnums::VideoFullscreenMode videoFullscreenMode)
-
+    SetVideoFullscreenMode(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::MediaPlayerEnums::VideoFullscreenMode mode)
+    ClearVideoFullscreenMode(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::MediaPlayerEnums::VideoFullscreenMode mode)
     TextTrackRepresentationUpdate(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::ShareableBitmapHandle textTrack)
     TextTrackRepresentationSetContentsScale(WebKit::PlaybackSessionContextIdentifier contextId, float scale)
     TextTrackRepresentationSetHidden(WebKit::PlaybackSessionContextIdentifier contextId, bool hidden)

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -1009,6 +1009,22 @@ void VideoPresentationManagerProxy::exitFullscreenWithoutAnimationToMode(Playbac
     hasVideoInPictureInPictureDidChange(targetMode & MediaPlayerEnums::VideoFullscreenModePictureInPicture);
 }
 
+void VideoPresentationManagerProxy::setVideoFullscreenMode(PlaybackSessionContextIdentifier contextId, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode)
+{
+    MESSAGE_CHECK((mode | HTMLMediaElementEnums::VideoFullscreenModeAllValidBitsMask) == HTMLMediaElementEnums::VideoFullscreenModeAllValidBitsMask);
+
+    ensureInterface(contextId).setMode(mode, false);
+}
+
+void VideoPresentationManagerProxy::clearVideoFullscreenMode(PlaybackSessionContextIdentifier contextId, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode)
+{
+    MESSAGE_CHECK((mode | HTMLMediaElementEnums::VideoFullscreenModeAllValidBitsMask) == HTMLMediaElementEnums::VideoFullscreenModeAllValidBitsMask);
+
+#if PLATFORM(MAC)
+    ensureInterface(contextId).clearMode(mode);
+#endif
+}
+
 #if PLATFORM(IOS_FAMILY)
 
 void VideoPresentationManagerProxy::setInlineRect(PlaybackSessionContextIdentifier contextId, const WebCore::FloatRect& inlineRect, bool visible)
@@ -1252,8 +1268,10 @@ void VideoPresentationManagerProxy::didCleanupFullscreen(PlaybackSessionContextI
 
     m_page->send(Messages::VideoPresentationManager::DidCleanupFullscreen(contextId));
 
-    interface->setMode(HTMLMediaElementEnums::VideoFullscreenModeNone, false);
-    removeClientForContext(contextId);
+    if (!hasMode(HTMLMediaElementEnums::VideoFullscreenModeInWindow)) {
+        interface->setMode(HTMLMediaElementEnums::VideoFullscreenModeNone, false);
+        removeClientForContext(contextId);
+    }
 }
 
 void VideoPresentationManagerProxy::setVideoLayerFrame(PlaybackSessionContextIdentifier contextId, WebCore::FloatRect frame)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1272,6 +1272,16 @@ void WebChromeClient::exitVideoFullscreenToModeWithoutAnimation(HTMLVideoElement
     protectedPage()->videoPresentationManager().exitVideoFullscreenToModeWithoutAnimation(videoElement, targetMode);
 }
 
+void WebChromeClient::setVideoFullscreenMode(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode mode)
+{
+    protectedPage()->videoPresentationManager().setVideoFullscreenMode(videoElement, mode);
+}
+
+void WebChromeClient::clearVideoFullscreenMode(HTMLVideoElement& videoElement, HTMLMediaElementEnums::VideoFullscreenMode mode)
+{
+    protectedPage()->videoPresentationManager().clearVideoFullscreenMode(videoElement, mode);
+}
+
 #endif
 
 #if ENABLE(FULLSCREEN_API)
@@ -1284,11 +1294,26 @@ bool WebChromeClient::supportsFullScreenForElement(const Element&, bool withKeyb
 void WebChromeClient::enterFullScreenForElement(Element& element, HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
     protectedPage()->fullScreenManager()->enterFullScreenForElement(&element, mode);
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    if (RefPtr videoElement = dynamicDowncast<HTMLVideoElement>(&element); videoElement && mode == HTMLMediaElementEnums::VideoFullscreenModeInWindow)
+        setVideoFullscreenMode(*videoElement, mode);
+#endif
 }
 
 void WebChromeClient::exitFullScreenForElement(Element* element)
 {
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    bool exitingInWindowFullscreen = false;
+    if (element) {
+        if (RefPtr videoElement = dynamicDowncast<HTMLVideoElement>(*element))
+            exitingInWindowFullscreen = videoElement->fullscreenMode() == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
+    }
+#endif
     protectedPage()->fullScreenManager()->exitFullScreenForElement(element);
+#if ENABLE(VIDEO_PRESENTATION_MODE)
+    if (exitingInWindowFullscreen)
+        clearVideoFullscreenMode(*dynamicDowncast<HTMLVideoElement>(*element), HTMLMediaElementEnums::VideoFullscreenModeInWindow);
+#endif
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <WebCore/ChromeClient.h>
+#include <WebCore/HTMLVideoElement.h>
 #include <wtf/WeakRef.h>
 
 namespace WebCore {
@@ -320,6 +321,8 @@ private:
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     void exitVideoFullscreenToModeWithoutAnimation(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode) final;
+    void setVideoFullscreenMode(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
+    void clearVideoFullscreenMode(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
 #endif
 
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -153,7 +153,8 @@ public:
     void enterVideoFullscreenForVideoElement(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool standby);
     void exitVideoFullscreenForVideoElement(WebCore::HTMLVideoElement&, WTF::CompletionHandler<void(bool)>&& = [](bool) { });
     void exitVideoFullscreenToModeWithoutAnimation(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
-
+    void setVideoFullscreenMode(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
+    void clearVideoFullscreenMode(WebCore::HTMLVideoElement&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode);
     void updateTextTrackRepresentationForVideoElement(WebCore::HTMLVideoElement&, WebCore::ShareableBitmapHandle&&);
     void setTextTrackRepresentationContentScaleForVideoElement(WebCore::HTMLVideoElement&, float scale);
     void setTextTrackRepresentationIsHiddenForVideoElement(WebCore::HTMLVideoElement&, bool hidden);

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -476,6 +476,44 @@ void VideoPresentationManager::exitVideoFullscreenToModeWithoutAnimation(HTMLVid
     m_page->send(Messages::VideoPresentationManagerProxy::ExitFullscreenWithoutAnimationToMode(contextId, targetMode));
 }
 
+void VideoPresentationManager::setVideoFullscreenMode(HTMLVideoElement& videoElement, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode)
+{
+    INFO_LOG(LOGIDENTIFIER);
+
+    ASSERT(m_page);
+
+    if (!m_videoElements.contains(videoElement))
+        return;
+
+    auto contextId = m_videoElements.get(videoElement);
+    if (!contextId.isValid()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    if (m_page)
+        m_page->send(Messages::VideoPresentationManagerProxy::SetVideoFullscreenMode(contextId, mode));
+}
+
+void VideoPresentationManager::clearVideoFullscreenMode(HTMLVideoElement& videoElement, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode)
+{
+    INFO_LOG(LOGIDENTIFIER);
+
+    ASSERT(m_page);
+
+    if (!m_videoElements.contains(videoElement))
+        return;
+
+    auto contextId = m_videoElements.get(videoElement);
+    if (!contextId.isValid()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    if (m_page)
+        m_page->send(Messages::VideoPresentationManagerProxy::ClearVideoFullscreenMode(contextId, mode));
+}
+
 #pragma mark Interface to VideoPresentationInterfaceContext:
 
 void VideoPresentationManager::hasVideoChanged(PlaybackSessionContextIdentifier contextId, bool hasVideo)
@@ -692,9 +730,11 @@ void VideoPresentationManager::didCleanupFullscreen(PlaybackSessionContextIdenti
     if (videoElement)
         videoElement->didExitFullscreenOrPictureInPicture();
 
-    interface->setFullscreenMode(HTMLMediaElementEnums::VideoFullscreenModeNone);
     interface->setFullscreenStandby(false);
-    removeClientForContext(contextId);
+    if (interface->fullscreenMode() != HTMLMediaElementEnums::VideoFullscreenModeInWindow) {
+        interface->setFullscreenMode(HTMLMediaElementEnums::VideoFullscreenModeNone);
+        removeClientForContext(contextId);
+    }
 
     if (!videoElement || !targetIsFullscreen || mode == HTMLMediaElementEnums::VideoFullscreenModeNone) {
         setCurrentlyInFullscreen(*interface, false);


### PR DESCRIPTION
#### 4bb40628005815ca00ec87a46f102053546abd3f
<pre>
When exiting from pip to in-window fullscreen, the video content becomes small
<a href="https://bugs.webkit.org/show_bug.cgi?id=272108">https://bugs.webkit.org/show_bug.cgi?id=272108</a>
<a href="https://rdar.apple.com/123112852">rdar://123112852</a>

Reviewed by Jer Noble.

When exiting from pip to in-window mode, we now call exitVideoFullscreenForVideoElement instead of
exitToFullscreenModeWithoutAnimationIfPossible because the lack of animation was likely causing ref
counting issues. VideoPresentationManagerMac&apos;s mode is also now updated when we enter or exit in-window,
so that when entering in-window, then pip, then exiting pip, the class will remember that the new mode
should be in-window. Lastly, in didCleanupFullscreen, the new fullscreen mode should only be set to
inline and removeclientForContext should only be called if we are exiting from pip to inline and not
when we are exiting to in-window. When we call removeclientForContext, we lose the
VideoPresentationManager, which is needed to correctly size the video content in fullscreen.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::willBecomeFullscreenElement):
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(WebCore::VideoPresentationInterfaceMac::setupFullscreen):
(WebCore::VideoPresentationInterfaceMac::enterFullscreen):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setVideoFullscreenMode):
(WebKit::VideoPresentationManagerProxy::clearVideoFullscreenMode):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::setVideoFullscreenMode):
(WebKit::WebChromeClient::clearVideoFullscreenMode):
(WebKit::WebChromeClient::enterFullScreenForElement):
(WebKit::WebChromeClient::exitFullScreenForElement):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::setVideoFullscreenMode):
(WebKit::VideoPresentationManager::clearVideoFullscreenMode):
(WebKit::VideoPresentationManager::didCleanupFullscreen):

Canonical link: <a href="https://commits.webkit.org/277142@main">https://commits.webkit.org/277142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5da6bad5781c6c1af9f6f2ffcfbf91c5118ea6d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25933 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42819 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23397 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38117 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22937 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19409 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20271 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41421 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4818 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51321 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45393 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23069 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44350 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10342 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23564 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->