### PR TITLE
Drop CString constructors taking in a raw pointer and a length

### DIFF
--- a/Source/JavaScriptCore/API/ObjcRuntimeExtras.h
+++ b/Source/JavaScriptCore/API/ObjcRuntimeExtras.h
@@ -131,7 +131,7 @@ class StringRange {
     WTF_MAKE_NONCOPYABLE(StringRange);
 public:
     StringRange(const char* begin, const char* end)
-        : m_string(begin, end - begin)
+        : m_string({ begin, end })
     { }
     operator const char*() const { return m_string.data(); }
     const char* get() const { return m_string.data(); }

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -104,16 +104,16 @@ CString CodeBlock::inferredName() const
 {
     switch (codeType()) {
     case GlobalCode:
-        return "<global>";
+        return "<global>"_span;
     case EvalCode:
-        return "<eval>";
+        return "<eval>"_span;
     case FunctionCode:
         return jsCast<FunctionExecutable*>(ownerExecutable())->ecmaName().utf8();
     case ModuleCode:
-        return "<module>";
+        return "<module>"_span;
     default:
         CRASH();
-        return CString("", 0);
+        return ""_span;
     }
 }
 

--- a/Source/JavaScriptCore/parser/UnlinkedSourceCode.cpp
+++ b/Source/JavaScriptCore/parser/UnlinkedSourceCode.cpp
@@ -33,7 +33,7 @@ namespace JSC {
 CString UnlinkedSourceCode::toUTF8() const
 {
     if (!m_provider)
-        return CString("", 0);
+        return ""_span;
     
     return m_provider->source().substring(m_startOffset, m_endOffset - m_startOffset).utf8();
 }

--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -101,10 +101,9 @@ CString LocaleIDBuilder::toCanonical()
 
     auto buffer = canonicalizeLocaleIDWithoutNullTerminator(m_buffer.data());
     if (!buffer)
-        return CString();
+        return { };
 
-    auto result = canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization(WTFMove(buffer.value()));
-    return CString(result.data(), result.size());
+    return canonicalizeUnicodeExtensionsAfterICULocaleCanonicalization(WTFMove(buffer.value())).span();
 }
 
 // Because ICU's C API doesn't have set[Language|Script|Region] functions...

--- a/Source/WTF/wtf/StringHashDumpContext.h
+++ b/Source/WTF/wtf/StringHashDumpContext.h
@@ -48,7 +48,7 @@ public:
             CString fullHash = integerToSixCharacterHashString(hashValue).data();
             
             for (unsigned length = 2; length < 6; ++length) {
-                CString shortHash = CString(fullHash.data(), length);
+                CString shortHash { fullHash.span().first(length) };
                 if (!m_backwardMap.contains(shortHash)) {
                     m_forwardMap.add(value, shortHash);
                     m_backwardMap.add(shortHash, value);

--- a/Source/WTF/wtf/StringPrintStream.cpp
+++ b/Source/WTF/wtf/StringPrintStream.cpp
@@ -86,7 +86,7 @@ void StringPrintStream::vprintf(const char* format, va_list argList)
 CString StringPrintStream::toCString()
 {
     ASSERT(m_next == strlen(m_buffer));
-    return CString(m_buffer, m_next);
+    return CString({ m_buffer, m_next });
 }
 
 void StringPrintStream::reset()

--- a/Source/WTF/wtf/cf/FileSystemCF.cpp
+++ b/Source/WTF/wtf/cf/FileSystemCF.cpp
@@ -52,7 +52,7 @@ CString FileSystem::fileSystemRepresentation(const String& path)
         return CString();
     }
 
-    return CString(buffer.data(), strlen(buffer.data()));
+    return buffer.data();
 }
 
 String FileSystem::stringFromFileSystemRepresentation(const char* fileSystemRepresentation)

--- a/Source/WTF/wtf/cocoa/NSURLExtras.mm
+++ b/Source/WTF/wtf/cocoa/NSURLExtras.mm
@@ -36,6 +36,7 @@
 #import <wtf/URLHelpers.h>
 #import <wtf/Vector.h>
 #import <wtf/cf/CFURLExtras.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 namespace WTF {
@@ -316,8 +317,7 @@ NSData *originalURLData(NSURL *URL)
 
 NSString *userVisibleString(NSURL *URL)
 {
-    NSData *data = originalURLData(URL);
-    return URLHelpers::userVisibleURL(CString(static_cast<const char*>([data bytes]), [data length]));
+    return URLHelpers::userVisibleURL(span(originalURLData(URL)));
 }
 
 BOOL isUserVisibleURL(NSString *string)

--- a/Source/WTF/wtf/glib/FileSystemGlib.cpp
+++ b/Source/WTF/wtf/glib/FileSystemGlib.cpp
@@ -66,7 +66,7 @@ CString currentExecutablePath()
     ssize_t result = readlink("/proc/self/exe", readLinkBuffer, PATH_MAX);
     if (result == -1)
         return { };
-    return CString(readLinkBuffer, result);
+    return CString({ readLinkBuffer, static_cast<size_t>(result) });
 }
 #elif OS(HURD)
 CString currentExecutablePath()

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -45,31 +45,31 @@ Ref<CStringBuffer> CStringBuffer::createUninitialized(size_t length)
     return adoptRef(*new (NotNull, stringBuffer) CStringBuffer(length));
 }
 
