### PR TITLE
[Site Isolation] Resizing the window causes rendering issues inside cross-origin iframe.

### DIFF
--- a/LayoutTests/http/tests/site-isolation/scrolling/basic-scrolling-tree-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/scrolling/basic-scrolling-tree-expected.txt
@@ -21,15 +21,15 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
     (frame hosting node
       (has hosting context identifier )
       (frame scrolling node
-        (scrollable area size width=800 height=600)
-        (total content size width=800 height=600)
+        (scrollable area size width=300 height=300)
+        (total content size width=300 height=300)
         (last committed scroll position (0,0))
         (scrollable area parameters
           (horizontal scroll elasticity 0)
           (vertical scroll elasticity 0)
           (horizontal scrollbar mode 0)
           (vertical scrollbar mode 0))
-        (layout viewport (0,0) width=800 height=600)
+        (layout viewport (0,0) width=300 height=300)
         (min layoutViewport origin (0,0))
         (max layoutViewport origin (0,0))
         (behavior for fixed 1)))))

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1760,9 +1760,14 @@ void Page::removeActivityStateChangeObserver(ActivityStateChangeObserver& observ
 
 void Page::layoutIfNeeded(OptionSet<LayoutOptions> layoutOptions)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());
-    if (RefPtr view = localMainFrame ? localMainFrame->view() : nullptr)
+    for (auto& rootFrame : m_rootFrames) {
+        ASSERT(rootFrame->isRootFrame());
+        RefPtr view = rootFrame->view();
+        if (!view)
+            continue;
+
         view->updateLayoutAndStyleIfNeededRecursive(layoutOptions);
+    }
 }
 
 void Page::scheduleRenderingUpdate(OptionSet<RenderingUpdateStep> requestedSteps)


### PR DESCRIPTION
#### ce9d973285487efd092c8d5f8d4737e9506d5221
<pre>
[Site Isolation] Resizing the window causes rendering issues inside cross-origin iframe.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272419">https://bugs.webkit.org/show_bug.cgi?id=272419</a>
&lt;<a href="https://rdar.apple.com/126160881">rdar://126160881</a>&gt;

Reviewed by Alex Christensen.

When Page::layoutIfNeeded tries to layout all documents (and flush their compositing
layers), it should do so for all root frames, not just the main frame.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::layoutIfNeeded):

Canonical link: <a href="https://commits.webkit.org/277339@main">https://commits.webkit.org/277339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a2cd36451eaf47708cfb412e4cbafe29205a5bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43278 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38468 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23918 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21342 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41872 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5273 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43606 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42280 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51788 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22259 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18625 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45763 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23534 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44775 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24318 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6671 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->