### PR TITLE
Make _WKApplicationManifest initializer return nil when jsonData is not valid JSON

### DIFF
--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -41,13 +41,34 @@ namespace WebCore {
 ApplicationManifest ApplicationManifestParser::parse(Document& document, const String& source, const URL& manifestURL, const URL& documentURL)
 {
     ApplicationManifestParser parser { &document };
-    return parser.parseManifest(source, manifestURL, documentURL);
+    auto object = parser.createJSONObject(source);
+    if (!object)
+        object = JSON::Object::create();
+
+    return parser.parseManifest(*object, source, manifestURL, documentURL);
 }
 
 ApplicationManifest ApplicationManifestParser::parse(const String& source, const URL& manifestURL, const URL& documentURL)
 {
     ApplicationManifestParser parser { nullptr };
-    return parser.parseManifest(source, manifestURL, documentURL);
+    auto object = parser.createJSONObject(source);
+    if (!object)
+        object = JSON::Object::create();
+
+    return parser.parseManifest(*object, source, manifestURL, documentURL);
+}
+
+std::optional<ApplicationManifest> ApplicationManifestParser::parseWithValidation(const String& source, const URL& manifestURL, const URL& documentURL)
+{
+    if (!manifestURL.isValid() || !documentURL.isValid())
+        return std::nullopt;
+
+    ApplicationManifestParser parser { nullptr };
+    auto object = parser.createJSONObject(source);
+    if (!object)
+        return std::nullopt;
+
+    return parser.parseManifest(*object, source, manifestURL, documentURL);
 }
 
 ApplicationManifestParser::ApplicationManifestParser(RefPtr<Document> document)
@@ -55,44 +76,48 @@ ApplicationManifestParser::ApplicationManifestParser(RefPtr<Document> document)
 {
 }
 
-ApplicationManifest ApplicationManifestParser::parseManifest(const String& text, const URL& manifestURL, const URL& documentURL)
+RefPtr<JSON::Object> ApplicationManifestParser::createJSONObject(const String& text)
 {
-    m_manifestURL = manifestURL;
-
     auto jsonValue = JSON::Value::parseJSON(text);
     if (!jsonValue) {
         logDeveloperWarning("The manifest is not valid JSON data."_s);
-        jsonValue = JSON::Object::create();
+        return nullptr;
     }
 
-    auto manifest = jsonValue->asObject();
-    if (!manifest) {
+    auto jsontObject = jsonValue->asObject();
+    if (!jsontObject) {
         logDeveloperWarning("The manifest is not a JSON value of type \"object\"."_s);
-        manifest = JSON::Object::create();
+        return nullptr;
     }
 
+    return jsontObject;
+}
+
+ApplicationManifest ApplicationManifestParser::parseManifest(const JSON::Object& manifest, const String& text, const URL& manifestURL, const URL& documentURL)
+{
+    m_manifestURL = manifestURL;
     ApplicationManifest parsedManifest;
 
     parsedManifest.rawJSON = text;
     parsedManifest.manifestURL = manifestURL;
-    parsedManifest.startURL = parseStartURL(*manifest, documentURL);
-    parsedManifest.display = parseDisplay(*manifest);
-    parsedManifest.name = parseName(*manifest);
-    parsedManifest.description = parseDescription(*manifest);
-    parsedManifest.shortName = parseShortName(*manifest);
-    if (auto parsedScope = parseScope(*manifest, documentURL, parsedManifest.startURL))
+    parsedManifest.startURL = parseStartURL(manifest, documentURL);
+    parsedManifest.display = parseDisplay(manifest);
+    parsedManifest.name = parseName(manifest);
+    parsedManifest.description = parseDescription(manifest);
+    parsedManifest.shortName = parseShortName(manifest);
+    if (auto parsedScope = parseScope(manifest, documentURL, parsedManifest.startURL))
         parsedManifest.scope = WTFMove(*parsedScope);
     else {
         parsedManifest.scope = URL { parsedManifest.startURL, "./"_s };
         parsedManifest.isDefaultScope = true;
     }
-    parsedManifest.backgroundColor = parseColor(*manifest, "background_color"_s);
-    parsedManifest.themeColor = parseColor(*manifest, "theme_color"_s);
-    parsedManifest.categories = parseCategories(*manifest);
-    parsedManifest.icons = parseIcons(*manifest);
-    parsedManifest.shortcuts = parseShortcuts(*manifest);
-    parsedManifest.id = parseId(*manifest, parsedManifest.startURL);
-    parsedManifest.orientation = parseOrientation(*manifest);
+    parsedManifest.backgroundColor = parseColor(manifest, "background_color"_s);
+    parsedManifest.themeColor = parseColor(manifest, "theme_color"_s);
+    parsedManifest.categories = parseCategories(manifest);
+    parsedManifest.icons = parseIcons(manifest);
+    parsedManifest.shortcuts = parseShortcuts(manifest);
+    parsedManifest.id = parseId(manifest, parsedManifest.startURL);
+    parsedManifest.orientation = parseOrientation(manifest);
 
     if (m_document)
         m_document->processApplicationManifest(parsedManifest);

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h
@@ -40,11 +40,13 @@ class ApplicationManifestParser {
 public:
     WEBCORE_EXPORT static ApplicationManifest parse(Document&, const String&, const URL& manifestURL, const URL& documentURL);
     WEBCORE_EXPORT static ApplicationManifest parse(const String&, const URL& manifestURL, const URL& documentURL);
+    WEBCORE_EXPORT static std::optional<ApplicationManifest> parseWithValidation(const String&, const URL& manifestURL, const URL& documentURL);
 
 private:
     ApplicationManifestParser(RefPtr<Document>);
-    ApplicationManifest parseManifest(const String&, const URL&, const URL&);
+    ApplicationManifest parseManifest(const JSON::Object&, const String&, const URL&, const URL&);
 
+    RefPtr<JSON::Object> createJSONObject(const String&);
     URL parseStartURL(const JSON::Object&, const URL&);
     ApplicationManifest::Display parseDisplay(const JSON::Object&);
     const std::optional<ScreenOrientationLockType> parseOrientation(const JSON::Object&);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -252,9 +252,11 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
     if (!jsonString)
         return nil;
 
-    // FIXME: Return nil if jsonString cannot be deserialized into JSON object.
-    auto manifest = WebCore::ApplicationManifestParser::parse(jsonString.get(), URL(manifestURL), URL(documentURL));
-    API::Object::constructInWrapper<API::ApplicationManifest>(self, manifest);
+    auto manifest = WebCore::ApplicationManifestParser::parseWithValidation(jsonString.get(), URL(manifestURL), URL(documentURL));
+    if (!manifest)
+        return nil;
+
+    API::Object::constructInWrapper<API::ApplicationManifest>(self, *manifest);
 
     return self;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
@@ -426,6 +426,28 @@ TEST(WKApplicationManifest, JSONDataEncoding)
     EXPECT_NULL(manifest);
 }
 
+TEST(WKApplicationManifest, InvalidJSONData)
+{
+    RetainPtr<NSURL> manifestURL = [NSURL URLWithString:@"https://test.com/manifest.json"];
+    RetainPtr<NSURL> documentURL = [NSURL URLWithString:@"https://test.com"];
+
+    NSDictionary *jsonbject = @{ @"name": @"TestName" };
+    RetainPtr jsonData = [NSJSONSerialization dataWithJSONObject:jsonbject options:0 error:nil];
+    RetainPtr manifest = adoptNS([[_WKApplicationManifest alloc] initWithJSONData:jsonData.get() manifestURL:manifestURL.get() documentURL:documentURL.get()]);
+    EXPECT_NOT_NULL(manifest);
+    EXPECT_WK_STREQ("TestName", manifest.get().name);
+
+    NSString *testString = @"test string";
+    RetainPtr stringData = [testString dataUsingEncoding:NSUTF8StringEncoding allowLossyConversion:YES];
+    manifest = adoptNS([[_WKApplicationManifest alloc] initWithJSONData:stringData.get() manifestURL:manifestURL.get() documentURL:documentURL.get()]);
+    EXPECT_NULL(manifest);
+
+    RetainPtr mutableJSONData = adoptNS([[NSMutableData alloc] initWithData:jsonData.get()]);
+    [mutableJSONData appendData:stringData.get()];
+    manifest = adoptNS([[_WKApplicationManifest alloc] initWithJSONData:mutableJSONData.get() manifestURL:manifestURL.get() documentURL:documentURL.get()]);
+    EXPECT_NULL(manifest);
+}
+
 
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### fa54f7ce3cd9b71732786437b9d5dcde72a4c07f
<pre>
Make _WKApplicationManifest initializer return nil when jsonData is not valid JSON
<a href="https://bugs.webkit.org/show_bug.cgi?id=272161">https://bugs.webkit.org/show_bug.cgi?id=272161</a>
<a href="https://rdar.apple.com/125913241">rdar://125913241</a>

Reviewed by Chris Dumez.

API Test: WKApplicationManifest.InvalidJSONData

* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parse):
(WebCore::ApplicationManifestParser::parseWithValidation):
(WebCore::ApplicationManifestParser::createJSONObject):
(WebCore::ApplicationManifestParser::parseManifest):
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
(-[_WKApplicationManifest initWithJSONData:manifestURL:documentURL:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm:
(TestWebKitAPI::TEST(WKApplicationManifest, InvalidJSONData)):

Canonical link: <a href="https://commits.webkit.org/277098@main">https://commits.webkit.org/277098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92ce77d80c9c950b6a1a2db4e243e188ed2bcc64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25833 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49350 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23295 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19313 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41333 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4718 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42952 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51206 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21682 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45308 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44262 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10318 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22674 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->