### PR TITLE
[Site Isolation] `WebProcessProxy::pages()` should include remote pages

### DIFF
--- a/LayoutTests/http/tests/site-isolation/paste-in-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/paste-in-iframe-expected.txt
@@ -3,7 +3,7 @@ Tests that the iframe is able to receive paste events.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS event.data is 'onpaste'
+PASS event.data is 'Text to be copied and pasted'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/site-isolation/paste-in-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/paste-in-iframe.html
@@ -5,7 +5,7 @@ description("Tests that the iframe is able to receive paste events.");
 jsTestIsAsync = true;
 
 addEventListener("message", (event) => {
-    shouldBe("event.data", "'onpaste'");
+    shouldBe("event.data", "'Text to be copied and pasted'");
     finishJSTest();
 });
 </script>

--- a/LayoutTests/http/tests/site-isolation/resources/copy-and-paste-text.html
+++ b/LayoutTests/http/tests/site-isolation/resources/copy-and-paste-text.html
@@ -1,8 +1,7 @@
 <p>Text to be copied and pasted</p>
 <script>
 onpaste = (event) => {
-    // FIXME: This should send the pasted text.
-    window.parent.postMessage("onpaste", "*");
+    window.parent.postMessage(event.clipboardData.getData('text/plain'), "*");
 }
 
 onload = () => {

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -649,16 +649,6 @@ std::optional<DataOwnerType> WebPasteboardProxy::determineDataOwner(IPC::Connect
         }
     }
 
-    for (WeakPtr<RemotePageProxy> remotePage : process->remotePages()) {
-        if (!remotePage)
-            continue;
-
-        RefPtr page = remotePage->page();
-        if (page && page->webPageID() == *pageID) {
-            result = page->dataOwnerForPasteboard(intent);
-            break;
-        }
-    }
     // If this message check is hit, then the incoming web page ID doesn't correspond to any page
     // currently known to the UI process.
     MESSAGE_CHECK_WITH_RETURN_VALUE(result.has_value(), std::nullopt);

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -223,6 +223,7 @@ public:
     void removeRemotePageProxy(RemotePageProxy&);
 
     Vector<Ref<WebPageProxy>> pages() const;
+    Vector<Ref<WebPageProxy>> mainPages() const;
     unsigned pageCount() const { return m_pageMap.size(); }
     unsigned provisionalPageCount() const { return m_provisionalPages.computeSize(); }
     unsigned visiblePageCount() const { return m_visiblePageCounter.value(); }


### PR DESCRIPTION
#### 969d08bfde0bea8664a95499a6e9e7e4710d8b8b
<pre>
[Site Isolation] `WebProcessProxy::pages()` should include remote pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=272365">https://bugs.webkit.org/show_bug.cgi?id=272365</a>
<a href="https://rdar.apple.com/126107383">rdar://126107383</a>

Reviewed by Alex Christensen.

If a web process was not hosting the main frame we would not allow pasteboard access in
`WebPasteboardProxy::accessType()`.

* LayoutTests/http/tests/site-isolation/paste-in-iframe-expected.txt:
* LayoutTests/http/tests/site-isolation/paste-in-iframe.html:
* LayoutTests/http/tests/site-isolation/resources/copy-and-paste-text.html:
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::determineDataOwner const):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::pages const):
(WebKit::WebProcessProxy::mainPages const):
(WebKit::WebProcessProxy::shutDown):
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):
(WebKit::WebProcessProxy::didFinishLaunching):
* Source/WebKit/UIProcess/WebProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/277280@main">https://commits.webkit.org/277280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/217636bdec47d682adfe2aae96038098d418abc4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49861 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43227 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38436 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19748 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41819 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5222 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51737 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45730 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23480 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44738 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24266 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6639 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23197 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->