### PR TITLE
REGRESSION (277015@main): [ Sonoma WK2 ] fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-reveal.html is a consistent timeout

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-reveal.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-reveal.html
@@ -39,6 +39,8 @@
             const x = scrollerBounds.left + 10;
             const y = scrollerBounds.top + 10;
 
+            await UIHelper.renderingUpdate()
+
             debug('Initial state');
             var scrollbarState = await UIHelper.verticalScrollbarState(scroller);
             debug(scrollbarState);

--- a/LayoutTests/fast/scrolling/mac/scrollbars/svg-foreign-object-overlay-scrollbar-hovered.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/svg-foreign-object-overlay-scrollbar-hovered.html
@@ -33,13 +33,13 @@
             const y = scrollertBounds.top + 10;
 
             debug('Initial state');
-            verticalScrollbarStateForSelect = await UIHelper.verticalScrollbarState(scroller);
+            verticalScrollbarStateForSelect = internals.verticalScrollbarState(scroller);
             debug(verticalScrollbarStateForSelect);
 
             debug('Hovering vertical scrollbar should show expanded scrollbar');
             await UIHelper.mouseWheelScrollAt(x, y);
-            await UIHelper.waitForConditionAsync(async () => {
-                let state = await UIHelper.verticalScrollbarState(scroller);
+            await UIHelper.waitForConditionAsync(() => {
+                let state = internals.verticalScrollbarState(scroller);
                 let expanded = state.indexOf('expanded') != -1;
                 if (expanded)
                     testPassed('Scrollbar state: ' + state);
@@ -49,8 +49,8 @@
             debug('Unhovering vertical scrollbar should hide it');
             await UIHelper.moveMouseAndWaitForFrame(x - 10, y);
             await UIHelper.moveMouseAndWaitForFrame(x - 20, y);
-            await UIHelper.waitForConditionAsync(async () => {
-                let state = await UIHelper.verticalScrollbarState(scroller);
+            await UIHelper.waitForCondition(() => {
+                let state = internals.verticalScrollbarState(scroller);
                 let thumbHidden = state.indexOf('visible_thumb') == -1;
                 let trackHidden = state.indexOf('visible_track') == -1;
                 if (thumbHidden && trackHidden)

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1699,10 +1699,6 @@ webkit.org/b/260113 [ arm64 ] http/wpt/webauthn/ctap-hid-failure.https.html [ Pa
 [ Sonoma+ ] fast/scrolling/scroll-animator-overlay-scrollbars-hovered.html [ Failure ]
 [ Sonoma+ ] fast/scrolling/scroll-animator-select-list-events.html [ Failure ]
 
-# rdar://106116843 ([UI-side compositing] two fast/scrolling/mac/scrollbars overlay-scrollbar-reveal tests time out)
-[ Sonoma+ ] fast/scrolling/mac/scrollbars/overflow-in-iframe-overlay-scrollbar-reveal.html [ Failure ]
-[ Sonoma+ ] fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-reveal.html [ Failure Timeout ]
-
 # rdar://107437068 ([UI side compositing] fast/mediastream/video-rotation.html fails)
 [ Sonoma+ ] fast/mediastream/video-rotation.html [ Failure ]
 

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -908,9 +908,9 @@ window.UIHelper = class UIHelper {
         if (!this.isWebKit2() || this.isIOSFamily())
             return Promise.resolve();
 
-        var scrollingNodeID = internalFunctions.scrollingNodeIDForNode(scroller);
-        if (internals.isUsingUISideCompositing() && (!scroller || (scroller.nodeName != "SELECT" && scrollingNodeID[0] != 0))) {
-            return new Promise(resolve => {
+            if (internals.isUsingUISideCompositing() && (!scroller || scroller.nodeName != "SELECT")) {
+                var scrollingNodeID = internalFunctions.scrollingNodeIDForNode(scroller);
+                return new Promise(resolve => {
                 testRunner.runUIScript(`(function() {
                     uiController.doAfterNextStablePresentationUpdate(function() {
                         uiController.uiScriptComplete(uiController.scrollbarStateForScrollingNodeID(${scrollingNodeID[0]}, ${scrollingNodeID[1]}, ${isVertical}));


### PR DESCRIPTION
#### 2dc674ade9a440ea454fd5e535aa8b63cdc3b64c
<pre>
REGRESSION (277015@main): [ Sonoma WK2 ] fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-reveal.html is a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=272188">https://bugs.webkit.org/show_bug.cgi?id=272188</a>
<a href="https://rdar.apple.com/125932798">rdar://125932798</a>

Reviewed by Simon Fraser.

Since a scrollable area does not immediately have a scrolling node id, directly use the web process scrollbar state
for the svg foriegn object test added in <a href="https://commits.webkit.org/277015@main.">https://commits.webkit.org/277015@main.</a>

* LayoutTests/fast/scrolling/mac/scrollbars/overflow-overlay-scrollbar-reveal.html:
* LayoutTests/fast/scrolling/mac/scrollbars/svg-foreign-object-overlay-scrollbar-hovered.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/resources/ui-helper.js:

Canonical link: <a href="https://commits.webkit.org/277406@main">https://commits.webkit.org/277406@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3f50dca5e3cddcb936c00fa8a645f716378724a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43408 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23999 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38560 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40813 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19880 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41978 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5403 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43707 "Found 1 new API test failure: TestWebKitAPI.WKNavigation.ProcessCrashDuringCallback (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51958 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45886 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40964 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44936 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24450 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6696 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23384 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->