### PR TITLE
Port RemoteObjectInvocation to the new IPC serialization format

### DIFF
--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -254,6 +254,7 @@ $(PROJECT_DIR)/Shared/Cocoa/CoreIPCString.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/CoreIPCURL.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/DataDetectionResult.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/InsertTextOptions.serialization.in
+$(PROJECT_DIR)/Shared/Cocoa/RemoteObjectInvocation.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/RevealItem.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/SharedCARingBuffer.serialization.in
 $(PROJECT_DIR)/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -577,6 +577,7 @@ SERIALIZATION_DESCRIPTION_FILES = \
 	Shared/Cocoa/CoreIPCCFCharacterSet.serialization.in \
 	Shared/Cocoa/DataDetectionResult.serialization.in \
 	Shared/Cocoa/InsertTextOptions.serialization.in \
+	Shared/Cocoa/RemoteObjectInvocation.serialization.in \
 	Shared/Cocoa/RevealItem.serialization.in \
 	Shared/Cocoa/SharedCARingBuffer.serialization.in \
 	Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in \

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -261,6 +261,7 @@ list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/Cocoa/CacheStoragePolicy.serialization.in
     Shared/Cocoa/DataDetectionResult.serialization.in
     Shared/Cocoa/InsertTextOptions.serialization.in
+    Shared/Cocoa/RemoteObjectInvocation.serialization.in
     Shared/Cocoa/RevealItem.serialization.in
     Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
 )

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.h
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.h
@@ -53,11 +53,8 @@ public:
     RemoteObjectInvocation(const String& interfaceIdentifier, RefPtr<API::Dictionary>&& encodedInvocation, std::unique_ptr<ReplyInfo>&&);
 
     const String& interfaceIdentifier() const { return m_interfaceIdentifier; }
-    const API::Dictionary* encodedInvocation() const { return m_encodedInvocation.get(); }
-    const ReplyInfo* replyInfo() const { return m_replyInfo.get(); }
-
-    void encode(IPC::Encoder&) const;
-    static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, RemoteObjectInvocation&);
+    const RefPtr<API::Dictionary>& encodedInvocation() const { return m_encodedInvocation; }
+    const std::unique_ptr<ReplyInfo>& replyInfo() const { return m_replyInfo; }
 
 private:
     String m_interfaceIdentifier;

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.mm
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.mm
@@ -26,9 +26,6 @@
 #import "config.h"
 #import "RemoteObjectInvocation.h"
 
