### PR TITLE
[WGSL] Bounds checking needs to handle pointers

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/runtime-sized-array-resource.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/runtime-sized-array-resource.wgsl
@@ -6,4 +6,7 @@
 fn main()
 {
     x[0] = x[42];
+
+    // pointer access
+    _ = (&x)[0];
 }


### PR DESCRIPTION
#### 207014e9bc0ae60ec6376ffbd4cfe017b32ac621
<pre>
[WGSL] Bounds checking needs to handle pointers
<a href="https://bugs.webkit.org/show_bug.cgi?id=272477">https://bugs.webkit.org/show_bug.cgi?id=272477</a>
<a href="https://rdar.apple.com/126210788">rdar://126210788</a>

Reviewed by Mike Wyrzykowski.

Originally only array references could be used as the base for an index access,
but the spec was updated to support using pointers as well, but the code for
bounds check insertion wasn&apos;t updated.

* Source/WebGPU/WGSL/BoundsCheck.cpp:
(WGSL::BoundsCheckVisitor::visit):
* Source/WebGPU/WGSL/tests/valid/runtime-sized-array-resource.wgsl:

Canonical link: <a href="https://commits.webkit.org/277381@main">https://commits.webkit.org/277381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef700cd36d4435b435b44a4cba4b493c0f24fc09

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26526 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/49997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43395 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/23986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38552 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19872 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21501 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5390 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43699 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42371 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51905 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18716 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45860 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23651 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44899 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10470 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24437 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->