### PR TITLE
Use std::span more in StringImpl code

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp
@@ -289,7 +289,7 @@ void LazyJSValue::dumpInContext(PrintStream& out, DumpContext* context) const
     case SingleCharacterString:
         out.print("Lazy:SingleCharacterString(");
         out.printf("%04X", static_cast<unsigned>(character()));
-        out.print(" / ", StringImpl::utf8ForCharacters(&u.character, 1).value(), ")");
+        out.print(" / ", StringImpl::utf8ForCharacters(span(u.character)).value(), ")");
         return;
     case KnownStringImpl:
         out.print("Lazy:KnownString(", stringImpl(), ")");

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -404,7 +404,7 @@ String languageTagForLocaleID(const char* localeID, bool isImmortal)
         // This is used to store into static variables that may be shared across JSC execution threads.
         // This must be immortal to make concurrent ref/deref safe.
         if (isImmortal)
-            return StringImpl::createStaticStringImpl(buffer.data(), buffer.size());
+            return StringImpl::createStaticStringImpl(buffer.span());
         return buffer.span();
     };
 
@@ -434,7 +434,7 @@ static void addScriptlessLocaleIfNeeded(LocaleSet& availableLocales, StringView 
     ASSERT(subtags[2].is8Bit() && subtags[2].containsOnlyASCII());
     buffer.append(subtags[2].span8());
 
-    availableLocales.add(StringImpl::createStaticStringImpl(buffer.data(), buffer.size()));
+    availableLocales.add(StringImpl::createStaticStringImpl(buffer.span()));
 }
 
 const LocaleSet& intlAvailableLocales()
@@ -1088,7 +1088,7 @@ Vector<String> numberingSystemsForLocale(const String& locale)
             ASSERT(U_SUCCESS(status));
             // Only support algorithmic if it is the default fot the locale, handled below.
             if (!unumsys_isAlgorithmic(numsys))
-                availableNumberingSystems->append(String(StringImpl::createStaticStringImpl(result, resultLength)));
+                availableNumberingSystems->append(String(StringImpl::createStaticStringImpl({ result, static_cast<size_t>(resultLength) })));
             unumsys_close(numsys);
         }
         uenum_close(numberingSystemNames);
