### PR TITLE
Drop AtomString constructors that take in a raw pointer and a length

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNames.cpp
@@ -265,7 +265,7 @@ JSValue IntlDisplayNames::of(JSGlobalObject* globalObject, JSValue codeValue) co
         // ICU API document.
         // > Returns pointer to display string of 'len' UChars. If the resource data contains no entry for 'currency', then 'currency' itself is returned.
         if (status == U_USING_DEFAULT_WARNING && result == currency)
-            return (m_fallback == Fallback::None) ? jsUndefined() : jsString(vm, { currency, 3 });
+            return (m_fallback == Fallback::None) ? jsUndefined() : jsString(vm, StringView({ currency, 3 }));
         return jsString(vm, String({ result, static_cast<size_t>(length) }));
     }
     case Type::Calendar: {

--- a/Source/JavaScriptCore/runtime/JSString.cpp
+++ b/Source/JavaScriptCore/runtime/JSString.cpp
@@ -168,11 +168,11 @@ AtomString JSRopeString::resolveRopeToAtomString(JSGlobalObject* globalObject) c
         if (is8Bit()) {
             LChar buffer[maxLengthForOnStackResolve];
             resolveRopeInternalNoSubstring(buffer, stackLimit);
-            atomString = AtomString(buffer, length());
+            atomString = std::span<const LChar> { buffer, length() };
         } else {
             UChar buffer[maxLengthForOnStackResolve];
             resolveRopeInternalNoSubstring(buffer, stackLimit);
-            atomString = AtomString(buffer, length());
+            atomString = std::span<const UChar> { buffer, length() };
         }
     } else
         atomString = StringView { substringBase()->valueInternal() }.substring(substringOffset(), length()).toAtomString();

--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -63,7 +63,7 @@ SlowPath:
             localBuffer[i] = characters[i];
         for (unsigned i = failingIndex; i < length; ++i)
             localBuffer[i] = type == CaseConvertType::Lower ? toASCIILower(characters[i]) : toASCIIUpper(characters[i]);
-        return AtomString(localBuffer, length);
+        return std::span<const LChar> { localBuffer, length };
     }
 
     Ref<StringImpl> convertedString = type == CaseConvertType::Lower ? impl->convertToASCIILowercase() : impl->convertToASCIIUppercase();

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -33,10 +33,6 @@ public:
     AtomString(std::span<const LChar>);
     AtomString(std::span<const UChar>);
 
-    // FIXME: Update call sites to pass in a std::span and drop these constructors.
-    AtomString(const LChar* characters, size_t length) : AtomString(std::span { characters, length }) { }
-    AtomString(const UChar* characters, size_t length) : AtomString(std::span { characters, length }) { }
-
     ALWAYS_INLINE static AtomString fromLatin1(const char* characters) { return AtomString(characters); }
 
     AtomString(AtomStringImpl*);
@@ -126,7 +122,7 @@ public:
 
 #if OS(WINDOWS)
     AtomString(const wchar_t* characters, unsigned length)
-        : AtomString(ucharFrom(characters), length) { }
+        : AtomString({ ucharFrom(characters), length }) { }
 
     AtomString(const wchar_t* characters)
         : AtomString(characters, characters ? wcslen(characters) : 0) { }

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -589,11 +589,11 @@ AtomString tryMakeAtomStringFromAdapters(StringTypeAdapter adapter, StringTypeAd
         if (areAllAdapters8Bit) {
             LChar buffer[maxLengthToUseStackVariable];
             stringTypeAdapterAccumulator(buffer, adapter, adapters...);
-            return AtomString { buffer, length };
+            return std::span<const LChar> { buffer, length };
         }
         UChar buffer[maxLengthToUseStackVariable];
         stringTypeAdapterAccumulator(buffer, adapter, adapters...);
-        return AtomString { buffer, length };
+        return std::span<const UChar> { buffer, length };
     }
     return tryMakeStringImplFromAdaptersInternal(length, areAllAdapters8Bit, adapter, adapters...).get();
 }

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -302,7 +302,7 @@ static AtomString convertASCIILowercaseAtom(const CharacterType* input, unsigned
             return makeAtomString(asASCIILowercase(std::span { input, length }));
     }
     // Fast path when the StringView is already all lowercase.
