### PR TITLE
[WPE] REGRESSION(277190@main): build broken when using NEON filters

### DIFF
--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp
@@ -176,7 +176,7 @@ bool FEBlendNeonApplier::apply(const Filter&, const FilterImageVector& inputs, F
     if (!destinationPixelBuffer)
         return false;
 
-    auto* destinationPixelArray = destinationPixelBuffer->bytes();
+    auto* destinationPixelArray = destinationPixelBuffer->bytes().data();
 
     auto effectADrawingRect = result.absoluteImageRectRelativeTo(input);
     auto sourcePixelArrayA = input.getPixelBuffer(AlphaPremultiplication::Premultiplied, effectADrawingRect);
@@ -184,11 +184,11 @@ bool FEBlendNeonApplier::apply(const Filter&, const FilterImageVector& inputs, F
     auto effectBDrawingRect = result.absoluteImageRectRelativeTo(input2);
     auto sourcePixelArrayB = input2.getPixelBuffer(AlphaPremultiplication::Premultiplied, effectBDrawingRect);
 
-    unsigned sourcePixelArrayLength = sourcePixelArrayA->sizeInBytes();
-    ASSERT(sourcePixelArrayLength == sourcePixelArrayB->sizeInBytes());
+    unsigned sourcePixelArrayLength = sourcePixelArrayA->bytes().size();
+    ASSERT(sourcePixelArrayLength == sourcePixelArrayB->bytes().size());
 
     if (sourcePixelArrayLength >= 8) {
-        applyPlatform(sourcePixelArrayA->bytes(), sourcePixelArrayB->bytes(), destinationPixelArray, sourcePixelArrayLength);
+        applyPlatform(sourcePixelArrayA->bytes().data(), sourcePixelArrayB->bytes().data(), destinationPixelArray, sourcePixelArrayLength);
         return true;
     }
 
@@ -197,8 +197,8 @@ bool FEBlendNeonApplier::apply(const Filter&, const FilterImageVector& inputs, F
     uint32_t sourceA[2] = { 0, 0 };
     uint32_t sourceBAndDest[2] = { 0, 0 };
 
-    sourceA[0] = reinterpret_cast<uint32_t*>(sourcePixelArrayA->bytes())[0];
-    sourceBAndDest[0] = reinterpret_cast<uint32_t*>(sourcePixelArrayB->bytes())[0];
+    sourceA[0] = reinterpret_cast<uint32_t*>(sourcePixelArrayA->bytes().data())[0];
+    sourceBAndDest[0] = reinterpret_cast<uint32_t*>(sourcePixelArrayB->bytes().data())[0];
     applyPlatform(reinterpret_cast<uint8_t*>(sourceA), reinterpret_cast<uint8_t*>(sourceBAndDest), reinterpret_cast<uint8_t*>(sourceBAndDest), 8);
     reinterpret_cast<uint32_t*>(destinationPixelArray)[0] = sourceBAndDest[0];
     return true;

--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeNeonArithmeticApplier.cpp
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeNeonArithmeticApplier.cpp
@@ -110,11 +110,11 @@ bool FECompositeNeonArithmeticApplier::apply(const Filter&, const FilterImageVec
     IntRect effectBDrawingRect = result.absoluteImageRectRelativeTo(input2);
     input2.copyPixelBuffer(*destinationPixelBuffer, effectBDrawingRect);
 
-    auto* sourcePixelBytes = sourcePixelBuffer->bytes();
-    auto* destinationPixelBytes = destinationPixelBuffer->bytes();
+    auto* sourcePixelBytes = sourcePixelBuffer->bytes().data();
+    auto* destinationPixelBytes = destinationPixelBuffer->bytes().data();
 
-    auto length = sourcePixelBuffer->sizeInBytes();
-    ASSERT(length == destinationPixelBuffer->sizeInBytes());
+    auto length = sourcePixelBuffer->bytes().size();
+    ASSERT(length == destinationPixelBuffer->bytes().size());
 
     applyPlatform(sourcePixelBytes, destinationPixelBytes, length, m_effect.k1(), m_effect.k2(), m_effect.k3(), m_effect.k4());
     return true;

--- a/Source/WebCore/platform/graphics/cpu/arm/filters/FEGaussianBlurNEON.h
+++ b/Source/WebCore/platform/graphics/cpu/arm/filters/FEGaussianBlurNEON.h
@@ -37,8 +37,8 @@ namespace WebCore {
 inline void boxBlurNEON(const PixelBuffer& srcPixelBuffer, PixelBuffer& dstPixelBuffer,
                         unsigned dx, int dxLeft, int dxRight, int stride, int strideLine, int effectWidth, int effectHeight)
 {
-    const uint32_t* sourcePixel = reinterpret_cast<uint32_t*>(srcPixelBuffer.bytes());
-    uint32_t* destinationPixel = reinterpret_cast<uint32_t*>(dstPixelBuffer.bytes());
+    const uint32_t* sourcePixel = reinterpret_cast<uint32_t*>(srcPixelBuffer.bytes().data());
+    uint32_t* destinationPixel = reinterpret_cast<uint32_t*>(dstPixelBuffer.bytes().data());
 
     float32x4_t deltaX = vdupq_n_f32(1.0 / dx);
     int pixelLine = strideLine / 4;


### PR DESCRIPTION
#### edc1bf6b0c8a2afd710c417f5cbc4d77a03bf7fa
<pre>
[WPE] REGRESSION(277190@main): build broken when using NEON filters
<a href="https://bugs.webkit.org/show_bug.cgi?id=272380">https://bugs.webkit.org/show_bug.cgi?id=272380</a>

Reviewed by Michael Catanzaro and Darin Adler.

The change fixes a build for NEON platforms after change 277190@main.

* Source/WebCore/platform/graphics/cpu/arm/filters/FEBlendNeonApplier.cpp:
(WebCore::FEBlendNeonApplier::apply const):
* Source/WebCore/platform/graphics/cpu/arm/filters/FECompositeNeonArithmeticApplier.cpp:
(WebCore::FECompositeNeonArithmeticApplier::apply const):
* Source/WebCore/platform/graphics/cpu/arm/filters/FEGaussianBlurNEON.h:
(WebCore::boxBlurNEON):

Canonical link: <a href="https://commits.webkit.org/277365@main">https://commits.webkit.org/277365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32b8fa5cbc36d2dc93daa5d8f735be9ba1376fb8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/49983 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/31976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38520 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24016 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19834 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21457 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41928 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5343 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43658 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42344 "Found 1 new test failure: inspector/cpu-profiler/tracking.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51858 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45814 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23604 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44835 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10459 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24388 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->