@@ -1628,8 +1628,8 @@ const Vector<String>& intlAvailableCalendars()
 
         auto createImmortalThreadSafeString = [&](String&& string) {
             if (string.is8Bit())
-                return StringImpl::createStaticStringImpl(string.characters8(), string.length());
-            return StringImpl::createStaticStringImpl(string.characters16(), string.length());
+                return StringImpl::createStaticStringImpl(string.span8());
+            return StringImpl::createStaticStringImpl(string.span16());
         };
 
         availableCalendars.construct(count, [&](size_t) {
@@ -1891,8 +1891,8 @@ const Vector<String>& intlAvailableTimeZones()
 
         auto createImmortalThreadSafeString = [&](String&& string) {
             if (string.is8Bit())
-                return StringImpl::createStaticStringImpl(string.characters8(), string.length());
-            return StringImpl::createStaticStringImpl(string.characters16(), string.length());
+                return StringImpl::createStaticStringImpl(string.span8());
+            return StringImpl::createStaticStringImpl(string.span16());
         };
         availableTimeZones.get() = WTF::map(std::span(temporary.begin(), end), [&](auto&& string) -> String {
             return createImmortalThreadSafeString(WTFMove(string));

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.cpp
@@ -46,7 +46,7 @@ static inline void appendStringToData(CharacterType*& data, StringView string)
 template<typename OutputCharacterType, typename SeparatorCharacterType>
 static inline void appendStringToData(OutputCharacterType*& data, std::span<const SeparatorCharacterType> separator)
 {
-    StringImpl::copyCharacters(data, separator.data(), separator.size());
+    StringImpl::copyCharacters(data, separator);
     data += separator.size();
 }
 

--- a/Source/JavaScriptCore/runtime/StringConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/StringConstructor.cpp
@@ -97,7 +97,7 @@ JSC_DEFINE_HOST_FUNCTION(stringFromCharCode, (JSGlobalObject* globalObject, Call
         if (UNLIKELY(!isLatin1(character))) {
             UChar* buf16Bit;
             auto impl16Bit = StringImpl::createUninitialized(length, buf16Bit);
-            StringImpl::copyCharacters(buf16Bit, buf8Bit, i);
+            StringImpl::copyCharacters(buf16Bit, { buf8Bit, i });
             buf16Bit[i] = character;
             ++i;
             for (; i < length; ++i) {

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -321,7 +321,7 @@ static ALWAYS_INLINE JSString* jsSpliceSubstrings(JSGlobalObject* globalObject, 
         Checked<int, AssertNoOverflow> bufferPos = 0;
         for (int i = 0; i < rangeCount; i++) {
             int srcLen = substringRanges[i].distance();
-            StringImpl::copyCharacters(buffer + bufferPos.value(), sourceData + substringRanges[i].begin(), srcLen);
+            StringImpl::copyCharacters(buffer + bufferPos.value(), { sourceData + substringRanges[i].begin(), static_cast<size_t>(srcLen) });
             bufferPos += srcLen;
         }
 
@@ -340,7 +340,7 @@ static ALWAYS_INLINE JSString* jsSpliceSubstrings(JSGlobalObject* globalObject, 
     Checked<int, AssertNoOverflow> bufferPos = 0;
     for (int i = 0; i < rangeCount; i++) {
         int srcLen = substringRanges[i].distance();
-        StringImpl::copyCharacters(buffer + bufferPos.value(), sourceData + substringRanges[i].begin(), srcLen);
+        StringImpl::copyCharacters(buffer + bufferPos.value(), { sourceData + substringRanges[i].begin(), static_cast<size_t>(srcLen) });
         bufferPos += srcLen;
     }
 

--- a/Source/WTF/wtf/HexNumber.h
+++ b/Source/WTF/wtf/HexNumber.h
@@ -81,7 +81,7 @@ public:
 
     unsigned length() const { return m_buffer.length; }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, characters(), length()); }
+    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, m_buffer.span()); }
 
 private:
     const LChar* characters() const { return m_buffer.characters(); }

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -852,9 +852,9 @@ static String escapeUnsafeCharacters(const String& sourceBuffer)
 
     outBuffer.grow(i);
     if (sourceBuffer.is8Bit())
-        StringImpl::copyCharacters(outBuffer.data(), sourceBuffer.characters8(), i);
+        StringImpl::copyCharacters(outBuffer.data(), sourceBuffer.span8().first(i));
     else
-        StringImpl::copyCharacters(outBuffer.data(), sourceBuffer.characters16(), i);
+        StringImpl::copyCharacters(outBuffer.data(), sourceBuffer.span16().first(i));
 
     for (; i < length; ) {
         char32_t c = sourceBuffer.characterStartingAt(i);

--- a/Source/WTF/wtf/text/StringBuilder.cpp
+++ b/Source/WTF/wtf/text/StringBuilder.cpp
@@ -159,7 +159,7 @@ void StringBuilder::appendCharacters(std::span<const UChar> characters)
     }
     RELEASE_ASSERT(characters.size() < std::numeric_limits<uint32_t>::max());
     if (auto destination = extendBufferForAppendingWithUpconvert(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))))
-        StringImpl::copyCharacters(destination, characters.data(), characters.size());
+        StringImpl::copyCharacters(destination, characters);
 }
 
 void StringBuilder::appendCharacters(std::span<const LChar> characters)
@@ -169,10 +169,10 @@ void StringBuilder::appendCharacters(std::span<const LChar> characters)
     RELEASE_ASSERT(characters.size() < std::numeric_limits<uint32_t>::max());
     if (is8Bit()) {
         if (auto destination = extendBufferForAppending<LChar>(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))))
-            StringImpl::copyCharacters(destination, characters.data(), characters.size());
+            StringImpl::copyCharacters(destination, characters);
     } else {
         if (auto destination = extendBufferForAppending<UChar>(saturatedSum<uint32_t>(m_length, static_cast<uint32_t>(characters.size()))))
-            StringImpl::copyCharacters(destination, characters.data(), characters.size());
+            StringImpl::copyCharacters(destination, characters);
     }
 }
 

