### PR TITLE
[GStreamer][WebCodecs] Add VP8 temporal scalability encoding support

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1182,7 +1182,6 @@ media/media-hevc-video-as-img.html [ ImageOnlyFailure ]
 
 # Temporal scalability support
 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?h264 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp8 [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.html?vp9 [ Failure ]
 
 # HEVC support

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker_vp8-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/webcodecs/temporal-svc-encoding.https.any.worker_vp8-expected.txt
@@ -1,6 +1,0 @@
-
-Harness Error (FAIL), message = Error in remote https://web-platform.test:9443/resources/testharness.js: Error: assert_own_property: expected property "svc" missing
-
-FAIL SVC L1T2 assert_equals: expected 12 but got 0
-FAIL SVC L1T3 assert_equals: expected 6 but got 0
-

--- a/Source/WTF/wtf/glib/GUniquePtr.h
+++ b/Source/WTF/wtf/glib/GUniquePtr.h
@@ -67,6 +67,19 @@ using GUniquePtr = std::unique_ptr<T, U>;
 FOR_EACH_GLIB_DELETER(WTF_DEFINE_GPTR_DELETER)
 #undef FOR_EACH_GLIB_DELETER
 
+#define WTF_DEFINE_DEPRECATED_GPTR_DELETER(typeName, deleterFunc) \
+    template<> struct GPtrDeleter<typeName> { \
+        void operator()(typeName* ptr) const \
+        { \
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN; \
+            deleterFunc(ptr); \
+            ALLOW_DEPRECATED_DECLARATIONS_END; \
+        } \
+    };
+
+WTF_DEFINE_DEPRECATED_GPTR_DELETER(GValueArray, g_value_array_free)
+#undef WTF_DEFINE_DEPRECATED_GPTR_DELETER
+
 template <typename T> class GUniqueOutPtr {
     WTF_MAKE_NONCOPYABLE(GUniqueOutPtr);
 public:

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -94,6 +94,7 @@ using SetBitrateFunc = Function<void(GObject* encoder, const char* propertyName,
 using SetupFunc = Function<void(WebKitVideoEncoder*)>;
 using SetBitrateModeFunc = Function<void(GstElement*, BitrateMode)>;
 using SetLatencyModeFunc = Function<void(GstElement*, LatencyMode)>;
+using SetBitRateAllocationFunc = Function<void(GstElement*, const WebKitVideoEncoderBitRateAllocation&)>;
 
 struct EncoderDefinition {
     GRefPtr<GstCaps> caps;
@@ -105,9 +106,15 @@ struct EncoderDefinition {
     SetupFunc setupEncoder;
     SetBitrateModeFunc setBitrateMode;
     SetLatencyModeFunc setLatencyMode;
+    SetBitRateAllocationFunc setBitRateAllocation;
     const char* bitratePropertyName;
     const char* keyframeIntervalPropertyName;
 };
+
+static void defaultSetBitRateAllocation(GstElement*, const WebKitVideoEncoderBitRateAllocation&)
+{
+    notImplemented();
+}
 
 enum EncoderId {
     None,
@@ -133,7 +140,7 @@ public:
     }
 
     static void registerEncoder(EncoderId id, const char* name, const char* parserName, const char* capsString, const char* encodedFormatString,
-        SetupFunc&& setupEncoder, const char* bitratePropertyName, SetBitrateFunc&& setBitrate, const char* keyframeIntervalPropertyName, SetBitrateModeFunc&& setBitrateMode, SetLatencyModeFunc&& setLatency)
+        SetupFunc&& setupEncoder, const char* bitratePropertyName, SetBitrateFunc&& setBitrate, const char* keyframeIntervalPropertyName, SetBitrateModeFunc&& setBitrateMode, SetLatencyModeFunc&& setLatency, SetBitRateAllocationFunc&& setBitRateAllocation = defaultSetBitRateAllocation)
     {
         auto encoderFactory = adoptGRef(gst_element_factory_find(name));
         if (!encoderFactory) {
@@ -173,6 +180,7 @@ public:
             .setupEncoder = WTFMove(setupEncoder),
             .setBitrateMode = WTFMove(setBitrateMode),
             .setLatencyMode = WTFMove(setLatency),
+            .setBitRateAllocation = WTFMove(setBitRateAllocation),
             .bitratePropertyName = bitratePropertyName,
             .keyframeIntervalPropertyName = keyframeIntervalPropertyName,
         }));
@@ -208,6 +216,7 @@ struct _WebKitVideoEncoderPrivate {
     BitrateMode bitrateMode;
     LatencyMode latencyMode;
     String codecString;
+    RefPtr<WebKitVideoEncoderBitRateAllocation> bitRateAllocation;
 };
 
 #define webkit_video_encoder_parent_class parent_class
@@ -492,6 +501,17 @@ bool videoEncoderSetFormat(WebKitVideoEncoder* self, GRefPtr<GstCaps>&& caps, co
     }
 
     return videoEncoderSetEncoder(self, encoderId, WTFMove(caps), codecString);
+}
+
+void videoEncoderSetBitRateAllocation(WebKitVideoEncoder* self, RefPtr<WebKitVideoEncoderBitRateAllocation>&& allocation)
+{
+    auto* priv = self->priv;
+    priv->bitRateAllocation = WTFMove(allocation);
+
+    if (priv->encoderId != None) {
+        auto encoder = Encoders::definition(priv->encoderId);
+        encoder->setBitRateAllocation(priv->encoder.get(), *priv->bitRateAllocation);
+    }
 }
 
 static void videoEncoderSetProperty(GObject* object, guint propertyId, const GValue* value, GParamSpec* pspec)
@@ -795,6 +815,137 @@ static void webkit_video_encoder_class_init(WebKitVideoEncoderClass* klass)
                 gst_util_set_object_arg(G_OBJECT(encoder), "end-usage", "cq");
                 break;
             };
