### PR TITLE
[WPE] WPE Platform: Fix invisible cursor on wayland platform

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursor.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursor.h
@@ -53,6 +53,7 @@ private:
         int32_t x { 0 };
         int32_t y { 0 };
     } m_hotspot;
+    mutable bool m_cursorChanged { false };
 };
 
 } // namespace WPE


### PR DESCRIPTION
#### 474b00fa093a02cefdabc6d55750d46398ed1390
<pre>
[WPE] WPE Platform: Fix invisible cursor on wayland platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=272386">https://bugs.webkit.org/show_bug.cgi?id=272386</a>

Reviewed by Adrian Perez de Castro and Carlos Garcia Campos.

* Source/WebKit/WPEPlatform/wpe/WPECursorTheme.cpp:
(WPE::cursorsPath):
(WPE::CursorTheme::create):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursor.cpp:
(WPE::WaylandCursor::WaylandCursor):
(WPE::WaylandCursor::setFromName):
(WPE::WaylandCursor::setFromBuffer):
(WPE::WaylandCursor::update const):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandCursor.h:

Canonical link: <a href="https://commits.webkit.org/277726@main">https://commits.webkit.org/277726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25c021108e3d23bc277fe6b4086028947487b487

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51095 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44472 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25141 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25303 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20691 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22787 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44727 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53000 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23454 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24719 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/41988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45798 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25524 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6888 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24442 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->