### PR TITLE
[resultsdbpy] Handle retro-spective dashboard

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js
@@ -348,7 +348,26 @@ class Dashboard {
         if (!this.ref.state.displayed || !this.requestData)
             return;
 
-        const now = Math.floor(Date.now() / 1000);
+        const globalParams = this.documentParams()
+        let now = Math.floor(Date.now() / 1000);
+        if (Object.hasOwn(globalParams, 'before_time'))
+            now = Math.min(now, globalParams.before_time[0]);
+        if (Object.hasOwn(globalParams, 'before_timestamp'))
+            now = Math.min(now, globalPaarams.before_timestamp[0]);
+        if (Object.hasOwn(globalParams, 'before_uuid'))
+            now = Math.min(now, Math.floor(globalParams.before_uuid[0] / 100));
+        if (Object.hasOwn(globalParams, 'before_ref')) {
+            let commit_bank = CommitBank;
+            if (Object.hasOwn(globalParams, 'branch'))
+                commit_bank = CommitBank.forBranch(globalParams.branch);
+            for (const commit of CommitBank.commits) {
+                if (commit.identifier == globalParams.before_ref[0] || commit.revision == globalParams.before_ref[0] || commit.hash == globalParams.before_ref[0]) {
+                    now = Math.min(now, commit.timestamp);
+                    break;
+                }
+            }
+        }
+
         let oldestUuid = now * 100;
         let totalStatus = Expectations.stringToStateId('PASS');
         let tiles = [];


### PR DESCRIPTION
#### 8d657a94aa29fb75b6722dd16b7b2ca41562347a
<pre>
[resultsdbpy] Handle retro-spective dashboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=272397">https://bugs.webkit.org/show_bug.cgi?id=272397</a>
<a href="https://rdar.apple.com/126135192">rdar://126135192</a>

Reviewed by Elliott Williams.

When a user requests a dashboard from the past, we should set &apos;now&apos; based on
the time range the user requested, so we don&apos;t end up classify all queues as
exceeding our freshness threshold.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js:
(Dashboard.prototype.setTilesFromData): Determine &quot;now&quot; based on any &apos;before_&apos;
parameters.

Canonical link: <a href="https://commits.webkit.org/277252@main">https://commits.webkit.org/277252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a4878a6f806229185495d9cc21baa23af84039f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26321 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/49786 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/49826 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/43192 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49450 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/31627 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23779 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/49826 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47724 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/31627 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/49786 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/49826 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/47007 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/31627 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/49786 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/5187 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/31627 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/49786 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/51702 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18540 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/51702 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/47180 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/23444 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/49786 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/51702 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6621 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/23162 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->