### PR TITLE
iOS 17.4: WebContent crash-loops in iOS Simulator when trying to open any website

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2998,7 +2998,9 @@ sub setupIOSWebKitEnvironment($)
     $dyldFrameworkPath = File::Spec->rel2abs($dyldFrameworkPath);
 
     prependToEnvironmentVariableList("DYLD_FRAMEWORK_PATH", $dyldFrameworkPath);
+    prependToEnvironmentVariableList("__XPC_DYLD_FRAMEWORK_PATH", $dyldFrameworkPath);
     prependToEnvironmentVariableList("DYLD_LIBRARY_PATH", $dyldFrameworkPath);
+    prependToEnvironmentVariableList("__XPC_DYLD_LIBRARY_PATH", $dyldFrameworkPath);
     prependToEnvironmentVariableList("METAL_DEVICE_WRAPPER_TYPE", "1");
 
     setUpGuardMallocIfNeeded();


### PR DESCRIPTION
#### cde24af0fb2109ca6ec8bdc53f139ac35acf05ac
<pre>
iOS 17.4: WebContent crash-loops in iOS Simulator when trying to open any website
<a href="https://bugs.webkit.org/show_bug.cgi?id=272401">https://bugs.webkit.org/show_bug.cgi?id=272401</a>
<a href="https://rdar.apple.com/126137753">rdar://126137753</a>

Reviewed by NOBODY (OOPS!).

Attaching to the launched WebKit extension processes with Xcode shows that the DYLD_FRAMEWORK_PATH is not overridden
to point at the built products. Setting __XPC_DYLD_FRAMEWORK_PATH and __XPC_DYLD_LIBRARY_PATH resolves this.

* Tools/Scripts/webkitdirs.pm:
(setupIOSWebKitEnvironment):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cde24af0fb2109ca6ec8bdc53f139ac35acf05ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/47304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/26484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49955 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49988 "Failed to checkout and rebase branch from PR 27080") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/43353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49611 "Failed to checkout and rebase branch from PR 27080") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23944 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/49988 "Failed to checkout and rebase branch from PR 27080") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47885 "Failed to checkout and rebase branch from PR 27080") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/24027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/49988 "Failed to checkout and rebase branch from PR 27080") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/21467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5348 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/40575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51863 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/46794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45815 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/23609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54293 "Failed to checkout and rebase branch from PR 27080") | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23327 "Failed to checkout and rebase branch from PR 27080") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/54293 "Failed to checkout and rebase branch from PR 27080") | 
<!--EWS-Status-Bubble-End-->