### PR TITLE
REGRESSION (274863@main): Safari loads website content at a lower resolution with in-process layers and backdrop-filter.

### DIFF
--- a/LayoutTests/css3/filters/hidpi-backdrop-filter-rasterization-scale-expected.html
+++ b/LayoutTests/css3/filters/hidpi-backdrop-filter-rasterization-scale-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<style>
+div {
+    background-color: black;
+    width: 100px;
+    height: 100px;
+}
+
+</style>
+</head>
+<body>
+  Hello
+  <div></div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/hidpi-backdrop-filter-rasterization-scale.html
+++ b/LayoutTests/css3/filters/hidpi-backdrop-filter-rasterization-scale.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<style>
+div {
+    backdrop-filter: invert(1);
+    width: 100px;
+    height: 100px;
+}
+
+</style>
+</head>
+<body>
+  Hello
+  <div></div>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2811,6 +2811,7 @@ compositing/filters/backdrop-filter-root-element-no-backdrop-root.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-will-change/will-change-abspos-cb-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixedpos-cb-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-backdrop-filter-1.html [ ImageOnlyFailure ]
+css3/filters/hidpi-backdrop-filter-rasterization-scale.html [ ImageOnlyFailure ]
 
 # webkit.org/b/271865 REGRESSION (276749@main): [ MacOS WK1 ] 2X backdrop-filter tests are consistent failures 
 [ Sonoma+ ] css3/filters/backdrop/backdrop-filter-uneven-corner-radii.html [ ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/ca/cocoa/WebTiledBackingLayer.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/WebTiledBackingLayer.mm
@@ -55,6 +55,12 @@
 {
     ASSERT(!_tileController);
     _tileController = makeUnique<WebCore::TileController>(rootLayer);
+
+    // Sync the underlying layer with the controller's scale, and keep the rasterization scale the same, as PlatformCALayerCocoa does.
+    CGFloat initialScale = _tileController->contentsScale();
+    [super setContentsScale:initialScale];
+    [super setRasterizationScale:initialScale];
+
     return _tileController.get();
 }
 
@@ -115,6 +121,7 @@
 
 - (void)setContentsScale:(CGFloat)contentsScale
 {
+    [super setContentsScale:contentsScale];
     _tileController->setContentsScale(contentsScale);
 }
 


### PR DESCRIPTION
#### 703822b1f44ff45ca41be77a163a7adef9478ab4
<pre>
REGRESSION (274863@main): Safari loads website content at a lower resolution with in-process layers and backdrop-filter.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272430">https://bugs.webkit.org/show_bug.cgi?id=272430</a>
&lt;<a href="https://rdar.apple.com/123775320">rdar://123775320</a>&gt;

Reviewed by Simon Fraser.

WebTiledBackingLayer wasn&apos;t forwarding the contentScale/rasterizationScale onto the underlying CALayer,
and this value gets used when the layer forces rasterization as a backdrop root.

* LayoutTests/css3/filters/hidpi-backdrop-filter-rasterization-scale-expected.html: Added.
* LayoutTests/css3/filters/hidpi-backdrop-filter-rasterization-scale.html: Added.
* Source/WebCore/platform/graphics/ca/cocoa/WebTiledBackingLayer.mm:
(-[WebTiledBackingLayer createTileController:]):
(-[WebTiledBackingLayer setContentsScale:]):

Canonical link: <a href="https://commits.webkit.org/277370@main">https://commits.webkit.org/277370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24afe29b580bea2c5a95f8d4a5da32b5b7959e10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50040 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43405 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38556 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19876 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21513 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41977 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5400 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43706 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51916 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18730 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45854 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23661 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44883 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10465 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24447 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23381 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->