### PR TITLE
Do some more std::span adoption in WebCore

### DIFF
--- a/Source/WTF/wtf/SortedArrayMap.h
+++ b/Source/WTF/wtf/SortedArrayMap.h
@@ -234,13 +234,16 @@ constexpr int strcmpConstExpr(const char* a, const char* b)
     return *a == *b ? 0 : *a < *b ? -1 : 1;
 }
 
-template<typename CharacterType> inline bool lessThanASCIICaseFolding(const CharacterType* characters, unsigned length, const char* literalWithNoUppercase)
+template<typename CharacterType> inline bool lessThanASCIICaseFolding(std::span<const CharacterType> characters, const char* literalWithNoUppercase)
 {
-    for (unsigned i = 0; i < length; ++i) {
-        if (!literalWithNoUppercase[i])
+    for (auto character : characters) {
+        auto literalCharacter = *literalWithNoUppercase;
+        if (!literalCharacter)
             return false;
-        if (auto character = toASCIILower(characters[i]); character != literalWithNoUppercase[i])
-            return character < literalWithNoUppercase[i];
+        character = toASCIILower(character);
+        if (character != literalCharacter)
+            return character < literalCharacter;
+        ++literalWithNoUppercase;
     }
     return true;
 }
@@ -248,17 +251,20 @@ template<typename CharacterType> inline bool lessThanASCIICaseFolding(const Char
 inline bool lessThanASCIICaseFolding(StringView string, const char* literalWithNoUppercase)
 {
     if (string.is8Bit())
-        return lessThanASCIICaseFolding(string.characters8(), string.length(), literalWithNoUppercase);
-    return lessThanASCIICaseFolding(string.characters16(), string.length(), literalWithNoUppercase);
+        return lessThanASCIICaseFolding(string.span8(), literalWithNoUppercase);
+    return lessThanASCIICaseFolding(string.span16(), literalWithNoUppercase);
 }
 
-template<typename CharacterType> inline bool lessThanASCIICaseFolding(const char* literalWithNoUppercase, const CharacterType* characters, unsigned length)
+template<typename CharacterType> inline bool lessThanASCIICaseFolding(const char* literalWithNoUppercase, std::span<const CharacterType> characters)
 {
-    for (unsigned i = 0; i < length; ++i) {
-        if (!literalWithNoUppercase[i])
+    for (auto character : characters) {
+        auto literalCharacter = *literalWithNoUppercase;
+        if (!literalCharacter)
             return true;
-        if (auto character = toASCIILower(characters[i]); character != literalWithNoUppercase[i])
-            return literalWithNoUppercase[i] < character;
+        character = toASCIILower(character);
+        if (character != literalCharacter)
+            return literalCharacter < character;
+        ++literalWithNoUppercase;
     }
     return false;
 }
@@ -266,8 +272,8 @@ template<typename CharacterType> inline bool lessThanASCIICaseFolding(const char
 inline bool lessThanASCIICaseFolding(const char* literalWithNoUppercase, StringView string)
 {
     if (string.is8Bit())
-        return lessThanASCIICaseFolding(literalWithNoUppercase, string.characters8(), string.length());
-    return lessThanASCIICaseFolding(literalWithNoUppercase, string.characters16(), string.length());
+        return lessThanASCIICaseFolding(literalWithNoUppercase, string.span8());
+    return lessThanASCIICaseFolding(literalWithNoUppercase, string.span16());
 }
 
 template<ASCIISubset subset> constexpr bool operator==(ComparableASCIISubsetLiteral<subset> a, ComparableASCIISubsetLiteral<subset> b)

--- a/Source/WTF/wtf/URLParser.h
+++ b/Source/WTF/wtf/URLParser.h
@@ -89,7 +89,7 @@ private:
     static constexpr size_t defaultInlineBufferSize = 2048;
     using LCharBuffer = Vector<LChar, defaultInlineBufferSize>;
 
-    template<typename CharacterType> void parse(const CharacterType*, const unsigned length, const URL&, const URLTextEncoding*);
+    template<typename CharacterType> void parse(std::span<const CharacterType>, const URL&, const URLTextEncoding*);
     template<typename CharacterType> void parseAuthority(CodePointIterator<CharacterType>);
     enum class HostParsingResult : uint8_t { InvalidHost, IPv6WithPort, IPv6WithoutPort, IPv4WithPort, IPv4WithoutPort, DNSNameWithPort, DNSNameWithoutPort, NonSpecialHostWithoutPort, NonSpecialHostWithPort };
     template<typename CharacterType> HostParsingResult parseHostAndPort(CodePointIterator<CharacterType>);

--- a/Source/WTF/wtf/text/CodePointIterator.h
+++ b/Source/WTF/wtf/text/CodePointIterator.h
@@ -35,57 +35,57 @@ template<typename CharacterType>
 class CodePointIterator {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ALWAYS_INLINE CodePointIterator() { }
-    ALWAYS_INLINE CodePointIterator(const CharacterType* begin, const CharacterType* end)
-        : m_begin(begin)
-        , m_end(end)
+    ALWAYS_INLINE CodePointIterator() = default;
+    ALWAYS_INLINE CodePointIterator(std::span<const CharacterType> data)
+        : m_data(data)
     {
     }
     
     ALWAYS_INLINE CodePointIterator(const CodePointIterator& begin, const CodePointIterator& end)
-        : CodePointIterator(begin.m_begin, end.m_begin)
+        : CodePointIterator({ begin.m_data.data(), end.m_data.data() })
     {
-        ASSERT(end.m_begin >= begin.m_begin);
+        ASSERT(end.m_data.data() >= begin.m_data.data());
     }
     
     ALWAYS_INLINE char32_t operator*() const;
     ALWAYS_INLINE CodePointIterator& operator++();
 
-    ALWAYS_INLINE friend bool operator==(const CodePointIterator&, const CodePointIterator&) = default;
+    ALWAYS_INLINE friend bool operator==(const CodePointIterator& a, const CodePointIterator& b)
+    {
+        return a.m_data.data() == b.m_data.data() && a.m_data.size() == b.m_data.size();
+    }
 
     ALWAYS_INLINE bool atEnd() const
     {
-        ASSERT(m_begin <= m_end);
-        return m_begin >= m_end;
+        return m_data.empty();
     }
     
     ALWAYS_INLINE size_t codeUnitsSince(const CharacterType* reference) const
     {
-        ASSERT(m_begin >= reference);
-        return m_begin - reference;
+        ASSERT(m_data.data() >= reference);
+        return m_data.data() - reference;
     }
 
     ALWAYS_INLINE size_t codeUnitsSince(const CodePointIterator& other) const
     {
-        return codeUnitsSince(other.m_begin);
+        return codeUnitsSince(other.m_data.data());
     }
     
 private:
-    const CharacterType* m_begin { nullptr };
-    const CharacterType* m_end { nullptr };
+    std::span<const CharacterType> m_data;
 };
 
 template<>
 ALWAYS_INLINE char32_t CodePointIterator<LChar>::operator*() const
 {
     ASSERT(!atEnd());
-    return *m_begin;
+    return m_data.front();
 }
 
 template<>
 ALWAYS_INLINE auto CodePointIterator<LChar>::operator++() -> CodePointIterator&
 {
-    m_begin++;
+    m_data = m_data.subspan(1);
     return *this;
 }
 
@@ -94,7 +94,7 @@ ALWAYS_INLINE char32_t CodePointIterator<UChar>::operator*() const
 {
     ASSERT(!atEnd());
     char32_t c;
-    U16_GET(m_begin, 0, 0, m_end - m_begin, c);
+    U16_GET(m_data, 0, 0, m_data.size(), c);
     return c;
 }
 
@@ -102,10 +102,12 @@ template<>
 ALWAYS_INLINE auto CodePointIterator<UChar>::operator++() -> CodePointIterator&
 {
     unsigned i = 0;
-    size_t length = m_end - m_begin;
-    U16_FWD_1(m_begin, i, length);
-    m_begin += i;
+    size_t length = m_data.size();
+    U16_FWD_1(m_data, i, length);
+    m_data = m_data.subspan(i);
     return *this;
 }
+
+template<typename CharacterType> CodePointIterator(std::span<const CharacterType>) -> CodePointIterator<CharacterType>;
 
 } // namespace WTF

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -273,7 +273,7 @@ static Vector<uint8_t> eucJPEncode(StringView string, Function<void(char32_t, Ve
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator(characters.get(), characters.get() + string.length()); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<UChar> iterator({ characters.get(), string.length() }); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint)) {
             result.append(codePoint);
@@ -590,7 +590,7 @@ static Vector<uint8_t> iso2022JPEncode(StringView string, Function<void(char32_t
     };
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator(characters.get(), characters.get() + string.length()); !iterator.atEnd(); ++iterator)
+    for (WTF::CodePointIterator<UChar> iterator({ characters.get(), string.length() }); !iterator.atEnd(); ++iterator)
         parseCodePoint(*iterator);
 
     if (state != State::ASCII)
@@ -644,7 +644,7 @@ static Vector<uint8_t> shiftJISEncode(StringView string, Function<void(char32_t,
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator(characters.get(), characters.get() + string.length()); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<UChar> iterator({ characters.get(), string.length() }); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint) || codePoint == 0x0080) {
             result.append(codePoint);
@@ -712,7 +712,7 @@ static Vector<uint8_t> eucKREncode(StringView string, Function<void(char32_t, Ve
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator(characters.get(), characters.get() + string.length()); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<UChar> iterator({ characters.get(), string.length() }); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint)) {
             result.append(codePoint);
@@ -783,7 +783,7 @@ static Vector<uint8_t> big5Encode(StringView string, Function<void(char32_t, Vec
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator(characters.get(), characters.get() + string.length()); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<UChar> iterator({ characters.get(), string.length() }); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint)) {
             result.append(codePoint);
@@ -1045,7 +1045,7 @@ static Vector<uint8_t> gbEncodeShared(StringView string, Function<void(char32_t,
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator(characters.get(), characters.get() + string.length()); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<UChar> iterator({ characters.get(), string.length() }); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint)) {
             result.append(codePoint);


### PR DESCRIPTION
#### fa32236821c30e4b79550d58ae4e12e3e7aabe5d
<pre>
Do some more std::span adoption in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=272437">https://bugs.webkit.org/show_bug.cgi?id=272437</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/SortedArrayMap.h:
(WTF::lessThanASCIICaseFolding):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::copyBaseWindowsDriveLetter):
(WTF::URLParser::shouldPopPath):
(WTF::URLParser::isLocalhost):
(WTF::URLParser::URLParser):
(WTF::URLParser::parse):
(WTF::URLParser::subdomainStartsWithXNDashDash):
(WTF::URLParser::parseHostAndPort):
* Source/WTF/wtf/URLParser.h:
* Source/WTF/wtf/text/CodePointIterator.h:
(WTF::CodePointIterator::CodePointIterator):
(WTF::CodePointIterator::operator==):
(WTF::CodePointIterator::atEnd const):
(WTF::CodePointIterator::codeUnitsSince const):
(WTF::CodePointIterator&lt;LChar&gt;::operator const):
(WTF::CodePointIterator&lt;LChar&gt;::operator):
(WTF::CodePointIterator&lt;UChar&gt;::operator const):
(WTF::CodePointIterator&lt;UChar&gt;::operator):
(): Deleted.
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::eucJPEncode):
(PAL::iso2022JPEncode):
(PAL::shiftJISEncode):
(PAL::eucKREncode):
(PAL::big5Encode):
(PAL::gbEncodeShared):

Canonical link: <a href="https://commits.webkit.org/277448@main">https://commits.webkit.org/277448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82beadf35d9cbe805ae06ad78cd990b054f2b2c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47585 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50267 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43633 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24229 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38742 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24384 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41005 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20045 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42180 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5627 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40866 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Running jscore-test") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52148 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47075 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18955 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46045 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; 110 flakes 48 failures; Uploaded test results; 12 flakes 31 failures; Running compile-webkit-without-change") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23892 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45076 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24681 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54575 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6728 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23611 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11187 "Passed tests") | 
<!--EWS-Status-Bubble-End-->