### PR TITLE
Refine the mimeType detection for Image Fullscreen using `image->filenameExtension()`

### DIFF
--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -246,9 +246,12 @@ void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element, 
 
         auto mimeType = emptyString();
         if (auto* cachedImage = renderImage->cachedImage()) {
-            if (auto* image = cachedImage->image())
+            if (RefPtr image = cachedImage->image()) {
                 mimeType = image->mimeType();
 
+                if (!MIMETypeRegistry::isSupportedImageMIMEType(mimeType))
+                    mimeType = MIMETypeRegistry::mimeTypeForExtension(image->filenameExtension());
+            }
             if (!MIMETypeRegistry::isSupportedImageMIMEType(mimeType))
                 mimeType = MIMETypeRegistry::mimeTypeForPath(cachedImage->url().string());
         }


### PR DESCRIPTION
#### 60134b26c7259eac53c8cbb9cca7ea5887481ea7
<pre>
Refine the mimeType detection for Image Fullscreen using `image-&gt;filenameExtension()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=272330">https://bugs.webkit.org/show_bug.cgi?id=272330</a>
&lt;<a href="https://rdar.apple.com/126018476">rdar://126018476</a>&gt;

Reviewed by Sihui Liu.

For Image Fullscreen, we need a MIME type to build the Quick Look request.
But some images come with a generic `application/octet-stream` MIME
type, yet still display properly inline.

Instead of directly falling back to building a MIME type from the image&apos;s URL
extension, use the filename extension generated from the image metadata first.
This should be more reliable.

* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):

Canonical link: <a href="https://commits.webkit.org/277269@main">https://commits.webkit.org/277269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c4faa62da7a7de484efbd98d89e1fb5e1bde56b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49730 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49776 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43142 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38361 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47673 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40582 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19668 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5137 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51651 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18492 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45654 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23394 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44656 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10401 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24176 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->