### PR TITLE
[WPE] Fix crash on ThreadedCompositor::renderLayerTree() during video playlist transitions

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
@@ -87,6 +87,8 @@ void TextureMapperPlatformLayerProxyDMABuf::activateOnCompositingThread(Composit
     {
         Locker locker { m_lock };
         m_compositor = compositor;
+        if (m_targetLayer)
+            m_targetLayer->setContentsLayer(nullptr);
         m_targetLayer = targetLayer;
     }
 }
@@ -105,6 +107,8 @@ void TextureMapperPlatformLayerProxyDMABuf::invalidate()
     m_layers = { };
 
     m_compositor = nullptr;
+    if (m_targetLayer)
+        m_targetLayer->setContentsLayer(nullptr);
     m_targetLayer = nullptr;
 }
 


### PR DESCRIPTION
#### 3b4a4e93f1608825b13befdb6e76adec418763a1
<pre>
[WPE] Fix crash on ThreadedCompositor::renderLayerTree() during video playlist transitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=272150">https://bugs.webkit.org/show_bug.cgi?id=272150</a>

Reviewed by Miguel Gomez.

Unnoticed default usage of dmabuf was leading to missing checks in the dmabuf
proxy. This caused issues when activating a proxy in a TextureMapperLayer,
removing any reference that another layer might have had to the previous proxy.
Additionally, when invalidating, the reference to the proxy held by the TextureMapperLayer
was also removed.

This prevents an invalid memory access identified in the
CoordinatedGraphicsScene::paintToCurrentGLContext().

* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp:
(WebCore::TextureMapperPlatformLayerProxyDMABuf::activateOnCompositingThread):
(WebCore::TextureMapperPlatformLayerProxyDMABuf::invalidate):

Canonical link: <a href="https://commits.webkit.org/277071@main">https://commits.webkit.org/277071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1cff9cd707434045c6582f4dc336a8de2e7cec0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49262 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42630 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23204 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/37984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47164 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19251 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41264 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4630 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41643 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/51148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21592 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/17993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45245 "layout-tests (failure)") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44192 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10304 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->