### PR TITLE
Model element should composite the same way as media element

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -589,6 +589,9 @@ bool RenderLayer::shouldBeNormalFlowOnly() const
     return renderer().hasNonVisibleOverflow()
         || renderer().isRenderHTMLCanvas()
         || renderer().isRenderVideo()
+#if ENABLE(MODEL_ELEMENT)
+        || renderer().isRenderModel()
+#endif
         || renderer().isRenderEmbeddedObject()
         || renderer().isRenderIFrame()
         || (renderer().style().specifiesColumns() && !isRenderViewLayer())
@@ -5316,6 +5319,9 @@ bool RenderLayer::shouldBeSelfPaintingLayer() const
         || renderer().isRenderTableRow()
         || renderer().isRenderHTMLCanvas()
         || renderer().isRenderVideo()
+#if ENABLE(MODEL_ELEMENT)
+        || renderer().isRenderModel()
+#endif
         || renderer().isRenderEmbeddedObject()
         || renderer().isRenderIFrame()
         || renderer().isRenderFragmentedFlow();


### PR DESCRIPTION
#### ffc124497074d99440a16294f320ab8149eafdb0
<pre>
Model element should composite the same way as media element
<a href="https://rdar.apple.com/125941615">rdar://125941615</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=272202">https://bugs.webkit.org/show_bug.cgi?id=272202</a>

Reviewed by NOBODY (OOPS!).

In general Model element should behave like a video element in the sense that both
are replaced element. We are missing some of the treatment in Model element compared
to video element in the compositor.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::shouldBeNormalFlowOnly const):
(WebCore::RenderLayer::calculateClipRects const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d5450c1d6e66d5160355dbd0f2b9501f1af14f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47243 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49894 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49926 "Hash 1d5450c1 for PR 26879 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43292 "Hash 1d5450c1 for PR 26879 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23883 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/49926 "Hash 1d5450c1 for PR 26879 does not build (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40713 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/49926 "Hash 1d5450c1 for PR 26879 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21348 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41873 "Passed tests") | [❌ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5287 "Hash 1d5450c1 for PR 26879 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43610 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42281 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51802 "Hash 1d5450c1 for PR 26879 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22273 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18629 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/51802 "Hash 1d5450c1 for PR 26879 does not build (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23548 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/51802 "Hash 1d5450c1 for PR 26879 does not build (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24332 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->