### PR TITLE
Unreviewed, reverting 277285@main

### DIFF
--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -1026,9 +1026,6 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
 Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::Vector(const Vector& other)
     : Base(other.size(), other.size())
 {
-#ifdef __swift__
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("C++ copy constructors are not memory safe in Swift. Try to find a way to borrow the object instead.");
-#endif
     asanSetInitialBufferSizeTo(other.size());
 
     if (begin())
@@ -1040,9 +1037,6 @@ template<size_t otherCapacity, typename otherOverflowBehaviour, size_t otherMini
 Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::Vector(const Vector<T, otherCapacity, otherOverflowBehaviour, otherMinimumCapacity, OtherMalloc>& other)
     : Base(other.size(), other.size())
 {
-#ifdef __swift__
-    RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("C++ copy constructors are not memory safe in Swift. Try to find a way to borrow the object instead.");
-#endif
     asanSetInitialBufferSizeTo(other.size());
 
     if (begin())

--- a/Source/WebCore/Configurations/WebCore.xcconfig
+++ b/Source/WebCore/Configurations/WebCore.xcconfig
@@ -35,7 +35,7 @@ WK_APPLEJPEGXL_PREPROCESSOR_DEFINITIONS_YES = USE_JPEGXL=1;
 
 // FIXME: remove the interop setting here when rdar://124492036 is resolved.
 WK_HAVE_SWIFT_CPP_INTEROP = HAVE_SWIFT_CPP_INTEROP=0;
-WK_HAVE_SWIFT_CPP_INTEROP[sdk=macosx14*] = ;
+WK_HAVE_SWIFT_CPP_INTEROP[sdk=macos14*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=iphoneos17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=iphonesimulator17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=appletvos17*] = ;

--- a/Source/WebCore/PAL/Configurations/PAL.xcconfig
+++ b/Source/WebCore/PAL/Configurations/PAL.xcconfig
@@ -26,7 +26,7 @@
 
 // FIXME: remove the interop setting here when rdar://124492036 is resolved.
 WK_HAVE_SWIFT_CPP_INTEROP = HAVE_SWIFT_CPP_INTEROP=0;
-WK_HAVE_SWIFT_CPP_INTEROP[sdk=macosx14*] = ;
+WK_HAVE_SWIFT_CPP_INTEROP[sdk=macos14*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=iphoneos17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=iphonesimulator17*] = ;
 WK_HAVE_SWIFT_CPP_INTEROP[sdk=appletvos17*] = ;
@@ -101,7 +101,7 @@ OTHER_SWIFT_FLAGS_TVOS_SINCE_17 = -Xcc -std=c++20 -I $(SRCROOT)/pal -I $(SRCROOT
 
 // FIXME: remove the interop setting here when rdar://124492036 is resolved.
 EXCLUDED_SOURCE_FILE_NAMES = CryptoKitShim.swift UnsafeOverlays.swift
-EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx14*] = ;
+EXCLUDED_SOURCE_FILE_NAMES[sdk=macos14*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos17*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator17*] = ;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=appletvos17*] = ;

--- a/Source/WebCore/PAL/pal/PALSwift.h
+++ b/Source/WebCore/PAL/pal/PALSwift.h
@@ -28,20 +28,8 @@
 #include <cstdint>
 #include <wtf/Vector.h>
 
-namespace Cpp {
-
 using VectorUInt8 = WTF::Vector<uint8_t>;
 using SpanConstUInt8 = std::span<const uint8_t>;
-using OptionalVectorUInt8 = std::optional<WTF::Vector<uint8_t>>;
-
-
-// FIXME: remove when swift support is available rdar://118026392
-inline OptionalVectorUInt8 makeOptional(VectorUInt8 val)
-{
-    return val;
-}
-
-} // PAL
 
 #ifndef __swift__
 #include "PALSwift-Generated.h"

--- a/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
+++ b/Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift
@@ -30,10 +30,6 @@ import Foundation
 
 import PALSwift
 
-public typealias VectorUInt8 = Cpp.VectorUInt8
-public typealias SpanConstUInt8 = Cpp.SpanConstUInt8
-public typealias OptionalVectorUInt8 = Cpp.OptionalVectorUInt8
-
 public enum ErrorCodes: Int {
     case success = 0
     case wrongTagSize = 1
@@ -48,75 +44,153 @@ public enum ErrorCodes: Int {
 private class Utils {
     static let zeroArray = [UInt8](repeating: 0, count: 0)
 }
-public struct AesGcmRV {
-    public var cipherText: OptionalVectorUInt8 = OptionalVectorUInt8()
-    public var errorCode: ErrorCodes = .success
-}
 
 public class AesGcm {
     public static func encrypt(
-        key: SpanConstUInt8, iv: SpanConstUInt8, ad: SpanConstUInt8, message: SpanConstUInt8,
-        desiredTagLengthInBytes: Int
-    ) -> AesGcmRV {
-        var rv = AesGcmRV()
+        _ key: UnsafePointer<UInt8>,
+        keySize: UInt,
+        iv: UnsafePointer<UInt8>,
+        ivSize: UInt,
+        additionalData: UnsafePointer<UInt8>,
+        additionalDataSize: UInt,
+        plainText: UnsafePointer<UInt8>,
+        plainTextSize: UInt,
+        cipherText: UnsafeMutablePointer<UInt8>
+    ) -> ErrorCodes {
         do {
-            if iv.size() == 0 {
-                rv.errorCode = .invalidArgument
-                return rv
+            if keySize > Int.max
+                || ivSize > Int.max
+                || plainTextSize > Int.max
+                || additionalDataSize > Int.max
+            {
+                return .tooBigArguments
             }
-            let sealedBox: AES.GCM.SealedBox = try AES.GCM.seal(message, key: key, iv: iv, ad: ad)
-            if desiredTagLengthInBytes > sealedBox.tag.count {
-                rv.errorCode = .invalidArgument
-                return rv
+            if ivSize == 0 {
+                return .invalidArgument
             }
-            var result = sealedBox.ciphertext
-            result.append(
-                sealedBox.tag[
-                    sealedBox.tag.startIndex..<(sealedBox.tag.startIndex + desiredTagLengthInBytes)]
-            )
-            rv.errorCode = .success
-            rv.cipherText = Cpp.makeOptional(result.copyToVectorUInt8())
-            return rv
+            let nonce = try AES.GCM.Nonce(
+                data: UnsafeBufferPointer(start: iv, count: Int(ivSize)))
+            var message = UnsafeBufferPointer(start: plainText, count: Int(plainTextSize))
+            if plainTextSize == 0 {
+                Utils.zeroArray.withUnsafeBufferPointer { ptr in
+                    message = ptr
+                }
+            }
+            let symKey = SymmetricKey(
+                data: UnsafeBufferPointer(start: key, count: Int(keySize)))
+            let sealedBox: AES.GCM.SealedBox
+            if additionalDataSize > 0 {
+                sealedBox = try AES.GCM.seal(
+                    message,
+                    using: symKey,
+                    nonce: nonce,
+                    authenticating: UnsafeBufferPointer(
+                        start: additionalData, count: Int(additionalDataSize))
+                )
+            } else {
+                sealedBox = try AES.GCM.seal(
+                    message,
+                    using: symKey,
+                    nonce: nonce
+                )
+            }
+            sealedBox.ciphertext.copyBytes(to: cipherText, count: Int(plainTextSize))
+            sealedBox.tag.copyBytes(
+                to: cipherText + Int(plainTextSize), count: sealedBox.tag.count)
         } catch {
-            rv.errorCode = .encryptionFailed
+            return .encryptionFailed
         }
-        return rv
+        return .success
     }
 }
 
 public struct AesKwRV {
     public var errCode: ErrorCodes = ErrorCodes.success
-    public var result: OptionalVectorUInt8 = OptionalVectorUInt8()
+    public var outputSize: UInt64 = 0
 }
 
 public class AesKw {
-    public static func wrap(keyToWrap: SpanConstUInt8, using: SpanConstUInt8) -> AesKwRV {
+    public static func wrap(
+        _ key: UnsafePointer<UInt8>,
+        keySize: UInt,
+        data: UnsafePointer<UInt8>,
+        dataSize: UInt,
+        cipherText: UnsafeMutablePointer<UInt8>,
+        cipherTextSize: UInt64
+    ) -> AesKwRV {
         var rv = AesKwRV()
+        rv.errCode = .success
+        if keySize > Int.max
+            || dataSize > Int.max
+            || cipherTextSize > Int.max
+            || keySize == 0
+            || dataSize == 0
+            || cipherTextSize == 0
+        {
+            rv.errCode = .invalidArgument
+            return rv
+        }
         do {
-            let result = try AES.KeyWrap.wrap(keyToWrap, using: using)
+            let cipher = try AES.KeyWrap.wrap(
+                SymmetricKey(data: UnsafeBufferPointer(start: data, count: Int(dataSize))),
+                using: SymmetricKey(
+                    data: UnsafeBufferPointer(start: key, count: Int(keySize))))
+            if cipher.count > Int(cipherTextSize) {
+                rv.errCode = .encryptionFailed
+                return rv
+            }
+            cipher.copyBytes(to: cipherText, count: cipher.count)
             rv.errCode = .success
-            rv.result = Cpp.makeOptional(
-                result)
+            rv.outputSize = UInt64(cipher.count)
         } catch {
             rv.errCode = .encryptionFailed
+            return rv
         }
         return rv
     }
 
-    public static func unwrap(wrappedKey: SpanConstUInt8, using: SpanConstUInt8) -> AesKwRV {
+    public static func unwrap(
+        _ key: UnsafePointer<UInt8>,
+        keySize: UInt,
+        cipherText: UnsafePointer<UInt8>,
+        cipherTextSize: UInt,
+        data: UnsafeMutablePointer<UInt8>,
+        dataSize: UInt64
+    ) -> AesKwRV {
         var rv = AesKwRV()
+        rv.errCode = ErrorCodes.success
+        if keySize > Int.max
+            || dataSize > Int.max
+            || cipherTextSize > Int.max
+            || keySize == 0
+            || dataSize == 0
+            || cipherTextSize == 0
+        {
+            rv.errCode = .invalidArgument
+            return rv
+        }
         do {
-            let result = try AES.KeyWrap.unwrap(
-                wrappedKey, using: using)
+            let unwrappedKey = try AES.KeyWrap.unwrap(
+                UnsafeBufferPointer(start: cipherText, count: Int(cipherTextSize)),
+                using: SymmetricKey(
+                    data: UnsafeBufferPointer(start: key, count: Int(keySize))))
+            if (unwrappedKey.bitCount / 8) > Int(dataSize) {
+                rv.errCode = .encryptionFailed
+                return rv
+            }
+            unwrappedKey.withUnsafeBytes { buf in
+                let mutable = UnsafeMutableRawBufferPointer(
+                    start: data, count: Int(dataSize))
+                mutable.copyBytes(from: buf)
+            }
             rv.errCode = .success
-            rv.result = Cpp.makeOptional(
-                result.copyToVectorUInt8())
+            rv.outputSize = UInt64(unwrappedKey.bitCount / 8)
         } catch {
-            rv.errCode = .encryptionFailed
+            rv.errCode = .decryptionFailed
+            return rv
         }
         return rv
     }
-
 }  // AesKw
 
 public class Digest {
@@ -135,9 +209,17 @@ public class Digest {
     private static func digest<T: HashFunction>(_ data: SpanConstUInt8, _: T.Type)
         -> VectorUInt8
     {
+        let forceDestructorLink = VectorUInt8()
         var hasher = T()
         hasher.update(data: data)
-        return hasher.finalize().copyToVectorUInt8()
+        let digest = hasher.finalize()
+        var returnValue = VectorUInt8(T.Digest.byteCount)
+        var index = 0
+        digest.forEach { val in
+            returnValue[index] = val
+            index += 1
+        }
+        return returnValue
     }
 }
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp
@@ -63,18 +63,26 @@ static ExceptionOr<Vector<uint8_t>> unwrapKeyAESKW(const Vector<uint8_t>& key, c
 #if HAVE(SWIFT_CPP_INTEROP)
 static ExceptionOr<Vector<uint8_t>> wrapKeyAESKWCryptoKit(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
-    auto rv = PAL::AesKw::wrap(data.span(), key.span());
+    Vector<uint8_t> result(data.size() + CryptoAlgorithmAESKW::s_extraSize);
+    uint64_t resultSize = result.size();
+    const PAL::AesKwRV rv = PAL::AesKw::wrap(key.data(), key.size(), data.data(), data.size(), result.data(), resultSize);
     if (!rv.getErrCode().isSuccess())
         return Exception { ExceptionCode::OperationError };
-    return WTFMove(*rv.getResult());
+    result.shrink(rv.getOutputSize());
+    return WTFMove(result);
 }
 
 static ExceptionOr<Vector<uint8_t>> unwrapKeyAESKWCryptoKit(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
-    auto rv = PAL::AesKw::unwrap(data.span(), key.span());
+    Vector<uint8_t> dataOut(data.size());
+    uint64_t dataOutSize = dataOut.size();
+    const PAL::AesKwRV rv = PAL::AesKw::unwrap(key.data(), key.size(), data.data(), data.size(), dataOut.data(), dataOutSize);
     if (!rv.getErrCode().isSuccess())
         return Exception { ExceptionCode::OperationError };
-    return WTFMove(*rv.getResult());
+    if (rv.getOutputSize() % 8)
+        return Exception { ExceptionCode::OperationError };
+    dataOut.shrink(rv.getOutputSize());
+    return WTFMove(dataOut);
 }
 #endif
 


### PR DESCRIPTION
#### 9f89447abd9a1625c7a2e4f04ef7cb04a64d8c0d
<pre>
Unreviewed, reverting 277285@main
<a href="https://rdar.apple.com/126209631">rdar://126209631</a>

breaking the build

Reverted change:

    Replacing AES impls with interop
    <a href="https://bugs.webkit.org/show_bug.cgi?id=271680">https://bugs.webkit.org/show_bug.cgi?id=271680</a>
    <a href="https://rdar.apple.com/125367961">rdar://125367961</a>
    <a href="https://commits.webkit.org/277285@main">https://commits.webkit.org/277285@main</a>

Canonical link: <a href="https://commits.webkit.org/277302@main">https://commits.webkit.org/277302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb92ae9b734f052f4f2f63ce263bd30b74c58f7f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/47298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49949 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/49982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43347 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/49605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23938 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/49982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/47879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/24011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/49982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/21453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/41927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5342 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/40569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51857 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/46788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22328 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23603 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24387 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54287 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6649 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23321 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/11142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->