### PR TITLE
Use span for PixelBuffer

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/ArrayBufferView.h
@@ -78,6 +78,7 @@ public:
 
     void* data() const { return baseAddress(); }
     std::span<const uint8_t> span() const { return { static_cast<const uint8_t*>(data()), byteLength() }; }
+    std::span<uint8_t> mutableSpan() const { return { static_cast<uint8_t*>(data()), byteLength() }; }
     Vector<uint8_t> toVector() const { return span(); }
 
     size_t byteOffsetRaw() const { return m_byteOffset; }

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -224,38 +224,38 @@ static PixelFormat toPixelFormat(GPUTextureFormat textureFormat)
     return PixelFormat::RGBA8;
 }
 
-using ImageDataCallback = Function<void(const uint8_t*, size_t, size_t)>;
+using ImageDataCallback = Function<void(std::span<const uint8_t>, size_t)>;
 static void getImageBytesFromImageBuffer(ImageBuffer* imageBuffer, const auto& destination, ImageDataCallback&& callback)
 {
     if (!imageBuffer)
-        return callback(nullptr, 0, 0);
+        return callback({ }, 0);
 
     auto size = imageBuffer->truncatedLogicalSize();
     if (!size.width() || !size.height())
-        return callback(nullptr, 0, 0);
+        return callback({ }, 0);
 
     auto pixelBuffer = imageBuffer->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, toPixelFormat(destination.texture->format()), DestinationColorSpace::SRGB() }, { { }, size });
     if (!pixelBuffer)
-        return callback(nullptr, 0, 0);
+        return callback({ }, 0);
 
-    callback(pixelBuffer->bytes(), pixelBuffer->sizeInBytes(), size.height());
+    callback(pixelBuffer->bytes(), size.height());
 }
 
 #if PLATFORM(COCOA) && ENABLE(VIDEO) && ENABLE(WEB_CODECS)
 static void getImageBytesFromVideoFrame(const RefPtr<VideoFrame>& videoFrame, ImageDataCallback&& callback)
 {
     if (!videoFrame.get() || !videoFrame->pixelBuffer())
-        return callback(nullptr, 0, 0);
+        return callback({ }, 0);
 
     auto pixelBuffer = videoFrame->pixelBuffer();
     if (!pixelBuffer)
-        return callback(nullptr, 0, 0);
+        return callback({ }, 0);
 
     auto rows = CVPixelBufferGetHeight(pixelBuffer);
     auto sizeInBytes = rows * CVPixelBufferGetBytesPerRow(pixelBuffer);
 
     CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
-    callback(reinterpret_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer)), sizeInBytes, rows);
+    callback({ reinterpret_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer)), sizeInBytes }, rows);
     CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
 }
 #endif
@@ -267,40 +267,37 @@ static void imageBytesForSource(const auto& source, const auto& destination, Ima
         return getImageBytesFromImageBuffer(imageBitmap->buffer(), destination, WTFMove(callback));
 #if ENABLE(VIDEO) && ENABLE(WEB_CODECS)
     }, [&](const RefPtr<ImageData> imageData) -> ResultType {
-        auto rows = imageData->height();
-        auto pixelBuffer = imageData->pixelBuffer();
-        auto sizeInBytes = pixelBuffer->data().byteLength();
-        callback(pixelBuffer->data().data(), sizeInBytes, rows);
+        callback(imageData->pixelBuffer()->bytes(), imageData->height());
     }, [&](const RefPtr<HTMLImageElement> imageElement) -> ResultType {
 #if PLATFORM(COCOA)
         if (!imageElement)
-            return callback(nullptr, 0, 0);
+            return callback({ }, 0);
         auto* cachedImage = imageElement->cachedImage();
         if (!cachedImage)
-            return callback(nullptr, 0, 0);
+            return callback({ }, 0);
         RefPtr image = cachedImage->image();
         if (!image || !image->isBitmapImage())
-            return callback(nullptr, 0, 0);
+            return callback({ }, 0);
         RefPtr nativeImage = static_cast<BitmapImage*>(image.get())->nativeImage();
         if (!nativeImage)
-            return callback(nullptr, 0, 0);
+            return callback({ }, 0);
         RetainPtr platformImage = nativeImage->platformImage();
         if (!platformImage)
-            return callback(nullptr, 0, 0);
+            return callback({ }, 0);
         RetainPtr pixelDataCfData = adoptCF(CGDataProviderCopyData(CGImageGetDataProvider(platformImage.get())));
         if (!pixelDataCfData)
-            return callback(nullptr, 0, 0);
+            return callback({ }, 0);
 
         auto width = CGImageGetWidth(platformImage.get());
         auto height = CGImageGetHeight(platformImage.get());
         if (!width || !height)
-            return callback(nullptr, 0, 0);
+            return callback({ }, 0);
 
         auto sizeInBytes = height * CGImageGetBytesPerRow(platformImage.get());
         auto bytePointer = reinterpret_cast<const uint8_t*>(CFDataGetBytePtr(pixelDataCfData.get()));
         auto requiredSize = width * height * 4;
         if (sizeInBytes == requiredSize)
-            return callback(bytePointer, sizeInBytes, height);
+            return callback({ bytePointer, sizeInBytes }, height);
 
         auto bytesPerRow = CGImageGetBytesPerRow(platformImage.get());
         Vector<uint8_t> tempBuffer(requiredSize, 255);
@@ -314,10 +311,10 @@ static void imageBytesForSource(const auto& source, const auto& destination, Ima
                 }
             }
         }
-        callback(&tempBuffer[0], tempBuffer.size(), height);
+        callback(tempBuffer.span(), height);
 #else
         UNUSED_PARAM(imageElement);