-CString::CString(const char* str)
+CString::CString(const char* string)
 {
-    if (!str)
+    if (!string)
         return;
 
-    init(str, strlen(str));
+    init(WTF::span(string));
 }
 
-CString::CString(const char* str, size_t length)
+CString::CString(std::span<const char> string)
 {
-    if (!str) {
-        ASSERT(!length);
+    if (!string.data()) {
+        ASSERT(string.empty());
         return;
     }
 
-    init(str, length);
+    init(string);
 }
 
-void CString::init(const char* str, size_t length)
+void CString::init(std::span<const char> string)
 {
-    ASSERT(str);
+    ASSERT(string.data());
 
-    m_buffer = CStringBuffer::createUninitialized(length);
-    memcpy(m_buffer->mutableData(), str, length); 
-    m_buffer->mutableData()[length] = '\0';
+    m_buffer = CStringBuffer::createUninitialized(string.size());
+    memcpy(m_buffer->mutableData(), string.data(), string.size());
+    m_buffer->mutableData()[string.size()] = '\0';
 }
 
 char* CString::mutableData()

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -62,9 +62,8 @@ class CString final {
 public:
     CString() { }
     WTF_EXPORT_PRIVATE CString(const char*);
-    WTF_EXPORT_PRIVATE CString(const char*, size_t length);
-    CString(const uint8_t* data, size_t length) : CString(reinterpret_cast<const char*>(data), length) { }
-    CString(std::span<const uint8_t> bytes) : CString(reinterpret_cast<const char*>(bytes.data()), bytes.size()) { }
+    WTF_EXPORT_PRIVATE CString(std::span<const char>);
+    CString(std::span<const uint8_t> bytes) : CString({ reinterpret_cast<const char*>(bytes.data()), bytes.size() }) { }
     CString(CStringBuffer* buffer) : m_buffer(buffer) { }
     WTF_EXPORT_PRIVATE static CString newUninitialized(size_t length, char*& characterBuffer);
     CString(HashTableDeletedValueType) : m_buffer(HashTableDeletedValue) { }
@@ -112,7 +111,7 @@ public:
 
 private:
     void copyBufferIfNeeded();
-    void init(const char*, size_t length);
+    void init(std::span<const char>);
     RefPtr<CStringBuffer> m_buffer;
 };
 

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -1557,14 +1557,14 @@ static inline void putUTF8Triple(char*& buffer, UChar character)
 Expected<CString, UTF8ConversionError> StringImpl::utf8ForCharacters(const LChar* source, unsigned length)
 {
     return tryGetUTF8ForCharacters([] (std::span<const char> converted) {
-        return CString(converted.data(), converted.size());
+        return CString { converted };
     }, source, length);
 }
 
 Expected<CString, UTF8ConversionError> StringImpl::utf8ForCharacters(const UChar* characters, unsigned length, ConversionMode mode)
 {
     return tryGetUTF8ForCharacters([] (std::span<const char> converted) {
-        return CString(converted.data(), converted.size());
+        return CString { converted };
     }, characters, length, mode);
 }
 

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -92,7 +92,7 @@ bool StringView::endsWithIgnoringASCIICase(StringView suffix) const
 Expected<CString, UTF8ConversionError> StringView::tryGetUTF8(ConversionMode mode) const
 {
     if (isNull())
-        return CString("", 0);
+        return CString { ""_span };
     if (is8Bit())
         return StringImpl::utf8ForCharacters(characters8(), length());
     return StringImpl::utf8ForCharacters(characters16(), length(), mode);

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -414,7 +414,7 @@ CString String::latin1() const
     // preserved, characters outside of this range are converted to '?'.
 
     if (isEmpty())
-        return CString("", 0);
+        return ""_span;
 
     if (is8Bit())
         return CString(this->span8());
@@ -431,7 +431,7 @@ CString String::latin1() const
 
 Expected<CString, UTF8ConversionError> String::tryGetUTF8(ConversionMode mode) const
 {
-    return m_impl ? m_impl->tryGetUTF8(mode) : CString { "", 0 };
+    return m_impl ? m_impl->tryGetUTF8(mode) : CString { ""_span };
 }
 
 Expected<CString, UTF8ConversionError> String::tryGetUTF8() const

--- a/Source/WebCore/Modules/webtransport/WebTransport.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransport.cpp
@@ -210,7 +210,7 @@ DOMPromise& WebTransport::draining()
 static CString trimToValidUTF8Length1024(CString&& string)
 {
     if (string.length() > 1024)
-        string = CString(string.data(), 1024);
+        string = string.span().first(1024);
     else
         return WTFMove(string);
 
@@ -219,7 +219,7 @@ static CString trimToValidUTF8Length1024(CString&& string)
             return WTFMove(string);
         auto decoded = String::fromUTF8(string.span());
         if (!decoded)
-            string = CString(string.data(), string.length() - 1);
+            string = string.span().first(string.length() - 1);
         else
             return WTFMove(string);
     }

--- a/Source/WebKit/UIProcess/API/gtk/WebKitInputMethodContextImplGtk.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitInputMethodContextImplGtk.cpp
@@ -200,7 +200,7 @@ static void webkitInputMethodContextImplGtkNotifyCursorArea(WebKitInputMethodCon
 static void webkitInputMethodContextImplGtkNotifySurrounding(WebKitInputMethodContext* context, const gchar* text, unsigned length, unsigned cursorIndex, unsigned)
 {
     auto* priv = WEBKIT_INPUT_METHOD_CONTEXT_IMPL_GTK(context)->priv;
-    priv->surroundingText = { text, length };
+    priv->surroundingText = std::span { text, length };
     priv->surroundingCursorIndex = cursorIndex;
 }
 

--- a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
@@ -730,7 +730,7 @@ static std::optional<CString> directoryContainingDBusSocket(const char* dbusAddr
         while (*pathEnd && *pathEnd != ',')
             pathEnd++;
 
-        CString path(pathStart, pathEnd - pathStart);
+        CString path({ pathStart, pathEnd });
         GRefPtr<GFile> file = adoptGRef(g_file_new_for_path(path.data()));
         GRefPtr<GFile> parent = adoptGRef(g_file_get_parent(file.get()));
         if (!parent)

--- a/Tools/TestWebKitAPI/Tests/WTF/CString.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CString.cpp
@@ -30,19 +30,20 @@
 TEST(WTF, CStringNullStringConstructor)
 {
     CString string;
+    constexpr size_t zeroLength = 0;
     ASSERT_TRUE(string.isNull());
     ASSERT_EQ(string.data(), static_cast<const char*>(0));
-    ASSERT_EQ(string.length(), static_cast<size_t>(0));
+    ASSERT_EQ(string.length(), zeroLength);
 
     CString stringFromCharPointer(static_cast<const char*>(0));
     ASSERT_TRUE(stringFromCharPointer.isNull());
     ASSERT_EQ(stringFromCharPointer.data(), static_cast<const char*>(0));
-    ASSERT_EQ(stringFromCharPointer.length(), static_cast<size_t>(0));
+    ASSERT_EQ(stringFromCharPointer.length(), zeroLength);
 
-    CString stringFromCharAndLength(static_cast<const char*>(0), 0);
+    CString stringFromCharAndLength({ static_cast<const char*>(0), zeroLength });
     ASSERT_TRUE(stringFromCharAndLength.isNull());
     ASSERT_EQ(stringFromCharAndLength.data(), static_cast<const char*>(0));
-    ASSERT_EQ(stringFromCharAndLength.length(), static_cast<size_t>(0));
+    ASSERT_EQ(stringFromCharAndLength.length(), zeroLength);
 }
 
 TEST(WTF, CStringEmptyEmptyConstructor)
@@ -53,7 +54,7 @@ TEST(WTF, CStringEmptyEmptyConstructor)
     ASSERT_EQ(string.length(), static_cast<size_t>(0));
     ASSERT_EQ(string.data()[0], 0);
 
-    CString stringWithLength(emptyString, 0);
+    CString stringWithLength(""_span);
     ASSERT_FALSE(stringWithLength.isNull());
     ASSERT_EQ(stringWithLength.length(), static_cast<size_t>(0));
     ASSERT_EQ(stringWithLength.data()[0], 0);
@@ -68,7 +69,7 @@ TEST(WTF, CStringEmptyRegularConstructor)
     ASSERT_EQ(string.length(), strlen(referenceString));
     ASSERT_STREQ(referenceString, string.data());
 
-    CString stringWithLength(referenceString, 6);
+    CString stringWithLength({ referenceString, 6 });
     ASSERT_FALSE(stringWithLength.isNull());
     ASSERT_EQ(stringWithLength.length(), strlen(referenceString));
     ASSERT_STREQ(referenceString, stringWithLength.data());
@@ -92,7 +93,7 @@ TEST(WTF, CStringUninitializedConstructor)
 TEST(WTF, CStringZeroTerminated)
 {
     const char* referenceString = "WebKit";
-    CString stringWithLength(referenceString, 3);
+    CString stringWithLength({ referenceString, 3 });
     ASSERT_EQ(stringWithLength.data()[3], 0);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/CBORWriterTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CBORWriterTest.cpp
@@ -63,20 +63,20 @@ TEST(CBORWriterTest, TestWriteUint)
     static const UintTestCase kUintTestCases[] = {
         // Reminder: must specify length when creating string pieces
         // with null bytes, else the string will truncate prematurely.
-        {0, CString("\x00", 1)},
-        {1, CString("\x01")},
-        {10, CString("\x0a")},
-        {23, CString("\x17")},
-        {24, CString("\x18\x18")},
-        {25, CString("\x18\x19")},
-        {100, CString("\x18\x64")},
-        {1000, CString("\x19\x03\xe8")},
-        {1000000, CString("\x1a\x00\x0f\x42\x40", 5)},
-        {0xFFFFFFFF, CString("\x1a\xff\xff\xff\xff")},
-        {0x100000000,
-            CString("\x1b\x00\x00\x00\x01\x00\x00\x00\x00", 9)},
-        {std::numeric_limits<int64_t>::max(),
-            CString("\x1b\x7f\xff\xff\xff\xff\xff\xff\xff")}
+        { 0, CString({ "\x00", 1 }) },
+        { 1, CString("\x01") },
+        { 10, CString("\x0a") },
+        { 23, CString("\x17") },
+        { 24, CString("\x18\x18") },
+        { 25, CString("\x18\x19") },
+        { 100, CString("\x18\x64") },
+        { 1000, CString("\x19\x03\xe8") },
+        { 1000000, CString({ "\x1a\x00\x0f\x42\x40", 5 }) },
+        { 0xFFFFFFFF, CString("\x1a\xff\xff\xff\xff") },
+        { 0x100000000,
+            CString({ "\x1b\x00\x00\x00\x01\x00\x00\x00\x00", 9 }) },
+        { std::numeric_limits<int64_t>::max(),
+            CString("\x1b\x7f\xff\xff\xff\xff\xff\xff\xff") }
     };
 
     for (const UintTestCase& testCase : kUintTestCases) {
@@ -101,7 +101,7 @@ TEST(CBORWriterTest, TestWriteNegativeInteger)
         { -1000LL, CString("\x39\x03\xe7") },
         { -4294967296LL, CString("\x3a\xff\xff\xff\xff") },
         { -4294967297LL,
-            CString("\x3b\x00\x00\x00\x01\x00\x00\x00\x00", 9) },
+            CString({ "\x3b\x00\x00\x00\x01\x00\x00\x00\x00", 9 }) },
         { std::numeric_limits<int64_t>::min(),
             CString("\x3b\x7f\xff\xff\xff\xff\xff\xff\xff") },
     };

--- a/Tools/TestWebKitAPI/Tests/WebCore/CryptoDigest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CryptoDigest.cpp
@@ -42,7 +42,7 @@ static CString toHex(WTF::Vector<uint8_t>&& hash)
         buffer[2 * i + 1] = hex[lo];
     }
 
-    return CString(buffer.data(), buffer.size());
+    return buffer.span();
 }
 
 static void expect(PAL::CryptoDigest::Algorithm algorithm, const CString& input, int repeat, const CString& expected)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitNetworkSession.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitNetworkSession.cpp
@@ -131,7 +131,7 @@ public:
         waitUntilLoadFinished();
         size_t dataSize = 0;
         const char* data = mainResourceData(dataSize);
-        return CString(data, dataSize);
+        return std::span { data, dataSize };
     }
 
     GUniquePtr<char> proxyServerPortAsString()
@@ -220,7 +220,7 @@ static void testNetworkSessionProxySettings(ProxyTest* test, gconstpointer)
         g_assert_nonnull(data);
         auto* test = static_cast<ProxyTest*>(userData);
         GUniquePtr<char> proxyServerPortAsString = test->proxyServerPortAsString();
-        ASSERT_CMP_CSTRING(CString(data.get(), dataSize), ==, proxyServerPortAsString.get());
+        ASSERT_CMP_CSTRING(CString({ data.get(), dataSize }), ==, proxyServerPortAsString.get());
         test->quitMainLoop();
         }, test);
     g_main_loop_run(test->m_mainLoop);

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -463,7 +463,7 @@ static CString convertWebViewMainResourceDataToCString(WebViewTest* test)
 {
     size_t mainResourceDataSize = 0;
     const char* mainResourceData = test->mainResourceData(mainResourceDataSize);
-    return CString(mainResourceData, mainResourceDataSize);
+    return std::span { mainResourceData, mainResourceDataSize };
 }
 
 static void assertThatUserAgentIsSentInHeaders(WebViewTest* test, const CString& userAgent)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitWebContext.cpp
