### PR TITLE
Adding CryptoKit for ECDSA/ECDH

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp
@@ -169,11 +169,12 @@ RefPtr<ArrayBuffer> AuthenticatorAttestationResponse::getPublicKey() const
             return nullptr;
         }
         auto y = it->second.getByteString();
+        // FIXME: Enable cryptoKit here after it's enabled in SubtleCryptoAPI rdar://126352502
+        auto peerKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(x, y), true, CryptoKeyUsageDeriveBits, UseCryptoKit::No);
 
-        auto peerKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(x, y), true, CryptoKeyUsageDeriveBits);
         if (!peerKey)
             return nullptr;
-        auto keySpki = peerKey->exportSpki().releaseReturnValue();
+        auto keySpki = peerKey->exportSpki(UseCryptoKit::No).releaseReturnValue();
         return ArrayBuffer::tryCreate(keySpki.data(), keySpki.size());
     }
     default:

--- a/Source/WebCore/Modules/webauthn/fido/Pin.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.cpp
@@ -44,10 +44,14 @@
 #include "DeviceResponseConverter.h"
 #include "WebAuthenticationConstants.h"
 #include "WebAuthenticationUtils.h"
+#if HAVE(SWIFT_CPP_INTEROP)
+#include <pal/PALSwift.h>
+#endif
 #include <pal/crypto/CryptoDigest.h>
 
 namespace fido {
 using namespace WebCore;
+static constexpr auto useCryptoKit = UseCryptoKit::No;
 using CBOR = cbor::CBORValue;
 
 namespace pin {
@@ -124,6 +128,10 @@ KeyAgreementResponse::KeyAgreementResponse(Ref<CryptoKeyEC>&& peerKey)
 {
 }
 
+KeyAgreementResponse::~KeyAgreementResponse() = default;
+KeyAgreementResponse::KeyAgreementResponse(KeyAgreementResponse&&) = default;
+KeyAgreementResponse& KeyAgreementResponse::operator=(KeyAgreementResponse&&) = default;
+
 std::optional<KeyAgreementResponse> KeyAgreementResponse::parse(const Vector<uint8_t>& inBuffer)
 {
     auto decodedMap = decodeResponseMap(inBuffer);
@@ -162,7 +170,8 @@ std::optional<KeyAgreementResponse> KeyAgreementResponse::parseFromCOSE(const CB
 
     const auto& x = xIt->second.getByteString();
     const auto& y = yIt->second.getByteString();
-    auto peerKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(x, y), true, CryptoKeyUsageDeriveBits);
+    // FIXME: enable cryptoKit when it's enabled for SubtleCryptoAPI rdar://126352502
+    auto peerKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(x, y), true, CryptoKeyUsageDeriveBits, useCryptoKit);
     if (!peerKey)
         return std::nullopt;
 
@@ -238,12 +247,14 @@ std::optional<TokenRequest> TokenRequest::tryCreate(const CString& pin, const Cr
     // The following implements Section 5.5.4 Getting sharedSecret from Authenticator.
     // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#gettingSharedSecret
     // 1. Generate a P256 key pair.
-    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits);
+    // FIXME: enable cryptoKit when it's enabled for SubtleCryptoAPI rdar://126352502
+    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits, useCryptoKit);
     ASSERT(!keyPairResult.hasException());
     auto keyPair = keyPairResult.releaseReturnValue();
 
     // 2. Use ECDH and SHA-256 to compute the shared AES-CBC key.
-    auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), peerKey);
+    // FIXME: enable cryptoKit when it's enabled for SubtleCryptoAPI rdar://126352502
+    auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), peerKey, useCryptoKit);
     if (!sharedKeyResult)
         return std::nullopt;
 
@@ -255,7 +266,8 @@ std::optional<TokenRequest> TokenRequest::tryCreate(const CString& pin, const Cr
     ASSERT(sharedKey);
 
     // The following encodes the public key of the above key pair into COSE format.
-    auto rawPublicKeyResult = downcast<CryptoKeyEC>(*keyPair.publicKey).exportRaw();
+    // FIXME: enable cryptoKit when it's enabled for SubtleCryptoAPI rdar://126352502
+    auto rawPublicKeyResult = downcast<CryptoKeyEC>(*keyPair.publicKey).exportRaw(useCryptoKit);
     ASSERT(!rawPublicKeyResult.hasException());
     auto coseKey = encodeCOSEPublicKey(rawPublicKeyResult.returnValue());
 
@@ -303,12 +315,14 @@ std::optional<SetPinRequest> SetPinRequest::tryCreate(const String& inputPin, co
     // The following implements Section 5.5.4 Getting sharedSecret from Authenticator.
     // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#gettingSharedSecret
     // 1. Generate a P256 key pair.
-    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits);
+    // FIXME: enable cryptoKit when it's enabled for SubtleCryptoAPI rdar://126352502
+    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits, useCryptoKit);
     ASSERT(!keyPairResult.hasException());
     auto keyPair = keyPairResult.releaseReturnValue();
 
     // 2. Use ECDH and SHA-256 to compute the shared AES-CBC key.
-    auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), peerKey);
+    // FIXME: enable cryptoKit when it's enabled for SubtleCryptoAPI rdar://126352502
+    auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), peerKey, useCryptoKit);
     if (!sharedKeyResult)
         return std::nullopt;
 
