### PR TITLE
Split JSEntrypointCallee into JIT/Interpreted versions; fix no-jit build

### DIFF
--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -210,7 +210,6 @@ ALWAYS_INLINE MacroAssemblerCodeRef<tag> getWide32CodeRef(OpcodeID opcodeID)
     return MacroAssemblerCodeRef<tag>::createSelfManagedCodeRef(getWide32CodePtr<tag>(opcodeID));
 }
 
-#if ENABLE(JIT)
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getCodeFunctionPtr(OpcodeID opcodeID)
 {
@@ -220,6 +219,8 @@ ALWAYS_INLINE LLIntCode getCodeFunctionPtr(OpcodeID opcodeID)
     return reinterpret_cast<LLIntCode>(getCodePtr<tag>(opcodeID).template taggedPtr());
 #endif
 }
+
+#if ENABLE(JIT)
 
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getWide16CodeFunctionPtr(OpcodeID opcodeID)
@@ -354,7 +355,6 @@ ALWAYS_INLINE MacroAssemblerCodeRef<tag> getWide32CodeRef(WasmOpcodeID opcodeID)
     return MacroAssemblerCodeRef<tag>::createSelfManagedCodeRef(getWide32CodePtr<tag>(opcodeID));
 }
 
-#if ENABLE(JIT)
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getCodeFunctionPtr(WasmOpcodeID opcodeID)
 {
@@ -364,6 +364,8 @@ ALWAYS_INLINE LLIntCode getCodeFunctionPtr(WasmOpcodeID opcodeID)
     return reinterpret_cast<LLIntCode>(getCodePtr<tag>(opcodeID).template taggedPtr());
 #endif
 }
+
+#if ENABLE(JIT)
 
 template<PtrTag tag>
 ALWAYS_INLINE LLIntCode getWide16CodeFunctionPtr(WasmOpcodeID opcodeID)

--- a/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -800,6 +800,24 @@ MacroAssemblerCodeRef<JSEntryPtrTag> returnLocationThunk(OpcodeID opcodeID, Opco
 
 } // namespace LLInt
 
+#else // ENABLE(JIT)
+
+namespace LLInt {
+
+#if ENABLE(WEBASSEMBLY)
+MacroAssemblerCodeRef<JITThunkPtrTag> wasmFunctionEntryThunk()
+{
+    return { };
+}
+
+MacroAssemblerCodeRef<JITThunkPtrTag> wasmFunctionEntryThunkSIMD()
+{
+    return { };
+}
+#endif // ENABLE(WEBASSEMBLY)
+
+} // namespace LLInt
+
 #endif // ENABLE(JIT)
 
 #if ENABLE(C_LOOP)

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -1050,7 +1050,8 @@ static String tierName(SamplingProfiler::StackFrame& frame)
                 return Tiers::wasmllint;
             case Wasm::CompilationMode::IPIntMode:
                 return Tiers::ipint;
-            case Wasm::CompilationMode::JSEntrypointMode:
+            case Wasm::CompilationMode::JSEntrypointJITMode:
+            case Wasm::CompilationMode::JSEntrypointInterpreterMode:
             case Wasm::CompilationMode::JSToWasmICMode:
             case Wasm::CompilationMode::WasmToJSMode:
                 // Just say "Wasm" for now.

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.h
@@ -66,7 +66,7 @@ public:
 
     void work(CompilationEffort) final;
 
-    using CalleeInitializer = Function<void(uint32_t, RefPtr<JITCallee>&&, Ref<BBQCallee>&&)>;
+    using CalleeInitializer = Function<void(uint32_t, RefPtr<JSEntrypointCallee>&&, Ref<BBQCallee>&&)>;
     void initializeCallees(const CalleeInitializer&);
 
     bool didReceiveFunctionData(unsigned, const FunctionData&) final;
@@ -89,7 +89,7 @@ private:
     Vector<std::unique_ptr<InternalFunction>> m_wasmInternalFunctions;
     Vector<std::unique_ptr<LinkBuffer>> m_wasmInternalFunctionLinkBuffers;
     Vector<Vector<CodeLocationLabel<ExceptionHandlerPtrTag>>> m_exceptionHandlerLocations;
