### PR TITLE
[Skia] Add initial support for color spaces

### DIFF
--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -29,6 +29,7 @@ platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp
 
 platform/graphics/skia/TransformationMatrixSkia.cpp
 platform/graphics/skia/ColorSkia.cpp
+platform/graphics/skia/ColorSpaceSkia.cpp
 platform/graphics/skia/ComplexTextControllerSkia.cpp
 platform/graphics/skia/DrawGlyphsRecorderSkia.cpp
 platform/graphics/skia/FilterImageSkia.cpp

--- a/Source/WebCore/platform/graphics/ColorConversion.cpp
+++ b/Source/WebCore/platform/graphics/ColorConversion.cpp
@@ -429,16 +429,14 @@ ColorComponents<float, 4> convertAndResolveColorComponents(ColorSpace inputColor
     return platformConvertColorComponents(inputColorSpace, inputColorComponents, outputColorSpace);
 #else
     return callWithColorType(inputColorComponents, inputColorSpace, [outputColorSpace] (const auto& inputColor) {
-        switch (outputColorSpace.platformColorSpace()) {
-        case PlatformColorSpace::Name::SRGB:
+        if (outputColorSpace == DestinationColorSpace::SRGB())
             return asColorComponents(convertColor<SRGBA<float>>(inputColor).resolved());
-        case PlatformColorSpace::Name::LinearSRGB:
+        if (outputColorSpace == DestinationColorSpace::LinearSRGB())
             return asColorComponents(convertColor<LinearSRGBA<float>>(inputColor).resolved());
 #if ENABLE(DESTINATION_COLOR_SPACE_DISPLAY_P3)
-        case PlatformColorSpace::Name::DisplayP3:
+        if (outputColorSpace == DestinationColorSpace::DisplayP3())
             return asColorComponents(convertColor<DisplayP3<float>>(inputColor).resolved());
 #endif
-        }
 
         ASSERT_NOT_REACHED();
         return asColorComponents(convertColor<SRGBA<float>>(inputColor).resolved());

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -33,6 +33,10 @@
 
 #if USE(ACCELERATE) && USE(CG)
 #include <Accelerate/Accelerate.h>
+#elif USE(SKIA)
+IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
+#include <skia/core/SkPixmap.h>
+IGNORE_CLANG_WARNINGS_END
 #endif
 
 namespace WebCore {
@@ -135,6 +139,54 @@ static void convertImagePixelsAccelerated(const ConstPixelBufferConversionView& 
         const uint8_t map[4] = { 2, 1, 0, 3 };
         vImagePermuteChannels_ARGB8888(&sourceVImageBuffer, &destinationVImageBuffer, map, kvImageNoFlags);
     }
+}
+
+#elif USE(SKIA)
+
+static void convertImagePixelsSkia(const ConstPixelBufferConversionView& source, const PixelBufferConversionView& destination, const IntSize& destinationSize)
+{
+    auto toSkiaColorType = [](const PixelFormat& pixelFormat) {
+        switch (pixelFormat) {
+        case PixelFormat::RGBA8:
+            return SkColorType::kRGBA_8888_SkColorType;
+        case PixelFormat::BGRA8:
+            return SkColorType::kBGRA_8888_SkColorType;
+        case PixelFormat::BGRX8:
+        case PixelFormat::RGB10:
+        case PixelFormat::RGB10A8:
+            break;
+        }
+        ASSERT_NOT_REACHED();
+        return SkColorType::kUnknown_SkColorType;
+    };
+    auto toSkiaAlphaType = [](const AlphaPremultiplication& alphaFormat) {
+        switch (alphaFormat) {
+        case AlphaPremultiplication::Premultiplied:
+            return SkAlphaType::kPremul_SkAlphaType;
+        case AlphaPremultiplication::Unpremultiplied:
+            return SkAlphaType::kUnpremul_SkAlphaType;
+        }
+        ASSERT_NOT_REACHED();
+        return SkAlphaType::kUnknown_SkAlphaType;
+    };
+    SkImageInfo sourceImageInfo = SkImageInfo::Make(
+        destinationSize.width(),
+        destinationSize.height(),
+        toSkiaColorType(source.format.pixelFormat),
+        toSkiaAlphaType(source.format.alphaFormat),
+        source.format.colorSpace.platformColorSpace()
+    );
+    // Utilize SkPixmap which is a raw bytes wrapper capable of performing conversions.
+    SkPixmap sourcePixmap(sourceImageInfo, source.rows, source.bytesPerRow);
+    SkImageInfo destinationImageInfo = SkImageInfo::Make(
+        destinationSize.width(),
+        destinationSize.height(),
+        toSkiaColorType(destination.format.pixelFormat),
+        toSkiaAlphaType(destination.format.alphaFormat),
+        destination.format.colorSpace.platformColorSpace()
+    );
+    // Read pixels from source to destination and convert pixels if necessary.
+    sourcePixmap.readPixels(destinationImageInfo, destination.rows, destination.bytesPerRow);
 }
 
 #endif
@@ -251,6 +303,11 @@ void convertImagePixels(const ConstPixelBufferConversionView& source, const Pixe
             convertImagePixelsUnaccelerated<convertSinglePixelUnpremultipliedToUnpremultiplied<PixelFormatConversion::None>>(source, destination, destinationSize);
     } else
         convertImagePixelsAccelerated(source, destination, destinationSize);
+#elif USE(SKIA)
+    if (source.format.alphaFormat == destination.format.alphaFormat && source.format.pixelFormat == destination.format.pixelFormat && source.format.colorSpace == destination.format.colorSpace)
+        memcpy(destination.rows, source.rows, source.bytesPerRow * destinationSize.height());
+    else
+        convertImagePixelsSkia(source, destination, destinationSize);
 #else
     // FIXME: We don't currently support converting pixel data between different color spaces in the non-accelerated path.
     // This could be added using conversion functions from ColorConversion.h.

--- a/Source/WebCore/platform/graphics/PlatformColorSpace.h
+++ b/Source/WebCore/platform/graphics/PlatformColorSpace.h
@@ -28,6 +28,8 @@
 #if USE(CG)
 #include <wtf/RetainPtr.h>
 typedef struct CGColorSpace* CGColorSpaceRef;
+#elif USE(SKIA)
+#include <skia/core/SkColorSpace.h>
 #else
 #include <optional>
 #endif
@@ -38,6 +40,11 @@ namespace WebCore {
 
 using PlatformColorSpace = RetainPtr<CGColorSpaceRef>;
 using PlatformColorSpaceValue = CGColorSpaceRef;
+
+#elif USE(SKIA)
+
+using PlatformColorSpace = sk_sp<SkColorSpace>;
+using PlatformColorSpaceValue = sk_sp<SkColorSpace>;
 
 #else
 

--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -45,7 +45,7 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
     , m_bitmapInfo(calculateBitmapInfo(this->colorSpace(), isOpaque))
 #endif
 #if USE(SKIA)
-    , m_imageInfo(SkImageInfo::MakeN32Premul(size.width(), size.height()))
+    , m_imageInfo(SkImageInfo::MakeN32Premul(size.width(), size.height(), this->colorSpace().platformColorSpace()))
 #endif
 {
     ASSERT(!m_size.isEmpty());
@@ -65,7 +65,7 @@ ShareableBitmapConfiguration::ShareableBitmapConfiguration(const IntSize& size, 
     , m_bitmapInfo(bitmapInfo)
 #endif
 #if USE(SKIA)
-    , m_imageInfo(SkImageInfo::MakeN32Premul(size.width(), size.height()))
+    , m_imageInfo(SkImageInfo::MakeN32Premul(size.width(), size.height(), this->colorSpace().platformColorSpace()))
 #endif
 {
     // This constructor is called when decoding ShareableBitmapConfiguration. So this constructor

--- a/Source/WebCore/platform/graphics/filters/FEFlood.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEFlood.cpp
@@ -33,7 +33,7 @@ namespace WebCore {
 
 Ref<FEFlood> FEFlood::create(const Color& floodColor, float floodOpacity, DestinationColorSpace colorSpace)
 {
-#if USE(CG)
+#if USE(CG) || USE(SKIA)
     return adoptRef(*new FEFlood(floodColor, floodOpacity, colorSpace));
 #else
     UNUSED_PARAM(colorSpace);

--- a/Source/WebCore/platform/graphics/filters/FEFlood.h
+++ b/Source/WebCore/platform/graphics/filters/FEFlood.h
@@ -39,7 +39,7 @@ public:
     float floodOpacity() const { return m_floodOpacity; }
     bool setFloodOpacity(float);
 
-#if !USE(CG)
+#if !USE(CG) && !USE(SKIA)
     // feFlood does not perform color interpolation of any kind, so the result is always in the current
     // color space regardless of the value of color-interpolation-filters.
     void setOperatingColorSpace(const DestinationColorSpace&) override { }

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -231,7 +231,7 @@ static RefPtr<PixelBuffer> getConvertedPixelBuffer(PixelBuffer& sourcePixelBuffe
 
 bool FilterImage::requiresPixelBufferColorSpaceConversion(std::optional<DestinationColorSpace> colorSpace) const
 {
-#if USE(CG)
+#if USE(CG) || USE(SKIA)
     // This function determines whether we need the step of an extra color space conversion
     // We only need extra color conversion when 1) color space is different in the input
     // AND 2) the filter is manipulating raw pixels
@@ -378,8 +378,8 @@ void FilterImage::correctPremultipliedPixelBuffer()
 
 void FilterImage::transformToColorSpace(const DestinationColorSpace& colorSpace)
 {
-#if USE(CG)
-    // CG handles color space adjustments internally.
+#if USE(CG) || USE(SKIA)
+    // CG and SKIA handle color space adjustments internally.
     UNUSED_PARAM(colorSpace);
 #else
     if (colorSpace == m_colorSpace)

--- a/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp
@@ -91,7 +91,11 @@ ImageGStreamer::ImageGStreamer(GRefPtr<GstSample>&& sample)
         break;
     }
 
-    auto imageInfo = SkImageInfo::Make(videoFrame->width(), videoFrame->height(), colorType, alphaType);
+    auto toSkiaColorSpace = [](const PlatformVideoColorSpace&) {
+        notImplemented();
+        return SkColorSpace::MakeSRGB();
+    };
+    auto imageInfo = SkImageInfo::Make(videoFrame->width(), videoFrame->height(), colorType, alphaType, toSkiaColorSpace(videoColorSpaceFromInfo(videoInfo)));
     SkPixmap pixmap(imageInfo, videoFrame->planeData(0), videoFrame->planeStride(0));
     auto image = SkImages::RasterFromPixmap(pixmap, [](const void*, void* context) {
         std::unique_ptr<GstMappedFrame> videoFrame(static_cast<GstMappedFrame*>(context));

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
@@ -90,7 +90,7 @@ UnacceleratedBuffer::UnacceleratedBuffer(const WebCore::IntSize& size, Flags fla
     }
 
 #if USE(SKIA)
-    auto imageInfo = SkImageInfo::MakeN32Premul(size.width(), size.height());
+    auto imageInfo = SkImageInfo::MakeN32Premul(size.width(), size.height(), SkColorSpace::MakeSRGB());
     // FIXME: ref buffer and unref on release proc?
     SkSurfaceProps properties = { 0, WebCore::FontRenderOptions::singleton().subpixelOrder() };
     m_surface = SkSurfaces::WrapPixels(imageInfo, m_data.get(), imageInfo.minRowBytes64(), &properties);

--- a/Source/WebCore/platform/graphics/skia/ColorSpaceSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ColorSpaceSkia.cpp
@@ -24,22 +24,31 @@
  */
 
 #include "config.h"
-#include "ImageBackingStore.h"
+#include "ColorSpaceSkia.h"
 
-IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
-#include <skia/core/SkPixmap.h>
-IGNORE_CLANG_WARNINGS_END
+#include "PlatformColorSpace.h"
+
+#if USE(SKIA)
 
 namespace WebCore {
 
-PlatformImagePtr ImageBackingStore::image() const
+sk_sp<SkColorSpace> sRGBColorSpaceRef()
 {
-    m_pixels->ref();
-    auto info = SkImageInfo::MakeN32(size().width(), size().height(), m_premultiplyAlpha ? kPremul_SkAlphaType : kUnpremul_SkAlphaType, SkColorSpace::MakeSRGB());
-    SkPixmap pixmap(info, m_pixelsPtr, info.minRowBytes64());
-    return SkImages::RasterFromPixmap(pixmap, [](const void*, void* context) {
-        static_cast<DataSegment*>(context)->deref();
-    }, m_pixels.get());
+    return SkColorSpace::MakeSRGB();
 }
 
+sk_sp<SkColorSpace> linearSRGBColorSpaceRef()
+{
+    return SkColorSpace::MakeSRGBLinear();
+}
+
+#if ENABLE(DESTINATION_COLOR_SPACE_DISPLAY_P3)
+sk_sp<SkColorSpace> displayP3ColorSpaceRef()
+{
+    return SkColorSpace::MakeRGB(SkNamedTransferFn::kSRGB, SkNamedGamut::kDisplayP3);
+}
+#endif
+
 } // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/ColorSpaceSkia.h
+++ b/Source/WebCore/platform/graphics/skia/ColorSpaceSkia.h
@@ -23,23 +23,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "ImageBackingStore.h"
+#pragma once
 
-IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
-#include <skia/core/SkPixmap.h>
-IGNORE_CLANG_WARNINGS_END
+#if USE(SKIA)
+
+#include <skia/core/SkColorSpace.h>
 
 namespace WebCore {
 
-PlatformImagePtr ImageBackingStore::image() const
-{
-    m_pixels->ref();
-    auto info = SkImageInfo::MakeN32(size().width(), size().height(), m_premultiplyAlpha ? kPremul_SkAlphaType : kUnpremul_SkAlphaType, SkColorSpace::MakeSRGB());
-    SkPixmap pixmap(info, m_pixelsPtr, info.minRowBytes64());
-    return SkImages::RasterFromPixmap(pixmap, [](const void*, void* context) {
-        static_cast<DataSegment*>(context)->deref();
-    }, m_pixels.get());
-}
+WEBCORE_EXPORT sk_sp<SkColorSpace> sRGBColorSpaceRef();
+WEBCORE_EXPORT sk_sp<SkColorSpace> linearSRGBColorSpaceRef();
+#if ENABLE(DESTINATION_COLOR_SPACE_DISPLAY_P3)
+WEBCORE_EXPORT sk_sp<SkColorSpace> displayP3ColorSpaceRef();
+#endif
 
 } // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp
@@ -131,7 +131,7 @@ RefPtr<NativeImage> GraphicsContextGL::createNativeImageFromPixelBuffer(const Gr
         alphaType = kOpaque_SkAlphaType;
     else if (sourceContextAttributes.premultipliedAlpha)
         alphaType = kPremul_SkAlphaType;
-    auto imageInfo = SkImageInfo::Make(imageSize.width(), imageSize.height(), kRGBA_8888_SkColorType, alphaType);
+    auto imageInfo = SkImageInfo::Make(imageSize.width(), imageSize.height(), kRGBA_8888_SkColorType, alphaType, SkColorSpace::MakeSRGB());
 
     Ref protectedPixelBuffer = pixelBuffer;
     SkPixmap pixmap(imageInfo, pixelBuffer->bytes().data(), imageInfo.minRowBytes());

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -45,6 +45,7 @@
 #include <skia/core/SkPoint3.h>
 #include <skia/core/SkRRect.h>
 #include <skia/core/SkRegion.h>
+#include <skia/core/SkSurface.h>
 #include <skia/core/SkTileMode.h>
 #include <skia/effects/SkImageFilters.h>
 #include <wtf/MathExtras.h>
@@ -60,6 +61,7 @@ GraphicsContextSkia::GraphicsContextSkia(SkCanvas& canvas, RenderingMode renderi
     , m_renderingMode(renderingMode)
     , m_renderingPurpose(renderingPurpose)
     , m_destroyNotify(WTFMove(destroyNotify))
+    , m_colorSpace(canvas.imageInfo().colorSpace() ? DestinationColorSpace(canvas.imageInfo().refColorSpace()) : DestinationColorSpace::SRGB())
 {
 }
 
@@ -83,6 +85,11 @@ AffineTransform GraphicsContextSkia::getCTM(IncludeDeviceScale includeScale) con
 SkCanvas* GraphicsContextSkia::platformContext() const
 {
     return &m_canvas;
+}
+
+const DestinationColorSpace& GraphicsContextSkia::colorSpace() const
+{
+    return m_colorSpace;
 }
 
 bool GraphicsContextSkia::makeGLContextCurrentIfNeeded() const

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -42,6 +42,8 @@ public:
     bool hasPlatformContext() const final;
     SkCanvas* platformContext() const final;
 
+    const DestinationColorSpace& colorSpace() const final;
+
     void didUpdateState(GraphicsContextState&);
 
     void setLineCap(LineCap) final;
@@ -126,6 +128,7 @@ private:
     CompletionHandler<void()> m_destroyNotify;
     SkiaState m_skiaState;
     Vector<SkiaState, 1> m_skiaStateStack;
+    const DestinationColorSpace m_colorSpace;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp
@@ -54,7 +54,7 @@ std::unique_ptr<ImageBufferSkiaAcceleratedBackend> ImageBufferSkiaAcceleratedBac
 
     auto* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
     RELEASE_ASSERT(grContext);
-    auto imageInfo = SkImageInfo::MakeN32Premul(backendSize.width(), backendSize.height());
+    auto imageInfo = SkImageInfo::MakeN32Premul(backendSize.width(), backendSize.height(), parameters.colorSpace.platformColorSpace());
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
     auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, &properties);
     if (!surface || !surface->getCanvas())

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
@@ -43,7 +43,7 @@ std::unique_ptr<ImageBufferSkiaUnacceleratedBackend> ImageBufferSkiaUnaccelerate
     if (backendSize.isEmpty())
         return nullptr;
 
-    auto imageInfo = SkImageInfo::MakeN32Premul(backendSize.width(), backendSize.height());
+    auto imageInfo = SkImageInfo::MakeN32Premul(backendSize.width(), backendSize.height(), parameters.colorSpace.platformColorSpace());
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
     auto surface = SkSurfaces::Raster(imageInfo, &properties);
     if (!surface || !surface->getCanvas())

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -61,7 +61,9 @@ bool PlatformImageNativeImageBackend::hasAlpha() const
 
 DestinationColorSpace PlatformImageNativeImageBackend::colorSpace() const
 {
-    notImplemented();
+    if (auto colorSpace = platformImage()->refColorSpace())
+        return DestinationColorSpace(colorSpace);
+    // No color space means the default - SRGB.
     return DestinationColorSpace::SRGB();
 }
 

--- a/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
@@ -42,14 +42,14 @@ std::optional<DestinationColorSpace> ShareableBitmapConfiguration::validateColor
     return colorSpace;
 }
 
-CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerPixel(const DestinationColorSpace&)
+CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerPixel(const DestinationColorSpace& colorSpace)
 {
-    return 4;
+    return SkImageInfo::MakeN32Premul(1, 1, colorSpace.platformColorSpace()).bytesPerPixel();
 }
 
-CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerRow(const IntSize& size, const DestinationColorSpace&)
+CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerRow(const IntSize& size, const DestinationColorSpace& colorSpace)
 {
-    return SkImageInfo::MakeN32Premul(size.width(), size.height()).minRowBytes();
+    return SkImageInfo::MakeN32Premul(size.width(), size.height(), colorSpace.platformColorSpace()).minRowBytes();
 }
 
 std::unique_ptr<GraphicsContext> ShareableBitmap::createGraphicsContext()

--- a/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
@@ -79,7 +79,7 @@ RefPtr<Nicosia::Buffer> SkiaAcceleratedBufferPool::createAcceleratedBuffer(const
 {
     auto* grContext = PlatformDisplay::sharedDisplayForCompositing().skiaGrContext();
     RELEASE_ASSERT(grContext);
-    auto imageInfo = SkImageInfo::MakeN32Premul(size.width(), size.height());
+    auto imageInfo = SkImageInfo::MakeN32Premul(size.width(), size.height(), SkColorSpace::MakeSRGB());
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
     auto surface = SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kNo, imageInfo, 0, kTopLeft_GrSurfaceOrigin, &properties);
     if (!surface)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -112,7 +112,7 @@ void RenderSVGResourceMasker::applyMask(PaintInfo& paintInfo, const RenderLayerM
 
     Ref svgStyle = style().svgStyle();
     if (svgStyle->colorInterpolation() == ColorInterpolation::LinearRGB) {
-#if USE(CG)
+#if USE(CG) || USE(SKIA)
         maskColorSpace = DestinationColorSpace::LinearSRGB();
 #endif
         drawColorSpace = DestinationColorSpace::LinearSRGB();
@@ -133,7 +133,7 @@ void RenderSVGResourceMasker::applyMask(PaintInfo& paintInfo, const RenderLayerM
     if (missingMaskerData) {
         checkedLayer()->paintSVGResourceLayer(maskImage->context(), contentTransform);
 
-#if !USE(CG)
+#if !USE(CG) && !USE(SKIA)
         maskImage->transformToColorSpace(drawColorSpace);
 #else
         UNUSED_PARAM(drawColorSpace);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp
@@ -81,7 +81,7 @@ bool LegacyRenderSVGResourceMasker::applyResource(RenderElement& renderer, const
         auto drawColorSpace = DestinationColorSpace::SRGB();
 
         if (style().svgStyle().colorInterpolation() == ColorInterpolation::LinearRGB) {
-#if USE(CG)
+#if USE(CG) || USE(SKIA)
             maskColorSpace = DestinationColorSpace::LinearSRGB();
 #endif
             drawColorSpace = DestinationColorSpace::LinearSRGB();
@@ -110,7 +110,7 @@ bool LegacyRenderSVGResourceMasker::drawContentIntoMaskImage(MaskerData* maskerD
     if (!drawContentIntoContext(maskImageContext, objectBoundingBox))
         return false;
 
-#if !USE(CG)
+#if !USE(CG) && !USE(SKIA)
     maskerData->maskImage->transformToColorSpace(colorSpace);
 #else
     UNUSED_PARAM(colorSpace);

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -70,6 +70,8 @@ list(APPEND WebKit_SERIALIZATION_IN_FILES
 
     Shared/gtk/ArgumentCodersGtk.serialization.in
 
+    Shared/skia/CoreIPCSkColorSpace.serialization.in
+
     Shared/soup/WebCoreArgumentCodersSoup.serialization.in
 )
 
@@ -281,6 +283,7 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/Shared/glib"
     "${WEBKIT_DIR}/Shared/gtk"
     "${WEBKIT_DIR}/Shared/linux"
+    "${WEBKIT_DIR}/Shared/skia"
     "${WEBKIT_DIR}/Shared/soup"
     "${WEBKIT_DIR}/UIProcess/API/C/cairo"
     "${WEBKIT_DIR}/UIProcess/API/C/glib"

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -105,6 +105,8 @@ list(APPEND WebKit_SERIALIZATION_IN_FILES
     Shared/glib/InputMethodState.serialization.in
     Shared/glib/UserMessage.serialization.in
 
+    Shared/skia/CoreIPCSkColorSpace.serialization.in
+
     Shared/soup/WebCoreArgumentCodersSoup.serialization.in
 )
 
@@ -381,6 +383,7 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/Shared/Extensions"
     "${WEBKIT_DIR}/Shared/glib"
     "${WEBKIT_DIR}/Shared/libwpe"
+    "${WEBKIT_DIR}/Shared/skia"
     "${WEBKIT_DIR}/Shared/soup"
     "${WEBKIT_DIR}/Shared/wpe"
     "${WEBKIT_DIR}/UIProcess/API/C/cairo"

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -32,6 +32,10 @@
 #include <wtf/ArgumentCoder.h>
 #include <wtf/EnumTraits.h>
 
+#if USE(SKIA)
+#include <skia/core/SkColorSpace.h>
+#endif
+
 #if PLATFORM(GTK)
 #include "ArgumentCodersGtk.h"
 #endif
@@ -63,6 +67,14 @@ template<> struct ArgumentCoder<WebCore::FontPlatformDataAttributes> {
 template<> struct ArgumentCoder<WebCore::FontCustomPlatformData> {
     static void encode(Encoder&, const WebCore::FontCustomPlatformData&);
     static std::optional<Ref<WebCore::FontCustomPlatformData>> decode(Decoder&);
+};
+#endif
+
+#if USE(SKIA)
+template<> struct ArgumentCoder<sk_sp<SkColorSpace>> {
+    static void encode(Encoder&, const sk_sp<SkColorSpace>&);
+    static void encode(StreamConnectionEncoder&, const sk_sp<SkColorSpace>&);
+    static std::optional<sk_sp<SkColorSpace>> decode(Decoder&);
 };
 #endif
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2030,6 +2030,9 @@ enum class WebCore::DiagnosticLoggingDomain : uint8_t {
 #if USE(CG)
 using WebCore::PlatformColorSpace = RetainPtr<CGColorSpaceRef>;
 #else
+#if USE(SKIA)
+using WebCore::PlatformColorSpace = sk_sp<SkColorSpace>;
+#else
 [Nested] enum class WebCore::PlatformColorSpace::Name : uint8_t {
         SRGB
         , LinearSRGB
@@ -2041,6 +2044,7 @@ using WebCore::PlatformColorSpace = RetainPtr<CGColorSpaceRef>;
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::PlatformColorSpace {
     WebCore::PlatformColorSpace::Name get();
 };
+#endif
 #endif
 
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::DestinationColorSpace {

--- a/Source/WebKit/Shared/skia/CoreIPCSkColorSpace.serialization.in
+++ b/Source/WebKit/Shared/skia/CoreIPCSkColorSpace.serialization.in
@@ -1,0 +1,31 @@
+# Copyright (C) 2024 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#if USE(SKIA)
+
+webkit_platform_headers: "CoreIPCSkColorSpace.h"
+
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCSkColorSpace {
+    std::span<const uint8_t> dataReference();
+}
+
+#endif // USE(SKIA)

--- a/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp
+++ b/Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp
@@ -28,6 +28,8 @@
 
 #if USE(SKIA)
 
+#include "CoreIPCSkColorSpace.h"
+#include "StreamConnectionEncoder.h"
 #include <WebCore/Font.h>
 
 namespace IPC {
@@ -52,6 +54,24 @@ bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(De
 {
     ASSERT_NOT_REACHED();
     return false;
+}
+
+void ArgumentCoder<sk_sp<SkColorSpace>>::encode(Encoder& encoder, const sk_sp<SkColorSpace>& colorSpace)
+{
+    encoder << WebKit::CoreIPCSkColorSpace(colorSpace);
+}
+
+void ArgumentCoder<sk_sp<SkColorSpace>>::encode(StreamConnectionEncoder& encoder, const sk_sp<SkColorSpace>& colorSpace)
+{
+    encoder << WebKit::CoreIPCSkColorSpace(colorSpace);
+}
+
+std::optional<sk_sp<SkColorSpace>> ArgumentCoder<sk_sp<SkColorSpace>>::decode(Decoder& decoder)
+{
+    auto colorSpace = decoder.decode<WebKit::CoreIPCSkColorSpace>();
+    if (UNLIKELY(!decoder.isValid()))
+        return std::nullopt;
+    return colorSpace->skColorSpace();
 }
 
 } // namespace IPC

--- a/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
+++ b/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
@@ -125,7 +125,7 @@ void BackingStore::incorporateUpdate(UpdateInfo&& updateInfo)
     }
 #elif USE(SKIA)
     cairo_surface_flush(m_surface.get());
-    auto imageInfo = SkImageInfo::MakeN32Premul(cairo_image_surface_get_width(m_surface.get()), cairo_image_surface_get_height(m_surface.get()));
+    auto imageInfo = SkImageInfo::MakeN32Premul(cairo_image_surface_get_width(m_surface.get()), cairo_image_surface_get_height(m_surface.get()) , SkColorSpace::MakeSRGB());
     auto surface = SkSurfaces::WrapPixels(imageInfo, cairo_image_surface_get_data(m_surface.get()), cairo_image_surface_get_stride(m_surface.get()), nullptr);
     SkCanvas* canvas = surface ? surface->getCanvas() : nullptr;
     if (!canvas)

--- a/Tools/WebKitTestRunner/gtk/PlatformWebViewGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/PlatformWebViewGtk.cpp
@@ -39,6 +39,7 @@
 
 #if USE(SKIA)
 IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
+#include <skia/core/SkColorSpace.h>
 #include <skia/core/SkPixmap.h>
 IGNORE_CLANG_WARNINGS_END
 #endif
@@ -273,7 +274,7 @@ SkImage* PlatformWebView::windowSnapshotImage()
         return nullptr;
 
     cairo_surface_flush(surface);
-    auto imageInfo = SkImageInfo::MakeN32Premul(cairo_image_surface_get_width(surface), cairo_image_surface_get_height(surface));
+    auto imageInfo = SkImageInfo::MakeN32Premul(cairo_image_surface_get_width(surface), cairo_image_surface_get_height(surface), SkColorSpace::MakeSRGB());
     SkPixmap pixmap(imageInfo, cairo_image_surface_get_data(surface), cairo_image_surface_get_stride(surface));
     return SkImages::RasterFromPixmap(pixmap, [](const void*, void* context) {
         cairo_surface_destroy(static_cast<cairo_surface_t*>(context));

--- a/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.cpp
@@ -34,6 +34,7 @@
 #include <cairo.h>
 #elif USE(SKIA)
 IGNORE_CLANG_WARNINGS_BEGIN("cast-align")
+#include <skia/core/SkColorSpace.h>
 #include <skia/core/SkPixmap.h>
 IGNORE_CLANG_WARNINGS_END
 #endif
@@ -91,7 +92,7 @@ PlatformImage PlatformWebViewClientWPE::snapshot()
 
     return surface;
 #elif USE(SKIA)
-    auto info = SkImageInfo::MakeN32Premul(width, height);
+    auto info = SkImageInfo::MakeN32Premul(width, height, SkColorSpace::MakeSRGB());
     SkPixmap pixmap(info, g_bytes_get_data(bytes, nullptr), info.minRowBytes64());
     return SkImages::RasterFromPixmap(pixmap, [](const void*, void* context) {
         g_object_unref(WPE_BUFFER(context));

--- a/Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp
+++ b/Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp
@@ -38,6 +38,7 @@
 #if defined(USE_SKIA) && USE_SKIA
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align"
+#include <skia/core/SkColorSpace.h>
 #include <skia/core/SkPixmap.h>
 #pragma GCC diagnostic pop
 #endif
@@ -111,7 +112,7 @@ HeadlessViewBackend::HeadlessViewBackend(uint32_t width, uint32_t height)
     }
 #elif defined(USE_SKIA) && USE_SKIA
     {
-        auto info = SkImageInfo::MakeN32Premul(m_width, m_height);
+        auto info = SkImageInfo::MakeN32Premul(m_width, m_height, SkColorSpace::MakeSRGB());
         size_t stride = info.minRowBytes();
         uint8_t* buffer = new uint8_t[stride * m_height];
         memset(buffer, 0, stride * m_height);
@@ -182,7 +183,7 @@ void HeadlessViewBackend::updateSnapshot(PlatformBuffer exportedBuffer)
 #if defined(USE_CAIRO) && USE_CAIRO
     uint32_t bufferStride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, m_width);
 #elif defined(USE_SKIA) && USE_SKIA
-    auto info = SkImageInfo::MakeN32Premul(m_width, m_height);
+    auto info = SkImageInfo::MakeN32Premul(m_width, m_height, SkColorSpace::MakeSRGB());
     uint32_t bufferStride = info.minRowBytes();
 #endif
     uint8_t* buffer = new uint8_t[bufferStride * m_height];


### PR DESCRIPTION
#### 3466e3a573ebcaa89a49e3f0649627c1409435f9
<pre>
[Skia] Add initial support for color spaces
<a href="https://bugs.webkit.org/show_bug.cgi?id=272453">https://bugs.webkit.org/show_bug.cgi?id=272453</a>

Reviewed by Carlos Garcia Campos.

With this change, the colorspaces are now enabled in all the codepaths requiring them.
This change leaves some codepaths unimplemented - to be implemented in followup PRs.
All the SVG filters are working now as good as they worked with cairo.

* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/ColorConversion.cpp:
(WebCore::convertAndResolveColorComponents):
* Source/WebCore/platform/graphics/DestinationColorSpace.cpp:
(WebCore::DestinationColorSpace::SRGB):
(WebCore::DestinationColorSpace::LinearSRGB):
(WebCore::DestinationColorSpace::DisplayP3):
(WebCore::operator==):
(WebCore::DestinationColorSpace::asRGB const):
* Source/WebCore/platform/graphics/DestinationColorSpace.h:
(WebCore::DestinationColorSpace::platformColorSpace const):
* Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
(WebCore::convertImagePixelsSkia):
(WebCore::convertImagePixels):
* Source/WebCore/platform/graphics/PlatformColorSpace.h:
* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
(WebCore::ShareableBitmapConfiguration::ShareableBitmapConfiguration):
* Source/WebCore/platform/graphics/filters/FEFlood.cpp:
(WebCore::FEFlood::create):
* Source/WebCore/platform/graphics/filters/FEFlood.h:
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::FilterImage::requiresPixelBufferColorSpaceConversion const):
(WebCore::FilterImage::transformToColorSpace):
* Source/WebCore/platform/graphics/gstreamer/ImageGStreamerSkia.cpp:
(WebCore::ImageGStreamer::ImageGStreamer):
* Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp:
(Nicosia::UnacceleratedBuffer::UnacceleratedBuffer):
* Source/WebCore/platform/graphics/skia/ColorSpaceSkia.cpp: Copied from Source/WebCore/platform/image-decoders/skia/ImageBackingStoreSkia.cpp.
(WebCore::sRGBColorSpaceRef):
(WebCore::linearSRGBColorSpaceRef):
(WebCore::displayP3ColorSpaceRef):
* Source/WebCore/platform/graphics/skia/ColorSpaceSkia.h: Copied from Source/WebCore/platform/image-decoders/skia/ImageBackingStoreSkia.cpp.
* Source/WebCore/platform/graphics/skia/GraphicsContextGLSkia.cpp:
(WebCore::GraphicsContextGL::createNativeImageFromPixelBuffer):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::GraphicsContextSkia):
(WebCore::GraphicsContextSkia::colorSpace const):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::create):
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp:
(WebCore::ImageBufferSkiaUnacceleratedBackend::create):
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::PlatformImageNativeImageBackend::colorSpace const):
* Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp:
(WebCore::ShareableBitmapConfiguration::calculateBytesPerPixel):
(WebCore::ShareableBitmapConfiguration::calculateBytesPerRow):
* Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp:
(WebCore::SkiaAcceleratedBufferPool::createAcceleratedBuffer):
* Source/WebCore/platform/image-decoders/skia/ImageBackingStoreSkia.cpp:
(WebCore::ImageBackingStore::image const):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::applyMask):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.cpp:
(WebCore::LegacyRenderSVGResourceMasker::applyResource):
(WebCore::LegacyRenderSVGResourceMasker::drawContentIntoMaskImage):
* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/skia/CoreIPCSkColorSpace.h: Copied from Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp.
(WebKit::CoreIPCSkColorSpace::CoreIPCSkColorSpace):
(WebKit::CoreIPCSkColorSpace::skColorSpace const):
(WebKit::CoreIPCSkColorSpace::dataReference const):
* Source/WebKit/Shared/skia/CoreIPCSkColorSpace.serialization.in: Added.
* Source/WebKit/Shared/skia/WebCoreArgumentCodersSkia.cpp:
(IPC::ArgumentCoder&lt;sk_sp&lt;SkColorSpace&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;sk_sp&lt;SkColorSpace&gt;&gt;::decode):
* Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp:
(WebKit::BackingStore::incorporateUpdate):
* Tools/WebKitTestRunner/gtk/PlatformWebViewGtk.cpp:
(WTR::PlatformWebView::windowSnapshotImage):
* Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.cpp:
(WTR::PlatformWebViewClientWPE::snapshot):
* Tools/wpe/backends/fdo/HeadlessViewBackendFdo.cpp:
(WPEToolingBackends::HeadlessViewBackend::HeadlessViewBackend):
(WPEToolingBackends::HeadlessViewBackend::updateSnapshot):

Canonical link: <a href="https://commits.webkit.org/277802@main">https://commits.webkit.org/277802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fce8798ee973bb3771d94bf7b00a61e6d88a56c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27778 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51254 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44632 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50872 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39711 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20808 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43073 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6623 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53161 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47004 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45928 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25683 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6931 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->