### PR TITLE
ASCIILiteral could be a wrapper around std::span

### DIFF
--- a/Source/WTF/wtf/HashTraits.h
+++ b/Source/WTF/wtf/HashTraits.h
@@ -212,8 +212,8 @@ template<typename T> struct HashTraits<UniqueRef<T>> : SimpleClassHashTraits<Uni
 template<> struct HashTraits<ASCIILiteral> : SimpleClassHashTraits<ASCIILiteral> {
     static ASCIILiteral emptyValue() { return { }; }
 
-    static void constructDeletedValue(ASCIILiteral& slot) { slot = ASCIILiteral::fromLiteralUnsafe(reinterpret_cast<const char*>(-1)); }
-    static bool isDeletedValue(const ASCIILiteral& value) { return value.characters() == reinterpret_cast<const char*>(-1); }
+    static void constructDeletedValue(ASCIILiteral& slot) { slot = ASCIILiteral::deletedValue(); }
+    static bool isDeletedValue(const ASCIILiteral& value) { return value.isDeletedValue(); }
 };
 
 template<typename P, typename Q, typename R> struct HashTraits<RefPtr<P, Q, R>> : SimpleClassHashTraits<RefPtr<P, Q, R>> {

--- a/Source/WTF/wtf/text/ASCIILiteral.cpp
+++ b/Source/WTF/wtf/text/ASCIILiteral.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Yusuke Suzuki <utatane.tea@gmail.com>
+ * Copyright (C) 2024 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,12 +28,13 @@
 #include <wtf/text/ASCIILiteral.h>
 
 #include <wtf/PrintStream.h>
+#include <wtf/text/StringView.h>
 
 namespace WTF {
 
 void ASCIILiteral::dump(PrintStream& out) const
 {
-    out.print(m_characters);
+    out.print(StringView(span8()));
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Yusuke Suzuki <utatane.tea@gmail.com>
+ * Copyright (C) 2024 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +27,7 @@
 #pragma once
 
 #include <span>
+#include <string>
 #include <type_traits>
 #include <wtf/ASCIICType.h>
 #include <wtf/Forward.h>
@@ -41,10 +43,11 @@ class PrintStream;
 
 class ASCIILiteral final {
 public:
-    constexpr operator const char*() const { return m_characters; }
+    constexpr operator const char*() const { return m_charactersWithNullTerminator.data(); }
 
     static constexpr ASCIILiteral fromLiteralUnsafe(const char* string)
     {
+        ASSERT_UNDER_CONSTEXPR_CONTEXT(string);
         return ASCIILiteral { string };
     }
 
@@ -56,25 +59,35 @@ public:
     { }
 
     unsigned hash() const;
-    constexpr bool isNull() const { return !m_characters; }
+    constexpr bool isNull() const { return m_charactersWithNullTerminator.empty(); }
 
-    constexpr const char* characters() const { return m_characters; }
-    const LChar* characters8() const { return bitwise_cast<const LChar*>(m_characters); }
-    constexpr size_t length() const;
+    constexpr const char* characters() const { return m_charactersWithNullTerminator.data(); }
+    const LChar* characters8() const { return bitwise_cast<const LChar*>(characters()); }
+    constexpr size_t length() const { return !m_charactersWithNullTerminator.empty() ? m_charactersWithNullTerminator.size() - 1 : 0; }
     std::span<const LChar> span8() const { return { characters8(), length() }; }
-    size_t isEmpty() const { return !m_characters || !*m_characters; }
+    size_t isEmpty() const { return m_charactersWithNullTerminator.size() <= 1; }
 
-    constexpr char characterAt(unsigned index) const { return m_characters[index]; }
+    constexpr char characterAt(unsigned index) const { return m_charactersWithNullTerminator[index]; }
 
 #ifdef __OBJC__
     // This function convert null strings to empty strings.
     WTF_EXPORT_PRIVATE RetainPtr<NSString> createNSString() const;
 #endif
 
-private:
-    constexpr explicit ASCIILiteral(const char* characters) : m_characters(characters) { }
+    static ASCIILiteral deletedValue();
+    bool isDeletedValue() const { return characters() == reinterpret_cast<char*>(-1); }
 
-    const char* m_characters { nullptr };
+private:
+    constexpr explicit ASCIILiteral(const char* characters)
+        : m_charactersWithNullTerminator(characters, std::char_traits<char>::length(characters) + 1)
+    {
+#if ASSERT_ENABLED
+    for (size_t i = 0; i < length(); ++i)
+        ASSERT_UNDER_CONSTEXPR_CONTEXT(isASCII(m_charactersWithNullTerminator[i]));
+#endif
+    }
+
+    std::span<const char> m_charactersWithNullTerminator;
 };
 
 inline bool operator==(ASCIILiteral a, const char* b)
@@ -89,23 +102,6 @@ inline bool operator==(ASCIILiteral a, ASCIILiteral b)
     if (!a || !b)
         return a.characters() == b.characters();
     return !strcmp(a.characters(), b.characters());
-}
-
-inline constexpr size_t ASCIILiteral::length() const
-{
-    if (std::is_constant_evaluated()) {
-        if (!m_characters)
-            return 0;
-
-        size_t length = 0;
-        while (true) {
-            if (!m_characters[length])
-                return length;
-            ++length;
-        }
-        return length;
-    }
-    return strlen(m_characters);
 }
 
 inline unsigned ASCIILiteral::hash() const
@@ -132,17 +128,21 @@ struct ASCIILiteralPtrHash {
     static constexpr bool safeToCompareToEmptyOrDeleted = false;
 };
 
+inline ASCIILiteral ASCIILiteral::deletedValue()
+{
+    ASCIILiteral result;
+    result.m_charactersWithNullTerminator = { reinterpret_cast<char*>(-1), static_cast<size_t>(0) };
+    return result;
+}
+
 inline namespace StringLiterals {
 
-constexpr ASCIILiteral operator"" _s(const char* characters, size_t n)
+constexpr ASCIILiteral operator"" _s(const char* characters, size_t)
 {
-#if ASSERT_ENABLED
-    for (size_t i = 0; i < n; ++i)
-        ASSERT_UNDER_CONSTEXPR_CONTEXT(isASCII(characters[i]));
-#else
-    UNUSED_PARAM(n);
-#endif
-    return ASCIILiteral::fromLiteralUnsafe(characters);
+    auto result = ASCIILiteral::fromLiteralUnsafe(characters);
+    // We rely on this for ASCIILiteralPtrHash above.
+    ASSERT_UNDER_CONSTEXPR_CONTEXT(result.characters() == characters);
+    return result;
 }
 
 constexpr std::span<const LChar> operator"" _span(const char* characters, size_t n)


### PR DESCRIPTION
#### 8bc5a4faf17f080969fd19205c89a90b0a82da47
<pre>
ASCIILiteral could be a wrapper around std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=272173">https://bugs.webkit.org/show_bug.cgi?id=272173</a>
<a href="https://rdar.apple.com/125920640">rdar://125920640</a>

Reviewed by Chris Dumez.

Right now ASCIILiteral just points to a `const char*` but now that
std::span exists we should consider using that as the underlying
storage for ASCIILiteral since it makes getting the length faster.

To make the characters8() function behave as expected we keep a
null terminator in the span we hold.

* Source/WTF/wtf/text/ASCIILiteral.cpp:
(WTF::ASCIILiteral::dump const):
* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::StringLiterals::operator _s):
(WTF::ASCIILiteral::length const): Deleted.

Canonical link: <a href="https://commits.webkit.org/277181@main">https://commits.webkit.org/277181@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/703e89c9bdea84e1835ff883099fa7cc85d1da42

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49511 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42881 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38144 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19447 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20323 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41471 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4879 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40081 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43063 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51385 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46316 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45431 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23130 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44398 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10360 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23643 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53458 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22840 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10980 "Passed tests") | 
<!--EWS-Status-Bubble-End-->