### PR TITLE
Make WillChangeData::AnimatableFeature::m_feature to Feature enum

### DIFF
--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1279,16 +1279,16 @@ static Ref<CSSValue> willChangePropertyValue(const WillChangeData* willChangeDat
     for (size_t i = 0; i < willChangeData->numFeatures(); ++i) {
         WillChangeData::FeaturePropertyPair feature = willChangeData->featureAt(i);
         switch (feature.first) {
-        case WillChangeData::ScrollPosition:
+        case WillChangeData::Feature::ScrollPosition:
             list.append(CSSPrimitiveValue::create(CSSValueScrollPosition));
             break;
-        case WillChangeData::Contents:
+        case WillChangeData::Feature::Contents:
             list.append(CSSPrimitiveValue::create(CSSValueContents));
             break;
-        case WillChangeData::Property:
+        case WillChangeData::Feature::Property:
             list.append(CSSPrimitiveValue::create(feature.second));
             break;
-        case WillChangeData::Invalid:
+        case WillChangeData::Feature::Invalid:
             ASSERT_NOT_REACHED();
             break;
         }

--- a/Source/WebCore/rendering/style/WillChangeData.cpp
+++ b/Source/WebCore/rendering/style/WillChangeData.cpp
@@ -36,7 +36,7 @@ bool WillChangeData::operator==(const WillChangeData& other) const
 bool WillChangeData::containsScrollPosition() const
 {
     for (const auto& feature : m_animatableFeatures) {
-        if (feature.feature() == ScrollPosition)
+        if (feature.feature() == Feature::ScrollPosition)
             return true;
     }
     return false;
@@ -45,7 +45,7 @@ bool WillChangeData::containsScrollPosition() const
 bool WillChangeData::containsContents() const
 {
     for (const auto& feature : m_animatableFeatures) {
-        if (feature.feature() == Contents)
+        if (feature.feature() == Feature::Contents)
             return true;
     }
     return false;
@@ -164,7 +164,7 @@ static bool propertyTriggersCompositingOnBoxesOnly(CSSPropertyID property)
 
 void WillChangeData::addFeature(Feature feature, CSSPropertyID propertyID)
 {
-    ASSERT(feature == Property || propertyID == CSSPropertyInvalid);
+    ASSERT(feature == Feature::Property || propertyID == CSSPropertyInvalid);
     m_animatableFeatures.append(AnimatableFeature(feature, propertyID));
 
     m_canCreateStackingContext |= propertyCreatesStackingContext(propertyID);
@@ -176,7 +176,7 @@ void WillChangeData::addFeature(Feature feature, CSSPropertyID propertyID)
 WillChangeData::FeaturePropertyPair WillChangeData::featureAt(size_t index) const
 {
     if (index >= m_animatableFeatures.size())
-        return FeaturePropertyPair(Invalid, CSSPropertyInvalid);
+        return FeaturePropertyPair(Feature::Invalid, CSSPropertyInvalid);
 
     return m_animatableFeatures[index].featurePropertyPair();
 }

--- a/Source/WebCore/rendering/style/WillChangeData.h
+++ b/Source/WebCore/rendering/style/WillChangeData.h
@@ -55,7 +55,7 @@ public:
     bool canTriggerCompositing() const { return m_canTriggerCompositing; }
     bool canTriggerCompositingOnInline() const { return m_canTriggerCompositingOnInline; }
 
-    enum Feature {
+    enum class Feature: uint8_t {
         ScrollPosition,
         Contents,
         Property,
@@ -78,17 +78,17 @@ private:
         static const int numCSSPropertyIDBits = 14;
         static_assert(numCSSProperties < (1 << numCSSPropertyIDBits), "CSSPropertyID should fit in 14_bits");
 
-        unsigned m_feature : 2;
+        Feature m_feature { Feature::Property };
         unsigned m_cssPropertyID : numCSSPropertyIDBits;
 
         Feature feature() const
         {
-            return static_cast<Feature>(m_feature);
+            return m_feature;
         }
 
         CSSPropertyID property() const
         {
-            return feature() == Property ? static_cast<CSSPropertyID>(m_cssPropertyID) : CSSPropertyInvalid;
+            return feature() == Feature::Property ? static_cast<CSSPropertyID>(m_cssPropertyID) : CSSPropertyInvalid;
         }
         
         FeaturePropertyPair featurePropertyPair() const
@@ -99,15 +99,15 @@ private:
         AnimatableFeature(Feature willChange, CSSPropertyID willChangeProperty = CSSPropertyInvalid)
         {
             switch (willChange) {
-            case Property:
+            case Feature::Property:
                 ASSERT(willChangeProperty != CSSPropertyInvalid);
                 m_cssPropertyID = willChangeProperty;
                 FALLTHROUGH;
-            case ScrollPosition:
-            case Contents:
-                m_feature = static_cast<unsigned>(willChange);
+            case Feature::ScrollPosition:
+            case Feature::Contents:
+                m_feature = willChange;
                 break;
-            case Invalid:
+            case Feature::Invalid:
                 ASSERT_NOT_REACHED();
                 break;
             }


### PR DESCRIPTION
#### a131c497b5931189b5074000df056174bc15fcc1
<pre>
Make WillChangeData::AnimatableFeature::m_feature to Feature enum
<a href="https://bugs.webkit.org/show_bug.cgi?id=272333">https://bugs.webkit.org/show_bug.cgi?id=272333</a>

Reviewed by Sihui Liu.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::willChangePropertyValue):
* Source/WebCore/rendering/style/WillChangeData.cpp:
(WebCore::WillChangeData::containsScrollPosition const):
(WebCore::WillChangeData::containsContents const):
(WebCore::WillChangeData::addFeature):
(WebCore::WillChangeData::featureAt const):
* Source/WebCore/rendering/style/WillChangeData.h:
(WebCore::WillChangeData::AnimatableFeature::feature const):
(WebCore::WillChangeData::AnimatableFeature::property const):
(WebCore::WillChangeData::AnimatableFeature::AnimatableFeature):

Canonical link: <a href="https://commits.webkit.org/277215@main">https://commits.webkit.org/277215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee0d4c587048bfd6a207b2074f555fc8f2a72ac2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49685 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43050 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23637 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38286 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40498 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19595 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41642 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5048 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51560 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18385 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23304 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44572 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10381 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24080 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->