### PR TITLE
[GTK] Correct scaling for DPI.

### DIFF
--- a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
@@ -86,6 +86,16 @@ bool screenHasInvertedColors()
 
 double fontDPI()
 {
+#if !USE(GTK4)
+    // The code in this conditionally-compiled block is needed in order to
+    // respect the GDK_DPI_SCALE setting that was present in GTK3 as an
+    // additional font scaling factor.
+    if (auto* display = gdk_display_get_default()) {
+        if (auto* screen = gdk_display_get_default_screen(display))
+            return gdk_screen_get_resolution(screen);
+    }
+#endif
+
     static GtkSettings* gtkSettings = gtk_settings_get_default();
     if (gtkSettings) {
         int gtkXftDpi;

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -86,7 +86,6 @@
 #include <wtf/text/StringBuilder.h>
 
 #if PLATFORM(GTK)
-#include "GtkSettingsManager.h"
 #include "WebKitFaviconDatabasePrivate.h"
 #include "WebKitInputMethodContextImplGtk.h"
 #include "WebKitPointerLockPermissionRequest.h"
@@ -350,8 +349,6 @@ struct _WebKitWebViewPrivate {
 
     CString defaultContentSecurityPolicy;
     WebKitWebExtensionMode webExtensionMode;
-
-    double textScaleFactor;
 
     bool isWebProcessResponsive;
 };
@@ -893,25 +890,6 @@ static void webkitWebViewConstructed(GObject* object)
 
     priv->backForwardList = adoptGRef(webkitBackForwardListCreate(&getPage(webView).backForwardList()));
     priv->windowProperties = adoptGRef(webkitWindowPropertiesCreate());
-
-#if PLATFORM(GTK)
-    double dpi = GtkSettingsManager::singleton().settingsState().xftDPI.value() / 1024.0;
-    priv->textScaleFactor = dpi / 96.;
-    getPage(webView).setTextZoomFactor(priv->textScaleFactor);
-    GtkSettingsManager::singleton().addObserver([webView](const GtkSettingsState& state) {
-        if (!state.xftDPI)
-            return;
-
-        double dpi = state.xftDPI.value() / 1024.0;
-        auto& page = getPage(webView);
-        auto zoomFactor = page.textZoomFactor() / webView->priv->textScaleFactor;
-        webView->priv->textScaleFactor = dpi / 96.;
-        page.setTextZoomFactor(zoomFactor * webView->priv->textScaleFactor);
-    }, webView);
-#else
-    priv->textScaleFactor = 1;
-#endif
-
     priv->isWebProcessResponsive = true;
 }
 
@@ -1134,10 +1112,6 @@ static void webkitWebViewDispose(GObject* object)
 
 #if PLATFORM(WPE)
     webView->priv->view->close();
-#endif
-
-#if PLATFORM(GTK)
-    GtkSettingsManager::singleton().removeObserver(webView);
 #endif
 
     G_OBJECT_CLASS(webkit_web_view_parent_class)->dispose(object);
@@ -3919,11 +3893,17 @@ void webkit_web_view_set_zoom_level(WebKitWebView* webView, gdouble zoomLevel)
     if (webkit_web_view_get_zoom_level(webView) == zoomLevel)
         return;
 
+#if PLATFORM(GTK)
+    auto [pageScale, textScale] = webkitWebViewBaseGetScaleFactors(WEBKIT_WEB_VIEW_BASE(webView));
+#else
+    const double pageScale = 1.0, textScale = 1.0;
+#endif
+
     auto& page = getPage(webView);
     if (webkit_settings_get_zoom_text_only(webView->priv->settings.get()))
-        page.setTextZoomFactor(zoomLevel * webView->priv->textScaleFactor);
+        page.setTextZoomFactor(zoomLevel * textScale);
     else
-        page.setPageZoomFactor(zoomLevel);
+        page.setPageZoomFactor(zoomLevel * pageScale);
     g_object_notify_by_pspec(G_OBJECT(webView), sObjProperties[PROP_ZOOM_LEVEL]);
 }
 
@@ -3942,9 +3922,15 @@ gdouble webkit_web_view_get_zoom_level(WebKitWebView* webView)
 {
     g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), 1);
 
