### PR TITLE
Use std::span more in JavaScriptCore

### DIFF
--- a/Source/JavaScriptCore/API/JSStringRef.cpp
+++ b/Source/JavaScriptCore/API/JSStringRef.cpp
@@ -37,7 +37,7 @@ using namespace WTF::Unicode;
 JSStringRef JSStringCreateWithCharacters(const JSChar* chars, size_t numChars)
 {
     JSC::initialize();
-    return &OpaqueJSString::create(reinterpret_cast<const UChar*>(chars), numChars).leakRef();
+    return &OpaqueJSString::create({ reinterpret_cast<const UChar*>(chars), numChars }).leakRef();
 }
 
 JSStringRef JSStringCreateWithUTF8CString(const char* string)
@@ -50,8 +50,8 @@ JSStringRef JSStringCreateWithUTF8CString(const char* string)
         bool sourceContainsOnlyASCII;
         if (convertUTF8ToUTF16(std::span { reinterpret_cast<const char8_t*>(string), length }, &p, p + length, &sourceContainsOnlyASCII)) {
             if (sourceContainsOnlyASCII)
-                return &OpaqueJSString::create(reinterpret_cast<const LChar*>(string), length).leakRef();
-            return &OpaqueJSString::create(buffer.data(), p - buffer.data()).leakRef();
+                return &OpaqueJSString::create({ reinterpret_cast<const LChar*>(string), length }).leakRef();
+            return &OpaqueJSString::create({ buffer.data(), p }).leakRef();
         }
     }
 

--- a/Source/JavaScriptCore/API/JSStringRefCF.cpp
+++ b/Source/JavaScriptCore/API/JSStringRefCF.cpp
@@ -41,18 +41,18 @@ JSStringRef JSStringCreateWithCFString(CFStringRef string)
     // it can hold.  (<rdar://problem/6806478>)
     size_t length = CFStringGetLength(string);
     if (!length)
-        return &OpaqueJSString::create(reinterpret_cast<const LChar*>(""), 0).leakRef();
+        return &OpaqueJSString::create(""_span).leakRef();
 
     Vector<LChar, 1024> lcharBuffer(length);
     CFIndex usedBufferLength;
     CFIndex convertedSize = CFStringGetBytes(string, CFRangeMake(0, length), kCFStringEncodingISOLatin1, 0, false, lcharBuffer.data(), length, &usedBufferLength);
     if (static_cast<size_t>(convertedSize) == length && static_cast<size_t>(usedBufferLength) == length)
-        return &OpaqueJSString::create(lcharBuffer.data(), length).leakRef();
+        return &OpaqueJSString::create(lcharBuffer.span()).leakRef();
 
     Vector<UniChar> buffer(length);
     CFStringGetCharacters(string, CFRangeMake(0, length), buffer.data());
     static_assert(sizeof(UniChar) == sizeof(UChar), "UniChar and UChar must be same size");
-    return &OpaqueJSString::create(reinterpret_cast<UChar*>(buffer.data()), length).leakRef();
+    return &OpaqueJSString::create({ reinterpret_cast<UChar*>(buffer.data()), length }).leakRef();
 }
 
 CFStringRef JSStringCopyCFString(CFAllocatorRef allocator, JSStringRef string)

--- a/Source/JavaScriptCore/API/OpaqueJSString.h
+++ b/Source/JavaScriptCore/API/OpaqueJSString.h
@@ -41,14 +41,14 @@ struct OpaqueJSString : public ThreadSafeRefCounted<OpaqueJSString> {
         return adoptRef(*new OpaqueJSString);
     }
 
-    static Ref<OpaqueJSString> create(const LChar* characters, unsigned length)
+    static Ref<OpaqueJSString> create(std::span<const LChar> characters)
     {
-        return adoptRef(*new OpaqueJSString(characters, length));
+        return adoptRef(*new OpaqueJSString(characters));
     }
 
-    static Ref<OpaqueJSString> create(const UChar* characters, unsigned length)
+    static Ref<OpaqueJSString> create(std::span<const UChar> characters)
     {
-        return adoptRef(*new OpaqueJSString(characters, length));
+        return adoptRef(*new OpaqueJSString(characters));
     }
 
     JS_EXPORT_PRIVATE static RefPtr<OpaqueJSString> tryCreate(const String&);
@@ -88,14 +88,14 @@ private:
     {
     }
 
-    OpaqueJSString(const LChar* characters, unsigned length) // FIXME: Should take in a span.
-        : m_string({ characters, length })
+    OpaqueJSString(std::span<const LChar> characters)
+        : m_string(characters)
         , m_characters(nullptr)
     {
     }
 
-    OpaqueJSString(const UChar* characters, unsigned length) // FIXME: Should take in a span.
-        : m_string({ characters, length })
+    OpaqueJSString(std::span<const UChar> characters)
+        : m_string(characters)
         , m_characters(m_string.impl() && m_string.is8Bit() ? nullptr : const_cast<UChar*>(m_string.characters16()))
     {
     }

--- a/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCache.h
@@ -45,11 +45,10 @@ public:
 
     using Cache = std::array<Slot, capacity>;
 
-    // FIXME: This should take in a std::span<const CharacterType>.
     template<typename CharacterType>
-    ALWAYS_INLINE Ref<AtomStringImpl> makeIdentifier(const CharacterType* characters, unsigned length)
+    ALWAYS_INLINE Ref<AtomStringImpl> makeIdentifier(std::span<const CharacterType> characters)
     {
-        return make(characters, length);
+        return make(characters);
     }
 
     ALWAYS_INLINE void clear()
