### PR TITLE
[LDM] Enforce LDM Font Policy in GPUP & avoid trusted list SFP is enabled

### DIFF
--- a/Source/WebCore/PAL/pal/cf/CoreTextSoftLink.cpp
+++ b/Source/WebCore/PAL/pal/cf/CoreTextSoftLink.cpp
@@ -27,11 +27,11 @@
 #include <pal/spi/cf/CoreTextSPI.h>
 #include <wtf/SoftLinking.h>
 
-SOFT_LINK_FRAMEWORK_FOR_SOURCE(PAL, CoreText)
+SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, CoreText, PAL_EXPORT)
 
 // FIXME: Move this to strong linking as soon as people have a chance to update to an SDK that includes it.
 SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(PAL, CoreText, CTFontCopyColorGlyphCoverage, CFBitVectorRef, (CTFontRef font), (font))
-SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE(PAL, CoreText, CTFontManagerCreateMemorySafeFontDescriptorFromData, CTFontDescriptorRef, (CFDataRef data), (data));
+SOFT_LINK_FUNCTION_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, CoreText, CTFontManagerCreateMemorySafeFontDescriptorFromData, CTFontDescriptorRef, (CFDataRef data), (data), PAL_EXPORT)
 
 SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE(PAL, OTSVG)
 

--- a/Source/WebCore/loader/cache/CachedFont.h
+++ b/Source/WebCore/loader/cache/CachedFont.h
@@ -61,7 +61,7 @@ public:
 
     virtual RefPtr<Font> createFont(const FontDescription&, bool syntheticBold, bool syntheticItalic, const FontCreationContext&);
 
-    bool didRefuseToParseCustomFont() const { return m_didRefuseToParseCustomFont; }
+    bool didRefuseToParseCustomFontWithSafeFontParser() const { return m_didRefuseToParseCustomFont; }
 
 protected:
     FontPlatformData platformDataFromCustomData(const FontDescription&, bool bold, bool italic, const FontCreationContext&);

--- a/Source/WebCore/loader/cache/CachedFontLoadRequest.h
+++ b/Source/WebCore/loader/cache/CachedFontLoadRequest.h
@@ -64,9 +64,9 @@ private:
     bool ensureCustomFontData() final
     {
         bool result = m_font->ensureCustomFontData();
-        if (!result && m_font->didRefuseToParseCustomFont()) {
+        if (!result && m_font->didRefuseToParseCustomFontWithSafeFontParser()) {
             if (RefPtr context = m_context.get()) {
-                auto message = makeString("[Lockdown Mode] This font has been blocked: ", m_font->url().string());
+                auto message = makeString("[Lockdown Mode] This font wasn't parsed: ", m_font->url().string());
                 context->addConsoleMessage(MessageSource::Security, MessageLevel::Info, message);
             }
         }

--- a/Source/WebCore/loader/cache/TrustedFonts.cpp
+++ b/Source/WebCore/loader/cache/TrustedFonts.cpp
@@ -874,16 +874,15 @@ FontParsingPolicy fontBinaryParsingPolicy(std::span<const uint8_t> data, Downloa
         return FontParsingPolicy::LoadWithSystemFontParser;
     case DownloadableBinaryFontTrustedTypes::None:
         return FontParsingPolicy::Deny;
-    case DownloadableBinaryFontTrustedTypes::Restricted:
-    case DownloadableBinaryFontTrustedTypes::FallbackParser: {
+    case DownloadableBinaryFontTrustedTypes::Restricted: {
         auto sha = hashForFontData(data);
         if (trustedFontHashesInLockdownMode().contains(sha))
             return FontParsingPolicy::LoadWithSystemFontParser;
-        if (trustedType == DownloadableBinaryFontTrustedTypes::FallbackParser)
-            return FontParsingPolicy::LoadWithSafeFontParser;
-        RELEASE_LOG(Fonts, "[Lockdown Mode] A font with a forbidden type has been blocked.");
+        RELEASE_LOG(Fonts, "[Lockdown Mode] A font with a forbidden type has been blocked from being parsed by system font parser.");
         return FontParsingPolicy::Deny;
     }
+    case DownloadableBinaryFontTrustedTypes::FallbackParser:
+        return FontParsingPolicy::LoadWithSafeFontParser;
     }
     ASSERT_NOT_REACHED();
     return FontParsingPolicy::Deny;

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -187,7 +187,9 @@ private:
     void createDisplayListRecorder(RefPtr<WebCore::ImageBuffer>, WebCore::RenderingResourceIdentifier);
     void releaseDisplayListRecorder(WebCore::RenderingResourceIdentifier);
 
+#if PLATFORM(COCOA)
     bool shouldUseLockdownFontParser() const;
+#endif
 
     Ref<IPC::StreamConnectionWorkQueue> m_workQueue;
     Ref<IPC::StreamServerConnection> m_streamConnection;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -340,6 +340,7 @@
 #include "WKStringCF.h"
 #include "WebRemoteObjectRegistry.h"
 #include <WebCore/LegacyWebArchive.h>
+#include <pal/cf/CoreTextSoftLink.h>
 #include <pal/spi/cg/ImageIOSPI.h>
 #include <wtf/MachSendRight.h>
 #include <wtf/spi/darwin/SandboxSPI.h>
@@ -4605,12 +4606,14 @@ void WebPage::adjustSettingsForLockdownMode(Settings& settings, const WebPrefere
 #if ENABLE(WEB_AUDIO)
     settings.setWebAudioEnabled(false);
 #endif
+#if PLATFORM(COCOA)
     if (settings.downloadableBinaryFontTrustedTypes() != DownloadableBinaryFontTrustedTypes::None) {
         settings.setDownloadableBinaryFontTrustedTypes(
-            settings.lockdownFontParserEnabled()
+            (settings.lockdownFontParserEnabled() && PAL::canLoad_CoreText_CTFontManagerCreateMemorySafeFontDescriptorFromData())
                 ? DownloadableBinaryFontTrustedTypes::FallbackParser
                 : DownloadableBinaryFontTrustedTypes::Restricted);
     }
+#endif
 #if ENABLE(WEB_CODECS)
     settings.setWebCodecsVideoEnabled(false);
     settings.setWebCodecsAV1Enabled(false);


### PR DESCRIPTION
#### 5b8f348c9f76a60a96c3a6ce9cd171d609c4bc77
<pre>
[LDM] Enforce LDM Font Policy in GPUP &amp; avoid trusted list SFP is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=272247">https://bugs.webkit.org/show_bug.cgi?id=272247</a>
<a href="https://rdar.apple.com/124235570">rdar://124235570</a>

Reviewed by Brent Fulgham.

If SafeFontParser is enabled we should use the SFP on both WCP and GPUP sides
and we should not parse trusted fonts with the system font parser.

When SFP is disabled we should switch to using the system parser but only
for trusted fonts, like before.

The difference after this patch is that if the SafeFontParser is enabled
we will no longer check first for trusted fonts that can be parsed
with the system font parser like before.

Canonical link: <a href="https://commits.webkit.org/277717@main">https://commits.webkit.org/277717@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afb353ecfb9410092f5a4279877863877a1e62d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44431 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25099 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25263 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22743 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6422 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52959 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/23413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24678 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/41956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10671 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/25483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->