### PR TITLE
OffscreenCanvas fails to render to placeholder with nested workers

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1326,6 +1326,7 @@ http/tests/websocket/tests/hybi/imported/blink/permessage-deflate-window-bits.ht
 http/wpt/offscreen-canvas/transferToImageBitmap-webgl.html [ ImageOnlyFailure Failure ]
 imported/w3c/web-platform-tests/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.resize.html [ Failure Pass ]
 imported/w3c/web-platform-tests/html/canvas/offscreen/the-offscreen-canvas/size.large.html [ Skip ]
+webkit.org/b/272327 fast/canvas/offscreen-nested-worker-serialization.html [ Failure Pass ]
 
 # MSE in worker is only supported on platform with the GPU process active and where MSE is enabled by default
 # (this excludes iPhone (no MediaSource) and Linux/Windows (no GPUP))

--- a/LayoutTests/fast/canvas/offscreen-nested-worker-serialization-expected.html
+++ b/LayoutTests/fast/canvas/offscreen-nested-worker-serialization-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<body style="margin:0">
+<canvas id="c" style="background: red;"></canvas>
+<script src="resources/offscreen-nested-worker.js"></script>
+<script>
+onmessage({data: {canvas: c}});
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            testRunner.notifyDone();
+        });
+    });
+}
+</script>
+</body>

--- a/LayoutTests/fast/canvas/offscreen-nested-worker-serialization.html
+++ b/LayoutTests/fast/canvas/offscreen-nested-worker-serialization.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseGPUProcessForWebGLEnabled=true OffscreenCanvasEnabled=true ] -->
+<body style="margin:0">
+<canvas id="c" style="background: red;"></canvas>
+<script>
+let worker = new Worker('resources/offscreen-worker.js');
+const offscreen = c.transferControlToOffscreen();
+worker.postMessage({canvas: offscreen},[offscreen]);
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    worker.onmessage = () => {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                testRunner.notifyDone();
+            });
+        });
+    };
+}
+</script>
+</body>