+#if PLATFORM(GTK)
+    auto [pageScale, textScale] = webkitWebViewBaseGetScaleFactors(WEBKIT_WEB_VIEW_BASE(webView));
+#else
+    const double pageScale = 1.0, textScale = 1.0;
+#endif
+
     auto& page = getPage(webView);
     gboolean zoomTextOnly = webkit_settings_get_zoom_text_only(webView->priv->settings.get());
-    return zoomTextOnly ? page.textZoomFactor() / webView->priv->textScaleFactor : page.pageZoomFactor();
+    return zoomTextOnly ? page.textZoomFactor() / textScale : page.pageZoomFactor() / pageScale;
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -48,6 +48,10 @@
 
 WebKitWebViewBase* webkitWebViewBaseCreate(const API::PageConfiguration&);
 WebKit::WebPageProxy* webkitWebViewBaseGetPage(WebKitWebViewBase*);
+struct WebKitWebViewBaseScaleFactors {
+    double pageScale, textScale;
+};
+WebKitWebViewBaseScaleFactors webkitWebViewBaseGetScaleFactors(WebKitWebViewBase*);
 void webkitWebViewBaseCreateWebPage(WebKitWebViewBase*, Ref<API::PageConfiguration>&&);
 void webkitWebViewBaseSetTooltipText(WebKitWebViewBase*, const char*);
 void webkitWebViewBaseSetTooltipArea(WebKitWebViewBase*, const WebCore::IntRect&);


### PR DESCRIPTION
#### 69ad530f10603697a1c53b063840abc8ba7d9efe
<pre>
[GTK] Correct scaling for DPI.
<a href="https://bugs.webkit.org/show_bug.cgi?id=247980">https://bugs.webkit.org/show_bug.cgi?id=247980</a>

Reviewed by NOBODY (OOPS!).

Move the scaling factor formerly in WebKitWebView.cpp (responsive to
the xft-dpi setting) into WebKitWebViewBase.cpp, and split it into two
scaling factors. The first, a page scaling factor, uses screenDPI to
ensure that a length specified by a CSS unit of 1in will appear on the
screen as one physical inch. The second, a text scaling factor, ensures
that text specified as 96px in size will have a height on-screen as
specified by fontDPI (which is primarily driven by the xft-dpi setting),
in terms of the number of screen pixels taken up.

The two scaling factors are refreshed when any one of the inputs for
computing them changes: the GDK_SCALE factor, the xft-dpi setting, or
the screenDPI of the device it is displayed on (say by being dragged
to a different monitor). Throughout, at the default zoom level, a CSS
1in dimension is kept at one physical inch.

The scale factors are kept internal to WebKitWebViewBase (which helps
keep GTK dependencies grouped and reduces the total code in WebKitWebView
enclosed in `#ifdef PLATFORM(GTK)`) but made available to WebKitWebView
so that its external interfaces can maintain zoom level 1 as the default
zoom level, and zoom in and out from there.

So indeed, if a user of WebKitWebView asks for a zoom level of 1.5, a
length specified in CSS as 1in will then occupy one and a half physical
inches on screen.

* Source/WebCore/platform/gtk/PlatformScreenGtk.cpp:
(WebCore::fontDPI):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewConstructed):
(webkitWebViewDispose):
(webkit_web_view_set_zoom_level):
(webkit_web_view_get_zoom_level):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(_WebKitWebViewBasePrivate::_WebKitWebViewBasePrivate):
(refreshInternalScaling):
(webkitWebViewBaseUpdateDisplayID):
(webkitWebViewBaseDispose):
(webkitWebViewBaseGetScaleFactors):
(deviceScaleFactorChanged):
(webkitWebViewBaseCreateWebPage):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69ad530f10603697a1c53b063840abc8ba7d9efe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52822 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/256 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51884 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26485 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/40474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26400 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/42706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/21589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/23853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43888 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7951 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/45771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54399 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24665 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/20846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/47845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/25934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/46869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10881 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26778 "Built successfully") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25658 "Failed to checkout and rebase branch from PR 26938") | | | 
<!--EWS-Status-Bubble-End-->