### PR TITLE
Unreviewed, Revert 277136@main "Clean up Signals and remove hardened fallback"

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3522,6 +3522,9 @@ int main(int argc, char** argv WTF_TZONE_EXTRA_MAIN_ARGS)
 
 #if OS(UNIX)
     if (getenv("JS_SHELL_WAIT_FOR_SIGUSR2_TO_EXIT")) {
+        uint32_t key = 0;
+        int mask = 0;
+        initializeSignalHandling(key, mask);
         addSignalHandler(Signal::Usr, SignalHandler([&] (Signal, SigInfo&, PlatformRegisters&) {
             dataLogLn("Signal handler hit, we can exit now.");
             waitToExit.signal();
@@ -3995,6 +3998,20 @@ void CommandLine::parseArguments(int argc, char** argv)
         }
         if (!strcmp(arg, "-s")) {
 #if OS(UNIX)
+            uint32_t key = 0;
+            int mask = 0;
+#if HAVE(MACH_EXCEPTIONS)
+            mask |= toMachMask(Signal::IllegalInstruction);
+            mask |= toMachMask(Signal::AccessFault);
+            mask |= toMachMask(Signal::FloatingPoint);
+            mask |= toMachMask(Signal::Breakpoint);
+#if !OS(DARWIN)
+            mask |= toMachMask(Signal::Abort);
+#endif // !OS(DARWIN)
+#endif // HAVE(MACH_EXCEPTIONS)
+
+            initializeSignalHandling(key, mask);
+
             SignalAction (*exit)(Signal, SigInfo&, PlatformRegisters&) = [] (Signal, SigInfo&, PlatformRegisters&) {
                 dataLogLn("Signal handler hit. Exiting with status 0");
                 // Deliberate exit with a SIGKILL code greater than 130.
@@ -4017,6 +4034,7 @@ void CommandLine::parseArguments(int argc, char** argv)
             addSignalHandler(Signal::Abort, SignalHandler(exit));
             activateSignalHandlersFor(Signal::Abort);
 #endif
+            finalizeSignalHandlers();
 #endif
             continue;
         }

--- a/Source/JavaScriptCore/runtime/JSCConfig.cpp
+++ b/Source/JavaScriptCore/runtime/JSCConfig.cpp
@@ -42,6 +42,12 @@ Config& Config::singleton()
     return g_jscConfig;
 }
 
+void Config::disableFreezingForTesting()
+{
+    RELEASE_ASSERT(!g_jscConfig.isPermanentlyFrozen());
+    g_jscConfig.disabledFreezingForTesting = true;
+}
+
 void Config::enableRestrictedOptions()
 {
     RELEASE_ASSERT(!g_jscConfig.isPermanentlyFrozen());

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -44,9 +44,9 @@ using JITWriteSeparateHeapsFunction = void (*)(off_t, const void*, size_t);
 struct Config {
     static Config& singleton();
 
-    static void disableFreezingForTesting() { g_wtfConfig.disableFreezingForTesting(); }
+    JS_EXPORT_PRIVATE static void disableFreezingForTesting();
     JS_EXPORT_PRIVATE static void enableRestrictedOptions();
-    static void finalize() { WTF::Config::finalize(); }
+    static void permanentlyFreeze() { WTF::Config::permanentlyFreeze(); }
 
     static void configureForTesting()
     {
@@ -60,8 +60,8 @@ struct Config {
     // All the fields in this struct should be chosen such that their
     // initial value is 0 / null / falsy because Config is instantiated
     // as a global singleton.
-    // FIXME: We should use a placement new constructor from JSC::initialize so we can use default initializers.
 
+    bool disabledFreezingForTesting;
     bool restrictedOptionsEnabled;
     bool jitDisabled;
     bool vmCreationDisallowed;

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -434,7 +434,8 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
         jitSizeStatistics = makeUnique<JITSizeStatistics>();
 #endif
 
-    Config::finalize();
+    if (!g_jscConfig.disabledFreezingForTesting)
+        Config::permanentlyFreeze();
 
     // We must set this at the end only after the VM is fully initialized.
     WTF::storeStoreFence();

--- a/Source/JavaScriptCore/runtime/VMEntryScope.cpp
+++ b/Source/JavaScriptCore/runtime/VMEntryScope.cpp
@@ -48,7 +48,8 @@ void VMEntryScope::setUpSlow()
         if (Wasm::isSupported())
             Wasm::startTrackingCurrentThread();
 #if HAVE(MACH_EXCEPTIONS)
-        registerThreadForMachExceptionHandling(thread);
+        if (g_wtfConfig.signalHandlers.initState == WTF::SignalHandlers::InitState::AddedHandlers)
+            registerThreadForMachExceptionHandling(thread);
 #endif
     }
 

--- a/Source/JavaScriptCore/runtime/VMTraps.cpp
+++ b/Source/JavaScriptCore/runtime/VMTraps.cpp
@@ -201,6 +201,7 @@ public:
         , m_vm(vm)
     {
         activateSignalHandlersFor(Signal::AccessFault);
+        finalizeSignalHandlers();
     }
 
     static void initializeSignals()

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2922,7 +2922,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(functionCallWithStackSize, SUPPRESS_ASA
         return throwVMError(globalObject, throwScope, "Not supported for this platform"_s);
 
 #if ENABLE(ASSEMBLER)
-    if (g_jscConfig.isPermanentlyFrozen() || !g_wtfConfig.disabledFreezingForTesting)
+    if (g_jscConfig.isPermanentlyFrozen() || !g_jscConfig.disabledFreezingForTesting)
         return throwVMError(globalObject, throwScope, "Options are frozen"_s);
 
     if (callFrame->argumentCount() < 2)

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -39,6 +39,7 @@
 #include "WasmMemory.h"
 #include "WasmThunks.h"
 #include <wtf/CodePtr.h>
+#include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/threads/Signals.h>
@@ -48,8 +49,18 @@ namespace JSC { namespace Wasm {
 using WTF::CodePtr;
 
 #if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-void* presignedTrampoline { nullptr };
-#endif
+void* presignedTrampoline = { };
+
+MachExceptionSigningKey::MachExceptionSigningKey()
+{
+    // Sign the trampoline pointer using a random diversifier and stash it away before webcontent has started so that
+    // even a PAC signing gadget cannot fake this random diversifier
+    randomSigningKey = WTF::cryptographicallyRandomNumber<uint32_t>() & __DARWIN_ARM_THREAD_STATE64_USER_DIVERSIFIER_MASK;
+    uint64_t diversifier = ptrauth_blend_discriminator((void *)(unsigned long)randomSigningKey, ptrauth_string_discriminator("pc"));
+    presignedTrampoline = JSC::LLInt::getCodePtr<CFunctionPtrTag>(wasm_throw_from_fault_handler_trampoline_reg_instance).untaggedPtr();
+    presignedTrampoline = ptrauth_sign_unauthenticated(presignedTrampoline, ptrauth_key_function_pointer, diversifier);
+}
+#endif // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
 
 namespace {
 namespace WasmFaultSignalHandlerInternal {
@@ -104,10 +115,12 @@ static SignalAction trapHandler(Signal signal, SigInfo& sigInfo, PlatformRegiste
 
             if (didFaultInWasm(faultingInstruction)) {
 #if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-                MachineContext::setInstructionPointer(context, presignedTrampoline);
-#else
-                MachineContext::setInstructionPointer(context, LLInt::getCodePtr<CFunctionPtrTag>(wasm_throw_from_fault_handler_trampoline_reg_instance));
+                if (!WTF::fallbackToOldExceptions.load()) {
+                    MachineContext::setInstructionPointer(context, presignedTrampoline);
+                    return SignalAction::Handled;
+                }
 #endif
+                MachineContext::setInstructionPointer(context, LLInt::getCodePtr<CFunctionPtrTag>(wasm_throw_from_fault_handler_trampoline_reg_instance));
                 return SignalAction::Handled;
             }
         }
@@ -126,6 +139,7 @@ void activateSignalingMemory()
             return;
 
         activateSignalHandlersFor(Signal::AccessFault);
+        WTF::finalizeSignalHandlers();
     });
 }
 
@@ -139,9 +153,6 @@ void prepareSignalingMemory()
         if (!Options::useWasmFaultSignalHandler())
             return;
 
-#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-        presignedTrampoline = g_wtfConfig.signalHandlers.presignReturnPCForHandler(LLInt::getCodePtr<NoPtrTag>(wasm_throw_from_fault_handler_trampoline_reg_instance));
-#endif
         addSignalHandler(Signal::AccessFault, [] (Signal signal, SigInfo& sigInfo, PlatformRegisters& ucontext) {
             return trapHandler(signal, sigInfo, ucontext);
         });

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.h
@@ -36,4 +36,12 @@ inline void activateSignalingMemory() { }
 inline void prepareSignalingMemory() { }
 #endif // ENABLE(WEBASSEMBLY)
 
+#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
+class MachExceptionSigningKey {
+public:
+    uint32_t randomSigningKey = { };
+    MachExceptionSigningKey();
+};
+#endif // CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
+
 } } // namespace JSC::Wasm

--- a/Source/WTF/wtf/PlatformRegisters.cpp
+++ b/Source/WTF/wtf/PlatformRegisters.cpp
@@ -54,8 +54,8 @@ void* threadStateLRInternal(PlatformRegisters& regs)
 void* threadStatePCInternal(PlatformRegisters& regs)
 {
 #if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-    // If we have modified the PC and set it to a presigned function we want to avoid
-    // authing the value as it is using a custom ptrauth signing scheme.
+    // If userspace has modified the PC and set it to the presignedTrampoline,
+    // we want to avoid authing the value as it is using a custom ptrauth signing scheme.
     _STRUCT_ARM_THREAD_STATE64* ts = &(regs);
     if (!(ts->__opaque_flags & __DARWIN_ARM_THREAD_STATE64_FLAGS_KERNEL_SIGNED_PC))
         return nullptr;

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -500,6 +500,9 @@ void initialize()
 #endif
         initializeDates();
         Thread::initializePlatformThreading();
+#if USE(PTHREADS) && HAVE(MACHINE_CONTEXT)
+        SignalHandlers::initialize();
+#endif
 #if PLATFORM(COCOA)
         initializeLibraryPathDiagnostics();
 #endif

--- a/Source/WTF/wtf/WTFConfig.h
+++ b/Source/WTF/wtf/WTFConfig.h
@@ -69,8 +69,6 @@ constexpr size_t ConfigSizeToProtect = std::max(CeilingOnPageSize, 16 * KB);
 struct Config {
     WTF_EXPORT_PRIVATE static void permanentlyFreeze();
     WTF_EXPORT_PRIVATE static void initialize();
-    WTF_EXPORT_PRIVATE static void finalize();
-    WTF_EXPORT_PRIVATE static void disableFreezingForTesting();
 
     struct AssertNotFrozenScope {
         AssertNotFrozenScope();
@@ -85,7 +83,6 @@ struct Config {
     uintptr_t highestAccessibleAddress;
 
     bool isPermanentlyFrozen;
-    bool disabledFreezingForTesting;
     bool useSpecialAbortForExtraSecurityImplications;
 #if PLATFORM(COCOA)
     bool disableForwardingVPrintfStdErrToOSLog;

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,7 +53,6 @@ extern "C" {
 
 #include <unistd.h>
 #include <wtf/Atomics.h>
-#include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/DataLog.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
@@ -64,19 +63,20 @@ extern "C" {
 #include <wtf/TranslatedProcess.h>
 #include <wtf/WTFConfig.h>
 
+#if CPU(ARM64) && HAVE(HARDENED_MACH_EXCEPTIONS)
+#include <wtf/spi/darwin/SandboxSPI.h>
+#endif
+
+
 namespace WTF {
 
-#if HAVE(MACH_EXCEPTIONS)
-static exception_mask_t toMachMask(Signal);
-#endif
+Atomic<bool> fallbackToOldExceptions { false };
 
 void SignalHandlers::add(Signal signal, SignalHandler&& handler)
 {
     Config::AssertNotFrozenScope assertScope;
-
-    ASSERT(signal < Signal::NumberOfSignals);
-    ASSERT(!useMach || signal != Signal::Usr);
-    RELEASE_ASSERT(initState == SignalHandlers::InitState::Initializing);
+    static Lock lock;
+    Locker locker { lock };
 
     size_t signalIndex = static_cast<size_t>(signal);
     size_t nextFree = numberOfHandlers[signalIndex];
@@ -88,7 +88,16 @@ void SignalHandlers::add(Signal signal, SignalHandler&& handler)
     SignalHandlerMemory* memory = &handlers[signalIndex][nextFree];
     new (memory) SignalHandler(WTFMove(handler));
 
+    // We deliberately do not want to increment the count until after we've
+    // fully initialized the memory. This way, forEachHandler() won't see a
+    // partially initialized handler.
+    storeStoreFence();
     numberOfHandlers[signalIndex]++;
+#if HAVE(MACH_EXCEPTIONS)
+    RELEASE_ASSERT(initState >= InitState::InitializedHandlerThread);
+    initState = InitState::AddedHandlers;
+#endif
+    loadLoadFence();
 }
 
 template<typename Func>
@@ -109,88 +118,76 @@ inline void SignalHandlers::forEachHandler(Signal signal, const Func& func) cons
 // and the Mach interface Generator (MiG) here:
 // http://www.cs.cmu.edu/afs/cs/project/mach/public/doc/unpublished/mig.ps
 
-#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-// Our secret key which we use as random diversifier when signing our return PC in the handler callbacks.
-// Be VERY careful to clear this before any web content is loaded.
-static uint32_t secretSigningKey;
-
-void* SignalHandlers::presignReturnPCForHandler(CodePtr<NoPtrTag> returnPC)
-{
-    ASSERT(initState < SignalHandlers::InitState::Finalized);
-    uint64_t diversifier = ptrauth_blend_discriminator(reinterpret_cast<void*>(secretSigningKey), ptrauth_string_discriminator("pc"));
-    return ptrauth_sign_unauthenticated(returnPC.untaggedPtr(), ptrauth_key_function_pointer, diversifier);
-}
-#endif
-
 static constexpr size_t maxMessageSize = 1 * KB;
+uint32_t randomSigningKey = 0;
 
-static void initMachExceptionHandlerThread()
+void initMachExceptionHandlerThread(bool enable, uint32_t signingKey, exception_mask_t mask)
 {
-    Config::AssertNotFrozenScope assertScope;
-    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    RELEASE_ASSERT_WITH_MESSAGE(!handlers.exceptionPort, "Mach exception handler thread was already created");
-    ASSERT(handlers.useMach);
+    static std::once_flag once;
+    std::call_once(once, [=] {
+        RELEASE_ASSERT(g_wtfConfig.signalHandlers.initState == SignalHandlers::InitState::Uninitialized);
+        g_wtfConfig.signalHandlers.initState = SignalHandlers::InitState::InitializedHandlerThread;
 
-    uint16_t flags = MPO_INSERT_SEND_RIGHT;
+        if (!enable || !g_wtfConfig.signalHandlers.useMach)
+            return;
+
+        Config::AssertNotFrozenScope assertScope;
+        SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+
+        uint16_t flags = MPO_INSERT_SEND_RIGHT;
 
 // This provisional flag can be removed once macos sonoma is no longer supported
 #ifdef MPO_PROVISIONAL_ID_PROT_OPTOUT
-    flags |= MPO_PROVISIONAL_ID_PROT_OPTOUT;
+        flags |= MPO_PROVISIONAL_ID_PROT_OPTOUT;
 #endif
 
 #if CPU(ARM64) && HAVE(HARDENED_MACH_EXCEPTIONS)
-    flags |= MPO_EXCEPTION_PORT;
+        flags |= MPO_EXCEPTION_PORT;
 #endif
-    mach_port_options_t opts = {
-        .flags = flags
-    };
+        mach_port_options_t opts = {
+            .flags = flags
+        };
 
-    kern_return_t kr = mach_port_construct(mach_task_self(), &opts, 0, &handlers.exceptionPort);
-    RELEASE_ASSERT(kr == KERN_SUCCESS);
-
-#if CPU(ARM64) && HAVE(HARDENED_MACH_EXCEPTIONS)
-#if !CPU(ARM64E)
-    uint32_t secretSigningKey = 0;
-#endif
-    uint64_t exceptionsAllowed = handlers.addedExceptions;
-    uint64_t behaviorsAllowed = EXCEPTION_STATE_IDENTITY_PROTECTED | MACH_EXCEPTION_CODES;
-    uint64_t flavorsAllowed = MACHINE_THREAD_STATE;
-
-    kr = task_register_hardened_exception_handler(current_task(), secretSigningKey, exceptionsAllowed,
-        behaviorsAllowed, flavorsAllowed, handlers.exceptionPort);
-    RELEASE_ASSERT_WITH_MESSAGE(kr == KERN_SUCCESS, "Failed to register hardened exception handler due to %s", mach_error_string(kr));
-
-    // Clear the key since we no longer need it anymore and we don't want an attacker to find it.
-    secretSigningKey = 0;
-#endif
-
-    dispatch_source_t source = dispatch_source_create(
-        DISPATCH_SOURCE_TYPE_MACH_RECV, handlers.exceptionPort, 0, DISPATCH_TARGET_QUEUE_DEFAULT);
-    RELEASE_ASSERT(source);
-
-    dispatch_source_set_event_handler(source, ^{
-        UNUSED_PARAM(source); // Capture a pointer to source in user space to silence the leaks tool.
-
-        kern_return_t kr = mach_msg_server_once(
-            mach_exc_server, maxMessageSize, handlers.exceptionPort, MACH_MSG_TIMEOUT_NONE);
+        kern_return_t kr = mach_port_construct(mach_task_self(), &opts, 0, &handlers.exceptionPort);
         RELEASE_ASSERT(kr == KERN_SUCCESS);
+
+#if CPU(ARM64) && HAVE(HARDENED_MACH_EXCEPTIONS)
+        uint64_t exceptionsAllowed = mask;
+        uint64_t behaviorsAllowed = EXCEPTION_STATE_IDENTITY_PROTECTED | MACH_EXCEPTION_CODES;
+        uint64_t flavorsAllowed = MACHINE_THREAD_STATE;
+
+        int ret = sandbox_check(getpid(), "user-preference-read", static_cast<sandbox_filter_type>(SANDBOX_CHECK_NO_REPORT | SANDBOX_FILTER_PREFERENCE_DOMAIN), "com.apple.webkit-new-sandbox-test");
+        if (ret == 1) {
+            fallbackToOldExceptions.store(true);
+        } else if (!ret) {
+            kr = task_register_hardened_exception_handler(current_task(), signingKey, exceptionsAllowed,
+                behaviorsAllowed, flavorsAllowed, handlers.exceptionPort);
+            if (kr != KERN_SUCCESS)
+                fallbackToOldExceptions.store(true);
+        } else
+            RELEASE_ASSERT_NOT_REACHED(ret);
+
+#else
+        UNUSED_PARAM(signingKey);
+        UNUSED_PARAM(mask);
+#endif
+
+        dispatch_source_t source = dispatch_source_create(
+            DISPATCH_SOURCE_TYPE_MACH_RECV, handlers.exceptionPort, 0, DISPATCH_TARGET_QUEUE_DEFAULT);
+        RELEASE_ASSERT(source);
+
+        dispatch_source_set_event_handler(source, ^{
+            UNUSED_PARAM(source); // Capture a pointer to source in user space to silence the leaks tool.
+
+            kern_return_t kr = mach_msg_server_once(
+                mach_exc_server, maxMessageSize, handlers.exceptionPort, MACH_MSG_TIMEOUT_NONE);
+            RELEASE_ASSERT(kr == KERN_SUCCESS);
+        });
+
+        // No need for a cancel handler because we never destroy exceptionPort.
+
+        dispatch_resume(source);
     });
-
-    // No need for a cancel handler because we never destroy exceptionPort.
-
-    dispatch_resume(source);
-}
-
-static exception_mask_t toMachMask(Signal signal)
-{
-    switch (signal) {
-    case Signal::AccessFault: return EXC_MASK_BAD_ACCESS;
-    case Signal::IllegalInstruction: return EXC_MASK_BAD_INSTRUCTION;
-    case Signal::FloatingPoint: return EXC_MASK_ARITHMETIC;
-    case Signal::Breakpoint: return EXC_MASK_BREAKPOINT;
-    default: break;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
 }
 
 static Signal fromMachException(exception_type_t type)
@@ -248,7 +245,7 @@ kern_return_t catch_mach_exception_raise_state_identity(mach_port_t, mach_port_t
     return KERN_FAILURE;
 }
 
-static kern_return_t runSignalHandlers(Signal signal, PlatformRegisters& registers, mach_msg_type_number_t dataCount, mach_exception_data_t exceptionData)
+static kern_return_t runSignalHandlers(Signal &signal, PlatformRegisters& registers, bool &didHandle, mach_msg_type_number_t dataCount, mach_exception_data_t exceptionData)
 {
     SigInfo info;
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
@@ -265,12 +262,11 @@ static kern_return_t runSignalHandlers(Signal signal, PlatformRegisters& registe
 #endif
     }
 
-    bool didHandle = false;
     handlers.forEachHandler(signal, [&] (const SignalHandler& handler) {
         SignalAction handlerResult = handler(signal, info, registers);
         didHandle |= handlerResult == SignalAction::Handled;
     });
-    return didHandle ? KERN_SUCCESS : KERN_FAILURE;
+    return KERN_SUCCESS;
 }
 
 #if defined(EXCEPTION_STATE_IDENTITY_PROTECTED)
@@ -317,10 +313,6 @@ kern_return_t catch_mach_exception_raise_state(
     Signal signal = fromMachException(exceptionType);
     RELEASE_ASSERT(signal != Signal::Unknown);
 
-#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-    ASSERT_WITH_MESSAGE(!secretSigningKey, "The secret key should have been cleared before any exception handlers are run");
-#endif
-
 #if CPU(ARM64E) && OS(DARWIN)
     ptrauth_generic_signature_t inStateHash = hashThreadState(inState);
 #endif
@@ -341,15 +333,20 @@ kern_return_t catch_mach_exception_raise_state(
     PlatformRegisters& registers = reinterpret_cast<arm_unified_thread_state*>(outState)->ts_32;
 #endif
 
-    kern_return_t kr = runSignalHandlers(signal, registers, dataCount, exceptionData);
+    bool didHandle = false;
+    kern_return_t kr = runSignalHandlers(signal, registers, didHandle, dataCount, exceptionData);
     if (kr != KERN_SUCCESS)
         return kr;
 
+    if (didHandle) {
 #if CPU(ARM64E) && OS(DARWIN)
-    RELEASE_ASSERT(inStateHash == hashThreadState(outState));
+        RELEASE_ASSERT(inStateHash == hashThreadState(outState));
 #endif
-    *outStateCount = inStateCount;
-    return KERN_SUCCESS;
+        *outStateCount = inStateCount;
+        return KERN_SUCCESS;
+    }
+
+    return KERN_FAILURE;
 }
 
 }; // extern "C"
@@ -367,14 +364,19 @@ inline void setExceptionPorts(const AbstractLocker& threadGroupLocker, Thread& t
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
 
 #if CPU(ARM64) && HAVE(HARDENED_MACH_EXCEPTIONS)
-    const exception_behavior_t newBehavior = MACH_EXCEPTION_CODES | EXCEPTION_STATE_IDENTITY_PROTECTED;
-    kern_return_t result = thread_adopt_exception_handler(thread.machThread(), handlers.exceptionPort, handlers.addedExceptions & activeExceptions, newBehavior, MACHINE_THREAD_STATE);
-    RELEASE_ASSERT_WITH_MESSAGE(result == KERN_SUCCESS, "thread adopt port failed due to %s", mach_error_string(result));
-#else
+    // If we are a translated process in rosetta or failed to set up a hardened handler, use the old exception style
+    if (!WTF::isX86BinaryRunningOnARM() && !fallbackToOldExceptions.loadRelaxed()) {
+        // Otherwise use the new style
+        const exception_behavior_t newBehavior = MACH_EXCEPTION_CODES | EXCEPTION_STATE_IDENTITY_PROTECTED;
+        kern_return_t result = thread_adopt_exception_handler(thread.machThread(), handlers.exceptionPort, handlers.addedExceptions & activeExceptions, newBehavior, MACHINE_THREAD_STATE);
+        RELEASE_ASSERT_WITH_MESSAGE(result == KERN_SUCCESS, "thread adopt port failed due to %s", mach_error_string(result));
+        return;
+    }
+#endif // CPU(ARM64) && HAVE(HARDENED_MACH_EXCEPTIONS)
+
     const exception_behavior_t newBehavior = MACH_EXCEPTION_CODES | EXCEPTION_STATE;
     kern_return_t result = thread_set_exception_ports(thread.machThread(), handlers.addedExceptions & activeExceptions, handlers.exceptionPort, newBehavior, MACHINE_THREAD_STATE);
     RELEASE_ASSERT_WITH_MESSAGE(result == KERN_SUCCESS, "thread set port failed due to %s", mach_error_string(result));
-#endif // CPU(ARM64) && HAVE(HARDENED_MACH_EXCEPTIONS)
 }
 
 static ThreadGroup& activeThreads()
@@ -382,6 +384,7 @@ static ThreadGroup& activeThreads()
     static LazyNeverDestroyed<std::shared_ptr<ThreadGroup>> activeThreads;
     static std::once_flag initializeKey;
     std::call_once(initializeKey, [&] {
+        Config::AssertNotFrozenScope assertScope;
         activeThreads.construct(ThreadGroup::create());
     });
     return (*activeThreads.get());
@@ -389,7 +392,7 @@ static ThreadGroup& activeThreads()
 
 void registerThreadForMachExceptionHandling(Thread& thread)
 {
-    RELEASE_ASSERT(g_wtfConfig.signalHandlers.initState >= SignalHandlers::InitState::Initializing);
+    RELEASE_ASSERT(g_wtfConfig.signalHandlers.initState == SignalHandlers::InitState::AddedHandlers);
     Locker locker { activeThreads().getLock() };
     if (activeThreads().add(locker, thread) == ThreadGroupAddResult::NewlyAdded)
         setExceptionPorts(locker, thread);
@@ -435,36 +438,72 @@ inline size_t offsetForSystemSignal(int sig)
     return static_cast<size_t>(signal) + (sig == SIGBUS);
 }
 
+static void jscSignalHandler(int, siginfo_t*, void*);
+
+void addSignalHandler(Signal signal, SignalHandler&& handler)
+{
+    Config::AssertNotFrozenScope assertScope;
+    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    ASSERT(signal < Signal::Unknown);
+    ASSERT(!handlers.useMach || signal != Signal::Usr);
+#if HAVE(MACH_EXCEPTIONS)
+    RELEASE_ASSERT(handlers.initState >= SignalHandlers::InitState::InitializedHandlerThread);
+#endif
+
+    static std::once_flag initializeOnceFlags[static_cast<size_t>(Signal::NumberOfSignals)];
+    std::call_once(initializeOnceFlags[static_cast<size_t>(signal)], [&] {
+        Config::AssertNotFrozenScope assertScope;
+        if (!handlers.useMach) {
+            struct sigaction action;
+            action.sa_sigaction = jscSignalHandler;
+            auto result = sigfillset(&action.sa_mask);
+            RELEASE_ASSERT(!result);
+            // Do not block this signal since it is used on non-Darwin systems to suspend and resume threads.
+            RELEASE_ASSERT(g_wtfConfig.isThreadSuspendResumeSignalConfigured);
+            result = sigdelset(&action.sa_mask, g_wtfConfig.sigThreadSuspendResume);
+            RELEASE_ASSERT(!result);
+            action.sa_flags = SA_SIGINFO;
+            auto systemSignals = toSystemSignal(signal);
+            result = sigaction(std::get<0>(systemSignals), &action, &handlers.oldActions[offsetForSystemSignal(std::get<0>(systemSignals))]);
+            if (std::get<1>(systemSignals))
+                result |= sigaction(*std::get<1>(systemSignals), &action, &handlers.oldActions[offsetForSystemSignal(*std::get<1>(systemSignals))]);
+            RELEASE_ASSERT(!result);
+        }
+    });
+
+    handlers.add(signal, WTFMove(handler));
+}
+
 void activateSignalHandlersFor(Signal signal)
 {
-    const SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    RELEASE_ASSERT(handlers.initState >= SignalHandlers::InitState::Initializing);
-    ASSERT_UNUSED(signal, signal < Signal::Unknown);
-
+    UNUSED_PARAM(signal);
 #if HAVE(MACH_EXCEPTIONS)
-    if (handlers.useMach) {
-        ASSERT(signal != Signal::Usr);
-        Locker locker { activeThreads().getLock() };
-        if (activeExceptions & toMachMask(signal))
-            return;
+    const SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    RELEASE_ASSERT(handlers.initState >= SignalHandlers::InitState::InitializedHandlerThread);
+    ASSERT(signal < Signal::Unknown);
+    ASSERT(!handlers.useMach || signal != Signal::Usr);
 
-        ASSERT(handlers.numberOfHandlers[static_cast<uint8_t>(signal)]);
+    if (handlers.useMach)
         activeExceptions |= toMachMask(signal);
-        // activeExceptions should be a subset of addedExceptions.
-        ASSERT(!(activeExceptions & ~handlers.addedExceptions));
+#endif
+}
+
+
+void finalizeSignalHandlers()
+{
+#if HAVE(MACH_EXCEPTIONS)
+    const SignalHandlers& handlers = g_wtfConfig.signalHandlers;
+    RELEASE_ASSERT(handlers.initState >= SignalHandlers::InitState::InitializedHandlerThread);
+
+    Locker locker { activeThreads().getLock() };
+    if (handlers.useMach) {
         for (auto& thread : activeThreads().threads(locker))
             setExceptionPorts(locker, thread.get());
-        return;
     }
 #endif
 }
 
-void addSignalHandler(Signal signal, SignalHandler&& handler)
-{
-    g_wtfConfig.signalHandlers.add(signal, WTFMove(handler));
-}
-
-static void jscSignalHandler(int sig, siginfo_t* info, void* ucontext)
+void jscSignalHandler(int sig, siginfo_t* info, void* ucontext)
 {
     Signal signal = fromSystemSignal(sig);
     SignalHandlers& handlers = g_wtfConfig.signalHandlers;
@@ -536,50 +575,14 @@ static void jscSignalHandler(int sig, siginfo_t* info, void* ucontext)
 
 void SignalHandlers::initialize()
 {
-    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    RELEASE_ASSERT(handlers.initState == SignalHandlers::InitState::Uninitialized);
-    handlers.initState = SignalHandlers::InitState::Initializing;
-
-#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-    // Set up our secret key which we use as random diversifier when signing our return PC in the handler callbacks.
-    secretSigningKey = WTF::cryptographicallyRandomNumber<uint32_t>() & __DARWIN_ARM_THREAD_STATE64_USER_DIVERSIFIER_MASK;
-#endif
-}
-
-void SignalHandlers::finalize()
-{
-    Config::AssertNotFrozenScope assertScope;
-    SignalHandlers& handlers = g_wtfConfig.signalHandlers;
-    RELEASE_ASSERT(handlers.initState == SignalHandlers::InitState::Initializing);
-    handlers.initState = SignalHandlers::InitState::Finalized;
-
 #if HAVE(MACH_EXCEPTIONS)
-    if (handlers.useMach)
-        initMachExceptionHandlerThread();
+    // In production configurations, this does not matter because signal handler
+    // installations will always trigger this initialization. However, in debugging
+    // configurations, we may end up disabling the use of all signal handlers but
+    // we still need this to be initialized. Hence, we need to initialize it
+    // eagerly to ensure that it is done before we freeze the WTF::Config.
+    activeThreads();
 #endif
-
-    if (!handlers.useMach) {
-        for (unsigned i = 0; i < numberOfSignals; ++i) {
-            if (!handlers.numberOfHandlers[i])
-                continue;
-
-            Signal signal = static_cast<Signal>(i);
-            struct sigaction action;
-            action.sa_sigaction = jscSignalHandler;
-            auto result = sigfillset(&action.sa_mask);
-            RELEASE_ASSERT(!result);
-            // Do not block this signal since it is used on non-Darwin systems to suspend and resume threads.
-            RELEASE_ASSERT(g_wtfConfig.isThreadSuspendResumeSignalConfigured);
-            result = sigdelset(&action.sa_mask, g_wtfConfig.sigThreadSuspendResume);
-            RELEASE_ASSERT(!result);
-            action.sa_flags = SA_SIGINFO;
-            auto systemSignals = toSystemSignal(signal);
-            result = sigaction(std::get<0>(systemSignals), &action, &handlers.oldActions[offsetForSystemSignal(std::get<0>(systemSignals))]);
-            if (std::get<1>(systemSignals))
-                result |= sigaction(*std::get<1>(systemSignals), &action, &handlers.oldActions[offsetForSystemSignal(*std::get<1>(systemSignals))]);
-            RELEASE_ASSERT(!result);
-        }
-    }
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/threads/Signals.h
+++ b/Source/WTF/wtf/threads/Signals.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <wtf/CodePtr.h>
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
 #include <wtf/PlatformRegisters.h>
@@ -60,7 +59,7 @@ enum class Signal {
     AccessFault, // For posix this is both SIGSEGV and SIGBUS
     NumberOfSignals = AccessFault + 2, // AccessFault is really two signals.
     Unknown = NumberOfSignals
-#else // not OS(UNIX)
+#else
     FloatingPoint,
     IllegalInstruction,
     AccessFault,
@@ -82,19 +81,13 @@ struct SigInfo {
 using SignalHandler = Function<SignalAction(Signal, SigInfo&, PlatformRegisters&)>;
 using SignalHandlerMemory = std::aligned_storage<sizeof(SignalHandler), std::alignment_of<SignalHandler>::value>::type;
 
+extern Atomic<bool> fallbackToOldExceptions;
 struct SignalHandlers {
     static void initialize();
-    static void finalize();
 
     void add(Signal, SignalHandler&&);
     template<typename Func>
     void forEachHandler(Signal, const Func&) const;
-
-    // We intentionally disallow presigning the return PC on platforms that can't authenticate it so
-    // we don't accidentally leave an unfrozen pointer in the heap somewhere.
-#if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)
-    void* presignReturnPCForHandler(CodePtr<NoPtrTag>);
-#endif
 
     static constexpr size_t numberOfSignals = static_cast<size_t>(Signal::NumberOfSignals);
     static constexpr size_t maxNumberOfHandlers = 4;
@@ -105,16 +98,16 @@ struct SignalHandlers {
     mach_port_t exceptionPort;
     exception_mask_t addedExceptions;
     bool useMach;
+
+    enum class InitState : uint8_t {
+        Uninitialized = 0,
+        InitializedHandlerThread,
+        AddedHandlers
+    };
+    InitState initState;
 #else
     static constexpr bool useMach = false;
 #endif
-    enum class InitState : uint8_t {
-        Uninitialized = 0,
-        Initializing,
-        Finalized,
-    };
-    InitState initState;
-
     uint8_t numberOfHandlers[numberOfSignals];
     SignalHandlerMemory handlers[numberOfSignals][maxNumberOfHandlers];
 
@@ -131,16 +124,38 @@ struct SignalHandlers {
 // These functions are a one way street i.e. once installed, a signal handler cannot be uninstalled
 // and once commited they can't be turned off.
 WTF_EXPORT_PRIVATE void addSignalHandler(Signal, SignalHandler&&);
-// Note: This function doesn't necessarily activate the signal right away. Signals are
-// activated when SignalHandlers::finalize() runs and that signal has been turned on.
-// This also only currently does something if using Mach exceptions rather than posix/windows signals.
 WTF_EXPORT_PRIVATE void activateSignalHandlersFor(Signal);
+WTF_EXPORT_PRIVATE void finalizeSignalHandlers();
+
+#if OS(UNIX) && HAVE(MACH_EXCEPTIONS)
+inline exception_mask_t toMachMask(Signal signal)
+{
+    switch (signal) {
+    case Signal::AccessFault: return EXC_MASK_BAD_ACCESS;
+    case Signal::IllegalInstruction: return EXC_MASK_BAD_INSTRUCTION;
+    case Signal::FloatingPoint: return EXC_MASK_ARITHMETIC;
+    case Signal::Breakpoint: return EXC_MASK_BREAKPOINT;
+    default: break;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+#endif // OS(UNIX) && HAVE(MACH_EXCEPTIONS)
 
 #if HAVE(MACH_EXCEPTIONS)
-void handleSignalsWithMach();
-
 class Thread;
 void registerThreadForMachExceptionHandling(Thread&);
+WTF_EXPORT_PRIVATE void initMachExceptionHandlerThread(bool, uint32_t, exception_mask_t);
+inline void initializeSignalHandling(uint32_t signingKey, exception_mask_t mask) { initMachExceptionHandlerThread(true, signingKey, mask); }
+inline void disableSignalHandling() { initMachExceptionHandlerThread(false, 0, 0); }
+
+void handleSignalsWithMach();
+#else
+inline void initializeSignalHandling(uint32_t signingKey, int mask)
+{
+    UNUSED_PARAM(signingKey);
+    UNUSED_PARAM(mask);
+}
+inline void disableSignalHandling() { }
 #endif // HAVE(MACH_EXCEPTIONS)
 
 } // namespace WTF
@@ -156,3 +171,6 @@ using WTF::SignalAction;
 using WTF::SignalHandler;
 using WTF::addSignalHandler;
 using WTF::activateSignalHandlersFor;
+using WTF::finalizeSignalHandlers;
+using WTF::initializeSignalHandling;
+using WTF::disableSignalHandling;

--- a/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
+++ b/Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm
@@ -66,5 +66,5 @@ void GPU_SERVICE_INITIALIZER(xpc_connection_t connection, xpc_object_t initializ
     WebKit::XPCServiceInitializer<WebKit::GPUProcess, WebKit::GPUServiceInitializerDelegate>(connection, initializerMessage);
 #endif // ENABLE(GPU_PROCESS)
 
-    JSC::Config::finalize();
+    JSC::Config::permanentlyFreeze();
 }

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1392,6 +1392,10 @@
         thread_info
         thread_policy
         thread_policy_set))
+
+; This rule is only temporary and should be removed shortly
+; See: rdar://125256111.
+(mobile-preferences-read "com.apple.webkit-new-sandbox-test")
     
 (allow mach-kernel-endpoint
     (apply-message-filter
@@ -1433,12 +1437,25 @@
 #if HAVE(HARDENED_MACH_EXCEPTIONS)
         (with-filter (require-not (lockdown-mode))
             (allow mach-message-send (kernel-mig-routine thread_adopt_exception_handler))
+#if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
             (with-filter (require-not (webcontent-process-launched))
-                (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler))))
+                (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler)))
+#else
+            (allow mach-message-send (kernel-mig-routine task_register_hardened_exception_handler))
+#endif ;; ENABLE(BLOCK_SET_EXCEPTION_PORTS)
+        )
 #else
         (with-filter (require-not (lockdown-mode))
-            (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
+#if ENABLE(BLOCK_SET_EXCEPTION_PORTS)
+            (with-filter (require-not (webcontent-process-launched))
+                (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
+#else
+            (allow mach-message-send (kernel-mig-routine thread_set_exception_ports))
+#endif ;; ENABLE(BLOCK_SET_EXCEPTION_PORTS)
+        )
 #endif ;; HAVE(HARDENED_MACH_EXCEPTIONS)
+
+
 
         (with-filter (lockdown-mode)
             (deny mach-message-send (with telemetry) (with message "Lockdown mode")

--- a/Tools/TestWebKitAPI/Tests/WTF/Signals.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Signals.cpp
@@ -28,7 +28,7 @@
 #include <type_traits>
 #include <wtf/DataLog.h>
 #include <wtf/Threading.h>
-#include <wtf/WTFConfig.h>
+#include <wtf/threads/Signals.h>
 #if OS(UNIX)
 #include <signal.h>
 #else
@@ -47,14 +47,18 @@ public:
 TEST(Signals, SignalsWorkOnExit)
 {
     static bool handlerRan = false;
+    uint32_t key = 0;
+    int mask = 0;
+    initializeSignalHandling(key, mask);
     addSignalHandler(Signal::Usr, [] (Signal signal, SigInfo&, PlatformRegisters&) -> SignalAction {
         RELEASE_ASSERT(signal == Signal::Usr);
 
+        dataLogLn("here");
         handlerRan = true;
         return SignalAction::Handled;
     });
     activateSignalHandlersFor(Signal::Usr);
-    WTF::Config::finalize();
+    finalizeSignalHandlers();
 
     Atomic<bool> receiverShouldKeepRunning(true);
     Ref<Thread> receiverThread = (Thread::create("ThreadMessage receiver",
@@ -78,6 +82,12 @@ TEST(Signals, SignalsWorkOnExit)
 TEST(Signals, SignalsAccessFault)
 {
     static bool handlerRan = false;
+    uint32_t key = 0;
+    int mask = 0;
+#if HAVE(MACH_EXCEPTIONS)
+    mask |= toMachMask(Signal::AccessFault);
+#endif // HAVE(MACH_EXCEPTIONS)
+    initializeSignalHandling(key, mask);
     addSignalHandler(Signal::AccessFault, [] (Signal signal, SigInfo& sigInfo, PlatformRegisters& context) -> SignalAction {
         RELEASE_ASSERT(signal == Signal::AccessFault);
 
@@ -95,7 +105,7 @@ TEST(Signals, SignalsAccessFault)
         return SignalAction::Handled;
     });
     activateSignalHandlersFor(Signal::AccessFault);
-    WTF::Config::finalize();
+    finalizeSignalHandlers();
 
     // Allocate a page of memory
     char* ptr = bitwise_cast<char*>(Gigacage::tryAllocateZeroedVirtualPages(Gigacage::Primitive, 4096));


### PR DESCRIPTION
#### eb9db9d4c5a2c74ead9656d6abe429b26cecb4f7
<pre>
Unreviewed, Revert 277136@main &quot;Clean up Signals and remove hardened fallback&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=272335">https://bugs.webkit.org/show_bug.cgi?id=272335</a>
<a href="https://rdar.apple.com/126077721">rdar://126077721</a>

Breaks OBJC API

Reverted change:

    Clean up Signals and remove hardened fallback
    <a href="https://bugs.webkit.org/show_bug.cgi?id=271766">https://bugs.webkit.org/show_bug.cgi?id=271766</a>
    <a href="https://rdar.apple.com/125256111">rdar://125256111</a>
    <a href="https://commits.webkit.org/277136@main">https://commits.webkit.org/277136@main</a>

Canonical link: <a href="https://commits.webkit.org/277210@main">https://commits.webkit.org/277210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/737362c70da0c61040d07d9fdd52a7226eceb24e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47000 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43048 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23635 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47581 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/23606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/19590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/20973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5046 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/40258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51558 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46486 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23302 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53991 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6591 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/23013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/11074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->