### PR TITLE
[libpas] Use sentinel page for primitive Gigacage

### DIFF
--- a/Source/bmalloc/bmalloc/Gigacage.cpp
+++ b/Source/bmalloc/bmalloc/Gigacage.cpp
@@ -80,31 +80,9 @@ DEFINE_STATIC_PER_PROCESS_STORAGE(PrimitiveDisableCallbacks);
 
 namespace Gigacage {
 
-// This is exactly 32GB because inside JSC, indexed accesses for arrays, typed arrays, etc,
-// use unsigned 32-bit ints as indices. The items those indices access are 8 bytes or less
-// in size. 2^32 * 8 = 32GB. This means if an access on a caged type happens to go out of
-// bounds, the access is guaranteed to land somewhere else in the cage or inside the runway.
-// If this were less than 32GB, those OOB accesses could reach outside of the cage.
-constexpr size_t gigacageRunway = 32llu * bmalloc::Sizes::GB;
-
 bool disablePrimitiveGigacageRequested = false;
 
 using namespace bmalloc;
-
-namespace {
-
-size_t runwaySize(Kind kind)
-{
-    switch (kind) {
-    case Kind::Primitive:
-        return gigacageRunway;
-    case Kind::NumberOfKinds:
-        RELEASE_BASSERT_NOT_REACHED();
-    }
-    return 0;
-}
-
-} // anonymous namespace
 
 void ensureGigacage()
 {
@@ -153,7 +131,6 @@ void ensureGigacage()
             
             for (Kind kind : shuffledKinds) {
                 totalSize = bump(kind, alignTo(kind, totalSize));
-                totalSize += runwaySize(kind);
                 maxAlignment = std::max(maxAlignment, alignment(kind));
             }
 
@@ -167,6 +144,7 @@ void ensureGigacage()
                 fprintf(stderr, "(Make sure you have not set a virtual memory limit.)\n");
                 BCRASH();
             }
+            vmDeallocatePhysicalPages(base, totalSize);
 
             size_t nextCage = 0;
             for (Kind kind : shuffledKinds) {
@@ -178,9 +156,10 @@ void ensureGigacage()
                 uint64_t random[2];
                 cryptoRandom(reinterpret_cast<unsigned char*>(random), sizeof(random));
                 size_t gigacageSize = maxSize(kind);
-                size_t size = roundDownToMultipleOf(vmPageSize(), gigacageSize - (random[0] % maximumCageSizeReductionForSlide));
+                size_t sizeWithSentinel = roundDownToMultipleOf(vmPageSize(), gigacageSize - (random[0] % maximumCageSizeReductionForSlide));
+                size_t size = sizeWithSentinel - vmPageSize();
                 g_gigacageConfig.setAllocSize(kind, size);
-                ptrdiff_t offset = roundDownToMultipleOf(vmPageSize(), random[1] % (gigacageSize - size));
+                ptrdiff_t offset = roundDownToMultipleOf(vmPageSize(), random[1] % (gigacageSize - sizeWithSentinel));
                 void* thisBase = reinterpret_cast<unsigned char*>(gigacageBasePtr) + offset;
                 g_gigacageConfig.setAllocBasePtr(kind, thisBase);
 
@@ -190,18 +169,14 @@ void ensureGigacage()
                     reinterpret_cast<uintptr_t>(thisBase),
                     reinterpret_cast<uintptr_t>(thisBase) + size);
 #endif
-                
-                if (runwaySize(kind) > 0) {
-                    char* runway = reinterpret_cast<char*>(base) + nextCage;
-                    // Make OOB accesses into the runway crash.
-                    vmRevokePermissions(runway, runwaySize(kind));
-                    nextCage += runwaySize(kind);
-                }
+
+                // Make OOB accesses into the last pages crash.
+                auto* lastPage = reinterpret_cast<unsigned char*>(thisBase) + size;
+                vmRevokePermissions(lastPage, (reinterpret_cast<unsigned char*>(gigacageBasePtr) + gigacageSize) - lastPage);
             }
 
             g_gigacageConfig.start = base;
             g_gigacageConfig.totalSize = totalSize;
-            vmDeallocatePhysicalPages(base, totalSize);
             g_gigacageConfig.isEnabled = true;
         });
 }

--- a/Source/bmalloc/bmalloc/Gigacage.h
+++ b/Source/bmalloc/bmalloc/Gigacage.h
@@ -66,7 +66,7 @@ constexpr bool hasCapacityToUseLargeGigacage = BOS_EFFECTIVE_ADDRESS_WIDTH > 36;
 
 #if GIGACAGE_ENABLED
 
-constexpr size_t primitiveGigacageSize = (hasCapacityToUseLargeGigacage ? 32 : 4) * bmalloc::Sizes::GB;
+constexpr size_t primitiveGigacageSize = (hasCapacityToUseLargeGigacage ? 64 : 32) * bmalloc::Sizes::GB;
 constexpr size_t maximumCageSizeReductionForSlide = hasCapacityToUseLargeGigacage ? 4 * bmalloc::Sizes::GB : bmalloc::Sizes::GB / 4;
 
 


### PR DESCRIPTION
#### 8f58d82a137299f5c1651599c265873bf17b3396
<pre>
[libpas] Use sentinel page for primitive Gigacage
<a href="https://bugs.webkit.org/show_bug.cgi?id=272171">https://bugs.webkit.org/show_bug.cgi?id=272171</a>
<a href="https://rdar.apple.com/125919093">rdar://125919093</a>

Reviewed by Mark Lam.

This patch uses sentinel page approach for primitive Gigacage and donate the rest of the memory to primitive Gigacage.

* Source/bmalloc/bmalloc/Gigacage.cpp:
(Gigacage::ensureGigacage):
(Gigacage::bmalloc::runwaySize): Deleted.
* Source/bmalloc/bmalloc/Gigacage.h:

Canonical link: <a href="https://commits.webkit.org/277093@main">https://commits.webkit.org/277093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc7e871bbf929d5d2c45478c3981ee3b54a92d8b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49304 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42672 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23248 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19289 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41298 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4672 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/39874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51157 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46109 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18033 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45284 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44237 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53252 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6527 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22627 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10922 "Passed tests") | 
<!--EWS-Status-Bubble-End-->