### PR TITLE
More std::span in the JavaScript parser and runtime

### DIFF
--- a/Source/JavaScriptCore/API/OpaqueJSString.cpp
+++ b/Source/JavaScriptCore/API/OpaqueJSString.cpp
@@ -71,14 +71,11 @@ Identifier OpaqueJSString::identifier(VM* vm) const
 {
     if (m_string.isNull())
         return Identifier();
-
     if (m_string.isEmpty())
         return Identifier(Identifier::EmptyIdentifier);
-
     if (m_string.is8Bit())
-        return Identifier::fromString(*vm, m_string.characters8(), m_string.length());
-
-    return Identifier::fromString(*vm, m_string.characters16(), m_string.length());
+        return Identifier::fromString(*vm, m_string.span8());
+    return Identifier::fromString(*vm, m_string.span16());
 }
 
 const UChar* OpaqueJSString::characters()

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -164,8 +164,7 @@ RegisterID* RegExpNode::emitBytecode(BytecodeGenerator& generator, RegisterID* d
     if (regExp->isValid())
         return generator.emitNewRegExp(generator.finalDestination(dst), regExp);
 
-    const char* messageCharacters = regExp->errorMessage();
-    const Identifier& message = generator.parserArena().identifierArena().makeIdentifier(generator.vm(), bitwise_cast<const LChar*>(messageCharacters), strlen(messageCharacters));
+    auto& message = generator.parserArena().identifierArena().makeIdentifier(generator.vm(), span8(regExp->errorMessage()));
     generator.emitThrowStaticError(ErrorTypeWithExtension::SyntaxError, message);
     return generator.emitLoad(generator.finalDestination(dst), jsUndefined());
 }

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -863,28 +863,28 @@ inline void Lexer<T>::record8(int c)
 }
 
 template <typename T>
-inline void Lexer<T>::append8(const T* p, size_t length)
+inline void Lexer<T>::append8(std::span<const T> span)
 {
     size_t currentSize = m_buffer8.size();
-    m_buffer8.grow(currentSize + length);
+    m_buffer8.grow(currentSize + span.size());
     LChar* rawBuffer = m_buffer8.data() + currentSize;
 
-    for (size_t i = 0; i < length; i++) {
-        T c = p[i];
+    for (size_t i = 0; i < span.size(); i++) {
+        T c = span[i];
         ASSERT(isLatin1(c));
         rawBuffer[i] = c;
     }
 }
 
 template <typename T>
-inline void Lexer<T>::append16(const LChar* p, size_t length)
+inline void Lexer<T>::append16(std::span<const LChar> span)
 {
     size_t currentSize = m_buffer16.size();
-    m_buffer16.grow(currentSize + length);
+    m_buffer16.grow(currentSize + span.size());
     UChar* rawBuffer = m_buffer16.data() + currentSize;
 
-    for (size_t i = 0; i < length; i++)
-        rawBuffer[i] = p[i];
+    for (size_t i = 0; i < span.size(); i++)
+        rawBuffer[i] = span[i];
 }
 
 template <typename T>
@@ -908,7 +908,7 @@ template<typename CharacterType> inline void Lexer<CharacterType>::recordUnicode
         record16(static_cast<UChar>(codePoint));
     else {
         UChar codeUnits[2] = { U16_LEAD(codePoint), U16_TRAIL(codePoint) };
-        append16(codeUnits, 2);
+        append16(codeUnits);
     }
 }
 
@@ -1047,11 +1047,10 @@ template <bool shouldCreateIdentifier> ALWAYS_INLINE JSTokenType Lexer<UChar>::p
     const Identifier* ident = nullptr;
     
     if (shouldCreateIdentifier) {
-        int identifierLength = currentSourcePtr() - identifierStart;
         if (isAll8Bit)
-            ident = makeIdentifierLCharFromUChar(identifierStart, identifierLength);
+            ident = makeIdentifierLCharFromUChar(std::span { identifierStart, currentSourcePtr() });
         else
-            ident = makeIdentifier(identifierStart, identifierLength);
+            ident = makeIdentifier(std::span { identifierStart, currentSourcePtr() });
         tokenData->ident = ident;
     } else
         tokenData->ident = nullptr;
