### PR TITLE
[GTK][WPE] Ensure that WebGL changes request a single composition

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
@@ -165,6 +165,14 @@ void TextureMapperPlatformLayerProxyDMABuf::pushDMABuf(Ref<DMABufLayer>&& dmabuf
         m_pendingLayer->release();
 
     m_pendingLayer = WTFMove(dmabufLayer);
+
+#if HAVE(DISPLAY_LINK)
+    // WebGL changes will cause a composition request during layerFlush. We cannot request
+    // a new compostion here as well or we may trigger two compositions instead of one.
+    if (contentType() == ContentType::WebGL)
+        return;
+#endif
+
     if (m_compositor)
         m_compositor->onNewBufferAvailable();
 }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp
@@ -133,6 +133,13 @@ void TextureMapperPlatformLayerProxyGL::pushNextBuffer(std::unique_ptr<TextureMa
     m_pendingBuffer = WTFMove(newBuffer);
     m_wasBufferDropped = false;
 
+#if HAVE(DISPLAY_LINK)
+    // WebGL changes will cause a composition request during layerFlush. We cannot request
+    // a new compostion here as well or we may trigger two compositions instead of one.
+    if (contentType() == ContentType::WebGL)
+        return;
+#endif
+
     if (m_compositor)
         m_compositor->onNewBufferAvailable();
 }


### PR DESCRIPTION
#### 8ce70fa03821ea1c7a19a3913730ffe6b8a522ed
<pre>
[GTK][WPE] Ensure that WebGL changes request a single composition
<a href="https://bugs.webkit.org/show_bug.cgi?id=272455">https://bugs.webkit.org/show_bug.cgi?id=272455</a>

Reviewed by Carlos Garcia Campos.

Proxies don&apos;t request compositions when new WebGL content is pushed.

* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp:
(WebCore::TextureMapperPlatformLayerProxyDMABuf::pushDMABuf):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyGL.cpp:
(WebCore::TextureMapperPlatformLayerProxyGL::pushNextBuffer):

Canonical link: <a href="https://commits.webkit.org/277366@main">https://commits.webkit.org/277366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4402e16a1e3a37d9ea21a421b98b5d9b35f0031

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49965 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43330 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49588 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38508 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/23991 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40750 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19822 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41912 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43643 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42319 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51840 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22311 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18658 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45799 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23586 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44813 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24370 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6679 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23304 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->