### PR TITLE
[JSC] We should fix the backwards propagation for DFG node use flags after the fixup phase

### DIFF
--- a/JSTests/stress/propogate-node-int-use-with-value-to-int32.js
+++ b/JSTests/stress/propogate-node-int-use-with-value-to-int32.js
@@ -1,0 +1,9 @@
+function test(e, n) {
+    return e[n >>> 5] |= 128 << 24 - n % 32;
+}
+noInline(test);
+
+arr = [1.1, 1.1, 1.1, 1.1];
+for (let i = 0; i < 1e3; i++) {
+    test(arr, 10 << 5);
+}

--- a/JSTests/stress/propogate-node-number-use-with-double-rep.js
+++ b/JSTests/stress/propogate-node-number-use-with-double-rep.js
@@ -1,0 +1,29 @@
+function test(opt) {
+    let expected = opt();
+    for (let i = 0; i < 1e3; i++) {
+        let actual = opt();
+        if (actual != expected)
+            throw new Error("bad actual " + actual + " expected " + expected);
+    }
+}
+
+{
+    function opt1(f) {
+        var x = -19278.05 >>> NaN;
+        var y = -19278.05 + x;
+        var z = y >> 0;
+        return z;
+    }
+    noInline(opt1);
+
+    function opt2(v) {
+        let x = -1 >>> v;
+        let y = x + -0.2;
+        let z = y | 0;
+        return z;
+    }
+    noInline(opt2);
+
+    test(opt1);
+    test(opt2);
+}

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -38,11 +38,14 @@ namespace JSC { namespace DFG {
 
 // This phase is run at the end of BytecodeParsing, so the graph isn't in a fully formed state.
 // For example, we can't access the predecessor list of any basic blocks yet.
-
-class BackwardsPropagationPhase {
+//
+// Note that, so far, this phase should only be used in the byte code parsing phase
+// or after the fix up phases. We don't want to validate graph since
+// unreachable blocks won't be removed until the end of the parsing phase.
+class BackwardsPropagationPhase : public Phase {
 public:
     BackwardsPropagationPhase(Graph& graph)
-        : m_graph(graph)
+        : Phase(graph, "backwards propagation", !graph.afterFixup())
         , m_flagsAtHead(graph)
     {
     }
@@ -590,11 +593,52 @@ private:
             break;
         }
 
-        case Identity: 
-            // This would be trivial to handle but we just assert that we cannot see these yet.
-            RELEASE_ASSERT_NOT_REACHED();
+        case Identity:
+            ASSERT(m_graph.afterFixup());
+            node->child1()->mergeFlags(flags);
             break;
-            
+
+        case ValueRep:
+            ASSERT(m_graph.afterFixup());
+            // ValueRep is used to box a double or int52 to a JSValue. So, we shouldn't propagate any node flags to its child.
+            break;
+
+        case Int52Rep:
+        case ValueToInt32:
+        case DoubleAsInt32:
+            ASSERT(m_graph.afterFixup());
+            // The results of these nodes are pure unboxed integers. Then, we
+            // should definitely tell their children that you will be used as an integer.
+            node->child1()->mergeFlags(NodeBytecodeUsesAsInt);
+            break;
+
+        case DoubleRep:
+            ASSERT(m_graph.afterFixup());
+            // The result of the node is pure unboxed floating point values.
+            node->child1()->mergeFlags(NodeBytecodeUsesAsNumber);
+            break;
+
+        case BooleanToNumber:
+            ASSERT(m_graph.afterFixup());
+            // The result of BooleanToNumber can be either an unboxed integer or a JSValue.
+            if (node->child1().useKind() == BooleanUse)
+                node->child1()->mergeFlags(NodeBytecodeUsesAsInt);
+            break;
+
+        case CheckStructureOrEmpty:
+        case CheckArrayOrEmpty:
+        case Arrayify:
+        case ArrayifyToStructure:
+        case GetIndexedPropertyStorage:
+        case ResolveRope:
+        case MakeRope:
+        case GetRegExpObjectLastIndex:
+        case HasIndexedProperty:
+        case CallDOM:
+            // Not interested so far.
+            ASSERT(m_graph.afterFixup());
+            break;
+
         // Note: ArithSqrt, ArithUnary and other math intrinsics don't have special
         // rules in here because they are always followed by Phantoms to signify that if the
         // method call speculation fails, the bytecode may use the arguments in arbitrary ways.
@@ -607,16 +651,15 @@ private:
         }
     }
     
-    Graph& m_graph;
     bool m_allowNestedOverflowingAdditions;
 
     BlockMap<Operands<NodeFlags>> m_flagsAtHead;
     Operands<NodeFlags> m_currentFlags;
 };
 
