### PR TITLE
Enable text indicator styling for specified ranges.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2771,6 +2771,43 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 #endif
 }
 
+- (NSUUID *)_enableTextIndicatorStylingAfterElementWithID:(NSString *)elementID
+{
+    RetainPtr nsUUID = [NSUUID UUID];
+
+    auto uuid = WTF::UUID::fromNSUUID(nsUUID.get());
+    if (!uuid)
+        return nil;
+
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    _page->enableTextIndicatorStyleAfterElementWithID(elementID, *uuid);
+
+#if PLATFORM(IOS_FAMILY)
+    [_contentView addTextIndicatorStyleForID:nsUUID.get()];
+#elif PLATFORM(MAC) && ENABLE(UNIFIED_TEXT_REPLACEMENT_UI)
+    _impl->addTextIndicatorStyleForID(*uuid);
+#endif
+    return nsUUID.get();
+#else
+    return nil;
+#endif
+}
+
+- (void)_disableTextIndicatorStylingWithUUID:(NSUUID *)nsuuid
+{
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+#if PLATFORM(IOS_FAMILY)
+    [_contentView removeTextIndicatorStyleForID:nsuuid];
+#elif PLATFORM(MAC) && ENABLE(UNIFIED_TEXT_REPLACEMENT_UI)
+    auto uuid = WTF::UUID::fromNSUUID(nsuuid);
+    if (!uuid)
+        return;
+    _impl->removeTextIndicatorStyleForID(*uuid);
+#endif
+#endif
+}
+
+
 - (void)_requestTargetedElementInfo:(_WKTargetedElementRequest *)request completionHandler:(void(^)(NSArray<_WKTargetedElementInfo *> *))completion
 {
     WebCore::TargetedElementRequest coreRequest {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -396,6 +396,9 @@ for this property.
 - (void)_addAppHighlight WK_API_AVAILABLE(macos(12.0), ios(15.0));
 - (void)_addAppHighlightInNewGroup:(BOOL)newGroup originatedInApp:(BOOL)originatedInApp WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
+- (NSUUID *)_enableTextIndicatorStylingAfterElementWithID:(NSString *)elementID WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+- (void)_disableTextIndicatorStylingWithUUID:(NSUUID *)nsUUID WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 // FIXME: Remove old `-[WKWebView _themeColor]` SPI <rdar://76662644>
 #if TARGET_OS_IPHONE
 @property (nonatomic, readonly) UIColor *_themeColor WK_API_DEPRECATED_WITH_REPLACEMENT("themeColor", ios(15.0, 15.0));

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1204,6 +1204,14 @@ void WebPageProxy::textReplacementSessionUpdateStateForReplacementWithUUID(const
     protectedPageClient()->textReplacementSessionUpdateStateForReplacementWithUUID(sessionUUID, state, replacementUUID);
 }
 
+void WebPageProxy::enableTextIndicatorStyleAfterElementWithID(const String& elementID, const WTF::UUID& uuid)
+{
+    if (!hasRunningProcess())
+        return;
+
+    send(Messages::WebPage::EnableTextIndicatorStyleAfterElementWithID(elementID, uuid));
+}
+
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2194,6 +2194,7 @@ public:
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
     void removeTextIndicatorStyleForID(const WTF::UUID&);
+    void enableTextIndicatorStyleAfterElementWithID(const String& elementID, const WTF::UUID&);
 #endif
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -733,7 +733,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     void textReplacementSessionDidReceiveTextWithReplacementRange(const WTF::UUID&, const WebCore::AttributedString&, const WebCore::CharacterRange&, const WebUnifiedTextReplacementContextData&);
 
     void textReplacementSessionDidReceiveEditAction(const WTF::UUID&, WebTextReplacementDataEditAction);
+#endif
 
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT_UI)
     void addTextIndicatorStyleForID(WTF::UUID);
     void removeTextIndicatorStyleForID(WTF::UUID);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm
@@ -704,43 +704,6 @@ void UnifiedTextReplacementController::updateStateForSelectedReplacementIfNeeded
     m_webPage->textReplacementSessionShowInformationForReplacementWithUUIDRelativeToRect(data.sessionUUID, data.uuid, rect);
 }
 