@@ -320,7 +334,8 @@ std::optional<SetPinRequest> SetPinRequest::tryCreate(const String& inputPin, co
     ASSERT(sharedKey);
 
     // The following encodes the public key of the above key pair into COSE format.
-    auto rawPublicKeyResult = downcast<CryptoKeyEC>(*keyPair.publicKey).exportRaw();
+    // FIXME: enable cryptoKit when it's enabled for SubtleCryptoAPI rdar://126352502
+    auto rawPublicKeyResult = downcast<CryptoKeyEC>(*keyPair.publicKey).exportRaw(useCryptoKit);
     ASSERT(!rawPublicKeyResult.hasException());
     auto coseKey = encodeCOSEPublicKey(rawPublicKeyResult.returnValue());
 

--- a/Source/WebCore/Modules/webauthn/fido/Pin.h
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.h
@@ -127,7 +127,9 @@ struct KeyAgreementResponse {
     WEBCORE_EXPORT static std::optional<KeyAgreementResponse> parseFromCOSE(const cbor::CBORValue::MapValue&);
 
     Ref<WebCore::CryptoKeyEC> peerKey;
-
+    WEBCORE_EXPORT ~KeyAgreementResponse();
+    WEBCORE_EXPORT KeyAgreementResponse(KeyAgreementResponse&&);
+    WEBCORE_EXPORT KeyAgreementResponse& operator=(KeyAgreementResponse&&);
 private:
     explicit KeyAgreementResponse(Ref<WebCore::CryptoKeyEC>&&);
 };

--- a/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
@@ -34,6 +34,10 @@ public typealias VectorUInt8 = Cpp.VectorUInt8
 public typealias SpanConstUInt8 = Cpp.SpanConstUInt8
 public typealias OptionalVectorUInt8 = Cpp.OptionalVectorUInt8
 
+private enum LocalErrors: Error {
+    case invalidArgument
+}
+
 public enum ErrorCodes: Int {
     case success = 0
     case wrongTagSize = 1
@@ -43,6 +47,14 @@ public enum ErrorCodes: Int {
     case tooBigArguments = 5
     case decryptionFailed = 6
     case hashingFailed = 7
+    case publicKeyProvidedToSign = 8
+    case failedToSign = 9
+    case failedToVerify = 10
+    case privateKeyProvidedForVerification = 11
+    case failedToImport = 12
+    case failedToDerive = 13
+    case failedToExport = 14
+    case defaultValue = 15
 }
 
 private class Utils {
@@ -119,25 +131,325 @@ public class AesKw {
 
 }  // AesKw
 
+public enum HashFunction {
+    case sha256
+    case sha384
+    case sha512
+    case sha1
+}
+
 public class Digest {
     public static func sha1(_ data: SpanConstUInt8) -> VectorUInt8 {
-        return digest(data, Insecure.SHA1.self)
+        return digest(data, t: Insecure.SHA1.self)
     }
     public static func sha256(_ data: SpanConstUInt8) -> VectorUInt8 {
-        return digest(data, SHA256.self)
+        return digest(data, t: SHA256.self)
     }
     public static func sha384(_ data: SpanConstUInt8) -> VectorUInt8 {
-        return digest(data, SHA384.self)
+        return digest(data, t: SHA384.self)
     }
     public static func sha512(_ data: SpanConstUInt8) -> VectorUInt8 {
-        return digest(data, SHA512.self)
+        return digest(data, t: SHA512.self)
     }
-    private static func digest<T: HashFunction>(_ data: SpanConstUInt8, _: T.Type)
-        -> VectorUInt8
+    fileprivate static func digest<T: CryptoKit.HashFunction>(_ data: SpanConstUInt8, _: T.Type)
+        -> T.Digest
     {
         var hasher = T()
         hasher.update(data: data)
-        return hasher.finalize().copyToVectorUInt8()
+        return hasher.finalize()
+    }
+
+    fileprivate static func digest<T: CryptoKit.HashFunction>(_ data: SpanConstUInt8, t: T.Type)
+        -> VectorUInt8
+    {
+        return Self.digest(data, t).copyToVectorUInt8()
+    }
+
+    fileprivate static func digest(_ data: SpanConstUInt8, hashFunction: HashFunction)
+    -> any CryptoKit.Digest
+    {
+        switch hashFunction {
+        case .sha256:
+            return digest(data, SHA256.self)
+        case .sha384:
+            return digest(data, SHA384.self)
+        case .sha512:
+            return digest(data, SHA512.self)
+        case .sha1:
+            return digest(data, Insecure.SHA1.self)
+        }
+    }
+}
+
+public enum ECCurve {
+    case p256
+    case p384
+    case p521
+}
+
+enum ECPrivateKey {
+    case p256(P256.Signing.PrivateKey)
+    case p384(P384.Signing.PrivateKey)
+    case p521(P521.Signing.PrivateKey)
+}
+
+enum ECPublicKey {
+    case p256(P256.Signing.PublicKey)
+    case p384(P384.Signing.PublicKey)
+    case p521(P521.Signing.PublicKey)
+}
+enum ECKeyInternal {
+    case priv(ECPrivateKey)
+    case pub(ECPublicKey)
+}
+
+public struct ECRv {
+    public var errCode: ErrorCodes = .defaultValue
+    public var signature: OptionalVectorUInt8 = OptionalVectorUInt8()
+    public var keyBytes: OptionalVectorUInt8 = OptionalVectorUInt8()
+    public var key: ECKey? = nil
+}
+
+public struct ECKey {
+    let key: ECKeyInternal
+    public init(curve: ECCurve) {
+        switch curve {
+        case .p256:
+            key = .priv(.p256(P256.Signing.PrivateKey(compactRepresentable: true)))
+        case .p384:
+            key = .priv(.p384(P384.Signing.PrivateKey(compactRepresentable: true)))
+        case .p521:
+            key = .priv(.p521(P521.Signing.PrivateKey(compactRepresentable: true)))
+        }
+    }
+    private init(pub: ECPublicKey) {
+        key = .pub(pub)
+    }
+    private init(priv: ECPrivateKey) {
+        key = .priv(priv)
+    }
+    private init(internalKey: ECKeyInternal) {
+        key = internalKey
+    }
+    public func toPub() -> ECKey {
+        switch key {
+        case .pub:
+            return self
+        case let .priv(v):
+            switch v {
+            case let .p256(u):
+                return ECKey(pub: .p256(u.publicKey))
+            case let .p384(u):
+                return ECKey(pub: .p384(u.publicKey))
+            case let .p521(u):
+                return ECKey(pub: .p521(u.publicKey))
+            }
+        }
+    }
+
+    public static func importX963Pub(data: SpanConstUInt8, curve: ECCurve) -> ECRv {
+        var rv = ECRv()
+        do {
+            switch curve {
+            case .p256:
+                rv.key = ECKey(internalKey: .pub(.p256(try P256.Signing.PublicKey(span: data))))
+            case .p384:
+                rv.key = ECKey(internalKey: .pub(.p384(try P384.Signing.PublicKey(span: data))))
+            case .p521:
+                rv.key = ECKey(internalKey: .pub(.p521(try P521.Signing.PublicKey(span: data))))
+            }
+            rv.errCode = .success
+        } catch {
+            rv.errCode = .failedToImport
+        }
+        return rv
+    }
+
+    public func exportX963Pub() -> ECRv {
+        var rv = ECRv()
+        do {
+            switch try getInternalPublic() {
+            case .p256(let k):
+                rv.keyBytes = Cpp.makeOptional(k.x963Representation.copyToVectorUInt8())
+            case .p384(let k):
+                rv.keyBytes = Cpp.makeOptional(k.x963Representation.copyToVectorUInt8())
+            case .p521(let k):
+                rv.keyBytes = Cpp.makeOptional(k.x963Representation.copyToVectorUInt8())
+            }
+            rv.errCode = .success
+        } catch {
+            rv.errCode = .failedToExport
+        }
+        return rv
+    }
+    public static func importCompressedPub(data: SpanConstUInt8, curve: ECCurve) -> ECRv {
+        var rv = ECRv()
+        do {
+            switch curve {
+            case .p256:
+                rv.key = ECKey(pub: .p256(try P256.Signing.PublicKey(spanCompressed: data)))
+            case .p384:
+                rv.key = ECKey(pub: .p384(try P384.Signing.PublicKey(spanCompressed: data)))
+            case .p521:
+                rv.key = ECKey(pub: .p521(try P521.Signing.PublicKey(spanCompressed: data)))
+            }
+            rv.errCode = .success
+        } catch {
+            rv.errCode = .failedToImport
+        }
+        return rv
+    }
+    public static func importX963Private(data: SpanConstUInt8, curve: ECCurve) -> ECRv {
+        var rv = ECRv()
+        do {
+            switch curve {
+            case .p256:
+                rv.key = ECKey(priv: .p256(try P256.Signing.PrivateKey(span: data)))
+            case .p384:
+                rv.key = ECKey(priv: .p384(try P384.Signing.PrivateKey(span: data)))
+            case .p521:
+                rv.key = ECKey(priv: .p521(try P521.Signing.PrivateKey(span: data)))
+            }
+            rv.errCode = .success
+        } catch {
+            rv.errCode = .failedToImport
+        }
+        return rv
+    }
+    public func exportX963Private() -> ECRv {
+        var rv = ECRv()
+        do {
+            switch try getInternalPrivate() {
+            case .p256(let k):
+                rv.keyBytes = Cpp.makeOptional(k.x963Representation.copyToVectorUInt8())
+            case .p384(let k):
+                rv.keyBytes = Cpp.makeOptional(k.x963Representation.copyToVectorUInt8())
+            case .p521(let k):
+                rv.keyBytes = Cpp.makeOptional(k.x963Representation.copyToVectorUInt8())
+            }
+            rv.errCode = .success
+        } catch {
+            rv.errCode = .failedToExport
+        }
+        return rv
+    }
+    public func sign(message: SpanConstUInt8, hashFunction: HashFunction) -> ECRv {
+        var rv = ECRv()
+        do {
+            switch try getInternalPrivate() {
+            case .p256(let cryptoKey):
+                rv.signature = Cpp.makeOptional(
+                    try cryptoKey.signature(for: Digest.digest(message, hashFunction: hashFunction))
+                        .rawRepresentation.copyToVectorUInt8())
+            case .p384(let cryptoKey):
+                rv.signature = Cpp.makeOptional(
+                    try cryptoKey.signature(for: Digest.digest(message, hashFunction: hashFunction))
+                        .rawRepresentation.copyToVectorUInt8())
+            case .p521(let cryptoKey):
+                rv.signature = Cpp.makeOptional(
+                    try cryptoKey.signature(for: Digest.digest(message, hashFunction: hashFunction))
+                        .rawRepresentation.copyToVectorUInt8())
+            }
+            rv.errCode = .success
+        } catch {
+            rv.errCode = .failedToSign
+        }
+        return rv
+    }
+
+    public func verify(
+        message: SpanConstUInt8, signature: SpanConstUInt8, hashFunction: HashFunction
+    ) -> ECRv {
+        var rv = ECRv()
+        do {
+            let internalPublic = try getInternalPublic()
+            switch internalPublic {
+            case .p256(let cryptoKey):
+                rv.errCode =
+                    cryptoKey.isValidSignature(
+                        try P256.Signing.ECDSASignature(span: signature),
+                        for: Digest.digest(message, hashFunction: hashFunction))
+                    ? .success : .failedToVerify
+            case .p384(let cryptoKey):
+                rv.errCode =
+                    cryptoKey.isValidSignature(
+                        try P384.Signing.ECDSASignature(span: signature),
+                        for: Digest.digest(message, hashFunction: hashFunction))
+                    ? .success : .failedToVerify
+            case .p521(let cryptoKey):
+                rv.errCode =
+                    cryptoKey.isValidSignature(
+                        try P521.Signing.ECDSASignature(span: signature),
+                        for: Digest.digest(message, hashFunction: hashFunction))
+                    ? .success : .failedToVerify
+            }
+        } catch {
+            rv.errCode = .failedToVerify
+        }
+        return rv
+    }
+    private func getInternalPrivate() throws -> ECPrivateKey {
+        switch key {
+        case .pub:
+            throw LocalErrors.invalidArgument
+        case .priv(let priv):
+            return priv
+        }
+    }
+    private func getInternalPublic() throws -> ECPublicKey {
+        switch key {
+        case .priv:
+            throw LocalErrors.invalidArgument
+        case .pub(let pub):
+            return pub
+        }
+    }
+
+    public func deriveBits(pub: ECKey) -> ECRv {
+        var rv = ECRv()
+        do {
+            let internalPrivate = try getInternalPrivate()
+            let internalPub = try pub.getInternalPublic()
+            switch internalPrivate {
+            case .p256(let signing):
+                let scalar = try P256.KeyAgreement.PrivateKey(
+                    rawRepresentation: signing.rawRepresentation)
+                if case let .p256(publicKey) = internalPub {
+                    let derived = try scalar.sharedSecretFromKeyAgreement(
+                        with: try P256.KeyAgreement.PublicKey(
+                            rawRepresentation: publicKey.rawRepresentation))
+                    rv.keyBytes = Cpp.makeOptional(derived.copyToVectorUInt8())
+                    break
+                }
+                rv.errCode = .invalidArgument
+            case .p384(let signing):
+                let scalar = try P384.KeyAgreement.PrivateKey(
+                    rawRepresentation: signing.rawRepresentation)
+                if case let .p384(publicKey) = internalPub {
+                    let derived = try scalar.sharedSecretFromKeyAgreement(
+                        with: try P384.KeyAgreement.PublicKey(
+                            rawRepresentation: publicKey.rawRepresentation))
+                    rv.keyBytes = Cpp.makeOptional(derived.copyToVectorUInt8())
+                    break
+                }
+                rv.errCode = .invalidArgument
+            case .p521(let signing):
+                let scalar = try P521.KeyAgreement.PrivateKey(
+                    rawRepresentation: signing.rawRepresentation)
+                if case let .p521(publicKey) = internalPub {
+                    let derived = try scalar.sharedSecretFromKeyAgreement(
+                        with: try P521.KeyAgreement.PublicKey(
+                            rawRepresentation: publicKey.rawRepresentation))
+                    rv.keyBytes = Cpp.makeOptional(derived.copyToVectorUInt8())
+                    break
+                }
+                rv.errCode = .invalidArgument
+            }
+            rv.errCode = .success
+        } catch {
+            rv.errCode = .failedToDerive
+        }
+        return rv
     }
 }
 

--- a/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift
@@ -35,7 +35,7 @@ enum UnsafeErrors: Error {
     case emptySpan
 }
 
-extension HashFunction {
+extension CryptoKit.HashFunction {
     mutating func update(data: SpanConstUInt8) {
         if data.empty() {
             self.update(data: Data.empty())
@@ -123,4 +123,105 @@ extension AES.KeyWrap {
         ).copyToVectorUInt8()
     }
 }
+
+extension P256.Signing.ECDSASignature {
+    init(span: SpanConstUInt8) throws {
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
+    }
+}
+extension P384.Signing.ECDSASignature {
+    init(span: SpanConstUInt8) throws {
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
+    }
+}
+extension P521.Signing.ECDSASignature {
+    init(span: SpanConstUInt8) throws {
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(rawRepresentation: Data.temporaryDataFromSpan(spanNoCopy: span))
+    }
+}
+
+extension P256.Signing.PublicKey {
+    init(span: SpanConstUInt8) throws {
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
+    }
+    init(spanCompressed: SpanConstUInt8) throws {
+        if spanCompressed.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(
+            compressedRepresentation: Data.temporaryDataFromSpan(spanNoCopy: spanCompressed))
+    }
+}
+
+extension P384.Signing.PublicKey {
+    init(span: SpanConstUInt8) throws {
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
+    }
+    init(spanCompressed: SpanConstUInt8) throws {
+        if spanCompressed.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(
+            compressedRepresentation: Data.temporaryDataFromSpan(spanNoCopy: spanCompressed))
+    }
+}
+
+extension P521.Signing.PublicKey {
+    init(span: SpanConstUInt8) throws {
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
+    }
+    init(spanCompressed: SpanConstUInt8) throws {
+        if spanCompressed.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(
+            compressedRepresentation: Data.temporaryDataFromSpan(spanNoCopy: spanCompressed))
+    }
+}
+
+extension P256.Signing.PrivateKey {
+    init(span: SpanConstUInt8) throws {
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
+    }
+}
+
+extension P384.Signing.PrivateKey {
+    init(span: SpanConstUInt8) throws {
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
+    }
+}
+
+extension P521.Signing.PrivateKey {
+    init(span: SpanConstUInt8) throws {
+        if span.empty() {
+            throw UnsafeErrors.emptySpan
+        }
+        try self.init(x963Representation: Data.temporaryDataFromSpan(spanNoCopy: span))
+    }
+}
+
 #endif

--- a/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
+++ b/Source/WebCore/PAL/pal/crypto/CryptoDigest.h
@@ -32,6 +32,7 @@
 namespace PAL {
 
 struct CryptoDigestContext;
+enum class UseCryptoKit : bool { No, Yes };
 
 class CryptoDigest {
     WTF_MAKE_NONCOPYABLE(CryptoDigest);
@@ -50,7 +51,7 @@ public:
     PAL_EXPORT void addBytes(std::span<const uint8_t>);
     PAL_EXPORT Vector<uint8_t> computeHash();
     PAL_EXPORT String toHexString();
-    PAL_EXPORT static std::optional<Vector<uint8_t>> computeHash(Algorithm, const Vector<uint8_t>&, bool);
+    PAL_EXPORT static std::optional<Vector<uint8_t>> computeHash(Algorithm, const Vector<uint8_t>&, UseCryptoKit);
     PAL_EXPORT CryptoDigest();
 
 private:

--- a/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
+++ b/Source/WebCore/PAL/pal/crypto/commoncrypto/CryptoDigestCommonCrypto.cpp
@@ -190,10 +190,10 @@ String CryptoDigest::toHexString()
     return String::fromUTF8(result.span());
 }
 
-std::optional<Vector<uint8_t>> CryptoDigest::computeHash(CryptoDigest::Algorithm algo, const Vector<uint8_t>& data, bool useCryptoKit)
+std::optional<Vector<uint8_t>> CryptoDigest::computeHash(CryptoDigest::Algorithm algo, const Vector<uint8_t>& data, UseCryptoKit useCryptoKit)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit) {
+    if (useCryptoKit == UseCryptoKit::Yes) {
         switch (algo) {
         case CryptoDigest::Algorithm::SHA_1:
             return PAL::Digest::sha1(data.span());

--- a/Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp
+++ b/Source/WebCore/PAL/pal/crypto/gcrypt/CryptoDigestGCrypt.cpp
@@ -94,7 +94,7 @@ Vector<uint8_t> CryptoDigest::computeHash()
     return result;
 }
 
-std::optional<Vector<uint8_t>> CryptoDigest::computeHash(CryptoDigest::Algorithm algo, const Vector<uint8_t>& input, bool)
+std::optional<Vector<uint8_t>> CryptoDigest::computeHash(CryptoDigest::Algorithm algo, const Vector<uint8_t>& input, UseCryptoKit)
 {
     std::unique_ptr<CryptoDigest> digest = WTF::makeUnique<CryptoDigest>();
     auto gcryptAlgorithm = getGcryptAlgorithm(algo);

--- a/Source/WebCore/PAL/pal/crypto/openssl/CryptoDigestOpenSSL.cpp
+++ b/Source/WebCore/PAL/pal/crypto/openssl/CryptoDigestOpenSSL.cpp
@@ -143,7 +143,7 @@ Vector<uint8_t> CryptoDigest::computeHash()
     return m_context->computeHash();
 }
 
-std::optional<Vector<uint8_t>> CryptoDigest::computeHash(CryptoDigest::Algorithm algo, const Vector<uint8_t>& data, bool)
+std::optional<Vector<uint8_t>> CryptoDigest::computeHash(CryptoDigest::Algorithm algo, const Vector<uint8_t>& data, UseCryptoKit)
 {
     std::unique_ptr<CryptoDigest> digest = WTF::makeUnique<CryptoDigest>();
     if (!digest)

--- a/Source/WebCore/crypto/CryptoAlgorithm.cpp
+++ b/Source/WebCore/crypto/CryptoAlgorithm.cpp
@@ -65,22 +65,22 @@ void CryptoAlgorithm::deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey
     exceptionCallback(ExceptionCode::NotSupportedError);
 }
 
-void CryptoAlgorithm::importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithm::importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     exceptionCallback(ExceptionCode::NotSupportedError);
 }
 
-void CryptoAlgorithm::exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithm::exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     exceptionCallback(ExceptionCode::NotSupportedError);
 }
 
-void CryptoAlgorithm::wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&& exceptionCallback, bool)
+void CryptoAlgorithm::wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     exceptionCallback(ExceptionCode::NotSupportedError);
 }
 
-void CryptoAlgorithm::unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&& exceptionCallback, bool)
+void CryptoAlgorithm::unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     exceptionCallback(ExceptionCode::NotSupportedError);
 }
@@ -118,7 +118,7 @@ void CryptoAlgorithm::dispatchOperationInWorkQueue(WorkQueue& workQueue, ScriptE
 
 void CryptoAlgorithm::dispatchDigest(WorkQueue& workQueue, ScriptExecutionContext& context, VectorCallback&& callback, ExceptionCallback&&exceptionCallback, Vector<uint8_t>&& message, PAL::CryptoDigest::Algorithm algo)
 {
-    bool useCryptoKit = context.settingsValues().cryptoKitEnabled;
+    PAL::UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? PAL::UseCryptoKit::Yes : PAL::UseCryptoKit::No;
     workQueue.dispatch([message = WTFMove(message), callback = WTFMove(callback), contextIdentifier = context.identifier(), exceptionCallback = WTFMove(exceptionCallback), useCryptoKit, algo]() mutable {
         auto result = PAL::CryptoDigest::computeHash(algo, message, useCryptoKit);
         ScriptExecutionContext::postTaskTo(contextIdentifier, [callback = WTFMove(callback), result = WTFMove(result), exceptionCallback = WTFMove(exceptionCallback)](auto&) mutable {

--- a/Source/WebCore/crypto/CryptoAlgorithm.h
+++ b/Source/WebCore/crypto/CryptoAlgorithm.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CryptoAlgorithmIdentifier.h"
+#include "CryptoKey.h"
 #include "CryptoKeyFormat.h"
 #include "CryptoKeyPair.h"
 #include "CryptoKeyUsage.h"
@@ -41,7 +42,6 @@
 namespace WebCore {
 
 class CryptoAlgorithmParameters;
-class CryptoKey;
 class ScriptExecutionContext;
 
 using KeyData = std::variant<Vector<uint8_t>, JsonWebKey>;
@@ -70,10 +70,10 @@ public:
     virtual void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&);
     virtual void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&);
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=169262
-    virtual void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&);
-    virtual void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&);
-    virtual void wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, bool);
-    virtual void unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, bool);
+    virtual void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit);
+    virtual void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit);
+    virtual void wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, UseCryptoKit);
+    virtual void unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, UseCryptoKit);
     virtual ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&);
 
     static void dispatchOperationInWorkQueue(WorkQueue&, ScriptExecutionContext&, VectorCallback&&, ExceptionCallback&&, Function<ExceptionOr<Vector<uint8_t>>()>&&);