--- a/Source/WTF/wtf/text/StringBuilderInternals.h
+++ b/Source/WTF/wtf/text/StringBuilderInternals.h
@@ -41,7 +41,7 @@ template<typename AllocationCharacterType, typename CurrentCharacterType> void S
     }
 
     ASSERT(!hasOverflowed());
-    StringImpl::copyCharacters(bufferCharacters, currentCharacters, m_length);
+    StringImpl::copyCharacters(bufferCharacters, { currentCharacters, m_length });
 
     m_buffer = WTFMove(buffer);
     m_string = { };

--- a/Source/WTF/wtf/text/StringCommon.cpp
+++ b/Source/WTF/wtf/text/StringCommon.cpp
@@ -209,10 +209,12 @@ const double* findDoubleAlignedImpl(const double* pointer, double target, size_t
 }
 
 SUPPRESS_ASAN
-const LChar* find8NonASCIIAlignedImpl(const LChar* pointer, size_t length)
+const LChar* find8NonASCIIAlignedImpl(std::span<const LChar> data)
 {
     constexpr uint8x16_t indexMask { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 
+    auto* pointer = data.data();
+    auto length = data.size();
     ASSERT(length);
     ASSERT(!(reinterpret_cast<uintptr_t>(pointer) & 0xf));
     ASSERT((reinterpret_cast<uintptr_t>(pointer) & ~static_cast<uintptr_t>(0xf)) == reinterpret_cast<uintptr_t>(pointer));
@@ -237,8 +239,10 @@ const LChar* find8NonASCIIAlignedImpl(const LChar* pointer, size_t length)
 }
 
 SUPPRESS_ASAN
-const UChar* find16NonASCIIAlignedImpl(const UChar* pointer, size_t length)
+const UChar* find16NonASCIIAlignedImpl(std::span<const UChar> data)
 {
+    auto* pointer = data.data();
+    auto length = data.size();
     ASSERT(!(reinterpret_cast<uintptr_t>(pointer) & 0x1));
 
     constexpr uint16x8_t indexMask { 0, 1, 2, 3, 4, 5, 6, 7 };

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -720,12 +720,14 @@ ALWAYS_INLINE const double* findDouble(const double* pointer, double target, siz
 #endif
 
 #if CPU(ARM64)
-WTF_EXPORT_PRIVATE const LChar* find8NonASCIIAlignedImpl(const LChar* pointer, size_t length);
+WTF_EXPORT_PRIVATE const LChar* find8NonASCIIAlignedImpl(std::span<const LChar>);
 
-ALWAYS_INLINE const LChar* find8NonASCII(const LChar* pointer, size_t length)
+ALWAYS_INLINE const LChar* find8NonASCII(std::span<const LChar> data)
 {
     constexpr size_t thresholdLength = 16;
     static_assert(!(thresholdLength % (16 / sizeof(LChar))), "length threshold should be 16-byte aligned to make find8NonASCIIAlignedImpl simpler");
+    auto* pointer = data.data();
+    auto length = data.size();
     uintptr_t unaligned = reinterpret_cast<uintptr_t>(pointer) & 0xf;
 
     size_t index = 0;
@@ -738,15 +740,17 @@ ALWAYS_INLINE const LChar* find8NonASCII(const LChar* pointer, size_t length)
         return nullptr;
 
     ASSERT(index < length);
-    return find8NonASCIIAlignedImpl(pointer + index, length - index);
+    return find8NonASCIIAlignedImpl({ pointer + index, length - index });
 }
 
-WTF_EXPORT_PRIVATE const UChar* find16NonASCIIAlignedImpl(const UChar* pointer, size_t length);
+WTF_EXPORT_PRIVATE const UChar* find16NonASCIIAlignedImpl(std::span<const UChar>);
 
-ALWAYS_INLINE const UChar* find16NonASCII(const UChar* pointer, size_t length)
+ALWAYS_INLINE const UChar* find16NonASCII(std::span<const UChar> data)
 {
     constexpr size_t thresholdLength = 16;
     static_assert(!(thresholdLength % (16 / sizeof(UChar))), "length threshold should be 16-byte aligned to make find16NonASCIIAlignedImpl simpler");
+    auto* pointer = data.data();
+    auto length = data.size();
     uintptr_t unaligned = reinterpret_cast<uintptr_t>(pointer) & 0xf;
 
     size_t index = 0;
@@ -759,7 +763,7 @@ ALWAYS_INLINE const UChar* find16NonASCII(const UChar* pointer, size_t length)
         return nullptr;
 
     ASSERT(index < length);
-    return find16NonASCIIAlignedImpl(pointer + index, length - index);
+    return find16NonASCIIAlignedImpl({ pointer + index, length - index });
 }
 #endif
 

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -127,7 +127,7 @@ public:
 
     unsigned length() const { return m_length; }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, m_characters, m_length); }
+    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, { m_characters, m_length }); }
 
 private:
     static unsigned computeLength(const LChar* characters)
