### PR TITLE
Workaround restrict error in GCC 12

### DIFF
--- a/Source/WTF/wtf/Int128.cpp
+++ b/Source/WTF/wtf/Int128.cpp
@@ -265,9 +265,9 @@ std::ostream& operator<<(std::ostream& os, Int128Impl v) {
       (flags & std::ios::basefield) == std::ios_base::fmtflags();
   if (print_as_decimal) {
     if (Int128High64(v) < 0) {
-      rep = "-";
+      rep.append("-");
     } else if (flags & std::ios::showpos) {
-      rep = "+";
+      rep.append("+");
     }
   }
 


### PR DESCRIPTION
#### bd1249cc9c4fe70efb4dae7cb463a790d684ce48
<pre>
Workaround restrict error in GCC 12
<a href="https://bugs.webkit.org/show_bug.cgi?id=272309">https://bugs.webkit.org/show_bug.cgi?id=272309</a>

Reviewed by Darin Adler.

In GCC 12.3.0:

In static member function ‘static constexpr std::char_traits&lt;char&gt;::char_type* std::char_traits&lt;char&gt;::copy(char_type*, const char_type*, std::size_t)’,
    inlined from ‘static constexpr void std::__cxx11::basic_string&lt;_CharT, _Traits, _Alloc&gt;::_S_copy(_CharT*, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits&lt;char&gt;; _Alloc = std::allocator&lt;char&gt;]’ at /usr/include/c++/12/bits/basic_string.h:431:21,
    inlined from ‘constexpr std::__cxx11::basic_string&lt;_CharT, _Traits, _Allocator&gt;&amp; std::__cxx11::basic_string&lt;_CharT, _Traits, _Alloc&gt;::_M_replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits&lt;char&gt;; _Alloc = std::allocator&lt;char&gt;]’ at /usr/include/c++/12/bits/basic_string.tcc:532:22,
    inlined from ‘constexpr std::__cxx11::basic_string&lt;_CharT, _Traits, _Alloc&gt;&amp; std::__cxx11::basic_string&lt;_CharT, _Traits, _Alloc&gt;::replace(size_type, size_type, const _CharT*, size_type) [with _CharT = char; _Traits = std::char_traits&lt;char&gt;; _Alloc = std::allocator&lt;char&gt;]’ at /usr/include/c++/12/bits/basic_string.h:2179:19,
    inlined from ‘constexpr std::__cxx11::basic_string&lt;_CharT, _Traits, _Alloc&gt;&amp; std::__cxx11::basic_string&lt;_CharT, _Traits, _Alloc&gt;::insert(size_type, const _CharT*) [with _CharT = char; _Traits = std::char_traits&lt;char&gt;; _Alloc = std::allocator&lt;char&gt;]’ at /usr/include/c++/12/bits/basic_string.h:1936:22,
    inlined from ‘std::ostream&amp; WTF::operator&lt;&lt;(std::ostream&amp;, Int128Impl)’ at /host/home/tingping/Projects/WebKit/Source/WTF/wtf/Int128.cpp:268:17:
/usr/include/c++/12/bits/char_traits.h:435:56: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ accessing 9223372036854775810 or more bytes at offsets [2, 9223372036854775807] and 1 may overlap up to 9223372036854775813 bytes at offset -3 [-Werror=restrict]
  435 |         return static_cast&lt;char_type*&gt;(__builtin_memcpy(__s1, __s2, __n));
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~

* Source/WTF/wtf/Int128.cpp:
(WTF::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/277203@main">https://commits.webkit.org/277203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fd1a255862ea3e287eacd31587a61ab3c132aba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46931 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26097 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42979 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38223 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23434 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40425 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19533 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20789 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41567 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4977 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40183 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43267 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41950 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51486 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46416 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45517 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23231 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44500 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10375 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23936 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53556 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22942 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11008 "Passed tests") | 
<!--EWS-Status-Bubble-End-->