### PR TITLE
[WGSL] Identifier lexing reads after EOF

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -41,7 +41,7 @@ static unsigned isIdentifierStart(UChar character, const UChar* start, const UCh
         return 1;
 
     unsigned length = 1;
-    if (u_charType(*(start + length - 1)) == U_SURROGATE && static_cast<unsigned>(end - start) > length)
+    if (end > start + 1 && u_charType(character) == U_SURROGATE)
         length++;
     if (u_stringHasBinaryProperty(start, length, UCHAR_XID_START))
         return length;
@@ -52,8 +52,9 @@ static unsigned isIdentifierContinue(UChar character, const UChar* start, const 
 {
     if (auto length = isIdentifierStart(character, start, end))
         return length;
+
     unsigned length = 1;
-    if (u_charType(*(start + length - 1)) == U_SURROGATE && static_cast<unsigned>(end - start) > length)
+    if (end > start + 1 && u_charType(character) == U_SURROGATE)
         length++;
     if (u_stringHasBinaryProperty(start, length, UCHAR_XID_CONTINUE))
         return length;
@@ -287,7 +288,10 @@ Token Lexer<T>::nextToken()
             unsigned length = consumed;
             const T* startOfToken = m_code;
             shift(consumed);
-            while (auto consumed = isIdentifierContinue(m_current, m_code, m_codeEnd)) {
+            while (!isAtEndOfFile()) {
+                auto consumed = isIdentifierContinue(m_current, m_code, m_codeEnd);
+                if (!consumed)
+                    break;
                 length += consumed;
                 shift(consumed);
             }

--- a/Source/WebGPU/WGSL/tests/invalid/unicode.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/unicode.wgsl
@@ -1,0 +1,4 @@
+// RUN: %not %wgslc | %check
+
+// CHECK-L: Expected a ), but got a EOF
+@group(5)@binding(xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx0߃


### PR DESCRIPTION
#### f0eff1790b685946e909097fcc0109afbaa414be
<pre>
[WGSL] Identifier lexing reads after EOF
<a href="https://bugs.webkit.org/show_bug.cgi?id=272403">https://bugs.webkit.org/show_bug.cgi?id=272403</a>
<a href="https://rdar.apple.com/126128360">rdar://126128360</a>

Reviewed by Mike Wyrzykowski and Alex Christensen.

After adding support for unicode identifiers we now need an explicit check for EOF.

* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::nextToken):
* Source/WebGPU/WGSL/tests/invalid/unicode.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/277382@main">https://commits.webkit.org/277382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc7d5d2273c3ee298f0eac8c87cc219c05c0e38c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50001 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43366 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38531 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21471 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5361 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43681 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51876 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22347 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18708 "Found 1 new test failure: media/video-pause-immediately.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45826 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23622 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44849 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10469 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->