### PR TITLE
[SVG] We should check firstLineStyle's FontCascade in SVGTextMetricsBuilder

### DIFF
--- a/LayoutTests/platform/ios/svg/text/scaling-font-with-geometric-precision-expected.txt
+++ b/LayoutTests/platform/ios/svg/text/scaling-font-with-geometric-precision-expected.txt
@@ -16,7 +16,7 @@ layer at (8,8) size 275x560
         chunk 1 text run 1 at (0.00,15.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
     RenderSVGText {text} at (0,12) size 72x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 72x10
-        chunk 1 text run 1 at (0.00,20.00) startOffset 0 endOffset 32 width 71.12: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
+        chunk 1 text run 1 at (0.00,20.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
     RenderSVGText {text} at (0,17) size 72x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 72x9
         chunk 1 text run 1 at (0.00,25.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
@@ -46,7 +46,7 @@ layer at (8,8) size 275x560
         chunk 1 text run 1 at (0.00,65.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
     RenderSVGText {text} at (0,62) size 72x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 72x9
-        chunk 1 text run 1 at (0.00,70.00) startOffset 0 endOffset 32 width 71.12: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
+        chunk 1 text run 1 at (0.00,70.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
     RenderSVGText {text} at (0,67) size 72x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 72x10
         chunk 1 text run 1 at (0.00,75.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
@@ -55,7 +55,7 @@ layer at (8,8) size 275x560
         chunk 1 text run 1 at (0.00,80.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
     RenderSVGText {text} at (0,77) size 72x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 72x10
-        chunk 1 text run 1 at (0.00,85.00) startOffset 0 endOffset 32 width 71.12: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
+        chunk 1 text run 1 at (0.00,85.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
     RenderSVGText {text} at (0,82) size 72x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 72x10
         chunk 1 text run 1 at (0.00,90.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"

--- a/LayoutTests/platform/mac/svg/text/scaling-font-with-geometric-precision-expected.txt
+++ b/LayoutTests/platform/mac/svg/text/scaling-font-with-geometric-precision-expected.txt
@@ -16,7 +16,7 @@ layer at (8,8) size 275x560
         chunk 1 text run 1 at (0.00,15.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
     RenderSVGText {text} at (0,12) size 72x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 72x10
-        chunk 1 text run 1 at (0.00,20.00) startOffset 0 endOffset 32 width 71.12: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
+        chunk 1 text run 1 at (0.00,20.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
     RenderSVGText {text} at (0,17) size 72x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 72x10
         chunk 1 text run 1 at (0.00,25.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
@@ -46,7 +46,7 @@ layer at (8,8) size 275x560
         chunk 1 text run 1 at (0.00,65.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
     RenderSVGText {text} at (0,62) size 72x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 72x10
-        chunk 1 text run 1 at (0.00,70.00) startOffset 0 endOffset 32 width 71.12: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
+        chunk 1 text run 1 at (0.00,70.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
     RenderSVGText {text} at (0,67) size 72x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 72x10
         chunk 1 text run 1 at (0.00,75.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
@@ -55,7 +55,7 @@ layer at (8,8) size 275x560
         chunk 1 text run 1 at (0.00,80.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
     RenderSVGText {text} at (0,77) size 72x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 72x10
-        chunk 1 text run 1 at (0.00,85.00) startOffset 0 endOffset 32 width 71.12: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
+        chunk 1 text run 1 at (0.00,85.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"
     RenderSVGText {text} at (0,82) size 72x10 contains 1 chunk(s)
       RenderSVGInlineText {#text} at (0,0) size 72x10
         chunk 1 text run 1 at (0.00,90.00) startOffset 0 endOffset 32 width 71.13: "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii"

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
@@ -107,7 +107,9 @@ void SVGTextMetricsBuilder::initializeMeasurementWithTextRenderer(RenderSVGInlin
         if (auto cachedValue = text.canUseSimplifiedTextMeasuring())
             m_canUseSimplifiedTextMeasuring = cachedValue.value();
         else {
-            m_canUseSimplifiedTextMeasuring = Layout::TextUtil::canUseSimplifiedTextMeasuring(m_run.text(), scaledFont, text.style().collapseWhiteSpace(), &text.firstLineStyle());
+            // Currently SVG implementation does not support first-line, so we always pass nullptr for firstLineStyle.
+            // When supporting first-line, we also need to update firstLineStyle's FontCascade to be aligned with scaledFont in RenderSVGInlineText.
+            m_canUseSimplifiedTextMeasuring = Layout::TextUtil::canUseSimplifiedTextMeasuring(m_run.text(), scaledFont, text.style().collapseWhiteSpace(), nullptr);
             text.setCanUseSimplifiedTextMeasuring(m_canUseSimplifiedTextMeasuring);
         }
     }


### PR DESCRIPTION
#### 1c7cadbfcd619e668186d5c35dc2ef38a35bacb3
<pre>
[SVG] We should check firstLineStyle&apos;s FontCascade in SVGTextMetricsBuilder
<a href="https://bugs.webkit.org/show_bug.cgi?id=272484">https://bugs.webkit.org/show_bug.cgi?id=272484</a>
<a href="https://rdar.apple.com/126232464">rdar://126232464</a>

Reviewed by Cameron McCormack.

Since SVG is not implementing ::first-line, it keeps FontCascade stale when RenderSVGInlineText gets scaled FontCascade.
As a result, we always go to the slow path in SVGTextMetricsBuilder when RenderSVGInlineText gets scaled font.
We pass `nullptr` now since we do not have support of first-line in SVG text.

* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp:
(WebCore::SVGTextMetricsBuilder::initializeMeasurementWithTextRenderer):

Canonical link: <a href="https://commits.webkit.org/277363@main">https://commits.webkit.org/277363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61fa780585b70e0e803ddc51c3e00abd78b0a268

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50105 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43470 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24062 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48003 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19925 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42034 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5465 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42444 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51982 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22454 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/45905 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23728 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6678 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23446 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->