### PR TITLE
REGRESSION (277022@main): [ MacOS iOS ] 2X TestWebKitAPI.WKWebExtension are constant failures and 1 is a constant crash.

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
@@ -235,14 +235,6 @@ using namespace WebKit;
     return [self _openDatabase:databaseURL withAccessType:SQLiteDatabaseAccessTypeReadWriteCreate deleteDatabaseFileOnError:NO];
 }
 
-- (void)_deleteExtensionStorageFolderIfEmpty
-{
-    dispatch_assert_queue(_databaseQueue);
-    ASSERT(!_useInMemoryDatabase);
-
-    FileSystem::deleteEmptyDirectory(_directory.path);
-}
-
 - (NSString *)_deleteDatabaseIfEmpty
 {
     dispatch_assert_queue(_databaseQueue);
@@ -269,9 +261,6 @@ using namespace WebKit;
         return databaseCloseErrorMessage;
 
     NSString *deleteDatabaseFileErrorMessage = [self _deleteDatabaseFileAtURL:self._databaseURL reopenDatabase:NO];
-
-    // We don't tell the extension if we fail to delete the enclosing folder since it only cares whether the database itself was deleted.
-    [self _deleteExtensionStorageFolderIfEmpty];
 
     // An error from closing the database takes precedence over an error deleting the database file.
     return databaseCloseErrorMessage.length ? databaseCloseErrorMessage : deleteDatabaseFileErrorMessage;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3284,7 +3284,7 @@ void WebExtensionContext::determineInstallReasonDuringLoad()
     auto *currentBundleHash = extension().bundleHash();
     m_state.get()[lastSeenBundleHashStateKey] = currentBundleHash;
 
-    bool extensionDidChange = ![lastSeenBundleHash isEqualToData:currentBundleHash];
+    bool extensionDidChange = lastSeenBundleHash && currentBundleHash && ![lastSeenBundleHash isEqualToData:currentBundleHash];
 
     m_shouldFireStartupEvent = extensionController()->isFreshlyCreated();
 


### PR DESCRIPTION
#### ca4dc0387b4055b3743ed35c86a1580673123378
<pre>
REGRESSION (277022@main): [ MacOS iOS ] 2X TestWebKitAPI.WKWebExtension are constant failures and 1 is a constant crash.
<a href="https://webkit.org/b/272177">https://webkit.org/b/272177</a>
<a href="https://rdar.apple.com/problem/125924822">rdar://problem/125924822</a>

Reviewed by Brian Weinstein.

Only consider an extension updated if it has bundle hashes to compare. When running tests,
both lastSeenBundleHash and currentBundleHash will be nil, meaning the isEqualToData:
will always be NO, but we set the inverse in extensionDidChange.

Also the crash in WKWebExtensionDataRecord.GetDataRecordsForMultipleContexts was due to the
extension thinking it was updated, so the registered content script database was being deleted.
In this case the extension folder was freshly created before the load, so it was empty. When
a database gets deleted, the empty containing folder is also deleted. This causes an error when
we go to save the State.plist file in the folder that should exist. That in turn caused the
record lookup to only find one of two extensions, leading to an exception in the array access.

Stop having the database code delete the empty parent directory, since that is a holdover from Safari
storage structure where there wasn&apos;t a State.plist file, and only database storage was inside the
extension directory.

* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
(-[_WKWebExtensionSQLiteStore _deleteDatabase]): Remove call to _deleteExtensionStorageFolderIfEmpty.
(-[_WKWebExtensionSQLiteStore _deleteExtensionStorageFolderIfEmpty]): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::determineInstallReasonDuringLoad): Check lastSeenBundleHash and currentBundleHash
for nil before calling isEqualToData:.

Canonical link: <a href="https://commits.webkit.org/277082@main">https://commits.webkit.org/277082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d17bbec3133fc65dd1781e2b8620ccf81cd3bc70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49328 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/42696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23273 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47230 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/19304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4696 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/41692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51182 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6521 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22651 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->