### PR TITLE
Make `shouldSuppressTextInputFromEditing` suppress paste from the UI process

### DIFF
--- a/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt
+++ b/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt
@@ -8,6 +8,8 @@ CONSOLE MESSAGE: Pressing "a".
 CONSOLE MESSAGE: Setting marked text to "b".
 CONSOLE MESSAGE: Inserting text "c".
 CONSOLE MESSAGE: Pasting text "d".
+CONSOLE MESSAGE: pasteevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Input element value after text input events: "".
 CONSOLE MESSAGE: Pressing "z" with access key modifiers should navigate to resources/keyboard-events-after-navigation.html.
 CONSOLE MESSAGE: Finished navigating to resources/keyboard-events-after-navigation.html.

--- a/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-navigation.html
+++ b/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-navigation.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ShouldSuppressTextInputFromEditingDuringProvisionalNavigation=true ] -->
 <html>
 <body>
     <a href="resources/keyboard-events-after-navigation.html" accesskey="z"></a>
@@ -7,7 +7,6 @@
         if (window.testRunner) {
             testRunner.dumpAsText();
             testRunner.waitUntilDone();
-            internals.settings.setShouldSuppressTextInputFromEditingDuringProvisionalNavigation(true);
         }
 
         runBeforeTest(window);

--- a/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-subframe-navigation-expected.txt
+++ b/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-subframe-navigation-expected.txt
@@ -8,6 +8,8 @@ CONSOLE MESSAGE: Pressing "a".
 CONSOLE MESSAGE: Setting marked text to "b".
 CONSOLE MESSAGE: Inserting text "c".
 CONSOLE MESSAGE: Pasting text "d".
+CONSOLE MESSAGE: pasteevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Input element value after text input events: "".
 CONSOLE MESSAGE: Pressing "z" with access key modifiers should navigate to resources/keyboard-events-after-navigation.html.
 CONSOLE MESSAGE: Finished navigating to resources/keyboard-events-after-navigation.html.

--- a/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-subframe-navigation.html
+++ b/LayoutTests/http/tests/navigation/keyboard-events-during-provisional-subframe-navigation.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ShouldSuppressTextInputFromEditingDuringProvisionalNavigation=true ] -->
 <html>
 <body>
     <iframe id="subframe"></iframe>
@@ -9,7 +9,6 @@
             testRunner.dumpAsText();
             testRunner.dumpChildFramesAsText();
             testRunner.waitUntilDone();
-            internals.settings.setShouldSuppressTextInputFromEditingDuringProvisionalNavigation(true);
         }
 
         runBeforeTest(window);

--- a/LayoutTests/http/tests/site-isolation/paste-in-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/paste-in-iframe-expected.txt
@@ -1,0 +1,10 @@
+Tests that the iframe is able to receive paste events.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is 'onpaste'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/paste-in-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/paste-in-iframe.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that the iframe is able to receive paste events.");
+jsTestIsAsync = true;
+
+addEventListener("message", (event) => {
+    shouldBe("event.data", "'onpaste'");
+    finishJSTest();
+});
+</script>
+<iframe src="http://localhost:8000/site-isolation/resources/copy-and-paste-text.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/resources/copy-and-paste-text.html
+++ b/LayoutTests/http/tests/site-isolation/resources/copy-and-paste-text.html
@@ -1,0 +1,13 @@
+<p>Text to be copied and pasted</p>
+<script>
+onpaste = (event) => {
+    // FIXME: This should send the pasted text.
+    window.parent.postMessage("onpaste", "*");
+}
+
+onload = () => {
+    document.execCommand("SelectAll");
+    document.execCommand("Copy");
+    document.execCommand("Paste");
+}
+</script>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1037,6 +1037,9 @@ webkit.org/b/152247 fast/forms/listbox-scrollbar-hit-test.html [ Skip ]
 # This is a Mac specific feature
 webkit.org/b/168466 http/tests/security/bypassing-cors-checks-for-extension-urls.html [ Skip ]
 
+http/tests/navigation/keyboard-events-during-provisional-navigation.html [ Skip ]
+http/tests/navigation/keyboard-events-during-provisional-subframe-navigation.html [ Skip ]
+
 # The test directly sends Cocoa events
 swipe/pushState-programmatic-back-while-swiping-crash.html [ Skip ]
 swipe/swipe-back-with-passive-wheel-listener.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -897,6 +897,10 @@ imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/b
 imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/events/015.html [ Pass Failure ]
 imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/readyState/006.html [ Pass Failure ]
 
