### PR TITLE
REGRESSION (277259@main): ASSERT(!forVisitedLink) in RenderThemeIOS::systemColor

### DIFF
--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1554,6 +1554,16 @@ auto RenderTheme::colorCache(OptionSet<StyleColorOptions> options) const -> Colo
     }).iterator->value;
 }
 
+static Color defaultLinkColor(bool useDarkAppearance)
+{
+    return useDarkAppearance ? SRGBA<uint8_t> { 158, 158, 255 } : SRGBA<uint8_t> { 0, 0, 238 };
+}
+
+static Color defaultVisitedLinkColor(bool useDarkAppearance)
+{
+    return useDarkAppearance ? SRGBA<uint8_t> { 208, 173, 240 } : SRGBA<uint8_t> { 85, 26, 139 };
+}
+
 Color RenderTheme::systemColor(CSSValueID cssValueId, OptionSet<StyleColorOptions> options) const
 {
     auto useDarkAppearance = options.contains(StyleColorOptions::UseDarkAppearance);
@@ -1573,12 +1583,12 @@ Color RenderTheme::systemColor(CSSValueID cssValueId, OptionSet<StyleColorOption
     // https://drafts.csswg.org/css-color-4/#valdef-system-color-linktext
     // Text in non-active, non-visited links. For light backgrounds, traditionally blue.
     case CSSValueLinktext:
-        return useDarkAppearance ? SRGBA<uint8_t> { 158, 158, 255 } : SRGBA<uint8_t> { 0, 0, 238 };
+        return defaultLinkColor(useDarkAppearance);
 
     // https://drafts.csswg.org/css-color-4/#valdef-system-color-visitedtext
     // Text in visited links. For light backgrounds, traditionally purple.
     case CSSValueVisitedtext:
-        return useDarkAppearance ? SRGBA<uint8_t> { 208, 173, 240 } : SRGBA<uint8_t> { 85, 26, 139 };
+        return defaultVisitedLinkColor(useDarkAppearance);
 
     // https://drafts.csswg.org/css-color-4/#valdef-system-color-activetext
     // Text in active links. For light backgrounds, traditionally red.
@@ -1667,8 +1677,8 @@ Color RenderTheme::systemColor(CSSValueID cssValueId, OptionSet<StyleColorOption
     // Non-standard addition.
     case CSSValueWebkitLink: {
         if (forVisitedLink)
-            return systemColor(CSSValueVisitedtext, options);
-        return systemColor(CSSValueLinktext, options);
+            return defaultVisitedLinkColor(useDarkAppearance);
+        return defaultLinkColor(useDarkAppearance);
     }
 
     // Deprecated system-colors:

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -471,8 +471,7 @@ Color RenderThemeMac::systemColor(CSSValueID cssValueID, OptionSet<StyleColorOpt
         return RenderTheme::systemColor(cssValueID, options);
     }
 
-    // -webkit-link requests Visitedtext when the link is visited, let it fetch Visitedtext from the cache if possible.
-    ASSERT(!forVisitedLink || cssValueID == CSSValueVisitedtext);
+    ASSERT(!forVisitedLink);
 
     auto it = cache.systemStyleColors.find(cssValueID);
     if (it != cache.systemStyleColors.end())


### PR DESCRIPTION
#### 5d42114d58682590ac6fb8e28dccc82c71538035
<pre>
REGRESSION (277259@main): ASSERT(!forVisitedLink) in RenderThemeIOS::systemColor
<a href="https://bugs.webkit.org/show_bug.cgi?id=272441">https://bugs.webkit.org/show_bug.cgi?id=272441</a>
<a href="https://rdar.apple.com/126190394">rdar://126190394</a>

Reviewed by Ryosuke Niwa and Tim Nguyen.

`-webkit-link` is a special value that resolves differently depending on whether
it is used with `:visited`. Due to this, there are assertions that ensure its
actual value is not inserted into caches that do not know about `:visited`
styles. These assertions work by checking `StyleColorOptions`.

277259@main made `-webkit-link` dependent on `VisitedText`. This means that
`VisitedText` was now also being passed along with the visited option.
277259@main relaxed the assertion in `RenderThemeMac` to allow for this, but
did not do so in `RenderThemeIOS`.

However, it does not make sense to pass the visited option along at all, given
`VisitedText` is independent of `:visited`. Additionally, the approach in
277259@main is slightly flawed, as it made `-webkit-link` dependent on other
system colors. This is incorrect, as in the future, it may be desirable to make
`LinkText` and `VisitedText` vary per-platform (as is allowed by the spec).
However, the value of `-webkit-link` (at least in light mode) is specified in
the HTML standard, and should never vary per-platform.

Fix by making `-webkit-link` independent of other system colors by introducing
static helpers. Additionally, revert the relaxed assertion.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::defaultLinkColor):
(WebCore::defaultVisitedLinkColor):
(WebCore::RenderTheme::systemColor const):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::systemColor const):

Canonical link: <a href="https://commits.webkit.org/277303@main">https://commits.webkit.org/277303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5d43edaa7c3fdf005f422b7ee821cf190f271ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49913 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49946 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43311 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38488 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19801 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41894 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5306 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43623 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42296 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51821 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22292 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18640 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45782 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23567 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44800 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10420 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24351 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->