### PR TITLE
Remove ENABLE(APPLICATION_MANIFEST) in Cocoa files

### DIFF
--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -70,6 +70,7 @@
 #import "WKWebsiteDataRecordInternal.h"
 #import "WKWebsiteDataStoreInternal.h"
 #import "WKWindowFeaturesInternal.h"
+#import "_WKApplicationManifestInternal.h"
 #import "_WKAttachmentInternal.h"
 #import "_WKAutomationSessionInternal.h"
 #import "_WKContentRuleListActionInternal.h"
@@ -96,10 +97,6 @@
 #import "_WKWebAuthenticationAssertionResponseInternal.h"
 #import "_WKWebAuthenticationPanelInternal.h"
 #import "_WKWebsiteDataStoreConfigurationInternal.h"
-
-#if ENABLE(APPLICATION_MANIFEST)
-#import "_WKApplicationManifestInternal.h"
-#endif
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
 #import "_WKInspectorExtensionInternal.h"
@@ -155,11 +152,9 @@ void* Object::newObject(size_t size, Type type)
     // API::Object, so they are allocated using +alloc.
 
     switch (type) {
-#if ENABLE(APPLICATION_MANIFEST)
     case Type::ApplicationManifest:
         wrapper = [_WKApplicationManifest alloc];
         break;
-#endif
 
     case Type::Array:
         wrapper = [WKNSArray alloc];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -108,6 +108,7 @@
 #import "_WKActivatedElementInfoInternal.h"
 #import "_WKAppHighlightDelegate.h"
 #import "_WKAppHighlightInternal.h"
+#import "_WKApplicationManifestInternal.h"
 #import "_WKArchiveConfiguration.h"
 #import "_WKArchiveExclusionRule.h"
 #import "_WKDataTaskInternal.h"
@@ -172,10 +173,6 @@
 #import <wtf/spi/darwin/dyldSPI.h>
 #import <wtf/text/StringToIntegerConversion.h>
 #import <wtf/text/TextStream.h>
-
-#if ENABLE(APPLICATION_MANIFEST)
-#import "_WKApplicationManifestInternal.h"
-#endif
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 #import "_WKWebExtensionControllerInternal.h"
@@ -3493,7 +3490,6 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
 - (void)_getApplicationManifestWithCompletionHandler:(void (^)(_WKApplicationManifest *))completionHandler
 {
     THROW_IF_SUSPENDED;
-#if ENABLE(APPLICATION_MANIFEST)
     _page->getApplicationManifest([completionHandler = makeBlockPtr(completionHandler)](const std::optional<WebCore::ApplicationManifest>& manifest) {
         if (completionHandler) {
             if (manifest) {
@@ -3503,10 +3499,6 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
                 completionHandler(nil);
         }
     });
-#else
-    if (completionHandler)
-        completionHandler(nil);
-#endif
 }
 
 - (void)_getTextFragmentMatchWithCompletionHandler:(void (^)(NSString *))completionHandler

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm
@@ -241,8 +241,6 @@ static std::optional<WebCore::ApplicationManifest::Shortcut> makeVectorElement(c
 
 @implementation _WKApplicationManifest
 
-#if ENABLE(APPLICATION_MANIFEST)
-
 - (instancetype)initWithJSONData:(NSData *)jsonData manifestURL:(NSURL *)manifestURL documentURL:(NSURL *)documentURL
 {
     if (!(self = [super init]))
@@ -480,93 +478,5 @@ static NSString *nullableNSString(const WTF::String& string)
 {
     return _applicationManifest->applicationManifest().id;
 }
-
-#else // ENABLE(APPLICATION_MANIFEST)
-
-- (instancetype)initWithJSONData:(NSData *)jsonData manifestURL:(NSURL *)manifestURL documentURL:(NSURL *)documentURL
-{
-    UNUSED_PARAM(jsonData);
-    UNUSED_PARAM(manifestURL);
-    UNUSED_PARAM(documentURL);
-
-    return nil;
-}
-
-+ (_WKApplicationManifest *)applicationManifestFromJSON:(NSString *)json manifestURL:(NSURL *)manifestURL documentURL:(NSURL *)documentURL
-{
-    UNUSED_PARAM(json);
-    UNUSED_PARAM(manifestURL);
-    UNUSED_PARAM(documentURL);
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-- (instancetype)initWithCoder:(NSCoder *)aDecoder
-{
-    UNUSED_PARAM(aDecoder);
-    [self release];
-    return nil;
-}
-
-- (void)encodeWithCoder:(NSCoder *)aCoder
-{
-    UNUSED_PARAM(aCoder);
-}
-
-- (NSString *)name
-{
-    return nil;
-}
-
-- (NSString *)shortName
-{
-    return nil;
-}
-
-- (NSString *)applicationDescription
-{
-    return nil;
-}
-
-- (NSURL *)scope
-{
-    return nil;
-}
-
-- (NSURL *)startURL
-{
-    return nil;
-}
-
-- (WebCore::CocoaColor *)backgroundColor
-{
-    return nil;
-}
-
-- (WebCore::CocoaColor *)themeColor
-{
-    return nil;
-}
-
-- (_WKApplicationManifestDisplayMode)displayMode
-{
-    return _WKApplicationManifestDisplayModeBrowser;
-}
-
-- (std::optional<_WKApplicationManifestOrientation>)orientation
-{
-    return std::nullopt;
-}
-
-- (NSArray<_WKApplicationManifestIcon *> *)icons
-{
-    return nil;
-}
-
-- (NSURL *)manifestId
-{
-    return nil;
-}
-
-#endif // ENABLE(APPLICATION_MANIFEST)
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifestInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifestInternal.h
@@ -29,8 +29,6 @@
 #import "_WKApplicationManifest.h"
 #import <wtf/cocoa/VectorCocoa.h>
 
-#if ENABLE(APPLICATION_MANIFEST)
-
 namespace WebKit {
 
 template<> struct WrapperTraits<API::ApplicationManifest> {
@@ -45,5 +43,3 @@ template<> struct WrapperTraits<API::ApplicationManifest> {
 }
 
 @end
-
-#endif // ENABLE(APPLICATION_MANIFEST)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm
@@ -25,8 +25,6 @@
 
 #import "config.h"
 
-#if ENABLE(APPLICATION_MANIFEST)
-
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestCocoa.h"
@@ -450,5 +448,3 @@ TEST(WKApplicationManifest, InvalidJSONData)
 
 
 } // namespace TestWebKitAPI
-
-#endif // ENABLE(APPLICATION_MANIFEST)


### PR DESCRIPTION
#### 12e8d81bdb136f756804970da4fa1318136bd423
<pre>
Remove ENABLE(APPLICATION_MANIFEST) in Cocoa files
<a href="https://bugs.webkit.org/show_bug.cgi?id=272166">https://bugs.webkit.org/show_bug.cgi?id=272166</a>
<a href="https://rdar.apple.com/125916173">rdar://125916173</a>

Reviewed by Per Arne Vollan.

ENABLE_APPLICATION_MANIFEST is true on Cocoa platforms.

* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _getApplicationManifestWithCompletionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifest.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifestInternal.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ApplicationManifest.mm:

Canonical link: <a href="https://commits.webkit.org/277128@main">https://commits.webkit.org/277128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/998196a4c16245ad32e98d72131e317e59ccd569

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49212 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49282 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42650 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38008 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19268 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20135 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41275 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4650 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51132 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45261 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22902 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44212 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10333 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23348 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->