### PR TITLE
Exclude -apple-pay-button from applying to any element that supports appearance: auto and is not a button

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -301,6 +301,8 @@ accessibility/ax-thread-text-apis [ Skip ]
 
 # ApplePay is only available on iOS (greater than iOS 10) and macOS (greater than macOS 10.12) and only for WebKit2.
 fast/css/appearance-apple-pay-button.html [ Skip ]
+fast/css/appearance-apple-pay-button-div.html [ Skip ]
+fast/css/appearance-apple-pay-button-input-type-button.html [ Skip ]
 fast/css/appearance-apple-pay-button-border-radius.html [ Skip ]
 fast/css/appearance-apple-pay-button-border-radius-longhands.html [ Skip ]
 fast/css/appearance-apple-pay-button-border-width.html [ Skip ]

--- a/LayoutTests/fast/css/appearance-apple-pay-button-div-expected.html
+++ b/LayoutTests/fast/css/appearance-apple-pay-button-div-expected.html
@@ -1,0 +1,51 @@
+<style>
+    .container {
+        position: relative;
+        background-color: silver;
+        padding: 25px;
+        width: 500px;
+    }
+
+    .apple-pay-button-div {
+        display: block;
+        margin: 25px;
+        height: 100px;
+        width: 400px;
+    }
+
+    .masker {
+        position: absolute;
+        width: 200px;
+        height: 80px;
+        background-color: blue;
+    }
+
+    .corner-mask {
+        position: absolute;
+        width: 20px;
+        height: 20px;
+        background-color: blue;
+    }
+</style>
+
+<div class="container">
+    <div style="background-color: black;" class="apple-pay-button-div"></div>
+    <div style="background-color: white;" class="apple-pay-button-div"></div>
+    <div style="background-color: black;" class="apple-pay-button-div"></div>
+    <div style="background-color: white;" class="apple-pay-button-div"></div>
+
+    <div class="masker" style="top: 60px; left: 150px"></div>
+    <div class="masker" style="top: 185px; left: 150px"></div>
+    <div class="masker" style="top: 310px; left: 150px"></div>
+    <div class="masker" style="top: 435px; left: 150px"></div>
+
+    <div class="corner-mask" style="top: 45px; left: 45px"></div>
+    <div class="corner-mask" style="top: 135px; left: 45px"></div>
+    <div class="corner-mask" style="top: 45px; left: 435px"></div>
+    <div class="corner-mask" style="top: 135px; left: 435px"></div>
+
+    <div class="corner-mask" style="top: 170px; left: 45px"></div>
+    <div class="corner-mask" style="top: 260px; left: 45px"></div>
+    <div class="corner-mask" style="top: 170px; left: 435px"></div>
+    <div class="corner-mask" style="top: 260px; left: 435px"></div>
+</div>

--- a/LayoutTests/fast/css/appearance-apple-pay-button-div.html
+++ b/LayoutTests/fast/css/appearance-apple-pay-button-div.html
@@ -1,0 +1,52 @@
+<style>
+    .container {
+        position: relative;
+        background-color: silver;
+        padding: 25px;
+        width: 500px;
+    }
+
+    .apple-pay-button-div {
+        display: block;
+        margin: 25px;
+        -webkit-appearance: -apple-pay-button;
+        height: 100px;
+        width: 400px;
+    }
+
+    .masker {
+        position: absolute;
+        width: 200px;
+        height: 80px;
+        background-color: blue;
+    }
+
+    .corner-mask {
+        position: absolute;
+        width: 20px;
+        height: 20px;
+        background-color: blue;
+    }
+</style>
+
+<div class="container">
+    <div style="-apple-pay-button-style: black;" class="apple-pay-button-div"></div>
+    <div style="-apple-pay-button-style: white;" class="apple-pay-button-div"></div>
+    <div style="-apple-pay-button-style: black; border-radius: 0px;" class="apple-pay-button-div"></div>
+    <div style="-apple-pay-button-style: white; border-radius: 0px;" class="apple-pay-button-div"></div>
+
+    <div class="masker" style="top: 60px; left: 150px"></div>
+    <div class="masker" style="top: 185px; left: 150px"></div>
+    <div class="masker" style="top: 310px; left: 150px"></div>
+    <div class="masker" style="top: 435px; left: 150px"></div>
+
+    <div class="corner-mask" style="top: 45px; left: 45px"></div>
+    <div class="corner-mask" style="top: 135px; left: 45px"></div>
+    <div class="corner-mask" style="top: 45px; left: 435px"></div>
+    <div class="corner-mask" style="top: 135px; left: 435px"></div>
+
+    <div class="corner-mask" style="top: 170px; left: 45px"></div>
+    <div class="corner-mask" style="top: 260px; left: 45px"></div>
+    <div class="corner-mask" style="top: 170px; left: 435px"></div>
+    <div class="corner-mask" style="top: 260px; left: 435px"></div>
+</div>

