### PR TITLE
Remove unused functions in `HistoryItem` and `HistoryController`

### DIFF
--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -330,11 +330,6 @@ const Vector<Ref<HistoryItem>>& HistoryItem::children() const
     return m_children;
 }
 
-bool HistoryItem::hasChildren() const
-{
-    return !m_children.isEmpty();
-}
-
 void HistoryItem::clearChildren()
 {
     m_children.clear();
@@ -372,24 +367,6 @@ bool HistoryItem::hasSameDocumentTree(HistoryItem& otherItem) const
         auto& child = children()[i].get();
         auto* otherChild = otherItem.childItemWithDocumentSequenceNumber(child.documentSequenceNumber());
         if (!otherChild || !child.hasSameDocumentTree(*otherChild))
-            return false;
-    }
-
-    return true;
-}
-
-// Does a non-recursive check that this item and its immediate children have the
-// same frames as the other item.
-bool HistoryItem::hasSameFrames(HistoryItem& otherItem) const
-{
-    if (target() != otherItem.target())
-        return false;
-        
-    if (children().size() != otherItem.children().size())
-        return false;
-
-    for (size_t i = 0; i < children().size(); i++) {
-        if (!otherItem.childItemWithTarget(children()[i]->target()))
             return false;
     }
 

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -151,11 +151,9 @@ public:
     WEBCORE_EXPORT HistoryItem* childItemWithTarget(const AtomString&);
     HistoryItem* childItemWithDocumentSequenceNumber(long long number);
     WEBCORE_EXPORT const Vector<Ref<HistoryItem>>& children() const;
-    WEBCORE_EXPORT bool hasChildren() const;
     void clearChildren();
     
     bool shouldDoSameDocumentNavigationTo(HistoryItem& otherItem) const;
-    bool hasSameFrames(HistoryItem& otherItem) const;
 
     bool isCurrentDocument(Document&) const;
     

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -109,16 +109,6 @@ Ref<LocalFrame> HistoryController::protectedFrame() const
     return m_frame.get();
 }
 
-void HistoryController::clearScrollPositionAndViewState()
-{
-    RefPtr currentItem = m_currentItem;
-    if (!currentItem)
-        return;
-
-    currentItem->clearScrollPosition();
-    currentItem->setPageScaleFactor(0);
-}
-
 /*
  There is a race condition between the layout and load completion that affects restoring the scroll position.
  We try to restore the scroll position at both the first layout and upon load completion.
@@ -810,24 +800,6 @@ bool HistoryController::itemsAreClones(HistoryItem& item1, HistoryItem* item2) c
     return item2
         && &item1 != item2
         && item1.itemSequenceNumber() == item2->itemSequenceNumber();
-}
-
-// Helper method that determines whether the current frame tree matches given history item's.
-bool HistoryController::currentFramesMatchItem(HistoryItem& item) const
-{
-    if ((!m_frame->tree().uniqueName().isEmpty() || !item.target().isEmpty()) && m_frame->tree().uniqueName() != item.target())
-        return false;
-
-    const auto& childItems = item.children();
-    if (childItems.size() != m_frame->tree().childCount())
-        return false;
-    
-    for (auto& item : childItems) {
-        if (!m_frame->tree().childByUniqueName(item->target()))
-            return false;
-    }
-    
-    return true;
 }
 
 void HistoryController::updateBackForwardListClippedAtTarget(bool doClip)

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -53,7 +53,6 @@ public:
     ~HistoryController();
 
     WEBCORE_EXPORT void saveScrollPositionAndViewStateToItem(HistoryItem*);
-    void clearScrollPositionAndViewState();
     WEBCORE_EXPORT void restoreScrollPositionAndViewState();
 
     void updateBackForwardListForFragmentScroll();
@@ -108,7 +107,6 @@ private:
     void recursiveUpdateForCommit();
     void recursiveUpdateForSameDocumentNavigation();
     bool itemsAreClones(HistoryItem&, HistoryItem*) const;
-    bool currentFramesMatchItem(HistoryItem&) const;
     void updateBackForwardListClippedAtTarget(bool doClip);
     void updateCurrentItem();
 


### PR DESCRIPTION
#### 3b02cf6edd0e7721c22d5181c77ccd57a0293f77
<pre>
Remove unused functions in `HistoryItem` and `HistoryController`
<a href="https://bugs.webkit.org/show_bug.cgi?id=272451">https://bugs.webkit.org/show_bug.cgi?id=272451</a>
<a href="https://rdar.apple.com/126193811">rdar://126193811</a>

Reviewed by Sihui Liu.

* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::hasSameFrames const): Deleted.
* Source/WebCore/history/HistoryItem.h:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::clearScrollPositionAndViewState): Deleted.
(WebCore::HistoryController::currentFramesMatchItem const): Deleted.
* Source/WebCore/loader/HistoryController.h:

Canonical link: <a href="https://commits.webkit.org/277313@main">https://commits.webkit.org/277313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f8edfbbcdebe01ec4704db328dabafba779e4f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49990 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43355 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31984 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23946 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38526 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19840 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21458 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41939 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5350 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43659 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51865 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18680 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23611 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44838 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24395 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6659 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23329 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->