### PR TITLE
[WebGPU] bool BindGroupLayout::validateDynamicOffsets should return a better error message

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroupLayout.h
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.h
@@ -133,7 +133,7 @@ public:
     uint32_t dynamicUniformBuffers() const;
     uint32_t dynamicStorageBuffers() const;
     uint32_t dynamicBufferCount() const;
-    bool validateDynamicOffsets(const uint32_t*, size_t, const BindGroup&) const;
+    NSString* errorValidatingDynamicOffsets(const uint32_t*, size_t, const BindGroup&) const;
     NSString* errorValidatingBindGroupCompatibility(const BindGroupLayout&) const;
 
 private:

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -422,8 +422,12 @@ void ComputePassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& grou
     }
 
     auto* bindGroupLayout = group.bindGroupLayout();
-    if (!bindGroupLayout || !bindGroupLayout->validateDynamicOffsets(dynamicOffsets, dynamicOffsetCount, group)) {
-        makeInvalid(@"GPUComputePassEncoder.setBindGroup: insufficient dynamic offsets in layout for bind group");
+    if (!bindGroupLayout) {
+        makeInvalid(@"GPUComputePassEncoder.setBindGroup: bind group is nil");
+        return;
+    }
+    if (NSString* error = bindGroupLayout->errorValidatingDynamicOffsets(dynamicOffsets, dynamicOffsetCount, group)) {
+        makeInvalid([NSString stringWithFormat:@"GPUComputePassEncoder.setBindGroup: %@", error]);
         return;
     }
 

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -815,8 +815,12 @@ void RenderBundleEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& gro
 
         if (dynamicOffsets) {
             auto* bindGroupLayout = group.bindGroupLayout();
-            if (!bindGroupLayout || !bindGroupLayout->validateDynamicOffsets(dynamicOffsets ? dynamicOffsets->data() : nullptr, dynamicOffsets ? dynamicOffsets->size() : 0, group)) {
-                makeInvalid(@"insufficient dynamic offsets in layout for bind group");
+            if (!bindGroupLayout) {
+                makeInvalid(@"GPURenderBundleEncoder.setBindGroup: bind group is nil");
+                return;
+            }
+            if (NSString* error = bindGroupLayout->errorValidatingDynamicOffsets(dynamicOffsets ? dynamicOffsets->data() : nullptr, dynamicOffsets ? dynamicOffsets->size() : 0, group)) {
+                makeInvalid([NSString stringWithFormat:@"GPURenderBundleEncoder.setBindGroup: %@", error]);
                 return;
             }
         }

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -813,8 +813,12 @@ void RenderPassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& group
     }
 
     auto* bindGroupLayout = group.bindGroupLayout();
-    if (!bindGroupLayout || !bindGroupLayout->validateDynamicOffsets(dynamicOffsets, dynamicOffsetCount, group)) {
-        makeInvalid(@"insufficient dynamic offsets in layout for bind group");
+    if (!bindGroupLayout) {
+        makeInvalid(@"GPURenderPassEncoder.setBindGroup: bind group is nil");
+        return;
+    }
+    if (NSString* error = bindGroupLayout->errorValidatingDynamicOffsets(dynamicOffsets, dynamicOffsetCount, group)) {
+        makeInvalid([NSString stringWithFormat:@"GPURenderPassEncoder.setBindGroup: %@", error]);
         return;
     }
 


### PR DESCRIPTION
#### e123f4c6215c28a36784bd937c37c1be9889205d
<pre>
[WebGPU] bool BindGroupLayout::validateDynamicOffsets should return a better error message
<a href="https://bugs.webkit.org/show_bug.cgi?id=272378">https://bugs.webkit.org/show_bug.cgi?id=272378</a>
<a href="https://rdar.apple.com/126119539">rdar://126119539</a>

Reviewed by Tadeu Zagallo.

PlayCanvas recently encountered an error that would have been easily diagnosable
had we surfaced better error messages from validateDynamicOffsets, so update that
function to do so.

PlayCanvas issue is reported in <a href="https://bugs.webkit.org/show_bug.cgi?id=270079">https://bugs.webkit.org/show_bug.cgi?id=270079</a>

* Source/WebGPU/WebGPU/BindGroupLayout.h:
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::BindGroupLayout::errorValidatingDynamicOffsets const):
(WebGPU::BindGroupLayout::validateDynamicOffsets const): Deleted.
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::setBindGroup):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::setBindGroup):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setBindGroup):

Canonical link: <a href="https://commits.webkit.org/277318@main">https://commits.webkit.org/277318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4bf76d9a5d1d32b253e96f068d0c95eefefb77d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49774 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43140 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23726 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38360 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21111 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5135 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43469 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51649 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18484 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45652 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23392 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44653 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10426 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24174 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->