### PR TITLE
[WGSL] Fix broken wgslc tests

### DIFF
--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -235,14 +235,14 @@ void AttributeValidator::visit(AST::Variable& variable)
 
         if (auto* idAttribute = dynamicDowncast<AST::IdAttribute>(attribute)) {
             auto& idExpression = idAttribute->value();
-            if (variable.flavor() != AST::VariableFlavor::Override || !satisfies(variable.storeType(), Constraints::Scalar))
+            if (variable.flavor() != AST::VariableFlavor::Override)
                 error(attribute.span(), "@id attribute must only be applied to override variables of scalar type");
+            RELEASE_ASSERT(satisfies(variable.storeType(), Constraints::Scalar));
+
             // https://gpuweb.github.io/cts/standalone/?q=webgpu:shader,validation,parse,attribute:expressions:value=%22override%22;attribute=%22binding%22
             auto& constantValue = idExpression.constantValue();
-            if (!constantValue) {
-                error(attribute.span(), "@id attribute must only be applied to override variables of scalar type");
-                continue;
-            }
+            RELEASE_ASSERT(constantValue);
+
             auto idValue = constantValue->integerValue();
             if (idValue < 0)
                 error(attribute.span(), "@id value must be non-negative");

--- a/Source/WebGPU/WGSL/tests/invalid/attribute-validation-during-type-checking.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/attribute-validation-during-type-checking.wgsl
@@ -1,0 +1,7 @@
+// RUN: %not %wgslc | %check
+
+// CHECK-L: 'array<i32, 1>' cannot be used as the type of an 'override'
+@id(0) override z: array<i32, 1>;
+
+// CHECK-L: cannot call function from constant context
+@id(u32(dpdx(0))) override y: i32;

--- a/Source/WebGPU/WGSL/tests/invalid/attribute-validation.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/attribute-validation.wgsl
@@ -7,7 +7,7 @@ struct S {
     // CHECK-L: @size value must be non-negative
     @size(-1) y: i32,
 
-    // CHECK-L: @align value must be non-negative
+    // CHECK-L: @align value must be positive
     @align(-1) z: i32,
 
     // CHECK-L: @align value must be a power of two
@@ -23,9 +23,6 @@ struct S {
 // CHECK-L: @id attribute must only be applied to override variables of scalar type
 // CHECK-L: @id value must be non-negative
 @id(-1) var<private> y: i32;
-
-// CHECK-L: @id attribute must only be applied to override variables of scalar type
-@id(0) override z: array<i32, 1>;
 
 // CHECK-L: @must_use can only be applied to functions that return a value
 @must_use

--- a/Source/WebGPU/WGSL/tests/valid/concretization.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/concretization.wgsl
@@ -11,7 +11,7 @@ fn testVariableInialization() {
 }
 
 @vertex
-fn testConcretizationOfArguments() {
+fn testConcretizationOfArguments() -> @builtin(position) vec4f {
   // CHECK-L: vec<unsigned, 2>(0, 0);
   let x1 = 0u + vec2(0, 0);
 
@@ -20,10 +20,12 @@ fn testConcretizationOfArguments() {
 
   // CHECK-L: vec<float, 2>(0, 0);
   let x3 = 0f + vec2(0, 0);
+
+  return vec4f();
 }
 
 @vertex
-fn testArrayConcretization() {
+fn testArrayConcretization() -> @builtin(position) vec4f  {
   // CHECK-L: vec<int, 2>(0, 0),
   let x1 = array<vec2<i32>, 1>(vec2(0, 0));
 
@@ -37,15 +39,19 @@ fn testArrayConcretization() {
   // CHECK-L: vec<unsigned, 2>(0, 0),
   // CHECK-L: vec<unsigned, 2>(0, 0),
   let x4 = array(vec2(0, 0), vec2(0u, 0u));
+
+  return vec4f();
 }
 
 @vertex
-fn testInitializerConcretization() {
+fn testInitializerConcretization() -> @builtin(position) vec4f  {
   // CHECK-L: vec<int, 2>(0, 0)
   let x1 = vec2(0, 0);
 
   // CHECK-L: vec<unsigned, 2>(0, 0)
   let x2 : vec2<u32> = vec2(0, 0);
+
+  return vec4f();
 }
 
 @group(0) @binding(0) var<storage, read_write> a: array<atomic<i32>>;

--- a/Source/WebGPU/WGSL/tests/valid/constants-utf16.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/constants-utf16.wgsl
@@ -66,7 +66,6 @@ fn testConstantAddition()
 }
 
 
-@compute @workgroup_size(1)
 fn testVectorConstants() -> i32
 {
     if (false) {

--- a/Source/WebGPU/WGSL/tests/valid/constants.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/constants.wgsl
@@ -65,7 +65,6 @@ fn testConstantAddition()
 }
 
 
-@compute @workgroup_size(1)
 fn testVectorConstants() -> i32
 {
     if (false) {

--- a/Source/WebGPU/WGSL/tests/valid/global-constant-vector.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/global-constant-vector.wgsl
@@ -4,7 +4,7 @@ const b = vec2f(a);
 @compute @workgroup_size(1)
 fn main() {
   // CHECK: vec.* local\d+ = vec<float, 4>\(0., 0., 0., 0.\)
-  // CHECK: \(void\)\(local\d+\[0\]\)
+  // CHECK: \(void\)\(local\d+\[min\(unsigned\(0\), \(4u - 1u\)\)\]\)
   let x = vec4f(b, 0, 0);
   _ = x[0];
 }

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -4743,7 +4743,7 @@ fn testTextureStore()
 
 // 16.8. Atomic Built-in Functions (https://www.w3.org/TR/WGSL/#atomic-builtin-functions)
 var<workgroup> x: atomic<i32>;
-@group(8) @binding(0) var<storage, read_write> y: atomic<i32>;
+@group(7) @binding(10) var<storage, read_write> y: atomic<i32>;
 
 // RUN: %metal-compile testAtomicFunctions
 @compute @workgroup_size(1)

--- a/Source/WebGPU/WGSL/tests/valid/packing.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/packing.wgsl
@@ -188,10 +188,10 @@ fn testFieldAccess() -> i32
 fn testIndexAccess() -> i32
 {
     // CHECK: local\d+ = __unpack\(global\d+\);
-    // CHECK-NEXT: local\d+\[0\] = __unpack\(global\d+\[0\]\);
-    // CHECK-NEXT: global\d+\[0\] = global\d+\[0\];
-    // CHECK-NEXT: global\d+\[0\] = __pack\(local\d+\[0\]\);
-    // CHECK-NEXT: global\d+\[global\d+\] = __pack\(local\d+\[global\d+\]\);
+    // CHECK-NEXT: local\d+\[min\(unsigned\(0\), \(2u - 1u\)\)\] = __unpack\(global\d+\[min\(unsigned\(0\), \(2u - 1u\)\)\]\);
+    // CHECK-NEXT: global\d+\[min\(unsigned\(0\), \(2u - 1u\)\)\] = global\d+\[min\(unsigned\(0\), \(2u - 1u\)\)\];
+    // CHECK-NEXT: global\d+\[min\(unsigned\(0\), \(2u - 1u\)\)\] = __pack\(local\d+\[min\(unsigned\(0\), \(2u - 1u\)\)\]\);
+    // CHECK-NEXT: global\d+\[min\(unsigned\(global\d+\), \(2u - 1u\)\)\] = __pack\(local\d+\[min\(unsigned\(global\d+\), \(2u - 1u\)\)\]\);
     var at = at1;
     at[0] = at1[0];
     at1[0] = at2[0];


### PR DESCRIPTION
#### c5b0e434b552f9ea9b45b699beeeea435b1bd048
<pre>
[WGSL] Fix broken wgslc tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=272227">https://bugs.webkit.org/show_bug.cgi?id=272227</a>
<a href="https://rdar.apple.com/125966589">rdar://125966589</a>

Reviewed by Mike Wyrzykowski and Dan Glastonbury.

The tests just needed to be updated because they contained invalid code that
is now being rejected after we added more validation.

* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
* Source/WebGPU/WGSL/tests/invalid/attribute-validation-during-type-checking.wgsl: Added.
* Source/WebGPU/WGSL/tests/invalid/attribute-validation.wgsl:
* Source/WebGPU/WGSL/tests/valid/concretization.wgsl:
* Source/WebGPU/WGSL/tests/valid/constants-utf16.wgsl:
* Source/WebGPU/WGSL/tests/valid/constants.wgsl:
* Source/WebGPU/WGSL/tests/valid/global-constant-vector.wgsl:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:
* Source/WebGPU/WGSL/tests/valid/packing.wgsl:

Canonical link: <a href="https://commits.webkit.org/277194@main">https://commits.webkit.org/277194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3807e36c7c7f7bf469f9b344360cd506b943a6f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49424 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42794 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38093 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40259 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19375 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20247 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4793 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51296 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18115 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45370 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23044 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44325 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10368 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23530 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->