--- a/LayoutTests/fast/css/appearance-apple-pay-button-inapplicable-expected.html
+++ b/LayoutTests/fast/css/appearance-apple-pay-button-inapplicable-expected.html
@@ -1,0 +1,40 @@
+<body>
+<input type="checkbox">
+<br>
+<input type="color">
+<br>
+<input type="date">
+<br>
+<input type="datetime-local">
+<br>
+<input type="email">
+<br>
+<input type="file">
+<br>
+<input type="hidden">
+<br>
+<input type="image">
+<br>
+<input type="month">
+<br>
+<input type="number">
+<br>
+<input type="password">
+<br>
+<input type="radio">
+<br>
+<input type="range">
+<br>
+<input type="search">
+<br>
+<input type="tel">
+<br>
+<input type="text">
+<br>
+<input type="time">
+<br>
+<input type="url">
+<br>
+<input type="week">
+</body>
+

--- a/LayoutTests/fast/css/appearance-apple-pay-button-inapplicable.html
+++ b/LayoutTests/fast/css/appearance-apple-pay-button-inapplicable.html
@@ -1,0 +1,40 @@
+<body>
+<input type="checkbox" style="appearance: -apple-pay-button">
+<br>
+<input type="color" style="appearance: -apple-pay-button">
+<br>
+<input type="date" style="appearance: -apple-pay-button">
+<br>
+<input type="datetime-local" style="appearance: -apple-pay-button">
+<br>
+<input type="email" style="appearance: -apple-pay-button">
+<br>
+<input type="file" style="appearance: -apple-pay-button">
+<br>
+<input type="hidden" style="appearance: -apple-pay-button">
+<br>
+<input type="image" style="appearance: -apple-pay-button">
+<br>
+<input type="month" style="appearance: -apple-pay-button">
+<br>
+<input type="number" style="appearance: -apple-pay-button">
+<br>
+<input type="password" style="appearance: -apple-pay-button">
+<br>
+<input type="radio" style="appearance: -apple-pay-button">
+<br>
+<input type="range" style="appearance: -apple-pay-button">
+<br>
+<input type="search" style="appearance: -apple-pay-button">
+<br>
+<input type="tel" style="appearance: -apple-pay-button">
+<br>
+<input type="text" style="appearance: -apple-pay-button">
+<br>
+<input type="time" style="appearance: -apple-pay-button">
+<br>
+<input type="url" style="appearance: -apple-pay-button">
+<br>
+<input type="week" style="appearance: -apple-pay-button">
+</body>
+

