### PR TITLE
IPC Testing API: asynchronous stream messages with replies not working

### DIFF
--- a/LayoutTests/ipc/async-with-reply-expected.txt
+++ b/LayoutTests/ipc/async-with-reply-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that async messages can be sent and replies received
+

--- a/LayoutTests/ipc/async-with-reply.html
+++ b/LayoutTests/ipc/async-with-reply.html
@@ -1,0 +1,53 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>Test that async messages can be sent and replies received</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+async function runTest() {
+    const defaultTimeout = 1000;
+    const testerID = 0;
+    const IPCTester_AsyncPingName = IPC.messages.IPCTester_AsyncPing.name;
+    const IPCTester_AsyncPingReplyName = IPC.messages.IPCTester_AsyncPingReply.name;
+
+    for (const processTarget of IPC.processTargets) {
+        // Test starts here.
+        let results = { };
+        let asyncReplyIDs = { };
+        const requestCount = 100;
+        let connection = IPC.connectionForProcessTarget(processTarget);
+        for (let request = 0; request < requestCount; ++request) {
+            asyncReplyIDs[request] = connection.sendWithAsyncReply(testerID, IPCTester_AsyncPingName, [{type: 'int32_t', value: request}], (message) => {
+                results[request] = message;
+            });
+            assert_greater_than(asyncReplyIDs[request], 0, "asyncReplyID is valid");
+            if (request == 17)
+                await sleep(100); // Let some requests be fullfilled asynchronously and some are force-waited.
+        }
+        for (let request = 0; request < requestCount; ++request) {
+            if (typeof results[request] === "undefined")
+                connection.waitForAsyncReplyAndDispatchImmediately(asyncReplyIDs[request], IPCTester_AsyncPingReplyName, defaultTimeout);
+        }
+        for (let request = 0; request < requestCount; ++request) {
+            const subcase = `${processTarget} request:${request}`
+            const result = results[request];
+            assert_equals(typeof result, "object", subcase);
+            const firstReply = result.arguments[0];
+            assert_equals(firstReply.type, "uint32_t", subcase);
+            assert_equals(firstReply.value, request + 1, subcase);
+        }
+    }
+    done();
+}
+
+setup({ single_test: true });
+if (window.IPC)
+    runTest();
+else
+    done();
+
+</script>
+</body>

--- a/LayoutTests/ipc/stream-async-with-reply-expected.txt
+++ b/LayoutTests/ipc/stream-async-with-reply-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that async stream messages can be sent and replies received
+

--- a/LayoutTests/ipc/stream-async-with-reply.html
+++ b/LayoutTests/ipc/stream-async-with-reply.html
@@ -1,0 +1,66 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>Test that async stream messages can be sent and replies received</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<body>
+<script>
+function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+async function runTest() {
+    const defaultTimeout = 1000;
+    const bufferSizeLog2 = 9;
+    const streamTesterID = 447;
+    const IPCStreamTester_AsyncPingName = IPC.messages.IPCStreamTester_AsyncPing.name;
+    const IPCStreamTester_AsyncPingReplyName = IPC.messages.IPCStreamTester_AsyncPingReply.name;
+
+    for (const processTarget of IPC.processTargets) {
+        const [streamConnection, serverConnectionHandle] = IPC.createStreamClientConnection(bufferSizeLog2);
+        streamConnection.open();
+        IPC.sendMessage(processTarget, 0, IPC.messages.IPCTester_CreateStreamTester.name, [
+            { type: 'uint64_t', value: streamTesterID },
+            { type: 'StreamServerConnectionHandle', value: serverConnectionHandle },
+        ]);
+        const arguments = streamConnection.waitForMessage(streamTesterID, IPC.messages.IPCStreamTesterProxy_WasCreated.name, defaultTimeout);
+        streamConnection.setSemaphores(arguments[0].value, arguments[1].value);
+        // Test starts here.
+        try {
+            let results = { };
+            let asyncReplyIDs = { };
+            const requestCount = 100;
+            for (let request = 0; request < requestCount; ++request) {
+                asyncReplyIDs[request] = streamConnection.sendWithAsyncReply(streamTesterID, IPCStreamTester_AsyncPingName, defaultTimeout, [{type: 'uint32_t', value: request}], (message) => {
+                    results[request] = message;
+                });
+                assert_greater_than(asyncReplyIDs[request], 0, "asyncReplyID is valid");
+                if (request == 17)
+                    await sleep(100); // Let some requests be fullfilled asynchronously and some are force-waited.
+            }
+            for (let request = 0; request < requestCount; ++request) {
+                if (typeof results[request] === "undefined")
+                    streamConnection.waitForAsyncReplyAndDispatchImmediately(asyncReplyIDs[request], IPCStreamTester_AsyncPingReplyName, defaultTimeout);
+            }
+            for (let request = 0; request < requestCount; ++request) {
+                const subcase = `${processTarget} request:${request}`
+                const result = results[request];
+                assert_equals(typeof result, "object", subcase);
+                const firstReply = result.arguments[0];
+                assert_equals(firstReply.type, "uint32_t", subcase);
+                assert_equals(firstReply.value, request + 1, subcase);
+            }
+        } finally {
+            IPC.sendSyncMessage(processTarget, 0, IPC.messages.IPCTester_ReleaseStreamTester.name, defaultTimeout, [{ type: 'uint64_t', value: streamTesterID }]);
+            streamConnection.invalidate();
+        }
+    }
+    done();
+}
+
+setup({ single_test: true });
+if (window.IPC)
+    runTest();
+else
+    done();
+
+</script>
+</body>

--- a/LayoutTests/resources/ipc.js
+++ b/LayoutTests/resources/ipc.js
@@ -2,10 +2,28 @@ function randomIPCID() {
     return Math.floor(Math.random() * 10000) + 1;
 }
 
