### PR TITLE
Remove leftover EnumTraits includes

### DIFF
--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPowerPreference.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPowerPreference.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPredefinedColorSpace.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPredefinedColorSpace.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureAspect.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureAspect.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureFormat.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureFormat.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore::WebGPU {
 

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h
@@ -30,7 +30,6 @@
 #include "Color.h"
 #include "ScreenOrientationLockType.h"
 #include <optional>
-#include <wtf/EnumTraits.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/Modules/contact-picker/ContactProperty.h
+++ b/Source/WebCore/Modules/contact-picker/ContactProperty.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class ContactProperty : uint8_t { Email, Name, Tel };

--- a/Source/WebCore/Modules/cookie-consent/CookieConsentDecisionResult.h
+++ b/Source/WebCore/Modules/cookie-consent/CookieConsentDecisionResult.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class CookieConsentDecisionResult : uint8_t {

--- a/Source/WebCore/Modules/indexeddb/IDBTransactionDurability.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransactionDurability.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class IDBTransactionDurability : uint8_t {

--- a/Source/WebCore/Modules/indexeddb/IDBTransactionMode.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransactionMode.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class IDBTransactionMode : uint8_t {

--- a/Source/WebCore/Modules/indexeddb/IndexedDB.h
+++ b/Source/WebCore/Modules/indexeddb/IndexedDB.h
@@ -26,8 +26,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 namespace IndexedDB {

--- a/Source/WebCore/Modules/indexeddb/shared/IDBGetRecordData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBGetRecordData.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "IDBKeyRangeData.h"
-#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResultData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResultData.h
@@ -35,7 +35,6 @@
 #include "IDBTransactionInfo.h"
 #include "ThreadSafeDataBuffer.h"
 #include <wtf/ArgumentCoder.h>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/mediastream/RTCErrorDetailType.h
+++ b/Source/WebCore/Modules/mediastream/RTCErrorDetailType.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class RTCErrorDetailType : uint8_t {

--- a/Source/WebCore/Modules/notifications/NotificationEventType.h
+++ b/Source/WebCore/Modules/notifications/NotificationEventType.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class NotificationEventType : bool {

--- a/Source/WebCore/Modules/permissions/PermissionName.h
+++ b/Source/WebCore/Modules/permissions/PermissionName.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class PermissionName : uint8_t {

--- a/Source/WebCore/Modules/permissions/PermissionQuerySource.h
+++ b/Source/WebCore/Modules/permissions/PermissionQuerySource.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class PermissionQuerySource : uint8_t {

--- a/Source/WebCore/Modules/permissions/PermissionState.h
+++ b/Source/WebCore/Modules/permissions/PermissionState.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class PermissionState : uint8_t {

--- a/Source/WebCore/Modules/push-api/PushPermissionState.h
+++ b/Source/WebCore/Modules/push-api/PushPermissionState.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class PushPermissionState : uint8_t {

--- a/Source/WebCore/Modules/reporting/ViolationReportType.h
+++ b/Source/WebCore/Modules/reporting/ViolationReportType.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class ViolationReportType : uint8_t {

--- a/Source/WebCore/Modules/speech/SpeechRecognitionUpdate.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionUpdate.h
@@ -30,7 +30,6 @@
 #include "SpeechRecognitionResultData.h"
 #include <variant>
 #include <wtf/ArgumentCoder.h>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/ExceptionCode.h
+++ b/Source/WebCore/dom/ExceptionCode.h
@@ -18,8 +18,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class ExceptionCode : uint8_t {

--- a/Source/WebCore/dom/SecurityPolicyViolationEventDisposition.h
+++ b/Source/WebCore/dom/SecurityPolicyViolationEventDisposition.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class SecurityPolicyViolationEventDisposition : bool { Enforce, Report };

--- a/Source/WebCore/dom/ViewportArguments.cpp
+++ b/Source/WebCore/dom/ViewportArguments.cpp
@@ -34,7 +34,6 @@
 #include "LocalFrame.h"
 #include "ScriptableDocumentParser.h"
 #include "Settings.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {

--- a/Source/WebCore/editing/CompositionUnderline.h
+++ b/Source/WebCore/editing/CompositionUnderline.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "Color.h"
-#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/editing/TextManipulationController.h
+++ b/Source/WebCore/editing/TextManipulationController.h
@@ -32,7 +32,6 @@
 #include "TextManipulationItem.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>

--- a/Source/WebCore/html/Autofill.h
+++ b/Source/WebCore/html/Autofill.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/html/DataListSuggestionInformation.h
+++ b/Source/WebCore/html/DataListSuggestionInformation.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "IntRect.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/Vector.h>
 
 #if ENABLE(DATALIST_ELEMENT)

--- a/Source/WebCore/html/EnterKeyHint.h
+++ b/Source/WebCore/html/EnterKeyHint.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/LinkIconType.h
+++ b/Source/WebCore/html/LinkIconType.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 // These values are arranged so that they can be used with OptionSet.

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -137,7 +137,6 @@
 #include <dom/ScriptDisallowedScope.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/Ref.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StdLibExtras.h>

--- a/Source/WebCore/loader/FrameLoaderTypes.h
+++ b/Source/WebCore/loader/FrameLoaderTypes.h
@@ -31,7 +31,6 @@
 #include "ElementContext.h"
 #include "IntRect.h"
 #include "ProcessIdentifier.h"
-#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/loader/LoadSchedulingMode.h
+++ b/Source/WebCore/loader/LoadSchedulingMode.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class LoadSchedulingMode : uint8_t {

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -39,7 +39,6 @@
 #include "RequestPriority.h"
 #include "ServiceWorkerTypes.h"
 #include "StoredCredentialsPolicy.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/loader/cache/TrustedFonts.h
+++ b/Source/WebCore/loader/cache/TrustedFonts.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 #include <wtf/RobinHoodHashSet.h>
 

--- a/Source/WebCore/page/DragActions.h
+++ b/Source/WebCore/page/DragActions.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <limits.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 #include <wtf/OptionSet.h>
 

--- a/Source/WebCore/page/MediaProducer.h
+++ b/Source/WebCore/page/MediaProducer.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/page/ScreenOrientationLockType.h
+++ b/Source/WebCore/page/ScreenOrientationLockType.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class ScreenOrientationLockType : uint8_t {

--- a/Source/WebCore/page/ScreenOrientationType.h
+++ b/Source/WebCore/page/ScreenOrientationType.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 #if PLATFORM(IOS) || PLATFORM(VISION)
 #import <pal/system/ios/Device.h>
 #endif

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -30,7 +30,6 @@
 
 #include "SecurityOriginData.h"
 #include <wtf/ArgumentCoder.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/Hasher.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/page/StorageBlockingPolicy.h
+++ b/Source/WebCore/page/StorageBlockingPolicy.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class StorageBlockingPolicy : uint8_t {

--- a/Source/WebCore/page/TextIndicator.h
+++ b/Source/WebCore/page/TextIndicator.h
@@ -27,7 +27,6 @@
 
 #include "FloatRect.h"
 #include "Image.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Seconds.h>

--- a/Source/WebCore/page/TranslationContextMenuInfo.h
+++ b/Source/WebCore/page/TranslationContextMenuInfo.h
@@ -29,7 +29,6 @@
 
 #include "IntPoint.h"
 #include "IntRect.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/Cursor.h
+++ b/Source/WebCore/platform/Cursor.h
@@ -29,7 +29,6 @@
 #include "IntPoint.h"
 #include <variant>
 #include <wtf/Assertions.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/RefPtr.h>
 
 #if PLATFORM(WIN)

--- a/Source/WebCore/platform/FileChooser.h
+++ b/Source/WebCore/platform/FileChooser.h
@@ -29,7 +29,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/platform/MediaSample.h
+++ b/Source/WebCore/platform/MediaSample.h
@@ -30,7 +30,6 @@
 #include "PlatformVideoColorSpace.h"
 #include "SharedBuffer.h"
 #include <functional>
-#include <wtf/EnumTraits.h>
 #include <wtf/MediaTime.h>
 #include <wtf/PrintStream.h>
 #include <wtf/ThreadSafeRefCounted.h>

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 
 #if PLATFORM(MAC)

--- a/Source/WebCore/platform/PopupMenuStyle.h
+++ b/Source/WebCore/platform/PopupMenuStyle.h
@@ -28,7 +28,6 @@
 #include "Color.h"
 #include "FontCascade.h"
 #include "Length.h"
-#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -28,7 +28,6 @@
 #include "DestinationColorSpace.h"
 #include "FloatRect.h"
 #include "PlatformScreen.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/HashMap.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -30,7 +30,6 @@
 #include "ProcessQualified.h"
 #include "RectEdges.h"
 #include "ScrollingNodeID.h"
-#include <wtf/EnumTraits.h>
 
 namespace WTF {
 class TextStream;

--- a/Source/WebCore/platform/UserInterfaceLayoutDirection.h
+++ b/Source/WebCore/platform/UserInterfaceLayoutDirection.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class UserInterfaceLayoutDirection : bool { LTR, RTL };

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -29,7 +29,6 @@
 
 #include <memory>
 #include <wtf/CompletionHandler.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Observer.h>

--- a/Source/WebCore/platform/graphics/ColorSpace.h
+++ b/Source/WebCore/platform/graphics/ColorSpace.h
@@ -27,7 +27,6 @@
 
 #include "ColorTypes.h"
 #include <functional>
-#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(WEBGL)
 #include <optional>
-#include <wtf/EnumTraits.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/GraphicsTypes.h
+++ b/Source/WebCore/platform/graphics/GraphicsTypes.h
@@ -29,7 +29,6 @@
 #include "FloatSize.h"
 #include "WindRule.h"
 #include <optional>
-#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 
 namespace WTF {

--- a/Source/WebCore/platform/graphics/ImageOrientation.h
+++ b/Source/WebCore/platform/graphics/ImageOrientation.h
@@ -29,7 +29,6 @@
 #include "AffineTransform.h"
 #include "FloatSize.h"
 #include <stdint.h>
-#include <wtf/EnumTraits.h>
 
 // X11 headers define a bunch of macros with common terms, interfering with WebCore and WTF enum values.
 // As a workaround, we explicitly undef them here.

--- a/Source/WebCore/platform/graphics/PixelFormat.h
+++ b/Source/WebCore/platform/graphics/PixelFormat.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/PlatformColorSpace.h
+++ b/Source/WebCore/platform/graphics/PlatformColorSpace.h
@@ -30,7 +30,6 @@
 typedef struct CGColorSpace* CGColorSpaceRef;
 #else
 #include <optional>
-#include <wtf/EnumTraits.h>
 #endif
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h
@@ -31,7 +31,6 @@
 #include "GraphicsLayerClient.h"
 #include "PlatformCAFilters.h"
 #include "TransformationMatrix.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -27,7 +27,6 @@
 
 #include "FloatRoundedRect.h"
 #include "GraphicsLayer.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeCasts.h>

--- a/Source/WebCore/platform/graphics/filters/FilterOperation.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperation.h
@@ -28,7 +28,6 @@
 #include "Color.h"
 #include "LayoutSize.h"
 #include "LengthBox.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebCore/platform/graphics/transforms/TransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperation.h
@@ -27,7 +27,6 @@
 #include "CompositeOperation.h"
 #include "FloatSize.h"
 #include "TransformationMatrix.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TypeCasts.h>

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -36,7 +36,6 @@
 #include "RealtimeMediaSourceSupportedConstraints.h"
 #include <cstdlib>
 #include <wtf/ArgumentCoder.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/Function.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/platform/network/ResourceErrorBase.h
+++ b/Source/WebCore/platform/network/ResourceErrorBase.h
@@ -26,7 +26,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/URL.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/platform/text/TextChecking.h
+++ b/Source/WebCore/platform/text/TextChecking.h
@@ -33,7 +33,6 @@
 
 #include "CharacterRange.h"
 #include "TextCheckingRequestIdentifier.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -29,7 +29,6 @@
 #include <optional>
 #include <variant>
 #include <vector>
-#include <wtf/EnumTraits.h>
 #include <wtf/Hasher.h>
 #include <wtf/Markable.h>
 

--- a/Source/WebCore/plugins/PluginData.h
+++ b/Source/WebCore/plugins/PluginData.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/RefCounted.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>

--- a/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
+++ b/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "RenderStyleConstants.h"
-#include <wtf/EnumTraits.h>
 
 namespace WTF {
 class TextStream;

--- a/Source/WebCore/storage/StorageType.h
+++ b/Source/WebCore/storage/StorageType.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WebCore {
 
 enum class StorageType : uint8_t {

--- a/Source/WebCore/style/StyleAppearance.h
+++ b/Source/WebCore/style/StyleAppearance.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
-
 namespace WTF {
 class TextStream;
 }

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -29,7 +29,6 @@
 #include "AST.h"
 #include "WGSLShaderModule.h"
 #include <wtf/DataLog.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/SetForScope.h>
 
 namespace WGSL::AST {

--- a/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
@@ -36,7 +36,6 @@
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/SecurityOrigin.h>
 #include <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/ProcessID.h>
 
 namespace WebKit {

--- a/Source/WebKit/Shared/ContextMenuContextData.h
+++ b/Source/WebKit/Shared/ContextMenuContextData.h
@@ -32,7 +32,6 @@
 #include "WebHitTestResultData.h"
 #include <WebCore/ContextMenuContext.h>
 #include <WebCore/ElementContext.h>
-#include <wtf/EnumTraits.h>
 
 namespace IPC {
 class Decoder;

--- a/Source/WebKit/Shared/DrawingAreaInfo.h
+++ b/Source/WebKit/Shared/DrawingAreaInfo.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <wtf/EnumTraits.h>
 #include <wtf/ObjectIdentifier.h>
 
 namespace WebKit {

--- a/Source/WebKit/Shared/EditingRange.h
+++ b/Source/WebKit/Shared/EditingRange.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "ArgumentCoders.h"
-#include <wtf/EnumTraits.h>
 #include <wtf/RefPtr.h>
 
 namespace WebCore {

--- a/Source/WebKit/Shared/PrintInfo.h
+++ b/Source/WebKit/Shared/PrintInfo.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <WebCore/LengthBox.h>
-#include <wtf/EnumTraits.h>
 
 #if USE(APPKIT)
 OBJC_CLASS NSPrintInfo;

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -32,7 +32,6 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/SerializedScriptValue.h>
 #include <wtf/ArgumentCoder.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/RunLoop.h>
 #include <wtf/URL.h>
 #include <wtf/Vector.h>

--- a/Source/WebKit/Shared/WebEvent.h
+++ b/Source/WebKit/Shared/WebEvent.h
@@ -33,7 +33,6 @@
 #include "WebEventModifier.h"
 #include "WebEventType.h"
 
-#include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/UUID.h>

--- a/Source/WebKit/Shared/WebHitTestResultData.h
+++ b/Source/WebKit/Shared/WebHitTestResultData.h
@@ -27,7 +27,6 @@
 #include <WebCore/PageOverlay.h>
 #include <WebCore/ShareableBitmap.h>
 #include <WebCore/SharedMemory.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
 #include <wtf/text/WTFString.h>

--- a/Source/WebKit/Shared/WebPopupItem.h
+++ b/Source/WebKit/Shared/WebPopupItem.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <WebCore/WritingMode.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebKit {

--- a/Source/WebKit/Shared/WebWheelEvent.h
+++ b/Source/WebKit/Shared/WebWheelEvent.h
@@ -29,7 +29,6 @@
 #include "WebEvent.h"
 #include <WebCore/FloatSize.h>
 #include <WebCore/IntPoint.h>
-#include <wtf/EnumTraits.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -43,7 +43,6 @@
 #include <WebCore/Pin.h>
 #include <WebCore/U2fCommandConstructor.h>
 #include <WebCore/WebAuthenticationUtils.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/RunLoop.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/StringConcatenateNumbers.h>

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
@@ -27,7 +27,6 @@
 
 #include "PlatformCAAnimationRemoteProperties.h"
 #include <WebCore/PlatformCAAnimation.h>
-#include <wtf/EnumTraits.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 

--- a/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h
@@ -33,7 +33,6 @@
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/TextureMapperSparseBackingStore.h>
 #include <optional>
-#include <wtf/EnumTraits.h>
 #include <wtf/OptionSet.h>
 
 namespace WebKit {


### PR DESCRIPTION
#### a0e6b6f7b1f79a9080998ed27c9a201c2824080a
<pre>
Remove leftover EnumTraits includes
<a href="https://bugs.webkit.org/show_bug.cgi?id=272221">https://bugs.webkit.org/show_bug.cgi?id=272221</a>

Reviewed by Sihui Liu.

Since the migration to the new IPC generators most uses of EnumTraits
have been removed, but the includes were left. Remove the leftovers.

* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUFeatureName.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPowerPreference.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUPredefinedColorSpace.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureAspect.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUTextureFormat.h:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifest.h:
* Source/WebCore/Modules/contact-picker/ContactProperty.h:
* Source/WebCore/Modules/cookie-consent/CookieConsentDecisionResult.h:
* Source/WebCore/Modules/indexeddb/IDBTransactionDurability.h:
* Source/WebCore/Modules/indexeddb/IDBTransactionMode.h:
* Source/WebCore/Modules/indexeddb/IndexedDB.h:
* Source/WebCore/Modules/indexeddb/shared/IDBGetRecordData.h:
* Source/WebCore/Modules/indexeddb/shared/IDBResultData.h:
* Source/WebCore/Modules/mediastream/RTCErrorDetailType.h:
* Source/WebCore/Modules/notifications/NotificationEventType.h:
* Source/WebCore/Modules/permissions/PermissionName.h:
* Source/WebCore/Modules/permissions/PermissionQuerySource.h:
* Source/WebCore/Modules/permissions/PermissionState.h:
* Source/WebCore/Modules/push-api/PushPermissionState.h:
* Source/WebCore/Modules/reporting/ViolationReportType.h:
* Source/WebCore/Modules/speech/SpeechRecognitionUpdate.h:
* Source/WebCore/dom/ExceptionCode.h:
* Source/WebCore/dom/SecurityPolicyViolationEventDisposition.h:
* Source/WebCore/dom/ViewportArguments.cpp:
* Source/WebCore/editing/CompositionUnderline.h:
* Source/WebCore/editing/TextManipulationController.h:
* Source/WebCore/html/Autofill.h:
* Source/WebCore/html/DataListSuggestionInformation.h:
* Source/WebCore/html/EnterKeyHint.h:
* Source/WebCore/html/LinkIconType.h:
* Source/WebCore/loader/FrameLoader.cpp:
* Source/WebCore/loader/FrameLoaderTypes.h:
* Source/WebCore/loader/LoadSchedulingMode.h:
* Source/WebCore/loader/ResourceLoaderOptions.h:
* Source/WebCore/loader/cache/TrustedFonts.h:
* Source/WebCore/page/DragActions.h:
* Source/WebCore/page/MediaProducer.h:
* Source/WebCore/page/ScreenOrientationLockType.h:
* Source/WebCore/page/ScreenOrientationType.h:
* Source/WebCore/page/SecurityOrigin.h:
* Source/WebCore/page/StorageBlockingPolicy.h:
* Source/WebCore/page/TextIndicator.h:
* Source/WebCore/page/TranslationContextMenuInfo.h:
* Source/WebCore/platform/Cursor.h:
* Source/WebCore/platform/FileChooser.h:
* Source/WebCore/platform/MediaSample.h:
* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/PopupMenuStyle.h:
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/platform/UserInterfaceLayoutDirection.h:
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/graphics/ColorSpace.h:
* Source/WebCore/platform/graphics/GraphicsContextGLAttributes.h:
* Source/WebCore/platform/graphics/GraphicsTypes.h:
* Source/WebCore/platform/graphics/ImageOrientation.h:
* Source/WebCore/platform/graphics/PixelFormat.h:
* Source/WebCore/platform/graphics/PlatformColorSpace.h:
* Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/filters/FilterOperation.h:
* Source/WebCore/platform/graphics/transforms/TransformOperation.h:
* Source/WebCore/platform/mediastream/MediaConstraints.h:
* Source/WebCore/platform/network/ResourceErrorBase.h:
* Source/WebCore/platform/text/TextChecking.h:
* Source/WebCore/platform/text/TextFlags.h:
* Source/WebCore/plugins/PluginData.h:
* Source/WebCore/rendering/style/StyleSelfAlignmentData.h:
* Source/WebCore/storage/StorageType.h:
* Source/WebCore/style/StyleAppearance.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
* Source/WebKit/NetworkProcess/NetworkLoadParameters.h:
* Source/WebKit/Shared/ContextMenuContextData.h:
* Source/WebKit/Shared/DrawingAreaInfo.h:
* Source/WebKit/Shared/EditingRange.h:
* Source/WebKit/Shared/PrintInfo.h:
* Source/WebKit/Shared/SessionState.h:
* Source/WebKit/Shared/WebEvent.h:
* Source/WebKit/Shared/WebHitTestResultData.h:
* Source/WebKit/Shared/WebPopupItem.h:
* Source/WebKit/Shared/WebWheelEvent.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h:
* Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h:

Canonical link: <a href="https://commits.webkit.org/277137@main">https://commits.webkit.org/277137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe30486f89e528f23c8af282be5b7e5085fb4d30

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49416 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42786 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38090 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19372 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20238 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41391 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4785 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/42991 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51288 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45364 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23036 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44318 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10339 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->