### PR TITLE
Assert hit in WebKit::RemoteImageBuffer::getShareableBitmap

### DIFF
--- a/LayoutTests/ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend-expected.txt
+++ b/LayoutTests/ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend-expected.txt
@@ -1,0 +1,5 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x8
+  RenderBlock {HTML} at (0,0) size 800x8
+    RenderBody {BODY} at (8,8) size 784x0

--- a/LayoutTests/ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html
+++ b/LayoutTests/ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html
@@ -1,0 +1,43 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<script>
+function fuzz() {
+    if (!window.IPC)
+        return;
+    const defaultTimeout = 1000;
+    o4=IPC.pageID;
+    o5=IPC.webPageProxyID;
+    let pair = IPC.createStreamClientConnection(14);
+    o35=pair[0];
+    o36=pair[1];
+    o35.open();
+
+    // Use random identifiers in case this test is run multiple times in the same process.
+    let backendID = Math.floor(Math.random() * 100000000) + 1;
+    let imageBufferID = Math.floor(Math.random() * 100000000) + 1;
+
+    IPC.sendMessage('GPU',0,IPC.messages.GPUConnectionToWebProcess_CreateRenderingBackend.name,
+                  [{type: 'uint64_t', value: backendID},
+                   {type: 'uint64_t', value: o5},
+                   {type: 'uint64_t', value: o4},
+                   {type: 'StreamServerConnectionHandle', value: o36}])
+    resp = o35.waitForMessage(backendID, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, defaultTimeout)
+    o35.setSemaphores(resp[0].value, resp[1].value);
+    o35.sendMessage(backendID, IPC.messages.RemoteRenderingBackend_CreateImageBuffer.name, 0.1,
+                  [{type: 'float', value: 804},
+                   {type: 'float', value: 486},
+                   {type: 'uint8_t', value: 0},
+                   {type: 'uint8_t', value: 2},
+                   {type: 'float', value: 184},
+                   {type: 'uint8_t', value: 0},
+                   {type: 'uint8_t', value: 0},
+                   {type: 'uint64_t', value: imageBufferID}])
+    try {
+        o35.waitForMessage(imageBufferID, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name, defaultTimeout);
+    } catch { }
+    try {
+        o35.sendSyncMessage(imageBufferID,IPC.messages.RemoteImageBuffer_GetShareableBitmap.name,0.1,[{type: 'bool',value: 0}]);
+    } catch { }
+    o35.invalidate();
+}
+</script>
+<body onload='fuzz()'></body>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2019,6 +2019,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/PixelBufferConversion.h
     platform/graphics/PixelBufferFormat.h
     platform/graphics/PixelFormat.h
+    platform/graphics/PixelFormatValidated.h
     platform/graphics/PlatformAudioTrackConfiguration.h
     platform/graphics/PlatformColorSpace.h
     platform/graphics/PlatformDisplay.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2369,6 +2369,7 @@ platform/graphics/PixelBuffer.cpp
 platform/graphics/PixelBufferConversion.cpp
 platform/graphics/PixelBufferFormat.cpp
 platform/graphics/PixelFormat.cpp