-        return callback(nullptr, 0, 0);
+        return callback({ }, 0);
 #endif
     }, [&](const RefPtr<HTMLVideoElement> videoElement) -> ResultType {
 #if PLATFORM(COCOA)
@@ -326,13 +323,13 @@ static void imageBytesForSource(const auto& source, const auto& destination, Ima
 #else
         UNUSED_PARAM(videoElement);
 #endif
-        return callback(nullptr, 0, 0);
+        return callback({ }, 0);
     }, [&](const RefPtr<WebCodecsVideoFrame> webCodecsFrame) -> ResultType {
 #if PLATFORM(COCOA)
         return getImageBytesFromVideoFrame(webCodecsFrame->internalFrame(), WTFMove(callback));
 #else
         UNUSED_PARAM(webCodecsFrame);
-        return callback(nullptr, 0, 0);
+        return callback({ }, 0);
 #endif
 #endif
     }, [&](const RefPtr<HTMLCanvasElement>& canvasElement) -> ResultType {
@@ -721,14 +718,15 @@ ExceptionOr<void> GPUQueue::copyExternalImageToTexture(ScriptExecutionContext& c
         return Exception { ExceptionCode::SecurityError, "GPUQueue.copyExternalImageToTexture: Cross origin external images are not allowed in WebGPU"_s };
 
     bool callbackScopeIsSafe { true };
-    imageBytesForSource(source.source, destination, [&](const uint8_t* imageBytes, size_t sizeInBytes, size_t rows) {
+    imageBytesForSource(source.source, destination, [&](std::span<const uint8_t> imageBytes, size_t rows) {
         RELEASE_ASSERT(callbackScopeIsSafe);
         auto destinationTexture = destination.texture;
-        if (!imageBytes || !sizeInBytes || !destinationTexture)
+        auto sizeInBytes = imageBytes.size();
+        if (!imageBytes.data() || !sizeInBytes || !destinationTexture)
             return;
 
         bool supportedFormat;
-        auto* newImageBytes = copyToDestinationFormat(imageBytes, destination.texture->format(), sizeInBytes, supportedFormat);
+        auto newImageBytes = copyToDestinationFormat(imageBytes.data(), destination.texture->format(), sizeInBytes, supportedFormat);
         GPUImageDataLayout dataLayout { 0, sizeInBytes / rows, rows };
         auto copyDestination = destination.convertToBacking();
 
@@ -737,9 +735,8 @@ ExceptionOr<void> GPUQueue::copyExternalImageToTexture(ScriptExecutionContext& c
         if (!supportedFormat || !(destinationTexture->usage() & GPUTextureUsage::RENDER_ATTACHMENT))
             copyDestination.mipLevel = INT_MAX;
 
-        m_backing->writeTexture(copyDestination, newImageBytes ? newImageBytes : imageBytes, sizeInBytes, dataLayout.convertToBacking(), convertToBacking(copySize));
-        if (newImageBytes)
-            free(newImageBytes);
+        m_backing->writeTexture(copyDestination, newImageBytes ? newImageBytes : imageBytes.data(), sizeInBytes, dataLayout.convertToBacking(), convertToBacking(copySize));
+        free(newImageBytes);
     });
     callbackScopeIsSafe = false;
 

--- a/Source/WebCore/html/CanvasNoiseInjection.cpp
+++ b/Source/WebCore/html/CanvasNoiseInjection.cpp
@@ -251,7 +251,7 @@ bool CanvasNoiseInjection::postProcessPixelBufferResults(PixelBuffer& pixelBuffe
     ASSERT(pixelBuffer.format().pixelFormat == PixelFormat::RGBA8);
 
     constexpr int bytesPerPixel = 4;
-    std::span<uint8_t> bytes = std::span(pixelBuffer.bytes(), pixelBuffer.sizeInBytes());
+    auto bytes = pixelBuffer.bytes();
     bool wasPixelBufferModified { false };
 
     // Salt value 0 is used for testing.

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -126,7 +126,7 @@ static std::optional<Lab<float>> sampleColor(Document& document, IntPoint&& loca
     if (!pixelBuffer)
         return std::nullopt;
 
-    if (pixelBuffer->sizeInBytes() < 4)
+    if (pixelBuffer->bytes().size() < 4)
         return std::nullopt;
 
     auto snapshotData = pixelBuffer->bytes();

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -114,6 +114,7 @@ public:
     }
 
     std::span<const uint8_t> span() const { return { static_cast<const uint8_t*>(m_data), m_size }; }
+    std::span<uint8_t> mutableSpan() const { return { static_cast<uint8_t*>(m_data), m_size }; }
 
 #if OS(WINDOWS)
     HANDLE handle() const { return m_handle.get(); }

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
@@ -96,7 +96,7 @@ RefPtr<ByteArrayPixelBuffer> ByteArrayPixelBuffer::tryCreate(const PixelBufferFo
 }
 
 ByteArrayPixelBuffer::ByteArrayPixelBuffer(const PixelBufferFormat& format, const IntSize& size, Ref<JSC::Uint8ClampedArray>&& data)
-    : PixelBuffer(format, size, data->data(), data->byteLength())
+    : PixelBuffer(format, size, data->mutableSpan())
     , m_data(WTFMove(data))
 {
 }

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -503,7 +503,7 @@ bool GraphicsContextGL::extractPixelBuffer(const PixelBuffer& pixelBuffer, DataF
         return false;
     data.resize(packSizes->imageBytes);
 
-    if (!packPixels(pixelBuffer.bytes(), sourceDataFormat, width, height, sourceImageSubRectangle, depth, 0, unpackImageHeight, format, type, premultiplyAlpha ? AlphaOp::DoPremultiply : AlphaOp::DoNothing, data.data(), flipY))
+    if (!packPixels(pixelBuffer.bytes().data(), sourceDataFormat, width, height, sourceImageSubRectangle, depth, 0, unpackImageHeight, format, type, premultiplyAlpha ? AlphaOp::DoPremultiply : AlphaOp::DoNothing, data.data(), flipY))
         return false;
 
     return true;

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -60,7 +60,7 @@ void ImageBufferBackend::convertToLuminanceMask()
         return;
     getPixelBuffer(sourceRect, *pixelBuffer);
 
-    unsigned pixelArrayLength = pixelBuffer->sizeInBytes();
+    unsigned pixelArrayLength = pixelBuffer->bytes().size();
     for (unsigned pixelOffset = 0; pixelOffset < pixelArrayLength; pixelOffset += 4) {
         uint8_t a = pixelBuffer->item(pixelOffset + 3);
         if (!a)
@@ -101,7 +101,7 @@ void ImageBufferBackend::getPixelBuffer(const IntRect& sourceRect, void* sourceD
     PixelBufferConversionView destination {
         destinationPixelBuffer.format(),
         destinationBytesPerRow,
-        destinationPixelBuffer.bytes() + destinationRect.y() * destinationBytesPerRow + destinationRect.x() * 4
+        destinationPixelBuffer.bytes().data() + destinationRect.y() * destinationBytesPerRow + destinationRect.x() * 4
     };
 
     convertImagePixels(source, destination, destinationRect.size());
@@ -127,7 +127,7 @@ void ImageBufferBackend::putPixelBuffer(const PixelBuffer& sourcePixelBuffer, co
     ConstPixelBufferConversionView source {
         sourcePixelBuffer.format(),
         sourceBytesPerRow,
-        sourcePixelBuffer.bytes() + sourceRectClipped.y() * sourceBytesPerRow + sourceRectClipped.x() * 4
+        sourcePixelBuffer.bytes().data() + sourceRectClipped.y() * sourceBytesPerRow + sourceRectClipped.x() * 4
     };
     unsigned destinationBytesPerRow = bytesPerRow();
     PixelBufferConversionView destination {

--- a/Source/WebCore/platform/graphics/PixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/PixelBuffer.cpp
@@ -59,44 +59,43 @@ CheckedUint32 PixelBuffer::computeBufferSize(PixelFormat pixelFormat, const IntS
 
 }
 
-PixelBuffer::PixelBuffer(const PixelBufferFormat& format, const IntSize& size, uint8_t* bytes, size_t sizeInBytes)
+PixelBuffer::PixelBuffer(const PixelBufferFormat& format, const IntSize& size, std::span<uint8_t> bytes)
     : m_format(format)
     , m_size(size)
     , m_bytes(bytes)
-    , m_sizeInBytes(sizeInBytes)
 {
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION((m_size.area() * 4) <= m_sizeInBytes);
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION((m_size.area() * 4) <= m_bytes.size());
 }
 
 PixelBuffer::~PixelBuffer() = default;
 
-bool PixelBuffer::setRange(const uint8_t* data, size_t dataByteLength, size_t byteOffset)
+bool PixelBuffer::setRange(std::span<const uint8_t> data, size_t byteOffset)
 {
-    if (!isSumSmallerThanOrEqual(byteOffset, dataByteLength, m_sizeInBytes))
+    if (!isSumSmallerThanOrEqual(byteOffset, data.size(), m_bytes.size()))
         return false;
 
-    memmove(m_bytes + byteOffset, data, dataByteLength);
+    memmove(m_bytes.data() + byteOffset, data.data(), data.size());
     return true;
 }
 
 bool PixelBuffer::zeroRange(size_t byteOffset, size_t rangeByteLength)
 {
-    if (!isSumSmallerThanOrEqual(byteOffset, rangeByteLength, m_sizeInBytes))
+    if (!isSumSmallerThanOrEqual(byteOffset, rangeByteLength, m_bytes.size()))
         return false;
 
-    memset(m_bytes + byteOffset, 0, rangeByteLength);
+    memset(m_bytes.data() + byteOffset, 0, rangeByteLength);
     return true;
 }
 
 uint8_t PixelBuffer::item(size_t index) const
 {
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(index < m_sizeInBytes);
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(index < m_bytes.size());
     return m_bytes[index];
 }
 
 void PixelBuffer::set(size_t index, double value)
 {
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(index < m_sizeInBytes);
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(index < m_bytes.size());
     m_bytes[index] = JSC::Uint8ClampedAdaptor::toNativeFromDouble(value);
 }
 

--- a/Source/WebCore/platform/graphics/PixelBuffer.h
+++ b/Source/WebCore/platform/graphics/PixelBuffer.h
@@ -47,27 +47,25 @@ public:
     const PixelBufferFormat& format() const { return m_format; }
     const IntSize& size() const { return m_size; }
 
-    uint8_t* bytes() const { return m_bytes; }
-    size_t sizeInBytes() const { return m_sizeInBytes; }
+    std::span<uint8_t> bytes() const { return m_bytes; }
 
     virtual bool isByteArrayPixelBuffer() const { return false; }
     virtual RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const = 0;
 
-    bool setRange(const uint8_t* data, size_t dataByteLength, size_t byteOffset);
+    bool setRange(std::span<const uint8_t> data, size_t byteOffset);
     WEBCORE_EXPORT bool zeroRange(size_t byteOffset, size_t rangeByteLength);
-    void zeroFill() { zeroRange(0, sizeInBytes()); }
+    void zeroFill() { zeroRange(0, bytes().size()); }
 
     WEBCORE_EXPORT uint8_t item(size_t index) const;
     void set(size_t index, double value);
 
 protected:
-    WEBCORE_EXPORT PixelBuffer(const PixelBufferFormat&, const IntSize&, uint8_t* bytes, size_t sizeInBytes);
+    WEBCORE_EXPORT PixelBuffer(const PixelBufferFormat&, const IntSize&, std::span<uint8_t> bytes);
     
     PixelBufferFormat m_format;
     IntSize m_size;
 
-    uint8_t* m_bytes { nullptr };
-    size_t m_sizeInBytes { 0 };
+    std::span<uint8_t> m_bytes;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ShadowBlur.cpp
+++ b/Source/WebCore/platform/graphics/ShadowBlur.cpp
@@ -897,7 +897,7 @@ void ShadowBlur::blurShadowBuffer(ImageBuffer& layerImage, const IntSize& templa
     if (!layerData)
         return;
 
-    blurLayerImage(layerData->bytes(), layerData->size(), layerData->size().width() * 4);
+    blurLayerImage(layerData->bytes().data(), layerData->size(), layerData->size().width() * 4);
     layerImage.putPixelBuffer(*layerData, blurRect);
 }
 

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp
@@ -111,8 +111,8 @@ RefPtr<NativeImage> GraphicsContextGL::createNativeImageFromPixelBuffer(const Gr
 
     // Convert RGBA to BGRA. BGRA is CAIRO_FORMAT_ARGB32 on little-endian architectures.
     Ref protectedPixelBuffer = pixelBuffer;
-    size_t totalBytes = pixelBuffer->sizeInBytes();
-    uint8_t* pixels = pixelBuffer->bytes();
+    size_t totalBytes = pixelBuffer->bytes().size();
+    uint8_t* pixels = pixelBuffer->bytes().data();
     for (size_t i = 0; i < totalBytes; i += 4)
         std::swap(pixels[i], pixels[i + 2]);
 
@@ -126,7 +126,7 @@ RefPtr<NativeImage> GraphicsContextGL::createNativeImageFromPixelBuffer(const Gr
 
     auto imageSize = pixelBuffer->size();
     RefPtr<cairo_surface_t> imageSurface = adoptRef(cairo_image_surface_create_for_data(
-        pixelBuffer->bytes(), CAIRO_FORMAT_ARGB32, imageSize.width(), imageSize.height(), imageSize.width() * 4));
+        pixels, CAIRO_FORMAT_ARGB32, imageSize.width(), imageSize.height(), imageSize.width() * 4));
     static cairo_user_data_key_t dataKey;
     cairo_surface_set_user_data(imageSurface.get(), &dataKey, &protectedPixelBuffer.leakRef(), [](void* buffer) {
         static_cast<PixelBuffer*>(buffer)->deref();

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
@@ -516,12 +516,11 @@ RefPtr<NativeImage> GraphicsContextGL::createNativeImageFromPixelBuffer(const Gr
         bitmapInfo |= kCGImageAlphaLast;
 
     Ref protectedPixelBuffer = pixelBuffer;
-    auto dataSize = pixelBuffer->sizeInBytes();
     auto data = pixelBuffer->bytes();
 
-    verifyImageBufferIsBigEnough(data, dataSize);
+    verifyImageBufferIsBigEnough(data.data(), data.size());
 
-    auto dataProvider = adoptCF(CGDataProviderCreateWithData(&protectedPixelBuffer.leakRef(), data, dataSize, [] (void* context, const void*, size_t) {
+    auto dataProvider = adoptCF(CGDataProviderCreateWithData(&protectedPixelBuffer.leakRef(), data.data(), data.size(), [] (void* context, const void*, size_t) {
         static_cast<PixelBuffer*>(context)->deref();
     }));
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
@@ -144,7 +144,7 @@ static bool encode(const PixelBuffer& source, const String& mimeType, std::optio
     CGImageAlphaInfo dataAlphaInfo = kCGImageAlphaLast;
     
     auto data = source.bytes();
-    auto dataSize = source.sizeInBytes();
+    auto dataSize = data.size();
 
     Vector<uint8_t> premultipliedData;
 
@@ -171,12 +171,12 @@ static bool encode(const PixelBuffer& source, const String& mimeType, std::optio
         }
 
         dataAlphaInfo = kCGImageAlphaNoneSkipLast; // Ignore the alpha channel.
-        data = premultipliedData.data();
+        data = premultipliedData.mutableSpan();
     }
 
-    verifyImageBufferIsBigEnough(data, dataSize);
+    verifyImageBufferIsBigEnough(data.data(), dataSize);
 
-    auto dataProvider = adoptCF(CGDataProviderCreateWithData(nullptr, data, dataSize, nullptr));
+    auto dataProvider = adoptCF(CGDataProviderCreateWithData(nullptr, data.data(), dataSize, nullptr));
     if (!dataProvider)
         return false;
 
@@ -186,7 +186,7 @@ static bool encode(const PixelBuffer& source, const String& mimeType, std::optio
     return encode(image.get(), mimeType, quality, function);
 }
 
-static bool encode(const std::span<const uint8_t>& data, const String& mimeType, std::optional<double> quality, const ScopedLambda<PutBytesCallback>& function)
+static bool encode(std::span<const uint8_t> data, const String& mimeType, std::optional<double> quality, const ScopedLambda<PutBytesCallback>& function)
 {
     if (data.empty())
         return false;
@@ -255,7 +255,7 @@ Vector<uint8_t> encodeData(const PixelBuffer& pixelBuffer, const String& mimeTyp
     return encodeToVector(pixelBuffer, mimeType, quality);
 }
 
-Vector<uint8_t> encodeData(const std::span<const uint8_t>& data, const String& mimeType, std::optional<double> quality)
+Vector<uint8_t> encodeData(std::span<const uint8_t> data, const String& mimeType, std::optional<double> quality)
 {
     return encodeToVector(data, mimeType, quality);
 }

--- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
@@ -40,7 +40,7 @@ RetainPtr<CFStringRef> utiFromImageBufferMIMEType(const String& mimeType);
 CFStringRef jpegUTI();
 Vector<uint8_t> encodeData(CGImageRef, const String& mimeType, std::optional<double> quality);
 Vector<uint8_t> encodeData(const PixelBuffer&, const String& mimeType, std::optional<double> quality);
-Vector<uint8_t> encodeData(const std::span<const uint8_t>&, const String& mimeType, std::optional<double> quality);
+Vector<uint8_t> encodeData(std::span<const uint8_t>, const String& mimeType, std::optional<double> quality);
 
 WEBCORE_EXPORT String dataURL(CGImageRef, const String& mimeType, std::optional<double> quality);
 String dataURL(const PixelBuffer&, const String& mimeType, std::optional<double> quality);

--- a/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
+++ b/Source/WebCore/platform/graphics/cv/VideoFrameCV.mm
@@ -500,7 +500,7 @@ RefPtr<VideoFrame> VideoFrame::createFromPixelBuffer(Ref<PixelBuffer>&& pixelBuf
     auto width = size.width();
     auto height = size.height();
 
-    auto dataBaseAddress = pixelBuffer->bytes();
+    auto dataBaseAddress = pixelBuffer->bytes().data();
     auto leakedBuffer = &pixelBuffer.leakRef();
     
     auto derefBuffer = [] (void* context, const void*) {

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -95,10 +95,10 @@ size_t FilterImage::memoryCost() const
         memoryCost += m_imageBuffer->memoryCost();
 
     if (m_unpremultipliedPixelBuffer)
-        memoryCost += m_unpremultipliedPixelBuffer->sizeInBytes();
+        memoryCost += m_unpremultipliedPixelBuffer->bytes().size();
 
     if (m_premultipliedPixelBuffer)
-        memoryCost += m_premultipliedPixelBuffer->sizeInBytes();
+        memoryCost += m_premultipliedPixelBuffer->bytes().size();
 
 #if USE(CORE_IMAGE)
     if (m_ciImage)
@@ -145,8 +145,8 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
     if (UNLIKELY(rowBytes.hasOverflowed()))
         return;
 
-    ConstPixelBufferConversionView source { sourcePixelBuffer.format(), rowBytes, sourcePixelBuffer.bytes() };
-    PixelBufferConversionView destination { destinationPixelBuffer.format(), rowBytes, destinationPixelBuffer.bytes() };
+    ConstPixelBufferConversionView source { sourcePixelBuffer.format(), rowBytes, sourcePixelBuffer.bytes().data() };
+    PixelBufferConversionView destination { destinationPixelBuffer.format(), rowBytes, destinationPixelBuffer.bytes().data() };
 
     convertImagePixels(source, destination, destinationSize);
 }
@@ -185,8 +185,8 @@ static void copyImageBytes(const PixelBuffer& sourcePixelBuffer, PixelBuffer& de
     if (UNLIKELY(size.hasOverflowed() || destinationBytesPerRow.hasOverflowed() || sourceBytesPerRow.hasOverflowed() || destinationOffset.hasOverflowed() || sourceOffset.hasOverflowed()))
         return;
 
-    uint8_t* destinationPixel = destinationPixelBuffer.bytes() + destinationOffset.value();
-    const uint8_t* sourcePixel = sourcePixelBuffer.bytes() + sourceOffset.value();
+    uint8_t* destinationPixel = destinationPixelBuffer.bytes().data() + destinationOffset.value();
+    const uint8_t* sourcePixel = sourcePixelBuffer.bytes().data() + sourceOffset.value();
 
     for (int y = 0; y < sourceRectClipped.height(); ++y) {
         memcpy(destinationPixel, sourcePixel, size);
@@ -328,8 +328,8 @@ void FilterImage::correctPremultipliedPixelBuffer()
     if (!m_premultipliedPixelBuffer || m_isValidPremultiplied)
         return;
 
-    uint8_t* pixelBytes = m_premultipliedPixelBuffer->bytes();
-    int pixelByteLength = m_premultipliedPixelBuffer->sizeInBytes();
+    uint8_t* pixelBytes = m_premultipliedPixelBuffer->bytes().data();
+    int pixelByteLength = m_premultipliedPixelBuffer->bytes().size();
 
     // We must have four bytes per pixel, and complete pixels
     ASSERT(!(pixelByteLength % 4));

--- a/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp
@@ -83,7 +83,7 @@ inline void FEColorMatrixSoftwareApplier::luminance(float& red, float& green, fl
 #if USE(ACCELERATE)
 void FEColorMatrixSoftwareApplier::applyPlatformAccelerated(PixelBuffer& pixelBuffer) const
 {
-    auto* pixelBytes = pixelBuffer.bytes();
+    auto* pixelBytes = pixelBuffer.bytes().data();
     auto bufferSize = pixelBuffer.size();
     const int32_t divisor = 256;
 
@@ -188,7 +188,7 @@ void FEColorMatrixSoftwareApplier::applyPlatformAccelerated(PixelBuffer& pixelBu
 
 void FEColorMatrixSoftwareApplier::applyPlatformUnaccelerated(PixelBuffer& pixelBuffer) const
 {
-    auto pixelByteLength = pixelBuffer.sizeInBytes();
+    auto pixelByteLength = pixelBuffer.bytes().size();
 
     switch (m_effect.type()) {
     case ColorMatrixType::FECOLORMATRIX_TYPE_UNKNOWN:

--- a/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp
@@ -114,8 +114,8 @@ FEComponentTransferSoftwareApplier::LookupTable FEComponentTransferSoftwareAppli
 
 void FEComponentTransferSoftwareApplier::applyPlatform(PixelBuffer& pixelBuffer) const
 {
-    auto* data = pixelBuffer.bytes();
-    auto pixelByteLength = pixelBuffer.sizeInBytes();
+    auto* data = pixelBuffer.bytes().data();
+    auto pixelByteLength = pixelBuffer.bytes().size();
 
     auto redTable   = computeLookupTable(m_effect.redFunction());
     auto greenTable = computeLookupTable(m_effect.greenFunction());

--- a/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp
@@ -149,11 +149,11 @@ bool FECompositeSoftwareArithmeticApplier::apply(const Filter&, const FilterImag
     IntRect effectBDrawingRect = result.absoluteImageRectRelativeTo(input2);
     input2.copyPixelBuffer(*destinationPixelBuffer, effectBDrawingRect);
 
-    auto* sourcePixelBytes = sourcePixelBuffer->bytes();
-    auto* destinationPixelBytes = destinationPixelBuffer->bytes();
+    auto* sourcePixelBytes = sourcePixelBuffer->bytes().data();
+    auto* destinationPixelBytes = destinationPixelBuffer->bytes().data();
 
-    auto length = sourcePixelBuffer->sizeInBytes();
-    ASSERT(length == destinationPixelBuffer->sizeInBytes());
+    auto length = sourcePixelBuffer->bytes().size();
+    ASSERT(length == destinationPixelBuffer->bytes().size());
 
     applyPlatform(sourcePixelBytes, destinationPixelBytes, length, m_effect.k1(), m_effect.k2(), m_effect.k3(), m_effect.k4());
     return true;

--- a/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp
@@ -68,7 +68,7 @@ bool FEDisplacementMapSoftwareApplier::apply(const Filter& filter, const FilterI
     if (!inputPixelBuffer || !displacementPixelBuffer)
         return false;
 
-    ASSERT(inputPixelBuffer->sizeInBytes() == displacementPixelBuffer->sizeInBytes());
+    ASSERT(inputPixelBuffer->bytes().size() == displacementPixelBuffer->bytes().size());
 
     auto paintSize = result.absoluteImageRect().size();
     auto scale = filter.resolvedSize({ m_effect.scale(), m_effect.scale() });
@@ -93,13 +93,13 @@ bool FEDisplacementMapSoftwareApplier::apply(const Filter& filter, const FilterI
             int srcX = x + static_cast<int>(scaleForColorX * displacementPixelBuffer->item(destinationIndex + displacementChannelX) + scaledOffsetX);
             int srcY = y + static_cast<int>(scaleForColorY * displacementPixelBuffer->item(destinationIndex + displacementChannelY) + scaledOffsetY);
 
-            unsigned* destinationPixelPtr = reinterpret_cast<unsigned*>(destinationPixelBuffer->bytes() + destinationIndex);
+            unsigned* destinationPixelPtr = reinterpret_cast<unsigned*>(destinationPixelBuffer->bytes().data() + destinationIndex);
             if (srcX < 0 || srcX >= paintSize.width() || srcY < 0 || srcY >= paintSize.height()) {
                 *destinationPixelPtr = 0;
                 continue;
             }
 
-            *destinationPixelPtr = *reinterpret_cast<unsigned*>(inputPixelBuffer->bytes() + byteOffsetOfPixel(srcX, srcY, rowBytes));
+            *destinationPixelPtr = *reinterpret_cast<unsigned*>(inputPixelBuffer->bytes().data() + byteOffsetOfPixel(srcX, srcY, rowBytes));
         }
     }
 

--- a/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp
@@ -65,7 +65,7 @@ bool FEDropShadowSoftwareApplier::apply(const Filter& filter, const FilterImageV
     if (!pixelBuffer)
         return false;
 
-    contextShadow.blurLayerImage(pixelBuffer->bytes(), pixelBuffer->size(), 4 * pixelBuffer->size().width());
+    contextShadow.blurLayerImage(pixelBuffer->bytes().data(), pixelBuffer->size(), 4 * pixelBuffer->size().width());
 
     resultImage->putPixelBuffer(*pixelBuffer, shadowArea);
 

--- a/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
@@ -75,8 +75,8 @@ inline void FEGaussianBlurSoftwareApplier::kernelPosition(int blurIteration, uns
 // This function only operates on Alpha channel.
 inline void FEGaussianBlurSoftwareApplier::boxBlurAlphaOnly(const PixelBuffer& srcPixelBuffer, PixelBuffer& dstPixelBuffer, unsigned dx, int& dxLeft, int& dxRight, int& stride, int& strideLine, int& effectWidth, int& effectHeight, const int& maxKernelSize)
 {
-    const uint8_t* srcData = srcPixelBuffer.bytes();
-    uint8_t* dstData = dstPixelBuffer.bytes();
+    const uint8_t* srcData = srcPixelBuffer.bytes().data();
+    uint8_t* dstData = dstPixelBuffer.bytes().data();
     // Memory alignment is: RGBA, zero-index based.
     const int channel = 3;
 
@@ -119,8 +119,8 @@ inline void FEGaussianBlurSoftwareApplier::boxBlur(const PixelBuffer& srcPixelBu
     if (alphaImage)
         return boxBlurAlphaOnly(srcPixelBuffer, dstPixelBuffer, dx, dxLeft, dxRight, stride, strideLine,  effectWidth, effectHeight, maxKernelSize);
 
-    const uint8_t* srcData = srcPixelBuffer.bytes();
-    uint8_t* dstData = dstPixelBuffer.bytes();
+    const uint8_t* srcData = srcPixelBuffer.bytes().data();
+    uint8_t* dstData = dstPixelBuffer.bytes().data();
 
     // Concerning the array width/length: it is Element size + Margin + Border. The number of pixels will be
     // P = width * height * channels.
@@ -245,7 +245,7 @@ inline void FEGaussianBlurSoftwareApplier::boxBlur(const PixelBuffer& srcPixelBu
 #if USE(ACCELERATE)
 inline void FEGaussianBlurSoftwareApplier::boxBlurAccelerated(PixelBuffer& ioBuffer, PixelBuffer& tempBuffer, unsigned kernelSize, int stride, int effectWidth, int effectHeight)
 {
-    if (!ioBuffer.bytes() || !tempBuffer.bytes()) {
+    if (!ioBuffer.bytes().data() || !tempBuffer.bytes().data()) {
         ASSERT_NOT_REACHED();
         return;
     }
@@ -260,13 +260,13 @@ inline void FEGaussianBlurSoftwareApplier::boxBlurAccelerated(PixelBuffer& ioBuf
         kernelSize += 1;
 
     vImage_Buffer effectInBuffer;
-    effectInBuffer.data = ioBuffer.bytes();
+    effectInBuffer.data = ioBuffer.bytes().data();
     effectInBuffer.width = effectWidth;
     effectInBuffer.height = effectHeight;
     effectInBuffer.rowBytes = stride;
 
     vImage_Buffer effectOutBuffer;
-    effectOutBuffer.data = tempBuffer.bytes();
+    effectOutBuffer.data = tempBuffer.bytes().data();
     effectOutBuffer.width = effectWidth;
     effectOutBuffer.height = effectHeight;
     effectOutBuffer.rowBytes = stride;
@@ -284,8 +284,8 @@ inline void FEGaussianBlurSoftwareApplier::boxBlurAccelerated(PixelBuffer& ioBuf
     fastFree(tmpBuffer);
 
     // The final result should be stored in ioBuffer.
-    ASSERT(ioBuffer.sizeInBytes() == tempBuffer.sizeInBytes());
-    memcpy(ioBuffer.bytes(), tempBuffer.bytes(), ioBuffer.sizeInBytes());
+    ASSERT(ioBuffer.bytes().size() == tempBuffer.bytes().size());
+    memcpy(ioBuffer.bytes().data(), tempBuffer.bytes().data(), ioBuffer.bytes().size());
 }
 #endif
 
@@ -329,8 +329,8 @@ inline void FEGaussianBlurSoftwareApplier::boxBlurUnaccelerated(PixelBuffer& ioB
 
     // The final result should be stored in ioBuffer.
     if (&ioBuffer != fromBuffer) {
-        ASSERT(ioBuffer.sizeInBytes() == fromBuffer->sizeInBytes());
-        memcpy(ioBuffer.bytes(), fromBuffer->bytes(), ioBuffer.sizeInBytes());
+        ASSERT(ioBuffer.bytes().size() == fromBuffer->bytes().size());
+        memcpy(ioBuffer.bytes().data(), fromBuffer->bytes().data(), ioBuffer.bytes().size());
     }
 }
 
@@ -391,7 +391,7 @@ inline void FEGaussianBlurSoftwareApplier::applyPlatform(PixelBuffer& ioBuffer, 
                 } else {
                     params.ioBuffer = ioBuffer.createScratchPixelBuffer(blockSize);
                     params.tempBuffer = tempBuffer.createScratchPixelBuffer(blockSize);
-                    memcpy(params.ioBuffer->bytes(), ioBuffer.bytes() + startY * scanline, params.ioBuffer->sizeInBytes());
+                    memcpy(params.ioBuffer->bytes().data(), ioBuffer.bytes().data() + startY * scanline, params.ioBuffer->bytes().size());
                 }
 
                 params.width = paintSize.width();
@@ -418,7 +418,7 @@ inline void FEGaussianBlurSoftwareApplier::applyPlatform(PixelBuffer& ioBuffer, 
                 destinationOffset = currentY * scanline;
                 size = adjustedBlockHeight * scanline;
 
-                memcpy(ioBuffer.bytes() + destinationOffset, params.ioBuffer->bytes() + sourceOffset, size);
+                memcpy(ioBuffer.bytes().data() + destinationOffset, params.ioBuffer->bytes().data() + sourceOffset, size);
             }
             return;
         }

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp
@@ -91,7 +91,7 @@ void FELightingSoftwareApplier::setPixelInternal(int offset, const LightingData&
         static_cast<uint8_t>(lightStrength * lightingData.colorVector.z() * 255.0f)
     };
     
-    data.pixels->setRange(pixelValue, 3, offset);
+    data.pixels->setRange({ pixelValue }, offset);
 }
 
 void FELightingSoftwareApplier::setPixel(int offset, const LightingData& data, const LightSource::PaintingData& paintingData, int x, int y, float factorX, float factorY, IntSize normal2DVector)

--- a/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp
@@ -42,10 +42,10 @@ inline ColorComponents<uint8_t, 4> FEMorphologySoftwareApplier::minOrMax(const C
 
 inline ColorComponents<uint8_t, 4> FEMorphologySoftwareApplier::columnExtremum(const PixelBuffer& srcPixelBuffer, int x, int yStart, int yEnd, int width, MorphologyOperatorType type)
 {
-    auto extremum = makeColorComponentsfromPixelValue(PackedColor::RGBA { *reinterpret_cast<const unsigned*>(srcPixelBuffer.bytes() + pixelArrayIndex(x, yStart, width)) });
+    auto extremum = makeColorComponentsfromPixelValue(PackedColor::RGBA { *reinterpret_cast<const unsigned*>(srcPixelBuffer.bytes().data() + pixelArrayIndex(x, yStart, width)) });
 
     for (int y = yStart + 1; y < yEnd; ++y) {
-        auto pixel = makeColorComponentsfromPixelValue(PackedColor::RGBA { *reinterpret_cast<const unsigned*>(srcPixelBuffer.bytes() + pixelArrayIndex(x, y, width)) });
+        auto pixel = makeColorComponentsfromPixelValue(PackedColor::RGBA { *reinterpret_cast<const unsigned*>(srcPixelBuffer.bytes().data() + pixelArrayIndex(x, y, width)) });
         extremum = minOrMax(extremum, pixel, type);
     }
     return extremum;
@@ -96,7 +96,7 @@ void FEMorphologySoftwareApplier::applyPlatformGeneric(const PaintingData& paint
             if (x > radiusX)
                 extrema.remove(0);
 
-            unsigned* destPixel = reinterpret_cast<unsigned*>(dstPixelBuffer.bytes() + pixelArrayIndex(x, y, width));
+            unsigned* destPixel = reinterpret_cast<unsigned*>(dstPixelBuffer.bytes().data() + pixelArrayIndex(x, y, width));
             *destPixel = makePixelValueFromColorComponents(kernelExtremum(extrema, paintingData.type)).value;
         }
     }

--- a/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp
@@ -285,7 +285,7 @@ void FETurbulenceSoftwareApplier::applyPlatformGeneric(const IntRect& filterRegi
             point.setX(point.x() + 1);
             FloatPoint localPoint = point.scaled(inverseScale.width(), inverseScale.height());
             auto values = calculateTurbulenceValueForPoint(paintingData, stitchData, localPoint);
-            pixelBuffer.setRange(values.components.data(), 4, indexOfPixelChannel);
+            pixelBuffer.setRange({ values.components.data(), 4 }, indexOfPixelChannel);
             indexOfPixelChannel += 4;
         }
     }

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -301,8 +301,8 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::createFromPixelBuffer(Ref<Pixel
     ensureVideoFrameDebugCategoryInitialized();
     auto size = pixelBuffer->size();
 
-    auto sizeInBytes = pixelBuffer->sizeInBytes();
-    auto dataBaseAddress = pixelBuffer->bytes();
+    auto sizeInBytes = pixelBuffer->bytes().size();
+    auto dataBaseAddress = pixelBuffer->bytes().data();
     auto leakedPixelBuffer = &pixelBuffer.leakRef();
 
     auto buffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_READONLY, dataBaseAddress, sizeInBytes, 0, sizeInBytes, leakedPixelBuffer, [](gpointer userData) {

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
@@ -119,7 +119,7 @@ RefPtr<NativeImage> GraphicsContextGL::createNativeImageFromPixelBuffer(const Gr
     auto imageInfo = SkImageInfo::Make(imageSize.width(), imageSize.height(), kRGBA_8888_SkColorType, alphaType);
 
     Ref protectedPixelBuffer = pixelBuffer;
-    SkPixmap pixmap(imageInfo, pixelBuffer->bytes(), imageInfo.minRowBytes());
+    SkPixmap pixmap(imageInfo, pixelBuffer->bytes().data(), imageInfo.minRowBytes());
     auto image = SkImages::RasterFromPixmap(pixmap, [](const void*, void* context) {
         static_cast<PixelBuffer*>(context)->deref();
     }, &protectedPixelBuffer.leakRef());

--- a/Source/WebCore/rendering/shapes/Shape.cpp
+++ b/Source/WebCore/rendering/shapes/Shape.cpp
@@ -209,14 +209,13 @@ Ref<const Shape> Shape::createRasterShape(Image* image, float threshold, const L
     if (!pixelBuffer)
         return createShape();
 
-    unsigned pixelArrayLength = pixelBuffer->sizeInBytes();
-    unsigned pixelArrayOffset = 3; // Each pixel is four bytes: RGBA.
-    uint8_t alphaPixelThreshold = static_cast<uint8_t>(lroundf(clampTo<float>(threshold, 0, 1) * 255.0f));
+    if (imageRect.area() * 4 == pixelBuffer->bytes().size()) {
+        unsigned pixelArrayOffset = 3; // Each pixel is four bytes: RGBA.
+        uint8_t alphaPixelThreshold = static_cast<uint8_t>(lroundf(clampTo<float>(threshold, 0, 1) * 255.0f));
 
-    int minBufferY = std::max(0, marginRect.y() - imageRect.y());
-    int maxBufferY = std::min(imageRect.height(), marginRect.maxY() - imageRect.y());
+        int minBufferY = std::max(0, marginRect.y() - imageRect.y());
+        int maxBufferY = std::min(imageRect.height(), marginRect.maxY() - imageRect.y());
 
-    if ((imageRect.area() * 4) == pixelArrayLength) {
         for (int y = minBufferY; y < maxBufferY; ++y) {
             int startX = -1;
             for (int x = 0; x < imageRect.width(); ++x, pixelArrayOffset += 4) {

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -88,10 +88,9 @@ void RemoteImageBuffer::getPixelBuffer(WebCore::PixelBufferFormat destinationFor
     MESSAGE_CHECK(memory, "No shared memory for getPixelBufferForImageBuffer"_s);
     MESSAGE_CHECK(WebCore::PixelBuffer::supportedPixelFormat(destinationFormat.pixelFormat), "Pixel format not supported"_s);
     IntRect srcRect(srcPoint, srcSize);
-    auto pixelBuffer = m_imageBuffer->getPixelBuffer(destinationFormat, srcRect);
-    if (pixelBuffer) {
-        MESSAGE_CHECK(pixelBuffer->sizeInBytes() <= memory->size(), "Shmem for return of getPixelBuffer is too small"_s);
-        memcpy(memory->data(), pixelBuffer->bytes(), pixelBuffer->sizeInBytes());
+    if (auto pixelBuffer = m_imageBuffer->getPixelBuffer(destinationFormat, srcRect)) {
+        MESSAGE_CHECK(pixelBuffer->bytes().size() <= memory->size(), "Shmem for return of getPixelBuffer is too small"_s);
+        memcpy(memory->data(), pixelBuffer->bytes().data(), pixelBuffer->bytes().size());
     } else
         memset(memory->data(), 0, memory->size());
     completionHandler();

--- a/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp
@@ -46,10 +46,10 @@ RefPtr<ShareablePixelBuffer> ShareablePixelBuffer::tryCreate(const PixelBufferFo
 }
 
 ShareablePixelBuffer::ShareablePixelBuffer(const PixelBufferFormat& format, const IntSize& size, Ref<SharedMemory>&& data)
-    : PixelBuffer(format, size, static_cast<uint8_t*>(data->data()), data->size())
+    : PixelBuffer(format, size, data->mutableSpan())
     , m_data(WTFMove(data))
 {
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION((m_size.area() * 4) <= sizeInBytes());
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_size.area() * 4 <= bytes().size());
 }
 
 RefPtr<PixelBuffer> ShareablePixelBuffer::createScratchPixelBuffer(const IntSize& size) const

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -244,7 +244,7 @@ RefPtr<PixelBuffer> RemoteImageBufferProxy::getPixelBuffer(const PixelBufferForm
     if (UNLIKELY(!pixelBuffer))
         return nullptr;
     if (LIKELY(m_remoteRenderingBackendProxy)) {
-        if (m_remoteRenderingBackendProxy->getPixelBufferForImageBuffer(m_renderingResourceIdentifier, destinationFormat, sourceRect, { pixelBuffer->bytes(), pixelBuffer->sizeInBytes() }))
+        if (m_remoteRenderingBackendProxy->getPixelBufferForImageBuffer(m_renderingResourceIdentifier, destinationFormat, sourceRect, pixelBuffer->bytes()))
             return pixelBuffer;
     }
     pixelBuffer->zeroFill();


### PR DESCRIPTION
#### a346affb13aa99421950e2b0b4a2bbc3ed1df39a
<pre>
Use span for PixelBuffer
<a href="https://rdar.apple.com/126049575">rdar://126049575</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=272306">https://bugs.webkit.org/show_bug.cgi?id=272306</a>

Reviewed by Chris Dumez.

* Source/JavaScriptCore/runtime/ArrayBufferView.h:
(JSC::ArrayBufferView::mutableSpan const): Added.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::getImageBytesFromImageBuffer): Use span.
(WebCore::getImageBytesFromVideoFrame): Ditto.
(WebCore::imageBytesForSource): Ditto.
(WebCore::GPUQueue::copyExternalImageToTexture): Ditto.
* Source/WebCore/html/CanvasNoiseInjection.cpp:
(WebCore::CanvasNoiseInjection::postProcessPixelBufferResults const): Ditto.
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::sampleColor): Ditto.

* Source/WebCore/platform/SharedMemory.h:
(WebCore::SharedMemory::mutableSpan const): Added.

* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp:
(WebCore::ByteArrayPixelBuffer::ByteArrayPixelBuffer): Use span.
* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::GraphicsContextGL::extractPixelBuffer): Ditto.
* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::convertToLuminanceMask): Ditto.
(WebCore::ImageBufferBackend::getPixelBuffer): Ditto.
(WebCore::ImageBufferBackend::putPixelBuffer): Ditto.
* Source/WebCore/platform/graphics/PixelBuffer.cpp:
(WebCore::PixelBuffer::PixelBuffer): Ditto.
(WebCore::PixelBuffer::setRange): Ditto.
(WebCore::PixelBuffer::zeroRange): Ditto.
(WebCore::PixelBuffer::item const): Ditto.
(WebCore::PixelBuffer::set): Ditto.
* Source/WebCore/platform/graphics/PixelBuffer.h: Ditto.
* Source/WebCore/platform/graphics/ShadowBlur.cpp:
(WebCore::ShadowBlur::blurShadowBuffer): Ditto.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::wipeAlphaChannelFromPixels): Ditto.
(WebCore::GraphicsContextGLANGLE::readPixelsForPaintResults): Ditto.
(WebCore::GraphicsContextGLANGLE::readPixelsImpl): Ditto.
(WebCore::GraphicsContextGLANGLE::drawingBufferToPixelBuffer): Ditto.
* Source/WebCore/platform/graphics/cairo/GraphicsContextGLCairo.cpp:
(WebCore::GraphicsContextGL::createNativeImageFromPixelBuffer): Ditto.
* Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp:
(WebCore::GraphicsContextGL::createNativeImageFromPixelBuffer): Ditto.
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp:
(WebCore::encode): Ditto.
(WebCore::encodeData): Ditto.
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h: Ditto.
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrame::createFromPixelBuffer): Ditto.
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::FilterImage::memoryCost const): Ditto.
(WebCore::copyImageBytes): Ditto.
(WebCore::FilterImage::correctPremultipliedPixelBuffer): Ditto.
* Source/WebCore/platform/graphics/filters/software/FEColorMatrixSoftwareApplier.cpp:
(WebCore::FEColorMatrixSoftwareApplier::applyPlatformAccelerated const): Ditto.
(WebCore::FEColorMatrixSoftwareApplier::applyPlatformUnaccelerated const): Ditto.
* Source/WebCore/platform/graphics/filters/software/FEComponentTransferSoftwareApplier.cpp:
(WebCore::FEComponentTransferSoftwareApplier::applyPlatform const): Ditto.
* Source/WebCore/platform/graphics/filters/software/FECompositeSoftwareArithmeticApplier.cpp:
(WebCore::FECompositeSoftwareArithmeticApplier::apply const): Ditto.
* Source/WebCore/platform/graphics/filters/software/FEDisplacementMapSoftwareApplier.cpp:
(WebCore::FEDisplacementMapSoftwareApplier::apply const): Ditto.
* Source/WebCore/platform/graphics/filters/software/FEDropShadowSoftwareApplier.cpp:
(WebCore::FEDropShadowSoftwareApplier::apply const): Ditto.
* Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp:
(WebCore::FEGaussianBlurSoftwareApplier::boxBlurAlphaOnly): Ditto.
(WebCore::FEGaussianBlurSoftwareApplier::boxBlur): Ditto.
(WebCore::FEGaussianBlurSoftwareApplier::boxBlurAccelerated): Ditto.
(WebCore::FEGaussianBlurSoftwareApplier::boxBlurUnaccelerated): Ditto.
(WebCore::FEGaussianBlurSoftwareApplier::applyPlatform): Ditto.
* Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.cpp:
(WebCore::FELightingSoftwareApplier::setPixelInternal): Ditto.
* Source/WebCore/platform/graphics/filters/software/FEMorphologySoftwareApplier.cpp:
(WebCore::FEMorphologySoftwareApplier::columnExtremum): Ditto.
(WebCore::FEMorphologySoftwareApplier::applyPlatformGeneric): Ditto.
* Source/WebCore/platform/graphics/filters/software/FETurbulenceSoftwareApplier.cpp:
(WebCore::FETurbulenceSoftwareApplier::applyPlatformGeneric): Ditto.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::createFromPixelBuffer): Ditto.
* Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp:
(WebCore::GraphicsContextGL::createNativeImageFromPixelBuffer): Ditto.
* Source/WebCore/rendering/shapes/Shape.cpp:
(WebCore::Shape::createRasterShape): Ditto.
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::getPixelBuffer): Ditto.
* Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp:
(WebKit::ShareablePixelBuffer::ShareablePixelBuffer): Ditto.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::getPixelBuffer const): Ditto.

Canonical link: <a href="https://commits.webkit.org/277190@main">https://commits.webkit.org/277190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5dddf6de76b61f73d1192cc84ffc60df7824410

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49617 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42983 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38227 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19537 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41571 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4981 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40188 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51490 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46419 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18303 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45520 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23236 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44503 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23952 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53560 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6580 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22946 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11011 "Passed tests") | 
<!--EWS-Status-Bubble-End-->