### PR TITLE
REGRESSION(275262@main) AudioContext.start() takes longer than it used to.

### DIFF
--- a/PerformanceTests/AudioContext/audio-context-creation.html
+++ b/PerformanceTests/AudioContext/audio-context-creation.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/runner.js"></script>
+<script>
+    function runTest() {
+        let isDone = false;
+        PerfTestRunner.prepareToMeasureValuesAsync({ done: () => isDone = true, unit: 'ms' });
+
+        async function runIteration() {
+            let startTime = PerfTestRunner.now();
+
+            let audioContexts = [];
+            for (let i = 0; i < 100; ++i) {
+                let context = new AudioContext();
+                audioContexts.push(context);
+                await context.resume();
+            }
+
+            for (let context of audioContexts) {
+                await context.suspend();
+            }
+
+            PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime);
+
+            if (!isDone) {
+                if (window.GCController)
+                    window.GCController.collect();
+
+                setTimeout(runIteration, 0);
+            }
+        }
+
+        runIteration();
+    }
+    window.addEventListener('load', event => {
+        let button = document.body.appendChild(document.createElement('button'));
+        button.innerText = 'Start test';
+        button.addEventListener('click', () => {
+            button.disabled = true;
+            runTest();
+        });
+    })
+    </script>
+</body>
+</html>

--- a/Source/WebCore/platform/audio/SharedAudioDestination.cpp
+++ b/Source/WebCore/platform/audio/SharedAudioDestination.cpp
@@ -61,7 +61,6 @@ private:
     void isPlayingDidChange() final { }
 
     void configureRenderThread(CompletionHandler<void(bool)>&&);
-    void callAllConfigurationHandlers(bool);
 
     Ref<AudioDestination> protectedDestination() { return m_destination; }
     Ref<AudioBus> protectedWorkBus() { return m_workBus; }
@@ -81,8 +80,6 @@ private:
 
     bool m_needsConfiguration WTF_GUARDED_BY_LOCK(m_renderLock) { true };
     RenderVector m_newRenderers WTF_GUARDED_BY_LOCK(m_renderLock);
-    using ConfigurationHandlerVector = Vector<CompletionHandler<void(bool)>>;
-    ConfigurationHandlerVector m_configurationCompletionHandlers WTF_GUARDED_BY_LOCK(m_renderLock);
 
     // Only accessed on the audio thread:
     RenderVector m_configuredRenderers;
@@ -122,7 +119,6 @@ SharedAudioDestinationAdapter::~SharedAudioDestinationAdapter()
     auto key = std::make_tuple(m_numberOfOutputChannels, m_sampleRate);
     sharedMap().remove(key);
     protectedDestination()->clearCallback();
-    callAllConfigurationHandlers(false);
 }
 
 void SharedAudioDestinationAdapter::addRenderer(SharedAudioDestination& renderer, CompletionHandler<void(bool)>&& completionHandler)
