### PR TITLE
GeolocationCoordinates should expose a Default .toJSON() method

### DIFF
--- a/LayoutTests/fast/dom/Geolocation/coordinates-interface-toJSON-expected.txt
+++ b/LayoutTests/fast/dom/Geolocation/coordinates-interface-toJSON-expected.txt
@@ -1,0 +1,54 @@
+Test GeolocationCoordinates toJSON() method
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof window.actual === 'object' is true
+PASS window.actual.latitude is window.expected.latitude
+PASS window.actual.longitude is window.expected.longitude
+PASS window.actual.altitude is window.expected.altitude
+PASS window.actual.accuracy is window.expected.accuracy
+PASS window.actual.altitudeAccuracy is window.expected.altitudeAccuracy
+PASS window.actual.heading is window.expected.heading
+PASS window.actual.speed is window.expected.speed
+PASS window.actual.floorLevel is window.expected.floorLevel
+PASS typeof window.actual === 'object' is true
+PASS window.actual.latitude is window.expected.latitude
+PASS window.actual.longitude is window.expected.longitude
+PASS window.actual.altitude is window.expected.altitude
+PASS window.actual.accuracy is window.expected.accuracy
+PASS window.actual.altitudeAccuracy is window.expected.altitudeAccuracy
+PASS window.actual.heading is window.expected.heading
+PASS window.actual.speed is window.expected.speed
+PASS window.actual.floorLevel is window.expected.floorLevel
+PASS typeof window.actual === 'object' is true
+PASS window.actual.latitude is window.expected.latitude
+PASS window.actual.longitude is window.expected.longitude
+PASS window.actual.altitude is window.expected.altitude
+PASS window.actual.accuracy is window.expected.accuracy
+PASS window.actual.altitudeAccuracy is window.expected.altitudeAccuracy
+PASS window.actual.heading is window.expected.heading
+PASS window.actual.speed is window.expected.speed
+PASS window.actual.floorLevel is window.expected.floorLevel
+PASS typeof window.actual === 'object' is true
+PASS window.actual.latitude is window.expected.latitude
+PASS window.actual.longitude is window.expected.longitude
+PASS window.actual.altitude is window.expected.altitude
+PASS window.actual.accuracy is window.expected.accuracy
+PASS window.actual.altitudeAccuracy is window.expected.altitudeAccuracy
+PASS window.actual.heading is window.expected.heading
+PASS window.actual.speed is window.expected.speed
+PASS window.actual.floorLevel is window.expected.floorLevel
+PASS typeof window.actual === 'object' is true
+PASS window.actual.latitude is window.expected.latitude
+PASS window.actual.longitude is window.expected.longitude
+PASS window.actual.altitude is window.expected.altitude
+PASS window.actual.accuracy is window.expected.accuracy
+PASS window.actual.altitudeAccuracy is window.expected.altitudeAccuracy
+PASS window.actual.heading is window.expected.heading
+PASS window.actual.speed is window.expected.speed
+PASS window.actual.floorLevel is window.expected.floorLevel
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/Geolocation/coordinates-interface-toJSON.html
+++ b/LayoutTests/fast/dom/Geolocation/coordinates-interface-toJSON.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+  <head>
+    <script src="../../../resources/js-test-pre.js"></script>
+  </head>
+  <body>
+    <script>
+      description("Test GeolocationCoordinates toJSON() method");
+
+      testRunner.setGeolocationPermission(true);
+
+      window.jsTestIsAsync = true;
+
+      const baseExpected = {
+        altitude: null,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null,
+        floorLevel: null,
+      };
+
+      const testData = [
+        [
+          { latitude: 1, longitude: 2, accuracy: 3 },
+          { ...baseExpected, latitude: 1, longitude: 2, accuracy: 3 },
+        ],
+        [
+          { latitude: 2, longitude: 3, accuracy: 4, speed: 5 },
+          { ...baseExpected, latitude: 2, longitude: 3, accuracy: 4, speed: 5 },
+        ],
+        [
+          {
+            latitude: 3,
+            longitude: 4,
+            accuracy: 5,
+            altitudeAccuracy: 6,
+            speed: 7,
+          },
+          {
+            ...baseExpected,
+            latitude: 3,
+            longitude: 4,
+            accuracy: 5,
+            altitudeAccuracy: 6,
+            speed: 7,
+          },
+        ],
+        [
+          {
+            latitude: 4,
+            longitude: 5,
+            accuracy: 6,
+            altitudeAccuracy: 7,
+            heading: 8,
+            speed: 9,
+          },
+          {
+            ...baseExpected,
+            latitude: 4,
+            longitude: 5,
+            accuracy: 6,
+            altitudeAccuracy: 7,
+            heading: 8,
+            speed: 9,
+          },
+        ],
+        [
+          {
+            latitude: 5,
+            longitude: 6,
+            accuracy: 7,
+            altitude: 8,
+            altitudeAccuracy: 9,
+            heading: 10,
+            speed: 11,
+          },
+          {
+            ...baseExpected,
+            latitude: 5,
+            longitude: 6,
+            accuracy: 7,
+            altitude: 8,
+            altitudeAccuracy: 9,
+            heading: 10,
+            speed: 11,
+          },
+        ],
+      ];
+
+      async function runNextTest() {
+        for (const [actual, expected] of testData) {
+          window.expected = expected;
+          const {
+            latitude,
+            longitude,
+            accuracy,
+            altitude,
+            altitudeAccuracy,
+            heading,
+            speed,
+            floorLevel,
+          } = actual;
+
+          testRunner.setMockGeolocationPosition(
+            latitude,
+            longitude,
+            accuracy,
+            altitude,
+            altitudeAccuracy,
+            heading,
+            speed,
+            floorLevel
+          );
+
+          const position = await new Promise((resolve, reject) =>
+            navigator.geolocation.getCurrentPosition(resolve, reject)
+          );
+
+          window.actual = position.coords.toJSON();
+
+          shouldBeTrue(`typeof window.actual === 'object'`);
+
+          // We use "actual" for future proofing on purpose, in case more properties get added to the interface.
+          for (const key in window.actual) {
+            shouldBe(`window.actual.${key}`, `window.expected.${key}`);
+          }
+        }
+      }
+
+      runNextTest().finally(finishJSTest);
+    </script>
+    <script src="../../../resources/js-test-post.js"></script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/geolocation/GeolocationCoordinates.idl
+++ b/Source/WebCore/Modules/geolocation/GeolocationCoordinates.idl
@@ -36,7 +36,8 @@
     readonly attribute unrestricted double? altitudeAccuracy;
     readonly attribute unrestricted double? heading;
     readonly attribute unrestricted double? speed;
