### PR TITLE
[LBSE] Adopt more smart pointers in SVG code

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
@@ -67,7 +67,7 @@ void RenderSVGBlock::updateFromStyle()
 
 bool RenderSVGBlock::needsHasSVGTransformFlags() const
 {
-    return graphicsElement().hasTransformRelatedAttributes();
+    return protectedGraphicsElement()->hasTransformRelatedAttributes();
 }
 
 void RenderSVGBlock::boundingRects(Vector<LayoutRect>& rects, const LayoutPoint& accumulatedOffset) const

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.h
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.h
@@ -30,6 +30,7 @@ class RenderSVGBlock : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGBlock);
 public:
     inline SVGGraphicsElement& graphicsElement() const;
+    inline Ref<SVGGraphicsElement> protectedGraphicsElement() const;
 
 protected:
     RenderSVGBlock(Type, SVGGraphicsElement&, RenderStyle&&);

--- a/Source/WebCore/rendering/svg/RenderSVGBlockInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGBlockInlines.h
@@ -35,5 +35,10 @@ inline SVGGraphicsElement& RenderSVGBlock::graphicsElement() const
     return downcast<SVGGraphicsElement>(nodeForNonAnonymous());
 }
 
+inline Ref<SVGGraphicsElement> RenderSVGBlock::protectedGraphicsElement() const
+{
+    return graphicsElement();
+}
+
 } // namespace WebCore
 

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -106,14 +106,14 @@ const RenderObject* RenderSVGModelObject::pushMappingToContainer(const RenderLay
     ASSERT(style().position() == PositionType::Static);
 
     bool ancestorSkipped;
-    RenderElement* container = this->container(ancestorToStopAt, ancestorSkipped);
+    CheckedPtr container = this->container(ancestorToStopAt, ancestorSkipped);
     if (!container)
         return nullptr;
 
     ASSERT_UNUSED(ancestorSkipped, !ancestorSkipped);
 
-    pushOntoGeometryMap(geometryMap, ancestorToStopAt, container, ancestorSkipped);
-    return container;
+    pushOntoGeometryMap(geometryMap, ancestorToStopAt, container.get(), ancestorSkipped);
+    return container.get();
 }
 
 LayoutRect RenderSVGModelObject::outlineBoundsForRepaint(const RenderLayerModelObject* repaintContainer, const RenderGeometryMap* geometryMap) const

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -222,20 +222,20 @@ void RenderSVGPath::drawMarkers(PaintInfo& paintInfo)
 
     SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
-    auto* markerStart = svgMarkerStartResourceFromStyle();
-    auto* markerMid = svgMarkerMidResourceFromStyle();
-    auto* markerEnd = svgMarkerEndResourceFromStyle();
+    CheckedPtr markerStart = svgMarkerStartResourceFromStyle();
+    CheckedPtr markerMid = svgMarkerMidResourceFromStyle();
+    CheckedPtr markerEnd = svgMarkerEndResourceFromStyle();
     if (!markerStart && !markerMid && !markerEnd)
         return;
 
     float strokeWidth = this->strokeWidth();
     for (auto& markerPosition : m_markerPositions) {
-        if (auto* marker = markerForType(markerPosition.type, markerStart, markerMid, markerEnd); marker && marker->hasLayer()) {
+        if (auto* marker = markerForType(markerPosition.type, markerStart.get(), markerMid.get(), markerEnd.get()); marker && marker->hasLayer()) {
             auto& context = paintInfo.context();
             GraphicsContextStateSaver stateSaver(context);
 
             auto contentTransform = marker->markerTransformation(markerPosition.origin, markerPosition.angle, strokeWidth);
-            marker->layer()->paintSVGResourceLayer(context, contentTransform);
+            marker->checkedLayer()->paintSVGResourceLayer(context, contentTransform);
         }
     }
 }
