### PR TITLE
[JSC] DesiredWeakReferences::reallyAdd should avoid allocating and destroying Vectors

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.h
+++ b/Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.h
@@ -56,7 +56,8 @@ public:
 
 private:
     CodeBlock* m_codeBlock;
-    HashSet<JSCell*> m_references;
+    HashSet<JSCell*> m_cells;
+    HashSet<StructureID> m_structures;
 };
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/runtime/JSCast.h
+++ b/Source/JavaScriptCore/runtime/JSCast.h
@@ -131,6 +131,7 @@ using JSResizableOrGrowableSharedBigUint64Array = JSGenericResizableOrGrowableSh
     macro(GetterSetter, JSType::GetterSetterType, JSType::GetterSetterType) \
     macro(CustomGetterSetter, JSType::CustomGetterSetterType, JSType::CustomGetterSetterType) \
     macro(NativeExecutable, JSType::NativeExecutableType, JSType::NativeExecutableType) \
+    macro(CodeBlock, JSType::CodeBlockType, JSType::CodeBlockType) \
     macro(JSObject, FirstObjectType, LastObjectType) \
     macro(JSFinalObject, JSType::FinalObjectType, JSType::FinalObjectType) \
     macro(JSFunction, JSType::JSFunctionType, JSType::JSFunctionType) \


### PR DESCRIPTION
#### e5e9b260874b56172ad5b7a4e75eaa946d627b34
<pre>
[JSC] DesiredWeakReferences::reallyAdd should avoid allocating and destroying Vectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=272421">https://bugs.webkit.org/show_bug.cgi?id=272421</a>
<a href="https://rdar.apple.com/126167184">rdar://126167184</a>

Reviewed by Justin Michaud.

This patch reorganizes DesiredWeakReferences.

1. DesiredWeakReferences should have separate HashSet for JSCell and Structure. So DesiredWeakReferences::reallyAdd becomes simpler.
   This is important since DesiredWeakReferences::reallyAdd runs on the main thread.
2. (1) allows us to compute FixedVector size before iterating HashSet in DesiredWeakReferences::reallyAdd. We stop using Vector and
   materialize exact sized FixedVector and fill them with values.

* Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.cpp:
(JSC::DFG::DesiredWeakReferences::addLazily):
(JSC::DFG::DesiredWeakReferences::contains):
(JSC::DFG::DesiredWeakReferences::reallyAdd):
(JSC::DFG::DesiredWeakReferences::visitChildren):
(JSC::DFG::DesiredWeakReferences::~DesiredWeakReferences): Deleted.
* Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.h:
* Source/JavaScriptCore/runtime/JSCast.h:

Canonical link: <a href="https://commits.webkit.org/277279@main">https://commits.webkit.org/277279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2ef4f39fec66a03d3451eb6584c47dd20642c17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49877 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43243 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23833 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38446 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19759 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41839 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5238 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/40463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42246 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51753 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46683 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18593 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45746 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23496 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44755 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54183 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6638 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23214 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/11121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->