### PR TITLE
(Re-land) Don't initialize mach exceptions if we didn't register any.

### DIFF
--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -134,6 +134,12 @@ void initMachExceptionHandlerThread(bool enable, uint32_t signingKey, exception_
         Config::AssertNotFrozenScope assertScope;
         SignalHandlers& handlers = g_wtfConfig.signalHandlers;
 
+        // We need this because some WebKit processes (e.g. GPU process) don't allow signal handling in their
+        // sandbox profiles. We don't use them there so there's no point in setting up a dispatch queue we're
+        // never going to use.
+        if (!handlers.addedExceptions)
+            return;
+
         uint16_t flags = MPO_INSERT_SEND_RIGHT;
 
 // This provisional flag can be removed once macos sonoma is no longer supported


### PR DESCRIPTION
#### 5144a8edcfab04c9cd2f55ab80b8fe670cb9d2e4
<pre>
(Re-land) Don&apos;t initialize mach exceptions if we didn&apos;t register any.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272261">https://bugs.webkit.org/show_bug.cgi?id=272261</a>
<a href="https://rdar.apple.com/126000755">rdar://126000755</a>

The original patch by Keith was reverted because it came after the enablement patch
for the new exceptions API. It turns out that even after reverting, we still need
this fix.

Original patch:
        Don&apos;t initialize mach exceptions if we didn&apos;t register any.
        <a href="https://bugs.webkit.org/show_bug.cgi?id=272261">https://bugs.webkit.org/show_bug.cgi?id=272261</a>
        <a href="https://rdar.apple.com/126000755">rdar://126000755</a>

        Reviewed by Justin Michaud.

        This also fixes GPU process crashing on launch because the sandbox doesn&apos;t allow `task_register_hardened_exception_handler`.

        * Source/WTF/wtf/threads/Signals.cpp:
        (WTF::initMachExceptionHandlerThread):

        Canonical link: <a href="https://commits.webkit.org/277143@main">https://commits.webkit.org/277143@main</a>
----------------

Canonical link: <a href="https://commits.webkit.org/277281@main">https://commits.webkit.org/277281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaf2f61f7586bc34cfc18405c1044d735ca70ece

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47213 "Failed to checkout and rebase branch from PR 27058") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49896 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43262 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23852 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47794 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/23887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/19768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/21300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5257 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/40483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51772 "") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/46702 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/51772 "") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23515 "Built successfully") | | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/51772 "") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54202 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6640 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23234 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/11126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->