### PR TITLE
[GTK] Rename screenDPI() to fontDPI() where used for font scaling.

### DIFF
--- a/LayoutTests/fast/box-sizing/247980-expected.html
+++ b/LayoutTests/fast/box-sizing/247980-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body style="font-size:96px;">
+<hr style="width:1in;height:1in;">
+</body>
+</html>

--- a/LayoutTests/fast/box-sizing/247980.html
+++ b/LayoutTests/fast/box-sizing/247980.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<body style="font-size:96px;">
+<hr style="width:1em;height:1em;">
+<!-- The box produced by this hr element should be identical in size
+     to one with a width and height of 1in in CSS units, since 1em is
+     defined as the nominal font size, which has been set to 96px. And
+     that dimension 96px is in turn required by the CSS standard to equal
+     1in. Also, the box should in either case measure exactly one inch on
+     screen, but it's not clear to me how to test that in WebKit's testing
+     framework.
+  -->
+</body>
+</html>

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp
@@ -784,7 +784,7 @@ AccessibilityObjectAtspi::TextAttributes AccessibilityObjectAtspi::textAttribute
         }
 
         addAttributeIfNeeded("family-name"_s, style.fontCascade().firstFamily());
-        addAttributeIfNeeded("size"_s, makeString(std::round(style.computedFontSize() * 72 / WebCore::screenDPI()), "pt"));
+        addAttributeIfNeeded("size"_s, makeString(std::round(style.computedFontSize() * 72 / WebCore::fontDPI()), "pt"));
         addAttributeIfNeeded("weight"_s, makeString(static_cast<float>(style.fontCascade().weight())));
         addAttributeIfNeeded("style"_s, style.fontCascade().italic() ? "italic"_s : "normal"_s);
         addAttributeIfNeeded("strikethrough"_s, style.textDecorationLine() & TextDecorationLine::LineThrough ? "true"_s : "false"_s);

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -72,7 +72,8 @@ WEBCORE_EXPORT DestinationColorSpace screenColorSpace(Widget* = nullptr);
 bool screenHasInvertedColors();
 
 #if USE(GLIB)
-double screenDPI();
+double fontDPI(); // dpi to use for font scaling
+double screenDPI(PlatformDisplayID); // dpi of the display device, corrected for device scaling
 #endif
 
 FloatRect screenRect(Widget*);

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -53,7 +53,7 @@ struct ScreenData {
 #endif
 #if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
     IntSize screenSize; // In millimeters.
-    double dpi;
+    double dpi; // Already corrected for device scaling.
 #endif
 
 #if PLATFORM(MAC) || PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/graphics/gtk/SystemFontDatabaseGTK.cpp
+++ b/Source/WebCore/platform/graphics/gtk/SystemFontDatabaseGTK.cpp
@@ -55,7 +55,7 @@ auto SystemFontDatabase::platformSystemFontShorthandInfo(FontShorthand) -> Syste
     int size = pango_font_description_get_size(pangoDescription) / PANGO_SCALE;
     // If the size of the font is in points, we need to convert it to pixels.
     if (!pango_font_description_get_size_is_absolute(pangoDescription))
-        size = size * (screenDPI() / 72.0);
+        size = size * (fontDPI() / 72.0);
 
     SystemFontShorthandInfo result { AtomString::fromLatin1(pango_font_description_get_family(pangoDescription)), static_cast<float>(size), normalWeightValue() };
     pango_font_description_free(pangoDescription);

--- a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
@@ -84,7 +84,7 @@ bool screenHasInvertedColors()
     return false;
 }
 
