### PR TITLE
Avoid over-eager clipping of child layers in multicolumn

### DIFF
--- a/LayoutTests/fast/multicol/overflowing-relpos-expected.html
+++ b/LayoutTests/fast/multicol/overflowing-relpos-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>There should be a hotpink square below.</p>
+<div style="margin-left:50px; width:200px; height:200px; background:hotpink;"></div>

--- a/LayoutTests/fast/multicol/overflowing-relpos.html
+++ b/LayoutTests/fast/multicol/overflowing-relpos.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<p>There should be a hotpink square below.</p>
+<div style="columns:2; column-fill:auto; width:100px; height:200px;">
+    <div style="position:relative; left:50px; width:200px; height:200px; background:hotpink;"></div>
+</div>

--- a/LayoutTests/fast/multicol/scale-transform-text-expected.html
+++ b/LayoutTests/fast/multicol/scale-transform-text-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<p>No parts of the characters below should be clipped. Hard to verify with the
+    naked eye. Pixel-compare with the ref. :)</p>
+<div style="transform:scale(0.35); width:200px; height:200px;">
+    <div style="font-size:29px; line-height:1em;">
+        _&Aring;<br>
+        j<br>
+        _<br>
+        j<br>
+        g_<br>
+    </div>
+</div>

--- a/LayoutTests/fast/multicol/scale-transform-text.html
+++ b/LayoutTests/fast/multicol/scale-transform-text.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<p>No parts of the characters below should be clipped. Hard to verify with the
+    naked eye. Pixel-compare with the ref. :)</p>
+<div style="transform:scale(0.35); width:200px; height:200px;">
+    <div style="font-size:29px; columns:2; column-fill:auto; height:100%; line-height:1em;">
+        _&Aring;<br>
+        j<br>
+        _<br>
+        j<br>
+        g_<br>
+    </div>
+</div>


### PR DESCRIPTION
<pre>
Avoid over-eager clipping of child layers in multicolumn
<a href="https://bugs.webkit.org/show_bug.cgi?id=272280">https://bugs.webkit.org/show_bug.cgi?id=272280</a>
rdar://problem/126413036

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/e500cbd3ba36bf3216087481790f5aece0e778a5">https://chromium.googlesource.com/chromium/src.git/+/e500cbd3ba36bf3216087481790f5aece0e778a5</a>

Self-painting layers (caused by e.g. position:relative) don't contribute to
visual overflow in their parent layout object; see
RenderBox::addOverflowFromChild(). We cannot use the visual overflow rectangle
set on the flow thread when calculating the bounding box of a fragment
established by a child layer.

Therefore, only clip in the flow thread's block direction in
overflowRectForFragmentedFlowPortion(), and leave the inline axis alone. I
simplified the implementation, since it's now way easier to start with an
infinite rectangle, and just limit the dimensions that need it afterwards.

Also got rid of an old check for shouldClipFragmentedFlowContent(), which must have been
residue from the CSS regions implementation.

This also happened to fix some inaccuracies mostly invisible to the naked
eye, when it comes to transform:scale()d text with glyphs that have negative
left bearing or overflow the line box vertically. It looks like we measure and
lay out with the CSS computed font, and then switch to a scaled font when
painting, so that it looks crisp and nice.

* Source/WebCore/rendering/RenderFragmentContainer.cpp:
(RenderFragmentContainer::overflowRectForFragmentedFlowPortion):
* LayoutTests/fast/multicol/scale-transform-text.html: Add Test Case
* LayoutTests/fast/multicol/scale-transform-text-expected.html: Add Test Case Expectation
* LayoutTests/fast/multicol/overflowing-relpos.html: Add Test Case
* LayoutTests/fast/multicol/overflowing-relpos-expected.html: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/248b108b57dd9e2a56cceb3e4dee01dc9fe74cdf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59800 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6630 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6824 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45432 "Found 4 new test failures: fast/multicol/client-rects.html imported/blink/fast/multicol/unbreakable-block-too-tall-at-column-start.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-018.html imported/w3c/web-platform-tests/css/css-break/relpos-inline-hit-testing.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4603 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26367 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30188 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-018.html imported/w3c/web-platform-tests/css/css-break/relpos-inline-hit-testing.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5808 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-018.html imported/w3c/web-platform-tests/css/css-break/relpos-inline-hit-testing.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5634 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52188 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6080 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-018.html imported/w3c/web-platform-tests/css/css-break/relpos-inline-hit-testing.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61483 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/102 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6204 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-018.html imported/w3c/web-platform-tests/css/css-break/relpos-inline-hit-testing.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52754 "Found 4 new test failures: fast/multicol/client-rects.html imported/blink/fast/multicol/unbreakable-block-too-tall-at-column-start.html imported/w3c/web-platform-tests/css/css-break/out-of-flow-in-multicolumn-018.html imported/w3c/web-platform-tests/css/css-break/relpos-inline-hit-testing.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/102 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48545 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52586 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/89 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31347 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32433 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->