### PR TITLE
Update RELEASE_ASSERT in FormState::willDetachPage

### DIFF
--- a/LayoutTests/fast/forms/form-submission-crash-4-expected.txt
+++ b/LayoutTests/fast/forms/form-submission-crash-4-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fast/forms/form-submission-crash-4.html
+++ b/LayoutTests/fast/forms/form-submission-crash-4.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner) {
+  testRunner.waitUntilDone();
+  testRunner.dumpAsText();
+}
+function runTest() {
+  form.submit();
+  p.appendChild(object);
+  object.foo;
+  setTimeout(function() {
+    document.write("PASS if no crash");
+    testRunner.notifyDone();
+  }, 10);
+}
+</script>
+<body onload=runTest()>
+  <p id="p"></p>
+  <object id="object" data="?foo=bar">
+    <form id="form"></form>
+  </object>
+</body>

--- a/Source/WebCore/loader/FormState.cpp
+++ b/Source/WebCore/loader/FormState.cpp
@@ -55,7 +55,7 @@ Ref<FormState> FormState::create(HTMLFormElement& form, StringPairVector&& textF
 void FormState::willDetachPage()
 {
     // Beartrap for <rdar://problem/37579354>
-    RELEASE_ASSERT(hasOneRef());
+    RELEASE_ASSERT(refCount());
 }
 
 Ref<Document> FormState::protectedSourceDocument() const


### PR DESCRIPTION
#### 4c17927610b9ae436eb76bd1dea3354921331c35
<pre>
Update RELEASE_ASSERT in FormState::willDetachPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=270479">https://bugs.webkit.org/show_bug.cgi?id=270479</a>
<a href="https://rdar.apple.com/123991819">rdar://123991819</a>

Reviewed by Chris Dumez.

During the call to continueLoadAfterNavigationPolicy(), it&apos;s possible for the frame to be detached. The
FrameDestructionObserver willDetachPage() implementation in FormState has the expectation that there
is only one reference at this stage, so having an extra one during the scope of
continueLoadAfterNavigationPolicy() might break this assumption.

To respect the new smart pointer adoption guidelines, but also keep the trap introduced in
<a href="https://trac.webkit.org/changeset/229683/webkit">https://trac.webkit.org/changeset/229683/webkit</a>, use refCount() instead.

* LayoutTests/fast/forms/form-submission-crash-4-expected.txt: Added.
* LayoutTests/fast/forms/form-submission-crash-4.html: Added.
* Source/WebCore/loader/FormState.cpp:
(WebCore::FormState::willDetachPage):

Canonical link: <a href="https://commits.webkit.org/277207@main">https://commits.webkit.org/277207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7940ad4e84a4a5c0aa49d767a070e2c66888432

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/46977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49659 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23611 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38264 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19572 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20947 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41621 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5023 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42014 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51533 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/21996 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18375 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45556 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44544 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10380 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/22990 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->