### PR TITLE
[MultiRep HEIC] Refactor attachment creation logic

### DIFF
--- a/Source/WebCore/platform/graphics/mac/ImageAdapterMac.mm
+++ b/Source/WebCore/platform/graphics/mac/ImageAdapterMac.mm
@@ -106,7 +106,7 @@ WebMultiRepresentationHEICAttachment *ImageAdapter::multiRepresentationHEIC()
     Vector<uint8_t> data = buffer->copyData();
 
     RetainPtr nsData = adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]);
-    m_multiRepHEIC = adoptNS([[PlatformWebMultiRepresentationHEICAttachment alloc] initWithData:nsData.get()]);
+    m_multiRepHEIC = adoptNS([[PlatformWebMultiRepresentationHEICAttachment alloc] initWithImageContent:nsData.get()]);
 
     return m_multiRepHEIC.get();
 }

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -47,6 +47,7 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 #import <WebKitAdditions/UnifiedTextReplacementAdditions.h>
+#import <WebKitAdditions/WebMultiRepresentationHEICAttachmentAdditions.h>
 #endif
 
 _WKOverlayScrollbarStyle toAPIScrollbarStyle(std::optional<WebCore::ScrollbarOverlayStyle> coreScrollbarStyle)


### PR DESCRIPTION
#### 9b9edc7971bf1bc083c3c02b329a3215adf0e4ad
<pre>
[MultiRep HEIC] Refactor attachment creation logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=272065">https://bugs.webkit.org/show_bug.cgi?id=272065</a>
<a href="https://rdar.apple.com/123389063">rdar://123389063</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(HTMLConverter::_addMultiRepresentationHEICAttachmentForImageElement):
(attributedStringWithAttachmentForElement):
(WebCore::editingAttributedString):
(attachmentForElement): Deleted.
* Source/WebCore/platform/graphics/mac/ImageAdapterMac.mm:
(WebCore::ImageAdapter::multiRepresentationHEIC):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:

Canonical link: <a href="https://commits.webkit.org/277081@main">https://commits.webkit.org/277081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3cb4172fb51f92bf1b1c2edcb0999116042da7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49103 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49176 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42540 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37936 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22673 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19190 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20050 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41198 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4544 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51016 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17937 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45186 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22796 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44127 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23214 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6519 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->