### PR TITLE
Add smart pointers to ARIAGrid

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp
@@ -65,7 +65,7 @@ AccessibilityTable* AccessibilityARIAGridCell::parentTable() const
     // including rows and interactive rowgroups. In addition, poorly-formed grids may contain elements
     // which pass the tests for inclusion.
     return dynamicDowncast<AccessibilityTable>(Accessibility::findAncestor<AccessibilityObject>(*this, false, [] (const auto& ancestor) {
-        auto* ancestorTable = dynamicDowncast<AccessibilityTable>(ancestor);
+        RefPtr ancestorTable = dynamicDowncast<AccessibilityTable>(ancestor);
         return ancestorTable && ancestorTable->isExposable() && !ancestorTable->accessibilityIsIgnored();
     }));
 }
@@ -77,7 +77,7 @@ String AccessibilityARIAGridCell::readOnlyValue() const
 
     // ARIA 1.1 requires user agents to propagate the grid's aria-readonly value to all
     // gridcell elements if the property is not present on the gridcell element itelf.
-    if (auto* parent = parentTable())
+    if (RefPtr parent = parentTable())
         return parent->readOnlyValue();
 
     return String();

--- a/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
+++ b/Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp
@@ -58,7 +58,7 @@ Ref<AccessibilityARIAGridRow> AccessibilityARIAGridRow::create(Node& node)
 
 bool AccessibilityARIAGridRow::isARIATreeGridRow() const
 {
-    AccessibilityObject* parent = parentTable();
+    RefPtr parent = parentTable();
     if (!parent)
         return false;
     
@@ -70,7 +70,7 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityARIAGridRow::disclosedRow
     AccessibilityChildrenVector disclosedRows;
     // The contiguous disclosed rows will be the rows in the table that 
     // have an aria-level of plus 1 from this row.
-    AccessibilityObject* parent = parentObjectUnignored();
+    RefPtr parent = parentObjectUnignored();
     if (auto* axTable = dynamicDowncast<AccessibilityTable>(*parent); !axTable || !axTable->isExposable())
         return disclosedRows;
 
@@ -84,7 +84,7 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityARIAGridRow::disclosedRow
     auto allRows = parent->rows();
     int rowCount = allRows.size();
     for (int k = index + 1; k < rowCount; ++k) {
-        auto* row = allRows[k].get();
+        RefPtr row = allRows[k].get();
         // Stop at the first row that doesn't match the correct level.
         if (row->hierarchicalLevel() != level + 1)
             break;
@@ -99,7 +99,7 @@ AXCoreObject* AccessibilityARIAGridRow::disclosedByRow() const
 {
     // The row that discloses this one is the row in the table
     // that is aria-level subtract 1 from this row.
-    AccessibilityObject* parent = parentObjectUnignored();
+    RefPtr parent = parentObjectUnignored();
     if (auto* axTable = dynamicDowncast<AccessibilityTable>(*parent); !axTable || !axTable->isExposable())
         return nullptr;
 


### PR DESCRIPTION
#### edf48c09af2496a259ac86b3b97633b510245b42
<pre>
Add smart pointers to ARIAGrid
<a href="https://bugs.webkit.org/show_bug.cgi?id=272282">https://bugs.webkit.org/show_bug.cgi?id=272282</a>
<a href="https://rdar.apple.com/126025723">rdar://126025723</a>

Reviewed by Chris Dumez.

* Source/WebCore/accessibility/AccessibilityARIAGridCell.cpp:
(WebCore::AccessibilityARIAGridCell::parentTable const):
(WebCore::AccessibilityARIAGridCell::readOnlyValue const):
* Source/WebCore/accessibility/AccessibilityARIAGridRow.cpp:
(WebCore::AccessibilityARIAGridRow::isARIATreeGridRow const):
(WebCore::AccessibilityARIAGridRow::disclosedRows):
(WebCore::AccessibilityARIAGridRow::disclosedByRow const):

Canonical link: <a href="https://commits.webkit.org/277217@main">https://commits.webkit.org/277217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02869776a61bbcebd3cd295bc723042f559c280d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49563 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42931 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23512 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38176 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19486 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41517 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4929 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51437 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45470 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23180 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44443 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10384 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23773 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22891 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->