### PR TITLE
[WebCore] Add 1-character WidthCache array

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -326,7 +326,7 @@ float FontCascade::width(const TextRun& run, SingleThreadWeakHashSet<const Font>
         *cacheEntry = result;
     return result;
 }
-NEVER_INLINE float FontCascade::widthForSimpleTextSlow(StringView text, TextDirection textDirection, float* cacheEntry) const
+NEVER_INLINE float FontCascade::widthForTextUsingSimplifiedMeasuringSlow(StringView text, TextDirection textDirection, float* cacheEntry) const
 {
     GlyphBuffer glyphBuffer;
     Ref font = primaryFont();

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -140,6 +140,7 @@ public:
     float widthOfTextRange(const TextRun&, unsigned from, unsigned to, SingleThreadWeakHashSet<const Font>* fallbackFonts = nullptr, float* outWidthBeforeRange = nullptr, float* outWidthAfterRange = nullptr) const;
     WEBCORE_EXPORT float width(const TextRun&, SingleThreadWeakHashSet<const Font>* fallbackFonts = nullptr, GlyphOverflow* = nullptr) const;
     float widthForTextUsingSimplifiedMeasuring(StringView text, TextDirection = TextDirection::LTR) const;
+    float widthForTextUsingSimplifiedMeasuring(UChar character, TextDirection = TextDirection::LTR) const;
     WEBCORE_EXPORT float widthForSimpleTextWithFixedPitch(StringView text, bool whitespaceIsCollapsed) const;
 
     std::unique_ptr<TextLayout, TextLayoutDeleter> createLayout(RenderText&, float xPos, bool collapseWhiteSpace) const;
@@ -237,7 +238,7 @@ private:
     float widthForTextUsingWidthIterator(const TextRun&, SingleThreadWeakHashSet<const Font>* fallbackFonts = nullptr, GlyphOverflow* = nullptr) const;
     int offsetForPositionForSimpleText(const TextRun&, float position, bool includePartialGlyphs) const;
     void adjustSelectionRectForSimpleText(const TextRun&, LayoutRect& selectionRect, unsigned from, unsigned to) const;
-    WEBCORE_EXPORT float widthForSimpleTextSlow(StringView text, TextDirection, float*) const;
+    WEBCORE_EXPORT float widthForTextUsingSimplifiedMeasuringSlow(StringView text, TextDirection, float*) const;
 
     std::optional<GlyphData> getEmphasisMarkGlyphData(const AtomString&) const;
     const Font* fontForEmphasisMark(const AtomString&) const;
@@ -417,7 +418,17 @@ inline float FontCascade::widthForTextUsingSimplifiedMeasuring(StringView text, 
     if (cacheEntry && !std::isnan(*cacheEntry))
         return *cacheEntry;
 
-    return widthForSimpleTextSlow(text, textDirection, cacheEntry);
+    return widthForTextUsingSimplifiedMeasuringSlow(text, textDirection, cacheEntry);
+}
+
+inline float FontCascade::widthForTextUsingSimplifiedMeasuring(UChar character, TextDirection textDirection) const
+{
+    ASSERT(codePath(TextRun(StringView(std::span { &character, 1 }))) != CodePath::Complex);
+    float* cacheEntry = protectedFonts()->widthCache().addSingleChar(character, std::numeric_limits<float>::quiet_NaN());
+    if (cacheEntry && !std::isnan(*cacheEntry))
+        return *cacheEntry;
+
+    return widthForTextUsingSimplifiedMeasuringSlow(StringView(std::span { &character, 1 }), textDirection, cacheEntry);
 }
 
 bool shouldSynthesizeSmallCaps(bool, const Font*, char32_t, std::optional<char32_t>, FontVariantCaps, bool);

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
@@ -171,7 +171,7 @@ std::tuple<unsigned, UChar> SVGTextMetricsBuilder::measureTextRenderer(RenderSVG
                 if ((valueListPosition + i - skippedCharacters + 1) == defaultPosition)
                     attributes->characterDataMap().set(i + 1, characterData);
 
-                float width = scaledFont.widthForTextUsingSimplifiedMeasuring(view.substring(i, 1), TextDirection::LTR);
+                float width = scaledFont.widthForTextUsingSimplifiedMeasuring(currentCharacter, TextDirection::LTR);
                 float scaledWidth = width / scalingFactor;
                 textMetricsValues->append(SVGTextMetrics(1, scaledWidth, scaledHeight));
                 lastCharacter = currentCharacter;


### PR DESCRIPTION
#### 26c85c6e4e5229b2db2a9c0691aac7ca413b5297
<pre>
[WebCore] Add 1-character WidthCache array
<a href="https://bugs.webkit.org/show_bug.cgi?id=272361">https://bugs.webkit.org/show_bug.cgi?id=272361</a>
<a href="https://rdar.apple.com/126105088">rdar://126105088</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::widthForTextUsingSimplifiedMeasuringSlow const):
(WebCore::FontCascade::widthForSimpleTextSlow const): Deleted.
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::widthForTextUsingSimplifiedMeasuring const):
* Source/WebCore/platform/graphics/WidthCache.h:
(WebCore::WidthCache::SingleCharArray::SingleCharArray):
(WebCore::WidthCache::addSingleChar):
(WebCore::WidthCache::add):
(WebCore::WidthCache::clear):
(WebCore::WidthCache::addSingleCharSlowCase):
(WebCore::WidthCache::addSlowCase):
(WebCore::WidthCache::WidthCache): Deleted.
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp:
(WebCore::SVGTextMetricsBuilder::measureTextRenderer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26c85c6e4e5229b2db2a9c0691aac7ca413b5297

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43091 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49351 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23680 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38317 "Found 13 new test failures: fast/css/text-overflow-ellipsis-text-align-justify.html, fast/css/text-overflow-ellipsis-text-align-left.html, fast/css/text-overflow-ellipsis-text-align-right.html, fast/css/vertical-text-overflow-ellipsis-text-align-center-mixed.html, fast/css/vertical-text-overflow-ellipsis-text-align-center.html, fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html, fast/css/vertical-text-overflow-ellipsis-text-align-justify.html, fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html, fast/css/vertical-text-overflow-ellipsis-text-align-left.html, fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47625 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23673 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 16 new passes 7 flakes 7 failures; Uploaded test results; Running re-run-layout-tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19626 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21040 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41683 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 16 flakes 7 failures; Uploaded test results; 9 flakes 7 failures; Running compile-webkit-without-change") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5089 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43432 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42078 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 22 flakes 7 failures; Uploaded test results; 13 flakes 7 failures; Running compile-webkit-without-change") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51603 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22066 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18434 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 9 flakes 6 failures; Uploaded test results; Running re-run-layout-tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45613 "Found 12 new test failures: fast/css/text-overflow-ellipsis-text-align-justify.html, fast/css/text-overflow-ellipsis-text-align-left.html, fast/css/text-overflow-ellipsis-text-align-right.html, fast/css/vertical-text-overflow-ellipsis-text-align-center.html, fast/css/vertical-text-overflow-ellipsis-text-align-justify-mixed.html, fast/css/vertical-text-overflow-ellipsis-text-align-justify.html, fast/css/vertical-text-overflow-ellipsis-text-align-left-mixed.html, fast/css/vertical-text-overflow-ellipsis-text-align-left.html, fast/css/vertical-text-overflow-ellipsis-text-align-right-mixed.html, fast/css/vertical-text-overflow-ellipsis-text-align-right.html ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23345 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44607 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24125 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->