### PR TITLE
Fix BBQ JIT handling of remu(x, -1)

### DIFF
--- a/JSTests/wasm/stress/remainder-by-constant-plusminus-1.js
+++ b/JSTests/wasm/stress/remainder-by-constant-plusminus-1.js
@@ -1,0 +1,149 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (func (export "testI32RemU_n1") (param i32) (result i32)
+        local.get 0
+        i32.const -1
+        i32.rem_u
+    )
+
+    (func (export "testI32RemS_n1") (param i32) (result i32)
+        local.get 0
+        i32.const -1
+        i32.rem_s
+    )
+
+    (func (export "testI64RemU_n1") (param i64) (result i64)
+        local.get 0
+        i64.const -1
+        i64.rem_u
+    )
+
+    (func (export "testI64RemS_n1") (param i64) (result i64)
+        local.get 0
+        i64.const -1
+        i64.rem_s
+    )
+
+    (func (export "testI32RemU_1") (param i32) (result i32)
+        local.get 0
+        i32.const 1
+        i32.rem_u
+    )
+
+    (func (export "testI32RemS_1") (param i32) (result i32)
+        local.get 0
+        i32.const 1
+        i32.rem_s
+    )
+
+    (func (export "testI64RemU_1") (param i64) (result i64)
+        local.get 0
+        i64.const 1
+        i64.rem_u
+    )
+
+    (func (export "testI64RemS_1") (param i64) (result i64)
+        local.get 0
+        i64.const 1
+        i64.rem_s
+    )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, {});
+    const { 
+        testI32RemU_n1,
+        testI32RemS_n1,
+        testI64RemU_n1,
+        testI64RemS_n1,
+        testI32RemU_1,
+        testI32RemS_1,
+        testI64RemU_1,
+        testI64RemS_1,
+    } = instance.exports;
+
+
+    /***** -1 ******/
+    assert.eq(testI32RemU_n1(0), 0);
+    assert.eq(testI32RemU_n1(1), 1);
+    assert.eq(testI32RemU_n1(2), 2);
+    assert.eq(testI32RemU_n1(7), 7);
+    assert.eq(testI32RemU_n1(8), 8);
+    assert.eq(testI32RemU_n1(9), 9);
+
+    assert.eq(testI32RemS_n1(0), 0);
+    assert.eq(testI32RemS_n1(1), 0);
+    assert.eq(testI32RemS_n1(2), 0);
+    assert.eq(testI32RemS_n1(7), 0);
+    assert.eq(testI32RemS_n1(8), 0);
+    assert.eq(testI32RemS_n1(9), 0);
+    assert.eq(testI32RemS_n1(-1), 0);
+    assert.eq(testI32RemS_n1(-2), 0);
+    assert.eq(testI32RemS_n1(-7), 0);
+    assert.eq(testI32RemS_n1(-8), 0);
+    assert.eq(testI32RemS_n1(-9), 0);
+
+    assert.eq(testI64RemU_n1(0n), 0n);
+    assert.eq(testI64RemU_n1(1n), 1n);
+    assert.eq(testI64RemU_n1(2n), 2n);
+    assert.eq(testI64RemU_n1(7n), 7n);
+    assert.eq(testI64RemU_n1(8n), 8n);
+    assert.eq(testI64RemU_n1(9n), 9n);
+
+    assert.eq(testI64RemS_n1(0n), 0n);
+    assert.eq(testI64RemS_n1(1n), 0n);
+    assert.eq(testI64RemS_n1(2n), 0n);
+    assert.eq(testI64RemS_n1(7n), 0n);
+    assert.eq(testI64RemS_n1(8n), 0n);
+    assert.eq(testI64RemS_n1(9n), 0n);
+    assert.eq(testI64RemS_n1(-1n), 0n);
+    assert.eq(testI64RemS_n1(-2n), 0n);
+    assert.eq(testI64RemS_n1(-7n), 0n);
+    assert.eq(testI64RemS_n1(-8n), 0n);
+    assert.eq(testI64RemS_n1(-9n), 0n);
+
+    /***** +1 ******/
+    assert.eq(testI32RemU_1(0), 0);
+    assert.eq(testI32RemU_1(1), 0);
+    assert.eq(testI32RemU_1(2), 0);
+    assert.eq(testI32RemU_1(7), 0);
+    assert.eq(testI32RemU_1(8), 0);
+    assert.eq(testI32RemU_1(9), 0);
+
+    assert.eq(testI32RemS_1(0), 0);
+    assert.eq(testI32RemS_1(1), 0);
+    assert.eq(testI32RemS_1(2), 0);
+    assert.eq(testI32RemS_1(7), 0);
+    assert.eq(testI32RemS_1(8), 0);
+    assert.eq(testI32RemS_1(9), 0);
+    assert.eq(testI32RemS_1(-1), 0);
+    assert.eq(testI32RemS_1(-2), 0);
+    assert.eq(testI32RemS_1(-7), 0);
+    assert.eq(testI32RemS_1(-8), 0);
+    assert.eq(testI32RemS_1(-9), 0);
+
+    assert.eq(testI64RemU_1(0n), 0n);
+    assert.eq(testI64RemU_1(1n), 0n);
+    assert.eq(testI64RemU_1(2n), 0n);
+    assert.eq(testI64RemU_1(7n), 0n);
+    assert.eq(testI64RemU_1(8n), 0n);
+    assert.eq(testI64RemU_1(9n), 0n);
+
+    assert.eq(testI64RemS_1(0n), 0n);
+    assert.eq(testI64RemS_1(1n), 0n);
+    assert.eq(testI64RemS_1(2n), 0n);
+    assert.eq(testI64RemS_1(7n), 0n);
+    assert.eq(testI64RemS_1(8n), 0n);
+    assert.eq(testI64RemS_1(9n), 0n);
+    assert.eq(testI64RemS_1(-1n), 0n);
+    assert.eq(testI64RemS_1(-2n), 0n);
+    assert.eq(testI64RemS_1(-7n), 0n);
+    assert.eq(testI64RemS_1(-8n), 0n);
+    assert.eq(testI64RemS_1(-9n), 0n);
+}
+
+assert.asyncTest(test());

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -267,15 +267,15 @@ void BBQJIT::emitModOrDiv(Value& lhs, Location lhsLocation, Value& rhs, Location
                 throwExceptionIf(ExceptionType::IntegerOverflow, jump);
             }
 
