### PR TITLE
Use correct top origin when checking firstPartyForCookies with site isolation enabled

### DIFF
--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -484,8 +484,6 @@ http/tests/site-isolation/selection-focus.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/top-level-data-url.window.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/windows/nested-browsing-contexts/name-attribute.window.html [ Skip ]
-imported/w3c/web-platform-tests/html/browsers/windows/post-message/third-party-to-first-party-cross-partition-cross-origin.sub.html [ Skip ]
-imported/w3c/web-platform-tests/html/browsers/windows/post-message/third-party-to-first-party-cross-partition-same-origin.sub.html [ Skip ]
 
 #######################
 # Tests that time out #
@@ -1139,6 +1137,8 @@ imported/w3c/web-platform-tests/html/browsers/windows/post-message/first-party-t
 imported/w3c/web-platform-tests/html/browsers/windows/post-message/first-party-to-first-party-same-partition.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/windows/post-message/first-party-to-third-party-cross-partition-cross-origin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/windows/post-message/first-party-to-third-party-cross-partition-same-origin.sub.html [ Skip ]
+imported/w3c/web-platform-tests/html/browsers/windows/post-message/third-party-to-first-party-cross-partition-cross-origin.sub.html [ Skip ]
+imported/w3c/web-platform-tests/html/browsers/windows/post-message/third-party-to-first-party-cross-partition-same-origin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/windows/post-message/third-party-to-third-party-cross-partition-cross-origin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/windows/post-message/third-party-to-third-party-cross-partition-same-origin.sub.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/windows/post-message/third-party-to-third-party-same-partition.sub.html [ Skip ]

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -977,6 +977,22 @@ Ref<SecurityOrigin> Document::protectedTopOrigin() const
     return topOrigin();
 }
 
+SecurityOrigin& Document::topOrigin() const
+{
+    // Keep exact pre-site-isolation behavior to avoid risking changing behavior when site isolation is not enabled.
+    if (!settings().siteIsolationEnabled())
+        return topDocument().securityOrigin();
+
+    RefPtr frame = this->frame();
+    if (RefPtr localMainFrame = frame ? dynamicDowncast<LocalFrame>(frame->mainFrame()) : nullptr) {
+        if (RefPtr mainFrameDocument = localMainFrame->document())
+            return mainFrameDocument->securityOrigin();
+    }
+    if (RefPtr page = this->page())
+        return page->mainFrameOrigin();
+    return SecurityOrigin::opaqueOrigin();
+}
+
 inline DocumentFontLoader& Document::fontLoader()
 {
     ASSERT(m_constructionDidFinish);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1577,7 +1577,7 @@ public:
 
     SecurityOrigin& securityOrigin() const { return *SecurityContext::securityOrigin(); }
     inline Ref<SecurityOrigin> protectedSecurityOrigin() const; // Defined in DocumentInlines.h.
-    SecurityOrigin& topOrigin() const final { return topDocument().securityOrigin(); }
+    WEBCORE_EXPORT SecurityOrigin& topOrigin() const final;
     Ref<SecurityOrigin> protectedTopOrigin() const;
     inline ClientOrigin clientOrigin() const;
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -730,6 +730,14 @@ void Page::setMainFrame(Ref<Frame>&& frame)
 void Page::setMainFrameURL(const URL& url)
 {
     m_mainFrameURL = url;
+    m_mainFrameOrigin = SecurityOrigin::create(url);
+}
+
+SecurityOrigin& Page::mainFrameOrigin() const
+{
+    if (!m_mainFrameOrigin)
+        return SecurityOrigin::opaqueOrigin();
+    return *m_mainFrameOrigin;
 }
 
 bool Page::openedByDOM() const

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -333,6 +333,7 @@ public:
     WEBCORE_EXPORT Ref<Frame> protectedMainFrame() const;
     WEBCORE_EXPORT void setMainFrame(Ref<Frame>&&);
     const URL& mainFrameURL() const { return m_mainFrameURL; }
+    SecurityOrigin& mainFrameOrigin() const;
     WEBCORE_EXPORT void setMainFrameURL(const URL&);
 
     bool openedByDOM() const;
@@ -1202,6 +1203,7 @@ private:
     UniqueRef<EditorClient> m_editorClient;
     Ref<Frame> m_mainFrame;
     URL m_mainFrameURL;
+    RefPtr<SecurityOrigin> m_mainFrameOrigin;
 
     RefPtr<PluginData> m_pluginData;
 

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -208,6 +208,12 @@ Ref<SecurityOrigin> SecurityOrigin::createOpaque()
     return origin;
 }
 