@@ -150,7 +150,7 @@ public:
     unsigned length() const { return m_length; }
     bool is8Bit() const { return !m_length; }
     void writeTo(LChar*) const { ASSERT(!m_length); }
-    void writeTo(UChar* destination) const { StringImpl::copyCharacters(destination, m_characters, m_length); }
+    void writeTo(UChar* destination) const { StringImpl::copyCharacters(destination, { m_characters, m_length }); }
 
 private:
     static unsigned computeLength(const UChar* characters)
@@ -204,7 +204,7 @@ public:
     {
         using CharacterTypeForString = std::conditional_t<sizeof(CharacterType) == sizeof(LChar), LChar, UChar>;
         static_assert(sizeof(CharacterTypeForString) == sizeof(CharacterType));
-        StringImpl::copyCharacters(destination, reinterpret_cast<const CharacterTypeForString*>(m_characters), m_length);
+        StringImpl::copyCharacters(destination, { reinterpret_cast<const CharacterTypeForString*>(m_characters), m_length });
     }
 
 private:

--- a/Source/WTF/wtf/text/StringConcatenateNumbers.h
+++ b/Source/WTF/wtf/text/StringConcatenateNumbers.h
@@ -77,10 +77,10 @@ public:
 
     unsigned length() const { return m_length; }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, buffer(), m_length); }
+    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, span()); }
 
 private:
-    const LChar* buffer() const { return reinterpret_cast<const LChar*>(&m_buffer[0]); }
+    std::span<const LChar> span() const { return { reinterpret_cast<const LChar*>(&m_buffer[0]), m_length }; }
 
     NumberToStringBuffer m_buffer;
     unsigned m_length;
@@ -107,6 +107,7 @@ public:
 
     unsigned length() const { return m_length; }
     const LChar* buffer() const { return reinterpret_cast<const LChar*>(&m_buffer[0]); }
+    std::span<const LChar> span() const { return { buffer(), length() }; }
 
 private:
     NumberToStringBuffer m_buffer;
@@ -122,7 +123,7 @@ public:
 
     unsigned length() const { return m_number.length(); }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, m_number.buffer(), m_number.length()); }
+    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, m_number.span()); }
 
 private:
     const FormattedNumber& m_number;
@@ -141,6 +142,7 @@ public:
 
     unsigned length() const { return m_length; }
     const LChar* buffer() const { return reinterpret_cast<const LChar*>(&m_buffer[0]); }
+    std::span<const LChar> span() const { return { buffer(), length() }; }
 
 private:
     NumberToCSSStringBuffer m_buffer;
