### PR TITLE
[Remote Inspection] Improve the heuristic for extracting CSS selectors for targeted elements

### DIFF
--- a/LayoutTests/fast/element-targeting/prefer-succinct-selectors-expected.txt
+++ b/LayoutTests/fast/element-targeting/prefer-succinct-selectors-expected.txt
@@ -1,0 +1,6 @@
+PASS firstTarget is "#overlay"
+PASS secondTarget is ".fixed"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This test requires WebKitTestRunner.

--- a/LayoutTests/fast/element-targeting/prefer-succinct-selectors.html
+++ b/LayoutTests/fast/element-targeting/prefer-succinct-selectors.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    margin: 0;
+}
+
+.fixed, #overlay {
+    top: 0;
+    left: 0;
+    background: tomato;
+    position: fixed;
+    width: 300px;
+    height: 150px;
+    display: block;
+    visibility: visible;
+    opacity: 0.5;
+}
+
+#overlay {
+    z-index: 1000;
+}
+
+.fixed {
+    z-index: 100;
+}
+
+.content {
+    width: 320px;
+    height: 200px;
+}
+</style>
+</head>
+<body>
+<div class="a0715da0-b1f2-4042-b3c5-31f4c6cd48ef" id="overlay"></div>
+<div class="fixed" id="c0340e6a-b85a-422f-a501-9315c248d230"></div>
+<p class="content">This test requires WebKitTestRunner.</p>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    firstTarget = await UIHelper.adjustVisibilityForFrontmostTarget(150, 75);
+    shouldBeEqualToString("firstTarget", "#overlay");
+    secondTarget = await UIHelper.adjustVisibilityForFrontmostTarget(150, 75);
+    shouldBeEqualToString("secondTarget", ".fixed");
+    finishJSTest();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 87b57ed36164d494c13f5dfec8e6701115a8b8dd
<pre>
[Remote Inspection] Improve the heuristic for extracting CSS selectors for targeted elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=272413">https://bugs.webkit.org/show_bug.cgi?id=272413</a>
<a href="https://rdar.apple.com/123615458">rdar://123615458</a>

Reviewed by Megan Gardner.

Refactor some of the logic around finding CSS selectors for targeted elements, such that we:

1.  Prefers shorter selector strings over longer ones.
2.  Prefers selectors that reference the target&apos;s class, ID or tag name over selectors that are
    relative to other elements.
3.  Allow for sibling-relative selectors as well as parent-relative ones.

This also sorts the returned selector strings, in order from most preferred to least preferred
selector. To avoid exponential runtime in this new algorithm (since we&apos;re now collecting both
sibling-relative and parent-relative selectors), we also plumb a `HashMap` as we&apos;re recursively
walking up the tree for each element, which we use to memoize `selectorForElementRecursive`. This
ensures `O(n^2)` performance in the worst case, where `n` is the number of nodes in the DOM (since
each visit could potentially trigger a `querySelector(…)` with class or tag names), but in practice,
means we&apos;ll typically get away with `O(n)`, since we&apos;ll stop after hitting the first ancestor or
sibling element with unique classes or IDs per target, and are typically a small number of targets.

* LayoutTests/fast/element-targeting/prefer-succinct-selectors-expected.txt: Added.
* LayoutTests/fast/element-targeting/prefer-succinct-selectors.html: Added.

Add a new layout test to exercise the &quot;prefers conciseness&quot; part of selector finding.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::computeIDSelector):
(WebCore::computeClassSelector):
(WebCore::shortestSelector):
(WebCore::selectorForElementRecursive):
(WebCore::siblingRelativeSelectorRecursive):
(WebCore::parentRelativeSelectorRecursive):

See above for more details.

(WebCore::selectorsForTarget):
(WebCore::targetedElementInfo):
(WebCore::ElementTargetingController::findTargets):

Canonical link: <a href="https://commits.webkit.org/277270@main">https://commits.webkit.org/277270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7b44bef5897b76a82968e9c68f53ada9d567a33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49478 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23808 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23828 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19732 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41803 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5215 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43549 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42209 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51730 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45716 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44723 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10403 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->