### PR TITLE
Assertion in WTF::Lock::lock when destroying RefPtr in ScrollerPairMac::valuesForOrientation

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -182,6 +182,8 @@ private:
 
     unsigned m_countOfTransactionsWithNonEmptyLayerChanges { 0 };
 
+    HashMap<WebCore::ProcessIdentifier, WebCore::FrameIdentifier> m_commitsForFrameID;
+
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     Seconds m_acceleratedTimelineTimeOrigin;
     MonotonicTime m_animationCurrentTime;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -288,6 +288,19 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction(IPC::Connection
                 m_remoteLayerTreeHost->detachRootLayer();
         }
 
+        // TODO: rdar://126001790 properly handle commits from a web process with multiple root frames.
+        // Currently we get commits for each frame if a web process has multiple root frames. This
+        // currently results in sending across the same scrolling tree multiple times, which can result
+        // in a cycle when a web process has a granparent and grandchild frame, with another process having
+        // the intermediate frame. For now only do scrolling tree commits for the first root frame we see
+        // from a process.
+        auto it = m_commitsForFrameID.find(layerTreeTransaction.processIdentifier());
+        if (it != m_commitsForFrameID.end()) {
+            if (it->value != scrollingTreeTransaction.rootFrameIdentifier())
+                return;
+        } else
+            m_commitsForFrameID.set(layerTreeTransaction.processIdentifier(), scrollingTreeTransaction.rootFrameIdentifier());
+
 #if ENABLE(ASYNC_SCROLLING)
 #if PLATFORM(IOS_FAMILY)
         if (!layerTreeTransaction.isMainFrameProcessTransaction()) {


### PR DESCRIPTION
#### 1a5f9aa863878a836c96eb2c7107485ec9e520f1
<pre>
Assertion in WTF::Lock::lock when destroying RefPtr in ScrollerPairMac::valuesForOrientation
<a href="https://bugs.webkit.org/show_bug.cgi?id=272352">https://bugs.webkit.org/show_bug.cgi?id=272352</a>
<a href="https://rdar.apple.com/125368542">rdar://125368542</a>

Reviewed by Alex Christensen.

Add temporary fix for crashing tests while investigating <a href="https://rdar.apple.com/126001790">rdar://126001790</a>.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction):

Canonical link: <a href="https://commits.webkit.org/277219@main">https://commits.webkit.org/277219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1510339b35b0748bedad17ab879e2225fda84ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49703 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43068 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23656 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38295 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19604 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/20998 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5066 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51579 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22041 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45586 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23322 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24099 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6596 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/23033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->