### PR TITLE
[iOS 17.5 beta] Crash in WebKit::ExtensionCapabilityGrant::operator=

### DIFF
--- a/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.h
+++ b/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.h
@@ -48,7 +48,7 @@ public:
     explicit ExtensionCapabilityGrant(String environmentIdentifier);
     ~ExtensionCapabilityGrant();
 
-    ExtensionCapabilityGrant& operator=(ExtensionCapabilityGrant&&) = default;
+    ExtensionCapabilityGrant& operator=(ExtensionCapabilityGrant&&);
     ExtensionCapabilityGrant isolatedCopy() &&;
 
     const String& environmentIdentifier() const { return m_environmentIdentifier; }

--- a/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.mm
+++ b/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.mm
@@ -75,6 +75,14 @@ ExtensionCapabilityGrant::~ExtensionCapabilityGrant()
     setPlatformGrant({ });
 }
 
+ExtensionCapabilityGrant& ExtensionCapabilityGrant::operator=(ExtensionCapabilityGrant&& grant)
+{
+    platformInvalidate(m_platformGrant);
+    m_environmentIdentifier = WTFMove(grant.m_environmentIdentifier);
+    m_platformGrant = WTFMove(grant.m_platformGrant);
+    return *this;
+}
+
 ExtensionCapabilityGrant ExtensionCapabilityGrant::isolatedCopy() &&
 {
     return {


### PR DESCRIPTION
#### e63aaa4c4c289b80bfa5d86e128a11fa22dc3963
<pre>
[iOS 17.5 beta] Crash in WebKit::ExtensionCapabilityGrant::operator=
<a href="https://bugs.webkit.org/show_bug.cgi?id=272170">https://bugs.webkit.org/show_bug.cgi?id=272170</a>
<a href="https://rdar.apple.com/125984025">rdar://125984025</a>

Reviewed by Sihui Liu.

We need to invalidate the grant before deallocating it.

* Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.h:
* Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.mm:
(WebKit::ExtensionCapabilityGrant::operator=):

Canonical link: <a href="https://commits.webkit.org/277141@main">https://commits.webkit.org/277141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2577f895f0d45d4583c72702942e07b6b65577ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/25987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49504 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42874 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30397 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23453 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47406 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/22993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19442 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4872 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/41838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51377 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23123 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44391 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/23632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6560 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/22833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->