### PR TITLE
Remove StringBuilder::appendCharacters, use std::span more

### DIFF
--- a/Source/JavaScriptCore/runtime/ConfigFile.cpp
+++ b/Source/JavaScriptCore/runtime/ConfigFile.cpp
@@ -315,7 +315,7 @@ void ConfigFile::parse()
                     while (*p && !isUnicodeCompatibleASCIIWhitespace(*p) && *p != '=')
                         p++;
 
-                    builder.appendCharacters(optionNameStart, p - optionNameStart);
+                    builder.append(std::span { optionNameStart, p });
 
                     while (*p && isUnicodeCompatibleASCIIWhitespace(*p) && *p != '=')
                         p++;

--- a/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h
@@ -238,7 +238,7 @@ void appendNumberFormatDigitOptionsToSkeleton(IntlType* intlInstance, StringBuil
             skeletonBuilder.append("0.");
             for (unsigned i = 0; i < (intlInstance->m_maximumFractionDigits - string.size()); ++i)
                 skeletonBuilder.append('0');
-            skeletonBuilder.appendCharacters(string.data(), string.size());
+            skeletonBuilder.append(string);
         } else {
             unsigned nonFraction = string.size() - intlInstance->m_maximumFractionDigits;
             skeletonBuilder.append(std::span(string.data(), nonFraction), '.', std::span(string.data() + nonFraction, intlInstance->m_maximumFractionDigits));

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -900,12 +900,12 @@ TokenType LiteralParser<CharType>::Lexer::lexStringSlow(LiteralParserToken<CharT
         }
 
         if (!m_builder.isEmpty())
-            m_builder.appendCharacters(runStart, m_ptr - runStart);
+            m_builder.append(std::span { runStart, m_ptr });
 
 slowPathBegin:
         if ((m_mode != SloppyJSON) && m_ptr < m_end && *m_ptr == '\\') {
             if (m_builder.isEmpty() && runStart < m_ptr)
-                m_builder.appendCharacters(runStart, m_ptr - runStart);
+                m_builder.append(std::span { runStart, m_ptr });
             ++m_ptr;
             if (m_ptr >= m_end) {
                 m_lexErrorMessage = "Unterminated string"_s;

--- a/Source/JavaScriptCore/tools/FunctionOverrides.cpp
+++ b/Source/JavaScriptCore/tools/FunctionOverrides.cpp
@@ -235,7 +235,7 @@ static String parseClause(const char* keyword, size_t keywordLength, FILE* file,
             if (p[strlen(terminator)] != '\n')
                 FAIL_WITH_ERROR(SYNTAX_ERROR, ("Unexpected characters after '", keyword, "' clause end delimiter '", delimiter, "':\n", line, "\n"));
 
-            builder.appendCharacters(line, p - line + 1);
+            builder.append(std::span { line, p + 1 });
             return builder.toString();
         }
         builder.append(line);

--- a/Source/WTF/wtf/text/StringBuilder.cpp
+++ b/Source/WTF/wtf/text/StringBuilder.cpp
@@ -149,7 +149,7 @@ UChar* StringBuilder::extendBufferForAppendingWithUpconvert(unsigned requiredLen
     return extendBufferForAppending<UChar>(requiredLength);
 }
 
-void StringBuilder::appendCharacters(std::span<const UChar> characters)
+void StringBuilder::append(std::span<const UChar> characters)
 {
     if (characters.empty() || hasOverflowed())
         return;
@@ -162,7 +162,7 @@ void StringBuilder::appendCharacters(std::span<const UChar> characters)
         StringImpl::copyCharacters(destination, characters);
 }
 
-void StringBuilder::appendCharacters(std::span<const LChar> characters)
+void StringBuilder::append(std::span<const LChar> characters)
 {
     if (characters.empty() || hasOverflowed())
         return;

--- a/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecICU.cpp
@@ -235,8 +235,8 @@ String TextCodecICU::decode(std::span<const uint8_t> bytes, bool flush, bool sto
     UErrorCode err = U_ZERO_ERROR;
 
     do {
-        int ucharsDecoded = decodeToBuffer(buffer, bufferLimit, source, sourceLimit, offsets, flush, err);
-        result.appendCharacters(buffer, ucharsDecoded);
+        size_t ucharsDecoded = decodeToBuffer(buffer, bufferLimit, source, sourceLimit, offsets, flush, err);
+        result.append(std::span { buffer, ucharsDecoded });
     } while (needsToGrowToProduceBuffer(err));
 
     if (U_FAILURE(err)) {

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -63,21 +63,20 @@ namespace WebCore {
 using namespace HTMLNames;
 
 struct EntityDescription {
-    const char* characters;
-    uint8_t length;
+    ASCIILiteral characters;
     std::optional<EntityMask> mask;
 };
 
-static const EntityDescription entitySubstitutionList[] = {
-    { "", 0, std::nullopt },
-    { "&amp;", 5, EntityMask::Amp },
-    { "&lt;", 4, EntityMask::Lt },
-    { "&gt;", 4, EntityMask::Gt },
-    { "&quot;", 6, EntityMask::Quot },
-    { "&nbsp;", 6, EntityMask::Nbsp },
-    { "&#9;", 4, EntityMask::Tab },
-    { "&#10;", 5, EntityMask::LineFeed },
-    { "&#13;", 5, EntityMask::CarriageReturn },
+constexpr EntityDescription entitySubstitutionList[] = {
+    { ""_s, std::nullopt },
+    { "&amp;"_s, EntityMask::Amp },
+    { "&lt;"_s, EntityMask::Lt },
+    { "&gt;"_s, EntityMask::Gt },
+    { "&quot;"_s, EntityMask::Quot },
+    { "&nbsp;"_s, EntityMask::Nbsp },
+    { "&#9;"_s, EntityMask::Tab },
+    { "&#10;"_s, EntityMask::LineFeed },
+    { "&#13;"_s, EntityMask::CarriageReturn },
 };
 
 namespace EntitySubstitutionIndex {
@@ -174,7 +173,7 @@ static inline void appendCharactersReplacingEntitiesInternal(StringBuilder& resu
         uint8_t substitution = character < std::size(entityMap) ? entityMap[character] : static_cast<uint8_t>(EntitySubstitutionIndex::Null);
         if (UNLIKELY(substitution != EntitySubstitutionIndex::Null) && entityMask.contains(*entitySubstitutionList[substitution].mask)) {
             result.appendSubstring(source, offset + positionAfterLastEntity, i - positionAfterLastEntity);
-            result.appendCharacters(entitySubstitutionList[substitution].characters, entitySubstitutionList[substitution].length);
+            result.append(entitySubstitutionList[substitution].characters);
             positionAfterLastEntity = i + 1;
         }
     }

--- a/Source/WebCore/platform/text/SegmentedString.cpp
+++ b/Source/WebCore/platform/text/SegmentedString.cpp
@@ -28,9 +28,9 @@ namespace WebCore {
 inline void SegmentedString::Substring::appendTo(StringBuilder& builder) const
 {
     if (is8Bit)
-        builder.appendCharacters(currentCharacter8, length);
+        builder.append(std::span { currentCharacter8, length });
     else
-        builder.appendCharacters(currentCharacter16, length);
+        builder.append(std::span { currentCharacter16, length });
 }
 
 SegmentedString& SegmentedString::operator=(SegmentedString&& other)

--- a/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp
@@ -68,7 +68,7 @@ TEST(StringBuilderTest, Append)
     expectBuilderContent("0123456789"_s, builder);
     builder.append("abcd");
     expectBuilderContent("0123456789abcd"_s, builder);
-    builder.appendCharacters("efgh", 3);
+    builder.append(std::span { reinterpret_cast<const LChar*>("efgh"), 3 });
     expectBuilderContent("0123456789abcdefg"_s, builder);
     builder.append("");
     expectBuilderContent("0123456789abcdefg"_s, builder);
@@ -77,11 +77,11 @@ TEST(StringBuilderTest, Append)
 
     builder.toString(); // Test after reifyString().
     StringBuilder builder1;
-    builder.appendCharacters("", 0);
+    builder.append(""_span);
     expectBuilderContent("0123456789abcdefg#"_s, builder);
-    builder1.appendCharacters(builder.characters8(), builder.length());
+    builder1.append(builder.span<LChar>());
     builder1.append("XYZ");
-    builder.appendCharacters(builder1.characters8(), builder1.length());
+    builder.append(builder1.span<LChar>());
     expectBuilderContent("0123456789abcdefg#0123456789abcdefg#XYZ"_s, builder);
 
     StringBuilder builder2;
@@ -108,12 +108,12 @@ TEST(StringBuilderTest, Append)
         StringBuilder builder2;
         char32_t frakturAChar = 0x1D504;
         const UChar data[] = { U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar) };
-        builder2.appendCharacters(data, 2);
+        builder2.append(std::span { data });
         EXPECT_EQ(2U, builder2.length());
         String result2 = builder2.toString();
         EXPECT_EQ(2U, result2.length());
         builder.append(builder2);
-        builder.appendCharacters(data, 2);
+        builder.append(std::span { data });
         EXPECT_EQ(4U, builder.length());
         const UChar resultArray[] = { U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar), U16_LEAD(frakturAChar), U16_TRAIL(frakturAChar) };
         expectBuilderContent(String({ resultArray, std::size(resultArray) }), builder);
@@ -409,7 +409,7 @@ TEST(StringBuilderTest, ToAtomStringOnEmpty)
     }
     { // AtomString constructed from an empty char* string.
         StringBuilder builder;
-        builder.appendCharacters("", 0);
+        builder.append(""_span);
         AtomString atomString = builder.toAtomString();
         EXPECT_EQ(emptyAtom(), atomString);
     }


### PR DESCRIPTION
#### 6e624ea204dd94f6d49d7d788f51ae17bd2d419d
<pre>
Remove StringBuilder::appendCharacters, use std::span more
<a href="https://bugs.webkit.org/show_bug.cgi?id=272284">https://bugs.webkit.org/show_bug.cgi?id=272284</a>
<a href="https://rdar.apple.com/problem/126026642">rdar://problem/126026642</a>

Reviewed by Chris Dumez.

No need for a separate name appendCharacters now that we can append a
run of characters with a single argument, a span.

* Source/JavaScriptCore/runtime/ConfigFile.cpp:
(JSC::ConfigFile::parse): Use append(span) instead of
appendCharacters(pointer, length).
* Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h:
(JSC::appendNumberFormatDigitOptionsToSkeleton): Ditto.
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lexStringSlow): Ditto.
* Source/JavaScriptCore/tools/FunctionOverrides.cpp:
(JSC::parseClause): Ditto.

* Source/WTF/wtf/text/StringBuilder.cpp:
(WTF::StringBuilder::append): Renamed from appendCharacters.

* Source/WTF/wtf/text/StringBuilder.h: Renamed appendCharacters to
append, deleted the overloads that took a separate pointer and length.
Updated all the callers in the inline functions.

* Source/WebCore/PAL/pal/text/TextCodecICU.cpp:
(PAL::TextCodecICU::decode): Use append(span) instead of
appendCharacters(pointer, length).

* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::appendCharactersReplacingEntitiesInternal): Use
append(ASCIILiteral) instead of appendCharacters(pointer, length)

* Source/WebCore/platform/text/SegmentedString.cpp:
(WebCore::SegmentedString::Substring::appendTo const): Use append(span)
instead of appendCharacters(pointer, length).
* Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp:
(TestWebKitAPI::TEST(StringBuilderTest, Append)): Ditto.
(TestWebKitAPI::TEST(StringBuilderTest, ToAtomStringOnEmpty)): Ditto.

Canonical link: <a href="https://commits.webkit.org/277176@main">https://commits.webkit.org/277176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b09695061cf6d8e04154a7c30e8a9fe073b4c932

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49581 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38193 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19503 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41529 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4946 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40149 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43174 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51454 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46383 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45485 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23197 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44461 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10358 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23810 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53525 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22908 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11002 "Passed tests") | 
<!--EWS-Status-Bubble-End-->