### PR TITLE
only dispatch valid invoke actions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt
@@ -17,16 +17,16 @@ PASS setting custom invokeAction property to --- (must include dash) sets event 
 PASS setting custom invokeaction attribute to --- (must include dash) sets event action
 PASS setting custom invokeAction property to show-picker (must include dash) sets event action
 PASS setting custom invokeaction attribute to show-picker (must include dash) sets event action
-FAIL setting custom invokeAction property to foo (no dash) did not dispatch an event assert_equals: event should not have fired expected null but got object "[object InvokeEvent]"
-FAIL setting custom invokeaction attribute to foo (no dash) did not dispatch an event assert_equals: event should not have fired expected null but got object "[object InvokeEvent]"
-FAIL setting custom invokeAction property to foobar (no dash) did not dispatch an event assert_equals: event should not have fired expected null but got object "[object InvokeEvent]"
-FAIL setting custom invokeaction attribute to foobar (no dash) did not dispatch an event assert_equals: event should not have fired expected null but got object "[object InvokeEvent]"
-FAIL setting custom invokeAction property to foo bar (no dash) did not dispatch an event assert_equals: event should not have fired expected null but got object "[object InvokeEvent]"
-FAIL setting custom invokeaction attribute to foo bar (no dash) did not dispatch an event assert_equals: event should not have fired expected null but got object "[object InvokeEvent]"
-FAIL setting custom invokeAction property to em—dash (no dash) did not dispatch an event assert_equals: event should not have fired expected null but got object "[object InvokeEvent]"
-FAIL setting custom invokeaction attribute to em—dash (no dash) did not dispatch an event assert_equals: event should not have fired expected null but got object "[object InvokeEvent]"
-FAIL setting custom invokeAction property to hidedocument (no dash) did not dispatch an event assert_equals: event should not have fired expected null but got object "[object InvokeEvent]"
-FAIL setting custom invokeaction attribute to hidedocument (no dash) did not dispatch an event assert_equals: event should not have fired expected null but got object "[object InvokeEvent]"
+PASS setting custom invokeAction property to foo (no dash) did not dispatch an event
+PASS setting custom invokeaction attribute to foo (no dash) did not dispatch an event
+PASS setting custom invokeAction property to foobar (no dash) did not dispatch an event
+PASS setting custom invokeaction attribute to foobar (no dash) did not dispatch an event
+PASS setting custom invokeAction property to foo bar (no dash) did not dispatch an event
+PASS setting custom invokeaction attribute to foo bar (no dash) did not dispatch an event
+PASS setting custom invokeAction property to em—dash (no dash) did not dispatch an event
+PASS setting custom invokeaction attribute to em—dash (no dash) did not dispatch an event
+PASS setting custom invokeAction property to hidedocument (no dash) did not dispatch an event
+PASS setting custom invokeaction attribute to hidedocument (no dash) did not dispatch an event
 PASS event does not dispatch if click:preventDefault is called
 PASS event does not dispatch if invoker is disabled
 PASS event dispatches if invokee is non-HTML Element

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -104,6 +104,18 @@ enum class ShadowRootClonable : bool { No, Yes };
 enum class ShadowRootSerializable : bool { No, Yes };
 enum class VisibilityAdjustment : uint8_t;
 
+// https://github.com/whatwg/html/pull/9841
+enum class InvokeAction: uint8_t {
+    Invalid,
+
+    Auto,
+    Custom,
+
+    TogglePopover,
+    HidePopover,
+    ShowPopover,
+};
+
 struct CheckVisibilityOptions;
 struct FullscreenOptions;
 struct GetAnimationsOptions;
@@ -629,7 +641,8 @@ public:
     void clearPopoverData();
     bool isPopoverShowing() const;
 
-    virtual bool handleInvokeInternal(const HTMLFormControlElement&, const AtomString&) { return false; }
+    virtual bool isValidInvokeAction(const InvokeAction action) { return action == InvokeAction::Auto; }
+    virtual bool handleInvokeInternal(const HTMLFormControlElement&, const InvokeAction&) { return false; }
 
     ExceptionOr<void> setPointerCapture(int32_t);
     ExceptionOr<void> releasePointerCapture(int32_t);

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1573,27 +1573,28 @@ void HTMLElement::popoverAttributeChanged(const AtomString& value)
         ensurePopoverData().setPopoverState(newPopoverState);
 }
 
