### PR TITLE
Web Inspector: Dark Mode: Increase the contrast in the settings tab for @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/BlackboxSettingsView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/BlackboxSettingsView.css
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -111,4 +112,16 @@
     width: 15px;
     height: 15px;
     margin-inline-start: 4px;
+}
+
+@media (prefers-color-scheme: dark) {
+    @media (prefers-contrast: more) {
+        .settings-view.blackbox > table > tbody td.url {
+            background-color: var(--background-color-content);
+        }
+
+        .settings-view.blackbox > table > tbody td:not(.remove-blackbox) {
+            border: 1px solid hsl(0, 0%, 70%, 0.8);
+        }
+    }
 }

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.css
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016-2020 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
  * Copyright (C) 2016-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall <frances_c@cox.net>.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -157,4 +158,22 @@
 .content-view.tab.settings > .settings-view > .container.reference > a > .go-to-arrow {
     margin: 0;
     vertical-align: -0.25em;
+}
+
+@media (prefers-color-scheme: dark) {
+    @media (prefers-contrast: more) {
+        .content-view.tab.settings > .settings-view > .container.reference > a {
+            color: hsl(0, 0%, 95%);
+        }
+
+        .content-view.tab.settings > .settings-view {
+            --background-color-content: hsl(0, 0%, 14%);
+            background-color: var(--background-color-content);
+        }
+
+        .content-view.tab.settings .navigation-bar {
+            --background-color-content: hsl(0, 0%, 17%);
+            background-color: var(--background-color-content);
+        }
+    }
 }


### PR DESCRIPTION
#### 6ece8504f30afbc5bad7a9840f96ca07b157d820
<pre>
Web Inspector: Dark Mode: Increase the contrast in the settings tab for @media (prefers-contrast: more) and @media (prefers-color-scheme: dark)
<a href="https://bugs.webkit.org/show_bug.cgi?id=272138">https://bugs.webkit.org/show_bug.cgi?id=272138</a>

Reviewed by NOBODY (OOPS!).

Lighten the border of the settings view blackbox in BlackboxSettingsView.ccss.
Darken the background of the settings view blackbox in BlackboxSettingsView.css.
Add background-color content to the background of the settings view blackbox in BlackboxSettingsView.css.
Lighten the container reference text color in SettingsTabContentView.css.
Darken the background color of the navigation bar and the settings view in SettingsTabContentView.css.

* Source/WebInspectorUI/UserInterface/Views/BlackboxSettingsView.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .settings-view.blackbox &gt; table &gt; tbody td.url):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .settings-view.blackbox &gt; table &gt; tbody td:not(.remove-blackbox)):
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.css:
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view.tab.settings &gt; .settings-view &gt; .container.reference &gt; a):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view.tab.settings &gt; .settings-view):
(@media (prefers-color-scheme: dark) @media (prefers-contrast: more) .content-view.tab.settings .navigation-bar):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ece8504f30afbc5bad7a9840f96ca07b157d820

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/31812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/4901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/55753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3202 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/2901 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42660 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2046 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/54576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29511 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/23749 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/26684 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2563 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1361 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/2714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57349 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/27608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/2746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50044 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/28839 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49298 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/29750 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/28586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->