-void performBackwardsPropagation(Graph& graph)
+bool performBackwardsPropagation(Graph& graph)
 {
-    BackwardsPropagationPhase(graph).run();
+    return runPhase<BackwardsPropagationPhase>(graph);
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.h
@@ -32,10 +32,18 @@ namespace JSC { namespace DFG {
 
 class Graph;
 
-// Infer basic information about how nodes are used by doing a block-local
+// Infer basic information about how nodes are likely to be used by doing a block-local
 // backwards flow analysis.
 
-void performBackwardsPropagation(Graph&);
+
+// Infer information after fixup has run. This should only pessimize the existing information.
+// By this point, we ensure that any new uses inserted by fixup are accounted for.
+//
+// For example, consider:
+//     b = a + 0.1
+// If {b} is PureInt, then we would propagate that to {a}. But we don't actually know
+// until after fixup if {a} may be used as a double.
+bool performBackwardsPropagation(Graph&);
 
 } } // namespace JSC::DFG
 

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -444,9 +444,7 @@ private:
             
         case UInt32ToNumber: {
             fixIntConvertingEdge(node->child1());
-            if (bytecodeCanTruncateInteger(node->arithNodeFlags()))
-                node->convertToIdentity();
-            else if (node->canSpeculateInt32(FixupPass))
+            if (bytecodeCanTruncateInteger(node->arithNodeFlags()) || node->canSpeculateInt32(FixupPass))
                 node->setArithMode(Arith::CheckOverflow);
             else {
                 node->setArithMode(Arith::DoOverflow);

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -1160,6 +1160,8 @@ public:
 
     const BoyerMooreHorspoolTable<uint8_t>* tryAddStringSearchTable8(const String&);
 
+    bool afterFixup() { return m_planStage >= PlanStage::AfterFixup; }
+
     StackCheck m_stackChecker;
     VM& m_vm;
     Plan& m_plan;

--- a/Source/JavaScriptCore/dfg/DFGPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPhase.cpp
@@ -56,7 +56,7 @@ void Phase::beginPhase()
 
 void Phase::endPhase()
 {
-    if (!Options::validateGraphAtEachPhase())
+    if (!Options::validateGraphAtEachPhase() || m_disableGraphValidation)
         return;
     validate();
 }

--- a/Source/JavaScriptCore/dfg/DFGPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGPhase.h
@@ -35,9 +35,10 @@ namespace JSC { namespace DFG {
 
 class Phase {
 public:
-    Phase(Graph& graph, const char* name)
+    Phase(Graph& graph, const char* name, const bool disableGraphValidation = false)
         : m_graph(graph)
         , m_name(name)
+        , m_disableGraphValidation(disableGraphValidation)
     {
         beginPhase();
     }
@@ -72,7 +73,8 @@ private:
     // Call these hooks when starting and finishing.
     void beginPhase();
     void endPhase();
-    
+
+    bool m_disableGraphValidation { false };
     CString m_graphDumpBeforePhase;
 };
 

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(DFG_JIT)
 
 #include "DFGArgumentsEliminationPhase.h"
+#include "DFGBackwardsPropagationPhase.h"
 #include "DFGByteCodeParser.h"
 #include "DFGCFAPhase.h"
 #include "DFGCFGSimplificationPhase.h"
@@ -274,6 +275,7 @@ Plan::CompilationPath Plan::compileInThreadImpl()
     if (validationEnabled())
         validate(dfg);
         
+    RUN_PHASE(performBackwardsPropagation);
     RUN_PHASE(performStrengthReduction);
     RUN_PHASE(performCPSRethreading);
     RUN_PHASE(performCFA);

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -114,6 +114,11 @@ private:
                 m_changed = true;
                 break;
             }
+            if (bytecodeCanTruncateInteger(m_node->arithNodeFlags())) {
+                m_node->convertToIdentity();
+                m_changed = true;
+                break;
+            }
             break;
             
         case ArithAdd:


### PR DESCRIPTION
#### 6c214dfbb5a1a44260d447560838346e8a0f7022
<pre>
[JSC] We should fix the backwards propagation for DFG node use flags after the fixup phase
<a href="https://bugs.webkit.org/show_bug.cgi?id=257949">https://bugs.webkit.org/show_bug.cgi?id=257949</a>
<a href="https://rdar.apple.com/110661900">rdar://110661900</a>

Reviewed by Yusuke Suzuki.

Given JS code:

    let x = -1 &gt;&gt;&gt; v;  // &lt;-- [1]
    let y = x + -0.2;  // &lt;-- [2]
    let z = y | 0;     // &lt;-- [3]

In the BackwardsPropagationPhase, Node {y} is a PureInt (The node
is never used as a number) since it&apos;s only used in [3] which will
be truncated to int32, see spec [4]. Then, the PureInt info will be
propagated to node {x} since the right operand (-0.2) at [2] is within
two to the 32th power range. Later then, the UInt32ToNumber emitted at
[1] will be optimized out in the FixupPhase due to the PureInt {x}.
However, this is not expected since {x} should be treated as a number
when being added with -0.2.

This brings us the concern that PureInt is not sufficiently proven in
the BackwardsPropagationPhase until the FixupPhase which is used to fixes
edge uses. In this case, since the {x} node has a number result because of
the emitted UInt32ToNumber, [2] wouldn&apos;t be treated as an integer add. As a
result, a DoubleRep(x) is introduced for the double arithmetic add at [2].
Here, the DoubleRep is basically a double representation which can be leveraged
by floating point arithmetic operations. With that we can confirm that the wrapped
node is definitely going to be used as a double and we should rely on that to
prove the number use of a DFG node.

So to fix this issue, we should run BackwardsPropagationPhase again after the
FixupPhase with those inserted double representation nodes as proofs in order
to fix the node uses. And move the corresponding UInt32ToNumber optimization
to the later StrengthReductionPhase.

Note that since we need to rerun the BackwardsPropagationPhase again after the
FixupPhase, any new node types introduced to the graph after the first
BackwardsPropagationPhase should be carefully handled by the second one.
This is already addressed in this patch by checking through all DFG node types.

[4] <a href="https://tc39.es/ecma262/#sec-numeric-types-number-bitwiseOR">https://tc39.es/ecma262/#sec-numeric-types-number-bitwiseOR</a>

Canonical link: <a href="https://commits.webkit.org/277456@main">https://commits.webkit.org/277456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dec31e90a48ee6fdf224d8375f757c5588bfac4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50181 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43546 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38664 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19985 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21894 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Running apply-patch; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42212 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5541 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40776 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52059 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46988 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18881 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45967 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23804 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45007 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24594 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54486 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6737 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23523 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11172 "Passed tests") | 
<!--EWS-Status-Bubble-End-->