### PR TITLE
[iOS] fast/writing-mode/english-bt-text-with-spelling-marker.html is a flaky failure after 277233@main

### DIFF
--- a/LayoutTests/fast/writing-mode/english-bt-text-with-spelling-marker-expected.html
+++ b/LayoutTests/fast/writing-mode/english-bt-text-with-spelling-marker-expected.html
@@ -1,7 +1,8 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ spellCheckingDots=true ] -->
 <html>
 <head>
 <script src="../../editing/editing.js"></script>
+<script src="../../resources/ui-helper.js"></script>
 <style>
 @font-face {
     font-family: Ahem;
@@ -27,11 +28,18 @@ if (window.internals)
 
 var expected = document.getElementById("expected");
 
-typeText("mispelled a", expected);
-queueCommand(() => window.internals && internals.updateEditorUINowIfScheduled()); // Trigger spell checking
+testRunner.waitUntilDone();
+typeText("mispelled a", expected).then(() => {
+    queueCommand(() => window.internals && internals.updateEditorUINowIfScheduled()); // Trigger spell checking
+});
 
-function typeText(text, element)
+async function typeText(text, element)
 {
+    await UIHelper.setSpellCheckerResults({
+        "mispelled a": [
+            { "type": "spelling", "from": 0, "to": 9 }
+        ]
+    });
     element.focus();
     for (const c of text)
         typeCharacterCommand(c);

--- a/LayoutTests/fast/writing-mode/english-bt-text-with-spelling-marker.html
+++ b/LayoutTests/fast/writing-mode/english-bt-text-with-spelling-marker.html
@@ -1,8 +1,9 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ spellCheckingDots=true ] -->
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=0-34; totalPixels=0-134" />
+<meta name="fuzzy" content="maxDifference=0-85; totalPixels=0-148" />
 <script src="../../editing/editing.js"></script>
+<script src="../../resources/ui-helper.js"></script>
 <style>
 @font-face {
     font-family: Ahem;
@@ -32,11 +33,18 @@ if (window.internals)
 
 var test = document.getElementById("test");
 
-typeText("a mispelled", test);
-queueCommand(() => window.internals && internals.updateEditorUINowIfScheduled()); // Trigger spell checking
+testRunner.waitUntilDone();
+typeText("a mispelled", test).then(() => {
+    queueCommand(() => window.internals && internals.updateEditorUINowIfScheduled()); // Trigger spell checking
+});
 
-function typeText(text, element)
+async function typeText(text, element)
 {
+    await UIHelper.setSpellCheckerResults({
+        "a mispelled": [
+            { "type": "spelling", "from": 2, "to": 11 }
+        ]
+    });
     element.focus();
     for (const c of text)
         typeCharacterCommand(c);


### PR DESCRIPTION
#### ef7c999e5c101b9113bb61a3002942f86f99f089
<pre>
[iOS] fast/writing-mode/english-bt-text-with-spelling-marker.html is a flaky failure after 277233@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=272395">https://bugs.webkit.org/show_bug.cgi?id=272395</a>

Reviewed by Aditya Keerthi.

After the changes in 277233@main, spelling dots are now showing up on iOS, in this test; this causes
a very slight image diff, as the direction of the gradient differs slightly between the reference
and test.

Fix this by adjusting the `maxDifference` to accommodate iOS 17, and also adjust the test itself to
reliably show spelling dots by adding `spellCheckingDots=true` as a test option, and also use
`UIHelper.setSpellCheckerResults` to force spellchecking to detect `&quot;mispelled&quot;` as a misspelled
word.

* LayoutTests/fast/writing-mode/english-bt-text-with-spelling-marker-expected.html:
* LayoutTests/fast/writing-mode/english-bt-text-with-spelling-marker.html:

Canonical link: <a href="https://commits.webkit.org/277254@main">https://commits.webkit.org/277254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec5f581c5a0f2ef2dc9f99f5350ce41fa1924a5f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49811 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43177 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38391 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19698 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21198 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41766 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5172 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51687 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22152 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18528 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45686 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44693 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10395 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24211 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->