@@ -155,31 +151,24 @@ void SharedAudioDestinationAdapter::configureRenderThread(CompletionHandler<void
         m_newRenderers = m_renderers;
         m_needsConfiguration = true;
         if (onlyNeedsConfiguration) {
-            // The destination is already running, but needs configuration. Move the
-            // completionHandler into a vector of outstanding handlers, to be called
-            // after the render thread finishes configuring the renderers.
-            m_configurationCompletionHandlers.append(WTFMove(completionHandler));
+            // The destination is already running, but needs configuration. Assume
+            // the configuration will succeed and call the completionHandler early.
+            callOnMainThread([completionHandler = WTFMove(completionHandler)] () mutable {
+                completionHandler(true);
+            });
             return;
         }
     }
 
     if (shouldStart) {
         m_started = true;
-        protectedDestination()->start(nullptr, [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (bool success) mutable {
-            // Ensure any outstanding configuration handlers are called and cleared.
-            callAllConfigurationHandlers(success);
-            completionHandler(success);
-        });
+        protectedDestination()->start(nullptr, WTFMove(completionHandler));
         return;
     }
 
     if (shouldStop) {
         m_started = false;
-        protectedDestination()->stop([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (bool success) mutable {
-            // Ensure any outstanding configuration handlers are called and cleared.
-            callAllConfigurationHandlers(success);
-            completionHandler(success);
-        });
+        protectedDestination()->stop(WTFMove(completionHandler));
         return;
     }
 
@@ -194,17 +183,6 @@ void SharedAudioDestinationAdapter::configureRenderThread(CompletionHandler<void
     }
 }
 
-void SharedAudioDestinationAdapter::callAllConfigurationHandlers(bool success)
-{
-    ConfigurationHandlerVector handlers;
-    {
-        Locker locker { m_renderLock };
-        std::swap(handlers, m_configurationCompletionHandlers);
-    }
-
-    for (auto& handler : handlers)
-        handler(success);
-}
 
 void SharedAudioDestinationAdapter::render(AudioBus* sourceBus, AudioBus* destinationBus, size_t numberOfFrames, const AudioIOPosition& outputPosition)
 {
@@ -217,9 +195,7 @@ void SharedAudioDestinationAdapter::render(AudioBus* sourceBus, AudioBus* destin
             // will be destroyed on the main thread.
             RenderVector oldRenderers = std::exchange(m_configuredRenderers, WTFMove(m_newRenderers));
             m_needsConfiguration = false;
-            callOnMainThread([this, protectedThis = Ref { *this }, oldRenderers = WTFMove(oldRenderers)] () mutable {
-                callAllConfigurationHandlers(true);
-            });
+            callOnMainThread([oldRenderers = WTFMove(oldRenderers)] () { });
         }
     }
 


### PR DESCRIPTION
#### a6d91e7d8f97f21ba3878cb1e722ae2bc75180cc
<pre>
REGRESSION(275262@main) AudioContext.start() takes longer than it used to.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272240">https://bugs.webkit.org/show_bug.cgi?id=272240</a>
<a href="https://rdar.apple.com/124071843">rdar://124071843</a>

Reviewed by Eric Carlson.

In 275262@main, SharedAudioDestination was added to reduce the runtime overhead of having
multiple AudioDestinations with the same configuration running simultaneously. The
SharedAudioDestination passes its start() and stop() completion handlers to
SharedAudioDestinationAdapter, which calls the completion handler when the underlying
AudioDestination starts and stops. But if the destination is already running, it waits
until that destination is fully &quot;configured&quot; to call the completion handler, and this
configuration happens on the audio render thread. The audio render thread spins every 3ms,
so this delay should average out to 1.5ms. However, the underlying RemoteAudioDestinationProxy
will run its completion handler without waitaing for the audio device to start, so the delay
for that class is much smaller: effecitvely the duration of the XPC call.

In the case that the AudioDestination starts and stops, continue to pass the completion
handler to that method. But in the case where the AudioDestination is already running and
the list of renderers just needs to be updated, assume that will succeed and just run the
completion handler in the next run loop.

* PerformanceTests/AudioContext/audio-context-creation.html: Added.
* Source/WebCore/platform/audio/SharedAudioDestination.cpp:
(WebCore::SharedAudioDestinationAdapter::~SharedAudioDestinationAdapter):
(WebCore::SharedAudioDestinationAdapter::configureRenderThread):
(WebCore::SharedAudioDestinationAdapter::render):
(WebCore::SharedAudioDestinationAdapter::callAllConfigurationHandlers): Deleted.

Canonical link: <a href="https://commits.webkit.org/277209@main">https://commits.webkit.org/277209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9ac863efc2dbcb3cf0eeb5c5e0d59acd78c2085

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49456 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42826 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49086 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38113 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40288 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19402 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41420 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4825 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43030 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51328 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45396 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23076 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44353 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10379 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23573 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->