### PR TITLE
Expose more type metadata to IPC test API

### DIFF
--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in
@@ -332,3 +332,5 @@ header: <WebCore/WebGPUTextureUsage.h>
 };
 
 using WebCore::WebGPU::TextureUsageFlags = OptionSet<WebCore::WebGPU::TextureUsage>;
+
+using WebCore::WebGPU::BufferUsageFlags = uint16_t

--- a/Source/WebCore/Modules/notifications/NotificationDirection.h
+++ b/Source/WebCore/Modules/notifications/NotificationDirection.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class NotificationDirection : uint8_t {
@@ -35,17 +33,11 @@ enum class NotificationDirection : uint8_t {
     Rtl
 };
 
+static inline bool isValidNotificationDirection(uint8_t value)
+{
+    return value == static_cast<uint8_t>(NotificationDirection::Auto)
+        || value == static_cast<uint8_t>(NotificationDirection::Ltr)
+        || value == static_cast<uint8_t>(NotificationDirection::Rtl);
+}
+
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::NotificationDirection> {
-    using values = EnumValues<
-        WebCore::NotificationDirection,
-        WebCore::NotificationDirection::Auto,
-        WebCore::NotificationDirection::Ltr,
-        WebCore::NotificationDirection::Rtl
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebCore/Modules/notifications/NotificationOptionsPayloadCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationOptionsPayloadCocoa.mm
@@ -48,7 +48,7 @@ std::optional<NotificationOptionsPayload> NotificationOptionsPayload::fromDictio
         return std::nullopt;
 
     auto dirValue = [dir unsignedCharValue];
-    if (!isValidEnum<NotificationDirection>(dirValue))
+    if (!isValidNotificationDirection(dirValue))
         return std::nullopt;
     auto rawDir = (NotificationDirection)dirValue;
 

--- a/Source/WebCore/svg/SVGUnitTypes.h
+++ b/Source/WebCore/svg/SVGUnitTypes.h
@@ -26,7 +26,7 @@ namespace WebCore {
 
 class SVGUnitTypes final : public RefCounted<SVGUnitTypes> {
 public:
-    enum SVGUnitType {
+    enum SVGUnitType : uint8_t {
         SVG_UNIT_TYPE_UNKNOWN               = 0,
         SVG_UNIT_TYPE_USERSPACEONUSE        = 1,
         SVG_UNIT_TYPE_OBJECTBOUNDINGBOX     = 2
@@ -66,17 +66,3 @@ struct SVGPropertyTraits<SVGUnitTypes::SVGUnitType> {
 };
 
 } // namespace WebCore
-
-namespace WTF {
-
-template<> struct EnumTraits<WebCore::SVGUnitTypes::SVGUnitType> {
-    using values = EnumValues<
-        WebCore::SVGUnitTypes::SVGUnitType,
-
-        WebCore::SVGUnitTypes::SVG_UNIT_TYPE_UNKNOWN,
-        WebCore::SVGUnitTypes::SVG_UNIT_TYPE_USERSPACEONUSE,
-        WebCore::SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX
-    >;
-};
-
-} // namespace WTF

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -23,14 +23,14 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> GPUConnectionToWebProcess WantsDispatchMessage {
-    void CreateRenderingBackend(struct WebKit::RemoteRenderingBackendCreationParameters creationParameters, IPC::StreamServerConnection::Handle connectionHandle) AllowedWhenWaitingForSyncReply
+    void CreateRenderingBackend(struct WebKit::RemoteRenderingBackendCreationParameters creationParameters, IPC::StreamServerConnectionHandle connectionHandle) AllowedWhenWaitingForSyncReply
     void ReleaseRenderingBackend(WebKit::RenderingBackendIdentifier renderingBackendIdentifier) AllowedWhenWaitingForSyncReply
     void ReleaseSerializedImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer)
 #if ENABLE(WEBGL)
-    [EnabledIf='isWebGLEnabled()'] void CreateGraphicsContextGL(struct WebCore::GraphicsContextGLAttributes attributes, WebKit::GraphicsContextGLIdentifier graphicsContextGLIdentifier, WebKit::RenderingBackendIdentifier renderingBackendIdentifier, IPC::StreamServerConnection::Handle serverConnection) AllowedWhenWaitingForSyncReply
+    [EnabledIf='isWebGLEnabled()'] void CreateGraphicsContextGL(struct WebCore::GraphicsContextGLAttributes attributes, WebKit::GraphicsContextGLIdentifier graphicsContextGLIdentifier, WebKit::RenderingBackendIdentifier renderingBackendIdentifier, IPC::StreamServerConnectionHandle serverConnection) AllowedWhenWaitingForSyncReply
     [EnabledIf='isWebGLEnabled()'] void ReleaseGraphicsContextGL(WebKit::GraphicsContextGLIdentifier graphicsContextGLIdentifier) AllowedWhenWaitingForSyncReply
 #endif
-    [EnabledIf='isWebGPUEnabled()'] void CreateRemoteGPU(WebKit::WebGPUIdentifier identifier, WebKit::RenderingBackendIdentifier renderingBackendIdentifier, IPC::StreamServerConnection::Handle serverConnection) AllowedWhenWaitingForSyncReply
+    [EnabledIf='isWebGPUEnabled()'] void CreateRemoteGPU(WebKit::WebGPUIdentifier identifier, WebKit::RenderingBackendIdentifier renderingBackendIdentifier, IPC::StreamServerConnectionHandle serverConnection) AllowedWhenWaitingForSyncReply
     [EnabledIf='isWebGPUEnabled()'] void ReleaseRemoteGPU(WebKit::WebGPUIdentifier identifier) AllowedWhenWaitingForSyncReply
     void ClearNowPlayingInfo()
     void SetNowPlayingInfo(struct WebCore::NowPlayingInfo nowPlayingInfo)

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -25,7 +25,7 @@
 messages -> GPUProcess LegacyReceiver {
     InitializeGPUProcess(struct WebKit::GPUProcessCreationParameters processCreationParameters)
 
-    CreateGPUConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, IPC::Connection::Handle connectionHandle, struct WebKit::GPUProcessConnectionParameters parameters) -> () AllowedWhenWaitingForSyncReply
+    CreateGPUConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, IPC::ConnectionHandle connectionHandle, struct WebKit::GPUProcessConnectionParameters parameters) -> () AllowedWhenWaitingForSyncReply
     UpdateGPUProcessPreferences(struct WebKit::GPUProcessPreferences preferences)
     UpdateSandboxAccess(Vector<WebKit::SandboxExtensionHandle> extensions);
 

--- a/Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in
+++ b/Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in
@@ -119,4 +119,4 @@ header: <WebCore/PathSegment.h>
     WebCore::PathSegment::Data data();
 };
 
-using WebCore::PathSegment::Data = std::variant<WebCore::PathMoveTo, WebCore::PathLineTo, WebCore::PathQuadCurveTo, WebCore::PathBezierCurveTo, WebCore::PathArcTo, WebCore::PathArc, WebCore::PathClosedArc, WebCore::PathEllipse, WebCore::PathEllipseInRect, WebCore::PathRect, WebCore::PathRoundedRect, WebCore::PathDataLine, WebCore::PathDataQuadCurve, WebCore::PathDataBezierCurve, WebCore::PathDataArc, WebCore::PathCloseSubpath >;
+using WebCore::PathSegment::Data = std::variant<WebCore::PathMoveTo, WebCore::PathLineTo, WebCore::PathQuadCurveTo, WebCore::PathBezierCurveTo, WebCore::PathArcTo, WebCore::PathArc, WebCore::PathClosedArc, WebCore::PathEllipse, WebCore::PathEllipseInRect, WebCore::PathRect, WebCore::PathRoundedRect, WebCore::PathDataLine, WebCore::PathDataQuadCurve, WebCore::PathDataBezierCurve, WebCore::PathDataArc, WebCore::PathCloseSubpath>;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.messages.in
@@ -27,7 +27,7 @@
 
 messages -> RemoteCDMInstanceSessionProxy NotRefCounted {
     SetLogIdentifier(uint64_t logIdentifier)
-    RequestLicense(WebCore::CDMInstanceSession::LicenseType type, WebCore::CDMInstanceSession::KeyGroupingStrategy keyGroupingStrategy, AtomString initDataType, RefPtr<WebCore::SharedBuffer> initData) -> (RefPtr<WebCore::SharedBuffer> message, String sessionId, bool needsIndividualization, bool succeeded)
+    RequestLicense(WebCore::CDMInstanceSession::LicenseType type, enum:bool WebCore::CDMKeyGroupingStrategy keyGroupingStrategy, AtomString initDataType, RefPtr<WebCore::SharedBuffer> initData) -> (RefPtr<WebCore::SharedBuffer> message, String sessionId, bool needsIndividualization, bool succeeded)
     UpdateLicense(String sessionId, WebCore::CDMInstanceSession::LicenseType type, RefPtr<WebCore::SharedBuffer> response) -> (bool sessionWasClosed, std::optional<WebCore::CDMInstanceSession::KeyStatusVector> changedKeys, std::optional<double> changedExpiration, std::optional<WebCore::CDMInstanceSession::Message> message, bool succeeded)
     LoadSession(WebCore::CDMInstanceSession::LicenseType type, String sessionId, String origin) -> (std::optional<WebCore::CDMInstanceSession::KeyStatusVector> changedKeys, std::optional<double> changedExpiration, std::optional<WebCore::CDMInstanceSession::Message> message, bool succeeded, enum:uint8_t WebCore::CDMInstanceSession::SessionLoadFailure loadFailure)
     CloseSession(String sessionId) -> ()

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in
@@ -31,7 +31,7 @@ messages -> RemoteMediaSourceProxy NotRefCounted {
     BufferedChanged(WebCore::PlatformTimeRanges buffered)
     SetMediaPlayerReadyState(enum:uint8_t WebCore::MediaPlayerReadyState readyState)
     SetTimeFudgeFactor(MediaTime fudgeFactor)
-    MarkEndOfStream(WebCore::MediaSourcePrivate::EndOfStreamStatus status)
+    MarkEndOfStream(enum:uint8_t WebCore::MediaSourcePrivateEndOfStreamStatus status)
     UnmarkEndOfStream()
 }
 

--- a/Source/WebKit/ModelProcess/ModelProcess.messages.in
+++ b/Source/WebKit/ModelProcess/ModelProcess.messages.in
@@ -25,7 +25,7 @@
 messages -> ModelProcess LegacyReceiver {
     InitializeModelProcess(struct WebKit::ModelProcessCreationParameters processCreationParameters)
 
-    CreateModelConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, IPC::Connection::Handle connectionHandle, struct WebKit::ModelProcessConnectionParameters parameters) -> () AllowedWhenWaitingForSyncReply
+    CreateModelConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, IPC::ConnectionHandle connectionHandle, struct WebKit::ModelProcessConnectionParameters parameters) -> () AllowedWhenWaitingForSyncReply
 
     PrepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime) -> ()
     ProcessDidResume()

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -23,7 +23,7 @@
 messages -> NetworkProcess LegacyReceiver {
     InitializeNetworkProcess(struct WebKit::NetworkProcessCreationParameters processCreationParameters) -> ()
 
-    CreateNetworkConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, struct WebKit::NetworkProcessConnectionParameters parameters) -> (std::optional<IPC::Connection::Handle> connectionHandle, enum:uint8_t WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy) AllowedWhenWaitingForSyncReply
+    CreateNetworkConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, struct WebKit::NetworkProcessConnectionParameters parameters) -> (std::optional<IPC::ConnectionHandle> connectionHandle, enum:uint8_t WebCore::HTTPCookieAcceptPolicy cookieAcceptPolicy) AllowedWhenWaitingForSyncReply
 
     AddAllowedFirstPartyForCookies(WebCore::ProcessIdentifier processIdentifier, WebCore::RegistrableDomain firstPartyForCookies, enum:bool WebKit::LoadedWebArchive loadedWebArchive) -> ()
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -137,9 +137,9 @@ def surround_in_condition(string, condition):
 
 def types_that_must_be_moved():
     return [
-        'IPC::Connection::Handle',
+        'IPC::ConnectionHandle',
         'IPC::Signal',
-        'IPC::StreamServerConnection::Handle',
+        'IPC::StreamServerConnectionHandle',
         'MachSendRight',
         'std::optional<WebKit::SharedVideoFrame>',
         'Vector<WebCore::SharedMemory::Handle>',
@@ -777,6 +777,7 @@ def headers_for_type(type):
         'IPC::AsyncReplyID': ['"Connection.h"'],
         'IPC::Signal': ['"IPCEvent.h"'],
         'IPC::Semaphore': ['"IPCSemaphore.h"'],
+        'IPC::StreamServerConnectionHandle': ['"StreamServerConnection.h"'],
         'JSC::MessageLevel': ['<JavaScriptCore/ConsoleTypes.h>'],
         'JSC::MessageSource': ['<JavaScriptCore/ConsoleTypes.h>'],
         'MachSendRight': ['<wtf/MachSendRight.h>'],
@@ -878,6 +879,7 @@ def headers_for_type(type):
         'WebCore::MediaProducerMutedState': ['<WebCore/MediaProducer.h>'],
         'WebCore::MediaPromise::Result': ['<WebCore/MediaPromiseTypes.h>'],
         'WebCore::MediaSettingsRange': ['<WebCore/MediaSettingsRange.h>'],
+        'WebCore::MediaSourcePrivateEndOfStreamStatus': ['<WebCore/MediaSourcePrivate.h>'],
         'WebCore::MessagePortChannelProvider::HasActivity': ['<WebCore/MessagePortChannelProvider.h>'],
         'WebCore::ModalContainerControlType': ['<WebCore/ModalContainerTypes.h>'],
         'WebCore::ModalContainerDecision': ['<WebCore/ModalContainerTypes.h>'],
@@ -897,6 +899,7 @@ def headers_for_type(type):
         'WebCore::PixelFormat': ['<WebCore/ImageBufferBackend.h>'],
         'WebCore::PhotoCapabilitiesOrError': ['<WebCore/RealtimeMediaSource.h>'],
         'WebCore::PlatformTextTrackData': ['<WebCore/PlatformTextTrack.h>'],
+        'WebCore::PlatformEventModifier': ['<WebCore/PlatformEvent.h>'],
         'WebCore::PlatformWheelEventPhase': ['<WebCore/PlatformWheelEvent.h>'],
         'WebCore::PlaybackSessionModelPlaybackState': ['<WebCore/PlaybackSessionModel.h>'],
         'WebCore::PluginInfo': ['<WebCore/PluginData.h>'],

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -1070,7 +1070,7 @@ std::optional<Vector<ArgumentDescription>> messageArgumentDescriptions(MessageNa
 #endif
     case MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection:
         return Vector<ArgumentDescription> {
-            { "handle", "IPC::StreamServerConnection::Handle", nullptr, false },
+            { "handle", "IPC::StreamServerConnectionHandle", nullptr, false },
         };
     case MessageName::TestWithEnabledIf_AlwaysEnabled:
         return Vector<ArgumentDescription> {

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandle.messages.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandle.messages.in
@@ -22,5 +22,5 @@
 
 # Tests Stream receiver attribute.
 messages -> TestWithStreamServerConnectionHandle  {
-    void SendStreamServerConnection(IPC::StreamServerConnection::Handle handle)
+    void SendStreamServerConnection(IPC::StreamServerConnectionHandle handle)
 }

--- a/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessages.h
+++ b/Source/WebKit/Scripts/webkit/tests/TestWithStreamServerConnectionHandleMessages.h
@@ -42,14 +42,14 @@ static inline IPC::ReceiverName messageReceiverName()
 
 class SendStreamServerConnection {
 public:
-    using Arguments = std::tuple<IPC::StreamServerConnection::Handle>;
+    using Arguments = std::tuple<IPC::StreamServerConnectionHandle>;
 
     static IPC::MessageName name() { return IPC::MessageName::TestWithStreamServerConnectionHandle_SendStreamServerConnection; }
     static constexpr bool isSync = false;
     static constexpr bool canDispatchOutOfOrder = false;
     static constexpr bool replyCanDispatchOutOfOrder = false;
 
-    explicit SendStreamServerConnection(IPC::StreamServerConnection::Handle&& handle)
+    explicit SendStreamServerConnection(IPC::StreamServerConnectionHandle&& handle)
         : m_arguments(WTFMove(handle))
     {
     }
@@ -60,7 +60,7 @@ public:
     }
 
 private:
-    std::tuple<IPC::StreamServerConnection::Handle&&> m_arguments;
+    std::tuple<IPC::StreamServerConnectionHandle&&> m_arguments;
 };
 
 } // namespace TestWithStreamServerConnectionHandle

--- a/Source/WebKit/Shared/ContextMenuContextData.serialization.in
+++ b/Source/WebKit/Shared/ContextMenuContextData.serialization.in
@@ -23,7 +23,7 @@
 #if ENABLE(CONTEXT_MENUS)
 
 class WebKit::ContextMenuContextData {
-    WebCore::ContextMenuContext::Type type();
+    WebCore::ContextMenuContextType type();
     WebCore::IntPoint menuLocation();
     Vector<WebKit::WebContextMenuItemData> menuItems();
     std::optional<WebKit::WebHitTestResultData> webHitTestResultData();

--- a/Source/WebKit/Shared/IPCTester.messages.in
+++ b/Source/WebKit/Shared/IPCTester.messages.in
@@ -25,10 +25,10 @@
 messages -> IPCTester NotRefCounted {
     StartMessageTesting(String driverName)
     StopMessageTesting() -> () Synchronous
-    CreateStreamTester(WebKit::IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle serverConnection)
+    CreateStreamTester(WebKit::IPCStreamTesterIdentifier identifier, IPC::StreamServerConnectionHandle serverConnection)
     ReleaseStreamTester(WebKit::IPCStreamTesterIdentifier identifier) -> () Synchronous
-    CreateConnectionTester(WebKit::IPCConnectionTesterIdentifier identifier, IPC::Connection::Handle connection)
-    CreateConnectionTesterAndSendAsyncMessages(WebKit::IPCConnectionTesterIdentifier identifier, IPC::Connection::Handle connection, uint32_t messageCount)
+    CreateConnectionTester(WebKit::IPCConnectionTesterIdentifier identifier, IPC::ConnectionHandle connection)
+    CreateConnectionTesterAndSendAsyncMessages(WebKit::IPCConnectionTesterIdentifier identifier, IPC::ConnectionHandle connection, uint32_t messageCount)
     ReleaseConnectionTester(WebKit::IPCConnectionTesterIdentifier identifier) -> () Synchronous
 
     SendSameSemaphoreBack(IPC::Semaphore semaphore)

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -230,3 +230,5 @@ enum class WTFLogLevel : uint8_t {
     Info,
     Debug
 };
+
+using FileSystem::Salt = std::array<uint8_t, 8>;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2846,7 +2846,7 @@ class WebCore::TransformOperations {
 
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::SourceBrush {
     WebCore::Color color();
-    WebCore::SourceBrush::OptionalPatternGradient patternGradient();
+    std::variant<std::monostate, WebCore::SourceBrushLogicalGradient, Ref<WebCore::Pattern>> patternGradient();
 }
 
 header: <WebCore/ThreadSafeDataBuffer.h>
@@ -4107,6 +4107,7 @@ enum class WebCore::CDMSessionType : uint8_t {
 };
 using WebCore::CDMInstanceSession::LicenseType = WebCore::CDMSessionType;
 using WebCore::CDMInstanceSession::Message = std::pair<WebCore::CDMMessageType, Ref<WebCore::SharedBuffer>>
+using WebCore::CDMInstanceSession::KeyStatusVector = Vector<std::pair<Ref<WebCore::SharedBuffer>, WebCore::CDMKeyStatus>>;
 
 struct WebCore::CDMRestrictions {
     bool distinctiveIdentifierDenied;
@@ -4727,11 +4728,14 @@ header: <WebCore/GraphicsTypes.h>
     DictationAlternatives
 };
 
-header: <WebCore/GraphicsTypes.h>
 [CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::DocumentMarkerLineStyle {
     WebCore::DocumentMarkerLineStyleMode mode;
     WebCore::Color color;
 };
+
+header: <WebCore/GraphicsTypesGL.h>
+using PlatformGLObject = GCGLuint
+using GCGLuint = unsigned
 
 [Nested, AdditionalEncoder=StreamConnectionEncoder]  enum class WebCore::ShadowRadiusMode : bool;
 
@@ -8040,4 +8044,26 @@ enum class WebCore::PlatformMediaError : uint8_t {
     DecoderCreationError,
     NotSupportedError,
     NetworkError,
+};
+
+#if USE(CG)
+using WebCore::DashArray = Vector<CGFloat>;
+#endif
+#if USE(CAIRO)
+using WebCore::DashArray = Vector<double>;
+#endif
+#if !USE(CG) && !USE(CAIRO)
+using WebCore::DashArray = Vector<float>;
+#endif
+
+[WebKitPlatform] enum class WebCore::NotificationDirection : uint8_t {
+    Auto,
+    Ltr,
+    Rtl
+};
+
+[Nested] enum class WebCore::SVGUnitTypes::SVGUnitType : uint8_t {
+    SVG_UNIT_TYPE_UNKNOWN
+    SVG_UNIT_TYPE_USERSPACEONUSE
+    SVG_UNIT_TYPE_OBJECTBOUNDINGBOX
 };

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.messages.in
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.messages.in
@@ -22,7 +22,7 @@
 
 messages -> WebInspectorUIProxy {
     OpenLocalInspectorFrontend(bool canAttach, bool underTest)
-    SetFrontendConnection(IPC::Connection::Handle connectionHandle)
+    SetFrontendConnection(IPC::ConnectionHandle connectionHandle)
 
     SendMessageToBackend(String message)
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -34,11 +34,11 @@ messages -> WebProcessProxy LegacyReceiver {
     GetNetworkProcessConnection() -> (struct WebKit::NetworkProcessConnectionInfo connectionInfo) Synchronous
 
 #if ENABLE(GPU_PROCESS)
-    CreateGPUProcessConnection(IPC::Connection::Handle connectionHandle, struct WebKit::GPUProcessConnectionParameters parameters) AllowedWhenWaitingForSyncReply
+    CreateGPUProcessConnection(IPC::ConnectionHandle connectionHandle, struct WebKit::GPUProcessConnectionParameters parameters) AllowedWhenWaitingForSyncReply
 #endif
 
 #if ENABLE(MODEL_PROCESS)
-    CreateModelProcessConnection(IPC::Connection::Handle connectionIdentifier, struct WebKit::ModelProcessConnectionParameters parameters) AllowedWhenWaitingForSyncReply
+    CreateModelProcessConnection(IPC::ConnectionHandle connectionIdentifier, struct WebKit::ModelProcessConnectionParameters parameters) AllowedWhenWaitingForSyncReply
 #endif
 
     SetIsHoldingLockedFiles(bool isHoldingLockedFiles)

--- a/Source/WebKit/WebProcess/Inspector/WebInspector.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspector.messages.in
@@ -37,5 +37,5 @@ messages -> WebInspector {
     StartElementSelection()
     StopElementSelection()
 
-    SetFrontendConnection(IPC::Connection::Handle connectionHandle)
+    SetFrontendConnection(IPC::ConnectionHandle connectionHandle)
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -660,7 +660,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     OpenPDFWithPreview(WebKit::PDFPluginIdentifier identifier) -> (String filename, struct WebKit::FrameInfoData frameInfo, std::span<const uint8_t> data, String uuid)
 #endif
 
-    UpdateCurrentModifierState(OptionSet<WebCore::PlatformEvent::Modifier> modifiers)
+    UpdateCurrentModifierState(OptionSet<WebCore::PlatformEventModifier> modifiers)
     SimulateDeviceOrientationChange(double alpha, double beta, double gamma)
 
 #if ENABLE(SPEECH_SYNTHESIS)
@@ -689,7 +689,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #endif
 
     StartTextManipulations(Vector<WebCore::TextManipulationControllerExclusionRule> exclusionRules, bool includeSubframes) -> ()
-    CompleteTextManipulation(Vector<WebCore::TextManipulationItem> items) -> (bool allFailed, Vector<WebCore::TextManipulationController::ManipulationFailure> failures)
+    CompleteTextManipulation(Vector<WebCore::TextManipulationItem> items) -> (bool allFailed, Vector<WebCore::TextManipulationControllerManipulationFailure> failures)
 
     SetOverriddenMediaType(String mediaType)
     GetProcessDisplayName() -> (String displayName)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -604,7 +604,7 @@ TEST(IPCTestingAPI, SerializedTypeInfo)
     NSDictionary *expectedMouseEventButtonDictionary = @{
         @"isOptionSet" : @NO,
         @"size" : @1,
-        @"validValues" : @[@1, @2, @254]
+        @"validValues" : @[@0, @1, @2, @254]
     };
     EXPECT_TRUE([enumInfo[@"WebKit::WebMouseEventButton"] isEqualToDictionary:expectedMouseEventButtonDictionary]);
 
@@ -679,7 +679,7 @@ TEST(IPCTestingAPI, SerializedTypeInfo)
 
     [typesNeedingDescriptions minusSet:typesHavingDescriptions];
     [typesNeedingDescriptions minusSet:fundamentalTypes];
-    EXPECT_LT(typesNeedingDescriptions.count, 50u); // FIXME: This should eventually be 0.
+    EXPECT_LT(typesNeedingDescriptions.count, 35u); // FIXME: This should eventually be 0.
 
     for (NSString *type in typesNeedingDescriptions) {
         // These are the last two types in the WebKit namespace with non-generated serializers.


### PR DESCRIPTION
#### 6aed9201ded09bfce33bd22143168e74786782c9
<pre>
Expose more type metadata to IPC test API
<a href="https://bugs.webkit.org/show_bug.cgi?id=272139">https://bugs.webkit.org/show_bug.cgi?id=272139</a>
<a href="https://rdar.apple.com/125891742">rdar://125891742</a>

Reviewed by Brady Eidson.

Also add the actually correct test expectations for the test I added in 276986@main
and has been failing since then.

* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.serialization.in:
* Source/WebCore/Modules/notifications/NotificationDirection.h:
(WebCore::isValidNotificationDirection):
* Source/WebCore/Modules/notifications/NotificationOptionsPayloadCocoa.mm:
(WebCore::NotificationOptionsPayload::fromDictionary):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/svg/SVGUnitTypes.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/GPUProcess/graphics/PathSegment.serialization.in:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.messages.in:
* Source/WebKit/ModelProcess/ModelProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_must_be_moved):
(headers_for_type):
* Source/WebKit/Shared/ContextMenuContextData.serialization.in:
* Source/WebKit/Shared/IPCTester.messages.in:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/WebProcess/Inspector/WebInspector.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
(SerializedTypeInfo)):

Canonical link: <a href="https://commits.webkit.org/277057@main">https://commits.webkit.org/277057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/342ba98fbb3b4ade51f471bbbd8f70daea05f9a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25748 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/49198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49268 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/42636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/48898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23210 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47170 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/49198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/19263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/46457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/49198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4636 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/49198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51117 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/49198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6505 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22591 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->