-function asyncFlush(processTarget) {
-    if (!IPC.processTargets.includes(processTarget))
-        throw Error("Invalid processTarget passed to asyncFlush")
-    return IPC.sendMessage(processTarget, 0, IPC.messages.IPCTester_AsyncPing.name, [{type: "uint32_t", value: 88}]);
+function sendWithPromisedReplyForConnection(connection, destinationID, messageName, args) {
+    return new Promise((resolve, reject) => {
+        function cb(result) {
+            if (typeof result == "object" && typeof result.arguments === "object")
+                resolve(result);
+            else
+                reject();
+        }
+        connection.sendWithAsyncReply(destinationID, messageName, args, cb);
+    });
+}
+
+if (window.IPC) {
+    IPC.sendWithPromisedReply = function(processTarget, destinationID, messageName, args) {
+        return sendWithPromisedReplyForConnection(IPC.connectionForProcessTarget(processTarget), destinationID, messageName, args);
+    }
+}
+
+async function asyncFlush(processTarget) {
+    let result = await IPC.sendWithPromisedReply(processTarget, 0, IPC.messages.IPCTester_AsyncPing.name, [{type: "uint32_t", value: 88}])
+    if (result.arguments[0].type != "uint32_t" || result.arguments[0].value != 89)
+        throw Error("invalid result");
 }
 
 function syncFlush(processTarget) {

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -107,9 +107,9 @@ void IPCStreamTester::syncCrashOnZero(int32_t value, CompletionHandler<void(int3
     completionHandler(value);
 }
 
-void IPCStreamTester::asyncMessage(bool value, CompletionHandler<void(bool)>&& completionHandler)
+void IPCStreamTester::asyncPing(uint32_t value, CompletionHandler<void(uint32_t)>&& completionHandler)
 {
-    completionHandler(!value);
+    completionHandler(value + 1);
 }
 
 #if USE(FOUNDATION)

--- a/Source/WebKit/Shared/IPCStreamTester.h
+++ b/Source/WebKit/Shared/IPCStreamTester.h
@@ -62,7 +62,7 @@ private:
     void syncMessageEmptyReply(uint32_t, CompletionHandler<void()>&&);
     void syncCrashOnZero(int32_t, CompletionHandler<void(int32_t)>&&);
     void checkAutoreleasePool(CompletionHandler<void(int32_t)>&&);
-    void asyncMessage(bool value, CompletionHandler<void(bool)>&&);
+    void asyncPing(uint32_t value, CompletionHandler<void(uint32_t)>&&);
 
     const Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     const Ref<IPC::StreamServerConnection> m_streamConnection;

--- a/Source/WebKit/Shared/IPCStreamTester.messages.in
+++ b/Source/WebKit/Shared/IPCStreamTester.messages.in
@@ -28,7 +28,7 @@ messages -> IPCStreamTester NotRefCounted Stream {
     SyncCrashOnZero(int32_t value) -> (int32_t sameValue) Synchronous
 
     CheckAutoreleasePool() -> (int32_t previousUseCount) Synchronous
-    AsyncMessage(bool value) -> (bool reply)
+    AsyncPing(uint32_t value) -> (uint32_t nextValue)
 }
 
 #endif

--- a/Source/WebKit/Shared/IPCTester.cpp
+++ b/Source/WebKit/Shared/IPCTester.cpp
@@ -203,7 +203,7 @@ void IPCTester::releaseConnectionTester(IPCConnectionTesterIdentifier identifier
     completionHandler();
 }
 
-void IPCTester::asyncPing(IPC::Connection&, uint32_t value, CompletionHandler<void(uint32_t)>&& completionHandler)
+void IPCTester::asyncPing(uint32_t value, CompletionHandler<void(uint32_t)>&& completionHandler)
 {
     completionHandler(value + 1);
 }

--- a/Source/WebKit/Shared/IPCTester.h
+++ b/Source/WebKit/Shared/IPCTester.h
@@ -71,7 +71,7 @@ private:
     void sendSameSemaphoreBack(IPC::Connection&, IPC::Semaphore&&);
     void sendSemaphoreBackAndSignalProtocol(IPC::Connection&, IPC::Semaphore&&);
     void sendAsyncMessageToReceiver(IPC::Connection&, uint32_t);
-    void asyncPing(IPC::Connection&, uint32_t value, CompletionHandler<void(uint32_t)>&&);
+    void asyncPing(uint32_t value, CompletionHandler<void(uint32_t)>&&);
     void syncPing(IPC::Connection&, uint32_t value, CompletionHandler<void(uint32_t)>&&);
     void syncPingEmptyReply(IPC::Connection&, uint32_t value, CompletionHandler<void()>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -65,6 +65,7 @@
 #include <WebCore/SharedMemory.h>
 #include <wtf/PageBlock.h>
 #include <wtf/Scope.h>
+#include <wtf/text/StringConcatenate.h>
 
 namespace WebKit {
 
@@ -80,7 +81,7 @@ static constexpr auto processTargetNameGPU = "GPU"_s;
 static constexpr auto processTargetNameNetworking = "Networking"_s;
 
 static std::optional<uint64_t> destinationIDFromArgument(JSC::JSGlobalObject*, JSValueRef, JSValueRef*);
-static std::optional<uint64_t> messageIDFromArgument(JSC::JSGlobalObject*, JSValueRef, JSValueRef*);
+static std::optional<IPC::MessageName> messageNameFromArgument(JSC::JSGlobalObject*, JSValueRef, JSValueRef*);
 static JSC::JSObject* jsResultFromReplyDecoder(JSC::JSGlobalObject*, IPC::MessageName, IPC::Decoder&);
 static bool encodeArgument(IPC::Encoder&, JSContextRef, JSValueRef, JSValueRef* exception);
 
@@ -149,15 +150,21 @@ class JSIPCConnection : public RefCounted<JSIPCConnection>, private IPC::Connect
 public:
     static Ref<JSIPCConnection> create(IPC::Connection::Identifier&& testedConnectionIdentifier)
     {
-        return adoptRef(*new JSIPCConnection(WTFMove(testedConnectionIdentifier)));
+        return adoptRef(*new JSIPCConnection(IPC::Connection::createServerConnection(WTFMove(testedConnectionIdentifier))));
+    }
+
+    static Ref<JSIPCConnection> create(Ref<IPC::Connection> connection)
+    {
+        return adoptRef(*new JSIPCConnection(WTFMove(connection)));
     }
 
     JSObjectRef createJSWrapper(JSContextRef);
     static JSIPCConnection* toWrapped(JSContextRef, JSValueRef);
 
+    Ref<IPC::Connection> connection() const { return m_testedConnection; }
 private:
-    JSIPCConnection(IPC::Connection::Identifier&& testedConnectionIdentifier)
-        : m_testedConnection { IPC::Connection::createServerConnection(testedConnectionIdentifier) }
+    JSIPCConnection(Ref<IPC::Connection> connection)
+        : m_testedConnection { WTFMove(connection) }
     {
     }
 
@@ -177,8 +184,10 @@ private:
     static JSValueRef open(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
     static JSValueRef invalidate(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
     static JSValueRef sendMessage(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
+    static JSValueRef sendWithAsyncReply(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
     static JSValueRef sendSyncMessage(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
     static JSValueRef waitForMessage(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
+    static JSValueRef waitForAsyncReplyAndDispatchImmediately(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
 
     Ref<IPC::Connection> m_testedConnection;
 };
@@ -211,7 +220,7 @@ private:
     static void initialize(JSContextRef, JSObjectRef);
     static void finalize(JSObjectRef);
 
-    static bool prepareToSendOutOfStreamMessage(JSContextRef, size_t argumentCount, const JSValueRef arguments[], JSIPC&, IPC::StreamClientConnection&, IPC::Encoder&, uint64_t destinationID, IPC::Timeout, JSValueRef* exception);
+    bool prepareToSendOutOfStreamMessage(uint64_t destinationID, IPC::Timeout);
 
     static const JSStaticFunction* staticFunctions();
     static JSValueRef open(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
@@ -219,9 +228,11 @@ private:
     static JSValueRef streamBuffer(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
     static JSValueRef setSemaphores(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
     static JSValueRef sendMessage(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
+    static JSValueRef sendWithAsyncReply(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
     static JSValueRef sendSyncMessage(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
     static JSValueRef sendIPCStreamTesterSyncCrashOnZero(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
     static JSValueRef waitForMessage(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
+    static JSValueRef waitForAsyncReplyAndDispatchImmediately(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
 
     WeakPtr<JSIPC> m_jsIPC;
     RefPtr<IPC::StreamClientConnection> m_streamConnection;
@@ -379,6 +390,8 @@ private:
     static const JSStaticFunction* staticFunctions();
     static const JSStaticValue* staticValues();
 
+    static JSValueRef connectionForProcessTarget(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
+
     static void addMessageListener(JSMessageListener::Type, JSContextRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
     static JSValueRef addIncomingMessageListener(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
     static JSValueRef addOutgoingMessageListener(JSContextRef, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception);
@@ -409,10 +422,15 @@ private:
     static JSValueRef objectIdentifiers(JSContextRef, JSObjectRef, JSStringRef, JSValueRef* exception);
     static JSValueRef processTargets(JSContextRef, JSObjectRef, JSStringRef, JSValueRef* exception);
 
+    RefPtr<JSIPCConnection> processTargetFromArgument(JSC::JSGlobalObject*, JSValueRef, JSValueRef* exception);
+
     WeakPtr<WebPage> m_webPage;
     WeakPtr<WebFrame> m_webFrame;
     Vector<UniqueRef<JSMessageListener>> m_messageListeners;
     IPCTesterReceiver m_testerProxy;
+    RefPtr<JSIPCConnection> m_uiConnection;
+    RefPtr<JSIPCConnection> m_networkConnection;
+    RefPtr<JSIPCConnection> m_gpuConnection;
 };
 
 static JSValueRef createError(JSContextRef context, const String& message)
@@ -427,6 +445,11 @@ static JSValueRef createTypeError(JSContextRef context, const String& message)
     return toRef(JSC::createTypeError(toJS(context), message));
 }
 
+static JSValueRef createErrorFromIPCError(JSContextRef context, IPC::Error error)
+{
+    return createError(context, makeString("IPC error:"_s, IPC::errorAsString(error)));
+}
+
 static std::optional<uint64_t> convertToUint64(JSC::JSValue jsValue)
 {
     if (jsValue.isNumber()) {
@@ -438,81 +461,6 @@ static std::optional<uint64_t> convertToUint64(JSC::JSValue jsValue)
     if (jsValue.isBigInt())
         return JSC::JSBigInt::toBigUInt64(jsValue);
     return std::nullopt;
-}
-
-
-static JSValueRef sendMessageWithJSArguments(IPC::Connection& connection, JSContextRef context, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
-{
-    auto* globalObject = toJS(context);
-    JSC::JSLockHolder lock(globalObject->vm());
-
-    auto destinationID = destinationIDFromArgument(globalObject, arguments[0], exception);
-    if (!destinationID)
-        return JSValueMakeUndefined(context);
-
-    auto messageID = messageIDFromArgument(globalObject, arguments[1], exception);
-    if (!messageID)
-        return JSValueMakeUndefined(context);
-
-    auto messageName = static_cast<IPC::MessageName>(*messageID);
-    auto encoder = makeUniqueRef<IPC::Encoder>(messageName, *destinationID);
-
-    if (argumentCount > 2) {
-        if (!encodeArgument(encoder.get(), context, arguments[2], exception))
-            return JSValueMakeUndefined(context);
-    }
-
-    JSValueRef returnValue = JSValueMakeUndefined(context);
-
-    bool hasReply = !!messageReplyArgumentDescriptions(messageName);
-    if (hasReply) {
-        JSObjectRef resolve;
-        JSObjectRef reject;
-ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-        returnValue = JSObjectMakeDeferredPromise(context, &resolve, &reject, exception); // NOLINT
-ALLOW_NEW_API_WITHOUT_GUARDS_END
-        if (!returnValue)  // NOLINT
-            return JSValueMakeUndefined(context);
-
-        JSGlobalContextRetain(JSContextGetGlobalContext(context));
-        JSValueProtect(context, resolve);
-        JSValueProtect(context, reject);
-        IPC::Connection::AsyncReplyHandler handler {
-            [messageName, context, resolve, reject](IPC::Decoder* replyDecoder) {
-                auto* globalObject = toJS(context);
-                auto& vm = globalObject->vm();
-                JSC::JSLockHolder lock(vm);
-
-                auto scope = DECLARE_CATCH_SCOPE(vm);
-
-                auto cleanup = makeScopeExit([context, resolve, reject] {
-                    JSValueUnprotect(context, reject);
-                    JSValueUnprotect(context, resolve);
-                    JSGlobalContextRelease(JSContextGetGlobalContext(context));
-                });
-
-                if (!replyDecoder || !replyDecoder->isValid())
-                    return;
-
-                auto* jsResult = jsResultFromReplyDecoder(globalObject, messageName, *replyDecoder);
-                if (auto* exception = scope.exception()) {
-                    scope.clearException();
-                    JSValueRef arguments[] = { toRef(globalObject, exception) };
-                    JSObjectCallAsFunction(context, reject, reject, 1, arguments, nullptr);
-                } else {
-                    JSValueRef arguments[] = { toRef(globalObject, jsResult) };
-                    JSObjectCallAsFunction(context, resolve, resolve, 1, arguments, nullptr);
-                }
-            },
-            IPC::Connection::AsyncReplyID::generate()
-        };
-        connection.sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(handler), IPC::SendOption::IPCTestingMessage);
-    } else
-        connection.sendMessage(WTFMove(encoder), IPC::SendOption::IPCTestingMessage);
-
-    // FIXME: Add the support for specifying IPC options.
-
-    return returnValue;
 }
 
 namespace {
@@ -533,8 +481,8 @@ static std::optional<SyncIPCMessageInfo> extractSyncIPCMessageInfo(JSContextRef 
     if (!destinationID)
         return std::nullopt;
 
-    auto messageID = messageIDFromArgument(globalObject, arguments[1], exception);
-    if (!messageID)
+    auto messageName = messageNameFromArgument(globalObject, arguments[1], exception);
+    if (!messageName)
         return std::nullopt;
 
     Seconds timeoutDuration;
@@ -547,31 +495,67 @@ static std::optional<SyncIPCMessageInfo> extractSyncIPCMessageInfo(JSContextRef 
         timeoutDuration = Seconds { jsValue.asNumber() };
     }
 
-    return { { *destinationID, static_cast<IPC::MessageName>(*messageID), { timeoutDuration } } };
+    return { { *destinationID, *messageName, { timeoutDuration } } };
 }
 
-static JSValueRef sendSyncMessageWithJSArguments(IPC::Connection& connection, JSContextRef context, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+static JSValueRef jsSend(IPC::Connection& connection, uint64_t destinationID, IPC::MessageName messageName, JSContextRef context, const JSValueRef messageArguments, JSValueRef* exception)
 {
-    auto* globalObject = toJS(context);
-    JSC::JSLockHolder lock(globalObject->vm());
-    auto info = extractSyncIPCMessageInfo(context, argumentCount, arguments, exception);
-    if (!info)
+    auto encoder = makeUniqueRef<IPC::Encoder>(messageName, destinationID);
+    if (messageArguments && !encodeArgument(encoder.get(), context, messageArguments, exception))
         return JSValueMakeUndefined(context);
+    connection.sendMessage(WTFMove(encoder), IPC::SendOption::IPCTestingMessage);
+    return JSValueMakeUndefined(context);
+}
 
-    auto [destinationID, messageName, timeout] = *info;
+static JSValueRef jsSendWithAsyncReply(IPC::Connection& connection, uint64_t destinationID, IPC::MessageName messageName, JSContextRef context, const JSObjectRef callback, const JSValueRef messageArguments, JSValueRef* exception)
+{
+    auto encoder = makeUniqueRef<IPC::Encoder>(messageName, destinationID);
+    if (messageArguments && !encodeArgument(encoder.get(), context, messageArguments, exception))
+        return JSValueMakeUndefined(context);
+    JSGlobalContextRetain(JSContextGetGlobalContext(context));
+    JSValueProtect(context, callback);
+    IPC::Connection::AsyncReplyHandler handler = {
+        [messageName, context, callback](IPC::Decoder* replyDecoder) {
+            auto* globalObject = toJS(context);
+            auto& vm = globalObject->vm();
+            JSC::JSLockHolder lock(vm);
+            auto scope = DECLARE_CATCH_SCOPE(vm);
+            auto cleanup = makeScopeExit([context, callback] {
+                JSValueUnprotect(context, callback);
+                JSGlobalContextRelease(JSContextGetGlobalContext(context));
+            });
+            JSC::JSObject* jsResult = nullptr;
+            if (replyDecoder && replyDecoder->isValid())
+                jsResult = jsResultFromReplyDecoder(globalObject, messageName, *replyDecoder);
+            JSValueRef arguments[1] = { nullptr };
+            if (auto* exception = scope.exception()) {
+                scope.clearException();
+                arguments[0] = toRef(globalObject, exception);
+            } else
+                arguments[0] = toRef(globalObject, jsResult);
+            JSObjectCallAsFunction(context, callback, callback, 1, arguments, nullptr);
+        },
+        IPC::Connection::AsyncReplyID::generate()
+    };
+    auto asyncReplyID = handler.replyID;
+    auto result = connection.sendMessageWithAsyncReply(WTFMove(encoder), WTFMove(handler), IPC::SendOption::IPCTestingMessage);
+    if (result != IPC::Error::NoError) {
+        *exception = createErrorFromIPCError(context, result);
+        return JSValueMakeUndefined(context);
+    }
+    return JSValueMakeNumber(context, asyncReplyID.toUInt64());
+}
 
-    // FIXME: Support the options.
-
+static JSValueRef jsSendSync(IPC::Connection& connection, uint64_t destinationID, IPC::MessageName messageName, IPC::Timeout timeout, JSContextRef context, const JSValueRef messageArguments, JSValueRef* exception)
+{
     IPC::Connection::SyncRequestID syncRequestID;
     auto encoder = connection.createSyncMessageEncoder(messageName, destinationID, syncRequestID);
-
-    if (argumentCount > 3) {
-        if (!encodeArgument(encoder.get(), context, arguments[3], exception))
-            return JSValueMakeUndefined(context);
-    }
-
+    if (messageArguments && !encodeArgument(encoder.get(), context, messageArguments, exception))
+        return JSValueMakeUndefined(context);
     auto replyDecoderOrError = connection.sendSyncMessage(syncRequestID, WTFMove(encoder), timeout, { });
     if (replyDecoderOrError.has_value()) {
+        auto* globalObject = toJS(context);
+        JSC::JSLockHolder lock(globalObject->vm());
         auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
         auto* jsResult = jsResultFromReplyDecoder(globalObject, messageName, replyDecoderOrError.value().get());
         if (scope.exception()) {
@@ -581,20 +565,13 @@ static JSValueRef sendSyncMessageWithJSArguments(IPC::Connection& connection, JS
         }
         return toRef(globalObject, jsResult);
     }
-
     return JSValueMakeUndefined(context);
 }
 
-static JSValueRef waitForMessageWithJSArguments(IPC::Connection& connection, JSContextRef context, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+static JSValueRef jsWaitForMessage(IPC::Connection& connection, uint64_t destinationID, IPC::MessageName messageName, IPC::Timeout timeout, JSContextRef context, JSValueRef* exception)
 {
     auto* globalObject = toJS(context);
     JSC::JSLockHolder lock(globalObject->vm());
-
-    auto info = extractSyncIPCMessageInfo(context, argumentCount, arguments, exception);
-    if (!info)
-        return JSValueMakeUndefined(context);
-
-    auto [destinationID, messageName, timeout] = *info;
     auto decoderOrError = connection.waitForMessageForTesting(messageName, destinationID, timeout, { });
     if (decoderOrError.has_value()) {
         auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
@@ -606,6 +583,22 @@ static JSValueRef waitForMessageWithJSArguments(IPC::Connection& connection, JSC
         }
         return jsResult ? toRef(globalObject, *jsResult) : JSValueMakeUndefined(context);
     }
+    return JSValueMakeUndefined(context);
+}
+
+static JSValueRef jsWaitForAsyncReplyAndDispatchImmediately(IPC::Connection& connection, uint64_t destinationID, IPC::MessageName messageName, IPC::Timeout timeout, JSContextRef context, JSValueRef* exception)
+{
+    auto handler = connection.takeAsyncReplyHandler(IPC::Connection::AsyncReplyID { destinationID });
+    if (!handler) {
+        *exception = createError(context, "IPC error: no handler"_s);
+        return JSValueMakeUndefined(context);
+    }
+    auto decoderOrError = connection.waitForMessageForTesting(messageName, destinationID, timeout, { });
+    if (!decoderOrError.has_value()) {
+        *exception = createErrorFromIPCError(context, decoderOrError.error());
+        return JSValueMakeUndefined(context);
+    }
+    handler(&decoderOrError.value().get());
     return JSValueMakeUndefined(context);
 }
 
@@ -802,8 +795,10 @@ const JSStaticFunction* JSIPCConnection::staticFunctions()
         { "open", open, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { "invalidate", invalidate, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { "sendMessage", sendMessage, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
+        { "sendWithAsyncReply", sendWithAsyncReply, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { "sendSyncMessage", sendSyncMessage, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { "waitForMessage", waitForMessage, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
+        { "waitForAsyncReplyAndDispatchImmediately", waitForAsyncReplyAndDispatchImmediately, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { 0, 0, 0 }
     };
     return functions;
@@ -811,30 +806,30 @@ const JSStaticFunction* JSIPCConnection::staticFunctions()
 
 JSValueRef JSIPCConnection::open(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t, const JSValueRef[], JSValueRef* exception)
 {
-    RefPtr self = toWrapped(context, thisObject);
-    if (!self) {
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    self->m_testedConnection->open(*self);
+    jsIPC->m_testedConnection->open(*jsIPC);
     return JSValueMakeUndefined(context);
 }
 
 JSValueRef JSIPCConnection::invalidate(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t, const JSValueRef[], JSValueRef* exception)
 {
-    RefPtr self = toWrapped(context, thisObject);
-    if (!self) {
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    self->m_testedConnection->invalidate();
+    jsIPC->m_testedConnection->invalidate();
     return JSValueMakeUndefined(context);
 }
 
 JSValueRef JSIPCConnection::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
-    RefPtr self = toWrapped(context, thisObject);
-    if (!self) {
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
@@ -842,13 +837,58 @@ JSValueRef JSIPCConnection::sendMessage(JSContextRef context, JSObjectRef, JSObj
         *exception = createTypeError(context, "Must specify the destination ID and message ID as the first two arguments"_s);
         return JSValueMakeUndefined(context);
     }
-    return sendMessageWithJSArguments(self->m_testedConnection, context, argumentCount, arguments, exception);
+    auto* globalObject = toJS(context);
+    JSC::JSLockHolder lock(globalObject->vm());
+    auto destinationID = destinationIDFromArgument(globalObject, arguments[0], exception);
+    if (!destinationID)
+        return JSValueMakeUndefined(context);
+    auto messageName = messageNameFromArgument(globalObject, arguments[1], exception);
+    if (!messageName)
+        return JSValueMakeUndefined(context);
+    JSValueRef messageArguments = argumentCount > 2 ? arguments[2] : nullptr;
+    return jsSend(jsIPC->m_testedConnection.get(), *destinationID, *messageName, context, messageArguments, exception);
+}
+
+JSValueRef JSIPCConnection::sendWithAsyncReply(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
+        *exception = createTypeError(context, "Wrong type"_s);
+        return JSValueMakeUndefined(context);
+    }
+    if (argumentCount < 4) {
+        *exception = createTypeError(context, "Must specify the destination ID, message ID, messageArguments, callback as the first four arguments"_s);
+        return JSValueMakeUndefined(context);
+    }
+    auto* globalObject = toJS(context);
+    JSC::JSLockHolder lock(globalObject->vm());
+    auto destinationID = destinationIDFromArgument(globalObject, arguments[0], exception);
+    if (!destinationID)
+        return JSValueMakeUndefined(context);
+    auto messageName = messageNameFromArgument(globalObject, arguments[1], exception);
+    if (!messageName)
+        return JSValueMakeUndefined(context);
+    if (!messageReplyArgumentDescriptions(*messageName)) {
+        *exception = createError(context, "Message does not have a reply"_s);
+        return JSValueMakeUndefined(context);
+    }
+    JSObjectRef callback = nullptr;
+    if (JSValueIsObject(context, arguments[3])) {
+        callback = JSValueToObject(context, arguments[3], exception);
+        if (!JSObjectIsFunction(context, callback))
+            callback = nullptr;
+    }
+    if (!callback) {
+        *exception = createTypeError(context, "Must specify callback as the fourth argument"_s);
+        return JSValueMakeUndefined(context);
+    }
+    return jsSendWithAsyncReply(jsIPC->m_testedConnection.get(), *destinationID, *messageName, context, callback, arguments[2], exception);
 }
 
 JSValueRef JSIPCConnection::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
-    RefPtr self = toWrapped(context, thisObject);
-    if (!self) {
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
@@ -856,13 +896,18 @@ JSValueRef JSIPCConnection::sendSyncMessage(JSContextRef context, JSObjectRef, J
         *exception = createTypeError(context, "Must specify the destination ID and message ID as the first two arguments"_s);
         return JSValueMakeUndefined(context);
     }
-    return sendSyncMessageWithJSArguments(self->m_testedConnection, context, argumentCount, arguments, exception);
+    auto info = extractSyncIPCMessageInfo(context, argumentCount, arguments, exception);
+    if (!info)
+        return JSValueMakeUndefined(context);
+    auto [destinationID, messageName, timeout] = *info;
+    JSValueRef messageArguments = argumentCount > 3 ? arguments[3] : nullptr;
+    return jsSendSync(jsIPC->m_testedConnection.get(), destinationID, messageName, timeout, context, messageArguments, exception);
 }
 
 JSValueRef JSIPCConnection::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
-    RefPtr self = toWrapped(context, thisObject);
-    if (!self) {
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
@@ -870,7 +915,29 @@ JSValueRef JSIPCConnection::waitForMessage(JSContextRef context, JSObjectRef, JS
         *exception = createTypeError(context, "Must specify the destination ID and message ID as the first two arguments"_s);
         return JSValueMakeUndefined(context);
     }
-    return waitForMessageWithJSArguments(self->m_testedConnection, context, argumentCount, arguments, exception);
+    auto info = extractSyncIPCMessageInfo(context, argumentCount, arguments, exception);
+    if (!info)
+        return JSValueMakeUndefined(context);
+    auto [destinationID, messageName, timeout] = *info;
+    return jsWaitForMessage(jsIPC->m_testedConnection.get(), destinationID, messageName, timeout, context, exception);
+}
+
+JSValueRef JSIPCConnection::waitForAsyncReplyAndDispatchImmediately(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
+        *exception = createTypeError(context, "Wrong type"_s);
+        return JSValueMakeUndefined(context);
+    }
+    if (argumentCount < 3) {
+        *exception = createTypeError(context, "Must specify the message name, async reply ID and timeout as the first three arguments"_s);
+        return JSValueMakeUndefined(context);
+    }
+    auto info = extractSyncIPCMessageInfo(context, argumentCount, arguments, exception);
+    if (!info)
+        return JSValueMakeUndefined(context);
+    auto [destinationID, messageName, timeout] = *info;
+    return jsWaitForAsyncReplyAndDispatchImmediately(jsIPC->m_testedConnection.get(), destinationID, messageName, timeout, context, exception);
 }
 
 JSObjectRef JSIPCStreamClientConnection::createJSWrapper(JSContextRef context)
@@ -930,9 +997,11 @@ const JSStaticFunction* JSIPCStreamClientConnection::staticFunctions()
         { "streamBuffer", streamBuffer, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { "setSemaphores", setSemaphores, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { "sendMessage", sendMessage, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
+        { "sendWithAsyncReply", sendWithAsyncReply, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { "sendSyncMessage", sendSyncMessage, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { "sendIPCStreamTesterSyncCrashOnZero", sendIPCStreamTesterSyncCrashOnZero, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { "waitForMessage", waitForMessage, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
+        { "waitForAsyncReplyAndDispatchImmediately", waitForAsyncReplyAndDispatchImmediately, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { 0, 0, 0 }
     };
     return functions;
@@ -940,23 +1009,23 @@ const JSStaticFunction* JSIPCStreamClientConnection::staticFunctions()
 
 JSValueRef JSIPCStreamClientConnection::open(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t, const JSValueRef[], JSValueRef* exception)
 {
-    RefPtr self = toWrapped(context, thisObject);
-    if (!self) {
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    self->m_streamConnection->open(self->m_dummyMessageReceiver);
+    jsIPC->m_streamConnection->open(jsIPC->m_dummyMessageReceiver);
     return JSValueMakeUndefined(context);
 }
 
 JSValueRef JSIPCStreamClientConnection::invalidate(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t, const JSValueRef[], JSValueRef* exception)
 {
-    RefPtr self = toWrapped(context, thisObject);
-    if (!self) {
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    self->m_streamConnection->invalidate();
+    jsIPC->m_streamConnection->invalidate();
     return JSValueMakeUndefined(context);
 }
 
@@ -1022,8 +1091,8 @@ static std::optional<IPCStreamMessageInfo> extractIPCStreamMessageInfo(JSContext
     if (!destinationID)
         return std::nullopt;
 
-    auto messageID = messageIDFromArgument(globalObject, arguments[1], exception);
-    if (!messageID)
+    auto messageName = messageNameFromArgument(globalObject, arguments[1], exception);
+    if (!messageName)
         return std::nullopt;
 
     Seconds timeoutDuration;
@@ -1036,92 +1105,90 @@ static std::optional<IPCStreamMessageInfo> extractIPCStreamMessageInfo(JSContext
         timeoutDuration = Seconds { jsValue.asNumber() };
     }
 
-    return { { *destinationID, static_cast<IPC::MessageName>(*messageID), { timeoutDuration } } };
+    return { { *destinationID, *messageName, { timeoutDuration } } };
 }
 
-bool JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage(JSContextRef context, size_t argumentCount, const JSValueRef arguments[], JSIPC& jsIPC, IPC::StreamClientConnection& streamConnection, IPC::Encoder& encoder, uint64_t destinationID, IPC::Timeout timeout, JSValueRef* exception)
+bool JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage(uint64_t destinationID, IPC::Timeout timeout)
 {
-    // FIXME: Add support for sending in-stream IPC messages when appropriate.
-    if (argumentCount > 3) {
-        if (!encodeArgument(encoder, context, arguments[3], exception))
-            return false;
-    }
-
-    if (streamConnection.trySendDestinationIDIfNeeded(destinationID, timeout) != IPC::Error::NoError)
+    if (m_streamConnection->trySendDestinationIDIfNeeded(destinationID, timeout) != IPC::Error::NoError)
         return false;
-
-    auto span = streamConnection.bufferForTesting().tryAcquire(timeout);
+    auto span = m_streamConnection->bufferForTesting().tryAcquire(timeout);
     if (!span)
         return false;
-
-    streamConnection.sendProcessOutOfStreamMessage(WTFMove(*span));
+    m_streamConnection->sendProcessOutOfStreamMessage(WTFMove(*span));
     return true;
 }
 
 JSValueRef JSIPCStreamClientConnection::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
-    auto* globalObject = toJS(context);
-    JSC::JSLockHolder lock(globalObject->vm());
-
-    auto returnValue = JSValueMakeUndefined(context);
-    RefPtr jsStreamConnection = toWrapped(context, thisObject);
-    if (!jsStreamConnection) {
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
-        return returnValue;
+        return JSValueMakeUndefined(context);
     }
-
     auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
     if (!info)
-        return returnValue;
-
+        return JSValueMakeUndefined(context);
     auto [destinationID, messageName, timeout] = *info;
-    auto& streamConnection = jsStreamConnection->connection();
-    Ref connection = streamConnection.connectionForTesting();
+    if (!jsIPC->prepareToSendOutOfStreamMessage(destinationID, timeout))
+        return JSValueMakeUndefined(context);
+    JSValueRef messageArguments = argumentCount > 3 ? arguments[3] : nullptr;
+    return jsSend(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, context, messageArguments, exception);
+}
 
-    auto encoder = makeUniqueRef<IPC::Encoder>(messageName, destinationID);
-    if (prepareToSendOutOfStreamMessage(context, argumentCount, arguments, *jsStreamConnection->m_jsIPC, streamConnection, encoder.get(), destinationID, timeout, exception))
-        connection->sendMessage(WTFMove(encoder), IPC::SendOption::IPCTestingMessage);
-
-    return returnValue;
+JSValueRef JSIPCStreamClientConnection::sendWithAsyncReply(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
+        *exception = createTypeError(context, "Wrong type"_s);
+        return JSValueMakeUndefined(context);
+    }
+    if (argumentCount < 5) {
+        *exception = createTypeError(context, "Must specify destination ID, message ID, timeout, messageArguments, callback as the first five arguments"_s);
+        return JSValueMakeUndefined(context);
+    }
+    auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
+    if (!info)
+        return JSValueMakeUndefined(context);
+    auto [destinationID, messageName, timeout] = *info;
+    if (!messageReplyArgumentDescriptions(messageName)) {
+        *exception = createError(context, "Message does not have a reply"_s);
+        return JSValueMakeUndefined(context);
+    }
+    JSObjectRef callback = nullptr;
+    if (JSValueIsObject(context, arguments[4])) {
+        callback = JSValueToObject(context, arguments[4], exception);
+        if (!JSObjectIsFunction(context, callback))
+            callback = nullptr;
+    }
+    if (!callback) {
+        *exception = createTypeError(context, "Must specify callback as the fifth argument"_s);
+            return JSValueMakeUndefined(context);
+        }
+    if (!jsIPC->prepareToSendOutOfStreamMessage(destinationID, timeout)) {
+        *exception = createError(context, "IPC error: prepare failed"_s);
+        return JSValueMakeUndefined(context);
+    }
+    return jsSendWithAsyncReply(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, context, callback, arguments[3], exception);
 }
 
 JSValueRef JSIPCStreamClientConnection::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
-    auto* globalObject = toJS(context);
-    JSC::JSLockHolder lock(globalObject->vm());
-
-    RefPtr jsStreamConnection = toWrapped(context, thisObject);
-    if (!jsStreamConnection) {
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
-        return JSValueMakeUndefined(context);
+    return JSValueMakeUndefined(context);
     }
-
     auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
     if (!info)
         return JSValueMakeUndefined(context);
-
     auto [destinationID, messageName, timeout] = *info;
-    auto& streamConnection = jsStreamConnection->connection();
-    Ref connection = streamConnection.connectionForTesting();
-
-    IPC::Connection::SyncRequestID syncRequestID;
-    auto encoder = connection->createSyncMessageEncoder(messageName, destinationID, syncRequestID);
-    if (!prepareToSendOutOfStreamMessage(context, argumentCount, arguments, *jsStreamConnection->m_jsIPC, streamConnection, encoder.get(), destinationID, timeout, exception))
+    if (!jsIPC->prepareToSendOutOfStreamMessage(destinationID, timeout)) {
+        *exception = createError(context, "IPC error: prepare failed"_s);
         return JSValueMakeUndefined(context);
-
-    auto replyDecoderOrError = connection->sendSyncMessage(syncRequestID, WTFMove(encoder), timeout, { });
-    if (replyDecoderOrError.has_value()) {
-        auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
-        auto* jsResult = jsResultFromReplyDecoder(globalObject, messageName, replyDecoderOrError.value().get());
-        if (scope.exception()) {
-            *exception = toRef(globalObject, scope.exception());
-            scope.clearException();
-            return JSValueMakeUndefined(context);
-        }
-        return toRef(globalObject, jsResult);
     }
-
-    return JSValueMakeUndefined(context);
+    JSValueRef messageArguments = argumentCount > 3 ? arguments[3] : nullptr;
+    return jsSendSync(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, timeout, context, messageArguments, exception);
 }
 
 // FIXME(http://webkit.org/b/237197): Cannot send arbitrary messages, so we hard-code this one to be able to send it.
@@ -1181,8 +1248,8 @@ JSValueRef JSIPCStreamClientConnection::sendIPCStreamTesterSyncCrashOnZero(JSCon
 
 JSValueRef JSIPCStreamClientConnection::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
-    RefPtr self = toWrapped(context, thisObject);
-    if (!self) {
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
@@ -1190,8 +1257,29 @@ JSValueRef JSIPCStreamClientConnection::waitForMessage(JSContextRef context, JSO
         *exception = createTypeError(context, "Must specify the destination ID and message ID as the first two arguments"_s);
         return JSValueMakeUndefined(context);
     }
-    Ref connection = self->m_streamConnection->connectionForTesting();
-    return waitForMessageWithJSArguments(connection, context, argumentCount, arguments, exception);
+    auto info = extractSyncIPCMessageInfo(context, argumentCount, arguments, exception);
+    if (!info)
+        return JSValueMakeUndefined(context);
+    auto [destinationID, messageName, timeout] = *info;
+    return jsWaitForMessage(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, timeout, context, exception);
+}
+
+JSValueRef JSIPCStreamClientConnection::waitForAsyncReplyAndDispatchImmediately(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
+        *exception = createTypeError(context, "Wrong type"_s);
+        return JSValueMakeUndefined(context);
+    }
+    if (argumentCount < 3) {
+        *exception = createTypeError(context, "Must specify the message name, async reply ID and timeout as the first three arguments"_s);
+        return JSValueMakeUndefined(context);
+    }
+    auto info = extractIPCStreamMessageInfo(context, argumentCount, arguments, exception);
+    if (!info)
+        return JSValueMakeUndefined(context);
+    auto [destinationID, messageName, timeout] = *info;
+    return jsWaitForAsyncReplyAndDispatchImmediately(jsIPC->m_streamConnection->connectionForTesting(), destinationID, messageName, timeout, context, exception);
 }
 
 JSObjectRef JSIPCStreamConnectionBuffer::createJSWrapper(JSContextRef context)
@@ -1770,6 +1858,7 @@ void JSIPC::finalize(JSObjectRef object)
 const JSStaticFunction* JSIPC::staticFunctions()
 {
     static const JSStaticFunction functions[] = {
+        { "connectionForProcessTarget", connectionForProcessTarget, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { "addIncomingMessageListener", addIncomingMessageListener, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { "addOutgoingMessageListener", addOutgoingMessageListener, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
         { "sendMessage", sendMessage, kJSPropertyAttributeDontDelete | kJSPropertyAttributeReadOnly },
@@ -1805,21 +1894,33 @@ const JSStaticValue* JSIPC::staticValues()
     return values;
 }
 
-static RefPtr<IPC::Connection> processTargetFromArgument(JSC::JSGlobalObject* globalObject, JSValueRef valueRef, JSValueRef* exception)
+RefPtr<JSIPCConnection> JSIPC::processTargetFromArgument(JSC::JSGlobalObject* globalObject, JSValueRef valueRef, JSValueRef* exception)
 {
     auto scope = DECLARE_CATCH_SCOPE(globalObject->vm());
     auto name = toJS(globalObject, valueRef).toWTFString(globalObject);
     if (scope.exception())
         return nullptr;
 
-    if (name == processTargetNameUI)
-        return WebProcess::singleton().parentProcessConnection();
+    if (name == processTargetNameUI) {
+        RefPtr connection = WebProcess::singleton().parentProcessConnection();
+        if (!m_uiConnection || m_uiConnection->connection().ptr() != connection)
+            m_uiConnection = JSIPCConnection::create(connection.releaseNonNull());
+        return m_uiConnection;
+    }
 #if ENABLE(GPU_PROCESS)
-    if (name == processTargetNameGPU)
-        return &WebProcess::singleton().ensureGPUProcessConnection().connection();
+    if (name == processTargetNameGPU) {
+        RefPtr connection = &WebProcess::singleton().ensureGPUProcessConnection().connection();
+        if (!m_gpuConnection || m_gpuConnection->connection().ptr() != connection)
+            m_gpuConnection = JSIPCConnection::create(connection.releaseNonNull());
+        return m_gpuConnection;
+    }
 #endif
-    if (name == processTargetNameNetworking)
-        return &WebProcess::singleton().ensureNetworkProcessConnection().connection();
+    if (name == processTargetNameNetworking) {
+        RefPtr connection = &WebProcess::singleton().ensureNetworkProcessConnection().connection();
+        if (!m_networkConnection || m_networkConnection->connection().ptr() != connection)
+            m_networkConnection = JSIPCConnection::create(connection.releaseNonNull());
+        return m_networkConnection;
+    }
 
     *exception = toRef(JSC::createTypeError(globalObject, "Target process must be UI, GPU, or Networking"_s));
     return nullptr;
@@ -1827,20 +1928,18 @@ static RefPtr<IPC::Connection> processTargetFromArgument(JSC::JSGlobalObject* gl
 
 void JSIPC::addMessageListener(JSMessageListener::Type type, JSContextRef context, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
-    auto* globalObject = toJS(context);
-    JSC::JSLockHolder lock(globalObject->vm());
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
         return;
     }
-
     if (argumentCount < 1) {
         *exception = createTypeError(context, "Must specify the target process as the first argument"_s);
         return;
     }
-
-    auto connection = processTargetFromArgument(globalObject, arguments[0], exception);
+    auto* globalObject = toJS(context);
+    JSC::JSLockHolder lock(globalObject->vm());
+    auto connection = jsIPC->processTargetFromArgument(globalObject, arguments[0], exception);
     if (!connection)
         return;
 
@@ -1856,7 +1955,7 @@ void JSIPC::addMessageListener(JSMessageListener::Type type, JSContextRef contex
         return;
     }
 
-    connection->addMessageObserver(*listener);
+    connection->connection()->addMessageObserver(*listener);
     jsIPC->m_messageListeners.append(makeUniqueRefFromNonNullUniquePtr(WTFMove(listener)));
 }
 
@@ -1881,13 +1980,15 @@ static std::optional<uint64_t> destinationIDFromArgument(JSC::JSGlobalObject* gl
     return result;
 }
 
-static std::optional<uint64_t> messageIDFromArgument(JSC::JSGlobalObject* globalObject, JSValueRef valueRef, JSValueRef* exception)
+static std::optional<IPC::MessageName> messageNameFromArgument(JSC::JSGlobalObject* globalObject, JSValueRef valueRef, JSValueRef* exception)
 {
-    auto jsValue = toJS(globalObject, valueRef);
-    auto result = convertToUint64(jsValue);
-    if (!result)
-        *exception = toRef(JSC::createTypeError(globalObject, "messageID must be an integer"_s));
-    return result;
+    auto result = convertToUint64(toJS(globalObject, valueRef));
+    if (!result) {
+        *exception = toRef(JSC::createTypeError(globalObject, "messageName must be an integer"_s));
+        return std::nullopt;
+    }
+    return static_cast<IPC::MessageName>(result.value());
+
 }
 
 static bool encodeTypedArray(IPC::Encoder& encoder, JSContextRef context, JSValueRef valueRef, JSTypedArrayType type, JSValueRef* exception)
@@ -2380,10 +2481,27 @@ static JSC::JSObject* jsResultFromReplyDecoder(JSC::JSGlobalObject* globalObject
     return jsResult;
 }
 
-JSValueRef JSIPC::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+JSValueRef JSIPC::connectionForProcessTarget(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
 {
+    RefPtr jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
+        *exception = createTypeError(context, "Wrong type"_s);
+        return JSValueMakeUndefined(context);
+    }
+    if (argumentCount < 1) {
+        *exception = createTypeError(context, "Must specify the target process"_s);
+        return JSValueMakeUndefined(context);
+    }
     auto* globalObject = toJS(context);
     JSC::JSLockHolder lock(globalObject->vm());
+    RefPtr connection = jsIPC->processTargetFromArgument(globalObject, arguments[0], exception);
+    if (!connection)
+        return JSValueMakeUndefined(context);
+    return connection->createJSWrapper(context);
+}
+
+JSValueRef JSIPC::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
+{
     RefPtr jsIPC = toWrapped(context, thisObject);
     if (!jsIPC) {
         *exception = createTypeError(context, "Wrong type"_s);
@@ -2393,10 +2511,19 @@ JSValueRef JSIPC::sendMessage(JSContextRef context, JSObjectRef, JSObjectRef thi
         *exception = createTypeError(context, "Must specify the target process, destination ID, and message ID as the first three arguments"_s);
         return JSValueMakeUndefined(context);
     }
-    auto connection = processTargetFromArgument(globalObject, arguments[0], exception);
+    auto* globalObject = toJS(context);
+    JSC::JSLockHolder lock(globalObject->vm());
+    auto connection = jsIPC->processTargetFromArgument(globalObject, arguments[0], exception);
     if (!connection)
         return JSValueMakeUndefined(context);
-    return sendMessageWithJSArguments(*connection, context, argumentCount - 1, arguments + 1, exception);
+    auto destinationID = destinationIDFromArgument(globalObject, arguments[1], exception);
+    if (!destinationID)
+        return JSValueMakeUndefined(context);
+    auto messageName = messageNameFromArgument(globalObject, arguments[2], exception);
+    if (!messageName)
+        return JSValueMakeUndefined(context);
+    JSValueRef messageArguments = argumentCount > 3 ? arguments[3] : nullptr;
+    return jsSend(connection->connection().get(), *destinationID, *messageName, context, messageArguments, exception);
 }
 
 JSValueRef JSIPC::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
@@ -2406,16 +2533,20 @@ JSValueRef JSIPC::waitForMessage(JSContextRef context, JSObjectRef, JSObjectRef 
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 3) {
-        *exception = createTypeError(context, "Must specify the target process, destination ID, and message ID as the first three arguments"_s);
+    if (argumentCount < 4) {
+        *exception = createTypeError(context, "Must specify the target process, destination ID, and message ID, timeout as the first four arguments"_s);
         return JSValueMakeUndefined(context);
     }
     auto* globalObject = toJS(context);
     JSC::JSLockHolder lock(globalObject->vm());
-    auto connection = processTargetFromArgument(globalObject, arguments[0], exception);
+    auto connection = jsIPC->processTargetFromArgument(globalObject, arguments[0], exception);
     if (!connection)
         return JSValueMakeUndefined(context);
-    return waitForMessageWithJSArguments(*connection, context, argumentCount - 1, arguments + 1, exception);
+    auto info = extractSyncIPCMessageInfo(context, argumentCount - 1, arguments + 1, exception);
+    if (!info)
+        return JSValueMakeUndefined(context);
+    auto [destinationID, messageName, timeout] = *info;
+    return jsWaitForMessage(connection->connection().get(), destinationID, messageName, timeout, context, exception);
 }
 
 JSValueRef JSIPC::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
@@ -2425,16 +2556,21 @@ JSValueRef JSIPC::sendSyncMessage(JSContextRef context, JSObjectRef, JSObjectRef
         *exception = createTypeError(context, "Wrong type"_s);
         return JSValueMakeUndefined(context);
     }
-    if (argumentCount < 3) {
-        *exception = createTypeError(context, "Must specify the target process, destination ID, and message ID as the first three arguments"_s);
+    if (argumentCount < 4) {
+        *exception = createTypeError(context, "Must specify the target process, destination ID, and message ID, timeout as the first four arguments"_s);
         return JSValueMakeUndefined(context);
     }
     auto* globalObject = toJS(context);
     JSC::JSLockHolder lock(globalObject->vm());
-    auto connection = processTargetFromArgument(globalObject, arguments[0], exception);
+    auto connection = jsIPC->processTargetFromArgument(globalObject, arguments[0], exception);
     if (!connection)
         return JSValueMakeUndefined(context);
-    return sendSyncMessageWithJSArguments(*connection, context, argumentCount - 1, arguments + 1, exception);
+    auto info = extractSyncIPCMessageInfo(context, argumentCount - 1, arguments + 1, exception);
+    if (!info)
+        return JSValueMakeUndefined(context);
+    auto [destinationID, messageName, timeout] = *info;
+    JSValueRef messageArguments = argumentCount > 4 ? arguments[4] : nullptr;
+    return jsSendSync(connection->connection().get(), destinationID, messageName, timeout, context, messageArguments, exception);
 }
 
 JSValueRef JSIPC::createConnectionPair(JSContextRef context, JSObjectRef, JSObjectRef thisObject, size_t argumentCount, const JSValueRef arguments[], JSValueRef* exception)
@@ -2533,13 +2669,13 @@ JSValueRef JSIPC::addTesterReceiver(JSContextRef context, JSObjectRef, JSObjectR
     auto& vm = globalObject->vm();
     JSC::JSLockHolder lock(vm);
 
-    auto* impl = toWrapped(context, thisObject);
-    if (!impl) {
+    auto* jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = toRef(JSC::createTypeError(toJS(context), "Wrong type"_s));
         return JSValueMakeUndefined(context);
     }
     // Currently supports only UI process, as there's no uniform way to add message receivers.
-    WebProcess::singleton().addMessageReceiver(Messages::IPCTesterReceiver::messageReceiverName(), impl->m_testerProxy);
+    WebProcess::singleton().addMessageReceiver(Messages::IPCTesterReceiver::messageReceiverName(), jsIPC->m_testerProxy);
     return JSValueMakeUndefined(context);
 }
 
@@ -2549,8 +2685,8 @@ JSValueRef JSIPC::removeTesterReceiver(JSContextRef context, JSObjectRef, JSObje
     auto* globalObject = toJS(context);
     auto& vm = globalObject->vm();
     JSC::JSLockHolder lock(vm);
-    auto* impl = toWrapped(context, thisObject);
-    if (!impl) {
+    auto* jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = toRef(JSC::createTypeError(toJS(context), "Wrong type"_s));
         return JSValueMakeUndefined(context);
     }
@@ -2579,7 +2715,7 @@ JSValueRef JSIPC::serializedTypeInfo(JSContextRef context, JSObjectRef thisObjec
 
             entry->putDirect(vm, JSC::Identifier::fromString(vm, "type"_s), JSC::jsString(vm, String(type.members[i].type)));
             RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
-            
+
             entry->putDirect(vm, JSC::Identifier::fromString(vm, "name"_s), JSC::jsString(vm, String(type.members[i].name)));
             RETURN_IF_EXCEPTION(scope, JSValueMakeUndefined(context));
 
@@ -2776,8 +2912,8 @@ JSValueRef JSIPC::messages(JSContextRef context, JSObjectRef thisObject, JSStrin
     auto& vm = globalObject->vm();
     JSC::JSLockHolder lock(vm);
 
-    auto* impl = toWrapped(context, thisObject);
-    if (!impl) {
+    auto* jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = toRef(JSC::createTypeError(toJS(context), "Wrong type"_s));
         return JSValueMakeUndefined(context);
     }
@@ -2826,8 +2962,8 @@ JSValueRef JSIPC::processTargets(JSContextRef context, JSObjectRef thisObject, J
     auto& vm = globalObject->vm();
     JSC::JSLockHolder lock(vm);
 
-    auto* impl = toWrapped(context, thisObject);
-    if (!impl) {
+    auto* jsIPC = toWrapped(context, thisObject);
+    if (!jsIPC) {
         *exception = toRef(JSC::createTypeError(toJS(context), "Wrong type"_s));
         return JSValueMakeUndefined(context);
     }


### PR DESCRIPTION
#### 08baee0f736008bb945716a2430aa9a513040f36
<pre>
IPC Testing API: asynchronous stream messages with replies not working
<a href="https://bugs.webkit.org/show_bug.cgi?id=272148">https://bugs.webkit.org/show_bug.cgi?id=272148</a>
<a href="https://rdar.apple.com/125084127">rdar://125084127</a>

Reviewed by Ryosuke Niwa.

Implement support for asynchronous replies in JS testing API:
 - JSIPCConnection::sendWithAsyncReply
 - JSIPCConnection::waitForAsyncReplyAndDispatchImmediately
 - JSIPCStreamClientConnection::sendWithAsyncReply
 - JSIPCStreamClientConnection::waitForAsyncReplyAndDispatchImmediately

Previously in JS, the JSIPC object would support sending the async message
and receiving it as a promise. Stream connections would not support it.

Replace it with more consistent connection-specific sendWithAsyncReply
calls that take a callback parameter, similar to C++. Implement the
promise variant in JS side.

This way the async reply id is available for the tests, if they need it.

Organize the code so that the JSIPCConnection and
JSIPCStreamClientConnection share the common implementation in jsSend,
jsSendSync, jsSendWithAsyncReply, jsWaitForMessage,
jsWaitForAsyncReplyAndDispatchImmediately. Organize
JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage to just
prepare the stream connection so that the above common functionality can
then be shared.

* LayoutTests/resources/ipc.js:
(connectionSendWithPromisedReply):
(IPC.sendWithPromisedReply):
(asyncFlush):
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::asyncPing):
(WebKit::IPCStreamTester::asyncMessage): Deleted.
* Source/WebKit/Shared/IPCStreamTester.h:
* Source/WebKit/Shared/IPCStreamTester.messages.in:
* Source/WebKit/Shared/IPCTester.cpp:
(WebKit::IPCTester::asyncPing):
* Source/WebKit/Shared/IPCTester.h:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSIPCConnection::create):
(WebKit::IPCTestingAPI::JSIPCConnection::connection const):
(WebKit::IPCTestingAPI::JSIPCConnection::JSIPCConnection):
(WebKit::IPCTestingAPI::createErrorFromIPCError):
(WebKit::IPCTestingAPI::extractSyncIPCMessageInfo):
(WebKit::IPCTestingAPI::jsSend):
(WebKit::IPCTestingAPI::jsSendWithAsyncReply):
(WebKit::IPCTestingAPI::jsSendSync):
(WebKit::IPCTestingAPI::jsWaitForMessage):
(WebKit::IPCTestingAPI::jsWaitForAsyncReplyAndDispatchImmediately):
(WebKit::IPCTestingAPI::JSIPCConnection::staticFunctions):
(WebKit::IPCTestingAPI::JSIPCConnection::sendMessage):
(WebKit::IPCTestingAPI::JSIPCConnection::sendWithAsyncReply):
(WebKit::IPCTestingAPI::JSIPCConnection::sendSyncMessage):
(WebKit::IPCTestingAPI::JSIPCConnection::waitForMessage):
(WebKit::IPCTestingAPI::JSIPCConnection::waitForAsyncReplyAndDispatchImmediately):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::staticFunctions):
(WebKit::IPCTestingAPI::extractIPCStreamMessageInfo):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::prepareToSendOutOfStreamMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendWithAsyncReply):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::sendSyncMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::waitForMessage):
(WebKit::IPCTestingAPI::JSIPCStreamClientConnection::waitForAsyncReplyAndDispatchImmediately):
(WebKit::IPCTestingAPI::JSIPC::staticFunctions):
(WebKit::IPCTestingAPI::JSIPC::processTargetFromArgument):
(WebKit::IPCTestingAPI::JSIPC::addMessageListener):
(WebKit::IPCTestingAPI::messageNameFromArgument):
(WebKit::IPCTestingAPI::encodeArgument):
(WebKit::IPCTestingAPI::JSIPC::getConnectionForProcessTarget):
(WebKit::IPCTestingAPI::JSIPC::sendMessage):
(WebKit::IPCTestingAPI::JSIPC::waitForMessage):
(WebKit::IPCTestingAPI::JSIPC::sendSyncMessage):
(WebKit::IPCTestingAPI::sendMessageWithJSArguments): Deleted.
(WebKit::IPCTestingAPI::sendSyncMessageWithJSArguments): Deleted.
(WebKit::IPCTestingAPI::waitForMessageWithJSArguments): Deleted.
(WebKit::IPCTestingAPI::processTargetFromArgument): Deleted.
(WebKit::IPCTestingAPI::messageIDFromArgument): Deleted.
* LayoutTests/ipc/async-with-reply-expected.txt: Added.
* LayoutTests/ipc/async-with-reply.html: Added.
* LayoutTests/ipc/stream-async-with-reply-expected.txt: Added.
* LayoutTests/ipc/stream-async-with-reply.html: Added.

Canonical link: <a href="https://commits.webkit.org/277239@main">https://commits.webkit.org/277239@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c3270df424526a2c50b493b154f941278079125

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49788 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43154 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38370 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47686 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/23756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19677 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/21159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41745 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5149 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51663 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22129 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45661 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44665 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10390 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24188 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->