-    
+    [Default] object toJSON();
+
     // Non standard.
     [EnabledBySetting=GeolocationFloorLevelEnabled] readonly attribute unrestricted double? floorLevel;
 };


### PR DESCRIPTION
#### 0160ba82ea224867551f48009bf73f578536c27d
<pre>
GeolocationCoordinates should expose a Default .toJSON() method
<a href="https://bugs.webkit.org/show_bug.cgi?id=272434">https://bugs.webkit.org/show_bug.cgi?id=272434</a>
<a href="https://rdar.apple.com/126183686">rdar://126183686</a>

Reviewed by Ryosuke Niwa.

Implements and tests the toJSON() method for the GeolocationCoordinates interface, as proposed:
<a href="https://github.com/w3c/geolocation-api/pull/147">https://github.com/w3c/geolocation-api/pull/147</a>

* LayoutTests/fast/dom/Geolocation/coordinates-interface-toJSON-expected.txt: Added.
* LayoutTests/fast/dom/Geolocation/coordinates-interface-toJSON.html: Added.
* Source/WebCore/Modules/geolocation/GeolocationCoordinates.idl:

Canonical link: <a href="https://commits.webkit.org/277347@main">https://commits.webkit.org/277347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e363098a48c40b86b371c3a12d93748870c4b864

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49911 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43277 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38467 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40711 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19779 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21338 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41871 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5272 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43603 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42279 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51787 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22258 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18623 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45771 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/40857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44783 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10449 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->