### PR TITLE
Add `pageX` and `pageY` on `MouseEvent` interface

### DIFF
--- a/LayoutTests/fast/events/init-events-expected.txt
+++ b/LayoutTests/fast/events/init-events-expected.txt
@@ -33,8 +33,6 @@ PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, fals
 PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, false, false, false').charCode is 0
 PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, false, false, false').layerX is 0
 PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, false, false, false').layerY is 0
-PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, false, false, false').pageX is 0
-PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, false, false, false').pageY is 0
 PASS testInitEvent('Keyboard', '"a", false, true, window, "b", 1001, false, false, false, false, false').which is 0
 PASS testInitEvent('Message', '"a", false, false, "b", "c", "d", window, []').type is 'a'
 PASS testInitEvent('Message', 'null, false, false, "b", "c", "d", window, []').type is 'null'
@@ -136,8 +134,6 @@ PASS 'keyCode' in testInitEvent('Text', '"a", false, false, window, "b"') is fal
 PASS 'charCode' in testInitEvent('Text', '"a", false, false, window, "b"') is false
 PASS testInitEvent('Text', '"a", false, false, window, "b"').layerX is 0
 PASS testInitEvent('Text', '"a", false, false, window, "b"').layerY is 0
-PASS testInitEvent('Text', '"a", false, false, window, "b"').pageX is 0
-PASS testInitEvent('Text', '"a", false, false, window, "b"').pageY is 0
 PASS testInitEvent('Text', '"a", false, false, window, "b"').which is 0
 PASS testInitEvent('UI', '"a", false, false, window, 1001').type is 'a'
 PASS testInitEvent('UI', 'null, false, false, window, 1001').type is 'null'
@@ -152,8 +148,6 @@ PASS 'keyCode' in testInitEvent('UI', '"a", false, false, window, 1001') is fals
 PASS 'charCode' in testInitEvent('UI', '"a", false, false, window, 1001') is false
 PASS testInitEvent('UI', '"a", false, false, window, 1001').layerX is 0
 PASS testInitEvent('UI', '"a", false, false, window, 1001').layerY is 0
-PASS testInitEvent('UI', '"a", false, false, window, 1001').pageX is 0
-PASS testInitEvent('UI', '"a", false, false, window, 1001').pageY is 0
 PASS testInitEvent('UI', '"a", false, false, window, 1001').which is 0
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/events/init-events.html
+++ b/LayoutTests/fast/events/init-events.html
@@ -56,8 +56,6 @@ shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, fa
 shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, false, false, false').charCode", "0");
 shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, false, false, false').layerX", "0");
 shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, false, false, false').layerY", "0");
-shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, false, false, false').pageX", "0");
-shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, false, false, false').pageY", "0");
 shouldBe("testInitEvent('Keyboard', '\"a\", false, true, window, \"b\", 1001, false, false, false, false, false').which", "0");
 
 shouldBe("testInitEvent('Message', '\"a\", false, false, \"b\", \"c\", \"d\", window, []').type", "'a'");
