### PR TITLE
Interaction Regions generation should get geometry from the RenderTree

### DIFF
--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -225,6 +225,13 @@ static bool isGuardContainer(const Element& element)
     return hasTransparentContainerStyle(renderer.style());
 }
 
+static FloatRect absoluteBoundingRect(const RenderObject& renderer)
+{
+    Vector<FloatQuad> quads;
+    renderer.absoluteQuads(quads);
+    return unitedBoundingBoxes(quads);
+}
+
 static bool cachedImageIsPhoto(const CachedImage& cachedImage)
 {
     if (cachedImage.errorOccurred())
@@ -423,8 +430,8 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     std::optional<Path> clipPath = std::nullopt;
     RefPtr styleClipPath = regionRenderer.style().clipPath();
 
-    if (styleClipPath && styleClipPath->type() == PathOperation::OperationType::Shape) {
-        auto boundingRect = originalElement->boundingClientRect();
+    if (styleClipPath && styleClipPath->type() == PathOperation::OperationType::Shape && originalElement) {
+        auto boundingRect = absoluteBoundingRect(regionRenderer);
         clipPath = styleClipPath->getPath(TransformOperationData(FloatRect(FloatPoint(), boundingRect.size())));
     } else if (iconImage && originalElement) {
         LayoutRect imageRect(rect);
@@ -432,7 +439,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         Shape::DisplayPaths paths;
         shape->buildDisplayPaths(paths);
         auto path = paths.shape;
-        auto boundingRect = originalElement->boundingClientRect();
+        auto boundingRect = absoluteBoundingRect(regionRenderer);
         path.translate(FloatSize(-boundingRect.x(), -boundingRect.y()));
         clipPath = path;
     } else if (svgClipElements) {


### PR DESCRIPTION
#### 857ff847c2c6ef4af573fe17ec37c98d0b0d4fab
<pre>
Interaction Regions generation should get geometry from the RenderTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=272328">https://bugs.webkit.org/show_bug.cgi?id=272328</a>
&lt;<a href="https://rdar.apple.com/125901606">rdar://125901606</a>&gt;

Reviewed by Alan Baradlay.

Interaction Regions generation happens during the EventRegion paint
phase, and should get geometry from the RenderTree instead of going
through the DOM.
Replace the calls to `Element#boundingClientRect()` with a custom
function based on `RenderObject#absoluteQuads()`.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::absoluteBoundingRect):
(WebCore::interactionRegionForRenderedRegion):

Canonical link: <a href="https://commits.webkit.org/277290@main">https://commits.webkit.org/277290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcbb981ba32bfb075eb89d6d25bb7de37c409a6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26308 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49773 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43179 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38394 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47711 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40624 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19701 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21199 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41771 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5174 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43518 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51689 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45687 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23431 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44694 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10413 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->