### PR TITLE
Add dyld related linker flags to WebKit process extensions

### DIFF
--- a/Source/WebKit/Configurations/GPUExtension.xcconfig
+++ b/Source/WebKit/Configurations/GPUExtension.xcconfig
@@ -31,3 +31,6 @@ PRODUCT_BUNDLE_NAME = GPUExtension;
 
 // For simulator builds, entitlements are added to a special __entitlements section on the binary rather than the signature.
 CODE_SIGN_ENTITLEMENTS[sdk=*simulator] = Shared/AuxiliaryProcessExtensions/GPUProcessExtension.entitlements;
+
+OTHER_LDFLAGS_YES_IOS_SINCE_18 = -Wl,-dyld_env,@$(WK_WEBKITADDITIONS_HEADERS_FOLDER_PATH)/dlsym.WebKit.GPU;
+OTHER_LDFLAGS[sdk=iphone*] = $(inherited) $(OTHER_LDFLAGS_$(USE_INTERNAL_SDK)$(WK_IOS_18));

--- a/Source/WebKit/Configurations/NetworkingExtension.xcconfig
+++ b/Source/WebKit/Configurations/NetworkingExtension.xcconfig
@@ -31,3 +31,6 @@ PRODUCT_BUNDLE_NAME = NetworkingExtension;
 
 // For simulator builds, entitlements are added to a special __entitlements section on the binary rather than the signature.
 CODE_SIGN_ENTITLEMENTS[sdk=*simulator] = Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.entitlements;
+
+OTHER_LDFLAGS_YES_IOS_SINCE_18 = -Wl,-dyld_env,@$(WK_WEBKITADDITIONS_HEADERS_FOLDER_PATH)/dlsym.WebKit.Networking;
+OTHER_LDFLAGS[sdk=iphone*] = $(inherited) $(OTHER_LDFLAGS_$(USE_INTERNAL_SDK)$(WK_IOS_18));

--- a/Source/WebKit/Configurations/WebContentExtension.xcconfig
+++ b/Source/WebKit/Configurations/WebContentExtension.xcconfig
@@ -31,3 +31,6 @@ PRODUCT_BUNDLE_NAME = WebContentExtension;
 
 // For simulator builds, entitlements are added to a special __entitlements section on the binary rather than the signature.
 CODE_SIGN_ENTITLEMENTS[sdk=*simulator] = Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.entitlements;
+
+OTHER_LDFLAGS_YES_IOS_SINCE_18 = -Wl,-dyld_env,@$(WK_WEBKITADDITIONS_HEADERS_FOLDER_PATH)/dlsym.WebKit.WebContent;
+OTHER_LDFLAGS[sdk=iphone*] = $(inherited) $(OTHER_LDFLAGS_$(USE_INTERNAL_SDK)$(WK_IOS_18));


### PR DESCRIPTION
#### a7a0a2b44ca50a99e4d42780310af13dddb993ea
<pre>
Add dyld related linker flags to WebKit process extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=272238">https://bugs.webkit.org/show_bug.cgi?id=272238</a>
<a href="https://rdar.apple.com/125978825">rdar://125978825</a>

Reviewed by Elliott Williams.

* Source/WebKit/Configurations/GPUExtension.xcconfig:
* Source/WebKit/Configurations/NetworkingExtension.xcconfig:
* Source/WebKit/Configurations/WebContentExtension.xcconfig:

Canonical link: <a href="https://commits.webkit.org/277447@main">https://commits.webkit.org/277447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/584a6d89a26378fd33657f60578e5aecc9822fc9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50010 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43375 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23966 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38536 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40780 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19851 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21478 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5370 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43676 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51885 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22356 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45835 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23631 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44859 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24415 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6727 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23349 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->