### PR TITLE
Use std::span more in TextCodecUTF8

### DIFF
--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp
@@ -66,7 +66,7 @@ void TextCodecUTF8::registerCodecs(TextCodecRegistrar registrar)
     });
 }
 
-static inline int nonASCIISequenceLength(uint8_t firstByte)
+static inline uint8_t nonASCIISequenceLength(uint8_t firstByte)
 {
     static const uint8_t lengths[256] = {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -89,7 +89,7 @@ static inline int nonASCIISequenceLength(uint8_t firstByte)
     return lengths[firstByte];
 }
 
-static inline int decodeNonASCIISequence(const uint8_t* sequence, int& length)
+static inline int decodeNonASCIISequence(const uint8_t* sequence, uint8_t& length)
 {
     ASSERT(!isASCII(sequence[0]));
     if (length == 2) {
@@ -181,7 +181,7 @@ void TextCodecUTF8::consumePartialSequenceByte()
     memmove(m_partialSequence, m_partialSequence + 1, m_partialSequenceSize);
 }
 
-bool TextCodecUTF8::handlePartialSequence(LChar*& destination, const uint8_t*& source, const uint8_t* end, bool flush)
+bool TextCodecUTF8::handlePartialSequence(LChar*& destination, std::span<const uint8_t>& source, bool flush)
 {
     ASSERT(m_partialSequenceSize);
     do {
@@ -190,15 +190,15 @@ bool TextCodecUTF8::handlePartialSequence(LChar*& destination, const uint8_t*& s
             consumePartialSequenceByte();
             continue;
         }
-        int count = nonASCIISequenceLength(m_partialSequence[0]);
+        auto count = nonASCIISequenceLength(m_partialSequence[0]);
         if (!count)
             return true;
 
         // Copy from `source` until we have `count` bytes.
-        if (count > m_partialSequenceSize && end > source) {
-            size_t additionalBytes = std::min<size_t>(count - m_partialSequenceSize, end - source);
-            memcpy(m_partialSequence + m_partialSequenceSize, source, additionalBytes);
-            source += additionalBytes;
+        if (count > m_partialSequenceSize && !source.empty()) {
+            size_t additionalBytes = std::min<size_t>(count - m_partialSequenceSize, source.size());
+            memcpy(m_partialSequence + m_partialSequenceSize, source.data(), additionalBytes);
+            source = source.subspan(additionalBytes);
             m_partialSequenceSize += additionalBytes;
         }
 
@@ -232,7 +232,7 @@ bool TextCodecUTF8::handlePartialSequence(LChar*& destination, const uint8_t*& s
     return false;
 }
 
-void TextCodecUTF8::handlePartialSequence(UChar*& destination, const uint8_t*& source, const uint8_t* end, bool flush, bool stopOnError, bool& sawError)
+void TextCodecUTF8::handlePartialSequence(UChar*& destination, std::span<const uint8_t>& source, bool flush, bool stopOnError, bool& sawError)
 {
     ASSERT(m_partialSequenceSize);
     do {
@@ -241,7 +241,7 @@ void TextCodecUTF8::handlePartialSequence(UChar*& destination, const uint8_t*& s
             consumePartialSequenceByte();
             continue;
         }
-        int count = nonASCIISequenceLength(m_partialSequence[0]);
+        auto count = nonASCIISequenceLength(m_partialSequence[0]);
         if (!count) {
             sawError = true;
             if (stopOnError)
@@ -252,10 +252,10 @@ void TextCodecUTF8::handlePartialSequence(UChar*& destination, const uint8_t*& s
         }
 
         // Copy from `source` until we have `count` bytes.
-        if (count > m_partialSequenceSize && end > source) {
-            size_t additionalBytes = std::min<size_t>(count - m_partialSequenceSize, end - source);
-            memcpy(m_partialSequence + m_partialSequenceSize, source, additionalBytes);
-            source += additionalBytes;
+        if (count > m_partialSequenceSize && !source.empty()) {
+            size_t additionalBytes = std::min<size_t>(count - m_partialSequenceSize, source.size());
+            memcpy(m_partialSequence + m_partialSequenceSize, source.data(), additionalBytes);
+            source = source.subspan(additionalBytes);
             m_partialSequenceSize += additionalBytes;
         }
 
@@ -303,9 +303,8 @@ String TextCodecUTF8::decode(std::span<const uint8_t> bytes, bool flush, bool st
     // each byte in an invalid sequence will turn into a replacement character.
     StringBuffer<LChar> buffer(m_partialSequenceSize + bytes.size());
 
-    const uint8_t* source = bytes.data();
-    const uint8_t* end = source + bytes.size();
-    const uint8_t* alignedEnd = WTF::alignToMachineWord(end);
+    auto source = bytes;
+    auto* alignedEnd = WTF::alignToMachineWord(bytes.data() + bytes.size());
     LChar* destination = buffer.characters();
 
     do {
@@ -314,51 +313,49 @@ String TextCodecUTF8::decode(std::span<const uint8_t> bytes, bool flush, bool st
             // local variables, which may harm code generation by disabling some optimizations
             // in some compilers.
             LChar* destinationForHandlePartialSequence = destination;
-            const uint8_t* sourceForHandlePartialSequence = source;
-            if (handlePartialSequence(destinationForHandlePartialSequence, sourceForHandlePartialSequence, end, flush)) {
-                source = sourceForHandlePartialSequence;
+            if (handlePartialSequence(destinationForHandlePartialSequence, source, flush)) {
                 goto upConvertTo16Bit;
             }
             destination = destinationForHandlePartialSequence;
-            source = sourceForHandlePartialSequence;
             if (m_partialSequenceSize)
                 break;
         }
 
-        while (source < end) {
-            if (isASCII(*source)) {
+        while (!source.empty()) {
+            if (isASCII(source.front())) {
                 // Fast path for ASCII. Most UTF-8 text will be ASCII.
-                if (WTF::isAlignedToMachineWord(source)) {
-                    while (source < alignedEnd) {
-                        auto chunk = *reinterpret_cast_ptr<const WTF::MachineWord*>(source);
+                if (WTF::isAlignedToMachineWord(source.data())) {
+                    while (source.data() < alignedEnd) {
+                        auto chunk = *reinterpret_cast_ptr<const WTF::MachineWord*>(source.data());
                         if (!WTF::containsOnlyASCII<LChar>(chunk))
                             break;
-                        copyASCIIMachineWord(destination, source);
-                        source += sizeof(WTF::MachineWord);
+                        copyASCIIMachineWord(destination, source.data());
+                        source = source.subspan(sizeof(WTF::MachineWord));
                         destination += sizeof(WTF::MachineWord);
                     }
-                    if (source == end)
+                    if (source.empty())
                         break;
-                    if (!isASCII(*source))
+                    if (!isASCII(source.front()))
                         continue;
                 }
-                *destination++ = *source++;
+                *destination++ = source.front();
+                source = source.subspan(1);
                 continue;
             }
-            int count = nonASCIISequenceLength(*source);
+            auto count = nonASCIISequenceLength(source.front());
             int character;
             if (!count)
                 character = nonCharacter;
             else {
-                if (count > end - source) {
-                    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(end - source < static_cast<ptrdiff_t>(sizeof(m_partialSequence)));
+                if (count > source.size()) {
+                    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(source.size() < static_cast<ptrdiff_t>(sizeof(m_partialSequence)));
                     ASSERT(!m_partialSequenceSize);
-                    m_partialSequenceSize = end - source;
-                    memcpy(m_partialSequence, source, m_partialSequenceSize);
-                    source = end;
+                    m_partialSequenceSize = source.size();
+                    memcpy(m_partialSequence, source.data(), m_partialSequenceSize);
+                    source = { };
                     break;
                 }
-                character = decodeNonASCIISequence(source, count);
+                character = decodeNonASCIISequence(source.data(), count);
             }
             if (character == nonCharacter) {
                 sawError = true;
@@ -370,7 +367,7 @@ String TextCodecUTF8::decode(std::span<const uint8_t> bytes, bool flush, bool st
             if (!isLatin1(character))
                 goto upConvertTo16Bit;
 
-            source += count;
+            source = source.subspan(count);
             *destination++ = character;
         }
     } while (m_partialSequenceSize);
@@ -397,58 +394,57 @@ upConvertTo16Bit:
             // local variables, which may harm code generation by disabling some optimizations
             // in some compilers.
             UChar* destinationForHandlePartialSequence = destination16;
-            const uint8_t* sourceForHandlePartialSequence = source;
-            handlePartialSequence(destinationForHandlePartialSequence, sourceForHandlePartialSequence, end, flush, stopOnError, sawError);
+            handlePartialSequence(destinationForHandlePartialSequence, source, flush, stopOnError, sawError);
             destination16 = destinationForHandlePartialSequence;
-            source = sourceForHandlePartialSequence;
             if (m_partialSequenceSize)
                 break;
         }
 
-        while (source < end) {
-            if (isASCII(*source)) {
+        while (!source.empty()) {
+            if (isASCII(source.front())) {
                 // Fast path for ASCII. Most UTF-8 text will be ASCII.
-                if (WTF::isAlignedToMachineWord(source)) {
-                    while (source < alignedEnd) {
-                        auto chunk = *reinterpret_cast_ptr<const WTF::MachineWord*>(source);
+                if (WTF::isAlignedToMachineWord(source.data())) {
+                    while (source.data() < alignedEnd) {
+                        auto chunk = *reinterpret_cast_ptr<const WTF::MachineWord*>(source.data());
                         if (!WTF::containsOnlyASCII<LChar>(chunk))
                             break;
-                        copyASCIIMachineWord(destination16, source);
-                        source += sizeof(WTF::MachineWord);
+                        copyASCIIMachineWord(destination16, source.data());
+                        source = source.subspan(sizeof(WTF::MachineWord));
                         destination16 += sizeof(WTF::MachineWord);
                     }
-                    if (source == end)
+                    if (source.empty())
                         break;
-                    if (!isASCII(*source))
+                    if (!isASCII(source.front()))
                         continue;
                 }
-                *destination16++ = *source++;
+                *destination16++ = source.front();
+                source = source.subspan(1);
                 continue;
             }
-            int count = nonASCIISequenceLength(*source);
+            auto count = nonASCIISequenceLength(source.front());
             int character;
             if (!count)
                 character = nonCharacter;
             else {
-                if (count > end - source) {
-                    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(end - source < static_cast<ptrdiff_t>(sizeof(m_partialSequence)));
+                if (count > source.size()) {
+                    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(source.size() < static_cast<ptrdiff_t>(sizeof(m_partialSequence)));
                     ASSERT(!m_partialSequenceSize);
-                    m_partialSequenceSize = end - source;
-                    memcpy(m_partialSequence, source, m_partialSequenceSize);
-                    source = end;
+                    m_partialSequenceSize = source.size();
+                    memcpy(m_partialSequence, source.data(), m_partialSequenceSize);
+                    source = { };
                     break;
                 }
-                character = decodeNonASCIISequence(source, count);
+                character = decodeNonASCIISequence(source.data(), count);
             }
             if (character == nonCharacter) {
                 sawError = true;
                 if (stopOnError)
                     break;
                 *destination16++ = replacementCharacter;
-                source += count ? count : 1;
+                source = source.subspan(count ? count : 1);
                 continue;
             }
-            source += count;
+            source = source.subspan(count);
             if (character == byteOrderMark && destination16 == buffer16.characters() && std::exchange(m_shouldStripByteOrderMark, false))
                 continue;
             destination16 = appendCharacter(destination16, character);

--- a/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
+++ b/Source/WebCore/PAL/pal/text/TextCodecUTF8.h
@@ -44,8 +44,8 @@ private:
     String decode(std::span<const uint8_t>, bool flush, bool stopOnError, bool& sawError) final;
     Vector<uint8_t> encode(StringView, UnencodableHandling) const final;
 
-    bool handlePartialSequence(LChar*& destination, const uint8_t*& source, const uint8_t* end, bool flush);
-    void handlePartialSequence(UChar*& destination, const uint8_t*& source, const uint8_t* end, bool flush, bool stopOnError, bool& sawError);
+    bool handlePartialSequence(LChar*& destination, std::span<const uint8_t>& source, bool flush);
+    void handlePartialSequence(UChar*& destination, std::span<const uint8_t>& source, bool flush, bool stopOnError, bool& sawError);
     void consumePartialSequenceByte();
 
     int m_partialSequenceSize { 0 };


### PR DESCRIPTION
#### 962ef529cf07bf3ef44a329e8842e450e735b612
<pre>
Use std::span more in TextCodecUTF8
<a href="https://bugs.webkit.org/show_bug.cgi?id=272281">https://bugs.webkit.org/show_bug.cgi?id=272281</a>

Reviewed by Darin Adler.

* Source/WebCore/PAL/pal/text/TextCodecUTF8.cpp:
(PAL::nonASCIISequenceLength):
(PAL::decodeNonASCIISequence):
(PAL::TextCodecUTF8::handlePartialSequence):
(PAL::TextCodecUTF8::decode):
* Source/WebCore/PAL/pal/text/TextCodecUTF8.h:

Canonical link: <a href="https://commits.webkit.org/277172@main">https://commits.webkit.org/277172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd83da8c917ae81faf71437a1614278b7e5afab2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49511 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49564 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42932 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23513 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38178 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23194 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19488 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20526 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41518 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4930 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43143 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51438 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45472 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23181 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44445 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23774 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6573 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->