@@ -166,8 +164,6 @@ shouldBeFalse("'keyCode' in testInitEvent('Text', '\"a\", false, false, window, 
 shouldBeFalse("'charCode' in testInitEvent('Text', '\"a\", false, false, window, \"b\"')");
 shouldBe("testInitEvent('Text', '\"a\", false, false, window, \"b\"').layerX", "0");
 shouldBe("testInitEvent('Text', '\"a\", false, false, window, \"b\"').layerY", "0");
-shouldBe("testInitEvent('Text', '\"a\", false, false, window, \"b\"').pageX", "0");
-shouldBe("testInitEvent('Text', '\"a\", false, false, window, \"b\"').pageY", "0");
 shouldBe("testInitEvent('Text', '\"a\", false, false, window, \"b\"').which", "0");
 
 shouldBe("testInitEvent('UI', '\"a\", false, false, window, 1001').type", "'a'");
@@ -183,8 +179,6 @@ shouldBeFalse("'keyCode' in testInitEvent('UI', '\"a\", false, false, window, 10
 shouldBeFalse("'charCode' in testInitEvent('UI', '\"a\", false, false, window, 1001')");
 shouldBe("testInitEvent('UI', '\"a\", false, false, window, 1001').layerX", "0");
 shouldBe("testInitEvent('UI', '\"a\", false, false, window, 1001').layerY", "0");
-shouldBe("testInitEvent('UI', '\"a\", false, false, window, 1001').pageX", "0");
-shouldBe("testInitEvent('UI', '\"a\", false, false, window, 1001').pageY", "0");
 shouldBe("testInitEvent('UI', '\"a\", false, false, window, 1001').which", "0");
 
 // WheelEvent has no init function yet; roughly speaking, we are waiting for that part of DOM 3 to stabilize.

--- a/Source/WebCore/dom/MouseEvent.idl
+++ b/Source/WebCore/dom/MouseEvent.idl
@@ -30,6 +30,8 @@
     readonly attribute long screenY;
     readonly attribute long clientX;
     readonly attribute long clientY;
+    readonly attribute long pageX;
+    readonly attribute long pageY;
     readonly attribute boolean ctrlKey;
     readonly attribute boolean shiftKey;
     readonly attribute boolean altKey;

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -259,14 +259,4 @@ int MouseRelatedEvent::offsetY()
     return roundToInt(m_offsetLocation.y());
 }
 
-int MouseRelatedEvent::pageX() const
-{
-    return m_pageLocation.x();
-}
-
-int MouseRelatedEvent::pageY() const
-{
-    return m_pageLocation.y();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/MouseRelatedEvent.h
+++ b/Source/WebCore/dom/MouseRelatedEvent.h
@@ -50,6 +50,8 @@ public:
     const IntPoint& screenLocation() const { return m_screenLocation; }
     int clientX() const { return m_clientLocation.x(); }
     int clientY() const { return m_clientLocation.y(); }
+    int pageX() const { return m_pageLocation.x(); }
+    int pageY() const { return m_pageLocation.y(); }
     double movementX() const { return m_movementX; }
     double movementY() const { return m_movementY; }
 
@@ -60,8 +62,6 @@ public:
     WEBCORE_EXPORT int offsetY();
     bool isSimulated() const { return m_isSimulated; }
     void setIsSimulated(bool value) { m_isSimulated = value; }
-    int pageX() const final;
-    int pageY() const final;
     WEBCORE_EXPORT FloatPoint locationInRootViewCoordinates() const;
 
     // Page point in "absolute" coordinates (i.e. post-zoomed, page-relative coords,

--- a/Source/WebCore/dom/TouchEvent.idl
+++ b/Source/WebCore/dom/TouchEvent.idl
@@ -38,6 +38,9 @@
     readonly attribute boolean shiftKey;
     readonly attribute boolean altKey;
     readonly attribute boolean metaKey;
+
+    readonly attribute long pageX;
+    readonly attribute long pageY;
 };
 
 dictionary TouchEventInit : UIEventInit {

--- a/Source/WebCore/dom/UIEvent.cpp
+++ b/Source/WebCore/dom/UIEvent.cpp
@@ -86,16 +86,6 @@ int UIEvent::layerY()
     return 0;
 }
 
-int UIEvent::pageX() const
-{
-    return 0;
-}
-
-int UIEvent::pageY() const
-{
-    return 0;
-}
-
 unsigned UIEvent::which() const
 {
     return 0;

--- a/Source/WebCore/dom/UIEvent.h
+++ b/Source/WebCore/dom/UIEvent.h
@@ -58,9 +58,6 @@ public:
     virtual int layerX();
     virtual int layerY();
 
-    virtual int pageX() const;
-    virtual int pageY() const;
-
     virtual unsigned which() const;
 
 protected:

--- a/Source/WebCore/dom/UIEvent.idl
+++ b/Source/WebCore/dom/UIEvent.idl
@@ -31,7 +31,5 @@
 
     readonly attribute long layerX;
     readonly attribute long layerY;
-    readonly attribute long pageX;
-    readonly attribute long pageY;
     readonly attribute unsigned long which;
 };

--- a/Source/WebKitLegacy/mac/DOM/DOMMouseEvent.h
+++ b/Source/WebKitLegacy/mac/DOM/DOMMouseEvent.h
@@ -36,6 +36,8 @@ WEBKIT_CLASS_DEPRECATED_MAC(10_4, 10_14)
 @property (readonly) int screenY;
 @property (readonly) int clientX;
 @property (readonly) int clientY;
+@property (readonly) int pageX;
+@property (readonly) int pageY;
 @property (readonly) BOOL ctrlKey;
 @property (readonly) BOOL shiftKey;
 @property (readonly) BOOL altKey;

--- a/Source/WebKitLegacy/mac/DOM/DOMMouseEvent.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMMouseEvent.mm
@@ -68,6 +68,18 @@
     return IMPL->clientY();
 }
 
