### PR TITLE
Fix warnings in Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -148,7 +148,7 @@ void U2fAuthenticator::responseReceived(Vector<uint8_t>&& response, CommandType 
         receiveRespond(ExceptionData { ExceptionCode::UnknownError, "Couldn't parse the APDU response."_s });
         return;
     }
-    U2F_RELEASE_LOG("responseReceived: Got response for command type: %hhu", type);
+    U2F_RELEASE_LOG("responseReceived: Got response for command type: %hhu", enumToUnderlyingType(type));
 
     switch (type) {
     case CommandType::RegisterCommand:
@@ -172,7 +172,7 @@ void U2fAuthenticator::responseReceived(Vector<uint8_t>&& response, CommandType 
 
 void U2fAuthenticator::continueRegisterCommandAfterResponseReceived(ApduResponse&& apduResponse)
 {
-    U2F_RELEASE_LOG("continueRegisterCommandAfterResponseReceived: Status %hu", apduResponse.status());
+    U2F_RELEASE_LOG("continueRegisterCommandAfterResponseReceived: Status %hu", enumToUnderlyingType(apduResponse.status()));
     switch (apduResponse.status()) {
     case ApduResponse::Status::SW_NO_ERROR: {
         auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
@@ -196,7 +196,7 @@ void U2fAuthenticator::continueRegisterCommandAfterResponseReceived(ApduResponse
 
 void U2fAuthenticator::continueCheckOnlyCommandAfterResponseReceived(ApduResponse&& apduResponse)
 {
-    U2F_RELEASE_LOG("continueCheckOnlyCommandAfterResponseReceived: Status %hu", apduResponse.status());
+    U2F_RELEASE_LOG("continueCheckOnlyCommandAfterResponseReceived: Status %hu", enumToUnderlyingType(apduResponse.status()));
     switch (apduResponse.status()) {
     case ApduResponse::Status::SW_NO_ERROR:
     case ApduResponse::Status::SW_CONDITIONS_NOT_SATISFIED:
@@ -209,7 +209,7 @@ void U2fAuthenticator::continueCheckOnlyCommandAfterResponseReceived(ApduRespons
 
 void U2fAuthenticator::continueBogusCommandExcludeCredentialsMatchAfterResponseReceived(ApduResponse&& apduResponse)
 {
-    U2F_RELEASE_LOG("continueBogusCommandExcludeCredentialsMatchAfterResponseReceived: Status %hu", apduResponse.status());
+    U2F_RELEASE_LOG("continueBogusCommandExcludeCredentialsMatchAfterResponseReceived: Status %hu", enumToUnderlyingType(apduResponse.status()));
     switch (apduResponse.status()) {
     case ApduResponse::Status::SW_NO_ERROR:
         receiveRespond(ExceptionData { ExceptionCode::InvalidStateError, "At least one credential matches an entry of the excludeCredentials list in the authenticator."_s });
@@ -225,7 +225,7 @@ void U2fAuthenticator::continueBogusCommandExcludeCredentialsMatchAfterResponseR
 
 void U2fAuthenticator::continueBogusCommandNoCredentialsAfterResponseReceived(ApduResponse&& apduResponse)
 {
-    U2F_RELEASE_LOG("continueBogusCommandNoCredentialsAfterResponseReceived: Status %hu", apduResponse.status());
+    U2F_RELEASE_LOG("continueBogusCommandNoCredentialsAfterResponseReceived: Status %hu", enumToUnderlyingType(apduResponse.status()));
     switch (apduResponse.status()) {
     case ApduResponse::Status::SW_NO_ERROR:
         if (auto* observer = this->observer())
@@ -243,7 +243,7 @@ void U2fAuthenticator::continueBogusCommandNoCredentialsAfterResponseReceived(Ap
 
 void U2fAuthenticator::continueSignCommandAfterResponseReceived(ApduResponse&& apduResponse)
 {
-    U2F_RELEASE_LOG("continueSignCommandAfterResponseReceived: Status %hu", apduResponse.status());
+    U2F_RELEASE_LOG("continueSignCommandAfterResponseReceived: Status %hu", enumToUnderlyingType(apduResponse.status()));
     auto& requestOptions = std::get<PublicKeyCredentialRequestOptions>(requestData().options);
     switch (apduResponse.status()) {
     case ApduResponse::Status::SW_NO_ERROR: {


### PR DESCRIPTION
#### 0abe80c522c75a75c85d6c475cbbf8acc2af9de2
<pre>
Fix warnings in Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=272198">https://bugs.webkit.org/show_bug.cgi?id=272198</a>

Reviewed by David Kilzer, Chris Dumez and Sihui Liu.

Use enumToUnderlyingType on enum classes.

* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp:
(WebKit::U2fAuthenticator::responseReceived):
(WebKit::U2fAuthenticator::continueRegisterCommandAfterResponseReceived):
(WebKit::U2fAuthenticator::continueCheckOnlyCommandAfterResponseReceived):
(WebKit::U2fAuthenticator::continueBogusCommandExcludeCredentialsMatchAfterResponseReceived):
(WebKit::U2fAuthenticator::continueBogusCommandNoCredentialsAfterResponseReceived):
(WebKit::U2fAuthenticator::continueSignCommandAfterResponseReceived):

Canonical link: <a href="https://commits.webkit.org/277100@main">https://commits.webkit.org/277100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f33eac4ec363293f76f18f71438db11e7263433

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49351 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42721 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23296 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38043 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40206 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19314 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4719 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42954 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41705 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51207 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21683 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18064 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45305 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/22971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44263 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6533 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22675 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->