### PR TITLE
[GStreamer] Ignore sinks position while seeking

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -346,8 +346,8 @@ protected:
 
     void setCachedPosition(const MediaTime&) const;
 
-    bool isPipelineSeeking(GstState current, GstState pending, GstStateChangeReturn) const;
-    bool isPipelineSeeking() const;
+    bool isPipelineWaitingPreroll(GstState current, GstState pending, GstStateChangeReturn) const;
+    bool isPipelineWaitingPreroll() const;
 
     Ref<MainThreadNotifier<MainThreadNotification>> m_notifier;
     ThreadSafeWeakPtr<MediaPlayer> m_player;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -335,18 +335,18 @@ size_t MediaPlayerPrivateGStreamerMSE::extraMemoryCost() const
 
 void MediaPlayerPrivateGStreamerMSE::updateStates()
 {
-    bool isSeeking = isPipelineSeeking();
+    bool isWaitingPreroll = isPipelineWaitingPreroll();
     bool shouldBePlaying = (!m_isPaused && readyState() >= MediaPlayer::ReadyState::HaveFutureData && m_playbackRatePausedState != PlaybackRatePausedState::RatePaused)
         || m_playbackRatePausedState == PlaybackRatePausedState::ShouldMoveToPlaying;
     GST_DEBUG_OBJECT(pipeline(), "shouldBePlaying = %s, m_isPipelinePlaying = %s, is seeking %s", boolForPrinting(shouldBePlaying),
-        boolForPrinting(m_isPipelinePlaying), boolForPrinting(isSeeking));
-    if (!isSeeking && shouldBePlaying && !m_isPipelinePlaying) {
+        boolForPrinting(m_isPipelinePlaying), boolForPrinting(isWaitingPreroll));
+    if (!isWaitingPreroll && shouldBePlaying && !m_isPipelinePlaying) {
         auto result = changePipelineState(GST_STATE_PLAYING);
         if (result == ChangePipelineStateResult::Failed)
             GST_ERROR_OBJECT(pipeline(), "Setting the pipeline to PLAYING failed");
         else if (result == ChangePipelineStateResult::Ok)
             m_playbackRatePausedState = PlaybackRatePausedState::Playing;
-    } else if (!isSeeking && !shouldBePlaying && m_isPipelinePlaying) {
+    } else if (!isWaitingPreroll && !shouldBePlaying && m_isPipelinePlaying) {
         if (changePipelineState(GST_STATE_PAUSED) == ChangePipelineStateResult::Failed)
             GST_ERROR_OBJECT(pipeline(), "Setting the pipeline to PAUSED failed");
     }


### PR DESCRIPTION
#### 40cfa6a6170658709d2eafdc10657bc67a6ec207
<pre>
[GStreamer] Ignore sinks position while seeking
<a href="https://bugs.webkit.org/show_bug.cgi?id=272167">https://bugs.webkit.org/show_bug.cgi?id=272167</a>

Reviewed by Alicia Boya Garcia.

After removing MSE data, sinks get flushed and are not able to return
valid playback time. Some implementation return invalid time, 0.00 or
even some random value. This value may be then reported up to
HTMLMediaElement and that may be confusing to web applications.

This commit doesn&apos;t trust sinks position when pipeline is not prerolled,
as behavor is different across devices. The last cached position is used
instead.

To reflect better what&apos;s actually happening, isPipelineSeeking() has been
renamed as isPipelineWaitingPreroll() and the condition now also includes
pending states higher than paused.

Original author: Andrzej Surdej (<a href="https://github.com/asurdej-comcast)">https://github.com/asurdej-comcast)</a>

See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1302">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1302</a>

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::isPipelineWaitingPreroll const): Renamed from isPipelineSeeking().
(WebCore::MediaPlayerPrivateGStreamer::play): isPipelineSeeking() now named as isPipelineWaitingPreroll().
(WebCore::MediaPlayerPrivateGStreamer::paused const): Ditto.
(WebCore::MediaPlayerPrivateGStreamer::changePipelineState): Ditto.
(WebCore::MediaPlayerPrivateGStreamer::playbackPosition const): Use GST_CLOCK_TIME_NONE when the pipeline isn&apos;t prerolled. This will force the usage of the target seek time (if possible) or the last cached position (in the worst case).
(WebCore::MediaPlayerPrivateGStreamer::isPipelineSeeking const): Deleted. Renamed to isPipelineWaitingPreroll().
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h: isPipelineSeeking() now named as isPipelineWaitingPreroll().
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::updateStates): isPipelineSeeking() now named as isPipelineWaitingPreroll().

Canonical link: <a href="https://commits.webkit.org/277541@main">https://commits.webkit.org/277541@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72247c49281ffbc940180a043290b9b3de5bf757

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49437 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42807 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38099 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19385 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20253 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41407 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4806 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51309 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21769 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45387 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23057 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44344 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10569 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->