### PR TITLE
Unreviewed, reverting 277143@main

### DIFF
--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -131,12 +131,6 @@ static void initMachExceptionHandlerThread()
     RELEASE_ASSERT_WITH_MESSAGE(!handlers.exceptionPort, "Mach exception handler thread was already created");
     ASSERT(handlers.useMach);
 
-    // We need this because some WebKit processes (e.g. GPU process) don't allow signal handling in their
-    // sandbox profiles. We don't use them there so there's no point in setting up a dispatch queue we're
-    // never going to use.
-    if (!handlers.addedExceptions)
-        return;
-
     uint16_t flags = MPO_INSERT_SEND_RIGHT;
 
 // This provisional flag can be removed once macos sonoma is no longer supported


### PR DESCRIPTION
#### cdadd16e6fa8270afc0f9b13979aaa3cd4828298
<pre>
Unreviewed, reverting 277143@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=272335">https://bugs.webkit.org/show_bug.cgi?id=272335</a>
<a href="https://rdar.apple.com/126077721">rdar://126077721</a>

Breaks OBJC API

Reverted change:

    Don&apos;t initialize mach exceptions if we didn&apos;t register any.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=272261">https://bugs.webkit.org/show_bug.cgi?id=272261</a>
    <a href="https://rdar.apple.com/126000755">rdar://126000755</a>
    <a href="https://commits.webkit.org/277143@main">https://commits.webkit.org/277143@main</a>

Canonical link: <a href="https://commits.webkit.org/277200@main">https://commits.webkit.org/277200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79d21e4c4fa75c4c9e73aedbe39dab225cd95020

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46975 "Failed to checkout and rebase branch from PR 26978") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49608 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49657 "Failed to checkout and rebase branch from PR 26978") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/43023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/31267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/51/builds/23609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/49657 "Failed to checkout and rebase branch from PR 26978") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47556 "Failed to checkout and rebase branch from PR 26978") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/31267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/49657 "Failed to checkout and rebase branch from PR 26978") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/31267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5021 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/40232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/31267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/51531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/46461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/21994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/51/builds/23609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/51531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/23277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/51531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/53966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6584 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/22988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/53966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->