### PR TITLE
Deploy std::span more broadly

### DIFF
--- a/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
+++ b/Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp
@@ -302,14 +302,14 @@ ASCIILiteral atomCanonicalTextEncodingName(const char* name)
     return textEncodingNameMap->get<HashTranslatorTextEncodingName>(name);
 }
 
-template<typename CharacterType> static ASCIILiteral atomCanonicalTextEncodingName(const CharacterType* characters, size_t length)
+template<typename CharacterType> static ASCIILiteral atomCanonicalTextEncodingName(std::span<const CharacterType> characters)
 {
     char buffer[maxEncodingNameLength + 1];
     size_t j = 0;
-    for (size_t i = 0; i < length; ++i) {
+    for (auto character : characters) {
         if (j == maxEncodingNameLength)
             return { };
-        buffer[j++] = characters[i];
+        buffer[j++] = character;
     }
     buffer[j] = 0;
     return atomCanonicalTextEncodingName(buffer);
@@ -321,9 +321,9 @@ ASCIILiteral atomCanonicalTextEncodingName(StringView alias)
         return { };
 
     if (alias.is8Bit())
-        return atomCanonicalTextEncodingName(alias.characters8(), alias.length());
+        return atomCanonicalTextEncodingName(alias.span8());
 
-    return atomCanonicalTextEncodingName(alias.characters16(), alias.length());
+    return atomCanonicalTextEncodingName(alias.span16());
 }
 
 bool noExtendedTextEncodingNameUsed()

--- a/Source/WebCore/css/CSSMarkup.cpp
+++ b/Source/WebCore/css/CSSMarkup.cpp
@@ -35,22 +35,20 @@
 namespace WebCore {
 
 template <typename CharacterType>
-static inline bool isCSSTokenizerIdentifier(const CharacterType* characters, unsigned length)
+static inline bool isCSSTokenizerIdentifier(std::span<const CharacterType> characters)
 {
-    const CharacterType* end = characters + length;
-
     // -?
-    if (characters != end && characters[0] == '-')
-        ++characters;
+    while (!characters.empty() && characters.front() == '-')
+        characters = characters.subspan(1);
 
     // {nmstart}
-    if (characters == end || !isNameStartCodePoint(characters[0]))
+    if (characters.empty() || !isNameStartCodePoint(characters.front()))
         return false;
-    ++characters;
+    characters = characters.subspan(1);
 
     // {nmchar}*
-    for (; characters != end; ++characters) {
-        if (!isNameCodePoint(characters[0]))
+    for (; !characters.empty(); characters = characters.subspan(1)) {
+        if (!isNameCodePoint(characters.front()))
             return false;
     }
 
@@ -60,14 +58,12 @@ static inline bool isCSSTokenizerIdentifier(const CharacterType* characters, uns
 // "ident" from the CSS tokenizer, minus backslash-escape sequences
 static bool isCSSTokenizerIdentifier(const String& string)
 {
-    unsigned length = string.length();
-
-    if (!length)
+    if (string.isEmpty())
         return false;
 
     if (string.is8Bit())
-        return isCSSTokenizerIdentifier(string.characters8(), length);
-    return isCSSTokenizerIdentifier(string.characters16(), length);
+        return isCSSTokenizerIdentifier(string.span8());
+    return isCSSTokenizerIdentifier(string.span16());
 }
 
 static void serializeCharacter(char32_t c, StringBuilder& appendTo)

--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -48,7 +48,7 @@ template<typename CharacterType> void CSSVariableData::updateBackingStringsInTok
         if (!token.hasStringBacking() || token.isBackedByStringLiteral())
             continue;
         unsigned length = token.value().length();
-        token.updateCharacters(currentOffset, length);
+        token.updateCharacters(std::span<const CharacterType> { currentOffset, length });
         currentOffset += length;
     }
     ASSERT(currentOffset == m_backingString.characters<CharacterType>() + m_backingString.length());

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -41,10 +41,10 @@ namespace WebCore {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CSSParserToken);
 
 template<typename CharacterType>
-CSSUnitType cssPrimitiveValueUnitFromTrie(const CharacterType* data, unsigned length)
+CSSUnitType cssPrimitiveValueUnitFromTrie(std::span<const CharacterType> data)
 {
-    ASSERT(data);
-    switch (length) {
+    ASSERT(data.data());
+    switch (data.size()) {
     case 1:
         switch (toASCIILower(data[0])) {
         case 'q':
@@ -348,8 +348,8 @@ CSSUnitType cssPrimitiveValueUnitFromTrie(const CharacterType* data, unsigned le
 CSSUnitType CSSParserToken::stringToUnitType(StringView stringView)
 {
     if (stringView.is8Bit())
-        return cssPrimitiveValueUnitFromTrie(stringView.characters8(), stringView.length());
-    return cssPrimitiveValueUnitFromTrie(stringView.characters16(), stringView.length());
+        return cssPrimitiveValueUnitFromTrie(stringView.span8());
+    return cssPrimitiveValueUnitFromTrie(stringView.span16());
 }
 
 CSSParserToken::CSSParserToken(CSSParserTokenType type, BlockType blockType)
@@ -562,7 +562,7 @@ bool CSSParserToken::tryUseStringLiteralBacking()
         if (value() != literal)
             return false;
 
-        updateCharacters(literal.characters8(), literal.length());
+        updateCharacters(literal.span8());
 
         m_isBackedByStringLiteral = true;
     }

--- a/Source/WebCore/css/parser/CSSParserToken.h
+++ b/Source/WebCore/css/parser/CSSParserToken.h
@@ -149,7 +149,7 @@ public:
     void serialize(StringBuilder&, const CSSParserToken* nextToken = nullptr, SerializationMode = SerializationMode::Normal) const;
 
     template<typename CharacterType>
-    void updateCharacters(const CharacterType* characters, unsigned length);
+    void updateCharacters(std::span<const CharacterType> characters);
 
 private:
     void initValueFromStringView(StringView string)
@@ -185,11 +185,11 @@ private:
 };
 
 template<typename CharacterType>
-inline void CSSParserToken::updateCharacters(const CharacterType* characters, unsigned length)
+inline void CSSParserToken::updateCharacters(std::span<const CharacterType> characters)
 {
-    m_valueLength = length;
+    m_valueLength = characters.size();
     m_valueIs8Bit = (sizeof(CharacterType) == 1);
-    m_valueDataCharRaw = characters;
+    m_valueDataCharRaw = characters.data();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLFontElement.cpp
+++ b/Source/WebCore/html/HTMLFontElement.cpp
@@ -55,13 +55,13 @@ Ref<HTMLFontElement> HTMLFontElement::create(const QualifiedName& tagName, Docum
 
 // http://www.whatwg.org/specs/web-apps/current-work/multipage/rendering.html#fonts-and-colors
 template <typename CharacterType>
-static bool parseFontSize(const CharacterType* characters, unsigned length, int& size)
+static bool parseFontSize(std::span<const CharacterType> characters, int& size)
 {
 
     // Step 1
     // Step 2
-    const CharacterType* position = characters;
-    const CharacterType* end = characters + length;
+    const CharacterType* position = characters.data();
+    const CharacterType* end = characters.data() + characters.size();
 
     // Step 3
     while (position < end) {
@@ -136,9 +136,9 @@ static bool parseFontSize(const String& input, int& size)
         return false;
 
     if (input.is8Bit())
-        return parseFontSize(input.characters8(), input.length(), size);
+        return parseFontSize(input.span8(), size);
 
-    return parseFontSize(input.characters16(), input.length(), size);
+    return parseFontSize(input.span16(), size);
 }
 
 bool HTMLFontElement::cssValueFromFontSizeNumber(const String& s, CSSValueID& size)

--- a/Source/WebCore/html/parser/CSSPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.cpp
@@ -172,10 +172,10 @@ inline void CSSPreloadScanner::tokenize(UChar c)
     }
 }
 
-static String parseCSSStringOrURL(const UChar* characters, size_t length) // FIXME: This should take in a span.
+static String parseCSSStringOrURL(std::span<const UChar> characters)
 {
     size_t offset = 0;
-    size_t reducedLength = length;
+    size_t reducedLength = characters.size();
 
     // Remove whitespace from the rule start
     while (reducedLength && isASCIIWhitespace(characters[offset])) {
@@ -213,7 +213,7 @@ static String parseCSSStringOrURL(const UChar* characters, size_t length) // FIX
             reducedLength -= 2;            
         }
 
-    return String({ characters + offset, reducedLength });
+    return String(characters.subspan(offset, reducedLength));
 }
 
 static bool hasValidImportConditions(StringView conditions)
@@ -238,7 +238,7 @@ void CSSPreloadScanner::emitRule()
 {
     StringView rule(m_rule.span());
     if (equalLettersIgnoringASCIICase(rule, "import"_s)) {
-        String url = parseCSSStringOrURL(m_ruleValue.data(), m_ruleValue.size());
+        String url = parseCSSStringOrURL(m_ruleValue.span());
         StringView conditions(m_ruleConditions.span());
         if (!url.isEmpty() && hasValidImportConditions(conditions)) {
             URL baseElementURL; // FIXME: This should be passed in from the HTMLPreloadScanner via scan(): without it we will get relative URLs wrong.

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4945,11 +4945,11 @@ void LocalFrameView::updateLayoutAndStyleIfNeededRecursive(OptionSet<LayoutOptio
 #include <span>
 
 template<typename CharacterType>
-static unsigned nonWhitespaceLength(const CharacterType* characters, unsigned length)
+static size_t nonWhitespaceLength(std::span<const CharacterType> characters)
 {
-    unsigned result = length;
-    for (unsigned i = 0; i < length; ++i) {
-        if (isASCIIWhitespace(characters[i]))
+    size_t result = characters.size();
+    for (auto character : characters) {
+        if (isASCIIWhitespace(character))
             --result;
     }
     return result;
@@ -4958,9 +4958,9 @@ static unsigned nonWhitespaceLength(const CharacterType* characters, unsigned le
 void LocalFrameView::incrementVisuallyNonEmptyCharacterCountSlowCase(const String& inlineText)
 {
     if (inlineText.is8Bit())
-        m_visuallyNonEmptyCharacterCount += nonWhitespaceLength(inlineText.characters8(), inlineText.length());
+        m_visuallyNonEmptyCharacterCount += nonWhitespaceLength(inlineText.span8());
     else
-        m_visuallyNonEmptyCharacterCount += nonWhitespaceLength(inlineText.characters16(), inlineText.length());
+        m_visuallyNonEmptyCharacterCount += nonWhitespaceLength(inlineText.span16());
     ++m_textRendererCountForVisuallyNonEmptyCharacters;
 }
 

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -563,32 +563,32 @@ int FontCascade::offsetForPosition(const TextRun& run, float x, bool includePart
 }
 
 template <typename CharacterType>
-static inline String normalizeSpacesInternal(const CharacterType* characters, unsigned length)
+static inline String normalizeSpacesInternal(std::span<const CharacterType> characters)
 {
     StringBuilder normalized;
-    normalized.reserveCapacity(length);
+    normalized.reserveCapacity(characters.size());
 
-    for (unsigned i = 0; i < length; ++i)
-        normalized.append(FontCascade::normalizeSpaces(characters[i]));
+    for (auto character : characters)
+        normalized.append(FontCascade::normalizeSpaces(character));
 
     return normalized.toString();
 }
 
-String FontCascade::normalizeSpaces(const LChar* characters, unsigned length)
+String FontCascade::normalizeSpaces(std::span<const LChar> characters)
 {
-    return normalizeSpacesInternal(characters, length);
+    return normalizeSpacesInternal(characters);
 }
 
-String FontCascade::normalizeSpaces(const UChar* characters, unsigned length)
+String FontCascade::normalizeSpaces(std::span<const UChar> characters)
 {
-    return normalizeSpacesInternal(characters, length);
+    return normalizeSpacesInternal(characters);
 }
 
 String FontCascade::normalizeSpaces(StringView stringView)
 {
     if (stringView.is8Bit())
-        return normalizeSpacesInternal(stringView.characters8(), stringView.length());
-    return normalizeSpacesInternal(stringView.characters16(), stringView.length());
+        return normalizeSpacesInternal(stringView.span8());
+    return normalizeSpacesInternal(stringView.span16());
 }
 
 static std::atomic<bool> disableFontSubpixelAntialiasingForTesting = false;

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -305,8 +305,8 @@ public:
         return character;
     }
 
-    static String normalizeSpaces(const LChar*, unsigned length);
-    static String normalizeSpaces(const UChar*, unsigned length);
+    static String normalizeSpaces(std::span<const LChar>);
+    static String normalizeSpaces(std::span<const UChar>);
     static String normalizeSpaces(StringView);
 
     bool useBackslashAsYenSymbol() const { return m_useBackslashAsYenSymbol; }

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1370,10 +1370,10 @@ void RenderText::computePreferredLogicalWidths(float leadWidth, SingleThreadWeak
     setPreferredLogicalWidthsDirty(false);
 }
 
-template<typename CharacterType> static inline bool containsOnlyCollapsibleWhitespace(const CharacterType* characters, unsigned length, const RenderStyle& style)
+template<typename CharacterType> static inline bool containsOnlyCollapsibleWhitespace(std::span<const CharacterType> characters, const RenderStyle& style)
 {
-    for (unsigned i = 0; i < length; ++i) {
-        if (!style.isCollapsibleWhiteSpace(characters[i]))
+    for (auto character : characters) {
+        if (!style.isCollapsibleWhiteSpace(character))
             return false;
     }
     return true;
@@ -1382,15 +1382,15 @@ template<typename CharacterType> static inline bool containsOnlyCollapsibleWhite
 bool RenderText::containsOnlyCollapsibleWhitespace() const
 {
     if (text().is8Bit())
-        return WebCore::containsOnlyCollapsibleWhitespace(text().characters8(), text().length(), style());
-    return WebCore::containsOnlyCollapsibleWhitespace(text().characters16(), text().length(), style());
+        return WebCore::containsOnlyCollapsibleWhitespace(text().span8(), style());
+    return WebCore::containsOnlyCollapsibleWhitespace(text().span16(), style());
 }
 
 // FIXME: merge this with isCSSSpace somehow
-template<typename CharacterType> static inline bool containsOnlyPossiblyCollapsibleWhitespace(const CharacterType* characters, unsigned length)
+template<typename CharacterType> static inline bool containsOnlyPossiblyCollapsibleWhitespace(std::span<const CharacterType> characters)
 {
-    for (unsigned i = 0; i < length; ++i) {
-        if (!(characters[i] == '\n' || characters[i] == ' ' || characters[i] == '\t'))
+    for (auto character : characters) {
+        if (!(character == '\n' || character == ' ' || character == '\t'))
             return false;
     }
     return true;
@@ -1402,8 +1402,8 @@ bool RenderText::containsOnlyCSSWhitespace(unsigned from, unsigned length) const
     ASSERT(length <= text().length());
     ASSERT(from + length <= text().length());
     if (text().is8Bit())
-        return containsOnlyPossiblyCollapsibleWhitespace(text().characters8() + from, length);
-    return containsOnlyPossiblyCollapsibleWhitespace(text().characters16() + from, length);
+        return containsOnlyPossiblyCollapsibleWhitespace(text().span8().subspan(from, length));
+    return containsOnlyPossiblyCollapsibleWhitespace(text().span16().subspan(from, length));
 }
 
 Vector<std::pair<unsigned, unsigned>> RenderText::draggedContentRangesBetweenOffsets(unsigned startOffset, unsigned endOffset) const


### PR DESCRIPTION
#### 20ff0f714457fc4549f05f522014652f38b7f37d
<pre>
Deploy std::span more broadly
<a href="https://bugs.webkit.org/show_bug.cgi?id=272314">https://bugs.webkit.org/show_bug.cgi?id=272314</a>

Reviewed by Darin Adler.

* Source/WebCore/PAL/pal/text/TextEncodingRegistry.cpp:
(PAL::atomCanonicalTextEncodingName):
* Source/WebCore/css/CSSMarkup.cpp:
(WebCore::isCSSTokenizerIdentifier):
* Source/WebCore/css/CSSVariableData.cpp:
(WebCore::CSSVariableData::updateBackingStringsInTokens):
* Source/WebCore/css/parser/CSSParserToken.cpp:
(WebCore::cssPrimitiveValueUnitFromTrie):
(WebCore::CSSParserToken::stringToUnitType):
(WebCore::CSSParserToken::tryUseStringLiteralBacking):
* Source/WebCore/css/parser/CSSParserToken.h:
(WebCore::CSSParserToken::updateCharacters):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::cssPropertyID):
(WebCore::cssValueKeywordID):
* Source/WebCore/html/HTMLFontElement.cpp:
(WebCore::parseFontSize):
* Source/WebCore/html/parser/CSSPreloadScanner.cpp:
(WebCore::parseCSSStringOrURL):
(WebCore::CSSPreloadScanner::emitRule):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::nonWhitespaceLength):
(WebCore::LocalFrameView::incrementVisuallyNonEmptyCharacterCountSlowCase):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::normalizeSpacesInternal):
(WebCore::FontCascade::normalizeSpaces):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/WidthCache.h:
(WebCore::WidthCache::SmallStringKey::SmallStringKey):
(WebCore::WidthCache::SmallStringKey::copySmallCharacters):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::containsOnlyCollapsibleWhitespace):
(WebCore::RenderText::containsOnlyCollapsibleWhitespace const):
(WebCore::containsOnlyPossiblyCollapsibleWhitespace):
(WebCore::RenderText::containsOnlyCSSWhitespace const):

Canonical link: <a href="https://commits.webkit.org/277198@main">https://commits.webkit.org/277198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2300a92bca597fdb91a0fb21d1b414a0ba7cce14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49619 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/42985 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38229 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19539 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20817 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41572 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/4983 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51492 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45522 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23238 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44505 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/23957 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6583 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22948 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->