+platform/graphics/PixelFormatValidated.cpp
 platform/graphics/PlatformTimeRanges.cpp
 platform/graphics/PositionedGlyphs.cpp
 platform/graphics/Region.cpp

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -114,7 +114,7 @@ IntSize ImageBuffer::calculateBackendSize(FloatSize logicalSize, float resolutio
 
 ImageBufferBackendParameters ImageBuffer::backendParameters(const ImageBufferParameters& parameters)
 {
-    return { calculateBackendSize(parameters.logicalSize, parameters.resolutionScale), parameters.resolutionScale, parameters.colorSpace, parameters.pixelFormat, parameters.purpose };
+    return { calculateBackendSize(parameters.logicalSize, parameters.resolutionScale), parameters.resolutionScale, parameters.colorSpace, convertPixelFormatValidatedToPixelFormat(parameters.pixelFormatValidated), parameters.purpose };
 }
 
 bool ImageBuffer::sizeNeedsClamping(const FloatSize& size)

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -29,6 +29,7 @@
 
 #include "ImageBufferAllocator.h"
 #include "ImageBufferBackend.h"
+#include "PixelFormatValidated.h"
 #include "PlatformScreen.h"
 #include "ProcessIdentity.h"
 #include "RenderingMode.h"
@@ -85,7 +86,7 @@ struct ImageBufferParameters {
     FloatSize logicalSize;
     float resolutionScale;
     DestinationColorSpace colorSpace;
-    PixelFormat pixelFormat;
+    PixelFormatValidated pixelFormatValidated;
     RenderingPurpose purpose;
 };
 
@@ -97,7 +98,7 @@ public:
     template<typename BackendType, typename ImageBufferType = ImageBuffer, typename... Arguments>
     static RefPtr<ImageBufferType> create(const FloatSize& size, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, RenderingPurpose purpose, const ImageBufferCreationContext& creationContext, Arguments&&... arguments)
     {
-        Parameters parameters { size, resolutionScale, colorSpace, pixelFormat, purpose };
+        Parameters parameters { size, resolutionScale, colorSpace, convertPixelFormatToPixelFormatValidated(pixelFormat), purpose };
         auto backendParameters = ImageBuffer::backendParameters(parameters);
         auto backend = BackendType::create(backendParameters, creationContext);
         if (!backend)
@@ -158,7 +159,8 @@ public:
     DestinationColorSpace colorSpace() const { return m_parameters.colorSpace; }
     
     RenderingPurpose renderingPurpose() const { return m_parameters.purpose; }
-    PixelFormat pixelFormat() const { return m_parameters.pixelFormat; }
+    PixelFormatValidated pixelFormatValidated() const { return m_parameters.pixelFormatValidated; }
+    PixelFormat pixelFormat() const { return convertPixelFormatValidatedToPixelFormat(m_parameters.pixelFormatValidated); }
     const Parameters& parameters() const { return m_parameters; }
 
     RenderingMode renderingMode() const { return m_backendInfo.renderingMode; }

--- a/Source/WebCore/platform/graphics/PixelFormatValidated.cpp
+++ b/Source/WebCore/platform/graphics/PixelFormatValidated.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PixelFormatValidated.h"
+
+namespace WebCore {
+
+PixelFormatValidated convertPixelFormatToPixelFormatValidated(PixelFormat format)
+{
+    switch (format) {
+    case PixelFormat::RGBA8:
+        ASSERT_NOT_REACHED();
+        return PixelFormatValidated::BGRX8;
+    case PixelFormat::BGRX8:
+        return PixelFormatValidated::BGRX8;
+    case PixelFormat::BGRA8:
+        return PixelFormatValidated::BGRA8;
+#if HAVE(IOSURFACE_RGB10)
+    case PixelFormat::RGB10:
+        return PixelFormatValidated::RGB10;
+    case PixelFormat::RGB10A8:
+        return PixelFormatValidated::RGB10A8;
+#else
+    case PixelFormat::RGB10:
+    case PixelFormat::RGB10A8:
+        ASSERT_NOT_REACHED();
+        return PixelFormatValidated::BGRX8;
+#endif
+    }
+
+    ASSERT_NOT_REACHED();
+    return PixelFormatValidated::BGRX8;
+}
+
+PixelFormat convertPixelFormatValidatedToPixelFormat(PixelFormatValidated format)
+{
+    switch (format) {
+    case PixelFormatValidated::BGRX8:
+        return PixelFormat::BGRX8;
+    case PixelFormatValidated::BGRA8:
+        return PixelFormat::BGRA8;
+#if HAVE(IOSURFACE_RGB10)
+    case PixelFormatValidated::RGB10:
+        return PixelFormat::RGB10;
+    case PixelFormatValidated::RGB10A8:
+        return PixelFormat::RGB10A8;
+#endif
+    }
+
+    ASSERT_NOT_REACHED();
+    return PixelFormat::BGRX8;
+}
+
+}

--- a/Source/WebCore/platform/graphics/PixelFormatValidated.h
+++ b/Source/WebCore/platform/graphics/PixelFormatValidated.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Forward.h>
+
+namespace WebCore {
+enum class PixelFormat : uint8_t;
+enum class PixelFormatValidated : uint8_t {
+    BGRX8,
+    BGRA8,
+#if HAVE(IOSURFACE_RGB10)
+    RGB10,
+    RGB10A8,
+#endif
+};
+
+WEBCORE_EXPORT PixelFormatValidated convertPixelFormatToPixelFormatValidated(PixelFormat);
+
+WEBCORE_EXPORT PixelFormat convertPixelFormatValidatedToPixelFormat(PixelFormatValidated);
+
+} // namespace WebCore

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -120,6 +120,8 @@ void RemoteImageBuffer::getShareableBitmap(WebCore::PreserveResolution preserveR
         auto backendSize = m_imageBuffer->backendSize();
         auto logicalSize = m_imageBuffer->logicalSize();
         auto resultSize = preserveResolution == WebCore::PreserveResolution::Yes ? backendSize : m_imageBuffer->truncatedLogicalSize();
+        if (resultSize.isEmpty())
+            return std::nullopt;
         auto bitmap = WebCore::ShareableBitmap::create({ resultSize, m_imageBuffer->colorSpace() });
         if (!bitmap)
             return std::nullopt;

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -47,6 +47,7 @@
 #include "StreamMessageReceiver.h"
 #include "StreamServerConnection.h"
 #include <WebCore/MediaPlayerIdentifier.h>
+#include <WebCore/PixelFormatValidated.h>
 #include <WebCore/ProcessIdentity.h>
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <wtf/HashMap.h>
@@ -140,7 +141,7 @@ private:
     uint64_t messageSenderDestinationID() const override;
 
     // Messages to be received.
-    void createImageBuffer(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormat, WebCore::RenderingResourceIdentifier);
+    void createImageBuffer(const WebCore::FloatSize& logicalSize, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::PixelFormatValidated, WebCore::RenderingResourceIdentifier);
     void releaseImageBuffer(WebCore::RenderingResourceIdentifier);
     void moveToSerializedBuffer(WebCore::RenderingResourceIdentifier);
     void moveToImageBuffer(WebCore::RenderingResourceIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -23,7 +23,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteRenderingBackend NotRefCounted Stream {
-    CreateImageBuffer(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose, float resolutionScale, WebCore::DestinationColorSpace colorSpace, enum:uint8_t WebCore::PixelFormat pixelFormat, WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
+    CreateImageBuffer(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose, float resolutionScale, WebCore::DestinationColorSpace colorSpace, enum:uint8_t WebCore::PixelFormatValidated pixelFormatValidated, WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
     ReleaseImageBuffer(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
     DestroyGetPixelBufferSharedMemory()
     CacheNativeImage(WebCore::ShareableBitmapHandle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2466,6 +2466,15 @@ enum class WebCore::PixelFormat : uint8_t {
     RGB10A8,
 };
 
+enum class WebCore::PixelFormatValidated : uint8_t {
+    BGRX8,
+    BGRA8,
+#if HAVE(IOSURFACE_RGB10)
+    RGB10,
+    RGB10A8,
+#endif
+};
+
 [AdditionalEncoder=StreamConnectionEncoder] struct WebCore::PixelBufferFormat {
     WebCore::AlphaPremultiplication alphaFormat;
     WebCore::PixelFormat pixelFormat;
@@ -4555,7 +4564,7 @@ header: <WebCore/ImageBuffer.h>
     WebCore::FloatSize logicalSize;
     float resolutionScale;
     WebCore::DestinationColorSpace colorSpace
-    WebCore::PixelFormat pixelFormat;
+    WebCore::PixelFormatValidated pixelFormatValidated;
     WebCore::RenderingPurpose purpose;
 };
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -50,7 +50,7 @@ public:
     template<typename BackendType>
     static RefPtr<RemoteImageBufferProxy> create(const WebCore::FloatSize& size, float resolutionScale, const WebCore::DestinationColorSpace& colorSpace, WebCore::PixelFormat pixelFormat, WebCore::RenderingPurpose purpose, RemoteRenderingBackendProxy& remoteRenderingBackendProxy, bool avoidBackendSizeCheck = false)
     {
-        Parameters parameters { size, resolutionScale, colorSpace, pixelFormat, purpose };
+        Parameters parameters { size, resolutionScale, colorSpace, convertPixelFormatToPixelFormatValidated(pixelFormat), purpose };
         auto backendParameters = ImageBuffer::backendParameters(parameters);
         if (!avoidBackendSizeCheck && BackendType::calculateSafeBackendSize(backendParameters).isEmpty())
             return nullptr;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -160,7 +160,7 @@ void RemoteRenderingBackendProxy::disconnectGPUProcess()
 
 void RemoteRenderingBackendProxy::createRemoteImageBuffer(ImageBuffer& imageBuffer)
 {
-    send(Messages::RemoteRenderingBackend::CreateImageBuffer(imageBuffer.logicalSize(), imageBuffer.renderingMode(), imageBuffer.renderingPurpose(), imageBuffer.resolutionScale(), imageBuffer.colorSpace(), imageBuffer.pixelFormat(), imageBuffer.renderingResourceIdentifier()));
+    send(Messages::RemoteRenderingBackend::CreateImageBuffer(imageBuffer.logicalSize(), imageBuffer.renderingMode(), imageBuffer.renderingPurpose(), imageBuffer.resolutionScale(), imageBuffer.colorSpace(), imageBuffer.pixelFormatValidated(), imageBuffer.renderingResourceIdentifier()));
 }
 
 RefPtr<ImageBuffer> RemoteRenderingBackendProxy::createImageBuffer(const FloatSize& size, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, OptionSet<ImageBufferOptions> options)
@@ -194,7 +194,7 @@ RefPtr<ImageBuffer> RemoteRenderingBackendProxy::createImageBuffer(const FloatSi
 std::unique_ptr<RemoteDisplayListRecorderProxy> RemoteRenderingBackendProxy::createDisplayListRecorder(WebCore::RenderingResourceIdentifier renderingResourceIdentifier, const FloatSize& size, RenderingPurpose purpose, float resolutionScale, const DestinationColorSpace& colorSpace, PixelFormat pixelFormat, OptionSet<ImageBufferOptions> options)
 {
     ASSERT(WebProcess::singleton().shouldUseRemoteRenderingFor(RenderingPurpose::DOM));
-    ImageBufferParameters parameters { size, resolutionScale, colorSpace, pixelFormat, purpose };
+    ImageBufferParameters parameters { size, resolutionScale, colorSpace, convertPixelFormatToPixelFormatValidated(pixelFormat), purpose };
     auto renderingMode = RenderingMode::Unaccelerated;
     auto transform = ImageBufferBackend::calculateBaseTransform(ImageBuffer::backendParameters(parameters), ImageBufferShareableBitmapBackend::isOriginAtBottomLeftCorner);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -44,6 +44,7 @@
 #include "StreamClientConnection.h"
 #include "ThreadSafeObjectHeap.h"
 #include "WorkQueueMessageReceiver.h"
+#include <WebCore/PixelFormatValidated.h>
 #include <WebCore/RenderingResourceIdentifier.h>
 #include <WebCore/SharedMemory.h>
 #include <WebCore/Timer.h>

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
@@ -32,6 +32,7 @@
 #include <WebCore/DisplayListDrawingContext.h>
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/ImageBuffer.h>
+#include <WebCore/PixelFormatValidated.h>
 #include <wtf/MathExtras.h>
 #if PLATFORM(COCOA)
 #include <WebCore/GraphicsContextCG.h>
@@ -71,10 +72,10 @@ static WebCore::Path createTestPath()
 static Ref<WebCore::ImageBuffer> createTestImageBuffer()
 {
     auto colorSpace = WebCore::DestinationColorSpace::SRGB();
-    auto pixelFormat = WebCore::PixelFormat::BGRA8;
+    auto pixelFormatValidated = WebCore::PixelFormatValidated::BGRA8;
     WebCore::FloatSize logicalSize { 3, 7 };
     float scale = 1;
-    auto result = WebCore::ImageBuffer::create(logicalSize, WebCore::RenderingPurpose::Unspecified, scale, colorSpace, pixelFormat);
+    auto result = WebCore::ImageBuffer::create(logicalSize, WebCore::RenderingPurpose::Unspecified, scale, colorSpace, convertPixelFormatValidatedToPixelFormat(pixelFormatValidated));
     RELEASE_ASSERT(result);
     return result.releaseNonNull();
 }


### PR DESCRIPTION
#### 393949a1c17caf79bfdab86b7b0a5fc9cf603ea9
<pre>
Assert hit in WebKit::RemoteImageBuffer::getShareableBitmap
<a href="https://bugs.webkit.org/show_bug.cgi?id=273285">https://bugs.webkit.org/show_bug.cgi?id=273285</a>
<a href="https://rdar.apple.com/122378565">rdar://122378565</a>

Reviewed by Alex Christensen.

The `IPC.messages.RemoteRenderingBackend_CreateImageBuffer` was able to send PixelFormat
values that are not valid and therefore caused a crash. Added an enum for only the valid
PixelFormat values so that only valid values can be sent over IPC

* LayoutTests/ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend-expected.txt: Added.
* LayoutTests/ipc/send-gpu-GetShareableBitmap-RemoteRenderingBackend.html: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::backendParameters):
* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::create):
(WebCore::ImageBuffer::pixelFormatValidated const):
(WebCore::ImageBuffer::pixelFormat const): Deleted.
* Source/WebCore/platform/graphics/PixelFormatValidated.cpp: Added.
(WebCore::convertPixelFormatToPixelFormatValidated):
(WebCore::convertPixelFormatValidatedToPixelFormat):
* Source/WebCore/platform/graphics/PixelFormatValidated.h: Added.
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::getShareableBitmap):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::isSmallLayerBacking):
(WebKit::allocateImageBufferInternal):
(WebKit::RemoteRenderingBackend::createImageBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::sinkIntoBufferForDifferentThread):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
(WebKit::RemoteImageBufferProxy::create):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::createRemoteImageBuffer):
(WebKit::RemoteRenderingBackendProxy::createDisplayListRecorder):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp:
(TestWebKitAPI::createTestImageBuffer):

Canonical link: <a href="https://commits.webkit.org/278192@main">https://commits.webkit.org/278192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2eb9fde8ea0ecd4e7d9ba746f38bfee5028f7ae7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/49784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29073 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/1993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/464 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/52088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/30 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/51884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26619 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/1993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/21744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/24057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/1993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8157 "Hash 2eb9fde8 for PR 26916 does not build (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/1993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54611 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/24878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/31 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/26138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/1993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/47039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/26993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7169 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/25866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->