+# ShouldSuppressTextInputFromEditingDuringProvisionalNavigation not supported in WK1
+http/tests/navigation/keyboard-events-during-provisional-navigation.html [ Skip ]
+http/tests/navigation/keyboard-events-during-provisional-subframe-navigation.html [ Skip ]
+
 # Tests are only relevant in WK2
 http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-redirect.html [ Skip ]
 http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-ws-redirect.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt
+++ b/LayoutTests/platform/mac-wk2/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt
@@ -8,6 +8,8 @@ CONSOLE MESSAGE: Pressing "a".
 CONSOLE MESSAGE: Setting marked text to "b".
 CONSOLE MESSAGE: Inserting text "c".
 CONSOLE MESSAGE: Pasting text "d".
+CONSOLE MESSAGE: pasteevent dispatched (isTrusted: true).
+CONSOLE MESSAGE: textInputevent dispatched (isTrusted: true).
 CONSOLE MESSAGE: Input element value after text input events: "".
 CONSOLE MESSAGE: Pressing "z" with access key modifiers should navigate to resources/keyboard-events-after-navigation.html.
 CONSOLE MESSAGE: keydownevent dispatched (isTrusted: true).

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -530,18 +530,6 @@ bool Editor::canCopy() const
     return selection.isRange() && (!selection.isInPasswordField() || selection.isInAutoFilledAndViewableField());
 }
 
