### PR TITLE
Text on daringfireball.net (with backdrop-filter) looks fuzzy when zoomed in.

### DIFF
--- a/LayoutTests/css3/filters/backdrop-filter-page-scale-expected.html
+++ b/LayoutTests/css3/filters/backdrop-filter-page-scale-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+    <script>
+        window.onload = function() {
+            if (window.internals)
+                window.internals.setPageScaleFactor(2, 0, 0);
+        }
+    </script>
+<style>
+div {
+    background-color: black;
+    width: 100px;
+    height: 100px;
+}
+
+</style>
+</head>
+<body>
+  Hello
+  <div></div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/backdrop-filter-page-scale.html
+++ b/LayoutTests/css3/filters/backdrop-filter-page-scale.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+    <script>
+        window.onload = function() {
+            if (window.internals)
+                window.internals.setPageScaleFactor(2, 0, 0);
+        }
+    </script>
+<style>
+div {
+    backdrop-filter: invert(1);
+    width: 100px;
+    height: 100px;
+}
+
+</style>
+</head>
+<body>
+  Hello
+  <div></div>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2805,6 +2805,7 @@ webkit.org/b/271423 [ Sonoma+ arm64 ] imported/w3c/web-platform-tests/html/canva
 webkit.org/b/271770 imported/w3c/web-platform-tests/xhr/setrequestheader-case-insensitive.htm [ Pass Failure ]
 
 # Unprefixed backdrop filter disabled on WK1
+css3/filters/backdrop-filter-page-scale.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/filter-effects [ Skip ]
 compositing/filters/backdrop-filter-root-element-no-backdrop-root.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-will-change/will-change-abspos-cb-003.html [ ImageOnlyFailure ]

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp
@@ -38,6 +38,7 @@ PlatformCALayerRemoteTiledBacking::PlatformCALayerRemoteTiledBacking(LayerType l
     : PlatformCALayerRemote(layerType, owner, context)
     , m_tileController(makeUnique<TileController>(this, WebCore::TileController::AllowScrollPerformanceLogging::No))
 {
+    PlatformCALayerRemote::setContentsScale(m_tileController->contentsScale());
 }
 
 PlatformCALayerRemoteTiledBacking::~PlatformCALayerRemoteTiledBacking()
@@ -103,6 +104,7 @@ float PlatformCALayerRemoteTiledBacking::contentsScale() const
 
 void PlatformCALayerRemoteTiledBacking::setContentsScale(float scale)
 {
+    PlatformCALayerRemote::setContentsScale(scale);
     m_tileController->setContentsScale(scale);
 }
 


### PR DESCRIPTION
#### bf2e585595911f4c963b4603c4e1fb32c444053e
<pre>
Text on daringfireball.net (with backdrop-filter) looks fuzzy when zoomed in.
<a href="https://bugs.webkit.org/show_bug.cgi?id=272432">https://bugs.webkit.org/show_bug.cgi?id=272432</a>
&lt;<a href="https://rdar.apple.com/124304151">rdar://124304151</a>&gt;

Reviewed by Simon Fraser.

UI-side compositing equivalent of bug 272430. We need to make sure the content scale
is forwarded to the underlying CALayer for the container, as well as the tile controller.

* LayoutTests/css3/filters/backdrop-filter-page-scale-expected.html: Added.
* LayoutTests/css3/filters/backdrop-filter-page-scale.html: Added.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteTiledBacking.cpp:
(WebKit::PlatformCALayerRemoteTiledBacking::PlatformCALayerRemoteTiledBacking):
(WebKit::PlatformCALayerRemoteTiledBacking::setContentsScale):

Canonical link: <a href="https://commits.webkit.org/277352@main">https://commits.webkit.org/277352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4f9ad6bd86f48d64af490d7ebd25eaacfdcb59b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50044 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43409 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24000 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38576 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47941 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24075 "Found 1 new test failure: http/tests/download/sandboxed-iframe-download-allowed-in-popup.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19896 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21512 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41995 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5404 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51920 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45862 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40981 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44892 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10453 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24451 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23385 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->