+SecurityOrigin& SecurityOrigin::opaqueOrigin()
+{
+    static NeverDestroyed<Ref<SecurityOrigin>> origin { createOpaque() };
+    return origin.get();
+}
+
 Ref<SecurityOrigin> SecurityOrigin::createNonLocalWithAllowedFilePath(const URL& url, const String& filePath)
 {
     ASSERT(!url.protocolIsFile());

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -50,6 +50,7 @@ public:
     WEBCORE_EXPORT static Ref<SecurityOrigin> create(const URL&);
     WEBCORE_EXPORT static Ref<SecurityOrigin> createForBlobURL(const URL&);
     WEBCORE_EXPORT static Ref<SecurityOrigin> createOpaque();
+    static SecurityOrigin& opaqueOrigin();
 
     WEBCORE_EXPORT static Ref<SecurityOrigin> createFromString(const String&);
     WEBCORE_EXPORT static Ref<SecurityOrigin> create(const String& protocol, const String& host, std::optional<uint16_t> port);

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1974,7 +1974,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
 {
     RegistrableDomain registrableDomain { navigation.currentRequest().url() };
     if (page.preferences().siteIsolationEnabled() && !registrableDomain.isEmpty()) {
-        RegistrableDomain mainFrameDomain(URL(page.pageLoadState().activeURL()));
+        auto mainFrameDomain = frameInfo.isMainFrame ? registrableDomain : RegistrableDomain(URL(page.pageLoadState().activeURL()));
         if (!frame.isMainFrame() && registrableDomain == mainFrameDomain) {
             Ref mainFrameProcess = page.mainFrame()->protectedProcess();
             if (!mainFrameProcess->isInProcessCache())


### PR DESCRIPTION
#### e8a014af82e87656aefc463f85ffb0e1e386b5bf
<pre>
Use correct top origin when checking firstPartyForCookies with site isolation enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=272373">https://bugs.webkit.org/show_bug.cgi?id=272373</a>
<a href="https://rdar.apple.com/126114826">rdar://126114826</a>

Reviewed by Charlie Wolfe and Sihui Liu.

There were two issues here:

1. Document::topOrigin was using topDocument() to get the SecurityOrigin, and with site isolation
enabled the top document isn&apos;t necessarily the main frame&apos;s Document.  Instead, use a strategy
like we do with mainFrameURL where the Page has the main frame&apos;s origin in all processes, whether
the main frame is remote or not.

2. In WebProcessPool::processForNavigation when navigating the main frame, use the RegistrableDomain
from the navigation instead of the PageLoadState, which may not have the activeURL yet.

With these 2 changes, we stop getting failures in NetworkProcess::allowsFirstPartyForCookies in 2 tests
when run with --site-isolation.  The tests change from crashes to regular time-outs.

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::topOrigin const):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setMainFrameURL):
(WebCore::Page::mainFrameOrigin const):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::opaqueOrigin):
* Source/WebCore/page/SecurityOrigin.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):

Canonical link: <a href="https://commits.webkit.org/277331@main">https://commits.webkit.org/277331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4d167ca403e89aac9ae3f2f89c7a1e5d2b0e256

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43398 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23989 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38553 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47930 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41970 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5393 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43703 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51908 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22380 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18719 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45856 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23654 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24440 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6667 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->