-#import "ArgumentCoders.h"
-#import "UserData.h"
-
 namespace WebKit {
 
 RemoteObjectInvocation::RemoteObjectInvocation() = default;
@@ -38,49 +35,6 @@ RemoteObjectInvocation::RemoteObjectInvocation(const String& interfaceIdentifier
     , m_encodedInvocation(WTFMove(encodedInvocation))
     , m_replyInfo(WTFMove(replyInfo))
 {
-}
-
-void RemoteObjectInvocation::encode(IPC::Encoder& encoder) const
-{
-    encoder << m_interfaceIdentifier;
-    encoder << m_encodedInvocation;
-    if (!m_replyInfo) {
-        encoder << false;
-        return;
-    }
-
-    encoder << true;
-    encoder << m_replyInfo->replyID;
-    encoder << m_replyInfo->blockSignature;
-}
-
-bool RemoteObjectInvocation::decode(IPC::Decoder& decoder, RemoteObjectInvocation& result)
-{
-    if (!decoder.decode(result.m_interfaceIdentifier))
-        return false;
-
-    auto encodedInvocation = decoder.decode<RefPtr<API::Dictionary>>();
-    if (!encodedInvocation)
-        return false;
-    result.m_encodedInvocation = WTFMove(*encodedInvocation);
-
-    bool hasReplyInfo;
-    if (!decoder.decode(hasReplyInfo))
-        return false;
-
-    if (hasReplyInfo) {
-        uint64_t replyID;
-        if (!decoder.decode(replyID))
-            return false;
-
-        String blockSignature;
-        if (!decoder.decode(blockSignature))
-            return false;
-
-        result.m_replyInfo = makeUnique<ReplyInfo>(replyID, WTFMove(blockSignature));
-    }
-
-    return true;
 }
 
 }

--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm
@@ -46,7 +46,7 @@ RemoteObjectRegistry::~RemoteObjectRegistry()
 void RemoteObjectRegistry::sendInvocation(const RemoteObjectInvocation& invocation)
 {
 
-    if (auto* replyInfo = invocation.replyInfo()) {
+    if (auto& replyInfo = invocation.replyInfo()) {
         ASSERT(!m_pendingReplies.contains(replyInfo->replyID));
         m_pendingReplies.add(replyInfo->replyID, backgroundActivity("RemoteObjectRegistry invocation"_s));
     }

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
@@ -225,7 +225,7 @@ static NSString *replyBlockSignature(Protocol *protocol, SEL selector, NSUIntege
     NSInvocation *invocation = [decoder decodeObjectOfClass:[NSInvocation class] forKey:invocationKey];
 
     NSMethodSignature *methodSignature = invocation.methodSignature;
-    auto* replyInfo = remoteObjectInvocation.replyInfo();
+    auto& replyInfo = remoteObjectInvocation.replyInfo();
 
     // Look for the block argument (if any).
     for (NSUInteger i = 0, count = methodSignature.numberOfArguments; i < count; ++i) {

--- a/Source/WebKit/Shared/Cocoa/RemoteObjectInvocation.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/RemoteObjectInvocation.serialization.in
@@ -1,0 +1,32 @@
+# Copyright (C) 2024 Igalia, S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+[Nested] struct WebKit::RemoteObjectInvocation::ReplyInfo {
+       uint64_t replyID;
+       String blockSignature;
+};
+
+class WebKit::RemoteObjectInvocation {
+      String interfaceIdentifier();
+      RefPtr<API::Dictionary> encodedInvocation();
+      std::unique_ptr<WebKit::RemoteObjectInvocation::ReplyInfo> replyInfo();
+};

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6725,6 +6725,7 @@
 		86DD518F28EF28E800DF2A58 /* WebEventModifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebEventModifier.h; sourceTree = "<group>"; };
 		86E0787B2ACE0ACE00B8FADC /* AccessibilityPreferences.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = AccessibilityPreferences.serialization.in; sourceTree = "<group>"; };
 		86E0787C2ACE0AE400B8FADC /* InsertTextOptions.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = InsertTextOptions.serialization.in; sourceTree = "<group>"; };
+		86F07F7C2FCE0FE400BFFFDC /* RemoteObjectInvocation.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteObjectInvocation.serialization.in; sourceTree = "<group>"; };
 		86E67A21190F411800004AB7 /* ProcessThrottler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessThrottler.h; sourceTree = "<group>"; };
 		86E67A22190F411800004AB7 /* ProcessThrottler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProcessThrottler.cpp; sourceTree = "<group>"; };
 		86E6E357291959C3006C25CA /* SecItemRequestData.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SecItemRequestData.serialization.in; sourceTree = "<group>"; };
@@ -11819,6 +11820,7 @@
 				376311FA1A3FB38B005A2E51 /* _WKSameDocumentNavigationTypeInternal.h */,
 				1A5704FA1BE1751100874AF1 /* RemoteObjectInvocation.h */,
 				1A5704F91BE1751100874AF1 /* RemoteObjectInvocation.mm */,
+				86F07F7C2FCE0FE400BFFFDC /* RemoteObjectInvocation.serialization.in */,
 				1AC1337E18590AE400F3EC05 /* RemoteObjectRegistry.h */,
 				1AC1338118590B0500F3EC05 /* RemoteObjectRegistry.messages.in */,
 				1AC1337D18590AE400F3EC05 /* RemoteObjectRegistry.mm */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -691,7 +691,6 @@ TEST(IPCTestingAPI, SerializedTypeInfo)
         @"NSURLRequest",
         @"MachSendRight",
         @"CGBitmapInfo",
-        @"WebKit::RemoteObjectInvocation",
         @"NSParagraphStyle",
 #if PLATFORM(MAC)
         @"WKDDActionContext",


### PR DESCRIPTION
#### 2b818804dc7a1ed06e832ec5fd30ed2648eb3a3c
<pre>
Port RemoteObjectInvocation to the new IPC serialization format
<a href="https://bugs.webkit.org/show_bug.cgi?id=272394">https://bugs.webkit.org/show_bug.cgi?id=272394</a>

Reviewed by Alex Christensen.

Modify also the return value of a couple of member methods
to use smart pointers instead of raw ones and allow their
serialization.

* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/PlatformMac.cmake:
* Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.h:
(WebKit::RemoteObjectInvocation::encodedInvocation const):
(WebKit::RemoteObjectInvocation::replyInfo const):
* Source/WebKit/Shared/API/Cocoa/RemoteObjectInvocation.mm:
(WebKit::RemoteObjectInvocation::encode const): Deleted.
(WebKit::RemoteObjectInvocation::decode): Deleted.
* Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm:
(WebKit::RemoteObjectRegistry::sendInvocation):
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm:
(-[_WKRemoteObjectRegistry _invokeMethod:]):
* Source/WebKit/Shared/Cocoa/RemoteObjectInvocation.serialization.in: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
(SerializedTypeInfo)): Update accordingly.

Canonical link: <a href="https://commits.webkit.org/277351@main">https://commits.webkit.org/277351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e439d3b9fad812b7f05b08046376f43c24611994

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50008 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43373 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38533 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40810 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19848 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21479 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41975 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5368 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43677 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51883 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45837 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23629 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44862 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10451 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24413 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->