@@ -60,9 +59,8 @@ public:
     VM& vm() const;
 
 private:
-    // FIXME: This should take in a std::span<const CharacterType>.
     template<typename CharacterType>
-    Ref<AtomStringImpl> make(const CharacterType*, unsigned length);
+    Ref<AtomStringImpl> make(std::span<const CharacterType>);
 
     ALWAYS_INLINE Slot& cacheSlot(UChar firstCharacter, UChar lastCharacter, UChar length)
     {

--- a/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h
@@ -34,25 +34,25 @@ namespace JSC {
 
 // FIXME: This should take in a std::span.
 template<typename CharacterType>
-ALWAYS_INLINE Ref<AtomStringImpl> JSONAtomStringCache::make(const CharacterType* characters, unsigned length)
+ALWAYS_INLINE Ref<AtomStringImpl> JSONAtomStringCache::make(std::span<const CharacterType> characters)
 {
-    if (!length)
+    if (characters.empty())
         return *static_cast<AtomStringImpl*>(StringImpl::empty());
 
-    auto firstCharacter = characters[0];
-    if (length == 1) {
+    auto firstCharacter = characters.front();
+    if (characters.size() == 1) {
         if (firstCharacter <= maxSingleCharacterString)
             return vm().smallStrings.singleCharacterStringRep(firstCharacter);
-    } else if (UNLIKELY(length > maxStringLengthForCache))
-        return AtomStringImpl::add(std::span { characters, length }).releaseNonNull();
+    } else if (UNLIKELY(characters.size() > maxStringLengthForCache))
+        return AtomStringImpl::add(characters).releaseNonNull();
 
-    auto lastCharacter = characters[length - 1];
-    auto& slot = cacheSlot(firstCharacter, lastCharacter, length);
-    if (UNLIKELY(slot.m_length != length || !equal(slot.m_buffer, { characters, length }))) {
-        auto result = AtomStringImpl::add(std::span { characters, length });
+    auto lastCharacter = characters.back();
+    auto& slot = cacheSlot(firstCharacter, lastCharacter, characters.size());
+    if (UNLIKELY(slot.m_length != characters.size() || !equal(slot.m_buffer, characters))) {
+        auto result = AtomStringImpl::add(characters);
         slot.m_impl = result;
-        slot.m_length = length;
-        WTF::copyElements(slot.m_buffer, characters, length);
+        slot.m_length = characters.size();
+        WTF::copyElements(slot.m_buffer, characters.data(), characters.size());
         return result.releaseNonNull();
     }
 

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -130,11 +130,11 @@ template <typename CharType>
 ALWAYS_INLINE Identifier LiteralParser<CharType>::makeIdentifier(VM& vm, typename Lexer::LiteralParserTokenPtr token)
 {
     if (token->type == TokIdentifier)
-        return Identifier::fromString(vm, vm.jsonAtomStringCache.makeIdentifier(token->identifierStart, token->stringOrIdentifierLength));
+        return Identifier::fromString(vm, vm.jsonAtomStringCache.makeIdentifier(token->identifier()));
     ASSERT(token->type == TokString);
     if (token->stringIs8Bit)
-        return Identifier::fromString(vm, vm.jsonAtomStringCache.makeIdentifier(token->stringStart8, token->stringOrIdentifierLength));
-    return Identifier::fromString(vm, vm.jsonAtomStringCache.makeIdentifier(token->stringStart16, token->stringOrIdentifierLength));
+        return Identifier::fromString(vm, vm.jsonAtomStringCache.makeIdentifier(token->string8()));
+    return Identifier::fromString(vm, vm.jsonAtomStringCache.makeIdentifier(token->string16()));
 }
 
 template <typename CharType>


### PR DESCRIPTION
#### d843b52783cc145dd09c2f199cd893af38b5e379
<pre>
Use std::span more in JavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=272402">https://bugs.webkit.org/show_bug.cgi?id=272402</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/API/JSStringRef.cpp:
(JSStringCreateWithCharacters):
(JSStringCreateWithUTF8CString):
* Source/JavaScriptCore/API/JSStringRefCF.cpp:
(JSStringCreateWithCFString):
* Source/JavaScriptCore/API/OpaqueJSString.h:
(OpaqueJSString::create):
(OpaqueJSString::OpaqueJSString):
(OpaqueJSString::m_characters): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::encode):
(JSC::decode):
* Source/JavaScriptCore/runtime/JSONAtomStringCache.h:
(JSC::JSONAtomStringCache::makeIdentifier):
* Source/JavaScriptCore/runtime/JSONAtomStringCacheInlines.h:
(JSC::JSONAtomStringCache::make):
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser&lt;CharType&gt;::makeIdentifier):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::escapePattern):
(JSC::RegExp::escapedPattern const):

Canonical link: <a href="https://commits.webkit.org/277265@main">https://commits.webkit.org/277265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/677d6c4a6af8f44bcb8be256cd3814ddd4178010

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49776 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49816 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43182 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23769 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38406 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19714 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21202 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5177 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40399 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43520 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51692 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46619 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18532 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45688 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23434 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44695 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/state-changed, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/accessible/event-listener (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24216 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54122 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6631 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23152 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11102 "Passed tests") | 
<!--EWS-Status-Bubble-End-->