--- a/LayoutTests/fast/css/appearance-apple-pay-button-input-type-button-expected.html
+++ b/LayoutTests/fast/css/appearance-apple-pay-button-input-type-button-expected.html
@@ -1,0 +1,51 @@
+<style>
+    .container {
+        position: relative;
+        background-color: silver;
+        padding: 25px;
+        width: 500px;
+    }
+
+    .apple-pay-button-div {
+        display: block;
+        margin: 25px;
+        height: 100px;
+        width: 400px;
+    }
+
+    .masker {
+        position: absolute;
+        width: 200px;
+        height: 80px;
+        background-color: blue;
+    }
+
+    .corner-mask {
+        position: absolute;
+        width: 20px;
+        height: 20px;
+        background-color: blue;
+    }
+</style>
+
+<div class="container">
+    <div style="background-color: black;" class="apple-pay-button-div"></div>
+    <div style="background-color: white;" class="apple-pay-button-div"></div>
+    <div style="background-color: black;" class="apple-pay-button-div"></div>
+    <div style="background-color: white;" class="apple-pay-button-div"></div>
+
+    <div class="masker" style="top: 60px; left: 150px"></div>
+    <div class="masker" style="top: 185px; left: 150px"></div>
+    <div class="masker" style="top: 310px; left: 150px"></div>
+    <div class="masker" style="top: 435px; left: 150px"></div>
+
+    <div class="corner-mask" style="top: 45px; left: 45px"></div>
+    <div class="corner-mask" style="top: 135px; left: 45px"></div>
+    <div class="corner-mask" style="top: 45px; left: 435px"></div>
+    <div class="corner-mask" style="top: 135px; left: 435px"></div>
+
+    <div class="corner-mask" style="top: 170px; left: 45px"></div>
+    <div class="corner-mask" style="top: 260px; left: 45px"></div>
+    <div class="corner-mask" style="top: 170px; left: 435px"></div>
+    <div class="corner-mask" style="top: 260px; left: 435px"></div>
+</div>

--- a/LayoutTests/fast/css/appearance-apple-pay-button-input-type-button.html
+++ b/LayoutTests/fast/css/appearance-apple-pay-button-input-type-button.html
@@ -1,0 +1,52 @@
+<style>
+    .container {
+        position: relative;
+        background-color: silver;
+        padding: 25px;
+        width: 500px;
+    }
+
+    .apple-pay-button-input {
+        display: block;
+        margin: 25px;
+        -webkit-appearance: -apple-pay-button;
+        height: 100px;
+        width: 400px;
+    }
+
+    .masker {
+        position: absolute;
+        width: 200px;
+        height: 80px;
+        background-color: blue;
+    }
+
+    .corner-mask {
+        position: absolute;
+        width: 20px;
+        height: 20px;
+        background-color: blue;
+    }
+</style>
+
+<div class="container">
+    <input type="button" style="-apple-pay-button-style: black;" class="apple-pay-button-input">
+    <input type="button" style="-apple-pay-button-style: white;" class="apple-pay-button-input">
+    <input type="button" style="-apple-pay-button-style: black; border-radius: 0px;" class="apple-pay-button-input">
+    <input type="button" style="-apple-pay-button-style: white; border-radius: 0px;" class="apple-pay-button-input">
+
+    <div class="masker" style="top: 60px; left: 150px"></div>
+    <div class="masker" style="top: 185px; left: 150px"></div>
+    <div class="masker" style="top: 310px; left: 150px"></div>
+    <div class="masker" style="top: 435px; left: 150px"></div>
+
+    <div class="corner-mask" style="top: 45px; left: 45px"></div>
+    <div class="corner-mask" style="top: 135px; left: 45px"></div>
+    <div class="corner-mask" style="top: 45px; left: 435px"></div>
+    <div class="corner-mask" style="top: 135px; left: 435px"></div>
+
+    <div class="corner-mask" style="top: 170px; left: 45px"></div>
+    <div class="corner-mask" style="top: 260px; left: 45px"></div>
+    <div class="corner-mask" style="top: 170px; left: 435px"></div>
+    <div class="corner-mask" style="top: 260px; left: 435px"></div>
+</div>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -41,6 +41,8 @@ fast/forms/ios/drag-range-thumb.html [ Pass Timeout Timeout ]
 fast/forms/ios/inputmode-change-update-keyboard.html [ Pass Timeout ]
 
 fast/css/appearance-apple-pay-button.html [ Pass ]