-constexpr ASCIILiteral togglePopoverLiteral = "togglepopover"_s;
-constexpr ASCIILiteral showPopoverLiteral = "showpopover"_s;
-constexpr ASCIILiteral hidePopoverLiteral = "hidepopover"_s;
+bool HTMLElement::isValidInvokeAction(const InvokeAction action)
+{
+    return Element::isValidInvokeAction(action) || action == InvokeAction::TogglePopover || action == InvokeAction::ShowPopover || action == InvokeAction::HidePopover;
+}
 
-bool HTMLElement::handleInvokeInternal(const HTMLFormControlElement& invoker, const AtomString& action)
+bool HTMLElement::handleInvokeInternal(const HTMLFormControlElement& invoker, const InvokeAction& action)
 {
     if (popoverState() == PopoverState::None)
         return false;
 
     if (isPopoverShowing()) {
-        bool shouldHide = action.isEmpty()
-            || equalLettersIgnoringASCIICase(action, togglePopoverLiteral)
-            || equalLettersIgnoringASCIICase(action, hidePopoverLiteral);
+        bool shouldHide = action == InvokeAction::Auto
+            || action == InvokeAction::TogglePopover
+            || action == InvokeAction::HidePopover;
         if (shouldHide) {
             hidePopover();
             return true;
         }
     } else {
-        bool shouldShow = action.isEmpty()
-            || equalLettersIgnoringASCIICase(action, togglePopoverLiteral)
-            || equalLettersIgnoringASCIICase(action, showPopoverLiteral);
+        bool shouldShow = action == InvokeAction::Auto
+            || action == InvokeAction::TogglePopover
+            || action == InvokeAction::ShowPopover;
         if (shouldShow) {
             showPopover(&invoker);
             return true;

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -160,7 +160,8 @@ public:
     void setPopover(const AtomString& value) { setAttributeWithoutSynchronization(HTMLNames::popoverAttr, value); };
     void popoverAttributeChanged(const AtomString& value);
 
-    bool handleInvokeInternal(const HTMLFormControlElement& invoker, const AtomString& action) final;
+    bool isValidInvokeAction(const InvokeAction) final;
+    bool handleInvokeInternal(const HTMLFormControlElement& invoker, const InvokeAction&) final;
 
 #if PLATFORM(IOS_FAMILY)
     static SelectionRenderingBehavior selectionRenderingBehavior(const Node*);

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -130,6 +130,7 @@ protected:
 
     void handlePopoverTargetAction() const;
 
+    InvokeAction invokeAction() const;
     void handleInvokeAction();
 
 private:


### PR DESCRIPTION
#### 0e2f71722daa1d2746d0feb18b74e15808b11892
<pre>
only dispatch valid invoke actions
<a href="https://bugs.webkit.org/show_bug.cgi?id=272307">https://bugs.webkit.org/show_bug.cgi?id=272307</a>

Reviewed by Tim Nguyen.

This changes `invokeAction` to return an enum of valid invoke
actions/sentinel values like `custom`, which can then be used to guard
event dispatching code, preventing dispatch for invalid actions.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/invokers/invoketarget-button-event-dispatch.tentative-expected.txt:
* Source/WebCore/dom/Element.h:
(WebCore::Element::isValidInvokeAction):
(WebCore::Element::handleInvokeInternal):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::isValidInvokeAction):
(WebCore::HTMLElement::handleInvokeInternal):
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::invokeAction const):
(WebCore::HTMLFormControlElement::handleInvokeAction):
* Source/WebCore/html/HTMLFormControlElement.h:

Canonical link: <a href="https://commits.webkit.org/278450@main">https://commits.webkit.org/278450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3187f585ae862ec9d77572d23df106916ca53481

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26085 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49604 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42970 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38215 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47503 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19525 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41559 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4968 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51477 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45513 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23222 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44490 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11081 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->