### PR TITLE
LinkText and VisitedText system colors doesn't obey color scheme

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt
@@ -54,5 +54,5 @@ FAIL Property color value 'Field' resolves to the same color as the background-c
 FAIL Property color value 'FieldText' resolves to the same color as text on a text area (dark) assert_equals: expected "rgb(255, 255, 255)" but got "rgba(255, 255, 255, 0.847)"
 PASS Property color value 'Mark' has the same color as the background-color of a mark element (dark)
 PASS Property color value 'MarkText' has the same color as the color of a mark element (dark)
-FAIL Property color value 'LinkText' has the same color as the color of an anchor element (dark) assert_equals: expected "rgb(158, 158, 255)" but got "rgb(0, 0, 238)"
+PASS Property color value 'LinkText' has the same color as the color of an anchor element (dark)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-support-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-support-expected.txt
@@ -1,8 +1,8 @@
 
 PASS System color Canvas works
 PASS System color CanvasText works
-FAIL System color LinkText works assert_not_equals: LinkText should react to color-scheme got disallowed value "rgb(0, 0, 238)"
-FAIL System color VisitedText works assert_not_equals: VisitedText should react to color-scheme got disallowed value "rgb(85, 26, 139)"
+PASS System color LinkText works
+PASS System color VisitedText works
 PASS System color ActiveText works
 FAIL System color ButtonFace works assert_not_equals: ButtonFace should react to color-scheme got disallowed value "rgb(192, 192, 192)"
 PASS System color ButtonText works

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-color/system-color-support-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-color/system-color-support-expected.txt
@@ -1,8 +1,8 @@
 
 PASS System color Canvas works
 PASS System color CanvasText works
-FAIL System color LinkText works assert_not_equals: LinkText should react to color-scheme got disallowed value "rgb(0, 0, 238)"
-FAIL System color VisitedText works assert_not_equals: VisitedText should react to color-scheme got disallowed value "rgb(85, 26, 139)"
+PASS System color LinkText works
+PASS System color VisitedText works
 PASS System color ActiveText works
 FAIL System color ButtonFace works assert_not_equals: ButtonFace should react to color-scheme got disallowed value "rgb(192, 192, 192)"
 PASS System color ButtonText works

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-color/system-color-support-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-color/system-color-support-expected.txt
@@ -1,8 +1,8 @@
 
 PASS System color Canvas works
 PASS System color CanvasText works
-FAIL System color LinkText works assert_not_equals: LinkText should react to color-scheme got disallowed value "rgb(0, 0, 238)"
-FAIL System color VisitedText works assert_not_equals: VisitedText should react to color-scheme got disallowed value "rgb(85, 26, 139)"
+PASS System color LinkText works
+PASS System color VisitedText works
 PASS System color ActiveText works
 FAIL System color ButtonFace works assert_not_equals: ButtonFace should react to color-scheme got disallowed value "rgb(192, 192, 192)"
 FAIL System color ButtonText works assert_not_equals: ButtonText should react to color-scheme got disallowed value "rgb(0, 0, 0)"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt
@@ -54,5 +54,5 @@ FAIL Property color value 'Field' resolves to the same color as the background-c
 FAIL Property color value 'FieldText' resolves to the same color as text on a text area (dark) assert_equals: expected "rgb(255, 255, 255)" but got "rgba(255, 255, 255, 0.847)"
 PASS Property color value 'Mark' has the same color as the background-color of a mark element (dark)
 PASS Property color value 'MarkText' has the same color as the color of a mark element (dark)
-FAIL Property color value 'LinkText' has the same color as the color of an anchor element (dark) assert_equals: expected "rgb(158, 158, 255)" but got "rgb(0, 0, 238)"
+PASS Property color value 'LinkText' has the same color as the color of an anchor element (dark)
 

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1559,12 +1559,12 @@ Color RenderTheme::systemColor(CSSValueID cssValueId, OptionSet<StyleColorOption
     // https://drafts.csswg.org/css-color-4/#valdef-system-color-linktext
     // Text in non-active, non-visited links. For light backgrounds, traditionally blue.
     case CSSValueLinktext:
-        return SRGBA<uint8_t> { 0, 0, 238 };
+        return useDarkAppearance ? SRGBA<uint8_t> { 158, 158, 255 } : SRGBA<uint8_t> { 0, 0, 238 };
 
     // https://drafts.csswg.org/css-color-4/#valdef-system-color-visitedtext
     // Text in visited links. For light backgrounds, traditionally purple.
     case CSSValueVisitedtext:
-        return SRGBA<uint8_t> { 85, 26, 139 };
+        return useDarkAppearance ? SRGBA<uint8_t> { 208, 173, 240 } : SRGBA<uint8_t> { 85, 26, 139 };
 
     // https://drafts.csswg.org/css-color-4/#valdef-system-color-activetext
     // Text in active links. For light backgrounds, traditionally red.
@@ -1652,9 +1652,9 @@ Color RenderTheme::systemColor(CSSValueID cssValueId, OptionSet<StyleColorOption
 
     // Non-standard addition.
     case CSSValueWebkitLink: {
-        if (useDarkAppearance)
-            return forVisitedLink ? SRGBA<uint8_t> { 208, 173, 240 } : SRGBA<uint8_t> { 158, 158, 255 };
-        return forVisitedLink ? SRGBA<uint8_t> { 85, 26, 139 } : SRGBA<uint8_t> { 0, 0, 238 };
+        if (forVisitedLink)
+            return systemColor(CSSValueVisitedtext, options);
+        return systemColor(CSSValueLinktext, options);
     }
 
     // Deprecated system-colors:

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -471,7 +471,8 @@ Color RenderThemeMac::systemColor(CSSValueID cssValueID, OptionSet<StyleColorOpt
         return RenderTheme::systemColor(cssValueID, options);
     }
 
-    ASSERT(!forVisitedLink);
+    // -webkit-link requests Visitedtext when the link is visited, let it fetch Visitedtext from the cache if possible.
+    ASSERT(!forVisitedLink || cssValueID == CSSValueVisitedtext);
 
     auto it = cache.systemStyleColors.find(cssValueID);
     if (it != cache.systemStyleColors.end())


### PR DESCRIPTION
#### b538c70c4d25f6ed285f69728f78a54cb4b9ad14
<pre>
LinkText and VisitedText system colors doesn&apos;t obey color scheme
<a href="https://bugs.webkit.org/show_bug.cgi?id=272299">https://bugs.webkit.org/show_bug.cgi?id=272299</a>

Reviewed by Tim Nguyen.

Change LinkText and VisitedText CSS system colors to use a different value when the used color scheme is dark.
The chosen colors are the same as `-webkit-link` and are what is expected by WPT tests.

* LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/system-color-support-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-color/system-color-support-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-color/system-color-support-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-color/system-color-consistency-expected.txt:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::systemColor const):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::systemColor const):

Canonical link: <a href="https://commits.webkit.org/277259@main">https://commits.webkit.org/277259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/228bd5c55465cfe9e60bd9a487d0857ba54a959d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26290 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43164 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38380 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19687 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21176 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41774 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5159 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43502 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51674 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45674 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23416 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44679 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10396 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24198 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->