### PR TITLE
Add -fsanitize=local-bounds to UBSan builds

### DIFF
--- a/Configurations/Sanitizers.xcconfig
+++ b/Configurations/Sanitizers.xcconfig
@@ -89,7 +89,7 @@ WK_XCODE_VERSION_AFTER_13_3_1700 = YES;
 // FIXME: UBSan checker -fsanitize=vptr is incompatible with GCC_ENABLE_CPP_RTTI=NO.
 // -fno-delete-null-pointer-checks: do not let the compiler remove nullptr checks that could otherwise be removed because they are considered undefined behavior.
 // -fno-optimize-sibling-calls: disable tail call elimination for more accurate crash stacks.
-WK_UNDEFINED_BEHAVIOR_SANITIZER_OTHER_CFLAGS_YES = -fno-delete-null-pointer-checks -fno-optimize-sibling-calls -fno-sanitize=vptr -fsanitize=enum,return;
+WK_UNDEFINED_BEHAVIOR_SANITIZER_OTHER_CFLAGS_YES = -fno-delete-null-pointer-checks -fno-optimize-sibling-calls -fno-sanitize=vptr -fsanitize=enum,local-bounds,return;
 
 // Sanitizer Coverage
 


### PR DESCRIPTION
#### 5cf22ee7f10acd98daae3fd8f16bcbb65f21c3ae
<pre>
Add -fsanitize=local-bounds to UBSan builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=272481">https://bugs.webkit.org/show_bug.cgi?id=272481</a>
&lt;<a href="https://rdar.apple.com/126231948">rdar://126231948</a>&gt;

Reviewed by Chris Dumez.

* Configurations/Sanitizers.xcconfig:
(WK_UNDEFINED_BEHAVIOR_SANITIZER_OTHER_CFLAGS_YES):
- Add local-bounds to existing -fsanitize argument.

Canonical link: <a href="https://commits.webkit.org/277345@main">https://commits.webkit.org/277345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4851cd198242e2f557375f0247bcc666b0ba4a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50054 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43419 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38568 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19888 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21522 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5414 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43715 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51930 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22401 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45865 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23676 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44895 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24461 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6673 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->