### PR TITLE
[run-webkit-tests] Only include defined versions in baseline search path

### DIFF
--- a/Tools/Scripts/webkitpy/port/visionos.py
+++ b/Tools/Scripts/webkitpy/port/visionos.py
@@ -72,7 +72,8 @@ class VisionOSPort(DevicePort):
         for version in versions_to_fallback:
             if apple_additions():
                 apple_name = VersionNameMap.map(self.host.platform).to_name(version, platform=VisionOSPort.port_name, table=INTERNAL_TABLE)
-                expectations.append(self._apple_baseline_path('{}-{}'.format(self.port_name, apple_name.lower().replace(' ', ''))))
+                if apple_name:
+                    expectations.append(self._apple_baseline_path('{}-{}'.format(self.port_name, apple_name.lower().replace(' ', ''))))
             expectations.append(self._webkit_baseline_path('{}-{}'.format(self.port_name, version.major)))
 
         if apple_additions():
@@ -84,8 +85,7 @@ class VisionOSPort(DevicePort):
             if apple_additions():
                 apple_name = VersionNameMap.map(self.host.platform).to_name(version, platform=VisionOSPort.port_name, table=INTERNAL_TABLE)
             if apple_name:
-                expectations.append(
-                    self._apple_baseline_path('{}-{}'.format(VisionOSPort.port_name, apple_name.lower().replace(' ', ''))))
+                expectations.append(self._apple_baseline_path('{}-{}'.format(VisionOSPort.port_name, apple_name.lower().replace(' ', ''))))
             expectations.append(self._webkit_baseline_path('{}-{}'.format(VisionOSPort.port_name, version.major)))
 
         if apple_additions():

--- a/Tools/Scripts/webkitpy/port/watch.py
+++ b/Tools/Scripts/webkitpy/port/watch.py
@@ -72,7 +72,8 @@ class WatchPort(DevicePort):
         for version in versions_to_fallback:
             if apple_additions():
                 apple_name = VersionNameMap.map(self.host.platform).to_name(version, platform=WatchPort.port_name, table=INTERNAL_TABLE)
-                expectations.append(self._apple_baseline_path('{}-{}'.format(self.port_name, apple_name.lower().replace(' ', ''))))
+                if apple_name:
+                    expectations.append(self._apple_baseline_path('{}-{}'.format(self.port_name, apple_name.lower().replace(' ', ''))))
             expectations.append(self._webkit_baseline_path('{}-{}'.format(self.port_name, version.major)))
 
         if apple_additions():


### PR DESCRIPTION
#### f833ff1ede3ca84aaebff4cd89575fbaf066a655
<pre>
[run-webkit-tests] Only include defined versions in baseline search path
<a href="https://bugs.webkit.org/show_bug.cgi?id=272475">https://bugs.webkit.org/show_bug.cgi?id=272475</a>
<a href="https://rdar.apple.com/126222004">rdar://126222004</a>

Reviewed by Tim Horton.

* Tools/Scripts/webkitpy/port/visionos.py:
(VisionOSPort.default_baseline_search_path): Skip apple_name if undefined.
* Tools/Scripts/webkitpy/port/watch.py:
(WatchPort.default_baseline_search_path): Ditto.

Canonical link: <a href="https://commits.webkit.org/277317@main">https://commits.webkit.org/277317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9732d6739f24ca4b22c74f33a67dd6e86ab8882

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50018 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/43383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23974 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47915 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/24046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/40788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/19857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/47198 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/21486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/41951 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5378 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51893 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/23639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6661 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/23357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->