### PR TITLE
Allow subclasses of WKWebViewConfiguration again

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -95,6 +95,11 @@ Ref<PageConfiguration> PageConfiguration::copy() const
     return copy;
 }
 
+void PageConfiguration::copyDataFrom(const PageConfiguration& other)
+{
+    m_data = other.m_data;
+}
+
 BrowsingContextGroup& PageConfiguration::browsingContextGroup() const
 {
     return m_data.browsingContextGroup.get();

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -95,6 +95,7 @@ public:
     virtual ~PageConfiguration();
 
     Ref<PageConfiguration> copy() const;
+    void copyDataFrom(const PageConfiguration&);
 
     WebKit::BrowsingContextGroup& browsingContextGroup() const;
     void setBrowsingContextGroup(RefPtr<WebKit::BrowsingContextGroup>&&);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -290,7 +290,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    return wrapper(_pageConfiguration->copy().leakRef());
+    WKWebViewConfiguration *configuration = [(WKWebViewConfiguration *)[[self class] allocWithZone:zone] init];
+    configuration->_pageConfiguration->copyDataFrom(*_pageConfiguration);
+    return configuration;
 }
 
 - (WKProcessPool *)processPool


### PR DESCRIPTION
#### 2e1d510b054f71f8611cce938af3793192e94516
<pre>
Allow subclasses of WKWebViewConfiguration again
<a href="https://bugs.webkit.org/show_bug.cgi?id=272406">https://bugs.webkit.org/show_bug.cgi?id=272406</a>
<a href="https://rdar.apple.com/125931255">rdar://125931255</a>

Reviewed by Ben Nham.

In 276566@main I made WKWebViewConfiguration just a wrapper around API::PageConfiguration
but I also changed the implementation of copyWithZone, which can be implemented and used
by subclasses, to be incompatible with that.  WKWebView already has an ivar for the actual
ObjC WKWebViewConfiguration or subclass.  This small change makes using that once again
possible.

* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration copyWithZone:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewConfiguration.mm:
(-[SubclassWebViewConfiguration subclassData]):
(-[SubclassWebViewConfiguration setSubclassData:]):
(-[SubclassWebViewConfiguration copyWithZone:]):
(TEST(WebKit, ConfigurationSubclass)):

Canonical link: <a href="https://commits.webkit.org/277262@main">https://commits.webkit.org/277262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03285516c881c1f8b7f40b8a9f447e81b4db0670

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49840 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43206 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23793 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38412 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47738 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19722 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41795 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5201 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51716 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22182 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18553 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23459 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24241 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6628 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->