### PR TITLE
Regression(277164@main) Crash under UserAgentStyle::initDefaultStyleSheet()

### DIFF
--- a/Source/WebCore/css/make-css-file-arrays.pl
+++ b/Source/WebCore/css/make-css-file-arrays.pl
@@ -67,11 +67,11 @@ for my $in (@ARGV) {
     # Write out a C array of the characters.
     my $length = length $text;
     if ($in =~ /(\w+)\.css$/) {
-        print HEADER "extern const char ${name}UserAgentStyleSheet[${length}];\n";
-        print OUT "extern const char ${name}UserAgentStyleSheet[${length}] = {\n";
+        print HEADER "extern const std::array<const char, ${length}> ${name}UserAgentStyleSheet;\n";
+        print OUT "extern const std::array<const char, ${length}> ${name}UserAgentStyleSheet = {\n";
     } else {
-        print HEADER "extern const char ${name}JavaScript[${length}];\n";
-        print OUT "extern const char ${name}JavaScript[${length}] = {\n";
+        print HEADER "extern const std::array<const char, ${length}> ${name}JavaScript;\n";
+        print OUT "extern const std::array<const char, ${length}> ${name}JavaScript = {\n";
     }
     my $i = 0;
     while ($i < $length) {

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -181,7 +181,7 @@ void UserAgentStyle::initDefaultStyleSheet()
     if (extraDefaultStyleSheet.isEmpty())
         defaultRules = StringImpl::createWithoutCopying(htmlUserAgentStyleSheet);
     else
-        defaultRules = makeString(htmlUserAgentStyleSheet, extraDefaultStyleSheet);
+        defaultRules = makeString(std::span { htmlUserAgentStyleSheet }, extraDefaultStyleSheet);
     defaultStyleSheet = parseUASheet(defaultRules);
     addToDefaultStyle(*defaultStyleSheet);
 
@@ -191,7 +191,7 @@ void UserAgentStyle::initDefaultStyleSheet()
     if (extraQuirksStyleSheet.isEmpty())
         quirksRules = StringImpl::createWithoutCopying(quirksUserAgentStyleSheet);
     else
-        quirksRules = makeString(quirksUserAgentStyleSheet, extraQuirksStyleSheet);
+        quirksRules = makeString(std::span { quirksUserAgentStyleSheet }, extraQuirksStyleSheet);
     quirksStyleSheet = parseUASheet(quirksRules);
 
     RuleSetBuilder quirkBuilder(*defaultQuirksStyle, screenEval());

--- a/Source/WebKit/NetworkProcess/soup/WebKitDirectoryInputStream.cpp
+++ b/Source/WebKit/NetworkProcess/soup/WebKitDirectoryInputStream.cpp
@@ -47,8 +47,8 @@ static GBytes* webkitDirectoryInputStreamCreateHeader(WebKitDirectoryInputStream
         "<html><head>"
         "<title>%s</title>"
         "<meta http-equiv=\"Content-Type\" content=\"text/html;\" charset=\"UTF-8\">"
-        "<style>%s</style>"
-        "<script>%s</script>"
+        "<style>%.*s</style>"
+        "<script>%.*s</script>"
         "</head>"
         "<body>"
         "<table>"
@@ -56,8 +56,10 @@ static GBytes* webkitDirectoryInputStreamCreateHeader(WebKitDirectoryInputStream
         "<th align=\"left\">%s</th><th align=\"right\">%s</th><th align=\"right\">%s</th>"
         "</thead>",
         stream->priv->uri.data(),
-        WebCore::directoryUserAgentStyleSheet,
-        WebCore::directoryJavaScript,
+        static_cast<int>(WebCore::directoryUserAgentStyleSheet.size()),
+        WebCore::directoryUserAgentStyleSheet.data(),
+        static_cast<int>(WebCore::directoryJavaScript.size()),
+        WebCore::directoryJavaScript.data(),
         _("Name"),
         _("Size"),
         _("Date Modified"));


### PR DESCRIPTION
#### ad622ae6c2ebbcc1f06d96fddb2d13565f4d6bab
<pre>
Regression(277164@main) Crash under UserAgentStyle::initDefaultStyleSheet()
<a href="https://bugs.webkit.org/show_bug.cgi?id=272363">https://bugs.webkit.org/show_bug.cgi?id=272363</a>

Reviewed by Sihui Liu.

In 277164@main, I made an minor optimization attempt in UserAgentStyle::initDefaultStyleSheet(),
to try to avoid constructing a StringImpl of the stylesheet when we end up calling makeString()
to concatenate later on.

This caused a crash because the stylesheets are of `const char[]` type and are NOT null
terminated. My intention was to construct a std::span from those arrays but I failed to do it
explicitly and it didn&apos;t happen implicitly.

To make this less error-prone, I am now using std::array&lt;const char&gt; for these stylesheets,
to avoid the implicit conversion to `const char*`, which is too error-prone given the lack of
null terminator.

* Source/WebCore/css/make-css-file-arrays.pl:
* Source/WebCore/style/UserAgentStyle.cpp:
(WebCore::Style::UserAgentStyle::initDefaultStyleSheet):

Canonical link: <a href="https://commits.webkit.org/277231@main">https://commits.webkit.org/277231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f269f2d69fe942b994f50138add22f5a3275715

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26222 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43099 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23688 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38321 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 40 flakes 82 failures; Uploaded test results; 21 flakes 56 failures; Running compile-webkit-without-change") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47633 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23682 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19631 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21052 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41688 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5097 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42088 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51611 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22074 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45616 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23353 "Built successfully") | | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44615 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; Running re-run-api-tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24133 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6607 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->