### PR TITLE
Use std::span more in AtomString / AtomStringImpl

### DIFF
--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -117,15 +117,10 @@ AtomString AtomString::number(double number)
     return AtomString::fromLatin1(numberToString(number, buffer));
 }
 
-AtomString AtomString::fromUTF8Internal(const char* start, const char* end)
+AtomString AtomString::fromUTF8Internal(std::span<const char> characters)
 {
-    ASSERT(start);
-
-    // Caller needs to handle empty string.
-    ASSERT(!end || end > start);
-    ASSERT(end || start[0]);
-
-    return AtomStringImpl::addUTF8(start, end ? end : start + std::strlen(start));
+    ASSERT(!characters.empty());
+    return AtomStringImpl::addUTF8(characters);
 }
 
 #ifndef NDEBUG

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -49,7 +49,7 @@ public:
 
     AtomString(ASCIILiteral);
 
-    static AtomString lookUp(const UChar* characters, unsigned length) { return AtomStringImpl::lookUp(std::span { characters, length }); }
+    static AtomString lookUp(std::span<const UChar> characters) { return AtomStringImpl::lookUp(characters); }
 
     // Hash table deleted values, which are only constructed and never copied or destroyed.
     AtomString(WTF::HashTableDeletedValueType) : m_string(WTF::HashTableDeletedValue) { }
@@ -129,7 +129,7 @@ public:
 #endif
 
     // AtomString::fromUTF8 will return a null string if the input data contains invalid UTF-8 sequences.
-    static AtomString fromUTF8(const char*, size_t);
+    static AtomString fromUTF8(std::span<const char>);
     static AtomString fromUTF8(const char*);
 
 #ifndef NDEBUG
@@ -142,7 +142,7 @@ private:
     enum class CaseConvertType { Upper, Lower };
     template<CaseConvertType> AtomString convertASCIICase() const;
 
-    WTF_EXPORT_PRIVATE static AtomString fromUTF8Internal(const char*, const char*);
+    WTF_EXPORT_PRIVATE static AtomString fromUTF8Internal(std::span<const char>);
 
     String m_string;
 };
@@ -269,13 +269,13 @@ inline AtomString::AtomString(ASCIILiteral literal)
 {
 }
 
-inline AtomString AtomString::fromUTF8(const char* characters, size_t length)
+inline AtomString AtomString::fromUTF8(std::span<const char> characters)
 {
-    if (!characters)
+    if (!characters.data())
         return nullAtom();
-    if (!length)
+    if (characters.empty())
         return emptyAtom();
-    return fromUTF8Internal(characters, characters + length);
+    return fromUTF8Internal(characters);
 }
 
 inline AtomString AtomString::fromUTF8(const char* characters)
@@ -284,7 +284,7 @@ inline AtomString AtomString::fromUTF8(const char* characters)
         return nullAtom();
     if (!*characters)
         return emptyAtom();
-    return fromUTF8Internal(characters, nullptr);
+    return fromUTF8Internal(span(characters));
 }
 
 inline AtomString String::toExistingAtomString() const

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -329,12 +329,12 @@ RefPtr<AtomStringImpl> AtomStringImpl::add(std::span<const LChar> characters)
     return addToStringTable<LCharBuffer, LCharBufferTranslator>(buffer);
 }
 
-Ref<AtomStringImpl> AtomStringImpl::addLiteral(const char* characters, unsigned length)
+Ref<AtomStringImpl> AtomStringImpl::addLiteral(std::span<const LChar> characters)
 {
-    ASSERT(characters);
-    ASSERT(length);
+    ASSERT(characters.data());
+    ASSERT(!characters.empty());
 
-    LCharBuffer buffer { std::span { reinterpret_cast<const LChar*>(characters), length } };
+    LCharBuffer buffer { characters };
     return addToStringTable<LCharBuffer, BufferFromStaticDataTranslator<LChar>>(buffer);
 }
 
