### PR TITLE
REGRESSION (275503@main): Double space in Mail compose on iOS doesn’t insert period

### DIFF
--- a/LayoutTests/editing/input/ios/autocorrection-replaces-space-with-period-expected.txt
+++ b/LayoutTests/editing/input/ios/autocorrection-replaces-space-with-period-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that pressing the Space key twice replaces a space character after 'Hi' with a period.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS editor.textContent became 'Hi.'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hi.

--- a/LayoutTests/editing/input/ios/autocorrection-replaces-space-with-period.html
+++ b/LayoutTests/editing/input/ios/autocorrection-replaces-space-with-period.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+.editor {
+    border: 1px solid tomato;
+    width: 300px;
+    height: 150px;
+    font-size: 16px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that pressing the Space key twice replaces a space character after 'Hi' with a period.");
+    await UIHelper.setHardwareKeyboardAttached(false);
+
+    editor = document.querySelector(".editor");
+    await UIHelper.activateElementAndWaitForInputSession(editor);
+
+    await UIHelper.callFunctionAndWaitForEvent(async () => {
+        await UIHelper.typeCharacter(" ");
+        await UIHelper.ensurePresentationUpdate();
+    }, editor, "keyup");
+
+    await UIHelper.applyAutocorrection(".", " ");
+    await shouldBecomeEqual("editor.textContent", "'Hi.'");
+
+    editor.blur();
+    await UIHelper.waitForKeyboardToHide();
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div contenteditable="true" class="editor">Hi</div>
+</body>
+</html>

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1644,43 +1644,45 @@ StringView WordAwareIterator::text() const
 
 // --------
 
-static inline UChar foldQuoteMark(UChar c)
+static inline UChar foldQuoteMarkAndReplaceNoBreakSpace(UChar c)
 {
     switch (c) {
-        case hebrewPunctuationGershayim:
-        case leftDoubleQuotationMark:
-        case leftLowDoubleQuotationMark:
-        case rightDoubleQuotationMark:
-        case leftPointingDoubleAngleQuotationMark:
-        case rightPointingDoubleAngleQuotationMark:
-        case doubleHighReversed9QuotationMark:
-        case doubleLowReversed9QuotationMark:
-        case reversedDoublePrimeQuotationMark:
-        case doublePrimeQuotationMark:
-        case lowDoublePrimeQuotationMark:
-        case fullwidthQuotationMark:
-            return '"';
-        case hebrewPunctuationGeresh:
-        case leftSingleQuotationMark:
-        case leftLowSingleQuotationMark:
-        case rightSingleQuotationMark:
-        case singleLow9QuotationMark:
-        case singleLeftPointingAngleQuotationMark:
-        case singleRightPointingAngleQuotationMark:
-        case leftCornerBracket:
-        case rightCornerBracket:
-        case leftWhiteCornerBracket:
-        case rightWhiteCornerBracket:
-        case presentationFormForVerticalLeftCornerBracket:
-        case presentationFormForVerticalRightCornerBracket:
-        case presentationFormForVerticalLeftWhiteCornerBracket:
-        case presentationFormForVerticalRightWhiteCornerBracket:
-        case fullwidthApostrophe:
-        case halfwidthLeftCornerBracket:
-        case halfwidthRightCornerBracket:
-            return '\'';
-        default:
-            return c;
+    case hebrewPunctuationGershayim:
+    case leftDoubleQuotationMark:
+    case leftLowDoubleQuotationMark:
+    case rightDoubleQuotationMark:
+    case leftPointingDoubleAngleQuotationMark:
+    case rightPointingDoubleAngleQuotationMark:
+    case doubleHighReversed9QuotationMark:
+    case doubleLowReversed9QuotationMark:
+    case reversedDoublePrimeQuotationMark:
+    case doublePrimeQuotationMark:
+    case lowDoublePrimeQuotationMark:
+    case fullwidthQuotationMark:
+        return '"';
+    case hebrewPunctuationGeresh:
+    case leftSingleQuotationMark:
+    case leftLowSingleQuotationMark:
+    case rightSingleQuotationMark:
+    case singleLow9QuotationMark:
+    case singleLeftPointingAngleQuotationMark:
+    case singleRightPointingAngleQuotationMark:
+    case leftCornerBracket:
+    case rightCornerBracket:
+    case leftWhiteCornerBracket:
+    case rightWhiteCornerBracket:
+    case presentationFormForVerticalLeftCornerBracket:
+    case presentationFormForVerticalRightCornerBracket:
+    case presentationFormForVerticalLeftWhiteCornerBracket:
+    case presentationFormForVerticalRightWhiteCornerBracket:
+    case fullwidthApostrophe:
+    case halfwidthLeftCornerBracket:
+    case halfwidthRightCornerBracket:
+        return '\'';
+    case noBreakSpace:
+        return ' ';
+    default:
+        return c;
     }
 }
 
@@ -2085,7 +2087,7 @@ inline size_t SearchBuffer::append(StringView text)
     ASSERT(usableLength);
     m_buffer.grow(oldLength + usableLength);
     for (unsigned i = 0; i < usableLength; ++i)
-        m_buffer[oldLength + i] = foldQuoteMark(text[i]);
+        m_buffer[oldLength + i] = foldQuoteMarkAndReplaceNoBreakSpace(text[i]);
     return usableLength;
 }
 