@@ -1122,7 +1121,7 @@ JSTokenType Lexer<CharacterType>::parseIdentifierSlowCase(JSTokenData* tokenData
             return INVALID_UNICODE_ENCODING_ERRORTOK;
         if (UNLIKELY(isStart ? !isNonLatin1IdentStart(codePoint) : !isNonLatin1IdentPart(codePoint)))
             return INVALID_IDENTIFIER_UNICODE_ERRORTOK;
-        append16(m_code, 2);
+        append16({ m_code, 2 });
         shift();
         shift();
         identifierStart = currentSourcePtr();
@@ -1150,7 +1149,7 @@ JSTokenType Lexer<CharacterType>::parseIdentifierSlowCase(JSTokenData* tokenData
     if (shouldCreateIdentifier) {
         if (identifierStart != currentSourcePtr())
             m_buffer16.append(std::span(identifierStart, currentSourcePtr() - identifierStart));
-        ident = makeIdentifier(m_buffer16.data(), m_buffer16.size());
+        ident = makeIdentifier(m_buffer16.span());
 
         tokenData->ident = ident;
     } else
@@ -1195,7 +1194,7 @@ template <bool shouldBuildStrings> ALWAYS_INLINE typename Lexer<T>::StringParseR
     while (m_current != stringQuoteCharacter) {
         if (UNLIKELY(m_current == '\\')) {
             if (stringStart != currentSourcePtr() && shouldBuildStrings)
-                append8(stringStart, currentSourcePtr() - stringStart);
+                append8({ stringStart, currentSourcePtr() });
             shift();
 
             LChar escape = singleEscape(m_current);
@@ -1239,9 +1238,9 @@ template <bool shouldBuildStrings> ALWAYS_INLINE typename Lexer<T>::StringParseR
     }
 
     if (currentSourcePtr() != stringStart && shouldBuildStrings)
-        append8(stringStart, currentSourcePtr() - stringStart);
+        append8({ stringStart, currentSourcePtr() });
     if (shouldBuildStrings) {
-        tokenData->ident = makeIdentifier(m_buffer8.data(), m_buffer8.size());
+        tokenData->ident = makeIdentifier(m_buffer8.span());
         m_buffer8.shrink(0);
     } else
         tokenData->ident = nullptr;
@@ -1359,7 +1358,7 @@ template <bool shouldBuildStrings> auto Lexer<T>::parseStringSlowCase(JSTokenDat
     while (m_current != stringQuoteCharacter) {
         if (UNLIKELY(m_current == '\\')) {
             if (stringStart != currentSourcePtr() && shouldBuildStrings)
-                append16(stringStart, currentSourcePtr() - stringStart);
+                append16({ stringStart, currentSourcePtr() });
             shift();
 
             LChar escape = singleEscape(m_current);
@@ -1395,9 +1394,9 @@ template <bool shouldBuildStrings> auto Lexer<T>::parseStringSlowCase(JSTokenDat
     }
 
     if (currentSourcePtr() != stringStart && shouldBuildStrings)
-        append16(stringStart, currentSourcePtr() - stringStart);
+        append16({ stringStart, currentSourcePtr() });
     if (shouldBuildStrings)
-        tokenData->ident = makeIdentifier(m_buffer16.data(), m_buffer16.size());
+        tokenData->ident = makeIdentifier(m_buffer16.span());
     else
         tokenData->ident = nullptr;
 
@@ -1415,7 +1414,7 @@ typename Lexer<T>::StringParseResult Lexer<T>::parseTemplateLiteral(JSTokenData*
     while (m_current != '`') {
         if (UNLIKELY(m_current == '\\')) {
             if (stringStart != currentSourcePtr())
-                append16(stringStart, currentSourcePtr() - stringStart);
+                append16({ stringStart, currentSourcePtr() });
             shift();
 
             LChar escape = singleEscape(m_current);
@@ -1471,7 +1470,7 @@ typename Lexer<T>::StringParseResult Lexer<T>::parseTemplateLiteral(JSTokenData*
                 if (m_current == '\r') {
                     // Normalize <CR>, <CR><LF> to <LF>.
                     if (stringStart != currentSourcePtr())
-                        append16(stringStart, currentSourcePtr() - stringStart);
+                        append16({ stringStart, currentSourcePtr() });
                     if (rawStringStart != currentSourcePtr() && rawStringsBuildMode == RawStringsBuildMode::BuildRawStrings)
                         m_bufferForRawTemplateString16.append(std::span(rawStringStart, currentSourcePtr() - rawStringStart));
 
@@ -1494,18 +1493,18 @@ typename Lexer<T>::StringParseResult Lexer<T>::parseTemplateLiteral(JSTokenData*
     bool isTail = m_current == '`';
 
     if (currentSourcePtr() != stringStart)
-        append16(stringStart, currentSourcePtr() - stringStart);
+        append16({ stringStart, currentSourcePtr() });
     if (rawStringStart != currentSourcePtr() && rawStringsBuildMode == RawStringsBuildMode::BuildRawStrings)
-        m_bufferForRawTemplateString16.append(std::span(rawStringStart, currentSourcePtr() - rawStringStart));
+        m_bufferForRawTemplateString16.append(std::span { rawStringStart, currentSourcePtr() });
 
     if (!parseCookedFailed)
-        tokenData->cooked = makeIdentifier(m_buffer16.data(), m_buffer16.size());
+        tokenData->cooked = makeIdentifier(m_buffer16.span());
     else
         tokenData->cooked = nullptr;
 
     // Line terminator normalization (e.g. <CR> => <LF>) should be applied to both the raw and cooked representations.
     if (rawStringsBuildMode == RawStringsBuildMode::BuildRawStrings)
-        tokenData->raw = makeIdentifier(m_bufferForRawTemplateString16.data(), m_bufferForRawTemplateString16.size());
+        tokenData->raw = makeIdentifier(m_bufferForRawTemplateString16.span());
     else
         tokenData->raw = nullptr;
 
@@ -1575,9 +1574,9 @@ ALWAYS_INLINE auto Lexer<T>::parseHex() -> std::optional<NumberParseResult>
     }
 
     if (UNLIKELY(m_current == 'n'))
-        return NumberParseResult { makeIdentifier(m_buffer8.data(), m_buffer8.size()) };
+        return NumberParseResult { makeIdentifier(m_buffer8.span()) };
     
-    return NumberParseResult { parseIntOverflow(m_buffer8.data(), m_buffer8.size(), 16) };
+    return NumberParseResult { parseIntOverflow(m_buffer8.span(), 16) };
 }
 
 template <typename T>
@@ -1626,12 +1625,12 @@ ALWAYS_INLINE auto Lexer<T>::parseBinary() -> std::optional<NumberParseResult>
     }
 
     if (UNLIKELY(m_current == 'n'))
-        return NumberParseResult { makeIdentifier(m_buffer8.data(), m_buffer8.size()) };
+        return NumberParseResult { makeIdentifier(m_buffer8.span()) };
 
     if (isASCIIDigit(m_current))
         return std::nullopt;
 
-    return NumberParseResult { parseIntOverflow(m_buffer8.data(), m_buffer8.size(), 2) };
+    return NumberParseResult { parseIntOverflow(m_buffer8.span(), 2) };
 }
 
 template <typename T>
@@ -1682,12 +1681,12 @@ ALWAYS_INLINE auto Lexer<T>::parseOctal() -> std::optional<NumberParseResult>
     }
 
     if (UNLIKELY(m_current == 'n') && !isLegacyLiteral)
-        return NumberParseResult { makeIdentifier(m_buffer8.data(), m_buffer8.size()) };
+        return NumberParseResult { makeIdentifier(m_buffer8.span()) };
 
     if (isASCIIDigit(m_current))
         return std::nullopt;
 
-    return NumberParseResult { parseIntOverflow(m_buffer8.data(), m_buffer8.size(), 8) };
+    return NumberParseResult { parseIntOverflow(m_buffer8.span(), 8) };
 }
 
 template <typename T>
@@ -1742,7 +1741,7 @@ ALWAYS_INLINE auto Lexer<T>::parseDecimal() -> std::optional<NumberParseResult>
     }
     
     if (UNLIKELY(m_current == 'n' && !isLegacyLiteral))
-        return NumberParseResult { makeIdentifier(m_buffer8.data(), m_buffer8.size()) };
+        return NumberParseResult { makeIdentifier(m_buffer8.span()) };
 
     return std::nullopt;
 }
@@ -2670,7 +2669,7 @@ JSTokenType Lexer<T>::scanRegExp(JSToken* tokenRecord, UChar patternPrefix)
         }
     }
 
-    tokenData->pattern = makeRightSizedIdentifier(m_buffer16.data(), m_buffer16.size(), charactersOredTogether);
+    tokenData->pattern = makeRightSizedIdentifier(m_buffer16, charactersOredTogether);
     m_buffer16.shrink(0);
 
     ASSERT(m_buffer8.isEmpty());
@@ -2692,7 +2691,7 @@ JSTokenType Lexer<T>::scanRegExp(JSToken* tokenRecord, UChar patternPrefix)
         return token;
     }
 
-    tokenData->flags = makeIdentifier(m_buffer8.data(), m_buffer8.size());
+    tokenData->flags = makeIdentifier(m_buffer8.span());
     m_buffer8.shrink(0);
 
     // Since RegExp always ends with / or flags (IdentifierPart), m_atLineStart always becomes false.

--- a/Source/JavaScriptCore/parser/ParserArena.h
+++ b/Source/JavaScriptCore/parser/ParserArena.h
@@ -46,9 +46,9 @@ namespace JSC {
         }
 
         template <typename T>
-        ALWAYS_INLINE const Identifier& makeIdentifier(VM&, const T* characters, size_t length);
+        ALWAYS_INLINE const Identifier& makeIdentifier(VM&, std::span<const T> characters);
         ALWAYS_INLINE const Identifier& makeEmptyIdentifier(VM&);
-        ALWAYS_INLINE const Identifier& makeIdentifierLCharFromUChar(VM&, const UChar* characters, size_t length);
+        ALWAYS_INLINE const Identifier& makeIdentifierLCharFromUChar(VM&, std::span<const UChar> characters);
         ALWAYS_INLINE const Identifier& makeIdentifier(VM&, SymbolImpl*);
 
         const Identifier* makeBigIntDecimalIdentifier(VM&, const Identifier&, uint8_t radix);
@@ -74,26 +74,26 @@ namespace JSC {
     };
 
     template <typename T>
-    ALWAYS_INLINE const Identifier& IdentifierArena::makeIdentifier(VM& vm, const T* characters, size_t length)
+    ALWAYS_INLINE const Identifier& IdentifierArena::makeIdentifier(VM& vm, std::span<const T> characters)
     {
-        if (!length)
+        if (characters.empty())
             return vm.propertyNames->emptyIdentifier;
-        if (characters[0] >= MaximumCachableCharacter) {
-            m_identifiers.append(Identifier::fromString(vm, characters, length));
+        if (characters.front() >= MaximumCachableCharacter) {
+            m_identifiers.append(Identifier::fromString(vm, characters));
             return m_identifiers.last();
         }
-        if (length == 1) {
-            if (Identifier* ident = m_shortIdentifiers[characters[0]])
+        if (characters.size() == 1) {
+            if (Identifier* ident = m_shortIdentifiers[characters.front()])
                 return *ident;
-            m_identifiers.append(Identifier::fromString(vm, characters, length));
-            m_shortIdentifiers[characters[0]] = &m_identifiers.last();
+            m_identifiers.append(Identifier::fromString(vm, characters));
+            m_shortIdentifiers[characters.front()] = &m_identifiers.last();
             return m_identifiers.last();
         }
-        Identifier* ident = m_recentIdentifiers[characters[0]];
-        if (ident && Identifier::equal(ident->impl(), characters, length))
+        Identifier* ident = m_recentIdentifiers[characters.front()];
+        if (ident && Identifier::equal(ident->impl(), characters))
             return *ident;
-        m_identifiers.append(Identifier::fromString(vm, characters, length));
-        m_recentIdentifiers[characters[0]] = &m_identifiers.last();
+        m_identifiers.append(Identifier::fromString(vm, characters));
+        m_recentIdentifiers[characters.front()] = &m_identifiers.last();
         return m_identifiers.last();
     }
 
@@ -109,26 +109,26 @@ namespace JSC {
         return vm.propertyNames->emptyIdentifier;
     }
 
-    ALWAYS_INLINE const Identifier& IdentifierArena::makeIdentifierLCharFromUChar(VM& vm, const UChar* characters, size_t length)
+    ALWAYS_INLINE const Identifier& IdentifierArena::makeIdentifierLCharFromUChar(VM& vm, std::span<const UChar> characters)
     {
-        if (!length)
+        if (characters.empty())
             return vm.propertyNames->emptyIdentifier;
-        if (characters[0] >= MaximumCachableCharacter) {
-            m_identifiers.append(Identifier::createLCharFromUChar(vm, characters, length));
+        if (characters.front() >= MaximumCachableCharacter) {
+            m_identifiers.append(Identifier::createLCharFromUChar(vm, characters));
             return m_identifiers.last();
         }
-        if (length == 1) {
-            if (Identifier* ident = m_shortIdentifiers[characters[0]])
+        if (characters.size() == 1) {
+            if (Identifier* ident = m_shortIdentifiers[characters.front()])
                 return *ident;
-            m_identifiers.append(Identifier::fromString(vm, characters, length));
-            m_shortIdentifiers[characters[0]] = &m_identifiers.last();
+            m_identifiers.append(Identifier::fromString(vm, characters));
+            m_shortIdentifiers[characters.front()] = &m_identifiers.last();
             return m_identifiers.last();
         }
-        Identifier* ident = m_recentIdentifiers[characters[0]];
-        if (ident && Identifier::equal(ident->impl(), characters, length))
+        Identifier* ident = m_recentIdentifiers[characters.front()];
+        if (ident && Identifier::equal(ident->impl(), characters))
             return *ident;
-        m_identifiers.append(Identifier::createLCharFromUChar(vm, characters, length));
-        m_recentIdentifiers[characters[0]] = &m_identifiers.last();
+        m_identifiers.append(Identifier::createLCharFromUChar(vm, characters));
+        m_recentIdentifiers[characters.front()] = &m_identifiers.last();
         return m_identifiers.last();
     }
     

--- a/Source/JavaScriptCore/runtime/Identifier.cpp
+++ b/Source/JavaScriptCore/runtime/Identifier.cpp
@@ -27,18 +27,17 @@
 
 namespace JSC {
 
-Ref<AtomStringImpl> Identifier::add8(VM& vm, const UChar* s, int length)
+Ref<AtomStringImpl> Identifier::add8(VM& vm, std::span<const UChar> s)
 {
-    if (length == 1) {
-        UChar c = s[0];
+    if (s.size() == 1) {
+        UChar c = s.front();
         ASSERT(isLatin1(c));
         if (canUseSingleCharacterString(c))
             return vm.smallStrings.singleCharacterStringRep(c);
     }
-    if (!length)
+    if (s.empty())
         return *static_cast<AtomStringImpl*>(StringImpl::empty());
-
-    return *AtomStringImpl::add(std::span { s, static_cast<size_t>(length) });
+    return *AtomStringImpl::add(s);
 }
 
 Identifier Identifier::from(VM& vm, unsigned value)

--- a/Source/JavaScriptCore/runtime/IdentifierInlines.h
+++ b/Source/JavaScriptCore/runtime/IdentifierInlines.h
@@ -85,14 +85,14 @@ ALWAYS_INLINE Identifier Identifier::fromString(VM& vm, ASCIILiteral s)
     return Identifier(vm, s);
 }
 
-inline Identifier Identifier::fromString(VM& vm, const LChar* s, int length)
+inline Identifier Identifier::fromString(VM& vm, std::span<const LChar> s)
 {
-    return Identifier(vm, s, length);
+    return Identifier(vm, s);
 }
 
-inline Identifier Identifier::fromString(VM& vm, const UChar* s, int length)
+inline Identifier Identifier::fromString(VM& vm, std::span<const UChar> s)
 {
-    return Identifier(vm, s, length);
+    return Identifier(vm, s);
 }
 
 inline Identifier Identifier::fromString(VM& vm, const String& string)

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -52,17 +52,17 @@ bool LiteralParser<CharType>::tryJSONPParse(Vector<JSONPData>& results, bool nee
     do {
         Vector<JSONPPathEntry> path;
         // Unguarded next to start off the lexer
-        Identifier name = Identifier::fromString(vm, m_lexer.currentToken()->identifierStart, m_lexer.currentToken()->stringOrIdentifierLength);
+        Identifier name = Identifier::fromString(vm, m_lexer.currentToken()->identifier());
         JSONPPathEntry entry;
         if (name == vm.propertyNames->varKeyword) {
             if (m_lexer.next() != TokIdentifier)
                 return false;
             entry.m_type = JSONPPathEntryTypeDeclareVar;
-            entry.m_pathEntryName = Identifier::fromString(vm, m_lexer.currentToken()->identifierStart, m_lexer.currentToken()->stringOrIdentifierLength);
+            entry.m_pathEntryName = Identifier::fromString(vm, m_lexer.currentToken()->identifier());
             path.append(entry);
         } else {
             entry.m_type = JSONPPathEntryTypeDot;
-            entry.m_pathEntryName = Identifier::fromString(vm, m_lexer.currentToken()->identifierStart, m_lexer.currentToken()->stringOrIdentifierLength);
+            entry.m_pathEntryName = Identifier::fromString(vm, m_lexer.currentToken()->identifier());
             path.append(entry);
         }
         if (isLexerKeyword(entry.m_pathEntryName))
@@ -89,7 +89,7 @@ bool LiteralParser<CharType>::tryJSONPParse(Vector<JSONPData>& results, bool nee
                 entry.m_type = JSONPPathEntryTypeDot;
                 if (m_lexer.next() != TokIdentifier)
                     return false;
-                entry.m_pathEntryName = Identifier::fromString(vm, m_lexer.currentToken()->identifierStart, m_lexer.currentToken()->stringOrIdentifierLength);
+                entry.m_pathEntryName = Identifier::fromString(vm, m_lexer.currentToken()->identifier());
                 break;
             }
             case TokLParen: {
@@ -144,11 +144,11 @@ ALWAYS_INLINE JSString* LiteralParser<CharType>::makeJSString(VM& vm, typename L
     if (token->stringIs8Bit) {
         if (token->stringOrIdentifierLength > maxAtomizeStringLength)
             return jsNontrivialString(vm, String({ token->stringStart8, token->stringOrIdentifierLength }));
-        return jsString(vm, Identifier::fromString(vm, token->stringStart8, token->stringOrIdentifierLength).string());
+        return jsString(vm, Identifier::fromString(vm, token->string8()).string());
     }
     if (token->stringOrIdentifierLength > maxAtomizeStringLength)
         return jsNontrivialString(vm, String({ token->stringStart16, token->stringOrIdentifierLength }));
-    return jsString(vm, Identifier::fromString(vm, token->stringStart16, token->stringOrIdentifierLength).string());
+    return jsString(vm, Identifier::fromString(vm, token->string16()).string());
 }
 
 [[maybe_unused]] static ALWAYS_INLINE bool cannotBeIdentPartOrEscapeStart(LChar)

--- a/Source/JavaScriptCore/runtime/LiteralParser.h
+++ b/Source/JavaScriptCore/runtime/LiteralParser.h
@@ -69,12 +69,9 @@ struct JSONPData {
     Strong<Unknown> m_value;
 };
 
-template <typename CharType>
-struct LiteralParserToken {
-private:
-WTF_MAKE_NONCOPYABLE(LiteralParserToken);
+template<typename CharacterType> struct LiteralParserToken {
+    WTF_MAKE_NONCOPYABLE(LiteralParserToken);
 
-public:
     LiteralParserToken() = default;
 
     TokenType type;
@@ -82,10 +79,14 @@ public:
     unsigned stringOrIdentifierLength : 31;
     union {
         double numberToken; // Only used for TokNumber.
-        const CharType* identifierStart;
+        const CharacterType* identifierStart;
         const LChar* stringStart8;
         const UChar* stringStart16;
     };
+
+    std::span<const CharacterType> identifier() const { return { identifierStart, stringOrIdentifierLength }; }
+    std::span<const LChar> string8() const { return { stringStart8, stringOrIdentifierLength }; }
+    std::span<const UChar> string16() const { return { stringStart16, stringOrIdentifierLength }; }
 };
 
 template <typename CharType>


### PR DESCRIPTION
#### 1f93f36baa8048713a0b926325fc4488e570fdb1
<pre>
More std::span in the JavaScript parser and runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=272304">https://bugs.webkit.org/show_bug.cgi?id=272304</a>
<a href="https://rdar.apple.com/126049411">rdar://126049411</a>

Reviewed by Chris Dumez.

* Source/JavaScriptCore/API/OpaqueJSString.cpp:
(OpaqueJSString::identifier const): Use span.
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::RegExpNode::emitBytecode): Ditto.
* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::Lexer&lt;T&gt;::append8): Ditto.
(JSC::Lexer&lt;T&gt;::append16): Ditto.
(JSC::Lexer&lt;CharacterType&gt;::recordUnicodeCodePoint): Ditto.
(JSC::Lexer&lt;UChar&gt;::parseIdentifier): Ditto.
(JSC::Lexer&lt;CharacterType&gt;::parseIdentifierSlowCase): Ditto.
(JSC::Lexer&lt;T&gt;::parseString): Ditto.
(JSC::Lexer&lt;T&gt;::parseStringSlowCase): Ditto.
(JSC::Lexer&lt;T&gt;::parseTemplateLiteral): Ditto.
(JSC::Lexer&lt;T&gt;::parseHex): Ditto.
(JSC::Lexer&lt;T&gt;::parseBinary): Ditto.
(JSC::Lexer&lt;T&gt;::parseOctal): Ditto.
(JSC::Lexer&lt;T&gt;::parseDecimal): Ditto.
(JSC::Lexer&lt;T&gt;::scanRegExp): Ditto.
* Source/JavaScriptCore/parser/Lexer.h: Ditto.
* Source/JavaScriptCore/parser/ParserArena.h: Ditto.
* Source/JavaScriptCore/runtime/Identifier.cpp:
(JSC::Identifier::add8): Ditto.
* Source/JavaScriptCore/runtime/Identifier.h: Ditto.
* Source/JavaScriptCore/runtime/IdentifierInlines.h: Ditto.
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser&lt;CharType&gt;::tryJSONPParse): Ditto.
(JSC::LiteralParser&lt;CharType&gt;::makeJSString): Ditto.
* Source/JavaScriptCore/runtime/LiteralParser.h: Ditto.

Canonical link: <a href="https://commits.webkit.org/277185@main">https://commits.webkit.org/277185@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0af7b4f6914d21d513bcb83c1b655e24dc846b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49601 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42967 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38216 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23407 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19526 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41555 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4965 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40169 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43253 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51474 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46402 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18285 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45510 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23217 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44494 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10363 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23909 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53544 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22929 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11005 "Passed tests") | 
<!--EWS-Status-Bubble-End-->