### PR TITLE
[Navigation] Support download navigations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-expected.txt
@@ -1,8 +1,6 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT <a> fires navigate and populates downloadRequest with '' Test timed out
-TIMEOUT <a> fires navigate and populates downloadRequest with 'filename' Test timed out
-TIMEOUT <area> fires navigate and populates downloadRequest with '' Test timed out
-TIMEOUT <area> fires navigate and populates downloadRequest with 'filename' Test timed out
+PASS <a> fires navigate and populates downloadRequest with ''
+PASS <a> fires navigate and populates downloadRequest with 'filename'
+PASS <area> fires navigate and populates downloadRequest with ''
+PASS <area> fires navigate and populates downloadRequest with 'filename'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-userInitiated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-userInitiated-expected.txt
@@ -1,6 +1,4 @@
 Click me
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT <a download> click fires navigate event Test timed out
+PASS <a download> click fires navigate event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL <a download> fires navigate, but not navigatesuccess or navigateerror when not intercepted by intercept() assert_true: expected true got false
+PASS <a download> fires navigate, but not navigatesuccess or navigateerror when not intercepted by intercept()
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -669,11 +669,10 @@ bool Navigation::dispatchPushReplaceReloadNavigateEvent(const URL& url, Navigati
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-download-request-navigate-event
-bool Navigation::dispatchDownloadNavigateEvent(const URL&, const String& downloadFilename)
+bool Navigation::dispatchDownloadNavigateEvent(const URL& url, const String& downloadFilename)
 {
-    // FIXME
-    UNUSED_PARAM(downloadFilename);
-    return false;
+    Ref destination = NavigationDestination::create(url, nullptr, false);
+    return innerDispatchNavigateEvent(NavigationNavigationType::Push, WTFMove(destination), downloadFilename);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### d41105b73082dcda0b1aa78c6850a77067c0bc20
<pre>
[Navigation] Support download navigations
<a href="https://bugs.webkit.org/show_bug.cgi?id=272349">https://bugs.webkit.org/show_bug.cgi?id=272349</a>

Reviewed by Alex Christensen.

Implement detecting download requests and firing a navigate event for them [1].

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-download-request-navigate-event">https://html.spec.whatwg.org/multipage/nav-history-apis.html#fire-a-download-request-navigate-event</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-anchor-download-userInitiated-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/ordering-and-transition/anchor-download-expected.txt:
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::FrameLoader::PolicyChecker::checkNavigationPolicy):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::dispatchDownloadNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/278950@main">https://commits.webkit.org/278950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8bff0183bbcc6f673bc486c9debc8ef1856ff8c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/51168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/30470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/3503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/54425 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1858 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/53471 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/36766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/1532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/41670 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/1067 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/53267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/28101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/44102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22787 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/25423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/1358 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/47403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/1431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/56021 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/26278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/1324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/49068 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/27526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/44169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/48207 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11390 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/28407 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/27257 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->