### PR TITLE
Finish porting StringImpl to std::span

### DIFF
--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -248,12 +248,12 @@ inline bool Identifier::equal(const StringImpl* r, const LChar* s)
 
 inline bool Identifier::equal(const StringImpl* r, const LChar* s, unsigned length)
 {
-    return WTF::equal(r, s, length);
+    return WTF::equal(r, { s, length });
 }
 
 inline bool Identifier::equal(const StringImpl* r, const UChar* s, unsigned length)
 {
-    return WTF::equal(r, s, length);
+    return WTF::equal(r, { s, length });
 }
 
 ALWAYS_INLINE std::optional<uint32_t> parseIndex(const Identifier& identifier)

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -87,12 +87,12 @@ public:
     bool contains(StringView) const;
     bool containsIgnoringASCIICase(StringView) const;
 
-    size_t find(UChar character, unsigned start = 0) const { return m_string.find(character, start); }
-    size_t find(ASCIILiteral literal, unsigned start = 0) const { return m_string.find(literal, start); }
-    size_t find(StringView, unsigned start = 0) const;
+    size_t find(UChar character, size_t start = 0) const { return m_string.find(character, start); }
+    size_t find(ASCIILiteral literal, size_t start = 0) const { return m_string.find(literal, start); }
+    size_t find(StringView, size_t start = 0) const;
     size_t findIgnoringASCIICase(StringView) const;
-    size_t findIgnoringASCIICase(StringView, unsigned start) const;
-    size_t find(CodeUnitMatchFunction matchFunction, unsigned start = 0) const { return m_string.find(matchFunction, start); }
+    size_t findIgnoringASCIICase(StringView, size_t start) const;
+    size_t find(CodeUnitMatchFunction matchFunction, size_t start = 0) const { return m_string.find(matchFunction, start); }
 
     bool startsWith(StringView) const;
     bool startsWithIgnoringASCIICase(StringView) const;
