### PR TITLE
Web Inspector: Dark Mode: Increase contrast in the graphics tab for @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/CollectionContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CollectionContentView.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +27,7 @@
 .content-view.collection {
     display: flex;
     flex-wrap: wrap;
-    overflow-y: auto !important;
+    overflow-y: auto;
 }
 
 .content-view.collection > .content-view {
@@ -46,4 +47,12 @@
     text-align: center;
     font-size: 13px;
     color: var(--text-color-gray-medium);
+}
+
+@media (prefers-color-scheme: dark) {
+    @media (prefers-contrast: more) {
+        .content-view.collection > .placeholder:not(.message-text-view) {
+            color: var(--text-color-light);
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/GraphicsOverviewContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/GraphicsOverviewContentView.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,7 +28,6 @@
     background-color: var(--background-color-content);
     overflow-y: auto;
     padding-bottom: var(--navigation-bar-height);
-    background-color: hsl(0, 0%, 90%);
 }
 
 .content-view.graphics-overview > section {
@@ -72,8 +72,10 @@
 }
 
 @media (prefers-color-scheme: dark) {
-    .content-view.graphics-overview {
-        background-color: hsl(0, 0%, 14%);
+    @media (prefers-contrast: more) {
+        .content-view.graphics-overview > section > .header {
+            border-bottom: 1px solid hsl(0, 0%, 80%);
+            border-top: 1px solid hsl(0, 0%, 80%);
+        }
     }
 }
-

--- a/Source/WebInspectorUI/UserInterface/Views/Variables.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Variables.css
@@ -37,6 +37,8 @@
     --text-color: black;
     --text-color-transparent: hsla(0, 0%, 0%, 0.4);
 
+    --text-color-light: hsl(0, 0%, 95%);
+
     --text-color-active: black;
 
     --text-color-secondary: hsl(0, 0%, 50%);


### PR DESCRIPTION
#### a70e754460e53dcbecdcd9b384b4bcccb31939fc
<pre>
Web Inspector: Dark Mode: Increase contrast in the graphics tab for @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)
<a href="https://bugs.webkit.org/show_bug.cgi?id=272133">https://bugs.webkit.org/show_bug.cgi?id=272133</a>

Reviewed by NOBODY (OOPS!).

Set placeholder color to var--text-color-light in CollectionContentView.css.
Lighten border-bottom and border-top in GraphicsOverviewContentView.css.
Delete second background-color in .content-view.graphics-overview in GraphicsOverviewContentView.css.
Create --text-color-light for light text in Variables.css.
Delete !important because it is not doing anything in CollectionContentView.css

* Source/WebInspectorUI/UserInterface/Views/CollectionContentView.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view.collection &gt; .placeholder:not(.message-text-view)):
* Source/WebInspectorUI/UserInterface/Views/GraphicsOverviewContentView.css:
(.content-view.graphics-overview):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view.graphics-overview &gt; section &gt; .header):
(@media (prefers-color-scheme: dark) .content-view.graphics-overview): Deleted.
* Source/WebInspectorUI/UserInterface/Views/Variables.css:
(:root):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a70e754460e53dcbecdcd9b384b4bcccb31939fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50003 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43401 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38555 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19875 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21511 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41973 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5396 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43700 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51912 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22383 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18722 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45851 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23657 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44879 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24443 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23376 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->