### PR TITLE
[visionOS] Re-baseline layer based tests

### DIFF
--- a/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-expected.txt
@@ -75,4 +75,7 @@
                               (layer position [x: 400 y: 400])
                               (layer cornerRadius 8))))))))))))))
     (
+      (layer bounds [x: 0 y: 0 width: 800 height: 86050])
+      (layer position [x: 400 y: 400]))
+    (
       (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
+++ b/LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt
@@ -60,4 +60,7 @@
                                       (layer position [x: 400 y: 400])
                                       (layer cornerRadius 8))))))))))))))))))
     (
+      (layer bounds [x: 0 y: 0 width: 800 height: 713])
+      (layer position [x: 400 y: 400]))
+    (
       (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -119,4 +119,7 @@
                                   (layer bounds [x: 0 y: 0 width: 800 height: 20])
                                   (layer position [x: 400 y: 400]))))))))))))))))
     (
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400]))
+    (
       (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt
@@ -52,4 +52,7 @@
                               (layer bounds [x: 0 y: 0 width: 100 height: 100])
                               (layer position [x: 350 y: 350]))))))))))))))
     (
+      (layer bounds [x: 0 y: 0 width: 800 height: 600])
+      (layer position [x: 400 y: 400]))
+    (
       (layer bounds [x: 0 y: 0 width: 0 height: 0]))))

--- a/LayoutTests/overlay-region/fixed-node-updates-expected.txt
+++ b/LayoutTests/overlay-region/fixed-node-updates-expected.txt
@@ -53,6 +53,9 @@
                                         (view [class: WKCompositingView]
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/full-page-dynamic-expected.txt
+++ b/LayoutTests/overlay-region/full-page-dynamic-expected.txt
@@ -68,6 +68,9 @@
                                         (view [class: WKCompositingView]
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/full-page-expected.txt
+++ b/LayoutTests/overlay-region/full-page-expected.txt
@@ -68,6 +68,9 @@
                                         (view [class: WKCompositingView]
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/full-page-horizontal-expected.txt
+++ b/LayoutTests/overlay-region/full-page-horizontal-expected.txt
@@ -49,6 +49,9 @@
                                             (view [class: WKCompositingView]
                                               (layer bounds [x: 0 y: 0 width: 50 height: 600])
                                               (layer anchorPoint [x: 0 y: 0]))))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 3000 height: 600])
+              (layer position [x: 1500 y: 1500]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/full-page-overflow-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-expected.txt
@@ -141,6 +141,9 @@
                                         (view [class: WKCompositingView]
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt
@@ -141,6 +141,9 @@
                                         (view [class: WKCompositingView]
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/full-page-overflow-snapping-expected.txt
+++ b/LayoutTests/overlay-region/full-page-overflow-snapping-expected.txt
@@ -138,6 +138,9 @@
                                         (view [class: WKCompositingView]
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/full-page-scrolling-expected.txt
+++ b/LayoutTests/overlay-region/full-page-scrolling-expected.txt
@@ -69,6 +69,9 @@
                                         (view [class: WKCompositingView]
                                           (layer bounds [x: 0 y: 0 width: 800 height: 50])
                                           (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 7113])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/many-candidates-expected.txt
+++ b/LayoutTests/overlay-region/many-candidates-expected.txt
@@ -269,6 +269,9 @@
                                                             (view [class: <class not in allowed list of classes>]
                                                               (layer bounds [x: 0 y: 0 width: 90 height: 6])
                                                               (layer position [x: 48 y: 48]))))))))))))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/map-expected.txt
+++ b/LayoutTests/overlay-region/map-expected.txt
@@ -97,6 +97,9 @@
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 28 height: 6])
                                                           (layer position [x: 17 y: 17]))))))))))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/map-small-expected.txt
+++ b/LayoutTests/overlay-region/map-small-expected.txt
@@ -94,6 +94,9 @@
                                                         (view [class: <class not in allowed list of classes>]
                                                           (layer bounds [x: 0 y: 0 width: 28 height: 6])
                                                           (layer position [x: 17 y: 17]))))))))))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/overlay-element-expected.txt
+++ b/LayoutTests/overlay-region/overlay-element-expected.txt
@@ -46,6 +46,9 @@
                                         (view [class: WKCompositingView]
                                           (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                           (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 7013])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/overlay-element-overflow-expected.txt
+++ b/LayoutTests/overlay-region/overlay-element-overflow-expected.txt
@@ -104,6 +104,9 @@
                                         (view [class: WKCompositingView]
                                           (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                           (layer position [x: 400 y: 400]))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/snapping-expected.txt
+++ b/LayoutTests/overlay-region/snapping-expected.txt
@@ -174,6 +174,9 @@
                                             (view [class: WKCompositingView]
                                               (layer bounds [x: 0 y: 0 width: 50 height: 50])
                                               (layer anchorPoint [x: 0 y: 0]))))))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]

--- a/LayoutTests/overlay-region/split-scrollers-expected.txt
+++ b/LayoutTests/overlay-region/split-scrollers-expected.txt
@@ -194,6 +194,9 @@
                                     (view [class: WKCompositingView]
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (layer position [x: 0 y: 0]))))))))))))))
+            (view [class: UIView]
+              (layer bounds [x: 0 y: 0 width: 800 height: 600])
+              (layer position [x: 400 y: 400]))
             (view [class: _UILayerHostView]
               (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (view [class: UIView]


### PR DESCRIPTION
#### dd34add77143b39d511f18371770d1df44bf9cf7
<pre>
[visionOS] Re-baseline layer based tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=272323">https://bugs.webkit.org/show_bug.cgi?id=272323</a>
<a href="https://rdar.apple.com/126070971">rdar://126070971</a>

Reviewed by Mike Wyrzykowski.

No code change.
An extra layer was added elsewhere so some tests need new expectations.

* LayoutTests/interaction-region/interaction-layers-culling-expected.txt:
* LayoutTests/interaction-region/interaction-layers-culling-layer-type-change-expected.txt:
* LayoutTests/interaction-region/layer-tree-expected.txt:
* LayoutTests/interaction-region/layer-tree-shape-reset-expected.txt:
* LayoutTests/overlay-region/fixed-node-updates-expected.txt:
* LayoutTests/overlay-region/full-page-dynamic-expected.txt:
* LayoutTests/overlay-region/full-page-expected.txt:
* LayoutTests/overlay-region/full-page-horizontal-expected.txt:
* LayoutTests/overlay-region/full-page-overflow-expected.txt:
* LayoutTests/overlay-region/full-page-overflow-scrolling-expected.txt:
* LayoutTests/overlay-region/full-page-overflow-snapping-expected.txt:
* LayoutTests/overlay-region/full-page-scrolling-expected.txt:
* LayoutTests/overlay-region/many-candidates-expected.txt:
* LayoutTests/overlay-region/map-expected.txt:
* LayoutTests/overlay-region/map-small-expected.txt:
* LayoutTests/overlay-region/overlay-element-expected.txt:
* LayoutTests/overlay-region/overlay-element-overflow-expected.txt:
* LayoutTests/overlay-region/snapping-expected.txt:
* LayoutTests/overlay-region/split-scrollers-expected.txt:

Canonical link: <a href="https://commits.webkit.org/277199@main">https://commits.webkit.org/277199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5bae3278930305a51c0ba3ba293b419d9fc0822

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49641 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43007 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38249 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20911 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41602 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5005 "Built successfully") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43331 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; 20 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/41995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51515 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45544 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23260 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44529 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10372 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24019 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22972 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->