### PR TITLE
[results.webkit.org] Link directly to SCM provider from timeline

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js
@@ -188,7 +188,7 @@ function xAxisFromScale(scale, repository, updatesArray, isTop=false, viewport=n
         if (!params.branch)
             delete params.branch;
         const query = paramsToQuery(params);
-        window.open(`/commit?${query}`, '_blank');
+        window.open(`/commit/info?${query}`, '_blank');
     }
 
     return Timeline.CanvasXAxisComponent(scaleForRepository(scale), {


### PR DESCRIPTION
#### eb693b0ca39e21aa29f5d359fa4380c3a235d2de
<pre>
[results.webkit.org] Link directly to SCM provider from timeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=272195">https://bugs.webkit.org/show_bug.cgi?id=272195</a>
<a href="https://rdar.apple.com/125937058">rdar://125937058</a>

Reviewed by Ryan Haddad.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/timeline.js:
(xAxisFromScale): Link directly to SCM provider&apos;s commit representation.

Canonical link: <a href="https://commits.webkit.org/277119@main">https://commits.webkit.org/277119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/715e84f7349e788295264040d5db52720c240e50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25827 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/49277 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49344 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/42712 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/48974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30187 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23289 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38039 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47247 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22801 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/49277 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19310 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/46533 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20179 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/49277 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4712 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42946 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/49277 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51200 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21674 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45299 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/46706 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22964 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/49277 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44256 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23421 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6544 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22667 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->