### PR TITLE
Add support for background preferred_environment in Web Extensions.

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -175,6 +175,9 @@
 /* Allow button title in user media prompt */
 "Allow (usermedia)" = "Allow";
 
+/* Message for requesting cross-site cookie and website data access. */
+"Allow related %@ websites to share cookies and website data?" = "Allow related %@ websites to share cookies and website data?";
+
 /* Allow screen button title in window and screen sharing prompt */
 "Allow to Share Screen" = "Allow to Share Screen";
 
@@ -208,15 +211,6 @@
 /* Message for user microphone access prompt */
 "Allow “%@” to use your microphone?" = "Allow “%@” to use your microphone?";
 
-/* Informative text for requesting cross-site cookie and website data access for two or three sites. */
-"Using the same cookies and website data is required for %s and %s to work correctly, but could make it easier to track your browsing across these websites." = "Using the same cookies and website data is required for %s and %s to work correctly, but could make it easier to track your browsing across these websites.";
-
-/* Informative text for requesting cross-site cookie and website data access for four or more sites. */
-"Using the same cookies and website data is required for %s, %s, and %lu other websites to work correctly, but could make it easier to track your browsing across these websites." = "Using the same cookies and website data is required for %s, %s, and %lu other websites to work correctly, but could make it easier to track your browsing across these websites.";
-
-/* Label describing the list of related websites controlled by the same organization. */
-"Related %@ websites" = "Related %@ websites";
-
 /* WKWebExtensionErrorUnknown description */
 "An unknown error has occurred." = "An unknown error has occurred.";
 
@@ -234,9 +228,6 @@
 
 /* Label for the plain Apple Pay button. */
 "Apple Pay" = "Apple Pay";
-
-/* Message for requesting cross-site cookie and website data access. */
-"Allow related %@ websites to share cookies and website data?" = "Allow related %@ websites to share cookies and website data?";
 
 /* Malware confirmation dialog title */
 "Are you sure you wish to go to this site?" = "Are you sure you wish to go to this site?";
@@ -949,8 +940,17 @@
 /* Media Element Source Type */
 "ManagedMediaSource (Media Element Source Type)" = "Managed Media Source";
 
+/* WKWebExtensionErrorInvalidBackgroundContent description for empty or invalid preferred environment key */
+"Manifest `background` entry has an empty or invalid `preferred_environment` key." = "Manifest `background` entry has an empty or invalid `preferred_environment` key.";
+
+/* WKWebExtensionErrorInvalidBackgroundContent description for missing background page or scripts keys */
+"Manifest `background` entry has missing or empty required `page` or `scripts` key for `preferred_environment` of `document`." = "Manifest `background` entry has missing or empty required `page` or `scripts` key for `preferred_environment` of `document`.";
+
 /* WKWebExtensionErrorInvalidBackgroundContent description for missing background required keys */
-"Manifest `background` entry has missing or empty required key `scripts`, `page`, or `service_worker`." = "Manifest `background` entry has missing or empty required key `scripts`, `page`, or `service_worker`.";
+"Manifest `background` entry has missing or empty required `scripts`, `page`, or `service_worker` key." = "Manifest `background` entry has missing or empty required `scripts`, `page`, or `service_worker` key.";
+
+/* WKWebExtensionErrorInvalidBackgroundContent description for missing background service_worker or scripts keys */
+"Manifest `background` entry has missing or empty required `service_worker` or `scripts` key for `preferred_environment` of `service_worker`." = "Manifest `background` entry has missing or empty required `service_worker` or `scripts` key for `preferred_environment` of `service_worker`.";
 
 /* WKWebExtensionErrorInvalidContentScripts description for missing or empty 'js' and 'css' arrays */
 "Manifest `content_scripts` entry has missing or empty 'js' and 'css' arrays." = "Manifest `content_scripts` entry has missing or empty 'js' and 'css' arrays.";
@@ -1188,6 +1188,9 @@
 
 /* label for first item in the menu that appears when clicking on the search field image, used as embedded menu title */
 "Recent Searches" = "Recent Searches";