--- a/Source/WebCore/crypto/CryptoKey.h
+++ b/Source/WebCore/crypto/CryptoKey.h
@@ -54,6 +54,8 @@ enum class CryptoKeyClass {
     Raw,
 };
 
+enum class UseCryptoKit : bool { No, Yes };
+
 class CryptoKey : public ThreadSafeRefCounted<CryptoKey> {
 public:
     using Type = CryptoKeyType;

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -914,8 +914,9 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
 
     auto index = promise.ptr();
     m_pendingPromises.add(index, WTFMove(promise));
+    UseCryptoKit useCryptoKit = scriptExecutionContext()->settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     WeakPtr weakThis { *this };
-    auto callback = [index, weakThis, importAlgorithm = WTFMove(importAlgorithm), importParams = crossThreadCopyImportParams(*importParams), extractable, keyUsagesBitmap](const Vector<uint8_t>& derivedKey) mutable {
+    auto callback = [index, weakThis, importAlgorithm = WTFMove(importAlgorithm), importParams = crossThreadCopyImportParams(*importParams), extractable, keyUsagesBitmap, useCryptoKit](const Vector<uint8_t>& derivedKey) mutable {
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=169395
         KeyData data = derivedKey;
         auto callback = [index, weakThis](CryptoKey& key) mutable {
@@ -932,7 +933,7 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
                 rejectWithException(promise.releaseNonNull(), ec);
         };
 
-        importAlgorithm->importKey(SubtleCrypto::KeyFormat::Raw, WTFMove(data), *importParams, extractable, keyUsagesBitmap, WTFMove(callback), WTFMove(exceptionCallback));
+        importAlgorithm->importKey(SubtleCrypto::KeyFormat::Raw, WTFMove(data), *importParams, extractable, keyUsagesBitmap, WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
     };
     auto exceptionCallback = [index, weakThis](ExceptionCode ec) mutable {
         if (auto promise = getPromise(index, weakThis))
@@ -1001,6 +1002,7 @@ void SubtleCrypto::importKey(JSC::JSGlobalObject& state, KeyFormat format, KeyDa
     auto index = promise.ptr();
     m_pendingPromises.add(index, WTFMove(promise));
     WeakPtr weakThis { *this };
+    UseCryptoKit useCryptoKit = scriptExecutionContext()->settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     auto callback = [index, weakThis](CryptoKey& key) mutable {
         if (auto promise = getPromise(index, weakThis)) {
             if ((key.type() == CryptoKeyType::Private || key.type() == CryptoKeyType::Secret) && !key.usagesBitmap()) {
@@ -1018,7 +1020,7 @@ void SubtleCrypto::importKey(JSC::JSGlobalObject& state, KeyFormat format, KeyDa
     // The 11 December 2014 version of the specification suggests we should perform the following task asynchronously:
     // https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-importKey
     // It is not beneficial for less time consuming operations. Therefore, we perform it synchronously.
-    algorithm->importKey(format, WTFMove(keyData), *params, extractable, keyUsagesBitmap, WTFMove(callback), WTFMove(exceptionCallback));
+    algorithm->importKey(format, WTFMove(keyData), *params, extractable, keyUsagesBitmap, WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
 }
 
 void SubtleCrypto::exportKey(KeyFormat format, CryptoKey& key, Ref<DeferredPromise>&& promise)
@@ -1038,6 +1040,7 @@ void SubtleCrypto::exportKey(KeyFormat format, CryptoKey& key, Ref<DeferredPromi
     auto index = promise.ptr();
     m_pendingPromises.add(index, WTFMove(promise));
     WeakPtr weakThis { *this };
+    UseCryptoKit useCryptoKit = scriptExecutionContext()->settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     auto callback = [index, weakThis](SubtleCrypto::KeyFormat format, KeyData&& key) mutable {
         if (auto promise = getPromise(index, weakThis)) {
             switch (format) {
@@ -1063,7 +1066,7 @@ void SubtleCrypto::exportKey(KeyFormat format, CryptoKey& key, Ref<DeferredPromi
     // The 11 December 2014 version of the specification suggests we should perform the following task asynchronously:
     // https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-exportKey
     // It is not beneficial for less time consuming operations. Therefore, we perform it synchronously.
-    algorithm->exportKey(format, key, WTFMove(callback), WTFMove(exceptionCallback));
+    algorithm->exportKey(format, key, WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
 }
 
 void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoKey& key, CryptoKey& wrappingKey, AlgorithmIdentifier&& wrapAlgorithmIdentifier, Ref<DeferredPromise>&& promise)
@@ -1112,7 +1115,8 @@ void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoK
     auto index = promise.ptr();
     m_pendingPromises.add(index, WTFMove(promise));
     WeakPtr weakThis { *this };
-    auto callback = [index, weakThis, wrapAlgorithm, wrappingKey = Ref { wrappingKey }, wrapParams = WTFMove(wrapParams), isEncryption, context, workQueue = m_workQueue](SubtleCrypto::KeyFormat format, KeyData&& key) mutable {
+    UseCryptoKit useCryptoKit = scriptExecutionContext()->settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
+    auto callback = [index, weakThis, wrapAlgorithm, wrappingKey = Ref { wrappingKey }, wrapParams = WTFMove(wrapParams), isEncryption, context, workQueue = m_workQueue, useCryptoKit](SubtleCrypto::KeyFormat format, KeyData&& key) mutable {
         if (!weakThis)
             return;
         RefPtr promise = weakThis->m_pendingPromises.get(index);
@@ -1150,7 +1154,7 @@ void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoK
             // The 11 December 2014 version of the specification suggests we should perform the following task asynchronously:
             // https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-wrapKey
             // It is not beneficial for less time consuming operations. Therefore, we perform it synchronously.
-            wrapAlgorithm->wrapKey(wrappingKey.get(), WTFMove(bytes), WTFMove(callback), WTFMove(exceptionCallback), context->settingsValues().cryptoKitEnabled);
+            wrapAlgorithm->wrapKey(wrappingKey.get(), WTFMove(bytes), WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
             return;
         }
         // The following operation should be performed asynchronously.
@@ -1162,7 +1166,7 @@ void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoK
     };
 
     // The following operation should be performed synchronously.
-    exportAlgorithm->exportKey(format, key, WTFMove(callback), WTFMove(exceptionCallback));
+    exportAlgorithm->exportKey(format, key, WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
 }
 
 void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, BufferSource&& wrappedKeyBufferSource, CryptoKey& unwrappingKey, AlgorithmIdentifier&& unwrapAlgorithmIdentifier, AlgorithmIdentifier&& unwrappedKeyAlgorithmIdentifier, bool extractable, Vector<CryptoKeyUsage>&& keyUsages, Ref<DeferredPromise>&& promise)
@@ -1217,8 +1221,8 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
     auto index = promise.ptr();
     m_pendingPromises.add(index, WTFMove(promise));
     WeakPtr weakThis { *this };
-
-    auto callback = [index, weakThis, format, importAlgorithm, unwrappedKeyAlgorithm = crossThreadCopyImportParams(*unwrappedKeyAlgorithm), extractable, keyUsagesBitmap](const Vector<uint8_t>& bytes) mutable {
+    UseCryptoKit useCryptoKit = scriptExecutionContext()->settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
+    auto callback = [index, weakThis, format, importAlgorithm, unwrappedKeyAlgorithm = crossThreadCopyImportParams(*unwrappedKeyAlgorithm), extractable, keyUsagesBitmap, useCryptoKit](const Vector<uint8_t>& bytes) mutable {
         if (!weakThis)
             return;
         RefPtr promise = weakThis->m_pendingPromises.get(index);
@@ -1267,7 +1271,7 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
         };
 
         // The following operation should be performed synchronously.
-        importAlgorithm->importKey(format, WTFMove(keyData), *unwrappedKeyAlgorithm, extractable, keyUsagesBitmap, WTFMove(callback), WTFMove(exceptionCallback));
+        importAlgorithm->importKey(format, WTFMove(keyData), *unwrappedKeyAlgorithm, extractable, keyUsagesBitmap, WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
     };
     auto exceptionCallback = [index, weakThis](ExceptionCode ec) mutable {
         if (auto promise = getPromise(index, weakThis))
@@ -1281,7 +1285,7 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
         RefPtr context = weakThis->scriptExecutionContext();
         if (!context)
             return;
-        unwrapAlgorithm->unwrapKey(unwrappingKey, WTFMove(wrappedKey), WTFMove(callback), WTFMove(exceptionCallback), context->settingsValues().cryptoKitEnabled);
+        unwrapAlgorithm->unwrapKey(unwrappingKey, WTFMove(wrappedKey), WTFMove(callback), WTFMove(exceptionCallback), useCryptoKit);
         return;
     }
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.cpp
@@ -105,7 +105,7 @@ void CryptoAlgorithmAESCBC::generateKey(const CryptoAlgorithmParameters& paramet
     callback(WTFMove(result));
 }
 
-void CryptoAlgorithmAESCBC::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmAESCBC::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmAESCBCInternal;
 
@@ -146,7 +146,7 @@ void CryptoAlgorithmAESCBC::importKey(CryptoKeyFormat format, KeyData&& data, co
     callback(*result);
 }
 
-void CryptoAlgorithmAESCBC::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmAESCBC::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmAESCBCInternal;
     const auto& aesKey = downcast<CryptoKeyAES>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.h
@@ -51,8 +51,8 @@ private:
     void encrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void decrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 };
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.cpp
@@ -105,7 +105,7 @@ void CryptoAlgorithmAESCFB::generateKey(const CryptoAlgorithmParameters& paramet
     callback(WTFMove(result));
 }
 
-void CryptoAlgorithmAESCFB::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmAESCFB::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmAESCFBInternal;
     
@@ -146,7 +146,7 @@ void CryptoAlgorithmAESCFB::importKey(CryptoKeyFormat format, KeyData&& data, co
     callback(*result);
 }
 
-void CryptoAlgorithmAESCFB::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmAESCFB::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmAESCFBInternal;
     const auto& aesKey = downcast<CryptoKeyAES>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.h
@@ -45,8 +45,8 @@ private:
     void encrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void decrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesCbcCfbParams&, const CryptoKeyAES&, const Vector<uint8_t>&);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.cpp
@@ -114,7 +114,7 @@ void CryptoAlgorithmAESCTR::generateKey(const CryptoAlgorithmParameters& paramet
     callback(WTFMove(result));
 }
 
-void CryptoAlgorithmAESCTR::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmAESCTR::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmAESCTRInternal;
 
@@ -155,7 +155,7 @@ void CryptoAlgorithmAESCTR::importKey(CryptoKeyFormat format, KeyData&& data, co
     callback(*result);
 }
 
-void CryptoAlgorithmAESCTR::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmAESCTR::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmAESCTRInternal;
     const auto& aesKey = downcast<CryptoKeyAES>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.h
@@ -73,8 +73,8 @@ private:
     void encrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void decrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesCtrParams&, const CryptoKeyAES&, const Vector<uint8_t>&);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp
@@ -96,7 +96,7 @@ void CryptoAlgorithmAESGCM::encrypt(const CryptoAlgorithmParameters& parameters,
         return;
     }
 
-    bool useCryptoKit = context.settingsValues().cryptoKitEnabled;
+    UseCryptoKit useCryptoKit = context.settingsValues().cryptoKitEnabled ? UseCryptoKit::Yes : UseCryptoKit::No;
     dispatchOperationInWorkQueue(workQueue, context, WTFMove(callback), WTFMove(exceptionCallback),
         [parameters = crossThreadCopy(aesParameters), key = WTFMove(key), plainText = WTFMove(plainText), useCryptoKit] {
             return platformEncrypt(parameters, downcast<CryptoKeyAES>(key.get()), plainText, useCryptoKit);
@@ -154,7 +154,7 @@ void CryptoAlgorithmAESGCM::generateKey(const CryptoAlgorithmParameters& paramet
     callback(WTFMove(result));
 }
 
-void CryptoAlgorithmAESGCM::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmAESGCM::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmAESGCMInternal;
 
@@ -195,7 +195,7 @@ void CryptoAlgorithmAESGCM::importKey(CryptoKeyFormat format, KeyData&& data, co
     callback(*result);
 }
 
-void CryptoAlgorithmAESGCM::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmAESGCM::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmAESGCMInternal;
     const auto& aesKey = downcast<CryptoKeyAES>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.h
@@ -46,11 +46,11 @@ private:
     void encrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void decrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 
-    static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesGcmParams&, const CryptoKeyAES&, const Vector<uint8_t>&, bool useCryptoKit);
+    static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmAesGcmParams&, const CryptoKeyAES&, const Vector<uint8_t>&, UseCryptoKit);
     static ExceptionOr<Vector<uint8_t>> platformDecrypt(const CryptoAlgorithmAesGcmParams&, const CryptoKeyAES&, const Vector<uint8_t>&);
 };
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp
@@ -69,7 +69,7 @@ void CryptoAlgorithmAESKW::generateKey(const CryptoAlgorithmParameters& paramete
     callback(WTFMove(result));
 }
 
-void CryptoAlgorithmAESKW::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmAESKW::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmAESKWInternal;
 
@@ -109,7 +109,7 @@ void CryptoAlgorithmAESKW::importKey(CryptoKeyFormat format, KeyData&& data, con
     callback(*result);
 }
 
-void CryptoAlgorithmAESKW::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmAESKW::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmAESKWInternal;
     const auto& aesKey = downcast<CryptoKeyAES>(key.get());
@@ -150,7 +150,7 @@ void CryptoAlgorithmAESKW::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& ke
     callback(format, WTFMove(result));
 }
 
-void CryptoAlgorithmAESKW::wrapKey(Ref<CryptoKey>&& key, Vector<uint8_t>&& data, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, bool useCryptoKit)
+void CryptoAlgorithmAESKW::wrapKey(Ref<CryptoKey>&& key, Vector<uint8_t>&& data, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit useCryptoKit)
 {
     if (data.size() % 8) {
         exceptionCallback(ExceptionCode::OperationError);
@@ -165,7 +165,7 @@ void CryptoAlgorithmAESKW::wrapKey(Ref<CryptoKey>&& key, Vector<uint8_t>&& data,
     callback(result.releaseReturnValue());
 }
 
-void CryptoAlgorithmAESKW::unwrapKey(Ref<CryptoKey>&& key, Vector<uint8_t>&& data, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, bool useCryptoKit)
+void CryptoAlgorithmAESKW::unwrapKey(Ref<CryptoKey>&& key, Vector<uint8_t>&& data, VectorCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit useCryptoKit)
 {
     auto result = platformUnwrapKey(downcast<CryptoKeyAES>(key.get()), WTFMove(data), useCryptoKit);
     if (result.hasException()) {

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.h
@@ -43,14 +43,14 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
-    void wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, bool) final;
-    void unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, bool) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void wrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, UseCryptoKit) final;
+    void unwrapKey(Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, UseCryptoKit) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 
-    static ExceptionOr<Vector<uint8_t>> platformWrapKey(const CryptoKeyAES&, const Vector<uint8_t>&, bool);
-    static ExceptionOr<Vector<uint8_t>> platformUnwrapKey(const CryptoKeyAES&, const Vector<uint8_t>&, bool);
+    static ExceptionOr<Vector<uint8_t>> platformWrapKey(const CryptoKeyAES&, const Vector<uint8_t>&, UseCryptoKit);
+    static ExceptionOr<Vector<uint8_t>> platformUnwrapKey(const CryptoKeyAES&, const Vector<uint8_t>&, UseCryptoKit);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.h
@@ -38,7 +38,7 @@ public:
     static Ref<CryptoAlgorithm> create();
 
     // Operations can be performed directly.
-    WEBCORE_EXPORT static std::optional<Vector<uint8_t>> platformDeriveBits(const CryptoKeyEC&, const CryptoKeyEC&);
+    WEBCORE_EXPORT static std::optional<Vector<uint8_t>> platformDeriveBits(const CryptoKeyEC&, const CryptoKeyEC&, UseCryptoKit);
 
 private:
     CryptoAlgorithmECDH() = default;
@@ -46,8 +46,8 @@ private:
 
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
     void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.h
@@ -45,11 +45,11 @@ private:
     void sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit) final;
 
-    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoAlgorithmEcdsaParams&, const CryptoKeyEC&, const Vector<uint8_t>&);
-    static ExceptionOr<bool> platformVerify(const CryptoAlgorithmEcdsaParams&, const CryptoKeyEC&, const Vector<uint8_t>&, const Vector<uint8_t>&);
+    static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoAlgorithmEcdsaParams&, const CryptoKeyEC&, const Vector<uint8_t>&, UseCryptoKit);
+    static ExceptionOr<bool> platformVerify(const CryptoAlgorithmEcdsaParams&, const CryptoKeyEC&, const Vector<uint8_t>&, const Vector<uint8_t>&, UseCryptoKit);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp
@@ -97,7 +97,7 @@ void CryptoAlgorithmEd25519::verify(const CryptoAlgorithmParameters&, Ref<Crypto
         });
 }
 
-void CryptoAlgorithmEd25519::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmEd25519::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     RefPtr<CryptoKeyOKP> result;
     switch (format) {
@@ -143,7 +143,7 @@ void CryptoAlgorithmEd25519::importKey(CryptoKeyFormat format, KeyData&& data, c
     callback(*result);
 }
 
-void CryptoAlgorithmEd25519::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmEd25519::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     const auto& okpKey = downcast<CryptoKeyOKP>(key.get());
     if (!okpKey.keySizeInBits()) {

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h
@@ -43,8 +43,8 @@ private:
     void generateKey(const CryptoAlgorithmParameters& , bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& , ExceptionCallback&& , ScriptExecutionContext&);
     void sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit) final;
 
     static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyOKP&, const Vector<uint8_t>&);
     static ExceptionOr<bool> platformVerify(const CryptoKeyOKP&, const Vector<uint8_t>&, const Vector<uint8_t>&);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp
@@ -56,7 +56,7 @@ void CryptoAlgorithmHKDF::deriveBits(const CryptoAlgorithmParameters& parameters
         });
 }
 
-void CryptoAlgorithmHKDF::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmHKDF::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     if (format != CryptoKeyFormat::Raw) {
         exceptionCallback(ExceptionCode::NotSupportedError);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h
@@ -43,7 +43,7 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformDeriveBits(const CryptoAlgorithmHkdfParams&, const CryptoKeyRaw&, size_t);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp
@@ -94,7 +94,7 @@ void CryptoAlgorithmHMAC::generateKey(const CryptoAlgorithmParameters& parameter
     callback(WTFMove(result));
 }
 
-void CryptoAlgorithmHMAC::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmHMAC::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmHMACInternal;
 
@@ -143,7 +143,7 @@ void CryptoAlgorithmHMAC::importKey(CryptoKeyFormat format, KeyData&& data, cons
     callback(*result);
 }
 
-void CryptoAlgorithmHMAC::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmHMAC::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmHMACInternal;
     const auto& hmacKey = downcast<CryptoKeyHMAC>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.h
@@ -48,8 +48,8 @@ private:
     void sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 };
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp
@@ -56,7 +56,7 @@ void CryptoAlgorithmPBKDF2::deriveBits(const CryptoAlgorithmParameters& paramete
         });
 }
 
-void CryptoAlgorithmPBKDF2::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmPBKDF2::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     if (format != CryptoKeyFormat::Raw) {
         exceptionCallback(ExceptionCode::NotSupportedError);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.h
@@ -43,7 +43,7 @@ private:
     CryptoAlgorithmIdentifier identifier() const final;
 
     void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
     ExceptionOr<size_t> getKeyLength(const CryptoAlgorithmParameters&) final;
 
     static ExceptionOr<Vector<uint8_t>> platformDeriveBits(const CryptoAlgorithmPbkdf2Params&, const CryptoKeyRaw&, size_t);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSAES_PKCS1_v1_5.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSAES_PKCS1_v1_5.cpp
@@ -92,7 +92,7 @@ void CryptoAlgorithmRSAES_PKCS1_v1_5::generateKey(const CryptoAlgorithmParameter
     CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier::RSAES_PKCS1_v1_5, CryptoAlgorithmIdentifier::SHA_1, false, rsaParameters.modulusLength, rsaParameters.publicExponentVector(), extractable, usages, WTFMove(keyPairCallback), WTFMove(failureCallback), &context);
 }
 
-void CryptoAlgorithmRSAES_PKCS1_v1_5::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmRSAES_PKCS1_v1_5::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     RefPtr<CryptoKeyRSA> result;
     switch (format) {
@@ -141,7 +141,7 @@ void CryptoAlgorithmRSAES_PKCS1_v1_5::importKey(CryptoKeyFormat format, KeyData&
     callback(*result);
 }
 
-void CryptoAlgorithmRSAES_PKCS1_v1_5::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmRSAES_PKCS1_v1_5::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     const auto& rsaKey = downcast<CryptoKeyRSA>(key.get());
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSAES_PKCS1_v1_5.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSAES_PKCS1_v1_5.h
@@ -44,8 +44,8 @@ private:
     void encrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void decrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoKeyRSA&, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformDecrypt(const CryptoKeyRSA&, const Vector<uint8_t>&);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp
@@ -98,7 +98,7 @@ void CryptoAlgorithmRSASSA_PKCS1_v1_5::generateKey(const CryptoAlgorithmParamete
     CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier::RSASSA_PKCS1_v1_5, rsaParameters.hashIdentifier, true, rsaParameters.modulusLength, rsaParameters.publicExponentVector(), extractable, usages, WTFMove(keyPairCallback), WTFMove(failureCallback), &context);
 }
 
-void CryptoAlgorithmRSASSA_PKCS1_v1_5::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmRSASSA_PKCS1_v1_5::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmRSASSA_PKCS1_v1_5Internal;
 
@@ -176,7 +176,7 @@ void CryptoAlgorithmRSASSA_PKCS1_v1_5::importKey(CryptoKeyFormat format, KeyData
     callback(*result);
 }
 
-void CryptoAlgorithmRSASSA_PKCS1_v1_5::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmRSASSA_PKCS1_v1_5::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmRSASSA_PKCS1_v1_5Internal;
     const auto& rsaKey = downcast<CryptoKeyRSA>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.h
@@ -44,8 +44,8 @@ private:
     void sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
 
     static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoKeyRSA&, const Vector<uint8_t>&);
     static ExceptionOr<bool> platformVerify(const CryptoKeyRSA&, const Vector<uint8_t>&, const Vector<uint8_t>&);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.cpp