@@ -253,15 +253,15 @@ FloatRect RenderSVGPath::computeMarkerBoundingBox(const SVGBoundingBoxComputatio
 
     SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
-    auto* markerStart = svgMarkerStartResourceFromStyle();
-    auto* markerMid = svgMarkerMidResourceFromStyle();
-    auto* markerEnd = svgMarkerEndResourceFromStyle();
+    CheckedPtr markerStart = svgMarkerStartResourceFromStyle();
+    CheckedPtr markerMid = svgMarkerMidResourceFromStyle();
+    CheckedPtr markerEnd = svgMarkerEndResourceFromStyle();
     if (!markerStart && !markerMid && !markerEnd)
         return { };
 
     FloatRect boundaries;
     for (auto& markerPosition : m_markerPositions) {
-        if (auto* marker = markerForType(markerPosition.type, markerStart, markerMid, markerEnd))
+        if (auto* marker = markerForType(markerPosition.type, markerStart.get(), markerMid.get(), markerEnd.get()))
             boundaries.unite(marker->computeMarkerBoundingBox(options, marker->markerTransformation(markerPosition.origin, markerPosition.angle, strokeWidth())));
     }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -143,7 +143,7 @@ void RenderSVGResourceClipper::applyMaskClipping(PaintInfo& paintInfo, const Ren
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);
 
-    if (auto* referencedClipperRenderer = svgClipperResourceFromStyle())
+    if (CheckedPtr referencedClipperRenderer = svgClipperResourceFromStyle())
         referencedClipperRenderer->applyMaskClipping(paintInfo, targetRenderer, objectBoundingBox);
 
     AffineTransform contentTransform;
@@ -178,7 +178,7 @@ void RenderSVGResourceClipper::applyMaskClipping(PaintInfo& paintInfo, const Ren
         context.setCompositeOperation(CompositeOperator::SourceOver);
     }
 
-    layer()->paintSVGResourceLayer(context, contentTransform);
+    checkedLayer()->paintSVGResourceLayer(context, contentTransform);
 
     if (pushTransparencyLayer)
         context.endTransparencyLayer();

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -131,7 +131,7 @@ void RenderSVGResourceMasker::applyMask(PaintInfo& paintInfo, const RenderLayerM
     context.beginTransparencyLayer(1);
 
     if (missingMaskerData) {
-        layer()->paintSVGResourceLayer(maskImage->context(), contentTransform);
+        checkedLayer()->paintSVGResourceLayer(maskImage->context(), contentTransform);
 
 #if !USE(CG)
         maskImage->transformToColorSpace(drawColorSpace);

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -150,7 +150,7 @@ bool RenderSVGResourcePattern::prepareStrokeOperation(GraphicsContext& context, 
     context.setAlpha(svgStyle.strokeOpacity());
     SVGRenderSupport::applyStrokeStyleToContext(context, style, targetRenderer);
     if (svgStyle.vectorEffect() == VectorEffect::NonScalingStroke) {
-        if (auto* shape = dynamicDowncast<RenderSVGShape>(targetRenderer))
+        if (CheckedPtr shape = dynamicDowncast<RenderSVGShape>(targetRenderer))
             pattern->setPatternSpaceTransform(shape->nonScalingStrokeTransform().multiply(m_transformMap.get(targetRenderer)));
     }
     context.setStrokePattern(*pattern);
@@ -177,7 +177,7 @@ bool RenderSVGResourcePattern::buildTileImageTransform(const RenderElement& rend
 
 RefPtr<ImageBuffer> RenderSVGResourcePattern::createTileImage(GraphicsContext& context, const PatternAttributes& attributes, const FloatSize& size, const FloatSize& scale, const AffineTransform& tileImageTransform) const
 {
-    auto* patternRenderer = static_cast<RenderSVGResourcePattern*>(attributes.patternContentElement()->renderer());
+    CheckedPtr patternRenderer = static_cast<RenderSVGResourcePattern*>(attributes.patternContentElement()->renderer());
     ASSERT(patternRenderer);
     ASSERT(patternRenderer->hasLayer());
 
@@ -205,7 +205,7 @@ RefPtr<ImageBuffer> RenderSVGResourcePattern::createTileImage(GraphicsContext& c
     GraphicsContextStateSaver stateSaver(tileImageContext);
 
     // Draw the content into the ImageBuffer.
-    patternRenderer->layer()->paintSVGResourceLayer(tileImageContext, tileImageTransform);
+    patternRenderer->checkedLayer()->paintSVGResourceLayer(tileImageContext, tileImageTransform);
     return tileImage;
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -415,7 +415,7 @@ void RenderSVGRoot::updateFromStyle()
 
     // Additionally update style of the anonymous RenderSVGViewportContainer,
     // which handles zoom / pan / viewBox transformations.
-    if (auto* viewportContainer = this->viewportContainer())
+    if (CheckedPtr viewportContainer = this->viewportContainer())
         viewportContainer->updateFromStyle();
 
     if (shouldApplyViewportClip())
@@ -486,7 +486,7 @@ void RenderSVGRoot::mapLocalToContainer(const RenderLayerModelObject* repaintCon
         return;
 
     bool containerSkipped;
-    auto* container = this->container(repaintContainer, containerSkipped);
+    CheckedPtr container = this->container(repaintContainer, containerSkipped);
     if (!container)
         return;
 
@@ -504,7 +504,7 @@ void RenderSVGRoot::mapLocalToContainer(const RenderLayerModelObject* repaintCon
     auto containerOffset = offsetFromContainer(*container, LayoutPoint(transformState.mappedPoint()));
 
     bool preserve3D = mode & UseTransforms && participatesInPreserve3D();
-    if (mode & UseTransforms && shouldUseTransformFromContainer(container)) {
+    if (mode & UseTransforms && shouldUseTransformFromContainer(container.get())) {
         TransformationMatrix t;
         getTransformFromContainer(containerOffset, t);
 

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -389,8 +389,7 @@ FloatRect RenderSVGShape::calculateApproximateStrokeBoundingBox() const
 
 float RenderSVGShape::strokeWidth() const
 {
-    Ref graphicsElement = this->graphicsElement();
-    SVGLengthContext lengthContext(graphicsElement.ptr());
+    SVGLengthContext lengthContext(protectedGraphicsElement().ptr());
     return lengthContext.valueForLength(style().strokeWidth());
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -289,7 +289,7 @@ void RenderSVGText::subtreeTextDidChange(RenderSVGInlineText* text)
 static inline void updateFontInAllDescendants(RenderSVGText& text)
 {
     for (RenderObject* descendant = &text; descendant; descendant = descendant->nextInPreOrder(&text)) {
-        if (auto* text = dynamicDowncast<RenderSVGInlineText>(*descendant))
+        if (CheckedPtr text = dynamicDowncast<RenderSVGInlineText>(*descendant))
             text->updateScaledFont();
     }
 }

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
@@ -111,7 +111,7 @@ FloatRect SVGBoundingBoxComputation::handleShapeOrTextOrInline(const SVGBounding
     //   - Otherwise, set box to be the union of box and the result of invoking the algorithm to compute a bounding box with child as
     //     the element, space as the target coordinate space, true for fill, stroke and markers, and clipped for clipped.
     if (options.contains(DecorationOption::IncludeMarkers)) {
-        if (auto* svgPath = dynamicDowncast<RenderSVGPath>(m_renderer)) {
+        if (CheckedPtr svgPath = dynamicDowncast<RenderSVGPath>(m_renderer)) {
             DecorationOptions optionsForMarker = { DecorationOption::IncludeFillShape, DecorationOption::IncludeStrokeShape, DecorationOption::IncludeMarkers };
             if (options.contains(DecorationOption::IncludeClippers))
                 optionsForMarker.add(DecorationOption::IncludeClippers);
@@ -210,9 +210,9 @@ FloatRect SVGBoundingBoxComputation::handleRootOrContainer(const SVGBoundingBoxC
         ASSERT(is<RenderSVGViewportContainer>(m_renderer) || is<RenderSVGResourceMarker>(m_renderer) || is<RenderSVGRoot>(m_renderer));
 
         LayoutRect overflowClipRect;
-        if (auto* svgModelObject = dynamicDowncast<RenderSVGModelObject>(m_renderer))
+        if (CheckedPtr svgModelObject = dynamicDowncast<RenderSVGModelObject>(m_renderer))
             overflowClipRect = svgModelObject->overflowClipRect(svgModelObject->currentSVGLayoutLocation());
-        else if (auto* box = dynamicDowncast<RenderBox>(m_renderer))
+        else if (CheckedPtr box = dynamicDowncast<RenderBox>(m_renderer))
             overflowClipRect = box->overflowClipRect(box->location());
         else {
             ASSERT_NOT_REACHED();
@@ -260,14 +260,14 @@ void SVGBoundingBoxComputation::adjustBoxForClippingAndEffects(const SVGBounding
     UNUSED_PARAM(includeFilter);
 
     if (options.contains(DecorationOption::IncludeClippers)) {
-        if (auto* referencedClipperRenderer = m_renderer.svgClipperResourceFromStyle()) {
+        if (CheckedPtr referencedClipperRenderer = m_renderer.svgClipperResourceFromStyle()) {
             auto repaintRectCalculation = options.contains(DecorationOption::CalculateFastRepaintRect) ? RepaintRectCalculation::Fast : RepaintRectCalculation::Accurate;
             box.intersect(referencedClipperRenderer->resourceBoundingBox(m_renderer, repaintRectCalculation));
         }
     }
 
     if (options.contains(DecorationOption::IncludeMaskers)) {
-        if (auto* referencedMaskerRenderer = m_renderer.svgMaskerResourceFromStyle()) {
+        if (CheckedPtr referencedMaskerRenderer = m_renderer.svgMaskerResourceFromStyle()) {
             // When masks are nested, the inner masks do not affect the outer mask dimension, so skip the computation for inner masks.
             static unsigned s_maskBoundingBoxNestingLevel = 0;
             NestingLevelIncrementer incrementer { s_maskBoundingBoxNestingLevel };

--- a/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
@@ -92,7 +92,7 @@ void SVGContainerLayout::layoutChildren(bool containerNeedsLayout)
         if (needsLayout)
             child.setNeedsLayout(MarkOnlyThis);
 
-        if (auto* element = dynamicDowncast<RenderElement>(child)) {
+        if (CheckedPtr element = dynamicDowncast<RenderElement>(child)) {
             if (element->needsLayout())
                 element->layout();
 

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -389,13 +389,13 @@ inline FloatRect clipPathReferenceBox(const RenderElement& renderer, CSSBoxType 
 inline bool isPointInCSSClippingArea(const RenderElement& renderer, const FloatPoint& point)
 {
     RefPtr clipPathOperation = renderer.style().clipPath();
-    if (auto* clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation.get())) {
+    if (RefPtr clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation.get())) {
         FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
         if (!referenceBox.contains(point))
             return false;
         return clipPath->pathForReferenceRect(referenceBox).contains(point, clipPath->windRule());
     }
-    if (auto* clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation.get())) {
+    if (RefPtr clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation.get())) {
         FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
         if (!referenceBox.contains(point))
             return false;
@@ -408,7 +408,7 @@ inline bool isPointInCSSClippingArea(const RenderElement& renderer, const FloatP
 void SVGRenderSupport::clipContextToCSSClippingArea(GraphicsContext& context, const RenderElement& renderer)
 {
     RefPtr clipPathOperation = renderer.style().clipPath();
-    if (auto* clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation.get())) {
+    if (RefPtr clipPath = dynamicDowncast<ShapePathOperation>(clipPathOperation.get())) {
         auto localToParentTransform = renderer.localToParentTransform();
 
         auto referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
@@ -419,7 +419,7 @@ void SVGRenderSupport::clipContextToCSSClippingArea(GraphicsContext& context, co
 
         context.clipPath(path, clipPath->windRule());
     }
-    if (auto* clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation.get())) {
+    if (RefPtr clipPath = dynamicDowncast<BoxPathOperation>(clipPathOperation.get())) {
         FloatRect referenceBox = clipPathReferenceBox(renderer, clipPath->referenceBox());
         context.clipPath(clipPath->pathForReferenceRect(FloatRoundedRect { referenceBox }));
     }
@@ -472,9 +472,9 @@ void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const
             ASSERT(renderer.isRenderOrLegacyRenderSVGShape());
             // FIXME: A value of zero is valid. Need to differentiate this case from being unspecified.
             if (float pathLength = geometryElement->pathLength()) {
-                if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
+                if (CheckedPtr shape = dynamicDowncast<LegacyRenderSVGShape>(renderer))
                     scaleFactor = shape->getTotalLength() / pathLength;
-                else if (auto* shape = dynamicDowncast<RenderSVGShape>(renderer))
+                else if (CheckedPtr shape = dynamicDowncast<RenderSVGShape>(renderer))
                     scaleFactor = shape->getTotalLength() / pathLength;
             }
         }


### PR DESCRIPTION
#### 985c2518b1d1140c5b2105e8c94b5e154c58e571
<pre>
[LBSE] Adopt more smart pointers in SVG code
<a href="https://bugs.webkit.org/show_bug.cgi?id=272470">https://bugs.webkit.org/show_bug.cgi?id=272470</a>

Reviewed by Chris Dumez.

Adopt more smart pointers in SVG code based on the Safer CPP Guidelines.

* Source/WebCore/rendering/svg/RenderSVGBlock.cpp:
(WebCore::RenderSVGBlock::needsHasSVGTransformFlags const):
* Source/WebCore/rendering/svg/RenderSVGBlock.h:
* Source/WebCore/rendering/svg/RenderSVGBlockInlines.h:
(WebCore::RenderSVGBlock::protectedGraphicsElement const):
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::pushMappingToContainer const):
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::markerForType):
(WebCore::RenderSVGPath::drawMarkers):
(WebCore::RenderSVGPath::computeMarkerBoundingBox const):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::applyMaskClipping):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::applyMask):
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::prepareStrokeOperation):
(WebCore::RenderSVGResourcePattern::createTileImage const):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::updateFromStyle):
(WebCore::RenderSVGRoot::mapLocalToContainer const):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::strokeWidth const):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::updateFontInAllDescendants):
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::handleShapeOrTextOrInline const):
(WebCore::SVGBoundingBoxComputation::handleRootOrContainer const):
(WebCore::SVGBoundingBoxComputation::adjustBoxForClippingAndEffects const):
* Source/WebCore/rendering/svg/SVGContainerLayout.cpp:
(WebCore::SVGContainerLayout::layoutChildren):
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::isPointInCSSClippingArea):
(WebCore::SVGRenderSupport::clipContextToCSSClippingArea):
(WebCore::SVGRenderSupport::applyStrokeStyleToContext):

Canonical link: <a href="https://commits.webkit.org/277452@main">https://commits.webkit.org/277452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c939a73fea644d4c5e67075dbfec43924c244a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50294 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43661 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49919 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24263 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38765 "Found 12 new test failures: imported/w3c/web-platform-tests/compat/webkit-box-rtl-flex.html, imported/w3c/web-platform-tests/css/css-pseudo/first-line-with-inline-block.html, imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-over-left-001.xht, imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-over-right-001.xht, imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-auto-last-word-001.html, imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vertical-001.html, imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-001.html, imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-002.html, imported/w3c/web-platform-tests/css/css-text/text-encoding/shaping-no-join-003.html, imported/w3c/web-platform-tests/css/css-values/ch-unit-018.html ... (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41025 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20064 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21896 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42213 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5654 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52178 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47102 "Build is in progress. Recent messages:") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18981 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46071 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23920 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45099 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10523 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24708 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->