@@ -156,7 +158,7 @@ public:
 
     unsigned length() const { return m_number.length(); }
     bool is8Bit() const { return true; }
-    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, m_number.buffer(), m_number.length()); }
+    template<typename CharacterType> void writeTo(CharacterType* destination) const { StringImpl::copyCharacters(destination, m_number.span()); }
 
 private:
     const FormattedCSSNumber& m_number;

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -94,8 +94,8 @@ Expected<CString, UTF8ConversionError> StringView::tryGetUTF8(ConversionMode mod
     if (isNull())
         return CString { ""_span };
     if (is8Bit())
-        return StringImpl::utf8ForCharacters(characters8(), length());
-    return StringImpl::utf8ForCharacters(characters16(), length(), mode);
+        return StringImpl::utf8ForCharacters(span8());
+    return StringImpl::utf8ForCharacters(span16(), mode);
 }
 
 CString StringView::utf8(ConversionMode mode) const

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -623,12 +623,12 @@ template<bool isSpecialCharacter(UChar)> inline bool StringView::containsOnly() 
 
 template<typename CharacterType> inline void StringView::getCharacters8(CharacterType* destination) const
 {
-    StringImpl::copyCharacters(destination, characters8(), m_length);
+    StringImpl::copyCharacters(destination, span8());
 }
 
 template<typename CharacterType> inline void StringView::getCharacters16(CharacterType* destination) const
 {
-    StringImpl::copyCharacters(destination, characters16(), m_length);
+    StringImpl::copyCharacters(destination, span16());
 }
 
 template<typename CharacterType> inline void StringView::getCharacters(CharacterType* destination) const
@@ -646,10 +646,8 @@ inline StringView::UpconvertedCharactersWithSize<N>::UpconvertedCharactersWithSi
         m_characters = string.characters16();
         return;
     }
-    const LChar* characters8 = string.characters8();
-    unsigned length = string.m_length;
-    m_upconvertedCharacters.grow(length);
-    StringImpl::copyCharacters(m_upconvertedCharacters.data(), characters8, length);
+    m_upconvertedCharacters.grow(string.m_length);
+    StringImpl::copyCharacters(m_upconvertedCharacters.data(), string.span8());
     m_characters = m_upconvertedCharacters.data();
 }
 
@@ -1485,8 +1483,8 @@ template<typename Func>
 inline Expected<std::invoke_result_t<Func, std::span<const char>>, UTF8ConversionError> StringView::tryGetUTF8(const Func& function, ConversionMode mode) const
 {
     if (is8Bit())
-        return StringImpl::tryGetUTF8ForCharacters(function, characters8(), length());
-    return StringImpl::tryGetUTF8ForCharacters(function, characters16(), length(), mode);
+        return StringImpl::tryGetUTF8ForCharacters(function, span8());
+    return StringImpl::tryGetUTF8ForCharacters(function, span16(), mode);
 }
 
 template<> struct VectorTraits<StringView> : VectorTraitsBase<false, void> {

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -450,7 +450,7 @@ String String::make8Bit(std::span<const UChar> source)
 {
     LChar* destination;
     String result = String::createUninitialized(source.size(), destination);
-    StringImpl::copyCharacters(destination, source.data(), source.size());
+    StringImpl::copyCharacters(destination, source);
     return result;
 }
 
@@ -458,10 +458,9 @@ void String::convertTo16Bit()
 {
     if (isNull() || !is8Bit())
         return;
-    auto length = this->length();
     UChar* destination;
-    auto convertedString = String::createUninitialized(length, destination);
-    StringImpl::copyCharacters(destination, characters8(), length);
+    auto convertedString = String::createUninitialized(length(), destination);
+    StringImpl::copyCharacters(destination, span8());
     *this = WTFMove(convertedString);
 }
 

--- a/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
@@ -140,7 +140,7 @@ static UBool uTextLatin1Access(UText* uText, int64_t index, UBool forward)
     }
     uText->chunkLength = static_cast<int32_t>(uText->chunkNativeLimit - uText->chunkNativeStart);
 