@@ -496,11 +496,11 @@ RefPtr<AtomStringImpl> AtomStringImpl::lookUpSlowCase(StringImpl& string)
     return nullptr;
 }
 
-RefPtr<AtomStringImpl> AtomStringImpl::addUTF8(const char* charactersStart, const char* charactersEnd)
+RefPtr<AtomStringImpl> AtomStringImpl::addUTF8(std::span<const char> characters)
 {
     HashAndUTF8Characters buffer;
-    buffer.characters = charactersStart;
-    buffer.hash = calculateStringHashAndLengthFromUTF8MaskingTop8Bits(charactersStart, charactersEnd, buffer.length, buffer.utf16Length);
+    buffer.characters = characters.data();
+    buffer.hash = calculateStringHashAndLengthFromUTF8MaskingTop8Bits(characters, buffer.length, buffer.utf16Length);
 
     if (!buffer.hash)
         return nullptr;

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -60,13 +60,13 @@ public:
         return add(string.releaseNonNull());
     }
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(const StaticStringImpl*);
-    ALWAYS_INLINE static Ref<AtomStringImpl> add(ASCIILiteral literal) { return addLiteral(literal.characters(), literal.length()); }
+    ALWAYS_INLINE static Ref<AtomStringImpl> add(ASCIILiteral literal) { return addLiteral(literal.span8()); }
 
     // Not using the add() naming to encourage developers to call add(ASCIILiteral) when they have a string literal.
     ALWAYS_INLINE static RefPtr<AtomStringImpl> addCString(const char* s) { return s ? add(WTF::span8(s)) : nullptr; }
 
     // Returns null if the input data contains an invalid UTF-8 sequence.
-    static RefPtr<AtomStringImpl> addUTF8(const char* start, const char* end);
+    static RefPtr<AtomStringImpl> addUTF8(std::span<const char> start);
 
 #if USE(CF)
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(CFStringRef);
@@ -105,7 +105,7 @@ private:
         return addSlowCase(WTFMove(string));
     }
 
-    WTF_EXPORT_PRIVATE static Ref<AtomStringImpl> addLiteral(const char* characters, unsigned length);
+    WTF_EXPORT_PRIVATE static Ref<AtomStringImpl> addLiteral(std::span<const LChar>);
 
     ALWAYS_INLINE static Ref<AtomStringImpl> add(AtomStringTable& stringTable, StringImpl& string)
     {

--- a/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
+++ b/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
@@ -178,7 +178,7 @@ private:
         UErrorCode status = U_ZERO_ERROR;
         int32_t lengthNeeded = uloc_setKeywordValue("lb", keywordValue, scratchBuffer.data(), scratchBuffer.size(), &status);
         if (U_SUCCESS(status))
-            return AtomString::fromUTF8(scratchBuffer.data(), lengthNeeded);
+            return AtomString::fromUTF8(scratchBuffer.subspan(0, lengthNeeded));
         if (needsToGrowToProduceBuffer(status)) {
             scratchBuffer.grow(lengthNeeded + 1);
             memset(scratchBuffer.data() + utf8Locale.length(), 0, scratchBuffer.size() - utf8Locale.length());
@@ -186,7 +186,7 @@ private:
             int32_t lengthNeeded2 = uloc_setKeywordValue("lb", keywordValue, scratchBuffer.data(), scratchBuffer.size(), &status);
             if (!U_SUCCESS(status) || lengthNeeded != lengthNeeded2)
                 return locale;
-            return AtomString::fromUTF8(scratchBuffer.data(), lengthNeeded);
+            return AtomString::fromUTF8(scratchBuffer.subspan(0, lengthNeeded));
         }
         return locale;
     }

--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -152,12 +152,13 @@ ComputeUTFLengthsResult computeUTFLengths(const char* sourceStart, const char* s
     return { result, sourceOffset, lengthUTF16, isASCII(orAllData) };
 }
 