+        }, [](GstElement* encoder, const WebKitVideoEncoderBitRateAllocation& bitRateAllocation) {
+            // Allow usage of deprecated GValueArray API.
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN;
+            GUniquePtr<GValueArray> bitrates(g_value_array_new(3));
+            GUniquePtr<GValueArray> layerIds(g_value_array_new(4));
+            GUniquePtr<GValueArray> decimators(g_value_array_new(3));
+            GValue intValue G_VALUE_INIT;
+            GValue boolValue G_VALUE_INIT;
+            unsigned numberLayers = 1;
+            Vector<bool> layerSyncFlags;
+            const char* scalabilityString = nullptr;
+            const char* layerFlags = nullptr;
+
+            g_value_init(&intValue, G_TYPE_INT);
+
+            switch (bitRateAllocation.scalabilityMode()) {
+            case VideoEncoder::ScalabilityMode::L1T1:
+                numberLayers = 1;
+                scalabilityString = "L1T1";
+                if (auto value = bitRateAllocation.getBitRate(0, 0)) {
+                    g_value_set_int(&intValue, *value);
+                    g_value_array_append(bitrates.get(), &intValue);
+                }
+                for (unsigned i = 0; i < 3; i++) {
+                    static const int decimatorValues[] = { 1, 1, 1 };
+                    g_value_set_int(&intValue, decimatorValues[i]);
+                    g_value_array_append(decimators.get(), &intValue);
+                }
+                break;
+            case VideoEncoder::ScalabilityMode::L1T2:
+                numberLayers = 2;
+                scalabilityString = "L1T2";
+                if (auto value = bitRateAllocation.getBitRate(0, 1)) {
+                    g_value_set_int(&intValue, *value);
+                    g_value_array_append(bitrates.get(), &intValue);
+                }
+                if (auto value = bitRateAllocation.getBitRate(0, 0)) {
+                    g_value_set_int(&intValue, *value);
+                    g_value_array_append(bitrates.get(), &intValue);
+                }
+                for (unsigned i = 0; i < 3; i++) {
+                    static const int decimatorValues[] = { 1, 1, 1 };
+                    g_value_set_int(&intValue, decimatorValues[i]);
+                    g_value_array_append(decimators.get(), &intValue);
+                }
+                for (unsigned i = 0; i < 4; i++) {
+                    static const int layerIdValues[] = { 0, 1, 0, 1 };
+                    g_value_set_int(&intValue, layerIdValues[i]);
+                    g_value_array_append(layerIds.get(), &intValue);
+                }
+                g_object_set(encoder, "temporal-scalability-layer-id", layerIds.get(), "temporal-scalability-periodicity", 2, nullptr);
+                layerFlags = \
+                    /* layer 0 */
+                    "<no-ref-golden+no-upd-golden+no-upd-alt,"
+                    /* layer 1 (sync) */
+                    "no-ref-golden+no-upd-last+no-upd-alt,"
+                    /* layer 0 */
+                    "no-ref-golden+no-upd-golden+no-upd-alt,"
+                    /* layer 1 */
+                    "no-upd-last+no-upd-alt>";
+                layerSyncFlags = { false, true, false, false };
+                break;
+            case VideoEncoder::ScalabilityMode::L1T3:
+                numberLayers = 3;
+                scalabilityString = "L1T3";
+                if (auto value = bitRateAllocation.getBitRate(0, 2)) {
+                    g_value_set_int(&intValue, *value);
+                    g_value_array_append(bitrates.get(), &intValue);
+                }
+                if (auto value = bitRateAllocation.getBitRate(0, 1)) {
+                    g_value_set_int(&intValue, *value);
+                    g_value_array_append(bitrates.get(), &intValue);
+                }
+                if (auto value = bitRateAllocation.getBitRate(0, 0)) {
+                    g_value_set_int(&intValue, *value);
+                    g_value_array_append(bitrates.get(), &intValue);
+                }
+                for (unsigned i = 0; i < 3; i++) {
+                    static const int decimatorValues[] = { 4, 2, 1 };
+                    g_value_set_int(&intValue, decimatorValues[i]);
+                    g_value_array_append(decimators.get(), &intValue);
+                }
+                for (unsigned i = 0; i < 4; i++) {
+                    static const int layerIdValues[] = { 0, 2, 1, 2 };
+                    g_value_set_int(&intValue, layerIdValues[i]);
+                    g_value_array_append(layerIds.get(), &intValue);
+                }
+                g_object_set(encoder, "temporal-scalability-layer-id", layerIds.get(), "temporal-scalability-periodicity", 4, nullptr);
+
+                layerFlags = \
+                    /* layer 0 */
+                    "<no-ref-golden+no-upd-golden+no-upd-alt,"
+                    /* layer 2 (sync) */
+                    "no-ref-golden+no-upd-last+no-upd-golden+no-upd-alt+no-upd-entropy,"
+                    /* layer 1 (sync) */
+                    "no-ref-golden+no-upd-last+no-upd-alt,"
+                    /* layer 2 */
+                    "no-upd-last+no-upd-golden+no-upd-alt+no-upd-entropy,"
+                    /* layer 0 */
+                    "no-ref-golden+no-upd-golden+no-upd-alt,"
+                    /* layer 2 */
+                    "no-upd-last+no-upd-golden+no-upd-alt+no-upd-entropy,"
+                    /* layer 1 */
+                    "no-upd-last+no-upd-alt,"
+                    /* layer 2 */
+                    "no-upd-last+no-upd-golden+no-upd-alt+no-upd-entropy>";
+                layerSyncFlags = { false, true, true, false, false, false, false, false };
+                break;
+            }
+
+            GST_DEBUG_OBJECT(encoder, "Configuring for %s scalability mode", scalabilityString);
+            g_object_set(encoder, "temporal-scalability-number-layers", numberLayers,
+                "temporal-scalability-rate-decimator", decimators.get(),
+                "temporal-scalability-target-bitrate", bitrates.get(), nullptr);
+
+            if (layerFlags) {
+                GValue layerSyncFlagsValue G_VALUE_INIT;
+
+                g_value_init(&boolValue, G_TYPE_BOOLEAN);
+                gst_value_array_init(&layerSyncFlagsValue, layerSyncFlags.size());
+                for (auto& flag : layerSyncFlags) {
+                    g_value_set_boolean(&boolValue, flag);
+                    gst_value_array_append_value(&layerSyncFlagsValue, &boolValue);
+                }
+
+                g_object_set_property(G_OBJECT(encoder), "temporal-scalability-layer-sync-flags", &layerSyncFlagsValue);
+                g_value_unset(&layerSyncFlagsValue);
+                gst_util_set_object_arg(G_OBJECT(encoder), "temporal-scalability-layer-flags", layerFlags);
+            }
+
+            ALLOW_DEPRECATED_DECLARATIONS_END;
         });
 
     Encoders::registerEncoder(Vp9, "vp9enc", nullptr, "video/x-vp9", nullptr,


### PR DESCRIPTION
#### ab193bff49cf4e6ef3ecf8bf4ff744f86f7a41f2
<pre>
[GStreamer][WebCodecs] Add VP8 temporal scalability encoding support
<a href="https://bugs.webkit.org/show_bug.cgi?id=272381">https://bugs.webkit.org/show_bug.cgi?id=272381</a>

Reviewed by Xabier Rodriguez-Calvar.

VP8 supports the L1T1, L1T2 and L1T3 scalability modes but it is configurable only for the GStreamer
vp8enc encoder at the moment. Support for WebRTC VP8 SVC will rely on this code as well, in a follow-up patch.

* LayoutTests/platform/glib/TestExpectations:
* Source/WTF/wtf/glib/GUniquePtr.h:
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::retrieveTemporalIndex):
(WebCore::GStreamerInternalVideoEncoder::GStreamerInternalVideoEncoder):
(WebCore::GStreamerInternalVideoEncoder::initialize):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(defaultSetBitRateAllocation):
(Encoders::registerEncoder):
(videoEncoderSetBitRateAllocation):
(webkit_video_encoder_class_init):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.h:
(WebKitVideoEncoderBitRateAllocation::create):
(WebKitVideoEncoderBitRateAllocation::setBitRate):
(WebKitVideoEncoderBitRateAllocation::getBitRate const):
(WebKitVideoEncoderBitRateAllocation::scalabilityMode const):
(WebKitVideoEncoderBitRateAllocation::WebKitVideoEncoderBitRateAllocation):

Canonical link: <a href="https://commits.webkit.org/277367@main">https://commits.webkit.org/277367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/711d57b2235cb2ca34aeef88771218d4594d3ab6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26284 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49792 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43158 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49416 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31550 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23745 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38375 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47690 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23766 "Found 1 new test failure: fast/writing-mode/english-bt-text-with-spelling-marker.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19682 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21153 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41748 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5153 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40372 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51668 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46595 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22133 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45669 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23410 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44675 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10461 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24192 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54098 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23127 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11098 "Passed tests") | 
<!--EWS-Status-Bubble-End-->