-    StringImpl::copyCharacters(const_cast<UChar*>(uText->chunkContents), static_cast<const LChar*>(uText->context) + uText->chunkNativeStart, uText->chunkLength);
+    StringImpl::copyCharacters(const_cast<UChar*>(uText->chunkContents), { static_cast<const LChar*>(uText->context) + uText->chunkNativeStart, static_cast<size_t>(uText->chunkLength) });
 
     uText->nativeIndexingLimit = uText->chunkLength;
 
@@ -178,7 +178,7 @@ static int32_t uTextLatin1Extract(UText* uText, int64_t start, int64_t limit, UC
         if (trimmedLength > destCapacity)
             trimmedLength = destCapacity;
 
-        StringImpl::copyCharacters(dest, static_cast<const LChar*>(uText->context) + start, trimmedLength);
+        StringImpl::copyCharacters(dest, { static_cast<const LChar*>(uText->context) + start, static_cast<size_t>(trimmedLength) });
     }
 
     if (length < destCapacity) {
@@ -291,7 +291,7 @@ static void textLatin1ContextAwareMoveInPrimaryContext(UText* text, int64_t nati
     text->chunkLength = length < std::numeric_limits<int32_t>::max() ? static_cast<int32_t>(length) : 0;
     text->nativeIndexingLimit = text->chunkLength;
     text->chunkOffset = forward ? 0 : text->chunkLength;
-    StringImpl::copyCharacters(const_cast<UChar*>(text->chunkContents), static_cast<const LChar*>(text->p) + (text->chunkNativeStart - text->b), text->chunkLength);
+    StringImpl::copyCharacters(const_cast<UChar*>(text->chunkContents), { static_cast<const LChar*>(text->p) + (text->chunkNativeStart - text->b), static_cast<size_t>(text->chunkLength) });
 }
 
 static void textLatin1ContextAwareSwitchToPrimaryContext(UText* text, int64_t nativeIndex, int64_t nativeLength, UBool forward)

--- a/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp
@@ -42,29 +42,29 @@ TEST(WTF_StringCommon, Find8NonASCII)
     Vector<LChar> vector(4096);
     vector.fill('a');
 
-    EXPECT_FALSE(WTF::find8NonASCII(vector.data(), 4096));
+    EXPECT_FALSE(WTF::find8NonASCII(vector.subspan(0, 4096)));
 
     vector[4095] = 0x80;
-    EXPECT_EQ(WTF::find8NonASCII(vector.data(), 4096) - vector.data(), 4095);
+    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.data(), 4095);
     for (unsigned i = 0; i < 16; ++i)
-        EXPECT_FALSE(WTF::find8NonASCII(vector.data(), 4095 - i));
+        EXPECT_FALSE(WTF::find8NonASCII(vector.subspan(0, 4095 - i)));
 
     vector[1024] = 0x80;
-    EXPECT_EQ(WTF::find8NonASCII(vector.data(), 4096) - vector.data(), 1024);
-    EXPECT_FALSE(WTF::find8NonASCII(vector.data(), 1023));
+    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.data(), 1024);
+    EXPECT_FALSE(WTF::find8NonASCII(vector.subspan(0, 1023)));
 
     vector[1024] = 0xff;
-    EXPECT_EQ(WTF::find8NonASCII(vector.data(), 4096) - vector.data(), 1024);
-    EXPECT_FALSE(WTF::find8NonASCII(vector.data(), 1023));
+    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.data(), 1024);
+    EXPECT_FALSE(WTF::find8NonASCII(vector.subspan(0, 1023)));
 
     vector[1024] = 0x7f;
-    EXPECT_EQ(WTF::find8NonASCII(vector.data(), 4096) - vector.data(), 4095);
+    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.data(), 4095);
 
     vector[0] = 0xff;