--- a/LayoutTests/fast/canvas/resources/offscreen-nested-worker.js
+++ b/LayoutTests/fast/canvas/resources/offscreen-nested-worker.js
@@ -1,0 +1,15 @@
+onmessage = function(event) {
+    console.log(event)
+    console.log(event.data)
+    console.log(event.data.canvas)
+    let gl = event.data.canvas.getContext('webgl');
+    gl.enable(gl.SCISSOR_TEST);
+    gl.scissor(0, 0, 150, 75);
+    gl.clearColor(0, 1, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.scissor(150, 75, 150, 75);
+    gl.clearColor(1, 1, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    if (typeof window == "undefined")
+        self.postMessage("done");
+};

--- a/LayoutTests/fast/canvas/resources/offscreen-worker.js
+++ b/LayoutTests/fast/canvas/resources/offscreen-worker.js
@@ -1,0 +1,7 @@
+const worker = new Worker("./offscreen-nested-worker.js");
+onmessage = function(e) {
+    worker.postMessage({canvas: e.data.canvas}, [e.data.canvas]);
+}
+worker.onmessage = function(e) {
+    self.postMessage("done");
+}

--- a/LayoutTests/webgl/resources/webgl_test_files/conformance2/offscreencanvas/offscreencanvas-sync.html
+++ b/LayoutTests/webgl/resources/webgl_test_files/conformance2/offscreencanvas/offscreencanvas-sync.html
@@ -35,8 +35,7 @@ found in the LICENSE.txt file.
       let canvas = new OffscreenCanvas(128, 128);
       let gl = canvas.getContext("webgl2");
       let sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
-      gl.clearColor(0.0, 1.0, 0.0, 1.0);
-      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.flush();
       tick(function() {
           const status = gl.getSyncParameter(sync, gl.SYNC_STATUS);
           if (status == gl.SIGNALED) {

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -74,13 +74,16 @@ using OffscreenRenderingContext = std::variant<
     RefPtr<OffscreenCanvasRenderingContext2D>
 >;
 
+class OffscreenCanvasPlaceholderData;
+
 class DetachedOffscreenCanvas {
     WTF_MAKE_NONCOPYABLE(DetachedOffscreenCanvas);
     WTF_MAKE_FAST_ALLOCATED;
     friend class OffscreenCanvas;
 
 public:
-    DetachedOffscreenCanvas(std::unique_ptr<SerializedImageBuffer>, const IntSize&, bool originClean);
+    DetachedOffscreenCanvas(std::unique_ptr<SerializedImageBuffer>, const IntSize&, bool originClean, RefPtr<OffscreenCanvasPlaceholderData>);
+    WEBCORE_EXPORT ~DetachedOffscreenCanvas();
 
     RefPtr<ImageBuffer> takeImageBuffer(ScriptExecutionContext&);
     const IntSize& size() const { return m_size; }
@@ -92,13 +95,13 @@ public:
             return buffer->memoryCost();
         return 0;
     }
-    WeakPtr<HTMLCanvasElement, WeakPtrImplWithEventTargetData> takePlaceholderCanvas();
+    RefPtr<OffscreenCanvasPlaceholderData> takePlaceholderData();
 
 private:
     std::unique_ptr<SerializedImageBuffer> m_buffer;
+    RefPtr<OffscreenCanvasPlaceholderData> m_placeholderData;
     IntSize m_size;
     bool m_originClean;
-    WeakPtr<HTMLCanvasElement, WeakPtrImplWithEventTargetData> m_placeholderCanvas;
 };
 
 class OffscreenCanvas final : public ActiveDOMObject, public RefCounted<OffscreenCanvas>, public CanvasBase, public EventTarget {
@@ -122,7 +125,7 @@ public:
 
     static Ref<OffscreenCanvas> create(ScriptExecutionContext&, unsigned width, unsigned height);
     static Ref<OffscreenCanvas> create(ScriptExecutionContext&, std::unique_ptr<DetachedOffscreenCanvas>&&);
-    static Ref<OffscreenCanvas> create(ScriptExecutionContext&, HTMLCanvasElement&);
+    static Ref<OffscreenCanvas> create(ScriptExecutionContext&, HTMLCanvasElement& placeholder);
     WEBCORE_EXPORT virtual ~OffscreenCanvas();
 
     void setWidth(unsigned);
@@ -159,7 +162,7 @@ public:
     bool isDetached() const { return m_detached; };
 
 private:
-    OffscreenCanvas(ScriptExecutionContext&, unsigned width, unsigned height);
+    OffscreenCanvas(ScriptExecutionContext&, IntSize, RefPtr<OffscreenCanvasPlaceholderData>);
 
     bool isOffscreenCanvas() const final { return true; }
 
@@ -179,36 +182,15 @@ private:
     std::unique_ptr<SerializedImageBuffer> takeImageBuffer() const;
 
     void reset();
-
-    void setPlaceholderCanvas(HTMLCanvasElement&);
-    void pushBufferToPlaceholder();
     void scheduleCommitToPlaceholderCanvas();
 
     std::unique_ptr<CanvasRenderingContext> m_context;
-
+    RefPtr<OffscreenCanvasPlaceholderData> m_placeholderData;
+    mutable RefPtr<Image> m_copiedImage;
     // m_hasCreatedImageBuffer means we tried to malloc the buffer. We didn't necessarily get it.
     mutable bool m_hasCreatedImageBuffer { false };
-
     bool m_detached { false };
-
-    mutable RefPtr<Image> m_copiedImage;
-
     bool m_hasScheduledCommit { false };
-
-    class PlaceholderData : public ThreadSafeRefCounted<PlaceholderData, WTF::DestructionThread::Main> {
-    public:
-        static Ref<PlaceholderData> create()
-        {
-            return adoptRef(*new PlaceholderData);
-        }
-
-        WeakPtr<HTMLCanvasElement, WeakPtrImplWithEventTargetData> canvas;
-        RefPtr<ImageBufferPipe::Source> bufferPipeSource;
-        std::unique_ptr<SerializedImageBuffer> pendingCommitBuffer;
-        mutable Lock bufferLock;
-    };
-
-    RefPtr<PlaceholderData> m_placeholderData;
 };
 
 }


### PR DESCRIPTION
#### 41096f3920bd4eaf1cfd4c9e1217b51955305ce1
<pre>
OffscreenCanvas fails to render to placeholder with nested workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=272320">https://bugs.webkit.org/show_bug.cgi?id=272320</a>
<a href="https://rdar.apple.com/126069375">rdar://126069375</a>

Reviewed by Matt Woodrow.

Upon constructing OffscreenCanvas from a detached OffscreenCanvas,
the OffscreenCanvas::create() function would post a main thread task
to populate the placeholder data (pipe and weak ptr to the placeholder).

If the OffscreenCanvas would be then detached and sent to a nested worker
before this main thread task would run, the detached OffscreenCanvas would
not have the placeholder data at all. This would cause failure to send
frames to the placeholder.

Fix by populating the placeholder data during transferControlToOffscreen(),
e.g. when creating the initial main thread OffscreenCanvas.

* LayoutTests/webgl/resources/webgl_test_files/conformance2/offscreencanvas/offscreencanvas-sync.html:
Fix the test to flush the offscreen canvas context after inserting the fence.
<a href="https://github.com/KhronosGroup/WebGL/issues/3639">https://github.com/KhronosGroup/WebGL/issues/3639</a>

* LayoutTests/fast/canvas/offscreen-nested-worker-serialization-expected.html: Added.
* LayoutTests/fast/canvas/offscreen-nested-worker-serialization.html: Added.
* LayoutTests/fast/canvas/resources/offscreen-nested-worker.js: Added.
(onmessage):
* LayoutTests/fast/canvas/resources/offscreen-worker.js: Added.
(onmessage):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvasPlaceholderData::create):
(WebCore::OffscreenCanvasPlaceholderData::placeholder const):
(WebCore::OffscreenCanvasPlaceholderData::pipeSource const):
(WebCore::OffscreenCanvasPlaceholderData::OffscreenCanvasPlaceholderData):
(WebCore::DetachedOffscreenCanvas::DetachedOffscreenCanvas):
(WebCore::DetachedOffscreenCanvas::takePlaceholderData):
(WebCore::OffscreenCanvas::create):
(WebCore::OffscreenCanvas::OffscreenCanvas):
(WebCore::OffscreenCanvas::detach):
(WebCore::OffscreenCanvas::commitToPlaceholderCanvas):
(WebCore::OffscreenCanvas::scheduleCommitToPlaceholderCanvas):
(WebCore::DetachedOffscreenCanvas::takePlaceholderCanvas): Deleted.
(WebCore::OffscreenCanvas::setPlaceholderCanvas): Deleted.
(WebCore::OffscreenCanvas::pushBufferToPlaceholder): Deleted.
* Source/WebCore/html/OffscreenCanvas.h:

Canonical link: <a href="https://commits.webkit.org/277328@main">https://commits.webkit.org/277328@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6eac2964acce04ee3da8cc776be6454ccefeb3c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49963 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43328 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38503 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40747 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19817 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41909 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5323 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43641 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42312 "Found 2 new test failures: fast/workers/dedicated-worker-lifecycle.html, inspector/cpu-profiler/tracking.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51838 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22309 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18656 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45798 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44812 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10429 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23302 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->