### PR TITLE
[MSE] Decoding errors when appending segment with B-frames and previous segment ends with an I-frame

### DIFF
--- a/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-sync-frames-expected.txt
+++ b/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-sync-frames-expected.txt
@@ -1,0 +1,22 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+First segment has normal, monotonically increasing samples, and ends with two key frames.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '4') OK
+{PTS({0/1 = 0.000000}), DTS({0/1 = 0.000000}), duration({2/1 = 2.000000}), flags(1), generation(0)}
+{PTS({2/1 = 2.000000}), DTS({2/1 = 2.000000}), duration({2/1 = 2.000000}), flags(0), generation(0)}
+{PTS({4/1 = 4.000000}), DTS({4/1 = 4.000000}), duration({2/1 = 2.000000}), flags(1), generation(0)}
+{PTS({6/1 = 6.000000}), DTS({6/1 = 6.000000}), duration({2/1 = 2.000000}), flags(1), generation(0)}
+Second, overlapping segment has out-of-display-order samples. This append should replace the last two samples from the previous append.
+RUN(sourceBuffer.appendBuffer(mediaSegment))
+EVENT(updateend)
+EXPECTED (bufferedSamples.length == '4') OK
+{PTS({0/1 = 0.000000}), DTS({0/1 = 0.000000}), duration({2/1 = 2.000000}), flags(1), generation(0)}
+{PTS({2/1 = 2.000000}), DTS({2/1 = 2.000000}), duration({2/1 = 2.000000}), flags(0), generation(0)}
+{PTS({8/1 = 8.000000}), DTS({3/1 = 3.000000}), duration({2/1 = 2.000000}), flags(1), generation(1)}
+{PTS({10/1 = 10.000000}), DTS({5/1 = 5.000000}), duration({2/1 = 2.000000}), flags(0), generation(1)}
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-sync-frames.html
+++ b/LayoutTests/media/media-source/media-source-samples-out-of-order-erase-sync-frames.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-samples-out-of-order</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initSegment;
+    var mediaSegment;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+        consoleWrite('First segment has normal, monotonically increasing samples, and ends with two key frames.');
+        mediaSegment = concatenateSamples([
+            makeAInit(4, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(0, 0, 2, 1, 0, SAMPLE_FLAG.SYNC, 0),
+            makeASample(2, 2, 2, 1, 0, SAMPLE_FLAG.NONE, 0),
+            makeASample(4, 4, 2, 1, 0, SAMPLE_FLAG.SYNC, 0),
+            makeASample(6, 6, 2, 1, 0, SAMPLE_FLAG.SYNC, 0),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 4);
+        bufferedSamples.forEach(consoleWrite);
+
+        consoleWrite('Second, overlapping segment has out-of-display-order samples. This append should replace the last two samples from the previous append.');
+        mediaSegment = concatenateSamples([
+            makeAInit(3, [makeATrack(0, 'mock', TRACK_KIND.VIDEO)]),
+            makeASample(8,  3, 2, 1, 0, SAMPLE_FLAG.SYNC, 1),
+            makeASample(10, 5, 2, 1, 0, SAMPLE_FLAG.NONE, 1),
+        ]);
+        run('sourceBuffer.appendBuffer(mediaSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 0);
+        testExpected("bufferedSamples.length", 4);
+        bufferedSamples.forEach(consoleWrite);
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>


### PR DESCRIPTION
#### ec49bb21041cfed7ffb5227ecf637c9e3ea2e594
<pre>
[MSE] Decoding errors when appending segment with B-frames and previous segment ends with an I-frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=272521">https://bugs.webkit.org/show_bug.cgi?id=272521</a>

Reviewed by Xabier Rodriguez-Calvar.

When a segment containing B-frames is appended, WebKit has logic to erase frames from the previous segment
and avoid decoding glitches (219507@main). However, the current logic falls short in one edge case: if
the previous segment ends with an I-frame in the overlap region to be erased.

If the demuxer honors ISOBMFF edit lists, then the first I-frame from an incoming segment with B-frames
can be placed earlier in decoding order than the last (I-)frame from the previous segment
(potentially with different resolution), and that last I-frame doesn&apos;t get erased, and will be pushed for
decoding. This confuses the decoder and the following P/B frames will fail to decode or decode incorrectly
with artifacts due to missing/incorrect reference frame.

This patch fixes this edge case by allowing I-frames to be erased from the track buffer only if they
are presented earlier than the incoming I-frame. We remove frames from the track buffer until we find an
I-frame that is presented later than the incoming I-frame. This handles the case when we get multiple I-frames
in the overlapping area, as exercised in the layout test.

Credit to Vivek Arumugam &lt;vivek_arumugam@comcast.com&gt; for initially finding the bug and investigating this.
This patch builds on top of a patch he proposed.

* LayoutTests/media/media-source/media-source-samples-out-of-order-erase-sync-frames-expected.txt: Added.
* LayoutTests/media/media-source/media-source-samples-out-of-order-erase-sync-frames.html: Added.
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::processMediaSample):

Canonical link: <a href="https://commits.webkit.org/277532@main">https://commits.webkit.org/277532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ec7cc2a196a0d29e59d46722ae43d4a2b0d4764

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43499 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24093 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38632 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40895 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42064 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5494 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43788 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52011 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45930 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23757 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44969 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10564 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23475 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->