### PR TITLE
[view-transitions] Add a timeout to the update callback

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/update-callback-timeout-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/update-callback-timeout-expected.txt
@@ -1,0 +1,3 @@
+
+PASS View transition should have an implementation-defined timeout on the update callback
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/update-callback-timeout.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/update-callback-timeout.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <title>View transitions: Transition has implementation-defined timeout.</title>
+  <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+  <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+  <meta name="timeout" content="long">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script>
+    promise_test(async t => {
+      assert_implements(document.startViewTransition, "Missing document.startViewTransition");
+      const transition = document.startViewTransition(() => {
+        return new Promise(() => {});
+      });
+      transition.updateCallbackDone.then(() => {
+        assert_unreached();
+      });
+      transition.finished.then(() => {
+        assert_unreached();
+      });
+      await promise_rejects_dom(t, "TimeoutError", transition.ready);
+    }, "View transition should have an implementation-defined timeout on the update callback");
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -172,8 +172,7 @@ private:
     PromiseAndWrapper m_ready;
     PromiseAndWrapper m_updateCallbackDone;
     PromiseAndWrapper m_finished;
-
-    FloatSize m_initialSnapshotContainingBlockSize;
+    EventLoopTimerHandle m_updateCallbackTimeout;
 };
 
 }


### PR DESCRIPTION
#### 2af8bf35f173cde9b114c2b371380ffae26fd3c7
<pre>
[view-transitions] Add a timeout to the update callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=272117">https://bugs.webkit.org/show_bug.cgi?id=272117</a>
<a href="https://rdar.apple.com/125877338">rdar://125877338</a>

Reviewed by Ryosuke Niwa and Simon Fraser.

Implement step 9 of <a href="https://drafts.csswg.org/css-view-transitions-1/#call-dom-update-callback-algorithm">https://drafts.csswg.org/css-view-transitions-1/#call-dom-update-callback-algorithm</a>

Follow Blink&apos;s timeout of 4 seconds: <a href="https://github.com/chromium/chromium/blob/a1aab3746bf8d8834086287b30c673e2a63eb633/third_party/blink/renderer/core/view_transition/view_transition.cc#L938-L945">https://github.com/chromium/chromium/blob/a1aab3746bf8d8834086287b30c673e2a63eb633/third_party/blink/renderer/core/view_transition/view_transition.cc#L938-L945</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/update-callback-timeout-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/update-callback-timeout.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::setupViewTransition):
* Source/WebCore/dom/ViewTransition.h:

Canonical link: <a href="https://commits.webkit.org/277045@main">https://commits.webkit.org/277045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6be09f0c287b08860239a4a8522c35d98078dbe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49191 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48821 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23133 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47092 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19200 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41205 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4558 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51031 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44134 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6494 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->