### PR TITLE
Further adopt std::span in StringCommon.h

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -361,7 +361,7 @@ const String& IntlLocale::maximal()
                 return m_maximal;
             }
 
-            auto endOfLanguageScriptRegionVariant = WTF::find(m_localeID.data(), m_localeID.length(), ULOC_KEYWORD_SEPARATOR);
+            auto endOfLanguageScriptRegionVariant = WTF::find(m_localeID.span(), ULOC_KEYWORD_SEPARATOR);
             if (endOfLanguageScriptRegionVariant != notFound)
                 maximal.appendRange(m_localeID.data() + endOfLanguageScriptRegionVariant, m_localeID.data() + m_localeID.length());
             maximal.append('\0');
@@ -412,7 +412,7 @@ const String& IntlLocale::minimal()
                 return m_minimal;
             }
 
-            auto endOfLanguageScriptRegionVariant = WTF::find(m_localeID.data(), m_localeID.length(), ULOC_KEYWORD_SEPARATOR);
+            auto endOfLanguageScriptRegionVariant = WTF::find(m_localeID.span(), ULOC_KEYWORD_SEPARATOR);
             if (endOfLanguageScriptRegionVariant != notFound)
                 minimal.appendRange(m_localeID.data() + endOfLanguageScriptRegionVariant, m_localeID.data() + m_localeID.length());
             minimal.append('\0');

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1201,13 +1201,11 @@ static ALWAYS_INLINE bool splitStringByOneCharacterImpl(Indice& result, StringIm
     // 12. Let q = p.
     size_t matchPosition;
     size_t position = 0;
-    unsigned stringLength = string->length();
-    const CharacterType* characters = string->characters<CharacterType>();
     // 13. Repeat, while q != s
     //   a. Call SplitMatch(S, q, R) and let z be its MatchResult result.
     //   b. If z is failure, then let q = q+1.
     //   c. Else, z is not failure
-    while ((matchPosition = WTF::find(characters, stringLength, separatorCharacter, position)) != notFound) {
+    while ((matchPosition = WTF::find(string->span<CharacterType>(), separatorCharacter, position)) != notFound) {
         // 1. Let T be a String value equal to the substring of S consisting of the characters at positions p (inclusive)
         //    through q (exclusive).
         // 2. Call the [[DefineOwnProperty]] internal method of A with arguments ToString(lengthA),

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -957,7 +957,7 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
                 // Since the passed-in length is used for both strings, the following checks that
                 // dateString has the time zone name as a prefix, not that it is equal.
                 auto length = strlen(knownZone.tzName);
-                if (equalLettersIgnoringASCIICase(dateString, knownZone.tzName, length)) {
+                if (equalLettersIgnoringASCIICase(dateString, { knownZone.tzName, length })) {
                     offset = knownZone.tzOffset;
                     dateString += length;
                     isLocalTime = false;

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -904,12 +904,12 @@ size_t StringImpl::find(StringView matchString)
     if (matchLength == 1) {
         if (is8Bit()) {
             if (matchString.is8Bit())
-                return WTF::find(characters8(), length(), matchString.characters8()[0]);
-            return WTF::find(characters8(), length(), matchString.characters16()[0]);
+                return WTF::find(span8(), matchString.characters8()[0]);
+            return WTF::find(span8(), matchString.characters16()[0]);
         }
         if (matchString.is8Bit())
-            return WTF::find(characters16(), length(), matchString.characters8()[0]);
-        return WTF::find(characters16(), length(), matchString.characters16()[0]);
+            return WTF::find(span16(), matchString.characters8()[0]);
+        return WTF::find(span16(), matchString.characters16()[0]);
     }
 
     // Check matchLength is in range.

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -309,6 +309,7 @@ public:
     ALWAYS_INLINE std::span<const UChar> span16() const { return { characters16(), length() }; }
 
     template<typename CharacterType> const CharacterType* characters() const;
+    template<typename CharacterType> std::span<const CharacterType> span() const { return { characters<CharacterType>(), length() }; }
 
     size_t cost() const;
     size_t costDuringGC();
@@ -735,8 +736,8 @@ inline size_t reverseFind(std::span<const LChar> characters, UChar matchCharacte
 inline size_t StringImpl::find(LChar character, size_t start)
 {
     if (is8Bit())
-        return WTF::find(characters8(), m_length, character, start);
-    return WTF::find(characters16(), m_length, character, start);
+        return WTF::find(span8(), character, start);
+    return WTF::find(span16(), character, start);
 }
 
 ALWAYS_INLINE size_t StringImpl::find(char character, size_t start)
@@ -747,8 +748,8 @@ ALWAYS_INLINE size_t StringImpl::find(char character, size_t start)
 inline size_t StringImpl::find(UChar character, size_t start)
 {
     if (is8Bit())
-        return WTF::find(characters8(), m_length, character, start);
-    return WTF::find(characters16(), m_length, character, start);
+        return WTF::find(span8(), character, start);
+    return WTF::find(span16(), character, start);
 }
 
 template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>*>

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -695,15 +695,15 @@ inline String StringView::toStringWithoutCopying() const
 inline size_t StringView::find(UChar character, unsigned start) const
 {
     if (is8Bit())
-        return WTF::find(characters8(), m_length, character, start);
-    return WTF::find(characters16(), m_length, character, start);
+        return WTF::find(span8(), character, start);
+    return WTF::find(span16(), character, start);
 }
 
 inline size_t StringView::find(LChar character, unsigned start) const
 {
     if (is8Bit())
-        return WTF::find(characters8(), m_length, character, start);
-    return WTF::find(characters16(), m_length, character, start);
+        return WTF::find(span8(), character, start);
+    return WTF::find(span16(), character, start);
 }
 
 template<typename CodeUnitMatchFunction, std::enable_if_t<std::is_invocable_r_v<bool, CodeUnitMatchFunction, UChar>>*>
@@ -1210,8 +1210,8 @@ inline size_t findCommon(StringView haystack, StringView needle, unsigned start)
     if (needleLength == 1) {
         UChar firstCharacter = needle.unsafeCharacterAt(0);
         if (haystack.is8Bit())
-            return WTF::find(haystack.characters8(), haystack.length(), firstCharacter, start);
-        return WTF::find(haystack.characters16(), haystack.length(), firstCharacter, start);
+            return WTF::find(haystack.span8(), firstCharacter, start);
+        return WTF::find(haystack.span16(), firstCharacter, start);
     }
 
     if (start > haystack.length())
@@ -1252,14 +1252,13 @@ inline size_t findIgnoringASCIICase(StringView source, StringView stringToFind, 
 
     if (source.is8Bit()) {
         if (stringToFind.is8Bit())
-            return findIgnoringASCIICase(source.characters8(), stringToFind.characters8(), start, searchLength, matchLength);
-        return findIgnoringASCIICase(source.characters8(), stringToFind.characters16(), start, searchLength, matchLength);
+            return findIgnoringASCIICase(source.span8().first(searchLength), stringToFind.span8(), static_cast<size_t>(start));
+        return findIgnoringASCIICase(source.span8().first(searchLength), stringToFind.span16(), static_cast<size_t>(start));
     }
 
     if (stringToFind.is8Bit())
-        return findIgnoringASCIICase(source.characters16(), stringToFind.characters8(), start, searchLength, matchLength);
-
-    return findIgnoringASCIICase(source.characters16(), stringToFind.characters16(), start, searchLength, matchLength);
+        return findIgnoringASCIICase(source.span16().first(searchLength), stringToFind.span8(), static_cast<size_t>(start));
+    return findIgnoringASCIICase(source.span16().first(searchLength), stringToFind.span16(), static_cast<size_t>(start));
 }
 
 inline bool startsWith(StringView reference, StringView prefix)
@@ -1279,18 +1278,17 @@ inline bool startsWith(StringView reference, StringView prefix)
 
 inline bool startsWithIgnoringASCIICase(StringView reference, StringView prefix)
 {
-    unsigned prefixLength = prefix.length();
-    if (prefixLength > reference.length())
+    if (prefix.length() > reference.length())
         return false;
 
     if (reference.is8Bit()) {
         if (prefix.is8Bit())
-            return equalIgnoringASCIICase(reference.characters8(), prefix.characters8(), prefixLength);
-        return equalIgnoringASCIICase(reference.characters8(), prefix.characters16(), prefixLength);
+            return equalIgnoringASCIICase(reference.characters8(), prefix.span8());
+        return equalIgnoringASCIICase(reference.characters8(), prefix.span16());
     }
     if (prefix.is8Bit())
-        return equalIgnoringASCIICase(reference.characters16(), prefix.characters8(), prefixLength);
-    return equalIgnoringASCIICase(reference.characters16(), prefix.characters16(), prefixLength);
+        return equalIgnoringASCIICase(reference.characters16(), prefix.span8());
+    return equalIgnoringASCIICase(reference.characters16(), prefix.span16());
 }
 
 inline bool endsWith(StringView reference, StringView suffix)
@@ -1323,12 +1321,12 @@ inline bool endsWithIgnoringASCIICase(StringView reference, StringView suffix)
 
     if (reference.is8Bit()) {
         if (suffix.is8Bit())
-            return equalIgnoringASCIICase(reference.characters8() + startOffset, suffix.characters8(), suffixLength);
-        return equalIgnoringASCIICase(reference.characters8() + startOffset, suffix.characters16(), suffixLength);
+            return equalIgnoringASCIICase(reference.characters8() + startOffset, suffix.span8());
+        return equalIgnoringASCIICase(reference.characters8() + startOffset, suffix.span16());
     }
     if (suffix.is8Bit())
-        return equalIgnoringASCIICase(reference.characters16() + startOffset, suffix.characters8(), suffixLength);
-    return equalIgnoringASCIICase(reference.characters16() + startOffset, suffix.characters16(), suffixLength);
+        return equalIgnoringASCIICase(reference.characters16() + startOffset, suffix.span8());
+    return equalIgnoringASCIICase(reference.characters16() + startOffset, suffix.span16());
 }
 
 inline size_t String::find(StringView string) const

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -642,7 +642,7 @@ template <typename CharType>
 static bool parseTransformTranslateArguments(CharType*& pos, CharType* end, unsigned expectedCount, CSSValueID transformType, CSSValueListBuilder& arguments)
 {
     while (expectedCount) {
-        size_t delimiter = find(pos, end - pos, expectedCount == 1 ? ')' : ',');
+        size_t delimiter = find({ pos, end }, expectedCount == 1 ? ')' : ',');
         if (delimiter == notFound)
             return false;
         unsigned argumentLength = static_cast<unsigned>(delimiter);
@@ -664,7 +664,7 @@ static bool parseTransformTranslateArguments(CharType*& pos, CharType* end, unsi
 template <typename CharType>
 static RefPtr<CSSValue> parseTransformAngleArgument(CharType*& pos, CharType* end)
 {
-    size_t delimiter = find(pos, end - pos, ')');
+    size_t delimiter = find({ pos, end }, ')');
     if (delimiter == notFound)
         return nullptr;
 
@@ -685,7 +685,7 @@ template <typename CharType>
 static bool parseTransformNumberArguments(CharType*& pos, CharType* end, unsigned expectedCount, CSSValueListBuilder& arguments)
 {
     while (expectedCount) {
-        size_t delimiter = find(pos, end - pos, expectedCount == 1 ? ')' : ',');
+        size_t delimiter = find({ pos, end }, expectedCount == 1 ? ')' : ',');
         if (delimiter == notFound)
             return false;
         unsigned argumentLength = static_cast<unsigned>(delimiter);
@@ -859,7 +859,7 @@ static bool transformCanLikelyUseFastPath(const CharType* chars, unsigned length
         default:
             return false;
         }
-        size_t argumentsEnd = find(chars, length, ')', i);
+        size_t argumentsEnd = find({ chars, length }, ')', i);
         if (argumentsEnd == notFound)
             return false;
         // Advance to the end of the arguments.

--- a/Source/WebCore/html/parser/ParsingUtilities.h
+++ b/Source/WebCore/html/parser/ParsingUtilities.h
@@ -201,7 +201,7 @@ template<typename CharacterType> bool skipExactlyIgnoringASCIICase(const Charact
     
     if (position + literalLength > end)
         return false;
-    if (!equalLettersIgnoringASCIICase(position, literalLength, literal))
+    if (!equalLettersIgnoringASCIICase(position, literal))
         return false;
     position += literalLength;
     return true;
@@ -213,7 +213,7 @@ template<typename CharacterType> bool skipExactlyIgnoringASCIICase(StringParsing
 
     if (buffer.lengthRemaining() < literalLength)
         return false;
-    if (!equalLettersIgnoringASCIICase(buffer.position(), literalLength, literal))
+    if (!equalLettersIgnoringASCIICase(buffer.position(), literal))
         return false;
     buffer += literalLength;
     return true;

--- a/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp
@@ -1056,8 +1056,8 @@ bool ApplicationCacheStorage::storeNewestCache(ApplicationCacheGroup& group)
 template<typename CharacterType>
 static inline void parseHeader(std::span<const CharacterType> header, ResourceResponse& response)
 {
-    ASSERT(WTF::find(header.data(), header.size(), ':') != notFound);
-    unsigned colonPosition = WTF::find(header.data(), header.size(), ':');
+    auto colonPosition = WTF::find(header, ':');
+    ASSERT(colonPosition != notFound);
 
     // Save memory by putting the header names into atom strings so each is stored only once,
     // even though the setHTTPHeaderField function does not require an atom string.

--- a/Source/WebCore/platform/SharedStringHash.cpp
+++ b/Source/WebCore/platform/SharedStringHash.cpp
@@ -126,7 +126,7 @@ static void cleanSlashDotDotSlashes(Vector<CharacterType, 512>& path, size_t fir
 template <typename CharacterType>
 static void mergeDoubleSlashes(Vector<CharacterType, 512>& path, size_t firstSlash)
 {
-    size_t refPos = find(path.data(), path.size(), '#');
+    size_t refPos = find(path.span(), '#');
     if (!refPos || refPos == notFound)
         refPos = path.size();
 


### PR DESCRIPTION
#### 56976d0ea5cb10b6e37488ea790e12118764e41b
<pre>
Further adopt std::span in StringCommon.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=272338">https://bugs.webkit.org/show_bug.cgi?id=272338</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::IntlLocale::maximal):
(JSC::IntlLocale::minimal):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::splitStringByOneCharacterImpl):
* Source/WTF/wtf/DateMath.cpp:
(WTF::parseDateFromNullTerminatedCharacters):
* Source/WTF/wtf/text/StringCommon.h:
(WTF::span):
(WTF::span8):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::find):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::span const):
(WTF::StringImpl::find):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::find const):
(WTF::findCommon):
(WTF::findIgnoringASCIICase):
(WTF::startsWithIgnoringASCIICase):
(WTF::endsWithIgnoringASCIICase):
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseTransformTranslateArguments):
(WebCore::parseTransformAngleArgument):
(WebCore::parseTransformNumberArguments):
(WebCore::transformCanLikelyUseFastPath):
* Source/WebCore/html/parser/ParsingUtilities.h:
(WebCore::skipExactlyIgnoringASCIICase):
* Source/WebCore/loader/appcache/ApplicationCacheStorage.cpp:
(WebCore::parseHeader):
* Source/WebCore/platform/SharedStringHash.cpp:
(WebCore::mergeDoubleSlashes):

Canonical link: <a href="https://commits.webkit.org/277245@main">https://commits.webkit.org/277245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffb463415f17fa1b01dccaf0b9d03eadffc7e34a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49745 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43113 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38339 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23707 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19646 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21081 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41707 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5107 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40324 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51621 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46548 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45636 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23364 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44639 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24145 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54052 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6616 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23078 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11091 "Passed tests") | 
<!--EWS-Status-Bubble-End-->