### PR TITLE
Move numeric parsing to std::span

### DIFF
--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -2263,7 +2263,7 @@ start:
             goto returnError;
         }
         size_t parsedLength;
-        tokenData->doubleValue = parseDouble(m_buffer8.data(), m_buffer8.size(), parsedLength);
+        tokenData->doubleValue = parseDouble(m_buffer8, parsedLength);
         if (token == INTEGER)
             token = tokenTypeForIntegerLikeToken(tokenData->doubleValue);
 
@@ -2450,7 +2450,7 @@ start:
                     goto returnError;
                 }
                 size_t parsedLength;
-                tokenData->doubleValue = parseDouble(m_buffer8.data(), m_buffer8.size(), parsedLength);
+                tokenData->doubleValue = parseDouble(m_buffer8, parsedLength);
                 if (token == INTEGER)
                     token = tokenTypeForIntegerLikeToken(tokenData->doubleValue);
             }

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp
@@ -327,7 +327,7 @@ static double jsStrDecimalLiteral(const CharType*& data, const CharType* end)
     RELEASE_ASSERT(data < end);
 
     size_t parsedLength;
-    double number = parseDouble(data, end - data, parsedLength);
+    double number = parseDouble(std::span { data, end }, parsedLength);
     if (parsedLength) {
         data += parsedLength;
         return number;

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -1087,7 +1087,7 @@ TokenType LiteralParser<CharType>::Lexer::lexNumber(LiteralParserToken<CharType>
     
     token.type = TokNumber;
     size_t parsedLength;
-    token.numberToken = parseDouble(start, m_ptr - start, parsedLength);
+    token.numberToken = parseDouble(std::span { start, m_ptr }, parsedLength);
     return TokNumber;
 }
 

--- a/Source/WTF/wtf/FastFloat.cpp
+++ b/Source/WTF/wtf/FastFloat.cpp
@@ -30,19 +30,19 @@
 
 namespace WTF {
 
-double parseDouble(const LChar* string, size_t length, size_t& parsedLength)
+double parseDouble(std::span<const LChar> string, size_t& parsedLength)
 {
     double doubleValue = 0;
-    auto result = fast_float::from_chars(reinterpret_cast<const char*>(string), reinterpret_cast<const char*>(string) + length, doubleValue);
-    parsedLength = result.ptr - reinterpret_cast<const char*>(string);
+    auto result = fast_float::from_chars(reinterpret_cast<const char*>(string.data()), reinterpret_cast<const char*>(string.data()) + string.size(), doubleValue);
+    parsedLength = result.ptr - reinterpret_cast<const char*>(string.data());
     return doubleValue;
 }
 
-double parseDouble(const UChar* string, size_t length, size_t& parsedLength)
+double parseDouble(std::span<const UChar> string, size_t& parsedLength)
 {
     double doubleValue = 0;
-    auto result = fast_float::from_chars(reinterpret_cast<const char16_t*>(string), reinterpret_cast<const char16_t*>(string) + length, doubleValue);
-    parsedLength = result.ptr - reinterpret_cast<const char16_t*>(string);
+    auto result = fast_float::from_chars(reinterpret_cast<const char16_t*>(string.data()), reinterpret_cast<const char16_t*>(string.data()) + string.size(), doubleValue);
+    parsedLength = result.ptr - reinterpret_cast<const char16_t*>(string.data());
     return doubleValue;
 }
 

--- a/Source/WTF/wtf/FastFloat.h
+++ b/Source/WTF/wtf/FastFloat.h
@@ -25,12 +25,13 @@
 
 #pragma once
 
+#include <span>
 #include <unicode/utypes.h>
 #include <wtf/ASCIICType.h>
 
 namespace WTF {
 
-WTF_EXPORT_PRIVATE double parseDouble(const LChar* string, size_t length, size_t& parsedLength);
-WTF_EXPORT_PRIVATE double parseDouble(const UChar* string, size_t length, size_t& parsedLength);
+WTF_EXPORT_PRIVATE double parseDouble(std::span<const LChar> string, size_t& parsedLength);
+WTF_EXPORT_PRIVATE double parseDouble(std::span<const UChar> string, size_t& parsedLength);
 
 } // namespace WTF

--- a/Source/WTF/wtf/dtoa.h
+++ b/Source/WTF/wtf/dtoa.h
@@ -51,8 +51,8 @@ WTF_EXPORT_PRIVATE const char* numberToCSSString(double, NumberToCSSStringBuffer
 inline double parseDouble(StringView string, size_t& parsedLength)
 {
     if (string.is8Bit())
-        return parseDouble(string.characters8(), string.length(), parsedLength);
-    return parseDouble(string.characters16(), string.length(), parsedLength);
+        return parseDouble(string.span8(), parsedLength);
+    return parseDouble(string.span16(), parsedLength);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringToIntegerConversion.h
+++ b/Source/WTF/wtf/text/StringToIntegerConversion.h
@@ -42,25 +42,20 @@ template<typename IntegralType> std::optional<IntegralType> parseIntegerAllowing
 
 enum class TrailingJunkPolicy { Disallow, Allow };
 
-template<typename IntegralType, typename CharacterType> std::optional<IntegralType> parseInteger(const CharacterType* data, size_t length, uint8_t base, TrailingJunkPolicy policy)
+template<typename IntegralType, typename CharacterType> std::optional<IntegralType> parseInteger(std::span<const CharacterType> data, uint8_t base, TrailingJunkPolicy policy)
 {
-    if (!data)
+    if (!data.data())
         return std::nullopt;
 
-    while (length && isUnicodeCompatibleASCIIWhitespace(*data)) {
-        --length;
-        ++data;
-    }
+    while (!data.empty() && isUnicodeCompatibleASCIIWhitespace(data.front()))
+        data = data.subspan(1);
 
     bool isNegative = false;
-    if (std::is_signed_v<IntegralType> && length && *data == '-') {
-        --length;
-        ++data;
+    if (std::is_signed_v<IntegralType> && !data.empty() && data.front() == '-') {
+        data = data.subspan(1);
         isNegative = true;
-    } else if (length && *data == '+') {
-        --length;
-        ++data;
-    }
+    } else if (!data.empty() && data.front() == '+')
+        data = data.subspan(1);
 
     auto isCharacterAllowedInBase = [] (auto character, auto base) {
         if (isASCIIDigit(character))
@@ -68,28 +63,27 @@ template<typename IntegralType, typename CharacterType> std::optional<IntegralTy
         return toASCIILowerUnchecked(character) >= 'a' && toASCIILowerUnchecked(character) < 'a' + std::min(base - 10, 26);
     };
 
-    if (!(length && isCharacterAllowedInBase(*data, base)))
+    if (!(!data.empty() && isCharacterAllowedInBase(data.front(), base)))
         return std::nullopt;
 
     Checked<IntegralType, RecordOverflow> value;
     do {
-        IntegralType digitValue = isASCIIDigit(*data) ? *data - '0' : toASCIILowerUnchecked(*data) - 'a' + 10;
+        IntegralType digitValue = isASCIIDigit(data.front()) ? data.front() - '0' : toASCIILowerUnchecked(data.front()) - 'a' + 10;
+        data = data.subspan(1);
         value *= static_cast<IntegralType>(base);
         if (isNegative)
             value -= digitValue;
         else
             value += digitValue;
-    } while (--length && isCharacterAllowedInBase(*++data, base));
+    } while (!data.empty() && isCharacterAllowedInBase(data.front(), base));
 
     if (UNLIKELY(value.hasOverflowed()))
         return std::nullopt;
 
     if (policy == TrailingJunkPolicy::Disallow) {
-        while (length && isUnicodeCompatibleASCIIWhitespace(*data)) {
-            --length;
-            ++data;
-        }
-        if (length)
+        while (!data.empty() && isUnicodeCompatibleASCIIWhitespace(data.front()))
+            data = data.subspan(1);
+        if (!data.empty())
             return std::nullopt;
     }
 
@@ -99,15 +93,15 @@ template<typename IntegralType, typename CharacterType> std::optional<IntegralTy
 template<typename IntegralType> std::optional<IntegralType> parseInteger(StringView string, uint8_t base)
 {
     if (string.is8Bit())
-        return parseInteger<IntegralType>(string.characters8(), string.length(), base, TrailingJunkPolicy::Disallow);
-    return parseInteger<IntegralType>(string.characters16(), string.length(), base, TrailingJunkPolicy::Disallow);
+        return parseInteger<IntegralType>(string.span8(), base, TrailingJunkPolicy::Disallow);
+    return parseInteger<IntegralType>(string.span16(), base, TrailingJunkPolicy::Disallow);
 }
 
 template<typename IntegralType> std::optional<IntegralType> parseIntegerAllowingTrailingJunk(StringView string, uint8_t base)
 {
     if (string.is8Bit())
-        return parseInteger<IntegralType>(string.characters8(), string.length(), base, TrailingJunkPolicy::Allow);
-    return parseInteger<IntegralType>(string.characters16(), string.length(), base, TrailingJunkPolicy::Allow);
+        return parseInteger<IntegralType>(string.span8(), base, TrailingJunkPolicy::Allow);
+    return parseInteger<IntegralType>(string.span16(), base, TrailingJunkPolicy::Allow);
 }
 
 }

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -540,7 +540,7 @@ static inline double toDoubleType(std::span<const CharacterType> data, bool* ok,
     while (leadingSpacesLength < data.size() && isUnicodeCompatibleASCIIWhitespace(data[leadingSpacesLength]))
         ++leadingSpacesLength;
 
-    double number = parseDouble(data.data() + leadingSpacesLength, data.size() - leadingSpacesLength, parsedLength);
+    double number = parseDouble(data.subspan(leadingSpacesLength), parsedLength);
     if (!parsedLength) {
         if (ok)
             *ok = false;

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -1038,7 +1038,7 @@ Token Lexer<T>::lexNumber()
 
     if (!isHex) {
         size_t parsedLength;
-        double result = parseDouble(integral, m_code - integral, parsedLength);
+        double result = parseDouble(std::span { integral, m_code }, parsedLength);
         ASSERT(integral + parsedLength == end);
         return convert(result);
     }


### PR DESCRIPTION
#### 6c4a382a605c9e699e24eb9a1d44251de35137f2
<pre>
Move numeric parsing to std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=272291">https://bugs.webkit.org/show_bug.cgi?id=272291</a>
<a href="https://rdar.apple.com/126030913">rdar://126030913</a>

Reviewed by Chris Dumez.

* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;T&gt;::lexWithoutClearingLineTerminator): Use span.
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::jsStrDecimalLiteral): Ditto.
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lexNumber): Ditto.
* Source/WTF/wtf/FastFloat.cpp:
(WTF::parseDouble): Ditto.
* Source/WTF/wtf/FastFloat.h: Ditto.
* Source/WTF/wtf/dtoa.h:
(WTF::parseDouble): Ditto.
* Source/WTF/wtf/text/StringToIntegerConversion.h:
(WTF::parseInteger): Ditto.
(WTF::parseIntegerAllowingTrailingJunk): Ditto.
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::toDoubleType): Ditto.
* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(WebCore::parseValidHTMLFloatingPointNumberInternal): Ditto.
(WebCore::parseValidHTMLFloatingPointNumber): Ditto.
(WebCore::parseHTMLListOfOfFloatingPointNumberValuesInternal): Ditto.
(WebCore::parseHTMLDimensionNumber): Ditto.
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lexNumber): Ditto.

Canonical link: <a href="https://commits.webkit.org/277178@main">https://commits.webkit.org/277178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06a572bdcd887abcdb3ad68af0725b4623b7486d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42944 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38195 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19505 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20582 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41527 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4942 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40145 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43172 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51450 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46379 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45483 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23193 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44458 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23804 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53521 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6576 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22904 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11000 "Passed tests") | 
<!--EWS-Status-Bubble-End-->