### PR TITLE
Some text fails to translate to Simplified Chinese on Apple TV+ page

### DIFF
--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -642,11 +642,11 @@ void TextIterator::handleTextRun()
         auto hasPrecedingCollapsedWhitespace = m_lastTextNodeEndedWithCollapsedSpace || (m_textRun == firstTextRun && textRunStart == runStart && runStart);
         auto shouldEmitWhitespace = !isAfterRangeEnd && hasPrecedingCollapsedWhitespace && m_lastCharacter && !renderer->style().isCollapsibleWhiteSpace(m_lastCharacter);
         if (shouldEmitWhitespace) {
-            if (m_lastTextNode == textNode.ptr() && runStart && rendererText[runStart - 1] == ' ') {
+            if (m_lastTextNode == textNode.ptr() && runStart && renderer->style().isCollapsibleWhiteSpace(rendererText[runStart - 1])) {
                 unsigned spaceRunStart = runStart - 1;
-                while (spaceRunStart && rendererText[spaceRunStart - 1] == ' ')
+                while (spaceRunStart && renderer->style().isCollapsibleWhiteSpace(rendererText[spaceRunStart - 1]))
                     --spaceRunStart;
-                emitText(textNode, renderer, spaceRunStart, spaceRunStart + 1);
+                emitCharacter(' ', WTFMove(textNode), nullptr, spaceRunStart, spaceRunStart + 1);
             } else
                 emitCharacter(' ', WTFMove(textNode), nullptr, runStart, runStart);
             return;
@@ -1179,6 +1179,15 @@ RefPtr<Node> TextIterator::protectedCurrentNode() const
 {
     return m_currentNode;
 }
+
+#if ENABLE(TREE_DEBUGGING)
+void TextIterator::showTreeForThis() const
+{
+    if (m_currentNode)
+        m_currentNode->showTreeForThis();
+    fprintf(stderr, "offset: %d\n", m_offset);
+}
+#endif
 
 // --------
 
@@ -2658,3 +2667,18 @@ bool containsPlainText(const String& document, const String& target, FindOptions
 }
 
 }
+
+#if ENABLE(TREE_DEBUGGING)
+
+void showTree(const WebCore::TextIterator& pos)
+{
+    pos.showTreeForThis();
+}
+
+void showTree(const WebCore::TextIterator* pos)
+{
+    if (pos)
+        pos->showTreeForThis();
+}
+
+#endif

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -111,6 +111,10 @@ public:
     const TextIteratorCopyableText& copyableText() const { ASSERT(!atEnd()); return m_copyableText; }
     void appendTextToStringBuilder(StringBuilder& builder) const { copyableText().appendToStringBuilder(builder); }
 
+#if ENABLE(TREE_DEBUGGING)
+    void showTreeForThis() const;
+#endif
+
 private:
     void init();
     void exitNode(Node*);
@@ -323,3 +327,9 @@ inline BoundaryPoint resolveCharacterLocation(const SimpleRange& scope, uint64_t
 }
 
 } // namespace WebCore
