### PR TITLE
[WebXR] Runtime reachability of WebXR IPC endpoints

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -141,6 +141,7 @@ public:
 
     bool isWebGPUEnabled() const { return m_preferences.isWebGPUEnabled; }
     bool isWebGLEnabled() const { return m_preferences.isWebGLEnabled; }
+    bool isWebXREnabled() const { return m_preferences.isWebXREnabled; }
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     bool isDynamicContentScalingEnabled() const { return m_preferences.isDynamicContentScalingEnabled; }

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -245,6 +245,14 @@ void RemoteGraphicsContextGL::paintNativeImageToImageBuffer(NativeImage& image, 
     });
 }
 
+bool RemoteGraphicsContextGL::webXREnabled() const
+{
+    RefPtr gpuConnectionToWebProcess = m_gpuConnectionToWebProcess.get();
+    if (gpuConnectionToWebProcess)
+        return gpuConnectionToWebProcess->isWebXREnabled();
+    return false;
+}
+
 void RemoteGraphicsContextGL::simulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting event)
 {
     assertIsCurrent(workQueue());

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -143,6 +143,7 @@ protected:
 
 private:
     void paintNativeImageToImageBuffer(WebCore::NativeImage&, WebCore::RenderingResourceIdentifier);
+    bool webXREnabled() const;
 
 protected:
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -329,10 +329,10 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void CreateExternalSync(uint32_t externalSync, WebCore::GraphicsContextGL::ExternalSyncSource arg0) NotStreamEncodable
     void DeleteExternalSync(uint32_t arg0)
     void ClientWaitExternalSyncWithFlush(uint32_t arg0, uint64_t timeout) -> (bool returnValue) Synchronous
-    void EnableRequiredWebXRExtensions() -> (bool returnValue) Synchronous
-    void AddFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const float> horizontalSamplesLeft, std::span<const float> verticalSamples, std::span<const float> horizontalSamplesRight) -> (bool returnValue) Synchronous
-    void EnableFoveation(uint32_t arg0)
-    void DisableFoveation()
+    [EnabledIf='webXREnabled()'] void EnableRequiredWebXRExtensions() -> (bool returnValue) Synchronous
+    [EnabledIf='webXREnabled()'] void AddFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const float> horizontalSamplesLeft, std::span<const float> verticalSamples, std::span<const float> horizontalSamplesRight) -> (bool returnValue) Synchronous
+    [EnabledIf='webXREnabled()'] void EnableFoveation(uint32_t arg0)
+    [EnabledIf='webXREnabled()'] void DisableFoveation()
 }
 
 #endif

