### PR TITLE
Add more smart pointers to AXCoreObject.cpp

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -249,7 +249,7 @@ bool AXCoreObject::hasPopup() const
     if (!equalLettersIgnoringASCIICase(popupValue(), "false"_s))
         return true;
 
-    for (auto* ancestor = parentObject(); ancestor; ancestor = ancestor->parentObject()) {
+    for (RefPtr ancestor = parentObject(); ancestor; ancestor = ancestor->parentObject()) {
         if (!ancestor->isLink())
             continue;
 
@@ -265,7 +265,7 @@ unsigned AXCoreObject::tableLevel() const
         return 0;
 
     unsigned level = 0;
-    auto* current = exposedTableAncestor(true /* includeSelf */);
+    RefPtr current = exposedTableAncestor(true /* includeSelf */);
     while (current) {
         level++;
         current = current->exposedTableAncestor(false);
@@ -362,7 +362,7 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::selectedCells()
             selectedCells.append(cell);
     }
 
-    if (auto* activeDescendant = this->activeDescendant()) {
+    if (RefPtr activeDescendant = this->activeDescendant()) {
         if (activeDescendant->isExposedTableCell() && !selectedCells.contains(activeDescendant))
             selectedCells.append(activeDescendant);
     }
@@ -535,7 +535,7 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::linkedObjects() const
     auto linkedObjects = flowToObjects();
 
     if (isLink()) {
-        if (auto* linkedAXElement = internalLinkElement())
+        if (RefPtr linkedAXElement = internalLinkElement())
             linkedObjects.append(linkedAXElement);
     } else if (isRadioButton())
         appendRadioButtonGroupMembers(linkedObjects);
@@ -566,7 +566,7 @@ void AXCoreObject::appendRadioButtonGroupMembers(AccessibilityChildrenVector& li
             linkedUIElements.append(radioSibling);
     } else {
         // If we didn't find any radio button siblings with the traditional naming, lets search for a radio group role and find its children.
-        for (auto* parent = parentObject(); parent; parent = parent->parentObject()) {
+        for (RefPtr parent = parentObject(); parent; parent = parent->parentObject()) {
             if (parent->roleValue() == AccessibilityRole::RadioGroup) {
                 appendRadioButtonDescendants(*parent, linkedUIElements);
                 break;


### PR DESCRIPTION
#### 9e77b37ecd015142c1ec3de9131c1b262a7f1b0e
<pre>
Add more smart pointers to AXCoreObject.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=272422">https://bugs.webkit.org/show_bug.cgi?id=272422</a>
<a href="https://rdar.apple.com/problem/126168150">rdar://problem/126168150</a>

Reviewed by Chris Dumez.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::hasPopup const):
(WebCore::AXCoreObject::tableLevel const):
(WebCore::AXCoreObject::selectedCells):
(WebCore::AXCoreObject::linkedObjects const):
(WebCore::AXCoreObject::appendRadioButtonGroupMembers const):

Canonical link: <a href="https://commits.webkit.org/277337@main">https://commits.webkit.org/277337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e184ecc45bf6e4729616f5fd1ceca3c81aedd8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50060 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43425 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32075 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24017 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47958 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/24087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19892 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21525 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41989 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5420 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51936 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23682 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10437 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->