### PR TITLE
[visionOS] Refine activation rules for Image Fullscreen

### DIFF
--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -113,6 +113,10 @@ private:
     std::optional<IntPoint> hotSpot() const final { return m_source->hotSpot(); }
     std::optional<Color> singlePixelSolidColor() const final { return m_source->singlePixelSolidColor(); }
 
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+    bool shouldUseQuickLookForFullscreen() const final { return m_source->shouldUseQuickLookForFullscreen(); }
+#endif
+
     // Image methods
     bool isBitmapImage() const final { return true; }
     bool isAnimating() const final { return m_source->isAnimating(); }

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -831,6 +831,13 @@ SubsamplingLevel BitmapImageSource::subsamplingLevelForScaleFactor(GraphicsConte
 #endif
 }
 
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+bool BitmapImageSource::shouldUseQuickLookForFullscreen() const
+{
+    return m_decoder->shouldUseQuickLookForFullscreen();
+}
+#endif
+
 IntSize BitmapImageSource::frameSizeAtIndex(unsigned index, SubsamplingLevel subsamplingLevel) const
 {
     return const_cast<BitmapImageSource&>(*this).frameAtIndexCacheIfNeeded(index, subsamplingLevel).size();

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -186,6 +186,10 @@ private:
 
     SubsamplingLevel subsamplingLevelForScaleFactor(GraphicsContext&, const FloatSize& scaleFactor, AllowImageSubsampling) final;
 
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+    bool shouldUseQuickLookForFullscreen() const;
+#endif
+
     // ImageFrame metadata
     IntSize frameSizeAtIndex(unsigned index, SubsamplingLevel = SubsamplingLevel::Default) const;
     ImageOrientation frameOrientationAtIndex(unsigned index) const final;

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -159,6 +159,9 @@ public:
 #if ASSERT_ENABLED
     virtual bool hasSolidColor() { return false; }
 #endif
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+    virtual bool shouldUseQuickLookForFullscreen() const { return false; }
+#endif
 
     virtual void dump(WTF::TextStream&) const;
 

--- a/Source/WebCore/platform/graphics/ImageDecoder.h
+++ b/Source/WebCore/platform/graphics/ImageDecoder.h
@@ -89,6 +89,10 @@ public:
     virtual String accessibilityDescription() const { return emptyString(); };
     virtual std::optional<IntPoint> hotSpot() const = 0;
 
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+    virtual bool shouldUseQuickLookForFullscreen() const { return false; }
+#endif
+
     virtual IntSize frameSizeAtIndex(size_t, SubsamplingLevel = SubsamplingLevel::Default) const = 0;
     virtual bool frameIsCompleteAtIndex(size_t) const = 0;
     virtual ImageOrientation frameOrientationAtIndex(size_t) const { return ImageOrientation::Orientation::None; }

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -90,6 +90,10 @@ public:
 
     virtual SubsamplingLevel subsamplingLevelForScaleFactor(GraphicsContext&, const FloatSize&, AllowImageSubsampling) { return SubsamplingLevel::Default; }
 
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+    virtual bool shouldUseQuickLookForFullscreen() const { return false; }
+#endif
+
     // ImageFrame Metadata
     virtual Seconds frameDurationAtIndex(unsigned) const { RELEASE_ASSERT_NOT_REACHED(); return 0_s; }
     virtual ImageOrientation frameOrientationAtIndex(unsigned) const { RELEASE_ASSERT_NOT_REACHED(); return ImageOrientation::Orientation::None; }

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -669,4 +669,16 @@ bool ImageDecoderCG::canDecodeType(const String& mimeType)
 
 }
 
+#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/ImageDecoderCGAdditions.cpp>)
+#include <WebKitAdditions/ImageDecoderCGAdditions.cpp>
+#else
+namespace WebCore {
+
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+bool ImageDecoderCG::shouldUseQuickLookForFullscreen() const { return false; }
+#endif // ENABLE(QUICKLOOK_FULLSCREEN)
+
+}
+#endif
+
 #endif // USE(CG)

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
@@ -77,6 +77,10 @@ public:
 
 private:
     String decodeUTI(const SharedBuffer&) const;
+
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+    bool shouldUseQuickLookForFullscreen() const;
+#endif
     
     bool m_isAllDataReceived { false };
     mutable EncodedDataStatus m_encodedDataStatus { EncodedDataStatus::Unknown };

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -230,7 +230,7 @@ void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element, 
                 return std::nullopt;
 
             auto* image = renderImage->cachedImage()->image();
-            if (!image || !image->isBitmapImage())
+            if (!image || !image->shouldUseQuickLookForFullscreen())
                 return std::nullopt;
 
             auto* buffer = renderImage->cachedImage()->resourceBuffer();


### PR DESCRIPTION
#### 4ac0a7c004e0484efe684fc41487727bb9b0c5c7
<pre>
[visionOS] Refine activation rules for Image Fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=272218">https://bugs.webkit.org/show_bug.cgi?id=272218</a>
&lt;<a href="https://rdar.apple.com/125913434">rdar://125913434</a>&gt;

Reviewed by Said Abou-Hallawa.

Introduce a `shouldUseQuickLookForFullscreen()` method on Images. It
defaults to false and queries the ImageDecoder for bitmap images.

Gate the use of Image Fullscreen on this flag.

* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::shouldUseQuickLookForFullscreen const):
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::shouldUseQuickLookForFullscreen const):
* Source/WebCore/platform/graphics/ImageDecoder.h:
(WebCore::ImageDecoder::shouldUseQuickLookForFullscreen const):
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::shouldUseQuickLookForFullscreen const):
Wire the `shouldUseQuickLookForFullscreen()` check to the ImageDecoder.

* Source/WebCore/platform/graphics/cg/ImageDecoderCG.h:
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::shouldUseQuickLookForFullscreen const):
Add the WKA entry point.

* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):
Add the `shouldUseQuickLookForFullscreen()` check.

Canonical link: <a href="https://commits.webkit.org/277177@main">https://commits.webkit.org/277177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8edeb5cdb116fb7fdfc3d8b32fd73d23c166bf4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49465 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42835 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49095 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38121 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19417 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20284 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41437 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4834 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43033 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41803 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51338 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18151 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45406 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23085 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44365 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10359 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23583 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->