### PR TITLE
[GStreamer][WebRTC] RTP extensions advertizing clean-up

### DIFF
--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
@@ -49,6 +49,8 @@ a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
 a=fingerprint:sha-256 {fingerprint:OK}
 a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
+a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
 a=fmtp:96 minptime=10;useinbandfec=1
 a=recvonly
 a=fingerprint:sha-256 {fingerprint:OK}

--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-offer-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-offer-expected.txt
@@ -24,6 +24,8 @@ a=rtcp-fb:96 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
 a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
+a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
 a=fmtp:96 minptime=10;useinbandfec=1
 a=rtpmap:9 G722/8000
 a=rtcp-fb:9 transport-cc
@@ -70,6 +72,8 @@ a=rtcp-fb:96 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
 a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
+a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
 a=fmtp:96 minptime=10;useinbandfec=1
 a=rtpmap:9 G722/8000
 a=rtcp-fb:9 transport-cc
@@ -107,10 +111,10 @@ a=rtcp-fb:97 ccm fir
 a=rtcp-fb:97 transport-cc
 a=msid:{media-stream-id:OK} {media-stream-track-id:OK}
 a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
-a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/color-space
-a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
-a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
-a=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
+a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
+a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
+a=extmap:5 http://www.webrtc.org/experiments/rtp-hdrext/color-space
 a=fmtp:97 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
 a=rtpmap:98 H264/90000
 a=rtcp-fb:98 nack

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -317,12 +317,11 @@ static std::optional<std::pair<RTCSdpType, String>> fetchDescription(GstElement*
         const auto attribute = gst_sdp_message_get_attribute(description->sdp, i);
         if (!g_strcmp0(attribute->key, "end-of-candidates")) {
             gst_sdp_message_remove_attribute(description->sdp, i);
-            break;
+            i--;
         }
     }
 
     GUniquePtr<char> sdpString(gst_sdp_message_as_text(description->sdp));
-    GST_TRACE_OBJECT(webrtcBin, "%s-description SDP: %s", name, sdpString.get());
     return { { fromSessionDescriptionType(*description.get()), String::fromLatin1(sdpString.get()) } };
 }
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1009,8 +1009,11 @@ static inline Vector<RTCRtpCapabilities::HeaderExtensionCapability> probeRtpExte
 
 void GStreamerRegistryScanner::fillAudioRtpCapabilities(Configuration configuration, RTCRtpCapabilities& capabilities)
 {
-    if (!m_audioRtpExtensions)
-        m_audioRtpExtensions = probeRtpExtensions(m_allAudioRtpExtensions);
+    if (!m_audioRtpExtensions) {
+        auto extensions = m_commonRtpExtensions;
+        extensions.appendVector(m_allAudioRtpExtensions);
+        m_audioRtpExtensions = probeRtpExtensions(extensions);
+    }
     if (m_audioRtpExtensions)
         capabilities.headerExtensions = copyToVector(*m_audioRtpExtensions);
 
@@ -1037,8 +1040,11 @@ void GStreamerRegistryScanner::fillAudioRtpCapabilities(Configuration configurat
 
 void GStreamerRegistryScanner::fillVideoRtpCapabilities(Configuration configuration, RTCRtpCapabilities& capabilities)
 {
-    if (!m_videoRtpExtensions)
-        m_videoRtpExtensions = probeRtpExtensions(m_allVideoRtpExtensions);
+    if (!m_videoRtpExtensions) {
+        auto extensions = m_commonRtpExtensions;
+        extensions.appendVector(m_allVideoRtpExtensions);
+        m_videoRtpExtensions = probeRtpExtensions(extensions);
+    }
     if (m_videoRtpExtensions)
         capabilities.headerExtensions = copyToVector(*m_videoRtpExtensions);
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -34,6 +34,10 @@
 #include <wtf/text/AtomStringHash.h>
 #include <wtf/text/StringHash.h>
 
+#if USE(GSTREAMER_WEBRTC)
+#include <gst/rtp/rtp.h>
+#endif
+
 namespace WebCore {
 class ContentType;
 
@@ -175,23 +179,24 @@ private:
     void fillAudioRtpCapabilities(Configuration, RTCRtpCapabilities&);
     void fillVideoRtpCapabilities(Configuration, RTCRtpCapabilities&);
 
-    Vector<const char*> m_allAudioRtpExtensions { "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
+    Vector<const char*> m_commonRtpExtensions {
+        "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
         "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time",
-        "urn:ietf:params:rtp-hdrext:sdes:mid"
+        GST_RTP_HDREXT_BASE "sdes:mid",
+        GST_RTP_HDREXT_BASE "sdes:repaired-rtp-stream-id",
+        GST_RTP_HDREXT_BASE "sdes:rtp-stream-id",
+        GST_RTP_HDREXT_BASE "toffset"
+    };
+    Vector<const char*> m_allAudioRtpExtensions {
         // This extension triggers caps negotiation issues. See https://bugs.webkit.org/show_bug.cgi?id=271519.
         // "urn:ietf:params:rtp-hdrext:ssrc-audio-level"
     };
-    Vector<const char*> m_allVideoRtpExtensions { "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
-        "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time",
+    Vector<const char*> m_allVideoRtpExtensions {
         "http://www.webrtc.org/experiments/rtp-hdrext/color-space",
         "http://www.webrtc.org/experiments/rtp-hdrext/playout-delay",
         "http://www.webrtc.org/experiments/rtp-hdrext/video-content-type",
         "http://www.webrtc.org/experiments/rtp-hdrext/video-timing",
-        "urn:3gpp:video-orientation",
-        "urn:ietf:params:rtp-hdrext:sdes:mid",
-        "urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id",
-        "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id",
-        "urn:ietf:params:rtp-hdrext:toffset",
+        "urn:3gpp:video-orientation"
     };
 
     std::optional<Vector<RTCRtpCapabilities::HeaderExtensionCapability>> m_audioRtpExtensions;


### PR DESCRIPTION
#### 921d8dd036b83497f2748bec96ad57604d50ac3d
<pre>
[GStreamer][WebRTC] RTP extensions advertizing clean-up
<a href="https://bugs.webkit.org/show_bug.cgi?id=272389">https://bugs.webkit.org/show_bug.cgi?id=272389</a>

Reviewed by Xabier Rodriguez-Calvar.

The sdes:repaired-rtp-stream-id and sdes:rtp-stream-id RTP header extensions are now listed in SDP
audio sections. The registry scanner code handling this was refactored a bit to avoid code
duplication in the various extension identifiers.

* LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt:
* LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-offer-expected.txt:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::fetchDescription):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::fillAudioRtpCapabilities):
(WebCore::GStreamerRegistryScanner::fillVideoRtpCapabilities):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:

Canonical link: <a href="https://commits.webkit.org/277295@main">https://commits.webkit.org/277295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abf2bfa4fafda07bccc9bcc0838b330f5d09df39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49796 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43162 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38378 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47694 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23771 "Found 1 new test failure: fast/writing-mode/english-bt-text-with-spelling-marker.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19685 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21171 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41752 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5157 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51672 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45673 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23414 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44678 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10417 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24196 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23131 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->