--- a/Source/WebKit/Shared/GPUProcessPreferencesForWebProcess.h
+++ b/Source/WebKit/Shared/GPUProcessPreferencesForWebProcess.h
@@ -32,6 +32,7 @@ namespace WebKit {
 struct GPUProcessPreferencesForWebProcess {
     bool isWebGLEnabled { false };
     bool isWebGPUEnabled { false };
+    bool isWebXREnabled { false };
     bool isDOMRenderingEnabled { false };
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     bool isDynamicContentScalingEnabled { false };

--- a/Source/WebKit/Shared/GPUProcessPreferencesForWebProcess.serialization.in
+++ b/Source/WebKit/Shared/GPUProcessPreferencesForWebProcess.serialization.in
@@ -25,6 +25,7 @@
 struct WebKit::GPUProcessPreferencesForWebProcess {
     bool isWebGLEnabled;
     bool isWebGPUEnabled;
+    bool isWebXREnabled;
     bool isDOMRenderingEnabled;
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     bool isDynamicContentScalingEnabled;

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -334,6 +334,7 @@ GPUProcessPreferencesForWebProcess PageConfiguration::preferencesForGPUProcess()
     return {
         preferences->webGLEnabled(),
         preferences->webGPUEnabled(),
+        preferences->webXREnabled(),
         preferences->useGPUProcessForDOMRenderingEnabled(),
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
         preferences->useCGDisplayListsForDOMRendering(),

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -43,6 +43,9 @@
 #include <wtf/HashMap.h>
 #include <wtf/WeakPtr.h>
 
+// Used by generate-gpup-webgl
+#define IPC_MESSAGE_ATTRIBUTE(x)
+
 namespace WebKit {
 
 struct RemoteGraphicsContextGLInitializationState;
@@ -369,10 +372,10 @@ public:
     void deleteExternalSync(GCGLExternalSync) final;
     bool clientWaitExternalSyncWithFlush(GCGLExternalSync, uint64_t timeout) final;
 
-    bool enableRequiredWebXRExtensions() final;
-    bool addFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const GCGLfloat> horizontalSamplesLeft, std::span<const GCGLfloat> verticalSamples, std::span<const GCGLfloat> horizontalSamplesRight) final;
-    void enableFoveation(GCGLuint) final;
-    void disableFoveation() final;
+    bool enableRequiredWebXRExtensions() IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
+    bool addFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const GCGLfloat> horizontalSamplesLeft, std::span<const GCGLfloat> verticalSamples, std::span<const GCGLfloat> horizontalSamplesRight) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
+    void enableFoveation(GCGLuint) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
+    void disableFoveation() IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
 
     // End of list used by generate-gpup-webgl script.
 

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -456,12 +456,14 @@ class cpp_func(object):
     name: str
     args: cpp_arg_list
     return_type: cpp_type
+    attr: str
     overload_suffix: str
 
-    def __init__(self, name: str, return_type: cpp_type, args: cpp_arg_list):
+    def __init__(self, name: str, return_type: cpp_type, args: cpp_arg_list, attr: str):
         self.name = name
         self.return_type = return_type
         self.args = args
+        self.attr = attr
         self.overload_suffix = ""
 
     def __str__(self):
@@ -604,11 +606,13 @@ non_stream_types = set({"WebCore::GraphicsContextGL::ExternalImageSource&&", "We
 
 
 class webkit_ipc_msg(object):
+    attr: str
     name: str
     in_args: cpp_arg_list
     out_args: cpp_arg_list
 
     def __init__(self, func: cpp_func):
+        self.attr = func.attr
         self.name = webkit_ipc_msg_name(func)
         in_args, out_args = func.get_args_categories()
         ipc_in_args = [cpp_arg(webkit_ipc_msg_arg_type(a.type), a.name) for a in in_args]
@@ -629,10 +633,11 @@ class webkit_ipc_msg(object):
             self.tags += ["NotStreamEncodable"]
 
     def __str__(self):
+        attr = f"[{self.attr}] " if self.attr else ""
         tags = f" {' '.join(self.tags)}" if self.tags else ""
         if len(self.out_args.args):
-            return f"\n    void {self.name}({str(self.in_args)}) -> ({str(self.out_args)}) Synchronous{tags}"
-        return f"\n    void {self.name}({str(self.in_args)}){tags}"
+            return f"\n    {attr}void {self.name}({str(self.in_args)}) -> ({str(self.out_args)}) Synchronous{tags}"
+        return f"\n    {attr}void {self.name}({str(self.in_args)}){tags}"
 
 
 class webkit_ipc_cpp_proxy_impl(object):
@@ -999,8 +1004,8 @@ def create_cpp_arg_list(args_specs: Iterable[str]):
     return cpp_arg_list([create_cpp_arg(arg_spec=e, arg_index=i) for i, e in enumerate(args_specs)])
 
 
-def create_cpp_func(name: str, return_spec: str, args_specs: List[str]):
-    return cpp_func(name=name, return_type=get_cpp_type(return_spec), args=create_cpp_arg_list(args_specs))
+def create_cpp_func(name: str, return_spec: str, args_specs: List[str], attr: str):
+    return cpp_func(name=name, return_type=get_cpp_type(return_spec), args=create_cpp_arg_list(args_specs), attr=attr)
 
 
 def read_lines_until(lines: Iterable[str], match: str) -> Generator[str, None, None]:
@@ -1026,13 +1031,14 @@ def main():
                 pass
 
             for line in read_lines_until(lines, "// End of list used by generate-gpup-webgl script."):
-                m = re.match(r"\s*(\S+)\s+(\w+)\((.*)\) final;", line)
+                m = re.match(r"\s*(\S+)\s+(\w+)\((.*?)\)\s+(IPC_MESSAGE_ATTRIBUTE\((\S+?)\)\s+)?final;", line)
                 if m:
                     func_name = m[2]
                     func = create_cpp_func(
                         name=func_name,
                         return_spec=m[1],
                         args_specs=cpp_split_args_specs(m[3]),
+                        attr=m[5]
                     )
                     if func.is_implemented():
                         funcs.append(func)


### PR DESCRIPTION
#### 7c2117c191df17ba95f1b1757ce374c235c27dfa
<pre>
[WebXR] Runtime reachability of WebXR IPC endpoints
<a href="https://bugs.webkit.org/show_bug.cgi?id=272438">https://bugs.webkit.org/show_bug.cgi?id=272438</a>
<a href="https://rdar.apple.com/121552524">rdar://121552524</a>

Reviewed by Mike Wyrzykowski.

This change uses [EnabledIf=&quot;&quot;] attribute to enable reachability to WebXR
related RemoteGraphicsContextGL IPC endpoints when WebXREnabled preference is
enabled. This allows runtime control over handling of messages, with any
messages received when disabled being dropped.

generate-gpup-webgl has been extended to allow specification of attributes on
the generated messages by adding macro IPC_MESSAGE_ATTRIBUTE(...) between
argument list and `final` keyword in the C++ function prototype. The contents of
IPC_MESSAGE_ATTRIBUTE is copied verbatim as the attribute on the generated
message signature.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
(WebKit::GPUConnectionToWebProcess::isWebXREnabled const):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::webXREnabled const):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/Shared/GPUProcessPreferencesForWebProcess.h:
* Source/WebKit/Shared/GPUProcessPreferencesForWebProcess.serialization.in:
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::preferencesForGPUProcess const):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Tools/Scripts/generate-gpup-webgl:
(cpp_func):
(cpp_func.__init__):
(webkit_ipc_msg):
(webkit_ipc_msg.__init__):
(webkit_ipc_msg.__str__):
(create_cpp_arg_list):
(create_cpp_func):
(main):

Canonical link: <a href="https://commits.webkit.org/277361@main">https://commits.webkit.org/277361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3569f181bfa226f4cf43c1f5e9992bf0fd228dfa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50092 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43457 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38595 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19915 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42023 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5452 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51969 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22441 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45894 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23715 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44927 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10458 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->