### PR TITLE
Regression(276505@main) new code is unsafe in PublicSuffixStore::topPrivatelyControlledDomain()

### DIFF
--- a/Source/WebCore/platform/PublicSuffixStore.cpp
+++ b/Source/WebCore/platform/PublicSuffixStore.cpp
@@ -82,19 +82,19 @@ String PublicSuffixStore::topPrivatelyControlledDomain(const String& host) const
 
     Locker locker { m_HostTopPrivatelyControlledDomainCacheLock };
     auto hostCopy = crossThreadCopy(host);
-    auto& result = m_hostTopPrivatelyControlledDomainCache.ensure(hostCopy, [&] {
+    auto result = m_hostTopPrivatelyControlledDomainCache.ensure(hostCopy, [&] {
         const auto lowercaseHost = hostCopy.convertToASCIILowercase();
         if (lowercaseHost == "localhost"_s || URL::hostIsIPAddress(lowercaseHost))
             return lowercaseHost;
 
         return platformTopPrivatelyControlledDomain(lowercaseHost);
-    }).iterator->value;
+    }).iterator->value.isolatedCopy();
 
     constexpr auto maxHostTopPrivatelyControlledDomainCache = 128;
     if (m_hostTopPrivatelyControlledDomainCache.size() > maxHostTopPrivatelyControlledDomainCache)
         m_hostTopPrivatelyControlledDomainCache.remove(m_hostTopPrivatelyControlledDomainCache.random());
 
-    return result.isolatedCopy();
+    return result;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 4908b6f006dd6044da9f9d5007195205efe82191
<pre>
Regression(276505@main) new code is unsafe in PublicSuffixStore::topPrivatelyControlledDomain()
<a href="https://bugs.webkit.org/show_bug.cgi?id=272359">https://bugs.webkit.org/show_bug.cgi?id=272359</a>

Reviewed by Sihui Liu and Ryosuke Niwa.

The code was storing a reference in `result` to a value inside the HashMap,
then modifying the HashMap, which could invalidate that reference. It would
later try to use `result` again to call `isolatedCopy()` on it.

* Source/WebCore/platform/PublicSuffixStore.cpp:
(WebCore::PublicSuffixStore::topPrivatelyControlledDomain const):

Canonical link: <a href="https://commits.webkit.org/277226@main">https://commits.webkit.org/277226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/495f4a2034acce4115e83485e78a0530f8f60704

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49719 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43083 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23671 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38310 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47617 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/23667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19619 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/21036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41673 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5081 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51595 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18424 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23337 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44598 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24117 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6602 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/23049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->