-    return AtomString(input, length);
+    return std::span { input, length };
 }
 
 AtomString StringView::convertToASCIILowercaseAtom() const

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -659,8 +659,8 @@ inline String StringView::toString() const
 inline AtomString StringView::toAtomString() const
 {
     if (is8Bit())
-        return AtomString(characters8(), m_length);
-    return AtomString(characters16(), m_length);
+        return span8();
+    return span16();
 }
 
 inline AtomString StringView::toExistingAtomString() const

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -3515,7 +3515,7 @@ private:
             if ((end - ptr) < static_cast<int>(length))
                 return false;
             if (shouldAtomize == ShouldAtomize::Yes)
-                str = AtomString { ptr, length };
+                str = AtomString({ ptr, length });
             else
                 str = String({ ptr, length });
             ptr += length;
@@ -3528,7 +3528,7 @@ private:
 
 #if ASSUME_LITTLE_ENDIAN
         if (shouldAtomize == ShouldAtomize::Yes)
-            str = AtomString(reinterpret_cast<const UChar*>(ptr), length);
+            str = AtomString({ reinterpret_cast<const UChar*>(ptr), length });
         else
             str = String({ reinterpret_cast<const UChar*>(ptr), length });
         ptr += length * sizeof(UChar);

--- a/Source/WebCore/dom/DatasetDOMStringMap.cpp
+++ b/Source/WebCore/dom/DatasetDOMStringMap.cpp
@@ -102,7 +102,7 @@ static inline AtomString convertPropertyNameToAttributeName(const StringImpl& na
         } else
             buffer.append(character);
     }
-    return AtomString(buffer.data(), buffer.size());
+    return AtomString(buffer.span());
 }
 
 static AtomString convertPropertyNameToAttributeName(const String& name)

--- a/Source/WebCore/html/parser/AtomHTMLToken.h
+++ b/Source/WebCore/html/parser/AtomHTMLToken.h
@@ -253,7 +253,7 @@ inline AtomHTMLToken::AtomHTMLToken(HTMLToken& token)
         if (LIKELY(token.name().size() == 4 && equal(HTMLNames::htmlTag->localName().impl(), token.name().data(), 4)))
             m_name = HTMLNames::htmlTag->localName();
         else
-            m_name = AtomString(token.name().data(), token.name().size());
+            m_name = AtomString(token.name().span());
         m_doctypeData = token.releaseDoctypeData();
         return;
     case Type::EndOfFile:
@@ -263,7 +263,7 @@ inline AtomHTMLToken::AtomHTMLToken(HTMLToken& token)
         m_selfClosing = token.selfClosing();
         m_tagName = findTagName(token.name());
         if (UNLIKELY(m_tagName == TagName::Unknown))
