### PR TITLE
Web Inspector: List of breakpoints in Sources tab disappears when inspector reloads

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/SourceCodeLocation.js
+++ b/Source/WebInspectorUI/UserInterface/Models/SourceCodeLocation.js
@@ -276,10 +276,10 @@ WI.SourceCodeLocation = class SourceCodeLocation extends WI.Object
 
     setSourceCode(sourceCode)
     {
-        console.assert((this._sourceCode === null && sourceCode instanceof WI.SourceCode) || (this._sourceCode instanceof WI.SourceCode && sourceCode === null));
-
         if (sourceCode === this._sourceCode)
             return;
+
+        console.assert((this._sourceCode === null && sourceCode instanceof WI.SourceCode) || (this._sourceCode instanceof WI.SourceCode && sourceCode === null) || this._sourceCode?.contentIdentifier === sourceCode?.contentIdentifier);
 
         this._makeChangeAndDispatchChangeEventIfNeeded(function() {
             if (this._sourceCode) {


### PR DESCRIPTION
#### c6550e29032bf25d2d2dd78a05e29a498d99fc02
<pre>
Web Inspector: List of breakpoints in Sources tab disappears when inspector reloads
<a href="https://rdar.apple.com/123641994">rdar://123641994</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=272098">https://bugs.webkit.org/show_bug.cgi?id=272098</a>

Reviewed by Devin Rousso.

The reported bug can be exposed one of three ways, that the list of
breakpoints shown in the source sidebar disappears:
   (1) When you reload the webpage while the inspector is open,
   (2) When you navigate to a different page and come back while the
       inspector is open, and
   (3) When you close and reopen the inspector.

This fix addresses the three ways. Here&apos;s how:

   - For way (1), this happens because:
      a. The source sidebar has the logic to prune &quot;stale&quot; tree
         elements, which are elements that point to resources that no
         longer exists in the current frame. Reloading the webpage
         causes the main resource to change, which triggers this pruning
         logic. (Source: <a href="https://github.com/WebKit/WebKit/blob/c927c492d5b93193bc5cae300f1ca39eb36cd74c/Source/WebInspectorUI/UserInterface/Views/NavigationSidebarPanel.js#L507-L508)">https://github.com/WebKit/WebKit/blob/c927c492d5b93193bc5cae300f1ca39eb36cd74c/Source/WebInspectorUI/UserInterface/Views/NavigationSidebarPanel.js#L507-L508)</a>
      b. When adding a breakpoint to show, the source sidebar first
         checks if there already exists a tree element representing
         the breakpoint. So, when the page reloads and its breakpoints
         are added (again), they don&apos;t actually get new corresponding
         tree elements created (Source: <a href="https://github.com/WebKit/WebKit/blob/c927c492d5b93193bc5cae300f1ca39eb36cd74c/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js#L1407-L1408).">https://github.com/WebKit/WebKit/blob/c927c492d5b93193bc5cae300f1ca39eb36cd74c/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js#L1407-L1408).</a>
      c. The above two operations are in a race. If (a) occurs after
         (b), the _parents_ of the existing breakpoints will get pruned,
         since they now point to removed resources from the old webpage
         and are considered stale. Now, the reason (a) may happen after
         (b) is because NavigationSidebarPanel uses setTimeout to
         coalesce potentially-multiple calls of
         pruneStaleResourceTreeElements into just one, and setTimeout
         may put the call behind schedule. (Source: <a href="https://github.com/WebKit/WebKit/blob/27862391346cb4703757a860478d07f255cf5b57/Source/WebInspectorUI/UserInterface/Views/NavigationSidebarPanel.js#L645-L649)">https://github.com/WebKit/WebKit/blob/27862391346cb4703757a860478d07f255cf5b57/Source/WebInspectorUI/UserInterface/Views/NavigationSidebarPanel.js#L645-L649)</a>
     So the fix is to remove the coalescence/buffer for calling
     pruneStaleResourceTreeElements and always allow it to be called.
     This does mean we&apos;re potentially pruning many times in a short
     time, but since pruning is only done for the top-level elements in
     the tree outlines, there shouldn&apos;t be a significant number of them
     in most cases. (Pruning nested tree elements when resources are
     sorted By Path is done by the code here: <a href="https://github.com/WebKit/WebKit/blob/bd841a09536799b70842b7e0a7e84890e9853fce/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js#L1073-L1077)">https://github.com/WebKit/WebKit/blob/bd841a09536799b70842b7e0a7e84890e9853fce/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js#L1073-L1077)</a>

   - For way (2), this happens because, when updating the source code
     resource for a breakpoint, which can happen as a result of loading
     a page a second time, that update is skipped unless either the
     old resource or the new resource is null. (Source: <a href="https://github.com/WebKit/WebKit/blob/c927c492d5b93193bc5cae300f1ca39eb36cd74c/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js#L1668-L1669)">https://github.com/WebKit/WebKit/blob/c927c492d5b93193bc5cae300f1ca39eb36cd74c/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js#L1668-L1669)</a>
     The fix is to make it always allow breakpoints&apos; resources to be
     updated, since when reloading the same page the resources will have
     new object references in the frame, and those have no reason to be
     blocked from being updated.

   - For way (3), this happens because:
      a. When the inspector is opened, the DebuggerManager loads the
         list of saved breakpoints from object stores. The manager tries
         to show them in the sidebar by dispatching the BreakpointAdded
         events, but they fail to get added because the breakpoints
         don&apos;t have their linked source code resources yet. (Source: <a href="https://github.com/WebKit/WebKit/blob/c927c492d5b93193bc5cae300f1ca39eb36cd74c/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js#L128-L135)">https://github.com/WebKit/WebKit/blob/c927c492d5b93193bc5cae300f1ca39eb36cd74c/Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js#L128-L135)</a>
      b. When a resource gets loaded, it links all loaded breakpoints
         that belong to this resource and show them in the sidebar.
         The breakpoints now succeed to show up because they first get
         linked to their resource. (Source: <a href="https://github.com/WebKit/WebKit/blob/c927c492d5b93193bc5cae300f1ca39eb36cd74c/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js#L1187-L1188)">https://github.com/WebKit/WebKit/blob/c927c492d5b93193bc5cae300f1ca39eb36cd74c/Source/WebInspectorUI/UserInterface/Views/SourcesNavigationSidebarPanel.js#L1187-L1188)</a>
      c. The above two operations are in a race. If (a) occurs after
         (b), then during (b) there are no breakpoints loaded to link,
         and during (a) the loaded breakpoints can&apos;t get shown without
         linked resources.
     So the fix is, during (b), we also record the resource by its
     `contentIdentifier`, so in case (a) happens afterwards, we can
     look up the loaded resource to link to the loaded breakpoints so
     they can get added.

* Source/WebInspectorUI/UserInterface/Views/NavigationSidebarPanel.js:
(WI.NavigationSidebarPanel):
(WI.NavigationSidebarPanel.prototype.closed):
(WI.NavigationSidebarPanel.prototype.pruneStaleResourceTreeElements):
(WI.NavigationSidebarPanel.prototype._checkOutlinesForPendingViewStateCookie):
(WI.NavigationSidebarPanel.prototype._checkForStaleResourcesIfNeeded): Deleted.
(WI.NavigationSidebarPanel.prototype._checkForStaleResources): Deleted.
   - Remove the logic for coalescing multiple calls into
     pruneStaleResourceTreeElements. Pruning needs to happen immediately
     when conditions are met to prevent stale tree elements from being
     discovered by incoming breakpoints which will be removed by a later
     call to prune.

* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype._associateBreakpointsWithSourceCode):
* Source/WebInspectorUI/UserInterface/Models/SourceCodeLocation.js:
(WI.SourceCodeLocation.prototype.setSourceCode):
   - Always allow breakpoints&apos; linked-to resource to be updated since
     it might just be a newer reference to the same resource.
   - Move the `console.assert` into `setSourceCode` instead since it
     makes more sense being there instead.

* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype.breakpointsForSourceCode):
   - If existing breakpoints haven&apos;t been loaded yet, record the
     resource by its `contentIdentifier` for later linking the loaded
     breakpoints.

* Source/WebInspectorUI/UserInterface/Controllers/DebuggerManager.js:
(WI.DebuggerManager.prototype.constructor):
   - When a breakpoint is loaded, see if its resource has already been
     loaded to be linked.

Canonical link: <a href="https://commits.webkit.org/279884@main">https://commits.webkit.org/279884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93cce2f8f1482f901d9e58e62a9f2797707d9a28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/53746 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/33114 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/6263 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/57026 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/4471 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/40606 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/4316 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/57026 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/4471 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/55845 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/40606 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/6263 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/57026 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/40606 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/6263 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/2626 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/40606 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/6263 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/58621 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/28913 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/4316 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/58621 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30108 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/6263 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/58621 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12046 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31043 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/29887 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->