+
+#if ENABLE(TREE_DEBUGGING)
+// Outside the WebCore namespace for ease of invocation from the debugger.
+void showTree(const WebCore::TextIterator&);
+void showTree(const WebCore::TextIterator*);
+#endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm
@@ -2972,8 +2972,8 @@ TEST(TextManipulation, CompleteTextManipulationCanMergeContentAndPreserveLineBre
 
 TEST(TextManipulation, CompleteTextManipulationIgnoreWhiteSpacesBetweenParagraphs)
 {
-    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    RetainPtr delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
     [webView _setTextManipulationDelegate:delegate.get()];
     [webView synchronouslyLoadHTMLString:@""
         "<style>"
@@ -2986,7 +2986,7 @@ TEST(TextManipulation, CompleteTextManipulationIgnoreWhiteSpacesBetweenParagraph
         "   <li class='list-item float-relative'><a class='inline-block'>hello</a>           <div class='hide-absolute'><a class='inline-block float-relative'>hide</a></div></li>"
         "   <li class='list-item float-relative'><a class='inline-block'>world</a></li>"
         "</ul>"];
-    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+    RetainPtr configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
 
     done = false;
     [webView _startTextManipulationsWithConfiguration:configuration.get() completion:^{
@@ -3005,6 +3005,48 @@ TEST(TextManipulation, CompleteTextManipulationIgnoreWhiteSpacesBetweenParagraph
     [webView _completeTextManipulationForItems:@[
         createItem(items[0].identifier, {{ items[0].tokens[0].identifier, @"Hello" }}).get(),
         createItem(items[1].identifier, {{ items[1].tokens[0].identifier, @"World" }}).get()
+    ] completion:^(NSArray<NSError *> *errors) {
+        EXPECT_EQ(errors, nil);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(TextManipulation, CompleteTextManipulationDoesNotSkipTabCharacterAtLineWrap)
+{
+    auto delegate = adoptNS([[TextManipulationDelegate alloc] init]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView _setTextManipulationDelegate:delegate.get()];
+    [webView synchronouslyLoadHTMLString:@""
+        "<!DOCTYPE html>"
+        "<html lang=en-US>"
+        "<div style='width: 32rem;'>"
+            "<p>This is another set of text to be translated. (1) "
+            "<strong>If this text is to be translated, then it should be something noteworthy</strong>"
+            " (2) A monthly subscription is just&#9;$10.</p>"
+        "</div>"];
+    auto configuration = adoptNS([[_WKTextManipulationConfiguration alloc] init]);
+
+    done = false;
+    [webView _startTextManipulationsWithConfiguration:configuration.get() completion:^{
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    auto *items = [delegate items];
+    EXPECT_EQ(items.count, 1UL);
+    EXPECT_EQ(items[0].tokens.count, 3UL);
+    EXPECT_WK_STREQ("This is another set of text to be translated. (1) ", items[0].tokens[0].content);
+    EXPECT_WK_STREQ("If this text is to be translated, then it should be something noteworthy", items[0].tokens[1].content);
+    EXPECT_WK_STREQ(" (2) A monthly subscription is just $10.", items[0].tokens[2].content);
+
+    [webView stringByEvaluatingJavaScript:@"document.documentElement.setAttribute('lang', 'zh-CN')"];
+
+    done = false;
+    [webView _completeTextManipulationForItems:@[
+        createItem(items[0].identifier, {
+            { items[0].tokens[0].identifier, @"Hello" }
+        }).get(),
     ] completion:^(NSArray<NSError *> *errors) {
         EXPECT_EQ(errors, nil);
         done = true;


### PR DESCRIPTION
#### f5c2130755ab39b4b005c196eabaa05406f586ea
<pre>
Some text fails to translate to Simplified Chinese on Apple TV+ page
<a href="https://bugs.webkit.org/show_bug.cgi?id=272214">https://bugs.webkit.org/show_bug.cgi?id=272214</a>
&lt;<a href="https://rdar.apple.com/72939899">rdar://72939899</a>&gt;

Reviewed by Sihui Liu and Wenson Hsieh.

The bug is caused by ParagraphContentIterator::advanceIteratorNodeAndUpdateText skipping a whitespace
generated for a tab character that appears at where a line wraps. When the layout of the page changes
slightly so that this tab character appears in the middle of a line, we don&apos;t skip the same whitespace.
As a result, TextManipulationController erroneously conclude that the content has changed and reject
the translation.

Fixed the bug by tweaking TextIterator to generate a non-collapsed range in this specific case so that
ParagraphContentIterator::advanceIteratorNodeAndUpdateText generates a whitespace as expected.
We already had a code path for a space so reuse the same code path for other collapsible whitespaces.

This PR also adds TextIterator::showTreeForThis and showTree(TextIterator&amp;) / showTree(TextIterator*)
to make debugging TextIterator easier.

Tests: TextManipulation.CompleteTextManipulationDoesNotSkipTabCharacterAtLineWrap

* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::handleTextRun):
(WebCore::TextIterator::showTreeForThis const): Added.
(showTree): Added.
* Source/WebCore/editing/TextIterator.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm:
(TextManipulation.CompleteTextManipulationDoesNotSkipTabCharacterAtLineWrap):

Canonical link: <a href="https://commits.webkit.org/277150@main">https://commits.webkit.org/277150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d59dadf0457a8e9ec3dcae65c1c774b977bd98eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46777 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49454 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42824 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23402 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38111 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19400 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41429 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41795 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51326 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45394 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23074 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44351 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23571 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6564 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22782 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->