### PR TITLE
[JSC] `RegExp.prototype[Symbol.matchAll]` should respect `v` flag

### DIFF
--- a/JSTests/stress/regexp-prototype-matchall-v-flag.js
+++ b/JSTests/stress/regexp-prototype-matchall-v-flag.js
@@ -1,0 +1,15 @@
+function assertSameArray(a, b) {
+    if (a.toString() !== b.toString())
+        throw new Error(`Expected ${a} but got ${b}`);
+}
+
+function doMatchAll(regex) {
+    // 𠮷 is a surrogate pair
+    const text = '𠮷a𠮷';
+    const matches = [...RegExp.prototype[Symbol.matchAll].call(regex, text)];
+    return matches.map(match => match.index);
+}
+
+assertSameArray([0, 1, 2, 3, 4, 5], doMatchAll(/(?:)/g));
+assertSameArray([0, 2, 3, 5], doMatchAll(/(?:)/gu));
+assertSameArray([0, 2, 3, 5], doMatchAll(/(?:)/gv));

--- a/Source/JavaScriptCore/builtins/RegExpPrototype.js
+++ b/Source/JavaScriptCore/builtins/RegExpPrototype.js
@@ -173,7 +173,7 @@ function matchAll(strArg)
     matcher.lastIndex = @toLength(regExp.lastIndex);
 
     var global = @stringIncludesInternal.@call(flags, "g");
-    var fullUnicode = @stringIncludesInternal.@call(flags, "u");
+    var fullUnicode = @stringIncludesInternal.@call(flags, "u") || @stringIncludesInternal.@call(flags, "v");
 
     return new @RegExpStringIterator(matcher, string, global, fullUnicode);
 }


### PR DESCRIPTION
#### 4b84428a953560574a27b3881ac06dc43ea42651
<pre>
[JSC] `RegExp.prototype[Symbol.matchAll]` should respect `v` flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=272274">https://bugs.webkit.org/show_bug.cgi?id=272274</a>

Reviewed by Alexey Shvayka.

This patch changes RegExp.prototype[Symbol.matchAll] to respect the `v` flag as well as the `u` flag.

* JSTests/stress/regexp-prototype-matchall-v-flag.js: Added.
(assertSameArray):
(doMatchAll):
* Source/JavaScriptCore/builtins/RegExpPrototype.js:
(overriddenName.string_appeared_here.matchAll):

Canonical link: <a href="https://commits.webkit.org/277160@main">https://commits.webkit.org/277160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a95f5c665259befce4c45af5c53ea4fa15ef4619

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49540 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42909 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30476 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38158 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19468 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20378 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41496 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4907 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40109 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43087 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51414 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46344 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18219 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45451 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23158 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44421 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23684 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53486 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6568 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22869 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10990 "Passed tests") | 
<!--EWS-Status-Bubble-End-->