### PR TITLE
Add scaffolding for page load observer

### DIFF
--- a/Source/WTF/wtf/cocoa/Entitlements.h
+++ b/Source/WTF/wtf/cocoa/Entitlements.h
@@ -28,12 +28,14 @@
 #if PLATFORM(COCOA)
 
 #include <wtf/Forward.h>
+#include <wtf/spi/cocoa/SecuritySPI.h>
 #include <wtf/spi/darwin/XPCSPI.h>
 
 namespace WTF {
 
 class String;
 
+WTF_EXPORT_PRIVATE bool hasEntitlement(SecTaskRef, ASCIILiteral entitlement);
 WTF_EXPORT_PRIVATE bool hasEntitlement(audit_token_t, ASCIILiteral entitlement);
 WTF_EXPORT_PRIVATE bool hasEntitlement(xpc_connection_t, StringView entitlement);
 WTF_EXPORT_PRIVATE bool hasEntitlement(xpc_connection_t, ASCIILiteral entitlement);

--- a/Source/WTF/wtf/cocoa/Entitlements.mm
+++ b/Source/WTF/wtf/cocoa/Entitlements.mm
@@ -29,12 +29,11 @@
 #import <wtf/OSObjectPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cf/TypeCastsCF.h>
-#import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/WTFString.h>
 
 namespace WTF {
 
-static bool hasEntitlement(SecTaskRef task, ASCIILiteral entitlement)
+bool hasEntitlement(SecTaskRef task, ASCIILiteral entitlement)
 {
     if (!task)
         return false;

--- a/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
+++ b/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
@@ -44,6 +44,7 @@
 
 #else
 
+#include <CoreFoundation/CoreFoundation.h>
 #include <Security/SecBase.h>
 
 #if __has_include(<Security/CSCommon.h>)

--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -87,6 +87,7 @@ extern "C" {
     M(Notifications) \
     M(PDF) \
     M(PDFAsyncRendering) \
+    M(PageLoadObserver) \
     M(PerformanceLogging) \
     M(Plugins) \
     M(Printing) \

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -688,6 +688,7 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
 
 - (WKBackForwardList *)backForwardList
 {
+    [self _didAccessBackForwardList];
     return wrapper(_page->backForwardList());
 }
 
@@ -855,19 +856,35 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
     return _page->pageLoadState().certificateInfo().trust().get();
 }
 
+- (void)_didAccessBackForwardList
+{
+    BOOL oldValue = _didAccessBackForwardList;
+    _didAccessBackForwardList = YES;
+
+#if ENABLE(PAGE_LOAD_OBSERVER)
+    if (!oldValue)
+        [self _updatePageLoadObserverState];
+#else
+    UNUSED_PARAM(oldValue);
+#endif
+}
+
 - (BOOL)canGoBack
 {
+    [self _didAccessBackForwardList];
     return _page->pageLoadState().canGoBack();
 }
 
 - (BOOL)canGoForward
 {
+    [self _didAccessBackForwardList];
     return _page->pageLoadState().canGoForward();
 }
 
 - (WKNavigation *)goBack
 {
     THROW_IF_SUSPENDED;
+    [self _didAccessBackForwardList];
     if (self._safeBrowsingWarning)
         return [self reload];
     return wrapper(_page->goBack()).autorelease();
@@ -876,6 +893,7 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
 - (WKNavigation *)goForward
 {
     THROW_IF_SUSPENDED;
+    [self _didAccessBackForwardList];
     return wrapper(_page->goForward()).autorelease();
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -36,6 +36,7 @@
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/spi/cocoa/NSObjCRuntimeSPI.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import "DynamicViewportSizeUpdate.h"
@@ -359,6 +360,12 @@ struct PerWebProcessState {
 #if PLATFORM(VISION)
     String _defaultSTSLabel;
 #endif
+
+    BOOL _didAccessBackForwardList;
+
+#if ENABLE(PAGE_LOAD_OBSERVER)
+    RetainPtr<NSString> _pendingPageLoadObserverHost;
+#endif
 }
 
 - (BOOL)_isValid;
@@ -396,6 +403,8 @@ struct PerWebProcessState {
 - (void)_clearSafeBrowsingWarningIfForMainFrameNavigation;
 
 - (std::optional<BOOL>)_resolutionForShareSheetImmediateCompletionForTesting;
+
+- (void)_didAccessBackForwardList NS_DIRECT;
 
 - (WKPageRef)_pageForTesting;
 - (NakedPtr<WebKit::WebPageProxy>)_page;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -26,6 +26,7 @@
 #import "WKBaseScrollView.h"
 #import "WKWebViewInternal.h"
 #import "_WKTapHandlingResult.h"
+#import <wtf/spi/cocoa/NSObjCRuntimeSPI.h>
 
 #if PLATFORM(IOS_FAMILY)
 
@@ -214,6 +215,11 @@ enum class TapHandlingResult : uint8_t;
 
 - (void)_overrideZoomScaleParametersWithMinimumZoomScale:(CGFloat)minimumZoomScale maximumZoomScale:(CGFloat)maximumZoomScale allowUserScaling:(BOOL)allowUserScaling;
 - (void)_clearOverrideZoomScaleParameters;
+
+#if ENABLE(PAGE_LOAD_OBSERVER)
+- (void)_updatePageLoadObserverState NS_DIRECT;
+#endif
+
 @end
 
 _WKTapHandlingResult wkTapHandlingResult(WebKit::TapHandlingResult);

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -245,6 +245,9 @@ public:
     // Return whether the view is visible.
     virtual bool isViewVisible() = 0;
 
+    // Called when the activity state of the page transitions from non-visible to visible.
+    virtual void viewIsBecomingVisible() { }
+
 #if PLATFORM(COCOA)
     virtual bool canTakeForegroundAssertions() = 0;
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6655,6 +6655,9 @@ void WebPageProxy::viewIsBecomingVisible()
     if (m_userMediaPermissionRequestManager)
         m_userMediaPermissionRequestManager->viewIsBecomingVisible();
 #endif
+
+    Ref protectedPageClient { pageClient() };
+    protectedPageClient->viewIsBecomingVisible();
 }
 
 void WebPageProxy::processIsNoLongerAssociatedWithPage(WebProcessProxy& process)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -69,6 +69,7 @@ private:
     bool isViewWindowActive() override;
     bool isViewFocused() override;
     bool isViewVisible() override;
+    void viewIsBecomingVisible() override;
     bool canTakeForegroundAssertions() override;
     bool isViewInWindow() override;
     bool isViewVisibleOrOccluded() override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -168,6 +168,14 @@ bool PageClientImpl::isViewVisible()
     return false;
 }
 
+void PageClientImpl::viewIsBecomingVisible()
+{
+#if ENABLE(PAGE_LOAD_OBSERVER)
+    if (RetainPtr webView = this->webView())
+        [webView _updatePageLoadObserverState];
+#endif
+}
+
 bool PageClientImpl::canTakeForegroundAssertions()
 {
     if (EndowmentStateTracker::singleton().isVisible()) {


### PR DESCRIPTION
#### 8b4eaddd4f17d90a968b4a45467e96c53c2924cf
<pre>
Add scaffolding for page load observer
<a href="https://bugs.webkit.org/show_bug.cgi?id=272266">https://bugs.webkit.org/show_bug.cgi?id=272266</a>
<a href="https://rdar.apple.com/125788604">rdar://125788604</a>

Reviewed by Brady Eidson.

This adds some scaffolding for a main frame page load observer object.

* Source/WTF/wtf/cocoa/Entitlements.h:
* Source/WTF/wtf/cocoa/Entitlements.mm:
(WTF::hasEntitlement):
* Source/WebKit/Platform/Logging.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView backForwardList]):
(-[WKWebView _didAccessBackForwardList]):
(-[WKWebView canGoBack]):
(-[WKWebView canGoForward]):
(-[WKWebView goBack]):
(-[WKWebView goForward]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _didCommitLoadForMainFrame]):
(-[WKWebView _frameOrBoundsMayHaveChanged]):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::viewIsBecomingVisible):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::viewIsBecomingVisible):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::viewIsBecomingVisible):

Canonical link: <a href="https://commits.webkit.org/277277@main">https://commits.webkit.org/277277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2f9fe1429834238b9adab1932463fad3bfa82c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47187 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49870 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43236 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23826 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38437 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19749 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21266 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41828 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5231 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/40455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51746 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46676 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45732 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23489 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44740 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10406 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54176 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23206 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/11119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->