### PR TITLE
[JSC] Read regexp.flags explicitly in RegExp.prototype[Symbol.match] slow path

### DIFF
--- a/JSTests/es6/Proxy_internal_get_calls_RegExp.prototype[Symbol.match].js
+++ b/JSTests/es6/Proxy_internal_get_calls_RegExp.prototype[Symbol.match].js
@@ -6,7 +6,7 @@ var p = new Proxy({ exec: function() { return null; } }, { get: function(o, k) {
 RegExp.prototype[Symbol.match].call(p);
 p.global = true;
 RegExp.prototype[Symbol.match].call(p);
-return get + '' === "global,exec,global,unicode,exec";
+return get + '' === "flags,exec,flags,exec";
       
 }
 

--- a/JSTests/stress/regexp-match-proxy.js
+++ b/JSTests/stress/regexp-match-proxy.js
@@ -33,7 +33,7 @@ let getProxyNullExec = new Proxy({
 
 resetTracking();
 RegExp.prototype[Symbol.match].call(getProxyNullExec);
-assert('get == "global,exec"');
+assert('get == "flags,exec"');
 
 let getSetProxyNullExec = new Proxy(
     {
@@ -46,6 +46,8 @@ let getSetProxyNullExec = new Proxy(
         {
             get.push(k);
             getSet.push(k);
+            if (k.toString() === "flags")
+                return "g";
             return o[k];
         },
         set: function(o, k, v)
@@ -61,9 +63,9 @@ getSetProxyNullExec.global = true;
 
 resetTracking();
 RegExp.prototype[Symbol.match].call(getSetProxyNullExec);
-assert('get == "global,unicode,exec"');
+assert('get == "flags,exec"');
 assert('set == "lastIndex"');
-assert('getSet == "global,unicode,lastIndex,exec"');
+assert('getSet == "flags,lastIndex,exec"');
 
 let regExpGlobal_s = new RegExp("s", "g");
 let getSetProxyMatches_s = new Proxy(
@@ -77,6 +79,8 @@ let getSetProxyMatches_s = new Proxy(
         {
             get.push(k);
             getSet.push(k);
+            if (k.toString() == "flags")
+                return regExpGlobal_s.flags;
             return o[k];
         },
         set: function(o, k, v)
@@ -92,9 +96,9 @@ getSetProxyMatches_s.global = true;
 resetTracking();
 let matchResult = RegExp.prototype[Symbol.match].call(getSetProxyMatches_s, "This is a test");
 assert('matchResult == "s,s,s"');
-assert('get == "global,unicode,exec,exec,exec,exec"');
+assert('get == "flags,exec,exec,exec,exec"');
 assert('set == "lastIndex"');
-assert('getSet == "global,unicode,lastIndex,exec,exec,exec,exec"');
+assert('getSet == "flags,lastIndex,exec,exec,exec,exec"');
 
 let regExpGlobal_tx_Greedy = new RegExp("[tx]*", "g");
 let getSetProxyMatches_tx_Greedy = new Proxy(
@@ -110,6 +114,8 @@ let getSetProxyMatches_tx_Greedy = new Proxy(
             getSet.push(k);
             if (k.toString() == "lastIndex")
                 return regExpGlobal_tx_Greedy.lastIndex;
+            if (k.toString() === "flags")
+                return regExpGlobal_tx_Greedy.flags;
             return o[k];
         },
         set: function(o, k, v)
@@ -128,9 +134,9 @@ getSetProxyMatches_tx_Greedy.global = true;
 resetTracking();
 matchResult = RegExp.prototype[Symbol.match].call(getSetProxyMatches_tx_Greedy, "testing");
 assert('matchResult == "t,,,t,,,,"');
-assert('get == "global,unicode,exec,exec,lastIndex,exec,lastIndex,exec,exec,lastIndex,exec,lastIndex,exec,lastIndex,exec,lastIndex,exec"');
+assert('get == "flags,exec,exec,lastIndex,exec,lastIndex,exec,exec,lastIndex,exec,lastIndex,exec,lastIndex,exec,lastIndex,exec"');
 assert('set == "lastIndex,lastIndex,lastIndex,lastIndex,lastIndex,lastIndex,lastIndex"');
-assert('getSet == "global,unicode,lastIndex,exec,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec"');
+assert('getSet == "flags,lastIndex,exec,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec"');
 
 let regExpGlobalUnicode_digit_nonGreedy = new RegExp("\\d{0,1}", "gu");
 let getSetProxyMatchesUnicode_digit_nonGreedy = new Proxy(
@@ -146,6 +152,8 @@ let getSetProxyMatchesUnicode_digit_nonGreedy = new Proxy(
             getSet.push(k);
             if (k.toString() == "lastIndex")
                 return regExpGlobalUnicode_digit_nonGreedy.lastIndex;
+            if (k.toString() === "flags")
+                return regExpGlobalUnicode_digit_nonGreedy.flags;
             return o[k];
         },
         set: function(o, k, v)
@@ -165,6 +173,6 @@ getSetProxyMatchesUnicode_digit_nonGreedy.unicode = true;
 resetTracking();
 matchResult = RegExp.prototype[Symbol.match].call(getSetProxyMatchesUnicode_digit_nonGreedy, "12X3\u{10400}4");
 assert('matchResult == "1,2,,3,,4,"');
-assert('get == "global,unicode,exec,exec,exec,lastIndex,exec,exec,lastIndex,exec,exec,lastIndex,exec"');
+assert('get == "flags,exec,exec,exec,lastIndex,exec,exec,lastIndex,exec,exec,lastIndex,exec"');
 assert('set == "lastIndex,lastIndex,lastIndex,lastIndex"');
-assert('getSet == "global,unicode,lastIndex,exec,exec,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec"');
+assert('getSet == "flags,lastIndex,exec,exec,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec"');

--- a/JSTests/stress/regexp-prototype-symbol-match-calls-each-flag-getter.js
+++ b/JSTests/stress/regexp-prototype-symbol-match-calls-each-flag-getter.js
@@ -1,0 +1,79 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+const re = /./;
+
+let hasIndicesCount = 0;
+let globalCount = 0;
+let ignoreCaseCount = 0;
+let multilineCount = 0;
+let dotAllCount = 0;
+let unicodeCount = 0;
+let unicodeSetsCount = 0;
+let stickyCount = 0;
+
+Object.defineProperties(re, {
+    hasIndices: {
+        get() {
+            hasIndicesCount++;
+            return false;
+        }
+    },
+    global: {
+        get() {
+            globalCount++;
+            return false;
+        }
+    },
+    ignoreCase: {
+        get() {
+            ignoreCaseCount++;
+            return false;
+        }
+    },
+    multiline: {
+        get() {
+            multilineCount++;
+            return false;
+        }
+    },
+    dotAll: {
+        get() {
+            dotAllCount++;
+            return false;
+        }
+    },
+    unicode: {
+        get() {
+            unicodeCount++;
+            return false;
+        }
+    },
+    unicodeSets: {
+        get() {
+            unicodeSetsCount++;
+            return false;
+        }
+    },
+    sticky: {
+        get() {
+            stickyCount++;
+            return false;
+        }
+    }
+});
+
+for (let i = 0; i < 1e3; i++) {
+    re[Symbol.match]('');
+}
+
+shouldBe(hasIndicesCount, 1e3);
+shouldBe(globalCount, 1e3);
+shouldBe(ignoreCaseCount, 1e3);
+shouldBe(multilineCount, 1e3);
+shouldBe(dotAllCount, 1e3);
+shouldBe(unicodeCount, 1e3);
+shouldBe(unicodeSetsCount, 1e3);
+shouldBe(stickyCount, 1e3);

--- a/JSTests/stress/regexp-prototype-symbol-match-calls-flags-getter.js
+++ b/JSTests/stress/regexp-prototype-symbol-match-calls-flags-getter.js
@@ -1,0 +1,17 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+const re = /./;
+let count = 0;
+Object.defineProperty(re, 'flags', {
+    get() {
+        count++;
+        return '';
+    }
+});
+for (let i = 0; i < 1e3; i++) {
+    re[Symbol.match]('');
+}
+shouldBe(count, 1e3);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -52,15 +52,6 @@ test/built-ins/Proxy/construct/return-not-object-throws-undefined-realm.js:
 test/built-ins/Proxy/construct/trap-is-not-callable-realm.js:
   default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
   strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/RegExp/prototype/Symbol.match/flags-tostring-error.js:
-  default: 'Test262Error: Expected a CustomError but got a Test262Error'
-  strict mode: 'Test262Error: Expected a CustomError but got a Test262Error'
-test/built-ins/RegExp/prototype/Symbol.match/get-flags-err.js:
-  default: 'Test262Error: Expected a CustomError but got a Test262Error'
-  strict mode: 'Test262Error: Expected a CustomError but got a Test262Error'
-test/built-ins/RegExp/prototype/Symbol.match/get-unicode-error.js:
-  default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
 test/built-ins/RegExp/prototype/Symbol.replace/flags-tostring-error.js:
   default: 'Test262Error: Expected a CustomError but got a Test262Error'
   strict mode: 'Test262Error: Expected a CustomError but got a Test262Error'

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -157,8 +157,10 @@ namespace JSC {
     macro(setPrototypeDirectOrThrow) \
     macro(regExpBuiltinExec) \
     macro(regExpMatchFast) \
+    macro(regExpProtoDotAllGetter) \
     macro(regExpProtoFlagsGetter) \
     macro(regExpProtoGlobalGetter) \
+    macro(regExpProtoHasIndicesGetter) \
     macro(regExpProtoIgnoreCaseGetter) \
     macro(regExpProtoMultilineGetter) \
     macro(regExpProtoSourceGetter) \

--- a/Source/JavaScriptCore/builtins/RegExpPrototype.js
+++ b/Source/JavaScriptCore/builtins/RegExpPrototype.js
@@ -88,9 +88,26 @@ function hasObservableSideEffectsForRegExpMatch(regexp)
     if (regexpExec !== @regExpBuiltinExec)
         return true;
 
+    var regexpHasIndices = @tryGetById(regexp, "hasIndices");
+    if (regexpHasIndices !== @regExpProtoHasIndicesGetter)
+        return true;
+
     var regexpGlobal = @tryGetById(regexp, "global");
     if (regexpGlobal !== @regExpProtoGlobalGetter)
         return true;
+
+    var regexpIgnoreCase = @tryGetById(regexp, "ignoreCase");
+    if (regexpIgnoreCase !== @regExpProtoIgnoreCaseGetter)
+        return true;
+
+    var regexpMultiline = @tryGetById(regexp, "multiline");
+    if (regexpMultiline !== @regExpProtoMultilineGetter)
+        return true;
+
+    var regexpDotAll = @tryGetById(regexp, "dotAll");
+    if (regexpDotAll !== @regExpProtoDotAllGetter)
+        return true;
+
     var regexpUnicode = @tryGetById(regexp, "unicode");
     if (regexpUnicode !== @regExpProtoUnicodeGetter)
         return true;
@@ -98,6 +115,14 @@ function hasObservableSideEffectsForRegExpMatch(regexp)
     var regexpUnicodeSets = @tryGetById(regexp, "unicodeSets");
     if (regexpUnicodeSets !== @regExpProtoUnicodeSetsGetter)
         return true;
+
+    var regexpSticky = @tryGetById(regexp, "sticky");
+    if (regexpSticky !== @regExpProtoStickyGetter)
+        return true;
+
+    var regexpFlags = @tryGetById(regexp, "flags");
+    if (regexpFlags !== @regExpProtoFlagsGetter)
+        return true
 
     return typeof regexp.lastIndex !== "number";
 }
@@ -107,10 +132,14 @@ function matchSlow(regexp, str)
 {
     "use strict";
 
-    if (!regexp.global)
+    var flags = @toString(regexp.flags);
+    var global = @stringIncludesInternal.@call(flags, "g");
+
+    if (!global)
         return @regExpExec(regexp, str);
-    
-    var unicode = regexp.unicode;
+
+    var unicode = @stringIncludesInternal.@call(flags, "u") || @stringIncludesInternal.@call(flags, "v");
+
     regexp.lastIndex = 0;
     var resultList = [];
 

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -86,8 +86,10 @@ class JSGlobalObject;
     v(moveFunctionToRealm, nullptr) \
     v(isConstructor, nullptr) \
     v(sameValue, nullptr) \
+    v(regExpProtoDotAllGetter, nullptr) \
     v(regExpProtoFlagsGetter, nullptr) \
     v(regExpProtoGlobalGetter, nullptr) \
+    v(regExpProtoHasIndicesGetter, nullptr) \
     v(regExpProtoIgnoreCaseGetter, nullptr) \
     v(regExpProtoMultilineGetter, nullptr) \
     v(regExpProtoSourceGetter, nullptr) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1437,12 +1437,18 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     if (Options::exposeInternalModuleLoader())
         putDirectWithoutTransition(vm, vm.propertyNames->Loader, moduleLoader(), static_cast<unsigned>(PropertyAttribute::DontEnum));
 
+    GetterSetter* regExpProtoDotAllGetter = getGetterById(this, m_regExpPrototype.get(), vm.propertyNames->dotAll);
+    catchScope.assertNoException();
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpProtoDotAllGetter)].set(vm, this, regExpProtoDotAllGetter);
     GetterSetter* regExpProtoFlagsGetter = getGetterById(this, m_regExpPrototype.get(), vm.propertyNames->flags);
     catchScope.assertNoException();
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpProtoFlagsGetter)].set(vm, this, regExpProtoFlagsGetter);
     GetterSetter* regExpProtoGlobalGetter = getGetterById(this, m_regExpPrototype.get(), vm.propertyNames->global);
     catchScope.assertNoException();
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpProtoGlobalGetter)].set(vm, this, regExpProtoGlobalGetter);
+    GetterSetter* regExpProtoHasIndicesGetter = getGetterById(this, m_regExpPrototype.get(), vm.propertyNames->hasIndices);
+    catchScope.assertNoException();
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpProtoHasIndicesGetter)].set(vm, this, regExpProtoHasIndicesGetter);
     GetterSetter* regExpProtoIgnoreCaseGetter = getGetterById(this, m_regExpPrototype.get(), vm.propertyNames->ignoreCase);
     catchScope.assertNoException();
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpProtoIgnoreCaseGetter)].set(vm, this, regExpProtoIgnoreCaseGetter);


### PR DESCRIPTION
#### 7d672d135674254ee1ef1c45f02ec9e89bd83a34
<pre>
[JSC] Read regexp.flags explicitly in RegExp.prototype[Symbol.match] slow path
<a href="https://bugs.webkit.org/show_bug.cgi?id=272206">https://bugs.webkit.org/show_bug.cgi?id=272206</a>

Reviewed by NOBODY (OOPS!).

According to the spec[1], RegExp.prototype[Symbol.match] calls the RegExp.prototype.flags getter.
The flags getter calls each getter such as global and unicode[2].
However, the current JSC was directly calling RegExp.prototype.global and RegExp.prototype.unicode.
This patch changes RegExp.prototype[Symbol.match] to explicitly call the RegExp.prototype.flags getter.

[1]: <a href="https://tc39.es/ecma262/#sec-regexp.prototype-@@match">https://tc39.es/ecma262/#sec-regexp.prototype-@@match</a>
[2]: <a href="https://tc39.es/ecma262/#sec-get-regexp.prototype.flags">https://tc39.es/ecma262/#sec-get-regexp.prototype.flags</a>

* JSTests/es6/Proxy_internal_get_calls_RegExp.prototype[Symbol.match].js:
* JSTests/stress/regexp-match-proxy.js:
* JSTests/stress/regexp-prototype-symbol-match-calls-each-flag-getter.js: Added.
(shouldBe):
* JSTests/stress/regexp-prototype-symbol-match-calls-flags-getter.js: Added.
(shouldBe):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/RegExpPrototype.js:
(linkTimeConstant.hasObservableSideEffectsForRegExpMatch):
(linkTimeConstant.matchSlow):
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d672d135674254ee1ef1c45f02ec9e89bd83a34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42791 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38091 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19373 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41396 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4790 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/39991 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42996 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51293 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46227 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45368 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23041 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44327 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23524 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53369 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22746 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10953 "Passed tests") | 
<!--EWS-Status-Bubble-End-->