-unsigned calculateStringHashAndLengthFromUTF8MaskingTop8Bits(const char* data, const char* dataEnd, unsigned& dataLength, unsigned& utf16Length)
+unsigned calculateStringHashAndLengthFromUTF8MaskingTop8Bits(std::span<const char> span, unsigned& dataLength, unsigned& utf16Length)
 {
     StringHasher stringHasher;
     utf16Length = 0;
     size_t inputOffset = 0;
-    size_t inputLength = dataEnd - data;
+    auto* data = span.data();
+    size_t inputLength = span.size();
     while (inputOffset < inputLength) {
         char32_t character;
         U8_NEXT(data, inputOffset, inputLength, character);

--- a/Source/WTF/wtf/unicode/UTF8Conversion.h
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.h
@@ -48,7 +48,7 @@ WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16(const char* sourceStart, const char* 
 WTF_EXPORT_PRIVATE bool convertUTF8ToUTF16ReplacingInvalidSequences(const char* sourceStart, const char* sourceEnd, UChar** targetStart, const UChar* targetEnd, bool* isSourceAllASCII = nullptr);
 WTF_EXPORT_PRIVATE bool convertLatin1ToUTF8(const LChar** sourceStart, const LChar* sourceEnd, char** targetStart, const char* targetEnd);
 WTF_EXPORT_PRIVATE ConversionResult convertUTF16ToUTF8(const UChar** sourceStart, const UChar* sourceEnd, char** targetStart, const char* targetEnd, bool strict = true);
-WTF_EXPORT_PRIVATE unsigned calculateStringHashAndLengthFromUTF8MaskingTop8Bits(const char* data, const char* dataEnd, unsigned& dataLength, unsigned& utf16Length);
+WTF_EXPORT_PRIVATE unsigned calculateStringHashAndLengthFromUTF8MaskingTop8Bits(std::span<const char> data, unsigned& dataLength, unsigned& utf16Length);
 
 // Like the other functions above, the computeUTFLengths function is strict.
 // The result can only be Success, SourceExhausted, or SourceIllegal.

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
@@ -155,7 +155,7 @@ bool HTMLMetaCharsetParser::checkForMetaCharset(std::span<const uint8_t> data)
     while (auto token = m_tokenizer.nextToken(m_input)) {
         bool isEnd = token->type() == HTMLToken::Type::EndTag;
         if (isEnd || token->type() == HTMLToken::Type::StartTag) {
-            auto knownTagName = AtomString::lookUp(token->name().data(), token->name().size());
+            auto knownTagName = AtomString::lookUp(token->name().span());
             if (!isEnd) {
                 m_tokenizer.updateStateFor(knownTagName);
                 if (knownTagName == metaTag && processMeta(*token)) {

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -119,7 +119,7 @@ public:
 
         Ref document = protectedDocument();
         for (auto& attribute : attributes) {
-            auto knownAttributeName = AtomString::lookUp(attribute.name.data(), attribute.name.size());
+            auto knownAttributeName = AtomString::lookUp(attribute.name.span());
             processAttribute(knownAttributeName, attribute.value.span(), pictureState);
         }
 
@@ -537,7 +537,7 @@ void HTMLPreloadScanner::scan(HTMLResourcePreloader& preloader, Document& docume
 
     while (auto token = m_tokenizer.nextToken(m_source)) {
         if (token->type() == HTMLToken::Type::StartTag)
-            m_tokenizer.updateStateFor(AtomString::lookUp(token->name().data(), token->name().size()));
+            m_tokenizer.updateStateFor(AtomString::lookUp(token->name().span()));
         m_scanner.scan(*token, requests, document);
     }
 

--- a/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp
@@ -64,14 +64,14 @@ std::optional<bool> AudioTrackPrivateWebM::defaultEnabled() const
 AtomString AudioTrackPrivateWebM::label() const
 {
     if (m_label.isNull())
-        m_label = m_track.name.is_present() ? AtomString::fromUTF8(m_track.name.value().data(), m_track.name.value().length()) : emptyAtom();
+        m_label = m_track.name.is_present() ? AtomString::fromUTF8(m_track.name.value()) : emptyAtom();
     return m_label;
 }
 
 AtomString AudioTrackPrivateWebM::language() const
 {
     if (m_language.isNull())
-        m_language = m_track.language.is_present() ? AtomString::fromUTF8(m_track.language.value().data(), m_track.language.value().length()) : emptyAtom();
+        m_language = m_track.language.is_present() ? AtomString::fromUTF8(m_track.language.value()) : emptyAtom();
     return m_language;
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp
@@ -74,14 +74,14 @@ std::optional<bool> VideoTrackPrivateWebM::defaultEnabled() const
 AtomString VideoTrackPrivateWebM::label() const
 {
     if (m_label.isNull())
-        m_label = m_track.name.is_present() ? AtomString::fromUTF8(m_track.name.value().data(), m_track.name.value().length()) : emptyAtom();
+        m_label = m_track.name.is_present() ? AtomString::fromUTF8(m_track.name.value()) : emptyAtom();
     return m_label;
 }
 
 AtomString VideoTrackPrivateWebM::language() const
 {
     if (m_language.isNull())
-        m_language = m_track.language.is_present() ? AtomString::fromUTF8(m_track.language.value().data(), m_track.language.value().length()) : emptyAtom();
+        m_language = m_track.language.is_present() ? AtomString::fromUTF8(m_track.language.value()) : emptyAtom();
     return m_language;
 }
 

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -699,7 +699,7 @@ static inline String toString(const xmlChar* string)
 
 static inline AtomString toAtomString(const xmlChar* string, size_t size)
 {
-    return AtomString::fromUTF8(reinterpret_cast<const char*>(string), size);
+    return AtomString::fromUTF8({ reinterpret_cast<const char*>(string), size });
 }
 
 static inline AtomString toAtomString(const xmlChar* string)


### PR DESCRIPTION
#### fca7a271ab7afb009bfc5f324cc0a9a5a333d160
<pre>
Use std::span more in AtomString / AtomStringImpl
<a href="https://bugs.webkit.org/show_bug.cgi?id=272174">https://bugs.webkit.org/show_bug.cgi?id=272174</a>

Reviewed by Brent Fulgham and Ryosuke Niwa.

* Source/WTF/wtf/text/AtomString.cpp:
(WTF::AtomString::fromUTF8Internal):
* Source/WTF/wtf/text/AtomString.h:
(WTF::AtomString::fromUTF8):
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::AtomStringImpl::addLiteral):
(WTF::AtomStringImpl::addUTF8):
* Source/WTF/wtf/text/AtomStringImpl.h:
* Source/WTF/wtf/text/icu/TextBreakIteratorICU.h:
(WTF::TextBreakIteratorICU::makeLocaleWithBreakKeyword):
* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::calculateStringHashAndLengthFromUTF8MaskingTop8Bits):
* Source/WTF/wtf/unicode/UTF8Conversion.h:
* Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp:
(WebCore::HTMLMetaCharsetParser::checkForMetaCharset):
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processAttributes):
(WebCore::HTMLPreloadScanner::scan):
* Source/WebCore/platform/graphics/cocoa/AudioTrackPrivateWebM.cpp:
(WebCore::AudioTrackPrivateWebM::label const):
(WebCore::AudioTrackPrivateWebM::language const):
* Source/WebCore/platform/graphics/cocoa/VideoTrackPrivateWebM.cpp:
(WebCore::VideoTrackPrivateWebM::label const):
(WebCore::VideoTrackPrivateWebM::language const):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::toAtomString):

Canonical link: <a href="https://commits.webkit.org/277087@main">https://commits.webkit.org/277087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14a4c448da77941f847176cf608a6030fdfa0776

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49341 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23286 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47244 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19317 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4709 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/39911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42948 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/41696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/51216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46146 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21671 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/51216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/51216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53289 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6525 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22664 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/10935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->