### PR TITLE
Grant should be invalidated on the granter queue

### DIFF
--- a/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.h
+++ b/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.h
@@ -48,7 +48,7 @@ public:
     explicit ExtensionCapabilityGrant(String environmentIdentifier);
     ~ExtensionCapabilityGrant();
 
-    ExtensionCapabilityGrant& operator=(ExtensionCapabilityGrant&&);
+    ExtensionCapabilityGrant& operator=(ExtensionCapabilityGrant&&) = default;
     ExtensionCapabilityGrant isolatedCopy() &&;
 
     const String& environmentIdentifier() const { return m_environmentIdentifier; }

--- a/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.mm
+++ b/Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.mm
@@ -75,14 +75,6 @@ ExtensionCapabilityGrant::~ExtensionCapabilityGrant()
     setPlatformGrant({ });
 }
 
-ExtensionCapabilityGrant& ExtensionCapabilityGrant::operator=(ExtensionCapabilityGrant&& grant)
-{
-    platformInvalidate(m_platformGrant);
-    m_environmentIdentifier = WTFMove(grant.m_environmentIdentifier);
-    m_platformGrant = WTFMove(grant.m_platformGrant);
-    return *this;
-}
-
 ExtensionCapabilityGrant ExtensionCapabilityGrant::isolatedCopy() &&
 {
     return {

--- a/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm
@@ -111,7 +111,7 @@ static bool prepareGrant(const String& environmentIdentifier, AuxiliaryProcessPr
     return true;
 }
 
-static bool finalizeGrant(const String& environmentIdentifier, AuxiliaryProcessProxy* auxiliaryProcess, ExtensionCapabilityGrant&& grant)
+static bool finalizeGrant(ExtensionCapabilityGranter& granter, const String& environmentIdentifier, AuxiliaryProcessProxy* auxiliaryProcess, ExtensionCapabilityGrant&& grant)
 {
     if (!auxiliaryProcess) {
         GRANTER_RELEASE_LOG_ERROR(environmentIdentifier, "auxiliaryProcess is null");
@@ -127,7 +127,13 @@ static bool finalizeGrant(const String& environmentIdentifier, AuxiliaryProcessP
     }
 
     if (grant.isValid()) {
-        iterator->value = WTFMove(grant);
+        auto& existingGrant = iterator->value;
+        ASSERT(!existingGrant.isValid());
+        if (existingGrant.isValid()) {
+            GRANTER_RELEASE_LOG_ERROR(environmentIdentifier, "grant not expected to be valid");
+            granter.invalidateGrants(Vector<ExtensionCapabilityGrant>::from(WTFMove(existingGrant)));
+        }
+        existingGrant = WTFMove(grant);
         return true;
     }
 
@@ -189,7 +195,7 @@ void ExtensionCapabilityGranter::grant(const ExtensionCapability& capability)
         grantsToInvalidate.reserveInitialCapacity(2);
 
         if (needsGPUProcessGrant) {
-            if (finalizeGrant(environmentIdentifier, m_client->gpuProcessForCapabilityGranter(*this).get(), WTFMove(gpuProcessGrant)))
+            if (finalizeGrant(*this, environmentIdentifier, m_client->gpuProcessForCapabilityGranter(*this).get(), WTFMove(gpuProcessGrant)))
                 GRANTER_RELEASE_LOG(environmentIdentifier, "granted for GPU process");
             else {
                 GRANTER_RELEASE_LOG_ERROR(environmentIdentifier, "failed to grant for GPU process");
@@ -199,7 +205,7 @@ void ExtensionCapabilityGranter::grant(const ExtensionCapability& capability)
             ASSERT(gpuProcessGrant.isEmpty());
 
         if (needsWebProcessGrant) {
-            if (finalizeGrant(environmentIdentifier, m_client->webProcessForCapabilityGranter(*this, environmentIdentifier).get(), WTFMove(webProcessGrant)))
+            if (finalizeGrant(*this, environmentIdentifier, m_client->webProcessForCapabilityGranter(*this, environmentIdentifier).get(), WTFMove(webProcessGrant)))
                 GRANTER_RELEASE_LOG(environmentIdentifier, "granted for WebContent process");
             else {
                 GRANTER_RELEASE_LOG_ERROR(environmentIdentifier, "failed to grant for WebContent process");


### PR DESCRIPTION
#### 7516bd41dd6f4d02ab5e85bd29c71eda6dd6e5c6
<pre>
Grant should be invalidated on the granter queue
<a href="https://bugs.webkit.org/show_bug.cgi?id=272398">https://bugs.webkit.org/show_bug.cgi?id=272398</a>
<a href="https://rdar.apple.com/125984025">rdar://125984025</a>

Reviewed by Chris Dumez.

Grant should be invalidated on the granter queue and not on the main thread.

* Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.h:
* Source/WebKit/Platform/cocoa/ExtensionCapabilityGrant.mm:
(WebKit::ExtensionCapabilityGrant::operator=): Deleted.
* Source/WebKit/UIProcess/Cocoa/ExtensionCapabilityGranter.mm:
(WebKit::finalizeGrant):

Canonical link: <a href="https://commits.webkit.org/277260@main">https://commits.webkit.org/277260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/132c75d6c04384a3f3376493df3eea86e8215dc5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43194 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38403 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19711 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21218 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5189 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51704 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22170 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18542 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45697 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23446 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44705 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24229 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6627 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->