+
+/* Label describing the list of related websites controlled by the same organization */
+"Related %@ websites" = "Related %@ websites";
 
 /* Reload context menu item */
 "Reload" = "Reload";
@@ -1612,6 +1615,12 @@
 /* The download was cancelled by the user */
 "User cancelled the download" = "User cancelled the download";
 
+/* Informative text for requesting cross-site cookie and website data access for two sites */
+"Using the same cookies and website data is required for %s and %s to work correctly, but could make it easier to track your browsing across these websites." = "Using the same cookies and website data is required for %s and %s to work correctly, but could make it easier to track your browsing across these websites.";
+
+/* Informative text for requesting cross-site cookie and website data access for four or more sites. */
+"Using the same cookies and website data is required for %s, %s, and %lu other websites to work correctly, but could make it easier to track your browsing across these websites." = "Using the same cookies and website data is required for %s, %s, and %lu other websites to work correctly, but could make it easier to track your browsing across these websites.";
+
 /* Codec Strings */
 "VP8 (Codec String)" = "VP8";
 
@@ -1653,9 +1662,6 @@
 
 /* Unwanted software warning title */
 "Website With Harmful Software Warning" = "Website With Harmful Software Warning";
-
-/* Accessory text for requesting cross-site cookie and website data access. */
-"While you are visiting %@, the following related websites will gain access to their cookies:\n  - %@" = "While you are visiting %@, the following related websites will gain access to their cookies:\n  - %@";
 
 /* Year label in date picker */
 "YEAR (Date picker for extra zoom mode)" = "YEAR";
@@ -1830,9 +1836,6 @@
 
 /* An ARIA accessibility group that contains mathematical symbols. */
 "math" = "math";
-
-/* accessibility label for meridiem fields. */
-"meridiem" = "meridiem";
 
 /* accessibility label for milliseconds fields. */
 "milliseconds" = "milliseconds";

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -94,8 +94,11 @@ static NSString * const backgroundScriptsManifestKey = @"scripts";
 static NSString * const backgroundPersistentManifestKey = @"persistent";
 static NSString * const backgroundPageTypeKey = @"type";
 static NSString * const backgroundPageTypeModuleValue = @"module";
+static NSString * const backgroundPreferredEnvironmentManifestKey = @"preferred_environment";
+static NSString * const backgroundDocumentManifestKey = @"document";
 
 static NSString * const generatedBackgroundPageFilename = @"_generated_background_page.html";
+static NSString * const generatedBackgroundServiceWorkerFilename = @"_generated_service_worker.js";
 
 static NSString * const devtoolsPageManifestKey = @"devtools_page";
 