-double screenDPI()
+double fontDPI()
 {
     static GtkSettings* gtkSettings = gtk_settings_get_default();
     if (gtkSettings) {
@@ -96,6 +96,13 @@ double screenDPI()
     auto* data = screenData(primaryScreenDisplayID());
     return data ? data->dpi : 96.;
 }
+
+double screenDPI(PlatformDisplayID screendisplayID)
+{
+    auto* data = screenData(screendisplayID);
+    return data ? data->dpi : 96.;
+}
+
 
 FloatRect screenRect(Widget* widget)
 {

--- a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
@@ -94,15 +94,21 @@ bool screenHasInvertedColors()
     return false;
 }
 
-double screenDPI()
+double screenDPI(PlatformDisplayID screendisplayID)
 {
 #if ENABLE(WPE_PLATFORM)
-    auto* data = screenData(primaryScreenDisplayID());
+    auto* data = screenData(screendisplayID);
     return data ? data->dpi : 96.;
 #else
     notImplemented();
     return 96;
 #endif
+}
+
+double fontDPI()
+{
+    // In WPE, there is no notion of font scaling separate from device DPI.
+    return screenDPI(primaryScreenDisplayID());
 }
 
 FloatRect screenRect(Widget* widget)

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -385,7 +385,8 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
     addTableRow(displayObject, "Screen work area"_s, makeString(rect.x(), ',', rect.y(), ' ', rect.width(), 'x', rect.height()));
     addTableRow(displayObject, "Depth"_s, String::number(screenDepth(nullptr)));
     addTableRow(displayObject, "Bits per color component"_s, String::number(screenDepthPerComponent(nullptr)));
-    addTableRow(displayObject, "DPI"_s, String::number(screenDPI()));
+    addTableRow(displayObject, "Font Scaling DPI"_s, String::number(fontDPI()));
+    addTableRow(displayObject, "Screen DPI"_s, String::number(screenDPI(displayID.value_or(primaryScreenDisplayID()))));
 
     if (displayID) {
         if (auto* displayLink = page.process().processPool().displayLinks().existingDisplayLinkForDisplay(*displayID)) {

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -3833,7 +3833,7 @@ void webkit_settings_set_enable_back_forward_navigation_gestures(WebKitSettings*
  */
 guint32 webkit_settings_font_size_to_points(guint32 pixels)
 {
-    return std::round(pixels * 72 / WebCore::screenDPI());
+    return std::round(pixels * 72 / WebCore::fontDPI());
 }
 
 /**
@@ -3853,7 +3853,7 @@ guint32 webkit_settings_font_size_to_points(guint32 pixels)
  */
 guint32 webkit_settings_font_size_to_pixels(guint32 points)
 {
-    return std::round(points * WebCore::screenDPI() / 72);
+    return std::round(points * WebCore::fontDPI() / 72);
 }
 #endif // PLATFORM(GTK)
 


### PR DESCRIPTION
#### 51f27458d0d4eed34bcca196cdf4fe2252fc0340
<pre>
[GTK] Rename screenDPI() to fontDPI() where used for font scaling.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272676">https://bugs.webkit.org/show_bug.cgi?id=272676</a>

Reviewed by Carlos Garcia Campos.

This commit lays the groundwork for addressing DPI scaling issues under
GTK, as described in the related bugzilla bug 247980, which seems to
have arisen by virtue of confusion between the physical DPI of the display
devices that WebKit is rendering on, and the GTK font scaling DPI that sets
the desired font sizes. Hence, in line with the concerns raised in the
references bug 272676, this commit renames WebCore::screenDPI() to
WebCore::fontDPI() to clarify its semantics and hopefully avoid future
similar confusions. For cases in which the underlying display density is
needed, it adds a new WebCore::screenDPI(PlatformDisplayID) function
to access that information, on a per-display basis.

This commit also creates a reftest that probes the status of the referenced
bug. Namely, the test compares a 1em box in a text size of 96px, with a
1in box. Note the test passes as the code stands, even though when I view
247980.html and 247980-expected.html in the minibrowser on my machine, the
two boxes are clearly very different in size, which is one key aspect of the
bug. Presumably, this pass occurs because the tests are run in an environment
insulated from my actual display resolution and GTK setup. Moreover, another
aspect of the bug is that when the two DPI measures referenced above agree,
both boxes should measure 1 physical inch on the screen, which they currently
do not (unless the display happens to have exactly 96 pixels per inch, low by
today&apos;s typical specs, and unlikely to happen to be the case even when device
scaling is employed). But I have no idea how such a condition could
practically be tested in the WebKit test framework.

* LayoutTests/fast/box-sizing/247980-expected.html: Added.
* LayoutTests/fast/box-sizing/247980.html: Added.
* Source/WebCore/accessibility/atspi/AccessibilityObjectTextAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::textAttributes const):
* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/ScreenProperties.h:
* Source/WebCore/platform/graphics/gtk/SystemFontDatabaseGTK.cpp:
(WebCore::SystemFontDatabase::platformSystemFontShorthandInfo):
* Source/WebCore/platform/gtk/PlatformScreenGtk.cpp:
(WebCore::fontDPI):
(WebCore::screenDPI):
* Source/WebCore/platform/wpe/PlatformScreenWPE.cpp:
(WebCore::fontDPI):
(WebCore::screenDPI):
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_font_size_to_points):
(webkit_settings_font_size_to_pixels):

Canonical link: <a href="https://commits.webkit.org/277537@main">https://commits.webkit.org/277537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41815f5332ff89c09f1a6750c06fa8bbcf091ea0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50504 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43876 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32886 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38922 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24690 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20215 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22170 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42522 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5870 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44188 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52398 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22859 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46234 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45272 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10567 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24920 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23852 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->