@@ -762,7 +762,7 @@ public:
         waitUntilLoadFinished();
         size_t dataSize = 0;
         const char* data = mainResourceData(dataSize);
-        return CString(data, dataSize);
+        return std::span { data, dataSize };
     }
 
     GUniquePtr<char> proxyServerPortAsString()
@@ -865,7 +865,7 @@ static void testWebContextProxySettings(ProxyTest* test, gconstpointer)
         g_assert_nonnull(data);
         auto* test = static_cast<ProxyTest*>(userData);
         GUniquePtr<char> proxyServerPortAsString = test->proxyServerPortAsString();
-        ASSERT_CMP_CSTRING(CString(data.get(), dataSize), ==, proxyServerPortAsString.get());
+        ASSERT_CMP_CSTRING(CString({ data.get(), dataSize }), ==, proxyServerPortAsString.get());
         test->quitMainLoop();
         }, test);
     g_main_loop_run(test->m_mainLoop);


### PR DESCRIPTION
#### a52537d513b7157f10fc5d1b9a6f9dde3053e038
<pre>
Drop CString constructors taking in a raw pointer and a length
<a href="https://bugs.webkit.org/show_bug.cgi?id=272179">https://bugs.webkit.org/show_bug.cgi?id=272179</a>

Reviewed by Darin Adler.

