### PR TITLE
WPT dom/events/shadow-relatedTarget.html fails partially

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/shadow-relatedTarget-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/shadow-relatedTarget-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL relatedTarget should not leak at capturing phase, at window object. assert_equals: expected Element node <div id="host"></div> but got Element node <input id="shadowInput"></input>
+PASS relatedTarget should not leak at capturing phase, at window object.
 PASS relatedTarget should not leak at target.
 

--- a/Source/WebCore/dom/EventContext.cpp
+++ b/Source/WebCore/dom/EventContext.cpp
@@ -45,7 +45,7 @@ void EventContext::handleLocalEvents(Event& event, EventInvokePhase phase) const
     event.setCurrentTarget(m_currentTarget.copyRef(), m_currentTargetIsInShadowTree);
 
     if (m_relatedTargetIsSet) {
-        ASSERT(!m_relatedTarget || m_type == Type::MouseOrFocus);
+        ASSERT(!m_relatedTarget || isMouseOrFocusEventContext() || isWindowContext());
         event.setRelatedTarget(m_relatedTarget.copyRef());
     }
 

--- a/Source/WebCore/dom/EventContext.h
+++ b/Source/WebCore/dom/EventContext.h
@@ -58,6 +58,7 @@ public:
 
     void handleLocalEvents(Event&, EventInvokePhase) const;
 
+    bool isNormalEventContext() const { return m_type == Type::Normal; }
     bool isMouseOrFocusEventContext() const { return m_type == Type::MouseOrFocus; }
     bool isTouchEventContext() const { return m_type == Type::Touch; }
     bool isWindowContext() const { return m_type == Type::Window; }

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -158,8 +158,8 @@ void EventPath::setRelatedTarget(Node& origin, Node& relatedNode)
     size_t originalEventPathSize = m_path.size();
     for (unsigned contextIndex = 0; contextIndex < originalEventPathSize; contextIndex++) {
         auto& context = m_path[contextIndex];
-        if (!context.isMouseOrFocusEventContext()) {
-            ASSERT(context.isWindowContext());
+        if (!(context.isMouseOrFocusEventContext() || context.isWindowContext())) {
+            ASSERT(context.isTouchEventContext() || context.isNormalEventContext());
             continue;
         }
 


### PR DESCRIPTION
#### 764534676c1acf239a45d9018755b8bcefa0f950
<pre>
WPT dom/events/shadow-relatedTarget.html fails partially
<a href="https://bugs.webkit.org/show_bug.cgi?id=272300">https://bugs.webkit.org/show_bug.cgi?id=272300</a>

Reviewed by Ryosuke Niwa.

This patch changes to see whether `EventContext` is window context or not
in `EventPath::setRelatedTarget`.

Probably, it might make related path simple
if EventPath have an another flag to indicate the context is for
window separately to coexit the `EventContext::Type::MouseOrFocus`,
but this patch choose only to add the condition to
it by that `EventPath::setRelatedTarget()` is called only for MouseEvent or
FocusEvent, and will be skipped essentially for other events.

* LayoutTests/imported/w3c/web-platform-tests/dom/events/shadow-relatedTarget-expected.txt:
* Source/WebCore/dom/EventContext.cpp:
(WebCore::EventContext::handleLocalEvents const):
* Source/WebCore/dom/EventContext.h:
(WebCore::EventContext::isNormalEventContext const):
* Source/WebCore/dom/EventPath.cpp:
(WebCore::EventPath::setRelatedTarget):

Canonical link: <a href="https://commits.webkit.org/278090@main">https://commits.webkit.org/278090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ed52fa63b38c6e59e3cb0882eb25c1fb5e28c85

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49593 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42959 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/30956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38205 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19515 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41545 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4957 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51466 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45498 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23208 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44482 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10863 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23879 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->