### PR TITLE
run-benchmark should set COEP and COOP headers

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/builtin_http_server.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/builtin_http_server.py
@@ -37,6 +37,11 @@ class Handler(SimpleHTTPRequestHandler):
         self.end_headers()
         self.server_shutdown()
 
+    def end_headers(self):
+        self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
+        self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
+        super().end_headers()
+
     def do_POST(self):
         report_path = self.web_root + '/report'
         if not self.translate_path(self.path).startswith(report_path):

--- a/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/twisted_http_server.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/twisted_http_server.py
@@ -36,6 +36,14 @@ class ServerControl(Resource):
         return 'OK'
 
 
+class StaticFileWithHeader(static.File):
+
+    def render_GET(self, request):
+        request.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
+        request.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
+        return super().render_GET(request)
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='python twisted_http_server.py web_root')
     parser.add_argument('web_root')
@@ -43,7 +51,7 @@ if __name__ == '__main__':
     parser.add_argument('--interface', default='')
     parser.add_argument('--log-path', default='/tmp/run-benchmark-http.log')
     args = parser.parse_args()
-    web_root = static.File(args.web_root)
+    web_root = StaticFileWithHeader(args.web_root)
     serverControl = ServerControl()
     web_root.putChild('shutdown'.encode('utf-8'), serverControl)
     web_root.putChild('report'.encode('utf-8'), serverControl)

--- a/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py
@@ -29,7 +29,7 @@ class SimpleHTTPServerDriver(HTTPServerDriver):
         self._ensure_http_server_dependencies()
 
     def serve(self, web_root):
-        _log.info('Launching an http server')
+        _log.info('Launching an {} http server'.format(self._server_type))
         http_server_file = 'http_server/{}_http_server.py'.format(self._server_type)
         http_server_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), http_server_file)
         extra_args = []


### PR DESCRIPTION
#### e22c33f16c0cd34de377ec9b76fbe50289090002
<pre>
run-benchmark should set COEP and COOP headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=272134">https://bugs.webkit.org/show_bug.cgi?id=272134</a>

Reviewed by Dewei Zhu.

Set the following headers to enable high precision performance.now()
Cross-Origin-Embedder-Policy: require-corp
Cross-Origin-Opener-Policy: same-origin

* Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/builtin_http_server.py:
(Handler.end_headers):
* Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/http_server/twisted_http_server.py:
(StaticFileWithHeader):
(StaticFileWithHeader.render_GET):
* Tools/Scripts/webkitpy/benchmark_runner/http_server_driver/simple_http_server_driver.py:
(SimpleHTTPServerDriver.serve):

Canonical link: <a href="https://commits.webkit.org/287979@main">https://commits.webkit.org/287979@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d4c019bc5eed655f95ff89c1a2822bf15c5a23a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49210 "Built successfully") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37955 "Passed tests") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40116 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19213 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/46399 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20067 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41229 "Passed tests") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51051 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-2-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/17964 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45203 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44145 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/12639 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21539 "Built successfully") | [⏳ 🛠 mac-safer-cpp ](https://ews-build.webkit.org/#/builders/macOS-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22830 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23258 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22533 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->