@@ -486,7 +489,11 @@ NSString *WebExtension::resourceStringForPath(NSString *path, CacheResult cacheR
     if (NSString *cachedString = objectForKey<NSString>(m_resources, path))
         return cachedString;
 
-    if ([path isEqualToString:generatedBackgroundPageFilename])
+    bool isServiceWorker = backgroundContentIsServiceWorker();
+    if (!isServiceWorker && [path isEqualToString:generatedBackgroundPageFilename])
+        return generatedBackgroundContent();
+
+    if (isServiceWorker && [path isEqualToString:generatedBackgroundServiceWorkerFilename])
         return generatedBackgroundContent();
 
     NSData *data = resourceDataForPath(path, CacheResult::No, suppressErrors);
@@ -538,7 +545,11 @@ NSData *WebExtension::resourceDataForPath(NSString *path, CacheResult cacheResul
     if (NSDictionary *cachedDictionary = objectForKey<NSDictionary>(m_resources, path))
         return encodeJSONData(cachedDictionary);
 
-    if ([path isEqualToString:generatedBackgroundPageFilename])
+    bool isServiceWorker = backgroundContentIsServiceWorker();
+    if (!isServiceWorker && [path isEqualToString:generatedBackgroundPageFilename])
+        return [generatedBackgroundContent() dataUsingEncoding:NSUTF8StringEncoding];
+
+    if (isServiceWorker && [path isEqualToString:generatedBackgroundServiceWorkerFilename])
         return [generatedBackgroundContent() dataUsingEncoding:NSUTF8StringEncoding];
 
     NSURL *resourceURL = resourceFileURLForPath(path);
@@ -1268,13 +1279,13 @@ bool WebExtension::backgroundContentIsPersistent()
 bool WebExtension::backgroundContentUsesModules()
 {
     populateBackgroundPropertiesIfNeeded();
-    return hasBackgroundContent() && m_backgroundPageUsesModules;
+    return hasBackgroundContent() && m_backgroundContentUsesModules;
 }
 
 bool WebExtension::backgroundContentIsServiceWorker()
 {
     populateBackgroundPropertiesIfNeeded();
-    return !!m_backgroundServiceWorkerPath;
+    return m_backgroundContentEnvironment == Environment::ServiceWorker;
 }
 
 NSString *WebExtension::backgroundContentPath()
@@ -1285,7 +1296,7 @@ NSString *WebExtension::backgroundContentPath()
         return m_backgroundServiceWorkerPath.get();
 
     if (m_backgroundScriptPaths.get().count)
-        return generatedBackgroundPageFilename;
+        return backgroundContentIsServiceWorker() ? generatedBackgroundServiceWorkerFilename : generatedBackgroundPageFilename;
 
     if (m_backgroundPagePath)
         return m_backgroundPagePath.get();
@@ -1301,20 +1312,31 @@ NSString *WebExtension::generatedBackgroundContent()
 
     populateBackgroundPropertiesIfNeeded();
 
-    if (m_backgroundServiceWorkerPath)
+    if (m_backgroundServiceWorkerPath || m_backgroundPagePath)
         return nil;
 
     if (!m_backgroundScriptPaths.get().count)
         return nil;
 
-    NSArray<NSString *> *scriptTagsArray = mapObjects(m_backgroundScriptPaths, ^(NSNumber *index, NSString *scriptPath) {
-        if (backgroundContentUsesModules())
-            return [NSString stringWithFormat:@"<script type=\"module\" src=\"%@\"></script>", scriptPath];
+    bool isServiceWorker = backgroundContentIsServiceWorker();
+    bool usesModules = backgroundContentUsesModules();
 
+    auto *scriptsArray = mapObjects(m_backgroundScriptPaths, ^(NSNumber *index, NSString *scriptPath) {
+        if (isServiceWorker) {
+            if (usesModules)
+                return [NSString stringWithFormat:@"import \"./%@\";", scriptPath];
+            return [NSString stringWithFormat:@"importScripts(\"%@\");", scriptPath];
+        }
+
+        if (usesModules)
+            return [NSString stringWithFormat:@"<script type=\"module\" src=\"%@\"></script>", scriptPath];
         return [NSString stringWithFormat:@"<script src=\"%@\"></script>", scriptPath];
     });
 
-    m_generatedBackgroundContent = [NSString stringWithFormat:@"<!DOCTYPE html>\n<body>\n%@\n</body>", [scriptTagsArray componentsJoinedByString:@"\n"]];
+    if (isServiceWorker)
+        m_generatedBackgroundContent = [scriptsArray componentsJoinedByString:@"\n"];
+    else
+        m_generatedBackgroundContent = [NSString stringWithFormat:@"<!DOCTYPE html>\n<body>\n%@\n</body>", [scriptsArray componentsJoinedByString:@"\n"]];
 
     return m_generatedBackgroundContent.get();
 }
@@ -1331,7 +1353,7 @@ void WebExtension::populateBackgroundPropertiesIfNeeded()
 
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background
 
-    NSDictionary<NSString *, id> *backgroundManifestDictionary = objectForKey<NSDictionary>(m_manifest, backgroundManifestKey);
+    auto *backgroundManifestDictionary = objectForKey<NSDictionary>(m_manifest, backgroundManifestKey);
     if (!backgroundManifestDictionary.count) {
         if ([m_manifest objectForKey:backgroundManifestKey])
             recordError(createError(Error::InvalidBackgroundContent));
@@ -1341,26 +1363,85 @@ void WebExtension::populateBackgroundPropertiesIfNeeded()
     m_backgroundScriptPaths = objectForKey<NSArray>(backgroundManifestDictionary, backgroundScriptsManifestKey, true, NSString.class);
     m_backgroundPagePath = objectForKey<NSString>(backgroundManifestDictionary, backgroundPageManifestKey);
     m_backgroundServiceWorkerPath = objectForKey<NSString>(backgroundManifestDictionary, backgroundServiceWorkerManifestKey);
-    m_backgroundPageUsesModules = [objectForKey<NSString>(backgroundManifestDictionary, backgroundPageTypeKey) isEqualToString:backgroundPageTypeModuleValue];
+    m_backgroundContentUsesModules = [objectForKey<NSString>(backgroundManifestDictionary, backgroundPageTypeKey) isEqualToString:backgroundPageTypeModuleValue];
 
     m_backgroundScriptPaths = filterObjects(m_backgroundScriptPaths, ^(NSNumber *index, NSString *scriptPath) {
         return !!scriptPath.length;
     });
 
-    // Page takes precedence over service worker.
-    if (m_backgroundPagePath)
-        m_backgroundServiceWorkerPath = nil;
+    static auto *supportedEnvironments = [NSOrderedSet orderedSetWithObjects:backgroundDocumentManifestKey, backgroundServiceWorkerManifestKey, nil];
 
-    // Scripts takes precedence over page and service worker.
-    if (m_backgroundScriptPaths.get().count) {
-        m_backgroundServiceWorkerPath = nil;
-        m_backgroundPagePath = nil;
+    NSOrderedSet *preferredEnvironments;
+    if (auto *environment = objectForKey<NSString>(backgroundManifestDictionary, backgroundPreferredEnvironmentManifestKey)) {
+        if ([supportedEnvironments containsObject:environment])
+            preferredEnvironments = [NSOrderedSet orderedSetWithObject:environment];
+    } else if (auto *environments = objectForKey<NSArray>(backgroundManifestDictionary, backgroundPreferredEnvironmentManifestKey, true, NSString.class)) {
+        auto *filteredEnvironments = filterObjects(environments, ^bool(NSNumber *, NSString *environment) {
+            return [supportedEnvironments containsObject:environment];
+        });
+
+        preferredEnvironments = [NSOrderedSet orderedSetWithArray:filteredEnvironments];
+    } else if (backgroundManifestDictionary[backgroundPreferredEnvironmentManifestKey])
+        recordError(createError(Error::InvalidBackgroundContent, WEB_UI_STRING("Manifest `background` entry has an empty or invalid `preferred_environment` key.", "WKWebExtensionErrorInvalidBackgroundContent description for empty or invalid preferred environment key")));
+
+    for (NSString *environment in preferredEnvironments) {
+        if ([environment isEqualToString:backgroundDocumentManifestKey]) {
+            m_backgroundContentEnvironment = Environment::Document;
+            m_backgroundServiceWorkerPath = nil;
+
+            if (m_backgroundPagePath) {
+                // Page takes precedence over scripts and service worker.
+                m_backgroundScriptPaths = nil;
+                break;
+            }
+
+            if (m_backgroundScriptPaths.get().count) {
+                // Scripts takes precedence over service worker.
+                break;
+            }
+
+            recordError(createError(Error::InvalidBackgroundContent, WEB_UI_STRING("Manifest `background` entry has missing or empty required `page` or `scripts` key for `preferred_environment` of `document`.", "WKWebExtensionErrorInvalidBackgroundContent description for missing background page or scripts keys")));
+            break;
+        }
+
+        if ([environment isEqualToString:backgroundServiceWorkerManifestKey]) {
+            m_backgroundContentEnvironment = Environment::ServiceWorker;
+            m_backgroundPagePath = nil;
+
+            if (m_backgroundServiceWorkerPath) {
+                // Service worker takes precedence over scripts and page.
+                m_backgroundScriptPaths = nil;
+                break;
+            }
+
+            if (m_backgroundScriptPaths.get().count) {
+                // Scripts takes precedence over page.
+                break;
+            }
+
+            recordError(createError(Error::InvalidBackgroundContent, WEB_UI_STRING("Manifest `background` entry has missing or empty required `service_worker` or `scripts` key for `preferred_environment` of `service_worker`.", "WKWebExtensionErrorInvalidBackgroundContent description for missing background service_worker or scripts keys")));
+            break;
+        }
     }
 
-    if (!m_backgroundScriptPaths.get().count && !m_backgroundPagePath && !m_backgroundServiceWorkerPath)
-        recordError(createError(Error::InvalidBackgroundContent, WEB_UI_STRING("Manifest `background` entry has missing or empty required key `scripts`, `page`, or `service_worker`.", "WKWebExtensionErrorInvalidBackgroundContent description for missing background required keys")));
+    if (!preferredEnvironments.count) {
+        // Page takes precedence over service worker.
+        if (m_backgroundPagePath)
+            m_backgroundServiceWorkerPath = nil;
 
-    NSNumber *persistentBoolean = objectForKey<NSNumber>(backgroundManifestDictionary, backgroundPersistentManifestKey);
+        // Scripts takes precedence over page and service worker.
+        if (m_backgroundScriptPaths.get().count) {
+            m_backgroundServiceWorkerPath = nil;
+            m_backgroundPagePath = nil;
+        }
+
+        m_backgroundContentEnvironment = m_backgroundServiceWorkerPath ? Environment::ServiceWorker : Environment::Document;
+
+        if (!m_backgroundScriptPaths.get().count && !m_backgroundPagePath && !m_backgroundServiceWorkerPath)
+            recordError(createError(Error::InvalidBackgroundContent, WEB_UI_STRING("Manifest `background` entry has missing or empty required `scripts`, `page`, or `service_worker` key.", "WKWebExtensionErrorInvalidBackgroundContent description for missing background required keys")));
+    }
+
+    auto *persistentBoolean = objectForKey<NSNumber>(backgroundManifestDictionary, backgroundPersistentManifestKey);
     m_backgroundContentIsPersistent = persistentBoolean ? persistentBoolean.boolValue : !(supportsManifestVersion(3) || m_backgroundServiceWorkerPath);
 
     if (m_backgroundContentIsPersistent && supportsManifestVersion(3)) {

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -115,6 +115,11 @@ public:
         DocumentEnd,
     };
 
+    enum class Environment : bool {
+        Document,
+        ServiceWorker,
+    };
+
     using PermissionsSet = HashSet<String>;
     using MatchPatternSet = HashSet<Ref<WebExtensionMatchPattern>>;
 
@@ -357,6 +362,7 @@ private:
     RetainPtr<NSString> m_backgroundPagePath;
     RetainPtr<NSString> m_backgroundServiceWorkerPath;
     RetainPtr<NSString> m_generatedBackgroundContent;
+    Environment m_backgroundContentEnvironment { Environment::Document };
 
     RetainPtr<NSString> m_inspectorBackgroundPagePath;
 
@@ -364,7 +370,7 @@ private:
     RetainPtr<NSString> m_overrideNewTabPagePath;
 
     bool m_backgroundContentIsPersistent : 1 { false };
-    bool m_backgroundPageUsesModules : 1 { false };
+    bool m_backgroundContentUsesModules : 1 { false };
     bool m_parsedManifest : 1 { false };
     bool m_parsedManifestDisplayStrings : 1 { false };
     bool m_parsedManifestContentSecurityPolicyStrings : 1 { false };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm
@@ -679,6 +679,170 @@ TEST(WKWebExtension, BackgroundParsing)
     EXPECT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidBackgroundPersistence));
 }
 
+TEST(WKWebExtension, BackgroundPreferredEnvironmentParsing)
+{
+    NSMutableDictionary *testManifestDictionary = [@{ @"manifest_version": @3, @"name": @"Test", @"description": @"Test", @"version": @"1.0" } mutableCopy];
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @[ @"service_worker", @"document" ],
+        @"service_worker": @"background.js",
+        @"scripts": @[ @"background.js" ],
+        @"page": @"background.html",
+    };
+
+    auto *testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_TRUE(testExtension._backgroundContentIsServiceWorker);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @[ @"document", @"service_worker" ],
+        @"service_worker": @"background.js",
+        @"scripts": @[ @"background.js" ],
+        @"page": @"background.html",
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension._backgroundContentIsServiceWorker);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @"service_worker",
+        @"service_worker": @"background.js",
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_TRUE(testExtension._backgroundContentIsServiceWorker);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @[ @"document" ],
+        @"page": @"background.html",
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension._backgroundContentIsServiceWorker);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @"document",
+        @"scripts": @[ @"background.js" ]
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension._backgroundContentIsServiceWorker);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @[ @"document", @"service_worker" ],
+        @"scripts": @[ @"background.js" ]
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension._backgroundContentIsServiceWorker);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @[ @"document", @42, @"unknown" ],
+        @"scripts": @[ @"background.js" ]
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension._backgroundContentIsServiceWorker);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @[ @"unknown", @42 ],
+        @"page": @"background.html",
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension._backgroundContentIsServiceWorker);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @"unknown",
+        @"service_worker": @"background.js",
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_TRUE(testExtension._backgroundContentIsServiceWorker);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @[ @"unknown", @"document"],
+        @"service_worker": @"background.js",
+        @"page": @"background.html",
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension._backgroundContentIsServiceWorker);
+    EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
+
+    // Invalid cases
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @[ ],
+        @"service_worker": @"background.js",
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_TRUE(testExtension._backgroundContentIsServiceWorker);
+    EXPECT_NE(testExtension.errors.count, 0ul);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @42,
+        @"service_worker": @"background.js",
+        @"page": @"background.html",
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_TRUE(testExtension.hasBackgroundContent);
+    EXPECT_FALSE(testExtension._backgroundContentIsServiceWorker);
+    EXPECT_NE(testExtension.errors.count, 0ul);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @[ @"service_worker", @"document" ],
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_FALSE(testExtension.hasBackgroundContent);
+    EXPECT_NE(testExtension.errors.count, 0ul);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @"document",
+        @"service_worker": @"background.js",
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_FALSE(testExtension.hasBackgroundContent);
+    EXPECT_NE(testExtension.errors.count, 0ul);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
+
+    testManifestDictionary[@"background"] = @{
+        @"preferred_environment": @"service_worker",
+        @"page": @"background.html",
+    };
+
+    testExtension = [[_WKWebExtension alloc] _initWithManifestDictionary:testManifestDictionary];
+    EXPECT_FALSE(testExtension.hasBackgroundContent);
+    EXPECT_NE(testExtension.errors.count, 0ul);
+    EXPECT_NOT_NULL(matchingError(testExtension.errors, _WKWebExtensionErrorInvalidManifestEntry));
+}
+
 TEST(WKWebExtension, OptionsPageParsing)
 {
     auto *testManifestDictionary = @{

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm
@@ -251,6 +251,233 @@ TEST(WKWebExtensionController, BackgroundPageWithModulesLoading)
     EXPECT_NS_EQUAL(testExtension.errors, @[ ]);
 }
 
+TEST(WKWebExtensionController, BackgroundWithServiceWorkerPreferredEnvironment)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+
+        @"background": @{
+            @"preferred_environment": @[ @"service_worker", @"document" ],
+            @"service_worker": @"service_worker.js",
+            @"scripts": @[ @"background.js" ],
+            @"page": @"background.html"
+        }
+    };
+
+    auto *serviceWorkerScript = Util::constructScript(@[
+        @"browser.test.assertTrue('ServiceWorkerGlobalScope' in self && self instanceof ServiceWorkerGlobalScope, 'Global scope should be ServiceWorkerGlobalScope');",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.notifyFail('This background script should not be used')"
+    ]);
+
+    auto *resources = @{
+        @"service_worker.js": serviceWorkerScript,
+        @"background.js": backgroundScript,
+        @"background.html": @"<script src='background.js'></script>",
+    };
+
+    Util::loadAndRunExtension(manifest, resources);
+}
+
+TEST(WKWebExtensionController, BackgroundWithPageDocumentPreferredEnvironment)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+
+        @"background": @{
+            @"preferred_environment": @[ @"document", @"service_worker" ],
+            @"service_worker": @"service_worker.js",
+            @"scripts": @[ @"other-background.js" ],
+            @"page": @"background.html"
+        }
+    };
+
+    auto *serviceWorkerScript = Util::constructScript(@[
+        @"browser.test.notifyFail('Service worker should not be used')"
+    ]);
+
+    auto *notUsedbackgroundScript = Util::constructScript(@[
+        @"browser.test.notifyFail('This background script should not be used')"
+    ]);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertTrue('Window' in self && self instanceof Window, 'Global scope should be Window')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto *resources = @{
+        @"service_worker.js": serviceWorkerScript,
+        @"other-background.js": notUsedbackgroundScript,
+        @"background.js": backgroundScript,
+        @"background.html": @"<script src='background.js'></script>",
+    };
+
+    Util::loadAndRunExtension(manifest, resources);
+}
+
+TEST(WKWebExtensionController, BackgroundWithScriptsDocumentPreferredEnvironment)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+
+        @"background": @{
+            @"preferred_environment": @"document",
+            @"scripts": @[ @"background.js" ]
+        }
+    };
+
+    auto *serviceWorkerScript = Util::constructScript(@[
+        @"browser.test.notifyFail('Service worker should not be used')"
+    ]);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertTrue('Window' in self && self instanceof Window, 'Global scope should be Window')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto *resources = @{
+        @"service_worker.js": serviceWorkerScript,
+        @"background.js": backgroundScript,
+    };
+
+    Util::loadAndRunExtension(manifest, resources);
+}
+
+TEST(WKWebExtensionController, BackgroundWithMultipleDocumentModuleScripts)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+
+        @"background": @{
+            @"preferred_environment": @"document",
+            @"scripts": @[ @"module1.js", @"module2.js" ],
+            @"type": @"module"
+        }
+    };
+
+    auto *module1 = Util::constructScript(@[
+        @"self.testValue = 'Test value set in Module 1';"
+    ]);
+
+    auto *module2 = Util::constructScript(@[
+        @"import { valueFromModule3 } from './module3.js'",
+
+        @"browser.test.assertEq(self.testValue, 'Test value set in Module 1', 'Module 1 value should be accessible')",
+        @"browser.test.assertEq(valueFromModule3, 'Value from Module 3', 'Value from Module 3 should be accessible')",
+
+        @"browser.test.notifyPass();"
+    ]);
+
+    auto *module3 = Util::constructScript(@[
+        @"export const valueFromModule3 = 'Value from Module 3';"
+    ]);
+
+    auto *resources = @{
+        @"module1.js": module1,
+        @"module2.js": module2,
+        @"module3.js": module3,
+    };
+
+    Util::loadAndRunExtension(manifest, resources);
+}
+
+TEST(WKWebExtensionController, BackgroundWithMultipleServiceWorkerScripts)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+
+        @"background": @{
+            @"preferred_environment": @"service_worker",
+            @"scripts": @[ @"script1.js", @"script2.js" ]
+        }
+    };
+
+    auto *script1 = Util::constructScript(@[
+        @"self.testValue = 'Test value set in Script 1'"
+    ]);
+
+    auto *script2 = Util::constructScript(@[
+        @"browser.test.assertEq(self.testValue, 'Test value set in Script 1')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto *resources = @{
+        @"script1.js": script1,
+        @"script2.js": script2,
+    };
+
+    Util::loadAndRunExtension(manifest, resources);
+}
+
+TEST(WKWebExtensionController, BackgroundWithMultipleServiceWorkerModuleScripts)
+{
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1.0",
+
+        @"background": @{
+            @"preferred_environment": @"service_worker",
+            @"scripts": @[ @"module1.js", @"module2.js" ],
+            @"type": @"module"
+        }
+    };
+
+    auto *module1 = Util::constructScript(@[
+        @"self.testValue = 'Test value set in Module 1'"
+    ]);
+
+    auto *module2 = Util::constructScript(@[
+        @"import { valueFromModule3 } from './module3.js'",
+
+        @"browser.test.assertEq(self.testValue, 'Test value set in Module 1')",
+        @"browser.test.assertEq(valueFromModule3, 'Value from Module 3')",
+
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto *module3 = Util::constructScript(@[
+        @"export const valueFromModule3 = 'Value from Module 3'"
+    ]);
+
+    auto *resources = @{
+        @"module1.js": module1,
+        @"module2.js": module2,
+        @"module3.js": module3,
+    };
+
+    Util::loadAndRunExtension(manifest, resources);
+}
+
 TEST(WKWebExtensionController, ContentScriptLoading)
 {
     TestWebKitAPI::HTTPServer server({


### PR DESCRIPTION
#### 6d27093d068a866cc0f2948e561882d1f2d8039b
<pre>
Add support for background preferred_environment in Web Extensions.
<a href="https://webkit.org/b/272244">https://webkit.org/b/272244</a>
<a href="https://rdar.apple.com/problem/125988233">rdar://problem/125988233</a>

Reviewed by Brian Weinstein.

Add support for extensions declaring a `preferred_environment` in the `background` entry.
The `preferred_environment` key can be a string or an array of strings. When an array is
used, the browser will prefer the first one it supports.

    &quot;background&quot;: {
        &quot;preferred_environment&quot;: [ &quot;service_worker&quot;, &quot;document&quot; ],
        &quot;scripts&quot;: [ &quot;script1.js&quot;, &quot;script2.js&quot; ]
    }

If no environments are specified or supported, then we fallback to the previous handling of
the `scripts`, `page` or `service_worker` keys (in that order) for backwards compatibility.

This allows cross-browser extensions to have a single manifest that works in multiple
browsers. Chrome plans to only support service workers going forward, but Safari and
Firefox plan to support pages and service workers, and extension might prefer a document
environment over a service worker in Safari and Firefox.

This also adds support for a `_generated_service_worker.js` script that works with normal
scripts or modules based on the `scripts` and `type` keys if `preferred_environment`
is `service_worker`.

WECG discussion here: <a href="https://github.com/w3c/webextensions/issues/282">https://github.com/w3c/webextensions/issues/282</a>

* Source/WebCore/en.lproj/Localizable.strings: Updated.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::resourceStringForPath): Support _generated_service_worker.js.
(WebKit::WebExtension::resourceDataForPath): Ditto.
(WebKit::WebExtension::backgroundContentUsesModules): Use renamed m_backgroundContentUsesModules.
(WebKit::WebExtension::backgroundContentIsServiceWorker): Use new m_backgroundContentEnvironment.
(WebKit::WebExtension::backgroundContentPath): Support _generated_service_worker.js.
(WebKit::WebExtension::generatedBackgroundContent): Generate the service worker script.
(WebKit::WebExtension::populateBackgroundPropertiesIfNeeded): Handle preferred_environment.
* Source/WebKit/UIProcess/Extensions/WebExtension.h: Added m_backgroundContentEnvironment and renamed
m_backgroundPageUsesModules to m_backgroundContentUsesModules.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, BackgroundPreferredEnvironmentParsing)): Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionController.mm:
(TestWebKitAPI::TEST(WKWebExtensionController, BackgroundWithServiceWorkerPreferredEnvironment)): Added.
(TestWebKitAPI::TEST(WKWebExtensionController, BackgroundWithPageDocumentPreferredEnvironment)): Added.
(TestWebKitAPI::TEST(WKWebExtensionController, BackgroundWithScriptsDocumentPreferredEnvironment)): Added.
(TestWebKitAPI::TEST(WKWebExtensionController, BackgroundWithMultipleDocumentModuleScripts)): Added.
(TestWebKitAPI::TEST(WKWebExtensionController, BackgroundWithMultipleServiceWorkerScripts)): Added.
(TestWebKitAPI::TEST(WKWebExtensionController, BackgroundWithMultipleServiceWorkerModuleScripts)): Added.

Canonical link: <a href="https://commits.webkit.org/277228@main">https://commits.webkit.org/277228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b17e69c05a88155b65d3a6ea8b45eca4913e9609

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49738 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43102 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49362 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23691 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47636 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/23681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/19633 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/21051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5100 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51614 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45618 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23357 "Failed to checkout and rebase branch from PR 26915") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44612 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6604 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/23069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->