-    HashMap<uint32_t, std::tuple<RefPtr<JITCallee>, std::unique_ptr<LinkBuffer>, std::unique_ptr<InternalFunction>>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsToWasmInternalFunctions;
+    HashMap<uint32_t, std::tuple<RefPtr<JSEntrypointCallee>, std::unique_ptr<LinkBuffer>, std::unique_ptr<InternalFunction>>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsToWasmInternalFunctions;
     Vector<CompilationContext> m_compilationContexts;
     Vector<RefPtr<BBQCallee>> m_callees;
     Vector<Vector<CodeLocationLabel<WasmEntryPtrTag>>> m_allLoopEntrypoints;

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -118,7 +118,7 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
             m_wasmIndirectCallWasmCallees = FixedVector<RefPtr<Wasm::Callee>>(m_calleeCount);
 
             BBQPlan* bbqPlan = static_cast<BBQPlan*>(m_plan.get());
-            bbqPlan->initializeCallees([&] (unsigned calleeIndex, RefPtr<JITCallee>&& jsEntrypointCallee, RefPtr<BBQCallee>&& wasmEntrypoint) {
+            bbqPlan->initializeCallees([&] (unsigned calleeIndex, RefPtr<JSEntrypointCallee>&& jsEntrypointCallee, RefPtr<BBQCallee>&& wasmEntrypoint) {
                 if (jsEntrypointCallee) {
                     auto result = m_jsEntrypointCallees.set(calleeIndex, WTFMove(jsEntrypointCallee));
                     ASSERT_UNUSED(result, result.isNewEntry);
@@ -187,7 +187,7 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
             m_wasmIndirectCallWasmCallees = FixedVector<RefPtr<Wasm::Callee>>(m_calleeCount);
 
             BBQPlan* bbqPlan = static_cast<BBQPlan*>(m_plan.get());
-            bbqPlan->initializeCallees([&] (unsigned calleeIndex, RefPtr<JITCallee>&& jsEntrypointCallee, RefPtr<BBQCallee>&& wasmEntrypoint) {
+            bbqPlan->initializeCallees([&] (unsigned calleeIndex, RefPtr<JSEntrypointCallee>&& jsEntrypointCallee, RefPtr<BBQCallee>&& wasmEntrypoint) {
                 if (jsEntrypointCallee) {
                     auto result = m_jsEntrypointCallees.set(calleeIndex, WTFMove(jsEntrypointCallee));
                     ASSERT_UNUSED(result, result.isNewEntry);

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -80,7 +80,7 @@ public:
 
     // These two callee getters are only valid once the callees have been populated.
 
-    Callee& jsEntrypointCalleeFromFunctionIndexSpace(unsigned functionIndexSpace)
+    JSEntrypointCallee& jsEntrypointCalleeFromFunctionIndexSpace(unsigned functionIndexSpace)
     {
         ASSERT(runnable());
         RELEASE_ASSERT(functionIndexSpace >= functionImportCount());
@@ -202,7 +202,7 @@ private:
 #endif
     RefPtr<IPIntCallees> m_ipintCallees;
     RefPtr<LLIntCallees> m_llintCallees;
-    HashMap<uint32_t, RefPtr<JITCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsEntrypointCallees;
+    HashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsEntrypointCallees;
     FixedVector<CodePtr<WasmEntryPtrTag>> m_wasmIndirectCallEntryPoints;
     FixedVector<RefPtr<Wasm::Callee>> m_wasmIndirectCallWasmCallees;
     FixedVector<MacroAssemblerCodeRef<WasmEntryPtrTag>> m_wasmToWasmExitStubs;

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.cpp
@@ -46,8 +46,10 @@ const char* makeString(CompilationMode mode)
         return "OMG";
     case CompilationMode::OMGForOSREntryMode:
         return "OMGForOSREntry";
-    case CompilationMode::JSEntrypointMode:
+    case CompilationMode::JSEntrypointJITMode:
         return "JSEntrypoint";
+    case CompilationMode::JSEntrypointInterpreterMode:
+        return "JSEntrypointInterpreter";
     case CompilationMode::JSToWasmICMode:
         return "JSToWasmIC";
     case CompilationMode::WasmToJSMode:

--- a/Source/JavaScriptCore/wasm/WasmCompilationMode.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationMode.h
@@ -34,7 +34,8 @@ enum class CompilationMode : uint8_t {
     BBQForOSREntryMode,
     OMGMode,
     OMGForOSREntryMode,
-    JSEntrypointMode,
+    JSEntrypointJITMode,
+    JSEntrypointInterpreterMode,
     JSToWasmICMode,
     WasmToJSMode,
 };
@@ -48,7 +49,8 @@ constexpr inline bool isOSREntry(CompilationMode compilationMode)
     case CompilationMode::IPIntMode:
     case CompilationMode::BBQMode:
     case CompilationMode::OMGMode:
-    case CompilationMode::JSEntrypointMode:
+    case CompilationMode::JSEntrypointJITMode:
+    case CompilationMode::JSEntrypointInterpreterMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
         return false;
@@ -69,7 +71,8 @@ constexpr inline bool isAnyBBQ(CompilationMode compilationMode)
     case CompilationMode::LLIntMode:
     case CompilationMode::IPIntMode:
     case CompilationMode::OMGMode:
-    case CompilationMode::JSEntrypointMode:
+    case CompilationMode::JSEntrypointJITMode:
+    case CompilationMode::JSEntrypointInterpreterMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
         return false;
@@ -87,7 +90,8 @@ constexpr inline bool isAnyOMG(CompilationMode compilationMode)
     case CompilationMode::BBQForOSREntryMode:
     case CompilationMode::LLIntMode:
     case CompilationMode::IPIntMode:
-    case CompilationMode::JSEntrypointMode:
+    case CompilationMode::JSEntrypointJITMode:
+    case CompilationMode::JSEntrypointInterpreterMode:
     case CompilationMode::JSToWasmICMode:
     case CompilationMode::WasmToJSMode:
         return false;

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -165,7 +165,7 @@ void IPIntPlan::didCompleteCompilation()
             CCallHelpers jit;
             // The LLInt always bounds checks
             MemoryMode mode = MemoryMode::BoundsChecking;
-            Ref<JITCallee> callee = JSEntrypointCallee::create();
+            auto callee = JSEntrypointJITCallee::create();
             std::unique_ptr<InternalFunction> function = createJSToWasmWrapper(jit, callee.get(), m_callees[functionIndex].ptr(), signature, &m_unlinkedWasmToWasmCalls[functionIndex], m_moduleInformation.get(), mode, functionIndex);
 
             LinkBuffer linkBuffer(jit, nullptr, LinkBuffer::Profile::WasmThunk, JITCompilationCanFail);

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
@@ -38,7 +38,7 @@ namespace Wasm {
 
 class IPIntCallee;
 
-using JSEntrypointCalleeMap = HashMap<uint32_t, RefPtr<JITCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+using JSEntrypointCalleeMap = HashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
 using TailCallGraph = HashMap<uint32_t, HashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 

--- a/Source/JavaScriptCore/wasm/WasmInstance.cpp
+++ b/Source/JavaScriptCore/wasm/WasmInstance.cpp
@@ -254,7 +254,7 @@ void Instance::initElementSegment(uint32_t tableIndex, const Element& segment, u
                 continue;
             }
 
-            Callee& jsEntrypointCallee = calleeGroup()->jsEntrypointCalleeFromFunctionIndexSpace(functionIndex);
+            auto& jsEntrypointCallee = calleeGroup()->jsEntrypointCalleeFromFunctionIndexSpace(functionIndex);
             auto* wasmCallee = calleeGroup()->wasmCalleeFromFunctionIndexSpace(functionIndex);
             WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = calleeGroup()->entrypointLoadLocationFromFunctionIndexSpace(functionIndex);
             const auto& signature = TypeInformation::getFunctionSignature(typeIndex);

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.h
@@ -41,7 +41,7 @@ class LLIntCallee;
 class JSEntrypointCallee;
 class StreamingCompiler;
 
-using JSEntrypointCalleeMap = HashMap<uint32_t, RefPtr<JITCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
+using JSEntrypointCalleeMap = HashMap<uint32_t, RefPtr<JSEntrypointCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 
 using TailCallGraph = HashMap<uint32_t, HashSet<uint32_t, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
 

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -214,7 +214,7 @@ void marshallJSResult(CCallHelpers& jit, const TypeDefinition& typeDefinition, c
     }
 }
 
-std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers& jit, Callee& entryCallee, Callee* wasmCallee, const TypeDefinition& typeDefinition, Vector<UnlinkedWasmToWasmCall>* unlinkedWasmToWasmCalls, const ModuleInformation& info, MemoryMode mode, unsigned functionIndex)
+std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers& jit, JSEntrypointCallee& entryCallee, Callee* wasmCallee, const TypeDefinition& typeDefinition, Vector<UnlinkedWasmToWasmCall>* unlinkedWasmToWasmCalls, const ModuleInformation& info, MemoryMode mode, unsigned functionIndex)
 {
     JIT_COMMENT(jit, "jsToWasm wrapper for wasm-function[", functionIndex, "] : ", typeDefinition);
     auto result = makeUnique<InternalFunction>();

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.h
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.h
@@ -42,9 +42,10 @@ class CCallHelpers;
 namespace Wasm {
 
 struct CallInformation;
+class JSEntrypointCallee;
 
 void marshallJSResult(CCallHelpers& jit, const TypeDefinition&, const CallInformation& wasmFrameConvention, const RegisterAtOffsetList& savedResultRegisters);
-std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers&, Callee&, Callee*, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>*, const ModuleInformation&, MemoryMode, uint32_t functionIndex);
+std::unique_ptr<InternalFunction> createJSToWasmWrapper(CCallHelpers&, JSEntrypointCallee&, Callee*, const TypeDefinition&, Vector<UnlinkedWasmToWasmCall>*, const ModuleInformation&, MemoryMode, uint32_t functionIndex);
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -452,7 +452,7 @@ CodePtr<JSEntryPtrTag> WebAssemblyFunction::jsCallEntrypointSlow()
 }
 #endif // ENABLE(JIT)
 
-WebAssemblyFunction* WebAssemblyFunction::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, unsigned length, const String& name, JSWebAssemblyInstance* instance, Wasm::Callee& jsEntrypoint, Wasm::Callee* wasmCallee, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Wasm::TypeIndex typeIndex, RefPtr<const Wasm::RTT> rtt)
+WebAssemblyFunction* WebAssemblyFunction::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, unsigned length, const String& name, JSWebAssemblyInstance* instance, Wasm::JSEntrypointCallee& jsEntrypoint, Wasm::Callee* wasmCallee, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Wasm::TypeIndex typeIndex, RefPtr<const Wasm::RTT> rtt)
 {
     NativeExecutable* base = vm.getHostFunction(callWebAssemblyFunction, ImplementationVisibility::Public, WasmFunctionIntrinsic, callHostFunctionAsConstructor, nullptr, String());
     // Since ClosureCall uses this executable as an identity for Wasm CallIC thunk, we need to make it diversified.
@@ -468,9 +468,9 @@ Structure* WebAssemblyFunction::createStructure(VM& vm, JSGlobalObject* globalOb
     return Structure::create(vm, globalObject, prototype, TypeInfo(JSFunctionType, StructureFlags), info());
 }
 
-WebAssemblyFunction::WebAssemblyFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, Wasm::Callee& jsEntrypoint, Wasm::Callee* wasmCallee, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Wasm::TypeIndex typeIndex, RefPtr<const Wasm::RTT> rtt)
+WebAssemblyFunction::WebAssemblyFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, Wasm::JSEntrypointCallee& jsEntrypoint, Wasm::Callee* wasmCallee, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Wasm::TypeIndex typeIndex, RefPtr<const Wasm::RTT> rtt)
     : Base { vm, executable, globalObject, structure, instance, Wasm::WasmToWasmImportableFunction { typeIndex, wasmToWasmEntrypointLoadLocation, &m_boxedWasmCallee, rtt.get() } }
-    , m_jsEntrypoint { jsEntrypoint.entrypoint() }
+    , m_jsEntrypoint { jsEntrypoint }
     , m_boxedWasmCallee(reinterpret_cast<uint64_t>(CalleeBits::boxNativeCalleeIfExists(wasmCallee)))
 { }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
@@ -56,13 +56,13 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    JS_EXPORT_PRIVATE static WebAssemblyFunction* create(VM&, JSGlobalObject*, Structure*, unsigned, const String&, JSWebAssemblyInstance*, Wasm::Callee& jsEntrypoint, Wasm::Callee* wasmCallee, WasmToWasmImportableFunction::LoadLocation, Wasm::TypeIndex, RefPtr<const Wasm::RTT>);
+    JS_EXPORT_PRIVATE static WebAssemblyFunction* create(VM&, JSGlobalObject*, Structure*, unsigned, const String&, JSWebAssemblyInstance*, Wasm::JSEntrypointCallee& jsEntrypoint, Wasm::Callee* wasmCallee, WasmToWasmImportableFunction::LoadLocation, Wasm::TypeIndex, RefPtr<const Wasm::RTT>);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
     CodePtr<WasmEntryPtrTag> jsEntrypoint(ArityCheckMode arity)
     {
         ASSERT_UNUSED(arity, arity == ArityCheckNotRequired || arity == MustCheckArity);
-        return m_jsEntrypoint;
+        return m_jsEntrypoint.entrypoint();
     }
 
     CodePtr<JSEntryPtrTag> jsCallEntrypoint()
@@ -78,7 +78,7 @@ public:
 
 private:
     DECLARE_VISIT_CHILDREN;
-    WebAssemblyFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSWebAssemblyInstance*, Wasm::Callee& jsEntrypoint, Wasm::Callee* wasmCallee, WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation, Wasm::TypeIndex, RefPtr<const Wasm::RTT>);
+    WebAssemblyFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSWebAssemblyInstance*, Wasm::JSEntrypointCallee& jsEntrypoint, Wasm::Callee* wasmCallee, WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation, Wasm::TypeIndex, RefPtr<const Wasm::RTT>);
 
 #if ENABLE(JIT)
     CodePtr<JSEntryPtrTag> jsCallEntrypointSlow();
@@ -88,10 +88,10 @@ private:
 
     RegisterSet calleeSaves() const;
 
-    // It's safe to just hold the raw jsEntrypoint because we have a reference
+    // It's safe to just hold the raw callee because we have a reference
     // to our Instance, which points to the Module that exported us, which
     // ensures that the actual Signature/code doesn't get deallocated.
-    CodePtr<WasmEntryPtrTag> m_jsEntrypoint;
+    Wasm::JSEntrypointCallee& m_jsEntrypoint;
     // This is the callee needed by LLInt/IPInt
     uintptr_t m_boxedWasmCallee;
 #if ENABLE(JIT)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -510,7 +510,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
             //     a. Let func be an Exported Function Exotic Object created from c.
             //     b. Append func to funcs.
             //     c. Return func.
-            Wasm::Callee& jsEntrypointCallee = calleeGroup->jsEntrypointCalleeFromFunctionIndexSpace(functionIndexSpace);
+            auto& jsEntrypointCallee = calleeGroup->jsEntrypointCalleeFromFunctionIndexSpace(functionIndexSpace);
             auto* wasmCallee = calleeGroup->wasmCalleeFromFunctionIndexSpace(functionIndexSpace);
             Wasm::WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = calleeGroup->entrypointLoadLocationFromFunctionIndexSpace(functionIndexSpace);
             Wasm::TypeIndex typeIndex = module->typeIndexFromFunctionIndexSpace(functionIndexSpace);
@@ -760,7 +760,7 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
             JSObject* startFunction = m_instance->instance().importFunction(startFunctionIndexSpace).get();
             m_startFunction.set(vm, this, startFunction);
         } else {
-            Wasm::Callee& jsEntrypointCallee = calleeGroup->jsEntrypointCalleeFromFunctionIndexSpace(startFunctionIndexSpace);
+            auto& jsEntrypointCallee = calleeGroup->jsEntrypointCalleeFromFunctionIndexSpace(startFunctionIndexSpace);
             auto* wasmCallee = calleeGroup->wasmCalleeFromFunctionIndexSpace(startFunctionIndexSpace);
             Wasm::WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = calleeGroup->entrypointLoadLocationFromFunctionIndexSpace(startFunctionIndexSpace);
             WebAssemblyFunction* function = WebAssemblyFunction::create(vm, globalObject, globalObject->webAssemblyFunctionStructure(), signature.argumentCount(), "start"_s, m_instance.get(), jsEntrypointCallee, wasmCallee, entrypointLoadLocation, typeIndex, Wasm::TypeInformation::getCanonicalRTT(typeIndex));

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -744,6 +744,10 @@
 #define ENABLE_WEBASSEMBLY_BBQJIT 1
 #endif
 
+#if !defined(ENABLE_WEBASSEMBLY) && CPU(ADDRESS64) && PLATFORM(COCOA)
+#define ENABLE_WEBASSEMBLY 1
+#endif
+
 /* The SamplingProfiler is the probabilistic and low-overhead profiler used by
  * JSC to measure where time is spent inside a JavaScript program.
  * In configurations other than Windows and Darwin, because layout of mcontext_t depends on standard libraries (like glibc),


### PR DESCRIPTION
#### 54a2d13bf308180a83e7832cb1160030a5a90b11
<pre>
Split JSEntrypointCallee into JIT/Interpreted versions; fix no-jit build
<a href="https://bugs.webkit.org/show_bug.cgi?id=272431">https://bugs.webkit.org/show_bug.cgi?id=272431</a>
<a href="https://rdar.apple.com/126177707">rdar://126177707</a>

Reviewed by Yusuke Suzuki and Ross Kirsling.

This is leading up to the first jit-less wasm entrypoint thunks. The last
patch broke some non-jit builds, so this patch aims to fix that.

This also splits JSEntrypointCallee into JIT/Interpreted versions. The interpreted
version does nothing so far, but this should ensure that all of the ifdef magic
is correct for non-jit builds.

* Source/JavaScriptCore/llint/LLIntData.h:
* Source/JavaScriptCore/llint/LLIntThunks.cpp:
(JSC::LLInt::wasmFunctionEntryThunk):
(JSC::LLInt::wasmFunctionEntryThunkSIMD):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::tierName):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::compileFunction):
(JSC::Wasm::BBQPlan::initializeCallees):
* Source/JavaScriptCore/wasm/WasmBBQPlan.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::Callee::runWithDowncast):
(JSC::Wasm::JSEntrypointJITCallee::setEntrypoint):
(JSC::Wasm::JSEntrypointInterpreterCallee::JSEntrypointInterpreterCallee):
(JSC::Wasm::JSEntrypointInterpreterCallee::entrypointImpl const):
(JSC::Wasm::JSEntrypointInterpreterCallee::calleeSaveRegistersImpl):
* Source/JavaScriptCore/wasm/WasmCallee.h:
(JSC::Wasm::JSEntrypointCallee::JSEntrypointCallee):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::CalleeGroup):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmCompilationMode.cpp:
(JSC::Wasm::makeString):
* Source/JavaScriptCore/wasm/WasmCompilationMode.h:
(JSC::Wasm::isOSREntry):
(JSC::Wasm::isAnyBBQ):
(JSC::Wasm::isAnyOMG):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.h:
* Source/JavaScriptCore/wasm/WasmInstance.cpp:
(JSC::Wasm::Instance::initElementSegment):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.h:
* Source/JavaScriptCore/wasm/js/JSToWasm.cpp:
(JSC::Wasm::createJSToWasmWrapper):
* Source/JavaScriptCore/wasm/js/JSToWasm.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp:
(JSC::WebAssemblyFunction::create):
(JSC::WebAssemblyFunction::WebAssemblyFunction):
* Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp:
(JSC::WebAssemblyModuleRecord::initializeExports):
* Source/WTF/wtf/PlatformEnable.h:

Canonical link: <a href="https://commits.webkit.org/277402@main">https://commits.webkit.org/277402@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a967842dd5f4e770e615f425e11aa58bddba3984

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47217 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49900 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43266 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23857 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38458 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19771 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21307 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41864 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5261 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40622 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43593 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42367 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51776 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46819 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22247 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18715 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45758 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23522 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44768 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10480 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24306 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54206 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23240 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11127 "Passed tests") | 
<!--EWS-Status-Bubble-End-->