-bool Editor::canPaste() const
-{
-    RefPtr localFrame = dynamicDowncast<LocalFrame>(document().frame()->mainFrame());
-    if (!localFrame)
-        return false;
-
-    if (localFrame->loader().shouldSuppressTextInputFromEditing())
-        return false;
-
-    return canEdit();
-}
-
 bool Editor::canDelete() const
 {
     const VisibleSelection& selection = document().selection().selection();
@@ -1606,7 +1594,7 @@ void Editor::paste(Pasteboard& pasteboard, FromMenuOrKeyBinding fromMenuOrKeyBin
 
     if (!dispatchClipboardEvent(findEventTargetFromSelection(), ClipboardEventKind::Paste))
         return; // DHTML did the whole operation
-    if (!canPaste())
+    if (!canEdit())
         return;
     updateMarkersForWordsAffectedByEditing(false);
     ResourceCacheValidationSuppressor validationSuppressor(document().cachedResourceLoader());
@@ -1622,7 +1610,7 @@ void Editor::pasteAsPlainText(FromMenuOrKeyBinding fromMenuOrKeyBinding)
 
     if (!dispatchClipboardEvent(findEventTargetFromSelection(), ClipboardEventKind::PasteAsPlainText))
         return;
-    if (!canPaste())
+    if (!canEdit())
         return;
     updateMarkersForWordsAffectedByEditing(false);
     pasteAsPlainTextWithPasteboard(*Pasteboard::createForCopyAndPaste(PagePasteboardContext::create(document().pageID())));
@@ -1634,7 +1622,7 @@ void Editor::pasteAsQuotation(FromMenuOrKeyBinding fromMenuOrKeyBinding)
 
     if (!dispatchClipboardEvent(findEventTargetFromSelection(), ClipboardEventKind::PasteAsQuotation))
         return;
-    if (!canPaste())
+    if (!canEdit())
         return;
     updateMarkersForWordsAffectedByEditing(false);
     Ref document = protectedDocument();
@@ -1652,7 +1640,7 @@ void Editor::pasteFont(FromMenuOrKeyBinding fromMenuOrKeyBinding)
 
     if (!dispatchClipboardEvent(findEventTargetFromSelection(), ClipboardEventKind::PasteFont))
         return;
-    if (!canPaste())
+    if (!canEdit())
         return;
     updateMarkersForWordsAffectedByEditing(false);
     ResourceCacheValidationSuppressor validationSuppressor(document().cachedResourceLoader());

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -205,7 +205,6 @@ public:
 
     WEBCORE_EXPORT bool canCut() const;
     WEBCORE_EXPORT bool canCopy() const;
-    WEBCORE_EXPORT bool canPaste() const;
     WEBCORE_EXPORT bool canDelete() const;
     WEBCORE_EXPORT bool canSmartCopyOrDelete();
     bool shouldSmartDelete();

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -1434,10 +1434,10 @@ static bool enabledPaste(LocalFrame& frame, Event*, EditorCommandSource source)
 {
     switch (source) {
     case EditorCommandSource::MenuOrKeyBinding:
-        return frame.editor().canDHTMLPaste() || frame.editor().canPaste();
+        return frame.editor().canDHTMLPaste() || frame.editor().canEdit();
     case EditorCommandSource::DOM:
     case EditorCommandSource::DOMWithUserInterface:
-        return allowPasteFromDOM(frame) && (frame.editor().canDHTMLPaste() || frame.editor().canPaste());
+        return allowPasteFromDOM(frame) && (frame.editor().canDHTMLPaste() || frame.editor().canEdit());
     }
     ASSERT_NOT_REACHED();
     return false;
@@ -1649,16 +1649,6 @@ static bool allowExecutionWhenDisabledCopyCut(LocalFrame&, EditorCommandSource s
     return false;
 }
 
-static bool allowExecutionWhenDisabledPaste(LocalFrame& frame, EditorCommandSource)
-{
-    auto* localFrame = dynamicDowncast<LocalFrame>(frame.mainFrame());
-    if (!localFrame)
-        return false;
-    if (localFrame->loader().shouldSuppressTextInputFromEditing())
-        return false;
-    return true;
-}
-
 // Map of functions
 
 struct CommandEntry {
@@ -1773,11 +1763,11 @@ static const CommandMap& createCommandMap()
         { "MoveWordRightAndModifySelection"_s, { executeMoveWordRightAndModifySelection, supportedFromMenuOrKeyBinding, enabledVisibleSelectionOrCaretBrowsing, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "Outdent"_s, { executeOutdent, supported, enabledInRichlyEditableText, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "OverWrite"_s, { executeToggleOverwrite, supportedFromMenuOrKeyBinding, enabledInRichlyEditableText, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
-        { "Paste"_s, { executePaste, supportedPaste, enabledPaste, stateNone, valueNull, notTextInsertion, allowExecutionWhenDisabledPaste } },
-        { "PasteAndMatchStyle"_s, { executePasteAndMatchStyle, supportedPaste, enabledPaste, stateNone, valueNull, notTextInsertion, allowExecutionWhenDisabledPaste } },
-        { "PasteAsPlainText"_s, { executePasteAsPlainText, supportedPaste, enabledPaste, stateNone, valueNull, notTextInsertion, allowExecutionWhenDisabledPaste } },
-        { "PasteAsQuotation"_s, { executePasteAsQuotation, supportedPaste, enabledPaste, stateNone, valueNull, notTextInsertion, allowExecutionWhenDisabledPaste } },
-        { "PasteFont"_s, { executePasteFont, supportedPaste, enabledPaste, stateNone, valueNull, notTextInsertion, allowExecutionWhenDisabledPaste } },
+        { "Paste"_s, { executePaste, supportedPaste, enabledPaste, stateNone, valueNull, notTextInsertion, allowExecutionWhenDisabled } },
+        { "PasteAndMatchStyle"_s, { executePasteAndMatchStyle, supportedPaste, enabledPaste, stateNone, valueNull, notTextInsertion, allowExecutionWhenDisabled } },
+        { "PasteAsPlainText"_s, { executePasteAsPlainText, supportedPaste, enabledPaste, stateNone, valueNull, notTextInsertion, allowExecutionWhenDisabled } },
+        { "PasteAsQuotation"_s, { executePasteAsQuotation, supportedPaste, enabledPaste, stateNone, valueNull, notTextInsertion, allowExecutionWhenDisabled } },
+        { "PasteFont"_s, { executePasteFont, supportedPaste, enabledPaste, stateNone, valueNull, notTextInsertion, allowExecutionWhenDisabled } },
         { "Print"_s, { executePrint, supported, enabled, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "Redo"_s, { executeRedo, supported, enabledRedo, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },
         { "RemoveFormat"_s, { executeRemoveFormat, supported, enabledRangeInEditableText, stateNone, valueNull, notTextInsertion, doNotAllowExecutionWhenDisabled } },

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -1515,14 +1515,14 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
             shouldEnable = frame->selection().isRange();
             break;
         case ContextMenuItemTagPaste:
-            shouldEnable = frame->editor().canDHTMLPaste() || frame->editor().canPaste();
+            shouldEnable = frame->editor().canDHTMLPaste() || frame->editor().canEdit();
             break;
         case ContextMenuItemTagCopyLinkToHighlight:
             shouldEnable = shouldEnableCopyLinkToHighlight();
             break;
 #if PLATFORM(GTK)
         case ContextMenuItemTagPasteAsPlainText:
-            shouldEnable = frame->editor().canDHTMLPaste() || frame->editor().canPaste();
+            shouldEnable = frame->editor().canDHTMLPaste() || frame->editor().canEdit();
             break;
         case ContextMenuItemTagDelete:
             shouldEnable = frame->editor().canDelete();

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -27,6 +27,7 @@
 #import "WebPasteboardProxy.h"
 
 #import "Connection.h"
+#import "PageLoadState.h"
 #import "PasteboardAccessIntent.h"
 #import "RemotePageProxy.h"
 #import "SandboxExtension.h"
@@ -107,6 +108,9 @@ std::optional<WebPasteboardProxy::PasteboardAccessType> WebPasteboardProxy::acce
 
     for (Ref page : process->pages()) {
         Ref preferences = page->preferences();
+        if (preferences->shouldSuppressTextInputFromEditingDuringProvisionalNavigation() && page->pageLoadState().isProvisional())
+            continue;
+
         if (!preferences->domPasteAllowed() || !preferences->javaScriptCanAccessClipboard())
             continue;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1495,7 +1495,7 @@ EditorState WebPage::editorState(ShouldPerformLayout shouldPerformLayout) const
             result.postLayoutData = std::optional<EditorState::PostLayoutData> { EditorState::PostLayoutData { } };
         result.postLayoutData->canCut = editor.canCut();
         result.postLayoutData->canCopy = editor.canCopy();
-        result.postLayoutData->canPaste = editor.canPaste();
+        result.postLayoutData->canPaste = editor.canEdit();
 
         if (!result.visualData)
             result.visualData = std::optional<EditorState::VisualData> { EditorState::VisualData { } };

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -2964,11 +2964,11 @@ IGNORE_WARNINGS_END
         return [self _hasSelection];
 
     if (action == @selector(paste:) || action == @selector(pasteAsPlainText:))
-        return frame && (frame->editor().canDHTMLPaste() || frame->editor().canPaste());
+        return frame && (frame->editor().canDHTMLPaste() || frame->editor().canEdit());
 
     if (action == @selector(pasteAsRichText:))
         return frame && (frame->editor().canDHTMLPaste()
-            || (frame->editor().canPaste() && frame->selection().selection().isContentRichlyEditable()));
+            || (frame->editor().canEdit() && frame->selection().selection().isContentRichlyEditable()));
 
     if (action == @selector(performFindPanelAction:))
         return NO;


### PR DESCRIPTION
#### a22b4ce00cb59b781765ba20e28a893471c55053
<pre>
Make `shouldSuppressTextInputFromEditing` suppress paste from the UI process
<a href="https://bugs.webkit.org/show_bug.cgi?id=272345">https://bugs.webkit.org/show_bug.cgi?id=272345</a>
<a href="https://rdar.apple.com/126089620">rdar://126089620</a>

Reviewed by Alex Christensen and Wenson Hsieh.

`shouldSuppressTextInputFromEditing` is used to prevent text input while Safari’s URL bar is showing
a provisional URL. Instead of suppressing the paste event from the web process, this patch makes it so
we do not allow the page to access pasteboard data during a provisional navigation. Paste events will be
sent now, but text on the clipboard will still not be pasted.

This is work towards making paste work with site isolation.

* LayoutTests/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt:
* LayoutTests/http/tests/navigation/keyboard-events-during-provisional-navigation.html:
* LayoutTests/http/tests/navigation/keyboard-events-during-provisional-subframe-navigation-expected.txt:
* LayoutTests/http/tests/navigation/keyboard-events-during-provisional-subframe-navigation.html:
* LayoutTests/http/tests/site-isolation/paste-in-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/paste-in-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/copy-and-paste-text.html: Added.
* LayoutTests/platform/mac-wk2/http/tests/navigation/keyboard-events-during-provisional-navigation-expected.txt:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::paste):
(WebCore::Editor::pasteAsPlainText):
(WebCore::Editor::pasteAsQuotation):
(WebCore::Editor::pasteFont):
(WebCore::Editor::canPaste const): Deleted.
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::enabledPaste):
(WebCore::createCommandMap):
(WebCore::allowExecutionWhenDisabledPaste): Deleted.
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::accessType const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::editorState const):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView validateUserInterfaceItemWithoutDelegate:]):

Canonical link: <a href="https://commits.webkit.org/277221@main">https://commits.webkit.org/277221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c89e85d3656afc845fd5858911b28d94a1b782f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47031 "Failed to checkout and rebase branch from PR 26983") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26200 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49713 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/43078 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49338 "Failed to checkout and rebase branch from PR 26983") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23666 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47612 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/23658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/19616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/21026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5076 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42066 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51590 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23332 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/40677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6598 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/23043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->