### PR TITLE
[ iOS ] 3x editing/spelling/* (layout-tests) are constant failures

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7285,11 +7285,6 @@ webkit.org/b/217669 http/wpt/service-workers/service-worker-spinning-pushsubscri
 
 webkit.org/b/217759 media/now-playing-status-without-media.html [ Pass Failure ]
 
-# rdar://125585822 ([ iOS ] 3x editing/spelling/* (layout-tests) are constant failures (271864))
-editing/spelling/document-markers-remain-after-removing-text.html [ Failure ]
-editing/spelling/grammar-and-spelling-error-styling.html [ ImageOnlyFailure ]
-editing/spelling/spellcheck-attribute-toggle.html [ ImageOnlyFailure ]
-
 # webkit.org/b/209139 fast/canvas/webgl/webgl-clear-composited-notshowing.html [ Failure ]
 
 webkit.org/b/224121 css2.1/20110323/replaced-intrinsic-ratio-001.htm [ Pass Failure ]

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -6901,11 +6901,7 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
     if (_focusedElementInformation.hasEverBeenPasswordField) {
         if ([privateTraits respondsToSelector:@selector(setLearnsCorrections:)])
             privateTraits.learnsCorrections = NO;
-#if USE(BROWSERENGINEKIT)
         extendedTraits.typingAdaptationEnabled = NO;
-#else
-        extendedTraits.typingAdaptationDisabled = YES;
-#endif
     }
 
     if ([privateTraits respondsToSelector:@selector(setShortcutConversionType:)])
@@ -13044,7 +13040,10 @@ inline static NSString *extendSelectionCommand(UITextLayoutDirection direction)
     if (!_extendedTextInputTraits)
         _extendedTextInputTraits = adoptNS([WKExtendedTextInputTraits new]);
 
-    if (!_isBlurringFocusedElement)
+    if (!self._hasFocusedElement && !_isFocusingElementWithKeyboard) {
+        [_extendedTextInputTraits restoreDefaultValues];
+        [_extendedTextInputTraits setSelectionColorsToMatchTintColor:[self _cascadeInteractionTintColor]];
+    } else if (!_isBlurringFocusedElement)
         [self _updateTextInputTraits:_extendedTextInputTraits.get()];
 
     return _extendedTextInputTraits.get();

--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h
@@ -49,25 +49,18 @@
 @property (nonatomic) UIReturnKeyType returnKeyType;
 @property (nonatomic, getter=isSecureTextEntry) BOOL secureTextEntry;
 @property (nonatomic, getter=isSingleLineDocument) BOOL singleLineDocument;
-#if USE(BROWSERENGINEKIT)
 @property (nonatomic, getter=isTypingAdaptationEnabled) BOOL typingAdaptationEnabled;
-#else
-@property (nonatomic) BOOL typingAdaptationDisabled;
-#endif
 @property (nonatomic, copy) UITextContentType textContentType;
 @property (nonatomic, copy) UITextInputPasswordRules *passwordRules;
 @property (nonatomic) UITextSmartInsertDeleteType smartInsertDeleteType;
 @property (nonatomic) BOOL enablesReturnKeyAutomatically;
 
 @property (nonatomic, strong) UIColor *insertionPointColor;
-#if USE(BROWSERENGINEKIT)
 @property (nonatomic, strong) UIColor *selectionHandleColor;
-#else
-@property (nonatomic, strong) UIColor *selectionBarColor;
-#endif
 @property (nonatomic, strong) UIColor *selectionHighlightColor;
 
 - (void)setSelectionColorsToMatchTintColor:(UIColor *)tintColor;
+- (void)restoreDefaultValues;
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
@@ -43,9 +43,7 @@
     if (!(self = [super init]))
         return nil;
 
-#if USE(BROWSERENGINEKIT)
     self.typingAdaptationEnabled = YES;
-#endif
     self.autocapitalizationType = UITextAutocapitalizationTypeSentences;
     return self;
 }
@@ -80,8 +78,6 @@
     return _insertionPointColor.get();
 }
 
-#if USE(BROWSERENGINEKIT)
-
 - (void)setSelectionHandleColor:(UIColor *)color
 {
     _selectionHandleColor = color;
@@ -91,20 +87,6 @@
 {
     return _selectionHandleColor.get();
 }
-
-#else
-
-- (void)setSelectionBarColor:(UIColor *)color
-{
-    _selectionHandleColor = color;
-}
-
-- (UIColor *)selectionBarColor
-{
-    return _selectionHandleColor.get();
-}
-
-#endif
 
 - (void)setSelectionHighlightColor:(UIColor *)color
 {
@@ -121,12 +103,33 @@
     static constexpr auto selectionHighlightAlphaComponent = 0.2;
     BOOL shouldUseTintColor = tintColor && tintColor != UIColor.systemBlueColor;
     self.insertionPointColor = shouldUseTintColor ? tintColor : nil;
-#if USE(BROWSERENGINEKIT)
     self.selectionHandleColor = shouldUseTintColor ? tintColor : nil;
-#else
-    self.selectionBarColor = shouldUseTintColor ? tintColor : nil;
-#endif
     self.selectionHighlightColor = shouldUseTintColor ? [tintColor colorWithAlphaComponent:selectionHighlightAlphaComponent] : nil;
+}
+
+- (void)restoreDefaultValues
+{
+    self.typingAdaptationEnabled = YES;
+#if HAVE(INLINE_PREDICTIONS)
+    self.inlinePredictionType = UITextInlinePredictionTypeDefault;
+#endif
+    self.autocapitalizationType = UITextAutocapitalizationTypeSentences;
+    self.autocorrectionType = UITextAutocorrectionTypeDefault;
+    self.spellCheckingType = UITextSpellCheckingTypeDefault;
+    self.smartQuotesType = UITextSmartQuotesTypeDefault;
+    self.smartDashesType = UITextSmartDashesTypeDefault;
+    self.keyboardType = UIKeyboardTypeDefault;
+    self.keyboardAppearance = UIKeyboardAppearanceDefault;
+    self.returnKeyType = UIReturnKeyDefault;
+    self.secureTextEntry = NO;
+    self.singleLineDocument = NO;
+    self.textContentType = nil;
+    self.passwordRules = nil;
+    self.smartInsertDeleteType = UITextSmartInsertDeleteTypeDefault;
+    self.enablesReturnKeyAutomatically = NO;
+    self.insertionPointColor = nil;
+    self.selectionHandleColor = nil;
+    self.selectionHighlightColor = nil;
 }
 
 @end


### PR DESCRIPTION
#### 697b1a86cea65c70aa013ce7402a16a516181baf
<pre>
[ iOS ] 3x editing/spelling/* (layout-tests) are constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=271864">https://bugs.webkit.org/show_bug.cgi?id=271864</a>
<a href="https://rdar.apple.com/125585822">rdar://125585822</a>

Reviewed by Aditya Keerthi.

Among the many other changes to adopt `BETextInput`, iOS 17.4 refactored `WKContentView` to stop
relying on the UIKit internal method `-_requiresKeyboardWhenFirstResponder`. Instead, UIKit now
returns `YES` when the delegate is a `BETextInput`, as long as either of the following are true:

1. The hardware keyboard is connected.
2. An editable element is focused.

However, a consequence of this refactoring is that `WKContentView` now vends text input traits to
keyboard code in UIKit when a hardware keyboard is attached, even in the case where there is no
focused element. In practice, this doesn&apos;t really matter, since these text input traits (which
contain `UITextAutocorrectionTypeNo`) are effectively unused. However, in the case of these three
layout tests that programmatically focus text inputs, insert text, and expect spellchecking to
occur outside of the context of any input session, we end up failing because the spelling
corrections are disabled by the traits.

To fix this, restore pre-iOS 17.4 behavior by reverting to `WKExtendedTextInputTraits`&apos;s default
values when no element is focused (or being focused). Namely, this ensures that the autocorrection
type is set to `UITextAutocorrectionTypeDefault`, which matches shipping behavior in the case when
the user isn&apos;t focusing anything editable, but still enables continuous spellchecking when
programmatically inserting text.

* LayoutTests/platform/ios/TestExpectations:

Mark these layout test as passing again.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateTextInputTraits:]):
(-[WKContentView extendedTraitsDelegate]):

See above for more details.

* Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h:
* Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm:
(-[WKExtendedTextInputTraits init]):
(-[WKExtendedTextInputTraits setSelectionColorsToMatchTintColor:]):
(-[WKExtendedTextInputTraits restoreDefaultValues]):

Add a new method to restore all default text input traits.

(-[WKExtendedTextInputTraits setSelectionBarColor:]): Deleted.
(-[WKExtendedTextInputTraits selectionBarColor]): Deleted.

Remove some old versions of the `UIAsyncTextInput` implementation that are no longer necessary,
since they&apos;ve all been superceded by `BETextInput`.

Canonical link: <a href="https://commits.webkit.org/277233@main">https://commits.webkit.org/277233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41e070e92f75bd5f4b03f4501805759abc7076f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49734 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43098 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38319 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19629 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21050 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41689 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5096 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51610 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22073 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18435 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 7 flakes 2 failures; Uploaded test results; Running re-run-layout-tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45614 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23352 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44608 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10387 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24132 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23065 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->