-    EXPECT_EQ(WTF::find8NonASCII(vector.data(), 4096) - vector.data(), 0);
+    EXPECT_EQ(WTF::find8NonASCII(vector.subspan(0, 4096)) - vector.data(), 0);
     for (int i = 0; i < 16; ++i) {
         vector[i] = 0xff;
-        EXPECT_EQ(WTF::find8NonASCII(vector.data() + i, 4096 - i) - vector.data(), i);
+        EXPECT_EQ(WTF::find8NonASCII(vector.subspan(i, 4096 - i)) - vector.data(), i);
     }
 }
 
@@ -73,29 +73,29 @@ TEST(WTF_StringCommon, Find16NonASCII)
     Vector<UChar> vector(4096);
     vector.fill('a');
 
-    EXPECT_FALSE(WTF::find16NonASCII(vector.data(), 4096));
+    EXPECT_FALSE(WTF::find16NonASCII(vector.subspan(0, 4096)));
 
     vector[4095] = 0x80;
-    EXPECT_EQ(WTF::find16NonASCII(vector.data(), 4096) - vector.data(), 4095);
+    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.data(), 4095);
     for (unsigned i = 0; i < 16; ++i)
-        EXPECT_FALSE(WTF::find16NonASCII(vector.data(), 4095 - i));
+        EXPECT_FALSE(WTF::find16NonASCII(vector.subspan(0, 4095 - i)));
 
     vector[1024] = 0x80;
-    EXPECT_EQ(WTF::find16NonASCII(vector.data(), 4096) - vector.data(), 1024);
-    EXPECT_FALSE(WTF::find16NonASCII(vector.data(), 1023));
+    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.data(), 1024);
+    EXPECT_FALSE(WTF::find16NonASCII(vector.subspan(0, 1023)));
 
     vector[1024] = 0xff;
-    EXPECT_EQ(WTF::find16NonASCII(vector.data(), 4096) - vector.data(), 1024);
-    EXPECT_FALSE(WTF::find16NonASCII(vector.data(), 1023));
+    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.data(), 1024);
+    EXPECT_FALSE(WTF::find16NonASCII(vector.subspan(0, 1023)));
 
     vector[1024] = 0x7f;
-    EXPECT_EQ(WTF::find16NonASCII(vector.data(), 4096) - vector.data(), 4095);
+    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.data(), 4095);
 
     vector[0] = 0xff;
-    EXPECT_EQ(WTF::find16NonASCII(vector.data(), 4096) - vector.data(), 0);
+    EXPECT_EQ(WTF::find16NonASCII(vector.subspan(0, 4096)) - vector.data(), 0);
     for (int i = 0; i < 16; ++i) {
         vector[i] = 0xff;
-        EXPECT_EQ(WTF::find16NonASCII(vector.data() + i, 4096 - i) - vector.data(), i);
+        EXPECT_EQ(WTF::find16NonASCII(vector.subspan(i, 4096 - i)) - vector.data(), i);
     }
 }
 #endif

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -733,10 +733,10 @@ TEST(WTF, StaticStringImpl)
 TEST(WTF, DynamicStaticStringImpl)
 {
     // Construct using MAKE_STATIC_STRING_IMPL.
-    String hello = StringImpl::createStaticStringImpl("hello", 5);
-    String world = StringImpl::createStaticStringImpl("world", 5);
-    String longer = StringImpl::createStaticStringImpl("longer", 6);
-    String hello2 = StringImpl::createStaticStringImpl("hello", 5);
+    String hello = StringImpl::createStaticStringImpl("hello"_span);
+    String world = StringImpl::createStaticStringImpl("world"_span);
+    String longer = StringImpl::createStaticStringImpl("longer"_span);
+    String hello2 = StringImpl::createStaticStringImpl("hello"_span);
 
     doStaticStringImplTests(StaticStringImplTestSet::DynamicallyAllocatedImpl, hello, world, longer, hello2);
 }


