### PR TITLE
[web-animations] web-animations/responsive/width.html is a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/width-expected.txt
@@ -1,6 +1,6 @@
 
 PASS width responsive to style changes
 PASS width clamped to 0px on keyframes
-FAIL width responsive to inherited changes from keyword assert_equals: expected "20px" but got "0px"
+PASS width responsive to inherited changes from keyword
 PASS width responsive to inherited changes from length
 


### PR DESCRIPTION
#### 1166d972ab8594ecf6202b5dfb7e4b9e674b2abe
<pre>
[web-animations] web-animations/responsive/width.html is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=272084">https://bugs.webkit.org/show_bug.cgi?id=272084</a>

Reviewed by Antti Koivisto.

In 242527@main, a check was added to return a zero-length in cases where we were trying to
blending lengths with mixed types, but one used a keyword. In the case of the WPT test
web-animations/responsive/width.html which tested `width` blending between `min-content`
and a fixed value, this meant that we would always resolve a zero-width for the first half
such an animation, instead of returning `min-content`.

We adjust the change made in 242527@main to deal with &quot;intrinsic&quot; values specifically since
these will always yield discrete interpolation, as established by `canInterpolateLengths()`,
and thus we can return either the &quot;from&quot; or &quot;to&quot; value.

* LayoutTests/imported/w3c/web-platform-tests/web-animations/responsive/width-expected.txt:
* Source/WebCore/platform/Length.cpp:
(WebCore::blendMixedTypes):

Canonical link: <a href="https://commits.webkit.org/277112@main">https://commits.webkit.org/277112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06ea4737dff11f421499c246424e6c900d24521f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49413 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42783 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23359 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22873 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19365 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41382 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4782 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/42986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51285 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45359 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23033 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44312 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6540 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->