@@ -2352,7 +2354,7 @@ inline bool SearchBuffer::atBreak() const
 
 inline void SearchBuffer::append(UChar c, bool isStart)
 {
-    m_buffer[m_cursor] = c == noBreakSpace ? ' ' : foldQuoteMark(c);
+    m_buffer[m_cursor] = foldQuoteMarkAndReplaceNoBreakSpace(c);
     m_isCharacterStartBuffer[m_cursor] = isStart;
     if (++m_cursor == m_target.length()) {
         m_cursor = 0;


### PR DESCRIPTION
#### ac57d4f365e1de0dfe1e90fed2b22c67e10cdac8
<pre>
REGRESSION (275503@main): Double space in Mail compose on iOS doesn’t insert period
<a href="https://bugs.webkit.org/show_bug.cgi?id=272237">https://bugs.webkit.org/show_bug.cgi?id=272237</a>
<a href="https://rdar.apple.com/125852636">rdar://125852636</a>

Reviewed by Abrar Protyasha and Ryosuke Niwa.

With the changes in 275503@main, we now use `WebCore::findPlainText` to discover the nearby text to
replace, in the case where the replacement range isn&apos;t just the last word. While `findPlainText`
(and the underlying `SearchBuffer` machinery) is intended to ignore non-breaking spaces for the
purposes of finding matches, this only works when `UCONFIG_NO_COLLATION` is disabled; otherwise,
searching for the target text `&quot; &quot;` against a single non-breaking space `&quot;0xA0&quot;` will fail to find
any matches.

This subsequently causes autocorrection replacement to fail, in the case where UIKit tries to
replace a space after a sentence with a period, when the user inserts two space characters in a row,
since we fail to match the non-breaking space character right after the word.

To fix this, we align the two find behaviors by moving the `UCONFIG_NO_COLLATION`-specific logic to
handle `nbsp`:

```
inline void SearchBuffer::append(UChar c, bool isStart)
{
    …

    m_buffer[m_cursor] = c == noBreakSpace ? &apos; &apos; : foldQuoteMark(c);
}
```

...into `foldQuoteMark`, renaming that helper function to `foldQuoteMarkAndReplaceNoBreakSpace`, and
finally deploying `foldQuoteMarkAndReplaceNoBreakSpace` in the `!UCONFIG_NO_COLLATION` codepath as
well.

Test: editing/input/ios/autocorrection-replaces-space-with-period.html

* LayoutTests/editing/input/ios/autocorrection-replaces-space-with-period-expected.txt: Added.
* LayoutTests/editing/input/ios/autocorrection-replaces-space-with-period.html: Added.
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::foldQuoteMarkAndReplaceNoBreakSpace):
(WebCore::SearchBuffer::append):
(WebCore::foldQuoteMark): Deleted.

Canonical link: <a href="https://commits.webkit.org/277151@main">https://commits.webkit.org/277151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a34f15c8fdfa7dcffbed69fc6d45b2aa10f1682e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42858 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23438 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19430 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20298 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41455 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4857 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43046 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51384 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18167 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45427 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44393 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10346 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->