### PR TITLE
Check bounds before reading character in Lexer<T>::nextToken

### DIFF
--- a/LayoutTests/fast/webgpu/unicode-shaders-expected.txt
+++ b/LayoutTests/fast/webgpu/unicode-shaders-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/unicode-shaders.html
+++ b/LayoutTests/fast/webgpu/unicode-shaders.html
@@ -1,0 +1,10 @@
+<script>
+  if (window.testRunner) { testRunner.waitUntilDone(); testRunner.dumpAsText() }
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter();
+    let device = await adapter.requestDevice();
+    device.createShaderModule({code: `\u00c0`});
+    if (window.testRunner) { testRunner.notifyDone() }
+  };
+</script>
+This test passes if it does not crash.

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -41,7 +41,7 @@ static unsigned isIdentifierStart(UChar character, const UChar* start, const UCh
         return 1;
 
     unsigned length = 1;
-    if (u_charType(*(start + length - 1)) == U_SURROGATE && static_cast<unsigned>(end - start) > length)
+    if (end > start + 1 && u_charType(*start) == U_SURROGATE)
         length++;
     if (u_stringHasBinaryProperty(start, length, UCHAR_XID_START))
         return length;
@@ -53,7 +53,7 @@ static unsigned isIdentifierContinue(UChar character, const UChar* start, const 
     if (auto length = isIdentifierStart(character, start, end))
         return length;
     unsigned length = 1;
-    if (u_charType(*(start + length - 1)) == U_SURROGATE && static_cast<unsigned>(end - start) > length)
+    if (end > start + 1 && u_charType(*start) == U_SURROGATE)
         length++;
     if (u_stringHasBinaryProperty(start, length, UCHAR_XID_CONTINUE))
         return length;


### PR DESCRIPTION
#### e3fb20d7964a9216dbd2f6de6b70504956a96c6f
<pre>
Check bounds before reading character in Lexer&lt;T&gt;::nextToken
<a href="https://bugs.webkit.org/show_bug.cgi?id=272405">https://bugs.webkit.org/show_bug.cgi?id=272405</a>
<a href="https://rdar.apple.com/126128360">rdar://126128360</a>

Reviewed by NOBODY (OOPS!).

277108@main introduced isIdentifierStart and isIdentifierContinue which
increment length if the first character is a surrogate character begin and
the buffer is long enough.  We need to check if the buffer is long enough
first because the buffer may have 0 characters.

* LayoutTests/fast/webgpu/unicode-shaders-expected.txt: Added.
* LayoutTests/fast/webgpu/unicode-shaders.html: Added.
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::isIdentifierStart):
(WGSL::isIdentifierContinue):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3fb20d7964a9216dbd2f6de6b70504956a96c6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49829 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43195 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38404 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40628 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19712 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41780 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5190 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43527 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51705 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18543 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45698 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44706 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23165 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->