@@ -100,7 +100,7 @@ void CryptoAlgorithmRSA_OAEP::generateKey(const CryptoAlgorithmParameters& param
     CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier::RSA_OAEP, rsaParameters.hashIdentifier, true, rsaParameters.modulusLength, rsaParameters.publicExponentVector(), extractable, usages, WTFMove(keyPairCallback), WTFMove(failureCallback), &context);
 }
 
-void CryptoAlgorithmRSA_OAEP::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmRSA_OAEP::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmRSA_OAEPInternal;
 
@@ -190,7 +190,7 @@ void CryptoAlgorithmRSA_OAEP::importKey(CryptoKeyFormat format, KeyData&& data, 
     callback(*result);
 }
 
-void CryptoAlgorithmRSA_OAEP::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmRSA_OAEP::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmRSA_OAEPInternal;
     const auto& rsaKey = downcast<CryptoKeyRSA>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.h
@@ -45,8 +45,8 @@ private:
     void encrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void decrypt(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
 
     static ExceptionOr<Vector<uint8_t>> platformEncrypt(const CryptoAlgorithmRsaOaepParams&, const CryptoKeyRSA&, const Vector<uint8_t>&);
     static ExceptionOr<Vector<uint8_t>> platformDecrypt(const CryptoAlgorithmRsaOaepParams&, const CryptoKeyRSA&, const Vector<uint8_t>&);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.cpp
@@ -102,7 +102,7 @@ void CryptoAlgorithmRSA_PSS::generateKey(const CryptoAlgorithmParameters& parame
     CryptoKeyRSA::generatePair(CryptoAlgorithmIdentifier::RSA_PSS, rsaParameters.hashIdentifier, true, rsaParameters.modulusLength, rsaParameters.publicExponentVector(), extractable, usages, WTFMove(keyPairCallback), WTFMove(failureCallback), &context);
 }
 
-void CryptoAlgorithmRSA_PSS::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmRSA_PSS::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters& parameters, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmRSA_PSSInternal;
 
@@ -180,7 +180,7 @@ void CryptoAlgorithmRSA_PSS::importKey(CryptoKeyFormat format, KeyData&& data, c
     callback(*result);
 }
 
-void CryptoAlgorithmRSA_PSS::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmRSA_PSS::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     using namespace CryptoAlgorithmRSA_PSSInternal;
     const auto& rsaKey = downcast<CryptoKeyRSA>(key.get());

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.h
@@ -47,8 +47,8 @@ private:
     void sign(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&&, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void verify(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, Vector<uint8_t>&& signature, Vector<uint8_t>&&, BoolCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
     void generateKey(const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyOrKeyPairCallback&&, ExceptionCallback&&, ScriptExecutionContext&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit = UseCryptoKit::No) final;
 
     static ExceptionOr<Vector<uint8_t>> platformSign(const CryptoAlgorithmRsaPssParams&, const CryptoKeyRSA&, const Vector<uint8_t>&);
     static ExceptionOr<bool> platformVerify(const CryptoAlgorithmRsaPssParams&, const CryptoKeyRSA&, const Vector<uint8_t>&, const Vector<uint8_t>&);

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp
@@ -115,7 +115,7 @@ void CryptoAlgorithmX25519::deriveBits(const CryptoAlgorithmParameters& paramete
         });
 }
 
-void CryptoAlgorithmX25519::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmX25519::importKey(CryptoKeyFormat format, KeyData&& data, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap usages, KeyCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     RefPtr<CryptoKeyOKP> result;
     switch (format) {
@@ -172,7 +172,7 @@ void CryptoAlgorithmX25519::importKey(CryptoKeyFormat format, KeyData&& data, co
     callback(*result);
 }
 
-void CryptoAlgorithmX25519::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback)
+void CryptoAlgorithmX25519::exportKey(CryptoKeyFormat format, Ref<CryptoKey>&& key, KeyDataCallback&& callback, ExceptionCallback&& exceptionCallback, UseCryptoKit)
 {
     const auto& ecKey = downcast<CryptoKeyOKP>(key.get());
 

--- a/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h
+++ b/Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h
@@ -37,8 +37,8 @@ private:
 
     void generateKey(const CryptoAlgorithmParameters& , bool extractable, CryptoKeyUsageBitmap usages, KeyOrKeyPairCallback&& , ExceptionCallback&& , ScriptExecutionContext&);
     void deriveBits(const CryptoAlgorithmParameters&, Ref<CryptoKey>&&, size_t length, VectorCallback&&, ExceptionCallback&&, ScriptExecutionContext&, WorkQueue&) final;
-    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&) final;
-    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&) final;
+    void importKey(CryptoKeyFormat, KeyData&&, const CryptoAlgorithmParameters&, bool extractable, CryptoKeyUsageBitmap, KeyCallback&&, ExceptionCallback&&, UseCryptoKit) final;
+    void exportKey(CryptoKeyFormat, Ref<CryptoKey>&&, KeyDataCallback&&, ExceptionCallback&&, UseCryptoKit) final;
 
     static std::optional<Vector<uint8_t>> platformDeriveBits(const CryptoKeyOKP&, const CryptoKeyOKP&);
 };

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp
@@ -81,10 +81,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return WTFMove(plainText);
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformEncrypt(const CryptoAlgorithmAesGcmParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& plainText, bool useCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformEncrypt(const CryptoAlgorithmAesGcmParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& plainText, UseCryptoKit useCryptoKit)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit)
+    if (useCryptoKit == UseCryptoKit::Yes)
         return encryptCryptoKitAESGCM(parameters.ivVector(), key.key(), plainText, parameters.additionalDataVector(), parameters.tagLength.value_or(0) / 8);
 #else
     UNUSED_PARAM(useCryptoKit);

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp
@@ -78,10 +78,10 @@ static ExceptionOr<Vector<uint8_t>> unwrapKeyAESKWCryptoKit(const Vector<uint8_t
 }
 #endif
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, bool useCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, UseCryptoKit useCryptoKit)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit)
+    if (useCryptoKit == UseCryptoKit::Yes)
         return wrapKeyAESKWCryptoKit(key.key(), data);
 #else
     UNUSED_PARAM(useCryptoKit);