+fast/css/appearance-apple-pay-button-div.html [ Pass ]
+fast/css/appearance-apple-pay-button-input-type-button.html [ Pass ]
 fast/css/appearance-apple-pay-button-border-radius.html [ Pass ]
 fast/css/appearance-apple-pay-button-border-radius-longhands.html [ Pass ]
 fast/css/appearance-apple-pay-button-border-width.html [ Pass ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1051,6 +1051,8 @@ webkit.org/b/158534 css3/filters/backdrop/dynamic-backdrop-filter-change.html [ 
 webkit.org/b/158649 fast/text/chinese-font-name-aliases-2.html [ ImageOnlyFailure ]
 
 fast/css/appearance-apple-pay-button.html [ Pass ]
+fast/css/appearance-apple-pay-button-div.html [ Pass ]
+fast/css/appearance-apple-pay-button-input-type-button.html [ Pass ]
 fast/css/appearance-apple-pay-button-border-radius.html [ Pass ]
 fast/css/appearance-apple-pay-button-border-radius-longhands.html [ Pass ]
 fast/css/appearance-apple-pay-button-border-width.html [ Pass ]

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -158,6 +158,20 @@ StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, cons
         return autoAppearance;
     }
 
+#if ENABLE(APPLE_PAY)
+    // Only apply `appearance: -apple-pay-button` on buttons and non-form controls.
+    if (appearance == StyleAppearance::ApplePayButton) {
+        if (autoAppearance == StyleAppearance::Button)
+            return appearance;
+
+        if (!inputElement && autoAppearance == StyleAppearance::None)
+            return appearance;
+
+        style.setUsedAppearance(autoAppearance);
+        return autoAppearance;
+    }
+#endif
+
     return appearance;
 }
 


### PR DESCRIPTION
#### 75f3ded86715b6a6ab4c4e750a005fae5f9b8e8e
<pre>
Exclude -apple-pay-button from applying to any element that supports appearance: auto and is not a button
<a href="https://bugs.webkit.org/show_bug.cgi?id=272366">https://bugs.webkit.org/show_bug.cgi?id=272366</a>
<a href="https://rdar.apple.com/126107516">rdar://126107516</a>

Reviewed by Tim Nguyen.

`appearance: -apple-pay-button` is non-standard, and must be maintained for
compatibility. However, it is not necessary for elements that already have an
`auto` appearance, and are not buttons, to support the non-standard value.

* LayoutTests/TestExpectations:
* LayoutTests/fast/css/appearance-apple-pay-button-div-expected.html: Added.
* LayoutTests/fast/css/appearance-apple-pay-button-div.html: Added.
* LayoutTests/fast/css/appearance-apple-pay-button-inapplicable-expected.html: Added.
* LayoutTests/fast/css/appearance-apple-pay-button-inapplicable.html: Added.
* LayoutTests/fast/css/appearance-apple-pay-button-input-type-button-expected.html: Added.
* LayoutTests/fast/css/appearance-apple-pay-button-input-type-button.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustAppearanceForElement const):

Ensure that `appearance: -apple-pay-button` remains supported on buttons and
element&apos;s that do not have an `auto` appearance, like `&lt;div&gt;`.

`&lt;input&gt;` with no `auto` appearance are excluded. This covers the `hidden`,
`file`, and `image` types, which have no requirement to support

`appearance: -apple-pay-button`.
Canonical link: <a href="https://commits.webkit.org/277268@main">https://commits.webkit.org/277268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b4ddf6e863917443ed7d28e4b3e2a81941c0b06

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49804 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49844 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43210 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38414 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47742 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/23831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40645 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19724 "Found 1 new API test failure: /WPE/TestResources:/webkit/WebKitWebView/sync-request-on-max-conns (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21239 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41798 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5205 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42204 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51720 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22186 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45718 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40791 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10400 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->