-            if constexpr (IsMod) {
-                // N % 1 == 0
-                if constexpr (is32)
-                    m_jit.xor32(resultLocation.asGPR(), resultLocation.asGPR());
-                else
-                    m_jit.xor64(resultLocation.asGPR(), resultLocation.asGPR());
-                return;
-            }
             if constexpr (isSigned) {
+                if constexpr (IsMod) {
+                    // N % 1 == 0
+                    if constexpr (is32)
+                        m_jit.xor32(resultLocation.asGPR(), resultLocation.asGPR());
+                    else
+                        m_jit.xor64(resultLocation.asGPR(), resultLocation.asGPR());
+                    return;
+                }
                 if constexpr (is32)
                     m_jit.neg32(lhsLocation.asGPR(), resultLocation.asGPR());
                 else


### PR DESCRIPTION
#### 3d5ca0a9487692276e62ca70fa01a426bad06aeb
<pre>
Fix BBQ JIT handling of remu(x, -1)
<a href="https://bugs.webkit.org/show_bug.cgi?id=272346">https://bugs.webkit.org/show_bug.cgi?id=272346</a>
<a href="https://rdar.apple.com/121010056">rdar://121010056</a>

Reviewed by Yusuke Suzuki.

The optimization emitModOrDiv was zeroing out the result whenever the
modulus was -1; this is only valid for signed operations, as for
unsigned modulus the above is equivalent to % UINT~_MAX, which does not
generally equal 0.

* JSTests/wasm/stress/remainder-by-constant-plusminus-1.js: Added.
(async test):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.h:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitModOrDiv):

Canonical link: <a href="https://commits.webkit.org/277263@main">https://commits.webkit.org/277263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa295504d809eb75970b344c4ca268da500b9db6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49686 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43051 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38283 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19592 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41643 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5049 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40261 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43382 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51561 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46489 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45576 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23305 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44570 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24081 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/53994 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6629 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23016 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11075 "Passed tests") | 
<!--EWS-Status-Bubble-End-->