### PR TITLE
[GTK][WPE] `webanimations/combining-transform-animations-with-different-acceleration-capabilities-7.html` is a constant timeout

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -50,6 +50,66 @@
 
 namespace WebCore {
 
+#if ENABLE(THREADED_ANIMATION_RESOLUTION)
+String acceleratedEffectPropertyIDAsString(AcceleratedEffectProperty property)
+{
+    switch (property) {
+    case AcceleratedEffectProperty::Opacity:
+        return "opacity"_s;
+    case AcceleratedEffectProperty::Transform:
+        return "transform"_s;
+    case AcceleratedEffectProperty::Translate:
+        return "translate"_s;
+    case AcceleratedEffectProperty::Rotate:
+        return "rotate"_s;
+    case AcceleratedEffectProperty::Scale:
+        return "scale"_s;
+    case AcceleratedEffectProperty::OffsetPath:
+        return "offset-path"_s;
+    case AcceleratedEffectProperty::OffsetDistance:
+        return "offset-distance"_s;
+    case AcceleratedEffectProperty::OffsetPosition:
+        return "offset-position"_s;
+    case AcceleratedEffectProperty::OffsetAnchor:
+        return "offset-anchor"_s;
+    case AcceleratedEffectProperty::OffsetRotate:
+        return "offset-rotate"_s;
+    case AcceleratedEffectProperty::Filter:
+        return "filter"_s;
+    case AcceleratedEffectProperty::BackdropFilter:
+        return "backdrop-filter"_s;
+    default:
+        ASSERT_NOT_REACHED();
+        return "invalid"_s;
+    }
+    ASSERT_NOT_REACHED();
+    return ""_s;
+}
+#endif
+
+String animatedPropertyIDAsString(AnimatedProperty property)
+{
+    switch (property) {
+    case AnimatedProperty::Translate:
+    case AnimatedProperty::Scale:
+    case AnimatedProperty::Rotate:
+    case AnimatedProperty::Transform:
+        return "transform"_s;
+    case AnimatedProperty::Opacity:
+        return "opacity"_s;
+    case AnimatedProperty::BackgroundColor:
+        return "background-color"_s;
+    case AnimatedProperty::Filter:
+        return "filter"_s;
+    case AnimatedProperty::WebkitBackdropFilter:
+        return "backdrop-filter"_s;
+    case AnimatedProperty::Invalid:
+        return "invalid"_s;
+    }
+    ASSERT_NOT_REACHED();
+    return ""_s;
+}
+
 typedef HashMap<const GraphicsLayer*, Vector<FloatRect>> RepaintMap;
 static RepaintMap& repaintRectMap()
 {

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -77,7 +77,10 @@ class TransformationMatrix;
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 struct AcceleratedEffectValues;
+String acceleratedEffectPropertyIDAsString(AcceleratedEffectProperty);
 #endif
+
+String animatedPropertyIDAsString(AnimatedProperty);
 
 namespace DisplayList {
 enum class AsTextFlag : uint8_t;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -4959,66 +4959,6 @@ double GraphicsLayerCA::backingStoreMemoryEstimate() const
     return m_layer->backingStoreBytesPerPixel() * size().width() * m_layer->contentsScale() * size().height() * m_layer->contentsScale();
 }
 
-static String animatedPropertyIDAsString(AnimatedProperty property)
-{
-    switch (property) {
-    case AnimatedProperty::Translate:
-    case AnimatedProperty::Scale:
-    case AnimatedProperty::Rotate:
-    case AnimatedProperty::Transform:
-        return "transform"_s;
-    case AnimatedProperty::Opacity:
-        return "opacity"_s;
-    case AnimatedProperty::BackgroundColor:
-        return "background-color"_s;
-    case AnimatedProperty::Filter:
-        return "filter"_s;
-    case AnimatedProperty::WebkitBackdropFilter:
-        return "backdrop-filter"_s;
-    case AnimatedProperty::Invalid:
-        return "invalid"_s;
-    }
-    ASSERT_NOT_REACHED();
-    return ""_s;
-}
-
-#if ENABLE(THREADED_ANIMATION_RESOLUTION)
-static String acceleratedEffectPropertyIDAsString(AcceleratedEffectProperty property)
-{
-    switch (property) {
-    case AcceleratedEffectProperty::Opacity:
-        return "opacity"_s;
-    case AcceleratedEffectProperty::Transform:
-        return "transform"_s;
-    case AcceleratedEffectProperty::Translate:
-        return "translate"_s;
-    case AcceleratedEffectProperty::Rotate:
-        return "rotate"_s;
-    case AcceleratedEffectProperty::Scale:
-        return "scale"_s;
-    case AcceleratedEffectProperty::OffsetPath:
-        return "offset-path"_s;
-    case AcceleratedEffectProperty::OffsetDistance:
-        return "offset-distance"_s;
-    case AcceleratedEffectProperty::OffsetPosition:
-        return "offset-position"_s;
-    case AcceleratedEffectProperty::OffsetAnchor:
-        return "offset-anchor"_s;
-    case AcceleratedEffectProperty::OffsetRotate:
-        return "offset-rotate"_s;
-    case AcceleratedEffectProperty::Filter:
-        return "filter"_s;
-    case AcceleratedEffectProperty::BackdropFilter:
-        return "backdrop-filter"_s;
-    default:
-        ASSERT_NOT_REACHED();
-        return "invalid"_s;
-    }
-    ASSERT_NOT_REACHED();
-    return ""_s;
-}
-#endif
-
 Vector<std::pair<String, double>> GraphicsLayerCA::acceleratedAnimationsForTesting(const Settings& settings) const
 {
     Vector<std::pair<String, double>> animations;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -1516,6 +1516,16 @@ double CoordinatedGraphicsLayer::backingStoreMemoryEstimate() const
     return 0.0;
 }
 
+Vector<std::pair<String, double>> CoordinatedGraphicsLayer::acceleratedAnimationsForTesting(const Settings&) const
+{
+    Vector<std::pair<String, double>> animations;
+
+    for (auto& animation : m_animations.animations())
+        animations.append({ animatedPropertyIDAsString(animation.keyframes().property()), animation.state() == Nicosia::Animation::AnimationState::Playing ? 1 : 0 });
+
+    return animations;
+}
+
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_ANIMATEDBACKINGSTORECLIENT(WebCore::CoordinatedAnimatedBackingStoreClient, type() == Nicosia::AnimatedBackingStoreClient::Type::Coordinated)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -184,6 +184,8 @@ public:
 
     double backingStoreMemoryEstimate() const override;
 
+    WEBCORE_EXPORT Vector<std::pair<String, double>> acceleratedAnimationsForTesting(const Settings&) const final;
+
 private:
     enum class FlushNotification {
         Required,


### PR DESCRIPTION
#### d133014b967a8d9655f58b909801bd5a0259c25a
<pre>
[GTK][WPE] `webanimations/combining-transform-animations-with-different-acceleration-capabilities-7.html` is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=272149">https://bugs.webkit.org/show_bug.cgi?id=272149</a>

Reviewed by Carlos Garcia Campos.

This patch implements `CoordinatedGraphicsLayer::acceleratedAnimationsForTesting()`
similarly to already existing `GraphicsLayerCA::acceleratedAnimationsForTesting()`.

* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::acceleratedEffectPropertyIDAsString):
(WebCore::animatedPropertyIDAsString):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::animatedPropertyIDAsString): Deleted.
(WebCore::acceleratedEffectPropertyIDAsString): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::acceleratedAnimationsForTesting const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:

Canonical link: <a href="https://commits.webkit.org/277104@main">https://commits.webkit.org/277104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/559fcac929f953c477bf6a78f9ee2c3aa931f9be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49273 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42641 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/37994 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19261 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20130 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41272 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4641 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42908 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51122 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45255 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22893 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44203 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10319 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23333 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22596 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->