### PR TITLE
Replace unique frame names with FrameIdentifier in `WebFoundTextRange`

### DIFF
--- a/Source/WebKit/Shared/WebFoundTextRange.h
+++ b/Source/WebKit/Shared/WebFoundTextRange.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ArgumentCoders.h"
+#include <WebCore/FrameIdentifier.h>
 #include <wtf/HashTraits.h>
 #include <wtf/text/WTFString.h>
 
@@ -34,7 +35,7 @@ namespace WebKit {
 struct WebFoundTextRange {
     uint64_t location { 0 };
     uint64_t length { 0 };
-    AtomString frameIdentifier;
+    WebCore::FrameIdentifier frameIdentifier;
     uint64_t order { 0 };
 
     bool operator==(const WebFoundTextRange& other) const;
@@ -53,7 +54,7 @@ struct WebFoundTextRangeHash {
 template<> struct HashTraits<WebKit::WebFoundTextRange> : GenericHashTraits<WebKit::WebFoundTextRange> {
     static WebKit::WebFoundTextRange emptyValue() { return { }; }
 
-    static void constructDeletedValue(WebKit::WebFoundTextRange& slot) { new (NotNull, &slot.frameIdentifier) AtomString { HashTableDeletedValue }; }
+    static void constructDeletedValue(WebKit::WebFoundTextRange& slot) { new (NotNull, &slot.frameIdentifier) WebCore::FrameIdentifier { HashTableDeletedValue }; }
     static bool isDeletedValue(const WebKit::WebFoundTextRange& range) { return range.frameIdentifier.isHashTableDeletedValue(); }
 };
 

--- a/Source/WebKit/Shared/WebFoundTextRange.serialization.in
+++ b/Source/WebKit/Shared/WebFoundTextRange.serialization.in
@@ -23,6 +23,6 @@
 struct WebKit::WebFoundTextRange {
     uint64_t location;
     uint64_t length;
-    AtomString frameIdentifier;
+    WebCore::FrameIdentifier frameIdentifier;
     uint64_t order;
 }

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -114,6 +114,7 @@
 #import <WebCore/FloatQuad.h>
 #import <WebCore/FloatRect.h>
 #import <WebCore/FontAttributeChanges.h>
+#import <WebCore/FrameIdentifier.h>
 #import <WebCore/InputMode.h>
 #import <WebCore/KeyEventCodesIOS.h>
 #import <WebCore/KeyboardScroll.h>
@@ -549,7 +550,7 @@ constexpr double fasterTapSignificantZoomThreshold = 0.8;
 
 @property (nonatomic) NSUInteger location;
 @property (nonatomic) NSUInteger length;
-@property (nonatomic, copy) NSString *frameIdentifier;
+@property (nonatomic) WebCore::FrameIdentifier frameIdentifier;
 @property (nonatomic) NSUInteger order;
 
 + (WKFoundTextRange *)foundTextRangeWithWebFoundTextRange:(WebKit::WebFoundTextRange)range;
@@ -14659,7 +14660,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)dealloc
 {
-    [_frameIdentifier release];
     [super dealloc];
 }
 


### PR DESCRIPTION
#### 43efba5a6d00cd2edfe762a350dcf4fbb1a05c4a
<pre>
Replace unique frame names with FrameIdentifier in `WebFoundTextRange`
<a href="https://bugs.webkit.org/show_bug.cgi?id=272246">https://bugs.webkit.org/show_bug.cgi?id=272246</a>
<a href="https://rdar.apple.com/125989046">rdar://125989046</a>

Reviewed by Aditya Keerthi.

Unique frame names will not work with site isolation.

* Source/WebKit/Shared/WebFoundTextRange.h:
(WTF::HashTraits&lt;WebKit::WebFoundTextRange&gt;::constructDeletedValue):
* Source/WebKit/Shared/WebFoundTextRange.serialization.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKFoundTextRange dealloc]):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::findTextRangesForStringMatches):
(WebKit::WebFoundTextRangeController::documentForFoundTextRange const):

Canonical link: <a href="https://commits.webkit.org/277166@main">https://commits.webkit.org/277166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dd022349bc827903ed99e5d662dd6fbc516e7b07

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42848 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38124 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/22969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19421 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/46667 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20296 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4847 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43044 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51351 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21810 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45409 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23098 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44369 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23598 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6571 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->