### PR TITLE
Use std::span more in StringCommon.h

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlObjectInlines.h
@@ -234,11 +234,12 @@ UCollationResult compareASCIIWithUCADUCETLevel3(const CharacterType1* characters
     return UCOL_EQUAL;
 }
 
+// FIXME: This should take is std::spans.
 template<typename CharacterType1, typename CharacterType2>
 inline std::optional<UCollationResult> compareASCIIWithUCADUCET(const CharacterType1* characters1, unsigned length1, const CharacterType2* characters2, unsigned length2)
 {
     if (length1 == length2) {
-        if (equal(characters1, characters2, length1))
+        if (equal(characters1, { characters2, length2 }))
             return UCOL_EQUAL;
     }
 

--- a/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
@@ -32,6 +32,7 @@
 
 namespace JSC {
 
+// FIXME: This should take in a std::span.
 template<typename CharacterType>
 ALWAYS_INLINE Ref<AtomStringImpl> JSONAtomStringCache::make(const CharacterType* characters, unsigned length)
 {
@@ -47,7 +48,7 @@ ALWAYS_INLINE Ref<AtomStringImpl> JSONAtomStringCache::make(const CharacterType*
 
     auto lastCharacter = characters[length - 1];
     auto& slot = cacheSlot(firstCharacter, lastCharacter, length);
-    if (UNLIKELY(slot.m_length != length || !equal(slot.m_buffer, characters, length))) {
+    if (UNLIKELY(slot.m_length != length || !equal(slot.m_buffer, { characters, length }))) {
         auto result = AtomStringImpl::add(std::span { characters, length });
         slot.m_impl = result;
         slot.m_length = length;

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -661,7 +661,7 @@ std::optional<String> mapHostName(const String& hostName, URLDecodeFunction deco
     if (length && (U_FAILURE(uerror) || processingDetails.errors & ~allowedErrors))
         return std::nullopt;
     
-    if (numCharactersConverted == static_cast<int32_t>(length) && equal(sourceBuffer.data(), destinationBuffer, length))
+    if (numCharactersConverted == static_cast<int32_t>(length) && equal(sourceBuffer.data(), { destinationBuffer, length }))
         return String();
 
     if (!decodeFunction && !allCharactersInAllowedIDNScriptList(destinationBuffer, numCharactersConverted) && !allCharactersAllowedByTLDRules(destinationBuffer, numCharactersConverted))

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -121,7 +121,7 @@ bool operator==(const CString& a, const CString& b)
         return false;
     if (a.length() != b.length())
         return false;
-    return equal(reinterpret_cast<const LChar*>(a.data()), reinterpret_cast<const LChar*>(b.data()), a.length());
+    return equal(a.dataAsUInt8Ptr(), b.span());
 }
 
 bool operator==(const CString& a, const char* b)

--- a/Source/WTF/wtf/text/StringSearch.h
+++ b/Source/WTF/wtf/text/StringSearch.h
@@ -53,9 +53,8 @@ public:
 
     ALWAYS_INLINE size_t find(StringView string, StringView matchString) const
     {
-        unsigned length = string.length();
         unsigned matchLength = matchString.length();
-        if (matchLength > length)
+        if (matchLength > string.length())
             return notFound;
 
         if (UNLIKELY(!matchLength))
@@ -63,13 +62,13 @@ public:
 
         if (string.is8Bit()) {
             if (matchString.is8Bit())
-                return findInner(string.characters8(), matchString.characters8(), length, matchLength);
-            return findInner(string.characters8(), matchString.characters16(), length, matchLength);
+                return findInner(string.span8(), matchString.span8());
+            return findInner(string.span8(), matchString.span16());
         }
 
         if (matchString.is8Bit())
-            return findInner(string.characters16(), matchString.characters8(), length, matchLength);
-        return findInner(string.characters16(), matchString.characters16(), length, matchLength);
+            return findInner(string.span16(), matchString.span8());
+        return findInner(string.span16(), matchString.span16());
     }
 
 private:
@@ -89,14 +88,14 @@ private:
     }
 
     template <typename SearchCharacterType, typename MatchCharacterType>
-    ALWAYS_INLINE size_t findInner(const SearchCharacterType* characters, const MatchCharacterType* matchCharacters, unsigned length, unsigned matchLength) const
+    ALWAYS_INLINE size_t findInner(std::span<const SearchCharacterType> characters, std::span<const MatchCharacterType> matchCharacters) const
     {
-        auto* cursor = characters;
-        auto* last = characters + length - matchLength;
+        auto* cursor = characters.data();
+        auto* last = characters.data() + characters.size() - matchCharacters.size();
         while (cursor <= last) {
-            if (equal(cursor, matchCharacters, matchLength))
-                return cursor - characters;
-            cursor += m_table[static_cast<uint8_t>(cursor[matchLength - 1])];
+            if (equal(cursor, matchCharacters))
+                return cursor - characters.data();
+            cursor += m_table[static_cast<uint8_t>(cursor[matchCharacters.size() - 1])];
         }
         return notFound;
     }

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -147,20 +147,19 @@ size_t StringView::find(std::span<const LChar> match, unsigned start) const
         return notFound;
 
     if (is8Bit())
-        return findInner(characters8() + start, match.data(), start, searchLength, match.size());
-    return findInner(characters16() + start, match.data(), start, searchLength, match.size());
+        return findInner(span8().subspan(start), match, start);
+    return findInner(span16().subspan(start), match, start);
 }
 
 size_t StringView::reverseFind(std::span<const LChar> match, unsigned start) const
 {
     ASSERT(!match.empty());
-    auto length = this->length();
-    if (match.size() > length)
+    if (match.size() > length())
         return notFound;
 
     if (is8Bit())
-        return reverseFindInner(characters8(), match.data(), start, length, match.size());
-    return reverseFindInner(characters16(), match.data(), start, length, match.size());
+        return reverseFindInner(span8(), match, start);
+    return reverseFindInner(span16(), match, start);
 }
 
 void StringView::SplitResult::Iterator::findNextSubstring()
@@ -393,24 +392,22 @@ size_t StringView::reverseFind(StringView matchString, unsigned start) const
     if (isNull())
         return notFound;
 
-    unsigned matchLength = matchString.length();
-    unsigned ourLength = length();
-    if (!matchLength)
-        return std::min(start, ourLength);
+    if (matchString.length())
+        return std::min(start, length());
 
     // Check start & matchLength are in range.
-    if (matchLength > ourLength)
+    if (matchString.length() > length())
         return notFound;
 
     if (is8Bit()) {
         if (matchString.is8Bit())
-            return reverseFindInner(characters8(), matchString.characters8(), start, ourLength, matchLength);
-        return reverseFindInner(characters8(), matchString.characters16(), start, ourLength, matchLength);
+            return reverseFindInner(span8(), matchString.span8(), start);
+        return reverseFindInner(span8(), matchString.span16(), start);
     }
 
     if (matchString.is8Bit())
-        return reverseFindInner(characters16(), matchString.characters8(), start, ourLength, matchLength);
-    return reverseFindInner(characters16(), matchString.characters16(), start, ourLength, matchLength);
+        return reverseFindInner(span16(), matchString.span8(), start);
+    return reverseFindInner(span16(), matchString.span16(), start);
 }
 
 String makeStringByReplacingAll(StringView string, UChar target, UChar replacement)

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -151,13 +151,13 @@ public:
     size_t findIgnoringASCIICase(StringView, unsigned start) const;
 
     template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>* = nullptr>
-    size_t find(CodeUnitMatchFunction matchFunction, size_t start = 0) const { return m_impl ? m_impl->find(matchFunction, start) : notFound; }
-    size_t find(ASCIILiteral literal, size_t start = 0) const { return m_impl ? m_impl->find(literal, start) : notFound; }
+    size_t find(CodeUnitMatchFunction matchFunction, unsigned start = 0) const { return m_impl ? m_impl->find(matchFunction, start) : notFound; }
+    size_t find(ASCIILiteral literal, unsigned start = 0) const { return m_impl ? m_impl->find(literal, start) : notFound; }
 
     // Find the last instance of a single character or string.
-    size_t reverseFind(UChar character, size_t start = MaxLength) const { return m_impl ? m_impl->reverseFind(character, start) : notFound; }
-    size_t reverseFind(ASCIILiteral literal, size_t start = MaxLength) const { return m_impl ? m_impl->reverseFind(literal, start) : notFound; }
-    size_t reverseFind(StringView, size_t start = MaxLength) const;
+    size_t reverseFind(UChar character, unsigned start = MaxLength) const { return m_impl ? m_impl->reverseFind(character, start) : notFound; }
+    size_t reverseFind(ASCIILiteral literal, unsigned start = MaxLength) const { return m_impl ? m_impl->reverseFind(literal, start) : notFound; }
+    size_t reverseFind(StringView, unsigned start = MaxLength) const;
 
     WTF_EXPORT_PRIVATE Expected<Vector<UChar>, UTF8ConversionError> charactersWithNullTermination() const;
     WTF_EXPORT_PRIVATE Expected<Vector<UChar>, UTF8ConversionError> charactersWithoutNullTermination() const;

--- a/Source/WebCore/dom/SpaceSplitString.cpp
+++ b/Source/WebCore/dom/SpaceSplitString.cpp
@@ -111,7 +111,7 @@ public:
     template <typename TokenCharacterType>
     bool processToken(std::span<const TokenCharacterType> characters)
     {
-        if (characters.size() == m_referenceLength && equal(characters.data(), m_referenceCharacters, characters.size())) {
+        if (characters.size() == m_referenceLength && equal(m_referenceCharacters, characters)) {
             m_referenceStringWasFound = true;
             return false;
         }

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -1392,13 +1392,7 @@ sub generateFindNameForLength
                     }
                     print F ")) {\n";
                 } else {
-                    print F "${indent}static constexpr characterType rest[] = { ";
-                    for (my $index = $currentIndex; $index < $length; $index = $index + 1) {
-                        my $letter = substr($string, $index, 1);
-                        print F "'$letter', ";
-                    }
-                    print F "};\n";
-                    print F "${indent}if (WTF::equal($bufferStart, rest, $lengthToCompare)) {\n";
+                    print F "${indent}if (WTF::equal($bufferStart, \"". substr($string, $currentIndex, $length - $currentIndex) . "\"_span)) {\n";
                 }
             }
             print F "$indent    return ${enumClass}::$enumValue;\n";

--- a/Source/WebCore/html/parser/HTMLToken.h
+++ b/Source/WebCore/html/parser/HTMLToken.h
@@ -436,7 +436,7 @@ inline const HTMLToken::Attribute* findAttribute(const HTMLToken::AttributeList&
 {
     for (auto& attribute : attributes) {
         // FIXME: The one caller that uses this probably wants to ignore letter case.
-        if (attribute.name.size() == name.size() && equal(attribute.name.data(), name.data(), name.size()))
+        if (attribute.name.size() == name.size() && equal(attribute.name.data(), name))
             return &attribute;
     }
     return nullptr;

--- a/Source/WebCore/html/parser/HTMLTokenizer.cpp
+++ b/Source/WebCore/html/parser/HTMLTokenizer.cpp
@@ -1405,7 +1405,7 @@ inline bool HTMLTokenizer::temporaryBufferIs(ASCIILiteral expectedString)
 {
     if (m_temporaryBuffer.size() != expectedString.length())
         return false;
-    return equal(m_temporaryBuffer.data(), expectedString.characters8(), m_temporaryBuffer.size());
+    return equal(m_temporaryBuffer.data(), expectedString.span8());
 }
 
 inline void HTMLTokenizer::appendToPossibleEndTag(UChar character)
@@ -1418,7 +1418,7 @@ inline bool HTMLTokenizer::isAppropriateEndTag() const
 {
     if (m_bufferedEndTagName.size() != m_appropriateEndTagName.size())
         return false;
-    return equal(m_bufferedEndTagName.data(), m_appropriateEndTagName.data(), m_bufferedEndTagName.size());
+    return equal(m_bufferedEndTagName.data(), m_appropriateEndTagName.span());
 }
 
 inline void HTMLTokenizer::parseError()

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -1211,11 +1211,11 @@ void VTTCue::setCueSettings(const String& inputString)
                     if (!input.scan(','))
                         break;
 
-                    if (input.scan(startKeyword().characters8(), startKeyword().length()))
+                    if (input.scan(startKeyword().span8()))
                         alignment = LineAlignSetting::Start;
-                    else if (input.scan(centerKeyword().characters8(), centerKeyword().length()))
+                    else if (input.scan(centerKeyword().span8()))
                         alignment = LineAlignSetting::Center;
-                    else if (input.scan(endKeyword().characters8(), endKeyword().length()))
+                    else if (input.scan(endKeyword().span8()))
                         alignment = LineAlignSetting::End;
                     else {
                         ERROR_LOG(LOGIDENTIFIER, "Invalid line setting alignment");
@@ -1284,11 +1284,11 @@ void VTTCue::setCueSettings(const String& inputString)
                     return false;
 
                 // 2.2 One of the following strings: "line-left", "center", "line-right"
-                if (input.scan(lineLeftKeyword().characters8(), lineLeftKeyword().length()))
+                if (input.scan(lineLeftKeyword().span8()))
                     alignment = PositionAlignSetting::LineLeft;
-                else if (input.scan(centerKeyword().characters8(), centerKeyword().length()))
+                else if (input.scan(centerKeyword().span8()))
                     alignment = PositionAlignSetting::Center;
-                else if (input.scan(lineRightKeyword().characters8(), lineRightKeyword().length()))
+                else if (input.scan(lineRightKeyword().span8()))
                     alignment = PositionAlignSetting::LineRight;
                 else {
                     ERROR_LOG(LOGIDENTIFIER, "Invalid position setting alignment");

--- a/Source/WebCore/html/track/VTTScanner.cpp
+++ b/Source/WebCore/html/track/VTTScanner.cpp
@@ -55,18 +55,18 @@ bool VTTScanner::scan(char c)
     return true;
 }
 
-bool VTTScanner::scan(const LChar* characters, size_t charactersCount)
+bool VTTScanner::scan(std::span<const LChar> characters)
 {
     unsigned matchLength = m_is8Bit ? m_end.characters8 - m_data.characters8 : m_end.characters16 - m_data.characters16;
-    if (matchLength < charactersCount)
+    if (matchLength < characters.size())
         return false;
     bool matched;
     if (m_is8Bit)
-        matched = equal(m_data.characters8, characters, charactersCount);
+        matched = equal(m_data.characters8, characters);
     else
-        matched = equal(m_data.characters16, characters, charactersCount);
+        matched = equal(m_data.characters16, characters);
     if (matched)
-        advance(charactersCount);
+        advance(characters.size());
     return matched;
 }
 

--- a/Source/WebCore/html/track/VTTScanner.h
+++ b/Source/WebCore/html/track/VTTScanner.h
@@ -78,7 +78,7 @@ public:
     // Scan the character |c|.
     bool scan(char);
     // Scan the first |charactersCount| characters of the string |characters|.
-    bool scan(const LChar* characters, size_t charactersCount);
+    bool scan(std::span<const LChar> characters);
 
     // Scan the literal |characters|.
     template<unsigned charactersCount>
@@ -160,7 +160,7 @@ inline size_t VTTScanner::Run::length() const
 template<unsigned charactersCount>
 inline bool VTTScanner::scan(const char (&characters)[charactersCount])
 {
-    return scan(reinterpret_cast<const LChar*>(characters), charactersCount - 1);
+    return scan({ reinterpret_cast<const LChar*>(characters), charactersCount - 1 });
 }
 
 template<bool characterPredicate(UChar)>


### PR DESCRIPTION
#### 4cfac5574bee015ca8149440b6658ffdb770ff0b
<pre>
Use std::span more in StringCommon.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=272311">https://bugs.webkit.org/show_bug.cgi?id=272311</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/runtime/IntlObjectInlines.h:
(JSC::compareASCIIWithUCADUCET):
* Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h:
(JSC::JSONAtomStringCache::make):
* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::mapHostName):
* Source/WTF/wtf/text/CString.cpp:
(WTF::operator==):
* Source/WTF/wtf/text/StringCommon.h:
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::find):
(WTF::StringImpl::reverseFind):
(WTF::equalInner):
(WTF::equalInternal):
* Source/WTF/wtf/text/StringSearch.h:
(WTF::BoyerMooreHorspoolTable::find const):
(WTF::BoyerMooreHorspoolTable::findInner const):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::reverseFind const):
* Source/WTF/wtf/text/StringView.h:
(WTF::equal):
(WTF::startsWith):
(WTF::endsWith):
* Source/WebCore/dom/SpaceSplitString.cpp:
(WebCore::TokenIsEqualToCharactersTokenProcessor::processToken):
* Source/WebCore/dom/make_names.pl:
(generateFindNameForLength):
* Source/WebCore/html/parser/HTMLToken.h:
(WebCore::findAttribute):
* Source/WebCore/html/parser/HTMLTokenizer.cpp:
(WebCore::HTMLTokenizer::temporaryBufferIs):
(WebCore::HTMLTokenizer::isAppropriateEndTag const):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::setCueSettings):
* Source/WebCore/html/track/VTTScanner.cpp:
(WebCore::VTTScanner::scan):
* Source/WebCore/html/track/VTTScanner.h:
(WebCore::VTTScanner::scan):

Canonical link: <a href="https://commits.webkit.org/277191@main">https://commits.webkit.org/277191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1be3c34f2a3a296fcc6f628fe26ca3a65fa081d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46933 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42981 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23567 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38225 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19535 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41568 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4979 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40186 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43269 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51488 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46417 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45519 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23234 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44502 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23942 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53558 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6581 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22944 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11009 "Passed tests") | 
<!--EWS-Status-Bubble-End-->