### PR TITLE
Avoid using ASCIILiteralPtrHash in WebKit2

### DIFF
--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -123,12 +123,6 @@ struct ASCIILiteralHash {
 template<typename T> struct DefaultHash;
 template<> struct DefaultHash<ASCIILiteral> : ASCIILiteralHash { };
 
-struct ASCIILiteralPtrHash {
-    static unsigned hash(const ASCIILiteral& key) { return IntHash<uintptr_t>::hash(reinterpret_cast<uintptr_t>(key.characters())); }
-    static bool equal(const ASCIILiteral& a, const ASCIILiteral& b) { return a.characters() == b.characters(); }
-    static constexpr bool safeToCompareToEmptyOrDeleted = false;
-};
-
 inline ASCIILiteral ASCIILiteral::deletedValue()
 {
     ASCIILiteral result;
@@ -141,7 +135,6 @@ inline namespace StringLiterals {
 constexpr ASCIILiteral operator"" _s(const char* characters, size_t)
 {
     auto result = ASCIILiteral::fromLiteralUnsafe(characters);
-    // We rely on this for ASCIILiteralPtrHash above.
     ASSERT_UNDER_CONSTEXPR_CONTEXT(result.characters() == characters);
     return result;
 }
@@ -159,5 +152,4 @@ constexpr std::span<const LChar> operator"" _span(const char* characters, size_t
 
 } // namespace WTF
 
-using WTF::ASCIILiteralPtrHash;
 using namespace WTF::StringLiterals;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -537,7 +537,7 @@ private:
     mutable String m_uiProcessBundleIdentifier;
     DownloadManager m_downloadManager;
 
-    using NetworkProcessSupplementMap = HashMap<ASCIILiteral, std::unique_ptr<NetworkProcessSupplement>, ASCIILiteralPtrHash>;
+    using NetworkProcessSupplementMap = HashMap<ASCIILiteral, std::unique_ptr<NetworkProcessSupplement>>;
     NetworkProcessSupplementMap m_supplements;
 
     HashSet<PAL::SessionID> m_sessionsControlledByAutomation;

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -729,7 +729,7 @@ private:
     bool m_memorySamplerEnabled { false };
     double m_memorySamplerInterval { 1400.0 };
 
-    using WebContextSupplementMap = HashMap<ASCIILiteral, RefPtr<WebContextSupplement>, ASCIILiteralPtrHash>;
+    using WebContextSupplementMap = HashMap<ASCIILiteral, RefPtr<WebContextSupplement>>;
     WebContextSupplementMap m_supplements;
 
 #if USE(SOUP)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -703,7 +703,7 @@ private:
 
     HashMap<WebCore::FrameIdentifier, WeakPtr<WebFrame>> m_frameMap;
 
-    using WebProcessSupplementMap = HashMap<ASCIILiteral, std::unique_ptr<WebProcessSupplement>, ASCIILiteralPtrHash>;
+    using WebProcessSupplementMap = HashMap<ASCIILiteral, std::unique_ptr<WebProcessSupplement>>;
     WebProcessSupplementMap m_supplements;
 
     TextCheckerState m_textCheckerState;


### PR DESCRIPTION
#### 6d203e19e2f4c0e9fdf867569940a41582532837
<pre>
Avoid using ASCIILiteralPtrHash in WebKit2
<a href="https://bugs.webkit.org/show_bug.cgi?id=272429">https://bugs.webkit.org/show_bug.cgi?id=272429</a>

Reviewed by Chris Dumez.

Use the default hash traits instead.

* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::ASCIILiteralPtrHash): Deleted.
(WTF::StringLiterals::operator _s):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/277320@main">https://commits.webkit.org/277320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41a5b14f3d0d8f101376843aaa2449c0faa17f90

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49948 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43313 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38493 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40735 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19807 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41897 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5308 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40534 "Found 4 new JSC stress test failures: stress/call-varargs-inlining-should-not-clobber-previous-to-free-register.js.default, stress/check-is-constant-non-cell-should-not-array-profile-during-osr-exit.js.no-ftl, stress/check-is-constant-non-cell-should-not-array-profile-during-osr-exit.js.no-llint, stress/set-iteration-oas.js.ftl-eager-no-cjit (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43624 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42299 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51823 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46753 "Found 3 new JSC stress test failures: stress/call-varargs-inlining-should-not-clobber-previous-to-free-register.js.default, stress/get-array-length-concurrently-change-mode.js.mini-mode, stress/reduce-loop-strength-multiple-exits.js.ftl-eager-no-cjit (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18643 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45788 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23569 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44799 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24353 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54253 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6663 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23287 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11136 "Passed tests") | 
<!--EWS-Status-Bubble-End-->