-            m_name = AtomString(token.name().data(), token.name().size());
+            m_name = AtomString(token.name().span());
         initializeAttributes(token.attributes());
         return;
     case Type::Comment: {

--- a/Source/WebCore/html/parser/HTMLNameCache.h
+++ b/Source/WebCore/html/parser/HTMLNameCache.h
@@ -68,15 +68,12 @@ private:
         if (string.empty())
             return emptyAtom();
 
-        auto length = string.size();
-        if (length > maxStringLengthForCache)
-            return AtomString(string.data(), length);
+        if (string.size() > maxStringLengthForCache)
+            return AtomString(string);
 
-        auto firstCharacter = string[0];
-        auto lastCharacter = string[length - 1];
-        auto& slot = atomStringCacheSlot(firstCharacter, lastCharacter, length);
-        if (!equal(slot.impl(), string.data(), length)) {
-            AtomString result(string.data(), length);
+        auto& slot = atomStringCacheSlot(string.front(), string.back(), string.size());
+        if (!equal(slot.impl(), string.data(), string.size())) {
+            AtomString result { string };
             slot = result;
             return result;
         }
@@ -90,15 +87,12 @@ private:
         if (string.empty())
             return nullQName();
 
-        auto length = string.size();
-        if (length > maxStringLengthForCache)
-            return QualifiedName(nullAtom(), AtomString(string.data(), length), nullAtom());
+        if (string.size() > maxStringLengthForCache)
+            return QualifiedName(nullAtom(), AtomString(string), nullAtom());
 
-        auto firstCharacter = string[0];
-        auto lastCharacter = string[length - 1];
-        auto& slot = qualifiedNameCacheSlot(firstCharacter, lastCharacter, length);
-        if (!slot || !equal(slot->m_localName.impl(), string.data(), length)) {
-            QualifiedName result(nullAtom(), AtomString(string.data(), length), nullAtom());
+        auto& slot = qualifiedNameCacheSlot(string.front(), string.back(), string.size());
+        if (!slot || !equal(slot->m_localName.impl(), string.data(), string.size())) {
+            QualifiedName result(nullAtom(), AtomString(string), nullAtom());
             slot = result.impl();
             return result;
         }

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -505,10 +505,10 @@ TextDirection TextUtil::directionForTextContent(StringView content)
 TextRun TextUtil::ellipsisTextRun(bool isHorizontal)
 {
     if (isHorizontal) {
-        static MainThreadNeverDestroyed<const AtomString> horizontalEllipsisStr(&horizontalEllipsis, 1);
+        static MainThreadNeverDestroyed<const AtomString> horizontalEllipsisStr(span(horizontalEllipsis));
         return TextRun { horizontalEllipsisStr->string() };
     }
-    static MainThreadNeverDestroyed<const AtomString> verticalEllipsisStr(&verticalEllipsis, 1);
+    static MainThreadNeverDestroyed<const AtomString> verticalEllipsisStr(span(verticalEllipsis));
     return TextRun { verticalEllipsisStr->string() };
 }
 

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -1054,15 +1054,15 @@ bool ApplicationCacheStorage::storeNewestCache(ApplicationCacheGroup& group)
 }
 
 template<typename CharacterType>
-static inline void parseHeader(const CharacterType* header, unsigned headerLength, ResourceResponse& response)
+static inline void parseHeader(std::span<const CharacterType> header, ResourceResponse& response)
 {
-    ASSERT(WTF::find(header, headerLength, ':') != notFound);
-    unsigned colonPosition = WTF::find(header, headerLength, ':');
+    ASSERT(WTF::find(header.data(), header.size(), ':') != notFound);
+    unsigned colonPosition = WTF::find(header.data(), header.size(), ':');
 
     // Save memory by putting the header names into atom strings so each is stored only once,
     // even though the setHTTPHeaderField function does not require an atom string.
-    AtomString headerName { header, colonPosition };
-    String headerValue({ header + colonPosition + 1, headerLength - colonPosition - 1 });
+    AtomString headerName { header.first(colonPosition) };
+    String headerValue(header.subspan(colonPosition + 1));
 
     response.setHTTPHeaderField(headerName, headerValue);
 }
@@ -1075,18 +1075,18 @@ static inline void parseHeaders(const String& headers, ResourceResponse& respons
         ASSERT(startPos != endPos);
 
         if (headers.is8Bit())
-            parseHeader(headers.characters8() + startPos, endPos - startPos, response);
+            parseHeader(headers.span8().subspan(startPos, endPos - startPos), response);
         else
-            parseHeader(headers.characters16() + startPos, endPos - startPos, response);
+            parseHeader(headers.span16().subspan(startPos, endPos - startPos), response);
         
         startPos = endPos + 1;
     }
     
     if (startPos != headers.length()) {
         if (headers.is8Bit())
-            parseHeader(headers.characters8(), headers.length(), response);
+            parseHeader(headers.span8(), response);
         else
-            parseHeader(headers.characters16(), headers.length(), response);
+            parseHeader(headers.span16(), response);
     }
 }
     

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -379,7 +379,7 @@ void EventSource::parseEventStreamLine(unsigned position, std::optional<unsigned
         m_data.append(m_receiveBuffer.subspan(position, valueLength));
         m_data.append('\n');
     } else if (field == "event"_s)
-        m_eventName = { &m_receiveBuffer[position], valueLength };
+        m_eventName = m_receiveBuffer.subspan(position, valueLength);
     else if (field == "id"_s) {
         StringView parsedEventId = m_receiveBuffer.subspan(position, valueLength);
         constexpr UChar nullCharacter = '\0';

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -459,8 +459,7 @@ bool FontCache::useBackslashAsYenSignForFamily(const AtomString& family)
     if (m_familiesUsingBackslashAsYenSign.isEmpty()) {
         auto add = [&] (ASCIILiteral name, std::initializer_list<UChar> unicodeName) {
             m_familiesUsingBackslashAsYenSign.add(AtomString { name });
-            unsigned unicodeNameLength = unicodeName.size();
-            m_familiesUsingBackslashAsYenSign.add(AtomString { unicodeName.begin(), unicodeNameLength });
+            m_familiesUsingBackslashAsYenSign.add(AtomString({ unicodeName.begin(), unicodeName.size() }));
         };
         add("MS PGothic"_s, { 0xFF2D, 0xFF33, 0x0020, 0xFF30, 0x30B4, 0x30B7, 0x30C3, 0x30AF });
         add("MS PMincho"_s, { 0xFF2D, 0xFF33, 0x0020, 0xFF30, 0x660E, 0x671D });

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2578,8 +2578,8 @@ const AtomString& RenderStyle::hyphenString() const
         return hyphenationString;
 
     // FIXME: This should depend on locale.
-    static MainThreadNeverDestroyed<const AtomString> hyphenMinusString(&hyphenMinus, 1);
-    static MainThreadNeverDestroyed<const AtomString> hyphenString(&hyphen, 1);
+    static MainThreadNeverDestroyed<const AtomString> hyphenMinusString(span(hyphenMinus));
+    static MainThreadNeverDestroyed<const AtomString> hyphenString(span(hyphen));
     return fontCascade().primaryFont().glyphForCharacter(hyphen) ? hyphenString : hyphenMinusString;
 }
 
@@ -2591,28 +2591,28 @@ const AtomString& RenderStyle::textEmphasisMarkString() const
     case TextEmphasisMark::Custom:
         return textEmphasisCustomMark();
     case TextEmphasisMark::Dot: {
-        static MainThreadNeverDestroyed<const AtomString> filledDotString(&bullet, 1);
-        static MainThreadNeverDestroyed<const AtomString> openDotString(&whiteBullet, 1);
+        static MainThreadNeverDestroyed<const AtomString> filledDotString(span(bullet));
+        static MainThreadNeverDestroyed<const AtomString> openDotString(span(whiteBullet));
         return textEmphasisFill() == TextEmphasisFill::Filled ? filledDotString : openDotString;
     }
     case TextEmphasisMark::Circle: {
-        static MainThreadNeverDestroyed<const AtomString> filledCircleString(&blackCircle, 1);
-        static MainThreadNeverDestroyed<const AtomString> openCircleString(&whiteCircle, 1);
+        static MainThreadNeverDestroyed<const AtomString> filledCircleString(span(blackCircle));
+        static MainThreadNeverDestroyed<const AtomString> openCircleString(span(whiteCircle));
         return textEmphasisFill() == TextEmphasisFill::Filled ? filledCircleString : openCircleString;
     }
     case TextEmphasisMark::DoubleCircle: {
-        static MainThreadNeverDestroyed<const AtomString> filledDoubleCircleString(&fisheye, 1);
-        static MainThreadNeverDestroyed<const AtomString> openDoubleCircleString(&bullseye, 1);
+        static MainThreadNeverDestroyed<const AtomString> filledDoubleCircleString(span(fisheye));
+        static MainThreadNeverDestroyed<const AtomString> openDoubleCircleString(span(bullseye));
         return textEmphasisFill() == TextEmphasisFill::Filled ? filledDoubleCircleString : openDoubleCircleString;
     }
     case TextEmphasisMark::Triangle: {
-        static MainThreadNeverDestroyed<const AtomString> filledTriangleString(&blackUpPointingTriangle, 1);
-        static MainThreadNeverDestroyed<const AtomString> openTriangleString(&whiteUpPointingTriangle, 1);
+        static MainThreadNeverDestroyed<const AtomString> filledTriangleString(span(blackUpPointingTriangle));
+        static MainThreadNeverDestroyed<const AtomString> openTriangleString(span(whiteUpPointingTriangle));
         return textEmphasisFill() == TextEmphasisFill::Filled ? filledTriangleString : openTriangleString;
     }
     case TextEmphasisMark::Sesame: {
-        static MainThreadNeverDestroyed<const AtomString> filledSesameString(&sesameDot, 1);
-        static MainThreadNeverDestroyed<const AtomString> openSesameString(&whiteSesameDot, 1);
+        static MainThreadNeverDestroyed<const AtomString> filledSesameString(span(sesameDot));
+        static MainThreadNeverDestroyed<const AtomString> openSesameString(span(whiteSesameDot));
         return textEmphasisFill() == TextEmphasisFill::Filled ? filledSesameString : openSesameString;
     }
     case TextEmphasisMark::Auto:


### PR DESCRIPTION
#### 36f7876c579ec5bc800b2e01934a012ca35a6444
<pre>
Drop AtomString constructors that take in a raw pointer and a length
<a href="https://bugs.webkit.org/show_bug.cgi?id=272132">https://bugs.webkit.org/show_bug.cgi?id=272132</a>

Reviewed by Brent Fulgham.

Drop AtomString constructors that take in a raw pointer and a length, in favor
of the ones taking in a std::span.

* Source/JavaScriptCore/runtime/IntlDisplayNames.cpp:
(JSC::IntlDisplayNames::of const):
* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC::JSRopeString::resolveRopeToAtomString const):
* Source/WTF/wtf/text/AtomString.cpp:
(WTF::AtomString::convertASCIICase const):
* Source/WTF/wtf/text/AtomString.h:
* Source/WTF/wtf/text/StringConcatenate.h:
(WTF::tryMakeAtomStringFromAdapters):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::convertASCIILowercaseAtom):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::toAtomString const):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readString):
* Source/WebCore/dom/DatasetDOMStringMap.cpp:
(WebCore::convertPropertyNameToAttributeName):
* Source/WebCore/dom/SpaceSplitString.cpp:
(WebCore::TokenAtomStringInitializer::processToken):
* Source/WebCore/html/parser/AtomHTMLToken.h:
(WebCore::AtomHTMLToken::AtomHTMLToken):
* Source/WebCore/html/parser/HTMLNameCache.h:
(WebCore::HTMLNameCache::makeAtomString):
(WebCore::HTMLNameCache::makeQualifiedName):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::ellipsisTextRun):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::parseHeader):
(WebCore::parseHeaders):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::parseEventStreamLine):
* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::FontCache::useBackslashAsYenSignForFamily):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::hyphenString const):
(WebCore::RenderStyle::textEmphasisMarkString const):

Canonical link: <a href="https://commits.webkit.org/277064@main">https://commits.webkit.org/277064@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9261c29f816a149f299bf9cc831b577721d700b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42585 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30061 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23163 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40122 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19220 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41236 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4589 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/39791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51064 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46027 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-jsc") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45214 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44156 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53169 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6509 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22544 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10906 "Passed tests") | 
<!--EWS-Status-Bubble-End-->