### PR TITLE
REGRESSION (276827@main): [ MacOS wk1 Debug ] tables/mozilla/bugs/bug4576.html is a flaky crash (272128)

### DIFF
--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2869,5 +2869,3 @@ imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties
 # webkit.org/b/272115 REGRESSION (274826@main): [ Sonoma WK1 ] 2X imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades tests are flaky failures
 [ Sonoma+ ] imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/image-upgrade.https.sub.html [ Pass Failure ]
 [ Sonoma+ ] imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/audio-upgrade.https.sub.html [ Pass Failure ]
-
- webkit.org/b/272128 [ Debug ] tables/mozilla/bugs/bug4576.html [ Pass Crash ]

--- a/Source/WebCore/platform/graphics/ImageFrameAnimator.cpp
+++ b/Source/WebCore/platform/graphics/ImageFrameAnimator.cpp
@@ -96,7 +96,8 @@ bool ImageFrameAnimator::imageFrameDecodeAtIndexHasFinished(unsigned index, Imag
     if (index != nextFrameIndex())
         return false;
 
-    ASSERT(hasEverAnimated());
+    if (!hasEverAnimated())
+        return false;
 
     // Don't advance to nextFrame if the timer has not fired yet.
     if (isAnimating())


### PR DESCRIPTION
#### d4196b8983b54794fd5536ae218f161241ace610
<pre>
REGRESSION (276827@main): [ MacOS wk1 Debug ] tables/mozilla/bugs/bug4576.html is a flaky crash (272128)
<a href="https://bugs.webkit.org/show_bug.cgi?id=272128">https://bugs.webkit.org/show_bug.cgi?id=272128</a>
<a href="https://rdar.apple.com/125879096">rdar://125879096</a>

Reviewed by Simon Fraser.

This assertion happens with DumpRenderTree on EWS only. It looks like there is
an animated image which is being decoded. But the animation of this image is reset
because a new page is loaded in the same WebProcess. When finishing the decoding,
the decoding thread returns the decoded frame to the BitmapImageSource which
sends it to ImageFrameAnimator. The ImageFrameAnimator sees that the animation
has not started yet on this page so the assertion fires.

An speculative fix is to change the assertion to an if-statement and make
ImageFrameAnimator returns false to BitmapImageSource in this case.

* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/platform/graphics/ImageFrameAnimator.cpp:
(WebCore::ImageFrameAnimator::imageFrameDecodeAtIndexHasFinished):

Canonical link: <a href="https://commits.webkit.org/277068@main">https://commits.webkit.org/277068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f41c13b0dabcb940746bdec927724d58a97e691

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49132 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49203 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23145 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19206 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41226 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4571 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41604 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/51145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17960 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45243 "layout-tests (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44190 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10298 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->