### PR TITLE
Adopt std::span in HTMLParserIdioms.cpp

### DIFF
--- a/Source/WebCore/html/parser/ParsingUtilities.h
+++ b/Source/WebCore/html/parser/ParsingUtilities.h
@@ -50,6 +50,15 @@ template<typename CharacterType, typename DelimiterType> bool skipExactly(const 
     return false;
 }
 
+template<typename CharacterType, typename DelimiterType> bool skipExactly(std::span<const CharacterType>& data, DelimiterType delimiter)
+{
+    if (!data.empty() && data.front() == delimiter) {
+        data = data.subspan(1);
+        return true;
+    }
+    return false;
+}
+
 template<typename CharacterType, typename DelimiterType> bool skipExactly(StringParsingBuffer<CharacterType>& buffer, DelimiterType delimiter)
 {
     if (buffer.hasCharactersRemaining() && *buffer == delimiter) {
@@ -147,6 +156,18 @@ template<bool characterPredicate(UChar)> void skipWhile(const UChar*& position, 
 {
     while (position < end && characterPredicate(*position))
         ++position;
+}
+
+template<bool characterPredicate(LChar)> void skipWhile(std::span<const LChar>& data)
+{
+    while (!data.empty() && characterPredicate(data.front()))
+        data = data.subspan(1);
+}
+
+template<bool characterPredicate(UChar)> void skipWhile(std::span<const UChar>& data)
+{
+    while (!data.empty() && characterPredicate(data.front()))
+        data = data.subspan(1);
 }
 
 template<bool characterPredicate(LChar)> void skipWhile(StringParsingBuffer<LChar>& buffer)


### PR DESCRIPTION
#### 0f5f1f492230ba3b45fa3f5ce17d780696b1ad57
<pre>
Adopt std::span in HTMLParserIdioms.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=272374">https://bugs.webkit.org/show_bug.cgi?id=272374</a>

Reviewed by Anne van Kesteren and Darin Adler.

* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(WebCore::parseHTMLIntegerInternal):
(WebCore::parseHTMLInteger):
(WebCore::parseValidHTMLNonNegativeIntegerInternal):
(WebCore::parseValidHTMLNonNegativeInteger):
(WebCore::parseHTMLListOfOfFloatingPointNumberValuesInternal):
(WebCore::parseHTMLListOfOfFloatingPointNumberValues):
(WebCore::parseHTTPRefreshInternal):
(WebCore::parseMetaHTTPEquivRefresh):
(WebCore::parseHTMLDimensionNumber):
(WebCore::parseHTMLDimensionInternal):
* Source/WebCore/html/parser/ParsingUtilities.h:
(WebCore::skipExactly):
(WebCore::characterPredicate):

Canonical link: <a href="https://commits.webkit.org/277244@main">https://commits.webkit.org/277244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a1625de40c044d0595fef0795c9eb3d935093d2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49760 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43126 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38343 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41709 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43453 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51635 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45638 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23378 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44646 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24160 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6615 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->