### PR DESCRIPTION
#### 27a1ee5ab6deb23c6e618ab2756faccce741e9e2
<pre>
Use std::span more in StringImpl code
<a href="https://bugs.webkit.org/show_bug.cgi?id=272208">https://bugs.webkit.org/show_bug.cgi?id=272208</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/dfg/DFGLazyJSValue.cpp:
(JSC::DFG::LazyJSValue::dumpInContext const):
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::languageTagForLocaleID):
(JSC::addScriptlessLocaleIfNeeded):
(JSC::numberingSystemsForLocale):
(JSC::intlAvailableCalendars):
(JSC::intlAvailableTimeZones):
* Source/JavaScriptCore/runtime/JSStringJoiner.cpp:
(JSC::appendStringToData):
* Source/JavaScriptCore/runtime/StringConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::jsSpliceSubstrings):
* Source/WTF/wtf/HexNumber.h:
(WTF::StringTypeAdapter&lt;HexNumberBuffer&gt;::writeTo const):
* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::escapeUnsafeCharacters):
* Source/WTF/wtf/text/StringBuilder.cpp:
(WTF::StringBuilder::appendCharacters):
* Source/WTF/wtf/text/StringBuilderInternals.h:
(WTF::StringBuilder::allocateBuffer):
* Source/WTF/wtf/text/StringCommon.cpp:
(WTF::find8NonASCIIAlignedImpl):
(WTF::find16NonASCIIAlignedImpl):
* Source/WTF/wtf/text/StringCommon.h:
* Source/WTF/wtf/text/StringConcatenate.h:
* Source/WTF/wtf/text/StringConcatenateNumbers.h:
(WTF::FormattedNumber::span const):
(WTF::StringTypeAdapter&lt;FormattedNumber&gt;::writeTo const):
(WTF::FormattedCSSNumber::span const):
(WTF::StringTypeAdapter&lt;FormattedCSSNumber&gt;::writeTo const):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::createInternal):
(WTF::StringImpl::createStaticStringImpl):
(WTF::StringImpl::create8BitIfPossible):
(WTF::StringImpl::foldCase):
(WTF::StringImpl::convertASCIICase):
(WTF::StringImpl::replace):
(WTF::StringImpl::utf8ForCharacters):
(WTF::StringImpl::utf8ForCharactersIntoBuffer):
(WTF::StringImpl::tryGetUTF8 const):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::create8BitIfPossible):
(WTF::StringImpl::createStaticStringImpl):
(WTF::StringImpl::copyCharacters):
(WTF::StringImpl::StringImpl):
(WTF::StringImpl::removeCharactersImpl):
(WTF::StringImpl::createByReplacingInCharacters):
(WTF::StringImpl::tryGetUTF8 const):
(WTF::StringImpl::tryGetUTF8ForCharacters):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::tryGetUTF8 const):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::getCharacters8 const):
(WTF::StringView::getCharacters16 const):
(WTF::StringView::UpconvertedCharactersWithSize&lt;N&gt;::UpconvertedCharactersWithSize):
(WTF::StringView::tryGetUTF8 const):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::make8Bit):
(WTF::String::convertTo16Bit):
* Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp:
(WTF::uTextLatin1Access):
(WTF::uTextLatin1Extract):
(WTF::textLatin1ContextAwareMoveInPrimaryContext):
* Tools/TestWebKitAPI/Tests/WTF/StringCommon.cpp:
(TestWebKitAPI::TEST(WTF_StringCommon, Find8NonASCII)):
(TestWebKitAPI::TEST(WTF_StringCommon, Find16NonASCII)):
* Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp:
(TestWebKitAPI::TEST(WTF, DynamicStaticStringImpl)):

Canonical link: <a href="https://commits.webkit.org/277147@main">https://commits.webkit.org/277147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a51cd720165a3f7b1ebed7d3e8d1f7a713bde87e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42890 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23470 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47422 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/23012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/19453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4888 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/40090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/41847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51394 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46325 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18198 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23139 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53467 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6562 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/22849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10983 "Passed tests") | 
<!--EWS-Status-Bubble-End-->