+- (int)pageX
+{
+    WebCore::JSMainThreadNullState state;
+    return IMPL->pageX();
+}
+
+- (int)pageY
+{
+    WebCore::JSMainThreadNullState state;
+    return IMPL->pageY();
+}
+
 - (BOOL)ctrlKey
 {
     WebCore::JSMainThreadNullState state;

--- a/Source/WebKitLegacy/mac/DOM/DOMUIEvent.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMUIEvent.mm
@@ -84,14 +84,12 @@
 
 - (int)pageX
 {
-    WebCore::JSMainThreadNullState state;
-    return IMPL->pageX();
+    return 0;
 }
 
 - (int)pageY
 {
-    WebCore::JSMainThreadNullState state;
-    return IMPL->pageY();
+    return 0;
 }
 
 - (int)which


### PR DESCRIPTION
#### 9c32d1d7565988d4055ad920930e9a9b1754d84f
<pre>
Add `pageX` and `pageY` on `MouseEvent` interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=271361">https://bugs.webkit.org/show_bug.cgi?id=271361</a>
<a href="https://rdar.apple.com/125529477">rdar://125529477</a>

Reviewed by NOBODY (OOPS!).

This patch moves the pageX/pageY fields from the UIEvent interface to
the MouseEvent interface. This change is prompted by the fact that these
attributes are specified as extensions to the MouseEvent interface (not
the UIEvent interface) in the CSSOM View Module specfication. -- c.f.
<a href="https://drafts.csswg.org/cssom-view/#extensions-to-the-mouseevent-interface.">https://drafts.csswg.org/cssom-view/#extensions-to-the-mouseevent-interface.</a>

These fields provided no value for non-mouse events anyway, bar
Gesture and Touch events, as they always reported 0. For Touch events,
this patch makes sure to retain pageX/pageY on its interface. The
bindings will &quot;just work&quot; because WebCore::TouchEvent inherits the right
getter from WebCore::MouseRelatedEvent.

This interface change also aligns us with the MouseEvent prototype shipped
by Blink and Gecko, and so is unlikely to be web incompatbile.

* LayoutTests/fast/events/init-events-expected.txt:
* LayoutTests/fast/events/init-events.html:
* Source/WebCore/dom/MouseEvent.idl:
* Source/WebCore/dom/MouseRelatedEvent.cpp:
(WebCore::MouseRelatedEvent::pageX const): Deleted.
(WebCore::MouseRelatedEvent::pageY const): Deleted.
* Source/WebCore/dom/MouseRelatedEvent.h:
(WebCore::MouseRelatedEvent::pageX const):
(WebCore::MouseRelatedEvent::pageY const):
(WebCore::MouseRelatedEvent::setIsSimulated):
* Source/WebCore/dom/UIEvent.cpp:
(WebCore::UIEvent::pageX const): Deleted.
(WebCore::UIEvent::pageY const): Deleted.
* Source/WebCore/dom/UIEvent.h:
* Source/WebCore/dom/UIEvent.idl:
* Source/WebKitLegacy/mac/DOM/DOMMouseEvent.h:
* Source/WebKitLegacy/mac/DOM/DOMMouseEvent.mm:
(-[DOMMouseEvent pageX]):
(-[DOMMouseEvent pageY]):
* Source/WebKitLegacy/mac/DOM/DOMUIEvent.mm:
(-[DOMUIEvent pageX]):
(-[DOMUIEvent pageY]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c32d1d7565988d4055ad920930e9a9b1754d84f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49257 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49324 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42692 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23269 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38034 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom-view/idlharness.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22808 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40197 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19302 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20173 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom-view/idlharness.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41318 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom-view/idlharness.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4692 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42941 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41690 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 14 flakes 2 failures; Uploaded test results; 28 flakes 2 failures; Running compile-webkit-without-change") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51178 "Hash 9c32d1d7 for PR 26866 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21654 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18052 "Found 1 new test failure: imported/w3c/web-platform-tests/css/cssom-view/idlharness.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/51178 "Hash 9c32d1d7 for PR 26866 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/22944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40359 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/51178 "Hash 9c32d1d7 for PR 26866 does not build (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22647 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->