-
-void UnifiedTextReplacementController::getTextIndicatorForID(const WTF::UUID& uuid, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&& completionHandler)
-{
-    RefPtr range = m_contextRanges.get(uuid);
-    auto simpleRange = makeSimpleRange(range.get());
-
-    if (!simpleRange) {
-        completionHandler(std::nullopt);
-        return;
-    }
-
-    RefPtr corePage = m_webPage->corePage();
-    if (!corePage) {
-        completionHandler(std::nullopt);
-        return;
-    }
-
-    RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage->mainFrame());
-    if (!localMainFrame) {
-        completionHandler(std::nullopt);
-        return;
-    }
-
-    constexpr OptionSet<WebCore::TextIndicatorOption> textIndicatorOptions {
-        WebCore::TextIndicatorOption::IncludeSnapshotOfAllVisibleContentWithoutSelection,
-        WebCore::TextIndicatorOption::ExpandClipBeyondVisibleRect,
-        WebCore::TextIndicatorOption::UseSelectionRectForSizing
-    };
-    RefPtr textIndicator = WebCore::TextIndicator::createWithRange(*simpleRange, textIndicatorOptions, WebCore::TextIndicatorPresentationTransition::None, { });
-    if (!textIndicator) {
-        completionHandler(std::nullopt);
-        return;
-    }
-
-    completionHandler(textIndicator->data());
-}
-
 } // namespace WebKit
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
@@ -73,7 +73,7 @@ public:
 
     void updateStateForSelectedReplacementIfNeeded();
 
-    void getTextIndicatorForID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
+    RefPtr<WebCore::Range> rangeForUUID(const WTF::UUID uuid) { return m_contextRanges.get(uuid); }
 
 private:
     void textReplacementSessionPerformEditActionForPlainText(WebCore::Document&, const WTF::UUID&, WebKit::WebTextReplacementData::EditAction);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1736,6 +1736,8 @@ public:
     void textReplacementSessionUpdateStateForReplacementWithUUID(const WTF::UUID& sessionUUID, WebTextReplacementDataState, const WTF::UUID& replacementUUID);
 
     void removeTextIndicatorStyleForID(const WTF::UUID&);
+
+    void enableTextIndicatorStyleAfterElementWithID(const String&, const WTF::UUID&);
 #endif
 
 private:
@@ -2778,6 +2780,7 @@ private:
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
     UniqueRef<UnifiedTextReplacementController> m_unifiedTextReplacementController;
+    HashMap<WTF::UUID, Ref<WebCore::Range>> m_textIndicatorStyleEnablementRanges;
 #endif
 
     mutable RefPtr<Logger> m_logger;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -788,6 +788,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     TextReplacementSessionDidReceiveTextWithReplacementRange(WTF::UUID uuid, struct WebCore::AttributedString attributedText, struct WebCore::CharacterRange range, struct WebKit::WebUnifiedTextReplacementContextData context);
 
     TextReplacementSessionDidReceiveEditAction(WTF::UUID uuid, enum:uint8_t WebKit::WebTextReplacementData::EditAction action);
+    
+    EnableTextIndicatorStyleAfterElementWithID(String elementID, WTF::UUID uuid);
 #endif
 
     ResetVisibilityAdjustmentsForTargetedElements(Vector<std::pair<WebCore::ElementIdentifier, WebCore::ScriptExecutionContextIdentifier>> identifiers) -> (bool success)


### PR DESCRIPTION
#### a35a92c62f0e85ebd505ed1fac53febe94facb6f
<pre>
Enable text indicator styling for specified ranges.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272293">https://bugs.webkit.org/show_bug.cgi?id=272293</a>
<a href="https://rdar.apple.com/125359006">rdar://125359006</a>

Reviewed by Wenson Hsieh.

Enable text indicator styling for specified ranges.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _enableTextIndicatorStylingAfterElementWithID:]):
(-[WKWebView _disableTextIndicatorStylingWithUUID:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::enableTextIndicatorStyleAfterElementWithID):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm:
(WebKit::UnifiedTextReplacementController::getTextIndicatorForID): Deleted.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getTextIndicatorForID):
(WebKit::WebPage::enableTextIndicatorStyleAfterElementWithID):
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/277284@main">https://commits.webkit.org/277284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff59882774bad13e73bab8a8a1fc0c22217f4ce3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47202 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49885 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43251 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38447 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40685 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19760 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21277 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5246 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51761 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45743 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23504 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44752 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10411 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24291 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->