@@ -151,7 +151,7 @@ static_assert(sizeof(AtomString) == sizeof(String), "AtomString and String must 
 
 inline bool operator==(const AtomString& a, const AtomString& b) { return a.impl() == b.impl(); }
 inline bool operator==(const AtomString& a, ASCIILiteral b) { return WTF::equal(a.impl(), b); }
-inline bool operator==(const AtomString& a, const Vector<UChar>& b) { return a.impl() && equal(a.impl(), b.data(), b.size()); }    
+inline bool operator==(const AtomString& a, const Vector<UChar>& b) { return a.impl() && equal(a.impl(), b.span()); }
 inline bool operator==(const AtomString& a, const String& b) { return equal(a.impl(), b.impl()); }
 inline bool operator==(const String& a, const AtomString& b) { return equal(a.impl(), b.impl()); }
 inline bool operator==(const Vector<UChar>& a, const AtomString& b) { return b == a; }

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -226,7 +226,7 @@ struct SubstringTranslator8 : SubstringTranslator {
 
     static bool equal(AtomStringTable::StringEntry const& string, const SubstringLocation& buffer)
     {
-        return WTF::equal(string.get(), buffer.baseString->characters8() + buffer.start, buffer.length);
+        return WTF::equal(string.get(), buffer.baseString->span8().subspan(buffer.start, buffer.length));
     }
 };
 
@@ -238,7 +238,7 @@ struct SubstringTranslator16 : SubstringTranslator {
 
     static bool equal(AtomStringTable::StringEntry const& string, const SubstringLocation& buffer)
     {
-        return WTF::equal(string.get(), buffer.baseString->characters16() + buffer.start, buffer.length);
+        return WTF::equal(string.get(), buffer.baseString->span16().subspan(buffer.start, buffer.length));
     }
 };
 

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -249,7 +249,6 @@ public:
     WTF_EXPORT_PRIVATE static Ref<StringImpl> create(std::span<const LChar>);
     ALWAYS_INLINE static Ref<StringImpl> create(std::span<const char> characters) { return create({ reinterpret_cast<const LChar*>(characters.data()), characters.size() }); }
     WTF_EXPORT_PRIVATE static Ref<StringImpl> create8BitIfPossible(std::span<const UChar>);
-    static Ref<StringImpl> create8BitIfPossible(const UChar* characters, unsigned length) { return create8BitIfPossible({ characters, length }); }
 
     // Not using create() naming to encourage developers to call create(ASCIILiteral) when they have a string literal.
     ALWAYS_INLINE static Ref<StringImpl> createFromCString(const char* characters) { return create(WTF::span8(characters)); }
@@ -266,8 +265,8 @@ public:
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createUninitialized(size_t length, UChar*&);
     template<typename CharacterType> static RefPtr<StringImpl> tryCreateUninitialized(size_t length, CharacterType*&);
 
-    static Ref<StringImpl> createByReplacingInCharacters(const LChar*, unsigned length, UChar target, UChar replacement, unsigned indexOfFirstTargetCharacter);
-    static Ref<StringImpl> createByReplacingInCharacters(const UChar*, unsigned length, UChar target, UChar replacement, unsigned indexOfFirstTargetCharacter);
+    static Ref<StringImpl> createByReplacingInCharacters(std::span<const LChar>, UChar target, UChar replacement, size_t indexOfFirstTargetCharacter);
+    static Ref<StringImpl> createByReplacingInCharacters(std::span<const UChar>, UChar target, UChar replacement, size_t indexOfFirstTargetCharacter);
 
     static Ref<StringImpl> createStaticStringImpl(std::span<const char> characters)
     {
@@ -465,40 +464,40 @@ public:
     bool containsOnlyLatin1() const;
     template<bool isSpecialCharacter(UChar)> bool containsOnly() const;
 
-    size_t find(LChar character, unsigned start = 0);
-    size_t find(char character, unsigned start = 0);
-    size_t find(UChar character, unsigned start = 0);
+    size_t find(LChar character, size_t start = 0);
+    size_t find(char character, size_t start = 0);
+    size_t find(UChar character, size_t start = 0);
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
-    size_t find(CodeUnitMatchFunction, unsigned start = 0);
-    ALWAYS_INLINE size_t find(ASCIILiteral literal, unsigned start = 0) { return find(literal.characters8(), literal.length(), start); }
+    size_t find(CodeUnitMatchFunction, size_t start = 0);
+    ALWAYS_INLINE size_t find(ASCIILiteral literal, size_t start = 0) { return find(literal.span8(), start); }
     WTF_EXPORT_PRIVATE size_t find(StringView);
-    WTF_EXPORT_PRIVATE size_t find(StringView, unsigned start);
+    WTF_EXPORT_PRIVATE size_t find(StringView, size_t start);
     WTF_EXPORT_PRIVATE size_t findIgnoringASCIICase(StringView) const;
-    WTF_EXPORT_PRIVATE size_t findIgnoringASCIICase(StringView, unsigned start) const;
+    WTF_EXPORT_PRIVATE size_t findIgnoringASCIICase(StringView, size_t start) const;
 
-    WTF_EXPORT_PRIVATE size_t reverseFind(UChar, unsigned start = MaxLength);
-    WTF_EXPORT_PRIVATE size_t reverseFind(StringView, unsigned start = MaxLength);
-    ALWAYS_INLINE size_t reverseFind(ASCIILiteral literal, unsigned start = MaxLength) { return reverseFind(literal.characters8(), literal.length(), start); }
+    WTF_EXPORT_PRIVATE size_t reverseFind(UChar, size_t start = MaxLength);
+    WTF_EXPORT_PRIVATE size_t reverseFind(StringView, size_t start = MaxLength);
+    ALWAYS_INLINE size_t reverseFind(ASCIILiteral literal, size_t start = MaxLength) { return reverseFind(literal.span8(), start); }
 
     WTF_EXPORT_PRIVATE bool startsWith(StringView) const;
     WTF_EXPORT_PRIVATE bool startsWithIgnoringASCIICase(StringView) const;
     WTF_EXPORT_PRIVATE bool startsWith(UChar) const;
-    WTF_EXPORT_PRIVATE bool startsWith(const char*, unsigned matchLength) const;
-    WTF_EXPORT_PRIVATE bool hasInfixStartingAt(StringView, unsigned start) const;
+    WTF_EXPORT_PRIVATE bool startsWith(std::span<const char>) const;
+    WTF_EXPORT_PRIVATE bool hasInfixStartingAt(StringView, size_t start) const;
 
     WTF_EXPORT_PRIVATE bool endsWith(StringView);
     WTF_EXPORT_PRIVATE bool endsWithIgnoringASCIICase(StringView) const;
     WTF_EXPORT_PRIVATE bool endsWith(UChar) const;
-    WTF_EXPORT_PRIVATE bool endsWith(const char*, unsigned matchLength) const;
-    WTF_EXPORT_PRIVATE bool hasInfixEndingAt(StringView, unsigned end) const;
+    WTF_EXPORT_PRIVATE bool endsWith(std::span<const char>) const;
+    WTF_EXPORT_PRIVATE bool hasInfixEndingAt(StringView, size_t end) const;
 
     WTF_EXPORT_PRIVATE Ref<StringImpl> replace(UChar, UChar);
     WTF_EXPORT_PRIVATE Ref<StringImpl> replace(UChar, StringView);
-    ALWAYS_INLINE Ref<StringImpl> replace(UChar pattern, const char* replacement, unsigned replacementLength) { return replace(pattern, reinterpret_cast<const LChar*>(replacement), replacementLength); }
-    WTF_EXPORT_PRIVATE Ref<StringImpl> replace(UChar, const LChar*, unsigned replacementLength);
-    Ref<StringImpl> replace(UChar, const UChar*, unsigned replacementLength);
+    ALWAYS_INLINE Ref<StringImpl> replace(UChar pattern, std::span<const char> replacement) { return replace(pattern, { reinterpret_cast<const LChar*>(replacement.data()), replacement.size() }); }
+    WTF_EXPORT_PRIVATE Ref<StringImpl> replace(UChar, std::span<const LChar>);
+    Ref<StringImpl> replace(UChar, std::span<const UChar>);
     WTF_EXPORT_PRIVATE Ref<StringImpl> replace(StringView, StringView);
-    WTF_EXPORT_PRIVATE Ref<StringImpl> replace(unsigned start, unsigned length, StringView);
+    WTF_EXPORT_PRIVATE Ref<StringImpl> replace(size_t start, size_t length, StringView);
 
     WTF_EXPORT_PRIVATE std::optional<UCharDirection> defaultWritingDirection();
 
@@ -534,8 +533,8 @@ private:
     template<typename> static size_t maxInternalLength();
     template<typename> static size_t tailOffset();
 
-    WTF_EXPORT_PRIVATE size_t find(const LChar*, unsigned length, unsigned start);
-    WTF_EXPORT_PRIVATE size_t reverseFind(const LChar*, unsigned length, unsigned start);
+    WTF_EXPORT_PRIVATE size_t find(std::span<const LChar>, size_t start);
+    WTF_EXPORT_PRIVATE size_t reverseFind(std::span<const LChar>, size_t start);
 
     bool requiresCopy() const;
     template<typename T> const T* tailPointer() const;
@@ -544,7 +543,7 @@ private:
     StringImpl*& substringBuffer();
 
     enum class CaseConvertType { Upper, Lower };
-    template<CaseConvertType, typename CharacterType> static Ref<StringImpl> convertASCIICase(StringImpl&, const CharacterType*, unsigned);
+    template<CaseConvertType, typename CharacterType> static Ref<StringImpl> convertASCIICase(StringImpl&, std::span<const CharacterType>);
 
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createWithoutCopyingNonEmpty(std::span<const LChar>);
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createWithoutCopyingNonEmpty(std::span<const UChar>);
@@ -607,17 +606,16 @@ template<> struct ValueCheck<StringImpl*> {
 WTF_EXPORT_PRIVATE bool equal(const StringImpl*, const StringImpl*);
 WTF_EXPORT_PRIVATE bool equal(const StringImpl*, const LChar*);
 inline bool equal(const StringImpl* a, const char* b) { return equal(a, reinterpret_cast<const LChar*>(b)); }
-WTF_EXPORT_PRIVATE bool equal(const StringImpl*, const LChar*, unsigned);
-WTF_EXPORT_PRIVATE bool equal(const StringImpl*, const UChar*, unsigned);
-template<typename CharacterType> bool equal(const StringImpl* impl, std::span<const CharacterType> characters) { return equal(impl, characters.data(), characters.size()); }
-ALWAYS_INLINE bool equal(const StringImpl* a, ASCIILiteral b) { return equal(a, b.characters8(), b.length()); }
-inline bool equal(const StringImpl* a, const char* b, unsigned length) { return equal(a, reinterpret_cast<const LChar*>(b), length); }
+WTF_EXPORT_PRIVATE bool equal(const StringImpl*, std::span<const LChar>);
+WTF_EXPORT_PRIVATE bool equal(const StringImpl*, std::span<const UChar>);
+ALWAYS_INLINE bool equal(const StringImpl* a, ASCIILiteral b) { return equal(a, b.span8()); }
+inline bool equal(const StringImpl* a, std::span<const char> b) { return equal(a, { reinterpret_cast<const LChar*>(b.data()), b.size() }); }
 inline bool equal(const LChar* a, StringImpl* b) { return equal(b, a); }
 inline bool equal(const char* a, StringImpl* b) { return equal(b, reinterpret_cast<const LChar*>(a)); }
 WTF_EXPORT_PRIVATE bool equal(const StringImpl& a, const StringImpl& b);
 
 WTF_EXPORT_PRIVATE bool equalIgnoringNullity(StringImpl*, StringImpl*);
-WTF_EXPORT_PRIVATE bool equalIgnoringNullity(const UChar*, size_t length, StringImpl*);
+WTF_EXPORT_PRIVATE bool equalIgnoringNullity(std::span<const UChar>, StringImpl*);
 
 bool equalIgnoringASCIICase(const StringImpl&, const StringImpl&);
 WTF_EXPORT_PRIVATE bool equalIgnoringASCIICase(const StringImpl*, const StringImpl*);
@@ -630,16 +628,16 @@ bool equalLettersIgnoringASCIICase(const StringImpl&, ASCIILiteral);
 bool equalLettersIgnoringASCIICase(const StringImpl*, ASCIILiteral);
 
 template<typename CodeUnit, typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, CodeUnit>>* = nullptr>
-size_t find(const CodeUnit*, unsigned length, CodeUnitMatchFunction&&, unsigned start = 0);
+size_t find(std::span<const CodeUnit>, CodeUnitMatchFunction&&, size_t start = 0);
 
-template<typename CharacterType> size_t reverseFindLineTerminator(const CharacterType*, unsigned length, unsigned start = StringImpl::MaxLength);
-template<typename CharacterType> size_t reverseFind(const CharacterType*, unsigned length, CharacterType matchCharacter, unsigned start = StringImpl::MaxLength);
-size_t reverseFind(const UChar*, unsigned length, LChar matchCharacter, unsigned start = StringImpl::MaxLength);
-size_t reverseFind(const LChar*, unsigned length, UChar matchCharacter, unsigned start = StringImpl::MaxLength);
+template<typename CharacterType> size_t reverseFindLineTerminator(std::span<const CharacterType>, size_t start = StringImpl::MaxLength);
+template<typename CharacterType> size_t reverseFind(std::span<const CharacterType>, CharacterType matchCharacter, size_t start = StringImpl::MaxLength);
+size_t reverseFind(std::span<const UChar>, LChar matchCharacter, size_t start = StringImpl::MaxLength);
+size_t reverseFind(std::span<const LChar>, UChar matchCharacter, size_t start = StringImpl::MaxLength);
 
 template<size_t inlineCapacity> bool equalIgnoringNullity(const Vector<UChar, inlineCapacity>&, StringImpl*);
 
-template<typename CharacterType1, typename CharacterType2> int codePointCompare(const CharacterType1*, unsigned length1, const CharacterType2*, unsigned length2);
+template<typename CharacterType1, typename CharacterType2> int codePointCompare(std::span<const CharacterType1>, std::span<const CharacterType2>);
 int codePointCompare(const StringImpl*, const StringImpl*);
 
 bool isUnicodeWhitespace(UChar);
@@ -684,9 +682,9 @@ template<> ALWAYS_INLINE const UChar* StringImpl::characters<UChar>() const
 }
 
 template<typename CodeUnit, typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, CodeUnit>>*>
-inline size_t find(const CodeUnit* characters, unsigned length, CodeUnitMatchFunction&& matchFunction, unsigned start)
+inline size_t find(std::span<const CodeUnit> characters, CodeUnitMatchFunction&& matchFunction, size_t start)
 {
-    while (start < length) {
+    while (start < characters.size()) {
         if (matchFunction(characters[start]))
             return start;
         ++start;
@@ -694,12 +692,12 @@ inline size_t find(const CodeUnit* characters, unsigned length, CodeUnitMatchFun
     return notFound;
 }
 
-template<typename CharacterType> inline size_t reverseFindLineTerminator(const CharacterType* characters, unsigned length, unsigned start)
+template<typename CharacterType> inline size_t reverseFindLineTerminator(std::span<const CharacterType> characters, size_t start)
 {
-    if (!length)
+    if (characters.empty())
         return notFound;
-    if (start >= length)
-        start = length - 1;
+    if (start >= characters.size())
+        start = characters.size() - 1;
     auto character = characters[start];
     while (character != '\n' && character != '\r') {
         if (!start--)
@@ -709,12 +707,12 @@ template<typename CharacterType> inline size_t reverseFindLineTerminator(const C
     return start;
 }
 
-template<typename CharacterType> inline size_t reverseFind(const CharacterType* characters, unsigned length, CharacterType matchCharacter, unsigned start)
+template<typename CharacterType> inline size_t reverseFind(std::span<const CharacterType> characters, CharacterType matchCharacter, size_t start)
 {
-    if (!length)
+    if (characters.empty())
         return notFound;
-    if (start >= length)
-        start = length - 1;
+    if (start >= characters.size())
+        start = characters.size() - 1;
     while (characters[start] != matchCharacter) {
         if (!start--)
             return notFound;
@@ -722,31 +720,31 @@ template<typename CharacterType> inline size_t reverseFind(const CharacterType* 
     return start;
 }
 
-ALWAYS_INLINE size_t reverseFind(const UChar* characters, unsigned length, LChar matchCharacter, unsigned start)
+ALWAYS_INLINE size_t reverseFind(std::span<const UChar> characters, LChar matchCharacter, size_t start)
 {
-    return reverseFind(characters, length, static_cast<UChar>(matchCharacter), start);
+    return reverseFind(characters, static_cast<UChar>(matchCharacter), start);
 }
 
-inline size_t reverseFind(const LChar* characters, unsigned length, UChar matchCharacter, unsigned start)
+inline size_t reverseFind(std::span<const LChar> characters, UChar matchCharacter, size_t start)
 {
     if (!isLatin1(matchCharacter))
         return notFound;
-    return reverseFind(characters, length, static_cast<LChar>(matchCharacter), start);
+    return reverseFind(characters, static_cast<LChar>(matchCharacter), start);
 }
 
-inline size_t StringImpl::find(LChar character, unsigned start)
+inline size_t StringImpl::find(LChar character, size_t start)
 {
     if (is8Bit())
         return WTF::find(characters8(), m_length, character, start);
     return WTF::find(characters16(), m_length, character, start);
 }
 
-ALWAYS_INLINE size_t StringImpl::find(char character, unsigned start)
+ALWAYS_INLINE size_t StringImpl::find(char character, size_t start)
 {
     return find(static_cast<LChar>(character), start);
 }
 
-inline size_t StringImpl::find(UChar character, unsigned start)
+inline size_t StringImpl::find(UChar character, size_t start)
 {
     if (is8Bit())
         return WTF::find(characters8(), m_length, character, start);
@@ -754,11 +752,11 @@ inline size_t StringImpl::find(UChar character, unsigned start)
 }
 
 template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>*>
-size_t StringImpl::find(CodeUnitMatchFunction matchFunction, unsigned start)
+size_t StringImpl::find(CodeUnitMatchFunction matchFunction, size_t start)
 {
     if (is8Bit())
-        return WTF::find(characters8(), m_length, matchFunction, start);
-    return WTF::find(characters16(), m_length, matchFunction, start);
+        return WTF::find(span8(), matchFunction, start);
+    return WTF::find(span16(), matchFunction, start);
 }
 
 template<size_t inlineCapacity> inline bool equalIgnoringNullity(const Vector<UChar, inlineCapacity>& a, StringImpl* b)
@@ -766,23 +764,25 @@ template<size_t inlineCapacity> inline bool equalIgnoringNullity(const Vector<UC
     return equalIgnoringNullity(a.data(), a.size(), b);
 }
 
-template<typename CharacterType1, typename CharacterType2> inline int codePointCompare(const CharacterType1* characters1, unsigned length1, const CharacterType2* characters2, unsigned length2)
+template<typename CharacterType1, typename CharacterType2> inline int codePointCompare(std::span<const CharacterType1> characters1, std::span<const CharacterType2> characters2)
 {
-    unsigned commonLength = std::min(length1, length2);
+    size_t commonLength = std::min(characters1.size(), characters2.size());
 
-    unsigned position = 0;
-    while (position < commonLength && *characters1 == *characters2) {
-        ++characters1;
-        ++characters2;
+    auto* characters1Ptr = characters1.data();
+    auto* characters2Ptr = characters2.data();
+    size_t position = 0;
+    while (position < commonLength && *characters1Ptr == *characters2Ptr) {
+        ++characters1Ptr;
+        ++characters2Ptr;
         ++position;
     }
 
     if (position < commonLength)
-        return (characters1[0] > characters2[0]) ? 1 : -1;
+        return (characters1Ptr[0] > characters2Ptr[0]) ? 1 : -1;
 
-    if (length1 == length2)
+    if (characters1.size() == characters2.size())
         return 0;
-    return (length1 > length2) ? 1 : -1;
+    return (characters1.size() > characters2.size()) ? 1 : -1;
 }
 
 inline int codePointCompare(const StringImpl* string1, const StringImpl* string2)
@@ -797,12 +797,12 @@ inline int codePointCompare(const StringImpl* string1, const StringImpl* string2
     bool string2Is8Bit = string2->is8Bit();
     if (string1Is8Bit) {
         if (string2Is8Bit)
-            return codePointCompare(string1->characters8(), string1->length(), string2->characters8(), string2->length());
-        return codePointCompare(string1->characters8(), string1->length(), string2->characters16(), string2->length());
+            return codePointCompare(string1->span8(), string2->span8());
+        return codePointCompare(string1->span8(), string2->span16());
     }
     if (string2Is8Bit)
-        return codePointCompare(string1->characters16(), string1->length(), string2->characters8(), string2->length());
-    return codePointCompare(string1->characters16(), string1->length(), string2->characters16(), string2->length());
+        return codePointCompare(string1->span16(), string2->span8());
+    return codePointCompare(string1->span16(), string2->span16());
 }
 
 // FIXME: For LChar, isUnicodeCompatibleASCIIWhitespace(character) || character == 0x0085 || character == noBreakSpace would be enough
@@ -1333,16 +1333,16 @@ inline Ref<StringImpl> StringImpl::removeCharacters(const Predicate& findMatch)
     return removeCharactersImpl(characters16(), findMatch);
 }
 
-inline Ref<StringImpl> StringImpl::createByReplacingInCharacters(const LChar* characters, unsigned length, UChar target, UChar replacement, unsigned indexOfFirstTargetCharacter)
+inline Ref<StringImpl> StringImpl::createByReplacingInCharacters(std::span<const LChar> characters, UChar target, UChar replacement, size_t indexOfFirstTargetCharacter)
 {
-    ASSERT(indexOfFirstTargetCharacter < length);
+    ASSERT(indexOfFirstTargetCharacter < characters.size());
     if (isLatin1(replacement)) {
         LChar* data;
         LChar oldChar = target;
         LChar newChar = replacement;
-        auto newImpl = createUninitializedInternalNonEmpty(length, data);
-        memcpy(data, characters, indexOfFirstTargetCharacter);
-        for (unsigned i = indexOfFirstTargetCharacter; i != length; ++i) {
+        auto newImpl = createUninitializedInternalNonEmpty(characters.size(), data);
+        memcpy(data, characters.data(), indexOfFirstTargetCharacter);
+        for (size_t i = indexOfFirstTargetCharacter; i != characters.size(); ++i) {
             LChar character = characters[i];
             data[i] = character == oldChar ? newChar : character;
         }
@@ -1350,21 +1350,19 @@ inline Ref<StringImpl> StringImpl::createByReplacingInCharacters(const LChar* ch
     }
 
     UChar* data;
-    auto newImpl = createUninitializedInternalNonEmpty(length, data);
-    for (unsigned i = 0; i != length; ++i) {
-        UChar character = characters[i];
-        data[i] = character == target ? replacement : character;
-    }
+    auto newImpl = createUninitializedInternalNonEmpty(characters.size(), data);
+    for (auto character : characters)
+        *data++ = character == target ? replacement : character;
     return newImpl;
 }
 
-inline Ref<StringImpl> StringImpl::createByReplacingInCharacters(const UChar* characters, unsigned length, UChar target, UChar replacement, unsigned indexOfFirstTargetCharacter)
+inline Ref<StringImpl> StringImpl::createByReplacingInCharacters(std::span<const UChar> characters, UChar target, UChar replacement, size_t indexOfFirstTargetCharacter)
 {
-    ASSERT(indexOfFirstTargetCharacter < length);
+    ASSERT(indexOfFirstTargetCharacter < characters.size());
     UChar* data;
-    auto newImpl = createUninitializedInternalNonEmpty(length, data);
-    copyCharacters(data, { characters, indexOfFirstTargetCharacter });
-    for (unsigned i = indexOfFirstTargetCharacter; i != length; ++i) {
+    auto newImpl = createUninitializedInternalNonEmpty(characters.size(), data);
+    copyCharacters(data, characters.first(indexOfFirstTargetCharacter));
+    for (size_t i = indexOfFirstTargetCharacter; i != characters.size(); ++i) {
         UChar character = characters[i];
         data[i] = character == target ? replacement : character;
     }

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -430,7 +430,7 @@ String makeStringByReplacingAll(StringView string, UChar target, UChar replaceme
         }
         if (i == length)
             return string.toString();
-        return StringImpl::createByReplacingInCharacters(characters, length, target, replacement, i);
+        return StringImpl::createByReplacingInCharacters({ characters, length }, target, replacement, i);
     }
 
     auto* characters = string.characters16();
@@ -442,7 +442,7 @@ String makeStringByReplacingAll(StringView string, UChar target, UChar replaceme
     }
     if (i == length)
         return string.toString();
-    return StringImpl::createByReplacingInCharacters(characters, length, target, replacement, i);
+    return StringImpl::createByReplacingInCharacters({ characters, length }, target, replacement, i);
 }
 
 int codePointCompare(StringView lhs, StringView rhs)
@@ -451,12 +451,12 @@ int codePointCompare(StringView lhs, StringView rhs)
     bool rhsIs8Bit = rhs.is8Bit();
     if (lhsIs8Bit) {
         if (rhsIs8Bit)
-            return codePointCompare(lhs.characters8(), lhs.length(), rhs.characters8(), rhs.length());
-        return codePointCompare(lhs.characters8(), lhs.length(), rhs.characters16(), rhs.length());
+            return codePointCompare(lhs.span8(), rhs.span8());
+        return codePointCompare(lhs.span8(), rhs.span16());
     }
     if (rhsIs8Bit)
-        return codePointCompare(lhs.characters16(), lhs.length(), rhs.characters8(), rhs.length());
-    return codePointCompare(lhs.characters16(), lhs.length(), rhs.characters16(), rhs.length());
+        return codePointCompare(lhs.span16(), rhs.span8());
+    return codePointCompare(lhs.span16(), rhs.span16());
 }
 
 template<typename CharacterType> static String makeStringBySimplifyingNewLinesSlowCase(const String& string, unsigned firstCarriageReturn)

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -711,15 +711,15 @@ template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<
 inline size_t StringView::find(CodeUnitMatchFunction&& matchFunction, unsigned start) const
 {
     if (is8Bit())
-        return WTF::find(characters8(), m_length, std::forward<CodeUnitMatchFunction>(matchFunction), start);
-    return WTF::find(characters16(), m_length, std::forward<CodeUnitMatchFunction>(matchFunction), start);
+        return WTF::find(span8(), std::forward<CodeUnitMatchFunction>(matchFunction), start);
+    return WTF::find(span16(), std::forward<CodeUnitMatchFunction>(matchFunction), start);
 }
 
 inline size_t StringView::reverseFind(UChar character, unsigned start) const
 {
     if (is8Bit())
-        return WTF::reverseFind(characters8(), m_length, character, start);
-    return WTF::reverseFind(characters16(), m_length, character, start);
+        return WTF::reverseFind(span8(), character, start);
+    return WTF::reverseFind(span16(), character, start);
 }
 
 #if !CHECK_STRINGVIEW_LIFETIME
@@ -1352,7 +1352,7 @@ inline size_t String::findIgnoringASCIICase(StringView string, unsigned start) c
     return m_impl ? m_impl->findIgnoringASCIICase(string, start) : notFound;
 }
 
-inline size_t String::reverseFind(StringView string, unsigned start) const
+inline size_t String::reverseFind(StringView string, size_t start) const
 {
     return m_impl ? m_impl->reverseFind(string, start) : notFound;
 }
@@ -1434,7 +1434,7 @@ inline bool String::hasInfixEndingAt(StringView suffix, unsigned end) const
     return m_impl && suffix && m_impl->hasInfixEndingAt(suffix, end);
 }
 
-inline size_t AtomString::find(StringView string, unsigned start) const
+inline size_t AtomString::find(StringView string, size_t start) const
 {
     return m_string.find(string, start);
 }
@@ -1444,7 +1444,7 @@ inline size_t AtomString::findIgnoringASCIICase(StringView string) const
     return m_string.findIgnoringASCIICase(string);
 }
 
-inline size_t AtomString::findIgnoringASCIICase(StringView string, unsigned start) const
+inline size_t AtomString::findIgnoringASCIICase(StringView string, size_t start) const
 {
     return m_string.findIgnoringASCIICase(string, start);
 }

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -151,13 +151,13 @@ public:
     size_t findIgnoringASCIICase(StringView, unsigned start) const;
 
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
-    size_t find(CodeUnitMatchFunction matchFunction, unsigned start = 0) const { return m_impl ? m_impl->find(matchFunction, start) : notFound; }
-    size_t find(ASCIILiteral literal, unsigned start = 0) const { return m_impl ? m_impl->find(literal, start) : notFound; }
+    size_t find(CodeUnitMatchFunction matchFunction, size_t start = 0) const { return m_impl ? m_impl->find(matchFunction, start) : notFound; }
+    size_t find(ASCIILiteral literal, size_t start = 0) const { return m_impl ? m_impl->find(literal, start) : notFound; }
 
     // Find the last instance of a single character or string.
-    size_t reverseFind(UChar character, unsigned start = MaxLength) const { return m_impl ? m_impl->reverseFind(character, start) : notFound; }
-    size_t reverseFind(ASCIILiteral literal, unsigned start = MaxLength) const { return m_impl ? m_impl->reverseFind(literal, start) : notFound; }
-    size_t reverseFind(StringView, unsigned start = MaxLength) const;
+    size_t reverseFind(UChar character, size_t start = MaxLength) const { return m_impl ? m_impl->reverseFind(character, start) : notFound; }
+    size_t reverseFind(ASCIILiteral literal, size_t start = MaxLength) const { return m_impl ? m_impl->reverseFind(literal, start) : notFound; }
+    size_t reverseFind(StringView, size_t start = MaxLength) const;
 
     WTF_EXPORT_PRIVATE Expected<Vector<UChar>, UTF8ConversionError> charactersWithNullTermination() const;
     WTF_EXPORT_PRIVATE Expected<Vector<UChar>, UTF8ConversionError> charactersWithoutNullTermination() const;
@@ -458,7 +458,7 @@ inline String WARN_UNUSED_RETURN makeStringByReplacingAll(const String& string, 
 ALWAYS_INLINE String WARN_UNUSED_RETURN makeStringByReplacingAll(const String& string, UChar target, ASCIILiteral literal)
 {
     if (auto impl = string.impl())
-        return String { impl->replace(target, literal.characters(), literal.length()) };
+        return String { impl->replace(target, literal.span8()) };
     return string;
 }
 

--- a/Source/WebCore/html/parser/AtomHTMLToken.h
+++ b/Source/WebCore/html/parser/AtomHTMLToken.h
@@ -250,7 +250,7 @@ inline AtomHTMLToken::AtomHTMLToken(HTMLToken& token)
         ASSERT_NOT_REACHED();
         return;
     case Type::DOCTYPE:
-        if (LIKELY(token.name().size() == 4 && equal(HTMLNames::htmlTag->localName().impl(), token.name().data(), 4)))
+        if (LIKELY(token.name().size() == 4 && equal(HTMLNames::htmlTag->localName().impl(), token.name().span())))
             m_name = HTMLNames::htmlTag->localName();
         else
             m_name = AtomString(token.name().span());

--- a/Source/WebCore/html/parser/HTMLNameCache.h
+++ b/Source/WebCore/html/parser/HTMLNameCache.h
@@ -72,7 +72,7 @@ private:
             return AtomString(string);
 
         auto& slot = atomStringCacheSlot(string.front(), string.back(), string.size());
-        if (!equal(slot.impl(), string.data(), string.size())) {
+        if (!equal(slot.impl(), string)) {
             AtomString result { string };
             slot = result;
             return result;
@@ -91,7 +91,7 @@ private:
             return QualifiedName(nullAtom(), AtomString(string), nullAtom());
 
         auto& slot = qualifiedNameCacheSlot(string.front(), string.back(), string.size());
-        if (!slot || !equal(slot->m_localName.impl(), string.data(), string.size())) {
+        if (!slot || !equal(slot->m_localName.impl(), string)) {
             QualifiedName result(nullAtom(), AtomString(string), nullAtom());
             slot = result.impl();
             return result;

--- a/Source/WebCore/html/track/VTTScanner.cpp
+++ b/Source/WebCore/html/track/VTTScanner.cpp
@@ -81,9 +81,9 @@ bool VTTScanner::scanRun(const Run& run, const String& toMatch)
         return false;
     bool matched;
     if (m_is8Bit)
-        matched = equal(toMatch.impl(), m_data.characters8, matchLength);
+        matched = equal(toMatch.impl(), { m_data.characters8, matchLength });
     else
-        matched = equal(toMatch.impl(), m_data.characters16, matchLength);
+        matched = equal(toMatch.impl(), { m_data.characters16, matchLength });
     if (matched)
         seekTo(run.end());
     return matched;

--- a/Source/WebCore/platform/SharedStringHash.cpp
+++ b/Source/WebCore/platform/SharedStringHash.cpp
@@ -108,7 +108,7 @@ static void cleanSlashDotDotSlashes(Vector<CharacterType, 512>& path, size_t fir
 {
     size_t slash = firstSlash;
     do {
-        size_t previousSlash = slash ? reverseFind(path.data(), path.size(), '/', slash - 1) : notFound;
+        size_t previousSlash = slash ? reverseFind(path.span(), '/', slash - 1) : notFound;
         // Don't remove the host, i.e. http://foo.org/../foo.html
         if (previousSlash == notFound || (previousSlash > 3 && path[previousSlash - 2] == ':' && path[previousSlash - 1] == '/')) {
             path[slash] = 0;

--- a/Source/WebCore/platform/sql/SQLiteStatement.cpp
+++ b/Source/WebCore/platform/sql/SQLiteStatement.cpp
@@ -283,7 +283,7 @@ String SQLiteStatement::columnBlobAsString(int col)
         return String();
 
     ASSERT(!(size % sizeof(UChar)));
-    return StringImpl::create8BitIfPossible(static_cast<const UChar*>(blob), size / sizeof(UChar));
+    return StringImpl::create8BitIfPossible({ static_cast<const UChar*>(blob), size / sizeof(UChar) });
 }
 
 Vector<uint8_t> SQLiteStatement::columnBlob(int col)

--- a/Source/WebCore/rendering/RenderQuote.cpp
+++ b/Source/WebCore/rendering/RenderQuote.cpp
@@ -417,7 +417,7 @@ static StringImpl* stringForQuoteCharacter(UChar character)
             return strings[i].string;
         if (!strings[i].character) {
             strings[i].character = character;
-            strings[i].string = &StringImpl::create8BitIfPossible(&character, 1).leakRef();
+            strings[i].string = &StringImpl::create8BitIfPossible(span(character)).leakRef();
             return strings[i].string;
         }
     }

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -64,41 +64,41 @@ TEST(WTF, StringImplReplaceWithLiteral)
     ASSERT_TRUE(testStringImpl->is8Bit());
 
     // Cases for 8Bit source.
-    testStringImpl = testStringImpl->replace('2', ""_s, 0);
+    testStringImpl = testStringImpl->replace('2', ""_span);
     ASSERT_TRUE(equal(testStringImpl.get(), "14"_s));
 
     testStringImpl = StringImpl::create("1224"_s);
     ASSERT_TRUE(testStringImpl->is8Bit());
 
-    testStringImpl = testStringImpl->replace('3', "NotFound"_s, 8);
+    testStringImpl = testStringImpl->replace('3', "NotFound"_span);
     ASSERT_TRUE(equal(testStringImpl.get(), "1224"_s));
 
-    testStringImpl = testStringImpl->replace('2', "3"_s, 1);
+    testStringImpl = testStringImpl->replace('2', "3"_span);
     ASSERT_TRUE(equal(testStringImpl.get(), "1334"_s));
 
     testStringImpl = StringImpl::create("1224"_s);
     ASSERT_TRUE(testStringImpl->is8Bit());
-    testStringImpl = testStringImpl->replace('2', "555"_s, 3);
+    testStringImpl = testStringImpl->replace('2', "555"_span);
     ASSERT_TRUE(equal(testStringImpl.get(), "15555554"_s));
 
     // Cases for 16Bit source.
     String testString = String::fromUTF8("résumé");
     ASSERT_FALSE(testString.impl()->is8Bit());
 
-    testStringImpl = testString.impl()->replace('2', "NotFound"_s, 8);
+    testStringImpl = testString.impl()->replace('2', "NotFound"_span);
     ASSERT_TRUE(equal(testStringImpl.get(), String::fromUTF8("résumé").impl()));
 
-    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), "e"_s, 1);
+    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), "e"_span);
     ASSERT_TRUE(equal(testStringImpl.get(), "resume"_s));
 
     testString = String::fromUTF8("résumé");
     ASSERT_FALSE(testString.impl()->is8Bit());
-    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), ""_s, 0);
+    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), ""_span);
     ASSERT_TRUE(equal(testStringImpl.get(), "rsum"_s));
 
     testString = String::fromUTF8("résumé");
     ASSERT_FALSE(testString.impl()->is8Bit());
-    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), "555"_s, 3);
+    testStringImpl = testString.impl()->replace(UChar(0x00E9 /*U+00E9 is 'é'*/), "555"_span);
     ASSERT_TRUE(equal(testStringImpl.get(), "r555sum555"_s));
 }
 


### PR DESCRIPTION
#### bb3dfb64d0c8167f4e3135b7aee4652f3525bdaa
<pre>
Finish porting StringImpl to std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=272290">https://bugs.webkit.org/show_bug.cgi?id=272290</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/runtime/Identifier.h:
(JSC::Identifier::equal):
* Source/WTF/wtf/text/AtomString.h:
(WTF::operator==):
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::SubstringTranslator8::equal):
(WTF::SubstringTranslator16::equal):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::substring):
(WTF::StringImpl::convertASCIICase):
(WTF::StringImpl::convertToASCIILowercase):
(WTF::StringImpl::convertToASCIIUppercase):
(WTF::StringImpl::find):
(WTF::StringImpl::reverseFind):
(WTF::StringImpl::findIgnoringASCIICase const):
(WTF::equalInner):
(WTF::StringImpl::startsWith const):
(WTF::StringImpl::hasInfixStartingAt const):
(WTF::StringImpl::endsWith const):
(WTF::StringImpl::hasInfixEndingAt const):
(WTF::StringImpl::replace):
(WTF::equalInternal):
(WTF::equal):
(WTF::equalIgnoringNullity):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::find):
(WTF::StringImpl::reverseFind):
(WTF::StringImpl::replace):
(WTF::equal):
(WTF::reverseFindLineTerminator):
(WTF::reverseFind):
(WTF::codePointCompare):
(WTF::StringImpl::createByReplacingInCharacters):
(WTF::StringImpl::create8BitIfPossible): Deleted.
* Source/WTF/wtf/text/StringView.cpp:
(WTF::makeStringByReplacingAll):
(WTF::codePointCompare):
* Source/WTF/wtf/text/StringView.h:
(WTF:: const):
(WTF::StringView::reverseFind const):
(WTF::String::reverseFind const):
(WTF::AtomString::find const):
(WTF::AtomString::findIgnoringASCIICase const):
* Source/WTF/wtf/text/WTFString.h:
(WTF::makeStringByReplacingAll):
* Source/WebCore/html/parser/AtomHTMLToken.h:
(WebCore::AtomHTMLToken::AtomHTMLToken):
* Source/WebCore/html/parser/HTMLNameCache.h:
(WebCore::HTMLNameCache::makeAtomString):
(WebCore::HTMLNameCache::makeQualifiedName):
* Source/WebCore/html/track/VTTScanner.cpp:
(WebCore::VTTScanner::scanRun):
* Source/WebCore/platform/SharedStringHash.cpp:
(WebCore::cleanSlashDotDotSlashes):
* Source/WebCore/platform/sql/SQLiteStatement.cpp:
(WebCore::SQLiteStatement::columnBlobAsString):
* Source/WebCore/rendering/RenderQuote.cpp:
(WebCore::stringForQuoteCharacter):
* Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp:
(TestWebKitAPI::TEST(WTF, StringImplReplaceWithLiteral)):

Canonical link: <a href="https://commits.webkit.org/277175@main">https://commits.webkit.org/277175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be14a002ccf243b198bc21c42532975f40e0482b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49576 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49202 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38188 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40387 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19498 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20580 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41526 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4941 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40144 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51449 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46378 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45482 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23192 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23802 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53520 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6575 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22903 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/10999 "Passed tests") | 
<!--EWS-Status-Bubble-End-->