### PR TITLE
Masonry isn't performing intrinsic sizing correctly.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/masonry-align-content-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/masonry-align-content-003-expected.html
@@ -16,7 +16,7 @@ grid {
   display: inline-grid;
   gap: 1px 2px;
   grid-template-columns: 1ch auto;
-  grid-template-rows: repeat(4,auto);
+  grid-template-rows: repeat(4,19px);
   background: content-box silver;
   border: 1px solid;
   padding: 0 3px 2px 0;
@@ -90,7 +90,7 @@ item {
   <item style="grid-row:3/4">6</item>
 </grid>
 
-<grid style="align-content:stretch">
+<grid style="align-content:stretch; grid-template-rows: repeat(4,29.25px);">
   <item class="tall" style="grid-row:1/2">1</item>
   <item style="grid-row:2/3">2</item>
   <item style="grid-row:3/4">3</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/masonry-align-content-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/masonry-align-content-003-ref.html
@@ -16,7 +16,7 @@ grid {
   display: inline-grid;
   gap: 1px 2px;
   grid-template-columns: 1ch auto;
-  grid-template-rows: repeat(4,auto);
+  grid-template-rows: repeat(4,19px);
   background: content-box silver;
   border: 1px solid;
   padding: 0 3px 2px 0;
@@ -90,7 +90,7 @@ item {
   <item style="grid-row:3/4">6</item>
 </grid>
 
-<grid style="align-content:stretch">
+<grid style="align-content:stretch; grid-template-rows: repeat(4,29.25px);">
   <item class="tall" style="grid-row:1/2">1</item>
   <item style="grid-row:2/3">2</item>
   <item style="grid-row:3/4">3</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html
@@ -64,10 +64,10 @@ test_computed_value("grid-template-columns", 'fit-content(calc(-0.5em + 10px))',
 // <track-repeat> = repeat( [ <positive-integer> ] , [ <line-names>? <track-size> ]+ <line-names>? )
 test_computed_value("grid-template-columns", 'repeat(1, 10px)', '10px');
 test_computed_value("grid-template-columns", 'repeat(1, [one two] 20%)', '[one two] 60px');
-test_computed_value("grid-template-columns", 'repeat(2, minmax(10px, auto))', '160px 140px');
+test_computed_value("grid-template-columns", 'repeat(2, minmax(10px, auto))', '150px 150px');
 
 test_computed_value("grid-template-columns", 'repeat(2, fit-content(20%) [three four] 30px 40px [five six])',
-                    '30px [three four] 30px 40px [five six] 0px [three four] 30px 40px [five six]');
+                    '30px [three four] 30px 40px [five six] 30px [three four] 30px 40px [five six]');
 
 // <track-list> = [ <line-names>? [ <track-size> | <track-repeat> ] ]+ <line-names>?
 test_computed_value("grid-template-columns", 'min-content repeat(5, minmax(10px, auto))',

--- a/Source/WebCore/rendering/Grid.cpp
+++ b/Source/WebCore/rendering/Grid.cpp
@@ -315,16 +315,15 @@ std::optional<GridArea> GridIterator::nextEmptyGridArea(unsigned fixedTrackSpan,
     return { };
 }
 
-GridIterator GridIterator::createForSubgrid(const RenderGrid& subgrid, const GridIterator& outer)
+GridIterator GridIterator::createForSubgrid(const RenderGrid& subgrid, const GridIterator& outer, GridSpan subgridSpanInOuter)
 {
     ASSERT(subgrid.isSubgridInParentDirection(outer.direction()));
     CheckedPtr parent = downcast<RenderGrid>(subgrid.parent());
-    auto fixedSpan = parent->gridSpanForChild(subgrid, outer.direction());
 
     // Translate the current row/column indices into the coordinate
     // space of the subgrid.
     unsigned fixedIndex = (outer.direction() == GridTrackSizingDirection::ForColumns) ? outer.m_columnIndex : outer.m_rowIndex;
-    fixedIndex -= fixedSpan.startLine();
+    fixedIndex -= subgridSpanInOuter.startLine();
 
     auto innerDirection = GridLayoutFunctions::flowAwareDirectionForChild(*parent, subgrid, outer.direction());
     ASSERT(subgrid.isSubgrid(innerDirection));

--- a/Source/WebCore/rendering/Grid.h
+++ b/Source/WebCore/rendering/Grid.h
@@ -120,7 +120,7 @@ public:
     // GridIterator(m_grid, ForColumns, 1) will walk over the rows of the 2nd column.
     GridIterator(const Grid&, GridTrackSizingDirection, unsigned fixedTrackIndex, unsigned varyingTrackIndex = 0);
 
-    static GridIterator createForSubgrid(const RenderGrid& subgrid, const GridIterator& outer);
+    static GridIterator createForSubgrid(const RenderGrid& subgrid, const GridIterator& outer, GridSpan subgridSpanInOuter);
 
     RenderBox* nextGridItem();
     bool isEmptyAreaEnough(unsigned rowSpan, unsigned columnSpan) const;

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1117,7 +1117,9 @@ void IndefiniteSizeStrategy::accumulateFlexFraction(double& flexFraction, GridIt
 {
     while (auto* gridItem = iterator.nextGridItem()) {
         if (CheckedPtr inner = dynamicDowncast<RenderGrid>(gridItem); inner && inner->isSubgridInParentDirection(iterator.direction())) {
-            GridIterator childIterator = GridIterator::createForSubgrid(*inner, iterator);
+            const RenderGrid& subgrid = *inner;
+            GridSpan span = downcast<RenderGrid>(subgrid.parent())->gridSpanForChild(subgrid, iterator.direction());
+            GridIterator childIterator = GridIterator::createForSubgrid(*inner, iterator, span);
             accumulateFlexFraction(flexFraction, childIterator, outermostDirection, itemsSet);
             continue;
         }
@@ -1353,11 +1355,40 @@ static LayoutUnit computeSubgridMarginBorderPadding(const RenderGrid* outermost,
     return subgridMbp;
 }
 
-void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack(GridTrack& track, unsigned trackIndex, GridIterator& iterator, Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, SingleThreadWeakHashSet<RenderBox>& itemsSet, LayoutUnit currentAccumulatedMbp)
+void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack(GridTrack& track, unsigned trackIndex, GridIterator& iterator, Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, SingleThreadWeakHashSet<RenderBox>& itemsSet, SingleThreadWeakListHashSet<RenderBox>& masonryIndefiniteItems, LayoutUnit currentAccumulatedMbp)
 {
-    while (auto* gridItem = iterator.nextGridItem()) {
+    auto extraMarginFromSubgridAncestorGutters = [&](RenderBox* gridItem, GridSpan span) -> std::optional<LayoutUnit> {
+        if (span.startLine() != trackIndex && span.endLine() - 1 != trackIndex)
+            return std::nullopt;
 
+        auto gutterTotal = 0_lu;
+        auto flowAwareDirection = iterator.direction();
+
+        for (auto& currentAncestorSubgrid : ancestorSubgridsOfGridItem(*gridItem, flowAwareDirection)) {
+            std::optional<LayoutUnit> availableSpace;
+            if (!GridLayoutFunctions::hasRelativeOrIntrinsicSizeForChild(currentAncestorSubgrid, flowAwareDirection))
+                availableSpace = currentAncestorSubgrid.availableSpaceForGutters(flowAwareDirection);
+
+            auto gridItemSpanInAncestor = currentAncestorSubgrid.gridSpanForChild(*gridItem, flowAwareDirection);
+            auto numTracksForCurrentAncestor = currentAncestorSubgrid.numTracks(flowAwareDirection);
+
+            const auto* currentAncestorSubgridParent = dynamicDowncast<RenderGrid>(currentAncestorSubgrid.parent());
+            ASSERT(currentAncestorSubgridParent);
+            if (!currentAncestorSubgridParent)
+                return std::nullopt;
+
+            if (gridItemSpanInAncestor.startLine())
+                gutterTotal += (currentAncestorSubgrid.gridGap(flowAwareDirection) - currentAncestorSubgridParent->gridGap(flowAwareDirection)) / 2;
+            if (span.endLine() != numTracksForCurrentAncestor)
+                gutterTotal += (currentAncestorSubgrid.gridGap(flowAwareDirection) - currentAncestorSubgridParent->gridGap(flowAwareDirection)) / 2;
+            flowAwareDirection = GridLayoutFunctions::flowAwareDirectionForParent(currentAncestorSubgrid, *currentAncestorSubgridParent, flowAwareDirection);
+        }
+        return gutterTotal;
+    };
+
+    auto accumulateIntrinsicSizes = [&](RenderBox* gridItem) {
         bool isNewEntry = itemsSet.add(*gridItem).isNewEntry;
+        GridSpan span = m_renderGrid->gridSpanForChild(*gridItem, m_direction);
 
         // Masonry Track Sizing
         // https://drafts.csswg.org/css-grid-3/#track-sizing
@@ -1365,68 +1396,58 @@ void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack(GridTrack& track
         //
         // - Items explicitly placed in that track contribute.
         // - Items without an explicit placement contribute (regardless of whether they are ultimately placed in that track).
-        if (m_renderGrid->isMasonry()) {
-            bool skipTrackSizing = true;
-
+        if (renderGrid()->isMasonry()) {
             // m_direction shall always be the gridAxisDirection.
             ASSERT(!isDirectionInMasonryDirection());
-            auto gridAxisDirection = m_direction;
-            auto span = GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem, gridAxisDirection);
+
+            isNewEntry = true;
+
+            // Correct the span as the grid item is coming from another track.
+            span = GridSpan::translatedDefiniteGridSpan(trackIndex, trackIndex + span.integerSpan());
+
+            bool skipTrackSizing = true;
 
             // Items specifically placed in this track.
-            if (m_renderGrid->gridSpanForChild(*gridItem, gridAxisDirection).startLine() == trackIndex)
+            if (m_renderGrid->gridSpanForChild(*gridItem, m_direction).startLine() == trackIndex)
                 skipTrackSizing = false;
 
             // Items that have an indefinite placement in the grid axis.
-            if (span.isIndefinite())
+            if (GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem, m_direction).isIndefinite())
                 skipTrackSizing = false;
 
+            // If the item is going past the end of track do not consider it for inclusion.
+            if (span.integerSpan() + trackIndex > tracks(m_direction).size())
+                skipTrackSizing = true;
+
             if (skipTrackSizing)
-                continue;
+                return;
         }
 
         if (CheckedPtr inner = dynamicDowncast<RenderGrid>(gridItem); inner && inner->isSubgridInParentDirection(iterator.direction())) {
             // Contribute the mbp of wrapper to the first and last tracks that we span.
-            GridSpan span = m_renderGrid->gridSpanForChild(*gridItem, m_direction);
+            GridSpan subgridSpan = downcast<RenderGrid>(inner->parent())->gridSpanForChild(*inner, iterator.direction());
+            if (renderGrid()->isMasonry())
+                subgridSpan = GridSpan::translatedDefiniteGridSpan(trackIndex, trackIndex + span.integerSpan());
 
-            auto extraMarginFromSubgridAncestorGutters = [&]() -> std::optional<LayoutUnit> {
-                if (span.startLine() != trackIndex && span.endLine() - 1 != trackIndex)
-                    return std::nullopt;
-
-                auto gutterTotal = 0_lu;
-                auto flowAwareDirection = iterator.direction();
-
-                for (auto& currentAncestorSubgrid : ancestorSubgridsOfGridItem(*gridItem, flowAwareDirection)) {
-                    std::optional<LayoutUnit> availableSpace;
-                    if (!GridLayoutFunctions::hasRelativeOrIntrinsicSizeForChild(currentAncestorSubgrid, flowAwareDirection))
-                        availableSpace = currentAncestorSubgrid.availableSpaceForGutters(flowAwareDirection);
-
-                    auto gridItemSpanInAncestor = currentAncestorSubgrid.gridSpanForChild(*gridItem, flowAwareDirection);
-                    auto numTracksForCurrentAncestor = currentAncestorSubgrid.numTracks(flowAwareDirection);
-
-                    const auto* currentAncestorSubgridParent = dynamicDowncast<RenderGrid>(currentAncestorSubgrid.parent());
-                    ASSERT(currentAncestorSubgridParent);
-                    if (!currentAncestorSubgridParent)
-                        return std::nullopt;
-
-                    if (gridItemSpanInAncestor.startLine())
-                        gutterTotal += (currentAncestorSubgrid.gridGap(flowAwareDirection) - currentAncestorSubgridParent->gridGap(flowAwareDirection)) / 2;
-                    if (span.endLine() != numTracksForCurrentAncestor)
-                        gutterTotal += (currentAncestorSubgrid.gridGap(flowAwareDirection) - currentAncestorSubgridParent->gridGap(flowAwareDirection)) / 2;
-                    flowAwareDirection = GridLayoutFunctions::flowAwareDirectionForParent(currentAncestorSubgrid, *currentAncestorSubgridParent, flowAwareDirection);
-                }
-                return gutterTotal;
-            }();
             auto accumulatedMbpWithSubgrid = currentAccumulatedMbp + computeSubgridMarginBorderPadding(m_renderGrid, m_direction, track, trackIndex, span, inner.get());
-            track.setBaseSize(std::max(track.baseSize(), accumulatedMbpWithSubgrid + extraMarginFromSubgridAncestorGutters.value_or(0_lu)));
+            track.setBaseSize(std::max(track.baseSize(), accumulatedMbpWithSubgrid + extraMarginFromSubgridAncestorGutters(gridItem, span).value_or(0_lu)));
 
-            GridIterator childIterator = GridIterator::createForSubgrid(*inner, iterator);
-            accumulateIntrinsicSizesForTrack(track, trackIndex, childIterator, itemsSortedByIncreasingSpan, itemsCrossingFlexibleTracks, itemsSet, accumulatedMbpWithSubgrid);
-            continue;
+            GridIterator childIterator = GridIterator::createForSubgrid(*inner, iterator, subgridSpan);
+            SingleThreadWeakListHashSet<RenderBox> childMasonryIndefiniteItems;
+
+            if (renderGrid()->isMasonry()) {
+                while (CheckedPtr<RenderBox> gridItem = childIterator.nextGridItem()) {
+                    if (GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem, m_direction).isIndefinite())
+                        childMasonryIndefiniteItems.add(*gridItem);
+                }
+            }
+
+            accumulateIntrinsicSizesForTrack(track, trackIndex, childIterator, itemsSortedByIncreasingSpan, itemsCrossingFlexibleTracks, itemsSet, childMasonryIndefiniteItems, accumulatedMbpWithSubgrid);
+            return;
         }
+
         if (!isNewEntry)
-            continue;
-        GridSpan span = m_renderGrid->gridSpanForChild(*gridItem, m_direction);
+            return;
 
         if (spanningItemCrossesFlexibleSizedTracks(span))
             itemsCrossingFlexibleTracks.append(GridItemWithSpan(*gridItem, span));
@@ -1434,6 +1455,18 @@ void GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack(GridTrack& track
             sizeTrackToFitNonSpanningItem(span, *gridItem, track);
         else
             itemsSortedByIncreasingSpan.append(GridItemWithSpan(*gridItem, span));
+    };
+
+    while (CheckedPtr<RenderBox> gridItem = iterator.nextGridItem()) {
+        if (renderGrid()->isMasonry() && GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem.get(), m_direction).isIndefinite())
+            continue;
+
+        accumulateIntrinsicSizes(gridItem.get());
+    }
+
+    for (auto it = masonryIndefiniteItems.begin(), end = masonryIndefiniteItems.end(); it != end; ++it) {
+        CheckedPtr<RenderBox> gridItem = it.get();
+        accumulateIntrinsicSizes(gridItem.get());
     }
 }
 
@@ -1448,6 +1481,16 @@ void GridTrackSizingAlgorithm::resolveIntrinsicTrackSizes()
         }
     };
 
+    auto computeIndefiniteItems = [&](SingleThreadWeakListHashSet<RenderBox>& indefiniteItems) {
+        for (auto trackIndex : m_contentSizedTracksIndex) {
+            GridIterator iterator(m_grid, m_direction, trackIndex);
+            while (CheckedPtr<RenderBox> gridItem = iterator.nextGridItem()) {
+                if (GridPositionsResolver::resolveGridPositionsFromStyle(*m_renderGrid, *gridItem, m_direction).isIndefinite())
+                    indefiniteItems.add(*gridItem);
+            }
+        }
+    };
+
     if (m_strategy->isComputingSizeContainment()) {
         handleInfinityGrowthLimit();
         return;
@@ -1456,13 +1499,18 @@ void GridTrackSizingAlgorithm::resolveIntrinsicTrackSizes()
     Vector<GridItemWithSpan> itemsSortedByIncreasingSpan;
     Vector<GridItemWithSpan> itemsCrossingFlexibleTracks;
     SingleThreadWeakHashSet<RenderBox> itemsSet;
+    SingleThreadWeakListHashSet<RenderBox> masonryIndefiniteItems;
 
     if (m_grid.hasGridItems()) {
+
+        if (renderGrid()->isMasonry())
+            computeIndefiniteItems(masonryIndefiniteItems);
+
         for (auto trackIndex : m_contentSizedTracksIndex) {
             GridIterator iterator(m_grid, m_direction, trackIndex);
             GridTrack& track = allTracks[trackIndex];
 
-            accumulateIntrinsicSizesForTrack(track, trackIndex, iterator, itemsSortedByIncreasingSpan, itemsCrossingFlexibleTracks, itemsSet, 0_lu);
+            accumulateIntrinsicSizesForTrack(track, trackIndex, iterator, itemsSortedByIncreasingSpan, itemsCrossingFlexibleTracks, itemsSet, masonryIndefiniteItems, 0_lu);
         }
         std::sort(itemsSortedByIncreasingSpan.begin(), itemsSortedByIncreasingSpan.end());
     }

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -197,7 +197,7 @@ private:
     void stretchFlexibleTracks(std::optional<LayoutUnit> freeSpace);
     void stretchAutoTracks();
 
-    void accumulateIntrinsicSizesForTrack(GridTrack&, unsigned trackIndex, GridIterator&, Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, SingleThreadWeakHashSet<RenderBox>& itemsSet, LayoutUnit currentAccumulatedMbp);
+    void accumulateIntrinsicSizesForTrack(GridTrack&, unsigned trackIndex, GridIterator&, Vector<GridItemWithSpan>& itemsSortedByIncreasingSpan, Vector<GridItemWithSpan>& itemsCrossingFlexibleTracks, SingleThreadWeakHashSet<RenderBox>& itemsSet, SingleThreadWeakListHashSet<RenderBox>& masonryIndefiniteItems, LayoutUnit currentAccumulatedMbp);
 
     bool copyUsedTrackSizesForSubgrid();
 


### PR DESCRIPTION
#### 58b046421e15c1f20ea7cc5dc0e64bd58e11cd92
<pre>
Masonry isn&apos;t performing intrinsic sizing correctly.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270663">https://bugs.webkit.org/show_bug.cgi?id=270663</a>
<a href="https://rdar.apple.com/problem/124240255">rdar://problem/124240255</a>

Reviewed by Sammy Gill.

Indefinite items from other intrinsic tracks were not being taken
into account during the calculation.

masonry-align-content-003-expected-ref/expected.html:
Updated to exact pixel lengths, since &apos;auto&apos; can have different lengths in grid.

masonry-grid-template-columns-computed-withcontent.html:
Updated to have all intrinsic tracks being the same width.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/masonry-align-content-003-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/masonry-align-content-003-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-grid-template-columns-computed-withcontent.html:
* Source/WebCore/rendering/Grid.cpp:
(WebCore::GridIterator::createForSubgrid):
* Source/WebCore/rendering/Grid.h:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::IndefiniteSizeStrategy::accumulateFlexFraction const):
(WebCore::GridTrackSizingAlgorithm::accumulateIntrinsicSizesForTrack):
(WebCore::GridTrackSizingAlgorithm::resolveIntrinsicTrackSizes):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:

Canonical link: <a href="https://commits.webkit.org/277403@main">https://commits.webkit.org/277403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66bb56cf3a83d07d42578287c7e56f98116e335f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47486 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50169 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43534 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38654 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19975 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21732 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42088 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5529 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43826 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52047 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22520 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Sonoma-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45958 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41070 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44997 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/attributes (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10481 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23510 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->