@@ -89,10 +89,10 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoK
     return wrapKeyAESKW(key.key(), data);
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformUnwrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, bool useCryptoKit)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformUnwrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, UseCryptoKit useCryptoKit)
 {
 #if HAVE(SWIFT_CPP_INTEROP)
-    if (useCryptoKit)
+    if (useCryptoKit == UseCryptoKit::Yes)
         return unwrapKeyAESKWCryptoKit(key.key(), data);
 #else
     UNUSED_PARAM(useCryptoKit);

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
@@ -33,8 +33,59 @@
 #include "CryptoKeyEC.h"
 
 namespace WebCore {
+#if HAVE(SWIFT_CPP_INTEROP)
 
-static ExceptionOr<Vector<uint8_t>> signECDSA(CryptoAlgorithmIdentifier hash, const PlatformECKey key, size_t keyLengthInBytes, const Vector<uint8_t>& data)
+static PAL::HashFunction toCKHashFunction(CryptoAlgorithmIdentifier hash)
+{
+    switch (hash) {
+    case CryptoAlgorithmIdentifier::SHA_256:
+        return PAL::HashFunction::sha256();
+        break;
+    case CryptoAlgorithmIdentifier::SHA_384:
+        return PAL::HashFunction::sha384();
+        break;
+    case CryptoAlgorithmIdentifier::SHA_512:
+        return PAL::HashFunction::sha512();
+        break;
+    case CryptoAlgorithmIdentifier::SHA_1:
+        return PAL::HashFunction::sha1();
+        break;
+    default:
+        ASSERT_NOT_REACHED();
+        return PAL::HashFunction::sha512();
+    }
+}
+
+static bool isValidHashParameter(CryptoAlgorithmIdentifier hash)
+{
+    return hash == CryptoAlgorithmIdentifier::SHA_1 || hash == CryptoAlgorithmIdentifier::SHA_256 || hash == CryptoAlgorithmIdentifier::SHA_384 || hash == CryptoAlgorithmIdentifier::SHA_512;
+}
+
+static ExceptionOr<Vector<uint8_t>> signECDSACryptoKit(CryptoAlgorithmIdentifier hash, const PlatformECKeyContainer& key, const Vector<uint8_t>& data)
+{
+    const CKPlatformECKeyContainer* priv = std::get_if<CKPlatformECKeyContainer>(&key);
+    if (!priv)
+        return Exception { ExceptionCode::OperationError };
+    if (!isValidHashParameter(hash))
+        return Exception { ExceptionCode::OperationError };
+    auto rv = (*priv)->sign(data.span(), toCKHashFunction(hash));
+    if (!(rv.getErrCode().isSuccess() && rv.getSignature()))
+        return Exception { ExceptionCode::OperationError };
+    return *rv.getSignature();
+}
+
+static ExceptionOr<bool> verifyECDSACryptoKit(CryptoAlgorithmIdentifier hash, const PlatformECKeyContainer& key, const Vector<uint8_t>& signature, const Vector<uint8_t> data)
+{
+    const CKPlatformECKeyContainer* pub = std::get_if<CKPlatformECKeyContainer>(&key);
+    if (!isValidHashParameter(hash))
+        return Exception { ExceptionCode::OperationError };
+    if (!pub)
+        return Exception { ExceptionCode::OperationError };
+    return (*pub)->verify(data.span(), signature.span(), toCKHashFunction(hash)).getErrCode().isSuccess();
+}
+#endif
+
+static ExceptionOr<Vector<uint8_t>> signECDSA(CryptoAlgorithmIdentifier hash, const PlatformECKeyContainer& key, size_t keyLengthInBytes, const Vector<uint8_t>& data)
 {
     CCDigestAlgorithm digestAlgorithm;
     if (!getCommonCryptoDigestAlgorithm(hash, digestAlgorithm))
@@ -53,8 +104,14 @@ static ExceptionOr<Vector<uint8_t>> signECDSA(CryptoAlgorithmIdentifier hash, co
     // tag + length(1) + tag + length(1) + InitialOctet(?) + keyLength in bytes + tag + length(1) + InitialOctet(?) + keyLength in bytes
     Vector<uint8_t> signature(8 + keyLengthInBytes * 2);
     size_t signatureSize = signature.size();
-
-    CCCryptorStatus status = CCECCryptorSignHash(key, digestData.data(), digestData.size(), signature.data(), &signatureSize);
+#if HAVE(SWIFT_CPP_INTEROP)
+    const CCPlatformECKeyContainer* priv = std::get_if<CCPlatformECKeyContainer>(&key);
+    if (!priv)
+        return Exception { ExceptionCode::OperationError };
+    CCCryptorStatus status = CCECCryptorSignHash((*priv).get(), digestData.data(), digestData.size(), signature.data(), &signatureSize);
+#else
+    CCCryptorStatus status = CCECCryptorSignHash(key.get(), digestData.data(), digestData.size(), signature.data(), &signatureSize);
+#endif
     if (status)
         return Exception { ExceptionCode::OperationError };
 
@@ -95,7 +152,7 @@ static ExceptionOr<Vector<uint8_t>> signECDSA(CryptoAlgorithmIdentifier hash, co
     return WTFMove(newSignature);
 }
 
-static ExceptionOr<bool> verifyECDSA(CryptoAlgorithmIdentifier hash, const PlatformECKey key, size_t keyLengthInBytes, const Vector<uint8_t>& signature, const Vector<uint8_t> data)
+static ExceptionOr<bool> verifyECDSA(CryptoAlgorithmIdentifier hash, const PlatformECKeyContainer& key, size_t keyLengthInBytes, const Vector<uint8_t>& signature, const Vector<uint8_t> data)
 {
     CCDigestAlgorithm digestAlgorithm;
     if (!getCommonCryptoDigestAlgorithm(hash, digestAlgorithm))
@@ -147,7 +204,14 @@ static ExceptionOr<bool> verifyECDSA(CryptoAlgorithmIdentifier hash, const Platf
     newSignature.append(signature.subspan(sStart, keyLengthInBytes * 2 - sStart));
 
     uint32_t valid;
-    CCCryptorStatus status = CCECCryptorVerifyHash(key, digestData.data(), digestData.size(), newSignature.data(), newSignature.size(), &valid);
+#if HAVE(SWIFT_CPP_INTEROP)
+    const auto* pub = std::get_if<CCPlatformECKeyContainer>(&key);
+    if (!pub)
+        return Exception { ExceptionCode::OperationError };
+    CCCryptorStatus status = CCECCryptorVerifyHash((*pub).get(), digestData.data(), digestData.size(), newSignature.data(), newSignature.size(), &valid);
+#else
+    CCCryptorStatus status = CCECCryptorVerifyHash(key.get(), digestData.data(), digestData.size(), newSignature.data(), newSignature.size(), &valid);
+#endif
     if (status) {
         WTFLogAlways("ERROR: CCECCryptorVerifyHash() returns error=%d", status);
         return false;
@@ -155,13 +219,21 @@ static ExceptionOr<bool> verifyECDSA(CryptoAlgorithmIdentifier hash, const Platf
     return valid;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data, [[maybe_unused]] UseCryptoKit useCryptoKit)
 {
+#if HAVE(SWIFT_CPP_INTEROP)
+    if (useCryptoKit == UseCryptoKit::Yes)
+        return signECDSACryptoKit(parameters.hashIdentifier, key.platformKey(), data);
+#endif
     return signECDSA(parameters.hashIdentifier, key.platformKey(), key.keySizeInBytes(), data);
 }
 
-ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, [[maybe_unused]] UseCryptoKit useCryptoKit)
 {
+#if HAVE(SWIFT_CPP_INTEROP)
+    if (useCryptoKit == UseCryptoKit::Yes)
+        return verifyECDSACryptoKit(parameters.hashIdentifier, key.platformKey(), signature, data);
+#endif
     return verifyECDSA(parameters.hashIdentifier, key.platformKey(), key.keySizeInBytes(), signature, data);
 }
 

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESGCMGCrypt.cpp
@@ -177,7 +177,7 @@ static std::optional<Vector<uint8_t>> gcryptDecrypt(const Vector<uint8_t>& key, 
     return output;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformEncrypt(const CryptoAlgorithmAesGcmParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& plainText, bool)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformEncrypt(const CryptoAlgorithmAesGcmParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& plainText, UseCryptoKit)
 {
     auto output = gcryptEncrypt(key.key(), parameters.ivVector(), plainText, parameters.additionalDataVector(), parameters.tagLength.value_or(0) / 8);
     if (!output)

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESKWGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmAESKWGCrypt.cpp
@@ -113,7 +113,7 @@ static std::optional<Vector<uint8_t>> gcryptUnwrapKey(const Vector<uint8_t>& key
     return output;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, bool)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, UseCryptoKit)
 {
     auto output = gcryptWrapKey(key.key(), data);
     if (!output)
@@ -121,7 +121,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoK
     return WTFMove(*output);
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformUnwrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, bool)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformUnwrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, UseCryptoKit)
 {
     auto output = gcryptUnwrapKey(key.key(), data);
     if (!output)

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDHGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDHGCrypt.cpp
@@ -98,9 +98,9 @@ static std::optional<Vector<uint8_t>> gcryptDerive(gcry_sexp_t baseKeySexp, gcry
     return mpiZeroPrefixedData(xMPI, keySizeInBytes);
 }
 
-std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey)
+std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey, UseCryptoKit)
 {
-    return gcryptDerive(baseKey.platformKey(), publicKey.platformKey(), (baseKey.keySizeInBits() + 7) / 8);
+    return gcryptDerive(baseKey.platformKey().get(), publicKey.platformKey().get(), (baseKey.keySizeInBits() + 7) / 8);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
+++ b/Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp
@@ -168,17 +168,17 @@ static std::optional<bool> gcryptVerify(gcry_sexp_t keySexp, const Vector<uint8_
     return { error == GPG_ERR_NO_ERROR };
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data, UseCryptoKit)
 {
-    auto output = gcryptSign(key.platformKey(), data, parameters.hashIdentifier, (key.keySizeInBits() + 7) / 8);
+    auto output = gcryptSign(key.platformKey().get(), data, parameters.hashIdentifier, (key.keySizeInBits() + 7) / 8);
     if (!output)
         return Exception { ExceptionCode::OperationError };
     return WTFMove(*output);
 }
 
-ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, UseCryptoKit)
 {
-    auto output = gcryptVerify(key.platformKey(), signature, data, parameters.hashIdentifier, (key.keySizeInBits() + 7)/ 8);
+    auto output = gcryptVerify(key.platformKey().get(), signature, data, parameters.hashIdentifier, (key.keySizeInBits() + 7)/ 8);
     if (!output)
         return Exception { ExceptionCode::OperationError };
     return WTFMove(*output);

--- a/Source/WebCore/crypto/keys/CryptoKeyAES.cpp
+++ b/Source/WebCore/crypto/keys/CryptoKeyAES.cpp
@@ -73,14 +73,14 @@ RefPtr<CryptoKeyAES> CryptoKeyAES::generate(CryptoAlgorithmIdentifier algorithm,
     return adoptRef(new CryptoKeyAES(algorithm, randomData(lengthBits / 8), extractable, usages));
 }
 
-RefPtr<CryptoKeyAES> CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier algorithm, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
+RefPtr<CryptoKeyAES> CryptoKeyAES::importRaw(CryptoAlgorithmIdentifier algorithm, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages, UseCryptoKit)
 {
     if (!lengthIsValid(keyData.size() * 8))
         return nullptr;
     return adoptRef(new CryptoKeyAES(algorithm, WTFMove(keyData), extractable, usages));
 }
 
-RefPtr<CryptoKeyAES> CryptoKeyAES::importJwk(CryptoAlgorithmIdentifier algorithm, JsonWebKey&& keyData, bool extractable, CryptoKeyUsageBitmap usages, CheckAlgCallback&& callback)
+RefPtr<CryptoKeyAES> CryptoKeyAES::importJwk(CryptoAlgorithmIdentifier algorithm, JsonWebKey&& keyData, bool extractable, CryptoKeyUsageBitmap usages, CheckAlgCallback&& callback, UseCryptoKit)
 {
     if (keyData.kty != "oct"_s)
         return nullptr;

--- a/Source/WebCore/crypto/keys/CryptoKeyAES.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyAES.h
@@ -52,9 +52,9 @@ public:
     static bool isValidAESAlgorithm(CryptoAlgorithmIdentifier);
 
     static RefPtr<CryptoKeyAES> generate(CryptoAlgorithmIdentifier, size_t lengthBits, bool extractable, CryptoKeyUsageBitmap);
-    WEBCORE_EXPORT static RefPtr<CryptoKeyAES> importRaw(CryptoAlgorithmIdentifier, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
+    WEBCORE_EXPORT static RefPtr<CryptoKeyAES> importRaw(CryptoAlgorithmIdentifier, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap, UseCryptoKit = UseCryptoKit::No);
     using CheckAlgCallback = Function<bool(size_t, const String&)>;
-    static RefPtr<CryptoKeyAES> importJwk(CryptoAlgorithmIdentifier, JsonWebKey&&, bool extractable, CryptoKeyUsageBitmap, CheckAlgCallback&&);
+    static RefPtr<CryptoKeyAES> importJwk(CryptoAlgorithmIdentifier, JsonWebKey&&, bool extractable, CryptoKeyUsageBitmap, CheckAlgCallback&&, UseCryptoKit = UseCryptoKit::No);
 
     CryptoKeyClass keyClass() const final { return CryptoKeyClass::AES; }
 

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmAESGCMOpenSSL.cpp
@@ -161,7 +161,7 @@ static std::optional<Vector<uint8_t>> cryptDecrypt(const Vector<uint8_t>& key, c
     return plainText;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformEncrypt(const CryptoAlgorithmAesGcmParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& plainText, bool)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESGCM::platformEncrypt(const CryptoAlgorithmAesGcmParams& parameters, const CryptoKeyAES& key, const Vector<uint8_t>& plainText, UseCryptoKit)
 {
     auto output = cryptEncrypt(key.key(), parameters.ivVector(), plainText, parameters.additionalDataVector(), parameters.tagLength.value_or(0) / 8);
     if (!output)

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmAESKWOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmAESKWOpenSSL.cpp
@@ -63,7 +63,7 @@ static std::optional<Vector<uint8_t>> cryptUnwrapKey(const Vector<uint8_t>& key,
     return plainText;
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, bool)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, UseCryptoKit)
 {
     auto output = cryptWrapKey(key.key(), data);
     if (!output)
@@ -71,7 +71,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformWrapKey(const CryptoK
     return WTFMove(*output);
 }
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformUnwrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, bool)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmAESKW::platformUnwrapKey(const CryptoKeyAES& key, const Vector<uint8_t>& data, UseCryptoKit)
 {
     auto output = cryptUnwrapKey(key.key(), data);
     if (!output)

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmECDHOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmECDHOpenSSL.cpp
@@ -31,16 +31,16 @@
 
 namespace WebCore {
 
-std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey)
+std::optional<Vector<uint8_t>> CryptoAlgorithmECDH::platformDeriveBits(const CryptoKeyEC& baseKey, const CryptoKeyEC& publicKey, UseCryptoKit)
 {
-    auto ctx = EvpPKeyCtxPtr(EVP_PKEY_CTX_new(baseKey.platformKey(), nullptr));
+    auto ctx = EvpPKeyCtxPtr(EVP_PKEY_CTX_new(baseKey.platformKey().get(), nullptr));
     if (!ctx)
         return std::nullopt;
 
     if (EVP_PKEY_derive_init(ctx.get()) <= 0)
         return std::nullopt;
 
-    if (EVP_PKEY_derive_set_peer(ctx.get(), publicKey.platformKey()) <= 0)
+    if (EVP_PKEY_derive_set_peer(ctx.get(), publicKey.platformKey().get()) <= 0)
         return std::nullopt;
 
     // Call with a nullptr to get the required buffer size.

--- a/Source/WebCore/crypto/openssl/CryptoAlgorithmECDSAOpenSSL.cpp
+++ b/Source/WebCore/crypto/openssl/CryptoAlgorithmECDSAOpenSSL.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data)
+ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& data, UseCryptoKit)
 {
     size_t keySizeInBytes = (key.keySizeInBits() + 7) / 8;
 
@@ -44,7 +44,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgo
     if (!digest)
         return Exception { ExceptionCode::OperationError };
 
-    EC_KEY* ecKey = EVP_PKEY_get0_EC_KEY(key.platformKey());
+    EC_KEY* ecKey = EVP_PKEY_get0_EC_KEY(key.platformKey().get());
     if (!ecKey)
         return Exception { ExceptionCode::OperationError };
 
@@ -65,7 +65,7 @@ ExceptionOr<Vector<uint8_t>> CryptoAlgorithmECDSA::platformSign(const CryptoAlgo
     return signature;
 }
 
-ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
+ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcdsaParams& parameters, const CryptoKeyEC& key, const Vector<uint8_t>& signature, const Vector<uint8_t>& data, UseCryptoKit)
 {
     size_t keySizeInBytes = (key.keySizeInBits() + 7) / 8;
 
@@ -88,7 +88,7 @@ ExceptionOr<bool> CryptoAlgorithmECDSA::platformVerify(const CryptoAlgorithmEcds
     if (!digest)
         return Exception { ExceptionCode::OperationError };
 
-    EC_KEY* ecKey = EVP_PKEY_get0_EC_KEY(key.platformKey());
+    EC_KEY* ecKey = EVP_PKEY_get0_EC_KEY(key.platformKey().get());
     if (!ecKey)
         return Exception { ExceptionCode::OperationError };
 

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -35,7 +35,6 @@
 #include <WebCore/AuthenticationExtensionsClientOutputs.h>
 #include <WebCore/AuthenticatorAttachment.h>
 #include <WebCore/CryptoKeyAES.h>
-#include <WebCore/CryptoKeyEC.h>
 #include <WebCore/CryptoKeyHMAC.h>
 #include <WebCore/DeviceRequestConverter.h>
 #include <WebCore/DeviceResponseConverter.h>

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp
@@ -74,7 +74,8 @@ TEST(CtapPinTest, TestValidateAndConvertToUTF8)
 TEST(CtapPinTest, TestSetPinRequest)
 {
     // Generate an EC key pair as the peer key.
-    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits);
+    // FIXME: enable cryptoKit when it's enabled in SubtleCryptoAPI rdar://126352502
+    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits, WebCore::UseCryptoKit::No);
     ASSERT_FALSE(keyPairResult.hasException());
     auto keyPair = keyPairResult.releaseReturnValue();
 
@@ -126,11 +127,13 @@ TEST(CtapPinTest, TestSetPinRequest)
     EXPECT_NE(xIt, coseKey.end());
     const auto& yIt = coseKey.find(CBORValue(COSE::y));
     EXPECT_NE(yIt, coseKey.end());
-    auto cosePublicKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(xIt->second.getByteString(), yIt->second.getByteString()), true, CryptoKeyUsageDeriveBits);
+    // FIXME: enable cryptoKit when it's enabled in SubtleCryptoAPI rdar://126352502
+    auto cosePublicKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(xIt->second.getByteString(), yIt->second.getByteString()), true, CryptoKeyUsageDeriveBits, WebCore::UseCryptoKit::No);
     EXPECT_TRUE(cosePublicKey);
 
     // Check the encrypted Pin.
-    auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), *cosePublicKey);
+    // FIXME: enable cryptoKit when it's enabled in SubtleCryptoAPI rdar://126352502
+    auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), *cosePublicKey, WebCore::UseCryptoKit::No);
     EXPECT_TRUE(sharedKeyResult);
 
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);
@@ -249,7 +252,8 @@ TEST(CtapPinTest, TestKeyAgreementResponse)
     // Success cases
     result = KeyAgreementResponse::parse(convertBytesToVector(TestData::kCtapClientPinKeyAgreementResponse, sizeof(TestData::kCtapClientPinKeyAgreementResponse)));
     EXPECT_TRUE(result);
-    auto exportedRawKey = result->peerKey->exportRaw();
+    // FIXME: enable cryptoKit when it's enabled in SubtleCryptoAPI rdar://126352502
+    auto exportedRawKey = result->peerKey->exportRaw(WebCore::UseCryptoKit::No);
     EXPECT_FALSE(exportedRawKey.hasException());
     Vector<uint8_t> expectedRawKey;
     expectedRawKey.reserveCapacity(65);
@@ -262,7 +266,8 @@ TEST(CtapPinTest, TestKeyAgreementResponse)
 TEST(CtapPinTest, TestTokenRequest)
 {
     // Generate an EC key pair as the peer key.
-    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits);
+    // FIXME: enable cryptoKit when it's enabled in SubtleCryptoAPI rdar://126352502
+    auto keyPairResult = CryptoKeyEC::generatePair(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, true, CryptoKeyUsageDeriveBits, WebCore::UseCryptoKit::No);
     ASSERT_FALSE(keyPairResult.hasException());
     auto keyPair = keyPairResult.releaseReturnValue();
 
@@ -314,11 +319,13 @@ TEST(CtapPinTest, TestTokenRequest)
     EXPECT_NE(xIt, coseKey.end());
     const auto& yIt = coseKey.find(CBORValue(COSE::y));
     EXPECT_NE(yIt, coseKey.end());
-    auto cosePublicKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(xIt->second.getByteString(), yIt->second.getByteString()), true, CryptoKeyUsageDeriveBits);
+    // FIXME: enable cryptoKit when it's enabled in SubtleCryptoAPI rdar://126352502
+    auto cosePublicKey = CryptoKeyEC::importRaw(CryptoAlgorithmIdentifier::ECDH, "P-256"_s, encodeRawPublicKey(xIt->second.getByteString(), yIt->second.getByteString()), true, CryptoKeyUsageDeriveBits, WebCore::UseCryptoKit::No);
     EXPECT_TRUE(cosePublicKey);
 
     // Check the encrypted Pin.
-    auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), *cosePublicKey);
+    // FIXME: enable cryptoKit when it's enabled in SubtleCryptoAPI rdar://126352502
+    auto sharedKeyResult = CryptoAlgorithmECDH::platformDeriveBits(downcast<CryptoKeyEC>(*keyPair.privateKey), *cosePublicKey, WebCore::UseCryptoKit::No);
     EXPECT_TRUE(sharedKeyResult);
 
     auto crypto = PAL::CryptoDigest::create(PAL::CryptoDigest::Algorithm::SHA_256);


