### PR TITLE
Fix an issue with the background page trying to message full page extension content

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -254,6 +254,7 @@ bool WebExtensionTab::extensionHasAccess() const
 bool WebExtensionTab::extensionHasPermission() const
 {
     ASSERT(extensionHasAccess());
+
     return extensionContext()->hasPermission(url(), const_cast<WebExtensionTab*>(this));
 }
 


### PR DESCRIPTION
#### 3b08a55102c5ec79db58f6aec9d18056b86c5425
<pre>
Fix an issue with the background page trying to message full page extension content
<a href="https://bugs.webkit.org/show_bug.cgi?id=272362">https://bugs.webkit.org/show_bug.cgi?id=272362</a>
<a href="https://rdar.apple.com/125996453">rdar://125996453</a>

Reviewed by Timothy Hatcher.

When an extension was trying to send a message from a background page to a tab with full page extension content, we were treating
the message as going to a content script and sending it to a non-main world, which led to a crash.

Additionally, we want to block an extension from sending a message to a tab showing full page content for a different extension. One
extension should have no idea about another&apos;s content.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsSendMessage):
(WebKit::WebExtensionContext::tabsConnect):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::extensionHasPermission const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundPageToFullPageExtensionContent)):

Canonical link: <a href="https://commits.webkit.org/277240@main">https://commits.webkit.org/277240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abda49bd630c9a51fde968d2b184532294492696

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49765 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43131 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49388 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23717 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38347 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47662 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23721 "Found 1 new test failure: http/tests/download/sandboxed-iframe-download-allowed-in-popup.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40575 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19655 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21098 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41724 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5126 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43461 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51640 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22105 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45641 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23383 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44647 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24165 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6612 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->