### PR TITLE
[web-animations] changing the value of a transform property while that property is animated with an implicit keyframe does not update the animation

### DIFF
--- a/LayoutTests/webanimations/accelerated-translate-animation-underlying-value-changed-in-flight-expected.html
+++ b/LayoutTests/webanimations/accelerated-translate-animation-underlying-value-changed-in-flight-expected.html
@@ -1,0 +1,14 @@
+<style>
+
+    #target {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100px;
+        height: 100px;
+        background-color: black;
+        translate: 300px;
+    }
+
+</style>
+<div id="target"></div>

--- a/LayoutTests/webanimations/accelerated-translate-animation-underlying-value-changed-in-flight.html
+++ b/LayoutTests/webanimations/accelerated-translate-animation-underlying-value-changed-in-flight.html
@@ -1,0 +1,41 @@
+<style>
+
+    #target {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100px;
+        height: 100px;
+        background-color: black;
+    }
+
+</style>
+<div id="target"></div>
+<script src="../resources/ui-helper.js"></script>
+<script>
+
+(async () => {
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    // Start an animation that lasts a day.
+    const duration = 24 * 60 * 60 * 1000;
+    const target = document.getElementById("target");
+    const animation = target.animate({ translate: "200px" }, duration);
+    animation.currentTime = duration / 2;
+
+    // Wait until the animation has been applied.
+    await animation.ready;
+    await UIHelper.ensureStablePresentationUpdate();
+
+    // Change the underlying value.
+    target.style.translate = "400px";
+
+    // Wait until that change was made.
+    await UIHelper.ensureStablePresentationUpdate();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+
+</script>

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -238,7 +238,6 @@ private:
     void computeCSSTransitionBlendingKeyframes(const RenderStyle& oldStyle, const RenderStyle& newStyle);
     void computeAcceleratedPropertiesState();
     void setBlendingKeyframes(BlendingKeyframes&&);
-    bool isTargetingTransformRelatedProperty() const;
     void checkForMatchingTransformFunctionLists();
     void computeHasImplicitKeyframeForAcceleratedProperty();
     void computeHasKeyframeComposingAcceleratedProperty();


### PR DESCRIPTION
#### 1b1ca4437c16d15f3c9ef82ae0a103e71017678e
<pre>
[web-animations] changing the value of a transform property while that property is animated with an implicit keyframe does not update the animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=272387">https://bugs.webkit.org/show_bug.cgi?id=272387</a>

Reviewed by Dean Jackson.

Ensure we re-compute accelerated animations targeting a transform-related property if it uses an implicit keyframe.

* LayoutTests/webanimations/accelerated-translate-animation-underlying-value-changed-in-flight-expected.html: Added.
* LayoutTests/webanimations/accelerated-translate-animation-underlying-value-changed-in-flight.html: Added.
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::propertiesContainTransformRelatedProperty):
(WebCore::KeyframeEffect::isRunningAcceleratedTransformRelatedAnimation const):
(WebCore::KeyframeEffect::transformRelatedPropertyDidChange):
(WebCore::KeyframeEffect::isTargetingTransformRelatedProperty const): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:

Canonical link: <a href="https://commits.webkit.org/277257@main">https://commits.webkit.org/277257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca821779119109d785b93914980df09e18f101cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49790 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43156 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49414 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38371 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19678 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41743 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5151 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51665 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18504 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45664 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44672 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24190 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6624 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23125 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->