Drop CString constructors taking in a raw pointer and a length, in favor of the
ones taking in a std::span.

* Source/JavaScriptCore/API/ObjcRuntimeExtras.h:
(StringRange::StringRange):
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::inferredName const):
* Source/JavaScriptCore/parser/UnlinkedSourceCode.cpp:
(JSC::UnlinkedSourceCode::toUTF8 const):
* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::LocaleIDBuilder::toCanonical):
* Source/WTF/wtf/StringHashDumpContext.h:
(WTF::StringHashDumpContext::getID):
* Source/WTF/wtf/StringPrintStream.cpp:
(WTF::StringPrintStream::toCString):
* Source/WTF/wtf/cf/FileSystemCF.cpp:
(WTF::FileSystem::fileSystemRepresentation):
* Source/WTF/wtf/cocoa/NSURLExtras.mm:
(WTF::userVisibleString):
* Source/WTF/wtf/text/CString.cpp:
(WTF::CString::CString):
(WTF::CString::init):
* Source/WTF/wtf/text/CString.h:
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::utf8ForCharacters):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::tryGetUTF8 const):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::latin1 const):
(WTF::String::tryGetUTF8 const):
* Source/WebCore/Modules/webtransport/WebTransport.cpp:
(WebCore::trimToValidUTF8Length1024):
* Tools/TestWebKitAPI/Tests/WTF/CString.cpp:
(TEST(WTF, CStringNullStringConstructor)):
(TEST(WTF, CStringEmptyEmptyConstructor)):
(TEST(WTF, CStringEmptyRegularConstructor)):
(TEST(WTF, CStringZeroTerminated)):
* Tools/TestWebKitAPI/Tests/WebCore/CBORWriterTest.cpp:
(TestWebKitAPI::TEST(CBORWriterTest, TestWriteUint)):
(TestWebKitAPI::TEST(CBORWriterTest, TestWriteNegativeInteger)):

Canonical link: <a href="https://commits.webkit.org/277140@main">https://commits.webkit.org/277140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43949476c5e4ef7aa382bb5a2599b72bc862d9e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46746 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49367 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49423 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42793 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38095 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19379 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20243 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41398 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4792 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39993 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51295 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46229 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21755 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45375 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23043 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44331 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23529 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53371 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6558 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22748 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10957 "Passed tests") | 
<!--EWS-Status-Bubble-End-->