### PR TITLE
Free a bit for Style::Validity value

### DIFF
--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -984,7 +984,7 @@ void Node::adjustStyleValidity(Style::Validity validity, Style::InvalidationMode
     case Style::InvalidationMode::Normal:
         break;
     case Style::InvalidationMode::RecompositeLayer:
-        setStyleFlag(NodeStyleFlag::StyleResolutionShouldRecompositeLayer);
+        setStateFlag(StateFlag::StyleResolutionShouldRecompositeLayer);
         break;
     case Style::InvalidationMode::RebuildRenderer:
     case Style::InvalidationMode::InsertedIntoAncestor:

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -358,7 +358,7 @@ public:
     bool needsStyleRecalc() const { return styleValidity() != Style::Validity::Valid || hasInvalidRenderer(); }
     Style::Validity styleValidity() const { return styleBitfields().styleValidity(); }
     bool hasInvalidRenderer() const { return hasStateFlag(StateFlag::HasInvalidRenderer); }
-    bool styleResolutionShouldRecompositeLayer() const { return hasStyleFlag(NodeStyleFlag::StyleResolutionShouldRecompositeLayer); }
+    bool styleResolutionShouldRecompositeLayer() const { return hasStateFlag(StateFlag::StyleResolutionShouldRecompositeLayer); }
     bool childNeedsStyleRecalc() const { return hasStyleFlag(NodeStyleFlag::DescendantNeedsStyleResolution); }
     bool isEditingText() const { return isTextNode() && hasTypeFlag(TypeFlag::IsSpecialInternalNode); }
 
@@ -636,12 +636,13 @@ protected:
         EffectiveLangKnownToMatchDocumentElement = 1 << 3,
         IsComputedStyleInvalidFlag = 1 << 4,
         HasInvalidRenderer = 1 << 5,
-        ContainsOnlyASCIIWhitespace = 1 << 6, // Only used on CharacterData.
-        ContainsOnlyASCIIWhitespaceIsValid = 1 << 7, // Only used on CharacterData.
-        HasHeldBackChildrenChanged = 1 << 8,
-        HasStartedDeletion = 1 << 9,
-        ContainsSelectionEndPoint = 1 << 10,
-        // 5-bits free.
+        StyleResolutionShouldRecompositeLayer = 1 << 6,
+        ContainsOnlyASCIIWhitespace = 1 << 7, // Only used on CharacterData.
+        ContainsOnlyASCIIWhitespaceIsValid = 1 << 8, // Only used on CharacterData.
+        HasHeldBackChildrenChanged = 1 << 9,
+        HasStartedDeletion = 1 << 10,
+        ContainsSelectionEndPoint = 1 << 11,
+        // 4 bits free.
     };
 
     enum class ElementStateFlag : uint16_t {
@@ -709,21 +710,20 @@ protected:
     enum class NodeStyleFlag : uint16_t {
         DescendantNeedsStyleResolution                          = 1 << 0,
         DirectChildNeedsStyleResolution                         = 1 << 1,
-        StyleResolutionShouldRecompositeLayer                   = 1 << 2,
 
-        AffectedByHasWithPositionalPseudoClass                  = 1 << 3,
-        ChildrenAffectedByFirstChildRules                       = 1 << 4,
-        ChildrenAffectedByLastChildRules                        = 1 << 5,
-        AffectsNextSiblingElementStyle                          = 1 << 6,
-        StyleIsAffectedByPreviousSibling                        = 1 << 7,
-        DescendantsAffectedByPreviousSibling                    = 1 << 8,
-        StyleAffectedByEmpty                                    = 1 << 9,
+        AffectedByHasWithPositionalPseudoClass                  = 1 << 2,
+        ChildrenAffectedByFirstChildRules                       = 1 << 3,
+        ChildrenAffectedByLastChildRules                        = 1 << 4,
+        AffectsNextSiblingElementStyle                          = 1 << 5,
+        StyleIsAffectedByPreviousSibling                        = 1 << 6,
+        DescendantsAffectedByPreviousSibling                    = 1 << 7,
+        StyleAffectedByEmpty                                    = 1 << 8,
         // We optimize for :first-child and :last-child. The other positional child selectors like nth-child or
         // *-child-of-type, we will just give up and re-evaluate whenever children change at all.
-        ChildrenAffectedByForwardPositionalRules                = 1 << 10,
-        DescendantsAffectedByForwardPositionalRules             = 1 << 11,
-        ChildrenAffectedByBackwardPositionalRules               = 1 << 12,
-        DescendantsAffectedByBackwardPositionalRules            = 1 << 13,
+        ChildrenAffectedByForwardPositionalRules                = 1 << 9,
+        DescendantsAffectedByForwardPositionalRules             = 1 << 10,
+        ChildrenAffectedByBackwardPositionalRules               = 1 << 11,
+        DescendantsAffectedByBackwardPositionalRules            = 1 << 12,
     };
 
     struct StyleBitfields {
@@ -742,7 +742,7 @@ protected:
 
     private:
         uint16_t m_styleValidity : 2;
-        uint16_t m_flags : 14;
+        uint16_t m_flags : 13;
     };
 
     StyleBitfields styleBitfields() const { return StyleBitfields::fromRaw(m_rendererWithStyleFlags.type()); }
@@ -950,10 +950,10 @@ inline void Node::setHasValidStyle()
 {
     auto bitfields = styleBitfields();
     bitfields.setStyleValidity(Style::Validity::Valid);
-    bitfields.clearFlag(NodeStyleFlag::StyleResolutionShouldRecompositeLayer);
     setStyleBitfields(bitfields);
     clearStateFlag(StateFlag::IsComputedStyleInvalidFlag);
     clearStateFlag(StateFlag::HasInvalidRenderer);
+    clearStateFlag(StateFlag::StyleResolutionShouldRecompositeLayer);
 }
 
 inline void Node::setTreeScopeRecursively(TreeScope& newTreeScope)


### PR DESCRIPTION
#### 15e9f9eebf67973430aafa6fd2a8587405bc88b5
<pre>
Free a bit for Style::Validity value
<a href="https://bugs.webkit.org/show_bug.cgi?id=272407">https://bugs.webkit.org/show_bug.cgi?id=272407</a>
<a href="https://rdar.apple.com/126149625">rdar://126149625</a>

Reviewed by Alan Baradlay and Ryosuke Niwa.

For future use.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::adjustStyleValidity):
* Source/WebCore/dom/Node.h:
(WebCore::Node::styleResolutionShouldRecompositeLayer const):

Move this bit to StateFlags so we can get one more bit for Style::Validity.

(WebCore::Node::setHasValidStyle):

Canonical link: <a href="https://commits.webkit.org/277294@main">https://commits.webkit.org/277294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46fe6f49fc51de09d3fb92cb464a4df729e9d46a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49845 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49469 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38426 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40653 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19737 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41806 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5206 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51721 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45721 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23464 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44728 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10416 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24246 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->