### PR DESCRIPTION
#### 2ca10927173d23111c5d44e97fab308f397e49b8
<pre>
Adding CryptoKit for ECDSA/ECDH
<a href="https://bugs.webkit.org/show_bug.cgi?id=272162">https://bugs.webkit.org/show_bug.cgi?id=272162</a>
<a href="https://rdar.apple.com/125914120">rdar://125914120</a>

Reviewed by Pascoe and Alex Christensen.

With this change:
1. When CryptoKit is enabled, Swift Objects of type ECKey will be held in C++ UniqueRef inside CryptokeyEC.h.
2. C++ UniqueRef should be able to clean memory for Swift objects.
3. TestWebKitAPI also links with the swift generated header for CtapPinTestAPI.
4. CryptoKeyEC is fundamentally changed but when CryptoKit is not enabled, it should behave as it does
   before this change.
All layout tests for LayoutTests/crypto have been manually run with CryptoKitEnabled to test the functionality.
Layout tests in EWS will test this change with CryptoKit off.
Some calls in Pin.cpp and AuthenticatorAttestationResponse.cpp are not part of the SubtleCrypto interface have not been selectively enabled to use CryptoKit yet.
They will be enabled once the SubtleCrypto interface is activated and livedOn for some time.

* Source/WebCore/Modules/webauthn/AuthenticatorAttestationResponse.cpp:
(WebCore::AuthenticatorAttestationResponse::getPublicKey const):
* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
(fido::pin::KeyAgreementResponse::parseFromCOSE):
(fido::pin::TokenRequest::tryCreate):
(fido::pin::SetPinRequest::tryCreate):
* Source/WebCore/Modules/webauthn/fido/Pin.h:
* Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift:
(Digest.sha1(_:)):
(Digest.sha256(_:)):
(Digest.sha384(_:)):
(Digest.sha512(_:)):
(Digest.digest(_:hashFunction:)):
(ECRv.errCode):
(ECRv.signature):
(ECRv.keyBytes):
(ECRv.key):
(ECKey.toPub):
(ECKey.importX963Pub(_:curve:)):
(ECKey.exportX963Pub):
(ECKey.importCompressedPub(_:curve:)):
(ECKey.importX963Private(_:curve:)):
(ECKey.exportX963Private):
(ECKey.sign(_:hashFunction:)):
(ECKey.getInternalPrivate):
(ECKey.getInternalPublic):
(ECKey.deriveBits(_:)):
* Source/WebCore/PAL/pal/PALSwift/UnsafeOverlays.swift:
(HashFunction.update(_:)): Deleted.
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::write):
(WebCore::CloneSerializer::isUsingCryptoKit):
(WebCore::CloneDeserializer::isUsingCryptoKit):
(WebCore::CloneDeserializer::readECKey):
* Source/WebCore/crypto/CryptoAlgorithm.cpp:
(WebCore::CryptoAlgorithm::importKey):
(WebCore::CryptoAlgorithm::exportKey):
* Source/WebCore/crypto/CryptoAlgorithm.h:
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::SubtleCrypto::deriveKey):
(WebCore::SubtleCrypto::importKey):
(WebCore::SubtleCrypto::exportKey):
(WebCore::SubtleCrypto::wrapKey):
(WebCore::SubtleCrypto::unwrapKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.cpp:
(WebCore::CryptoAlgorithmAESCBC::importKey):
(WebCore::CryptoAlgorithmAESCBC::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCBC.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.cpp:
(WebCore::CryptoAlgorithmAESCFB::importKey):
(WebCore::CryptoAlgorithmAESCFB::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCFB.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.cpp:
(WebCore::CryptoAlgorithmAESCTR::importKey):
(WebCore::CryptoAlgorithmAESCTR::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESCTR.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.cpp:
(WebCore::CryptoAlgorithmAESGCM::importKey):
(WebCore::CryptoAlgorithmAESGCM::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESGCM.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.cpp:
(WebCore::CryptoAlgorithmAESKW::importKey):
(WebCore::CryptoAlgorithmAESKW::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmAESKW.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.cpp:
(WebCore::CryptoAlgorithmECDH::generateKey):
(WebCore::CryptoAlgorithmECDH::deriveBits):
(WebCore::CryptoAlgorithmECDH::importKey):
(WebCore::CryptoAlgorithmECDH::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDH.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.cpp:
(WebCore::CryptoAlgorithmECDSA::sign):
(WebCore::CryptoAlgorithmECDSA::verify):
(WebCore::CryptoAlgorithmECDSA::generateKey):
(WebCore::CryptoAlgorithmECDSA::importKey):
(WebCore::CryptoAlgorithmECDSA::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmECDSA.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.cpp:
(WebCore::CryptoAlgorithmEd25519::importKey):
(WebCore::CryptoAlgorithmEd25519::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmEd25519.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.cpp:
(WebCore::CryptoAlgorithmHKDF::importKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHKDF.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.cpp:
(WebCore::CryptoAlgorithmHMAC::importKey):
(WebCore::CryptoAlgorithmHMAC::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmHMAC.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.cpp:
(WebCore::CryptoAlgorithmPBKDF2::importKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmPBKDF2.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSAES_PKCS1_v1_5.cpp:
(WebCore::CryptoAlgorithmRSAES_PKCS1_v1_5::importKey):
(WebCore::CryptoAlgorithmRSAES_PKCS1_v1_5::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSAES_PKCS1_v1_5.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp:
(WebCore::CryptoAlgorithmRSASSA_PKCS1_v1_5::importKey):
(WebCore::CryptoAlgorithmRSASSA_PKCS1_v1_5::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSASSA_PKCS1_v1_5.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.cpp:
(WebCore::CryptoAlgorithmRSA_OAEP::importKey):
(WebCore::CryptoAlgorithmRSA_OAEP::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_OAEP.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.cpp:
(WebCore::CryptoAlgorithmRSA_PSS::importKey):
(WebCore::CryptoAlgorithmRSA_PSS::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmRSA_PSS.h:
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.cpp:
(WebCore::CryptoAlgorithmX25519::importKey):
(WebCore::CryptoAlgorithmX25519::exportKey):
* Source/WebCore/crypto/algorithms/CryptoAlgorithmX25519.h:
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHMac.cpp:
(WebCore::platformDeriveBitsCC):
(WebCore::platformDeriveBitsCryptoKit):
(WebCore::CryptoAlgorithmECDH::platformDeriveBits):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp:
(WebCore::toCKHashFunction):
(WebCore::signECDSACryptoKit):
(WebCore::verifyECDSACryptoKit):
(WebCore::signECDSA):
(WebCore::verifyECDSA):
(WebCore::CryptoAlgorithmECDSA::platformSign):
(WebCore::CryptoAlgorithmECDSA::platformVerify):
* Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp:
(WebCore::CryptoKeyEC::keySizeInBits const):
(WebCore::namedCurveToCryptoKitCurve):
(WebCore::CryptoKeyEC::platformGeneratePair):
(WebCore::CryptoKeyEC::platformImportRaw):
(WebCore::CryptoKeyEC::platformExportRaw const):
(WebCore::CryptoKeyEC::platformImportJWKPublic):
(WebCore::CryptoKeyEC::platformImportJWKPrivate):
(WebCore::CryptoKeyEC::platformAddFieldElements const):
(WebCore::CryptoKeyEC::platformImportSpki):
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformImportPkcs8):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):
(WebCore::CryptoKeyEC::usingCryptoKit const):
(WebCore::CryptoKeyEC::platformKey const):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDHGCrypt.cpp:
(WebCore::CryptoAlgorithmECDH::platformDeriveBits):
* Source/WebCore/crypto/gcrypt/CryptoAlgorithmECDSAGCrypt.cpp:
(WebCore::CryptoAlgorithmECDSA::platformSign):
(WebCore::CryptoAlgorithmECDSA::platformVerify):
* Source/WebCore/crypto/gcrypt/CryptoKeyECGCrypt.cpp:
(WebCore::CryptoKeyEC::platformKey const):
(WebCore::CryptoKeyEC::usingCryptoKit const):
(WebCore::CryptoKeyEC::platformGeneratePair):
(WebCore::CryptoKeyEC::platformImportRaw):
(WebCore::CryptoKeyEC::platformImportJWKPublic):
(WebCore::CryptoKeyEC::platformImportJWKPrivate):
(WebCore::CryptoKeyEC::platformImportSpki):
(WebCore::CryptoKeyEC::platformImportPkcs8):
(WebCore::CryptoKeyEC::platformExportRaw const):
(WebCore::CryptoKeyEC::platformAddFieldElements const):
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):
* Source/WebCore/crypto/keys/CryptoKeyAES.cpp:
(WebCore::CryptoKeyAES::importRaw):
(WebCore::CryptoKeyAES::importJwk):
* Source/WebCore/crypto/keys/CryptoKeyAES.h:
* Source/WebCore/crypto/keys/CryptoKeyEC.cpp:
(WebCore::CryptoKeyEC::toCCPlatformECKeyContainer):
(WebCore::CryptoKeyEC::toCKPlatformECKeyContainer):
(WebCore::CryptoKeyEC::generatePair):
(WebCore::CryptoKeyEC::importRaw):
(WebCore::CryptoKeyEC::importJwk):
(WebCore::CryptoKeyEC::importSpki):
(WebCore::CryptoKeyEC::importPkcs8):
(WebCore::CryptoKeyEC::exportRaw const):
(WebCore::CryptoKeyEC::exportJwk const):
(WebCore::CryptoKeyEC::exportSpki const):
(WebCore::CryptoKeyEC::exportPkcs8 const):
* Source/WebCore/crypto/keys/CryptoKeyEC.h:
(WebCore::CCECCryptorRefDeleter::operator() const):
* Source/WebCore/crypto/openssl/CryptoAlgorithmECDHOpenSSL.cpp:
(WebCore::CryptoAlgorithmECDH::platformDeriveBits):
* Source/WebCore/crypto/openssl/CryptoAlgorithmECDSAOpenSSL.cpp:
(WebCore::CryptoAlgorithmECDSA::platformSign):
(WebCore::CryptoAlgorithmECDSA::platformVerify):
* Source/WebCore/crypto/openssl/CryptoKeyECOpenSSL.cpp:
(WebCore::CryptoKeyEC::usingCryptoKit const):
(WebCore::CryptoKeyEC::platformKey const):
(WebCore::CryptoKeyEC::platformGeneratePair):
(WebCore::CryptoKeyEC::platformImportRaw):
(WebCore::CryptoKeyEC::platformImportJWKPublic):
(WebCore::CryptoKeyEC::platformImportJWKPrivate):
(WebCore::CryptoKeyEC::platformImportSpki):
(WebCore::CryptoKeyEC::platformImportPkcs8):
(WebCore::CryptoKeyEC::platformExportRaw const):
(WebCore::CryptoKeyEC::platformAddFieldElements const):
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
* Tools/TestWebKitAPI/Tests/WebCore/CtapPinTest.cpp:
(TestWebKitAPI::TEST(CtapPinTest, TestSetPinRequest)):
(TestWebKitAPI::TEST(CtapPinTest, TestKeyAgreementResponse)):
(TestWebKitAPI::TEST(CtapPinTest, TestTokenRequest)):

Canonical link: <a href="https://commits.webkit.org/277711@main">https://commits.webkit.org/277711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf08fde60aee1a3b1a0e7ae687931a13c4837dbc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48211 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50899 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44276 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39379 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20522 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22599 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42839 "Found 1 new test failure: fast/css/viewport-height-outline.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6267 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41508 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44565 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52802 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47702 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46715 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24523 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45620 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25328 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55197 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6880 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24246 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11347 "Passed tests") | 
<!--EWS-Status-Bubble-End-->