### PR TITLE
REGRESSION (276827@main): BitmapImageSource may outlive its creator BitmapImage

### DIFF
--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -28,12 +28,14 @@
 #include "ImageFrameWorkQueue.h"
 #include "ImageSource.h"
 #include <wtf/Expected.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
 class BitmapImage;
 class ImageDecoder;
 class ImageFrameAnimator;
+class ImageObserver;
 
 class BitmapImageSource : public ImageSource {
 public:
@@ -194,6 +196,11 @@ private:
     IntSize frameSizeAtIndex(unsigned index, SubsamplingLevel = SubsamplingLevel::Default) const;
     ImageOrientation frameOrientationAtIndex(unsigned index) const final;
 
+    // BitmapImage metadata
+    RefPtr<ImageObserver> imageObserver() const;
+    String mimeType() const;
+    long long expectedContentLength() const;
+
     // Testing support
     unsigned decodeCountForTesting() const { return m_decodeCountForTesting; }
     void setMinimumDecodingDurationForTesting(Seconds) final;
@@ -204,7 +211,7 @@ private:
     void dump(TextStream&) const final;
 
     // State
-    BitmapImage& m_bitmapImage;
+    WeakPtr<BitmapImage> m_bitmapImage;
     AlphaOption m_alphaOption { AlphaOption::Premultiplied };
     GammaAndColorProfileOption m_gammaAndColorProfileOption { GammaAndColorProfileOption::Applied };
     bool m_allDataReceived { false };


### PR DESCRIPTION
#### 4a9fc932842d8047416f9c92551d741cdcaf34fc
<pre>
REGRESSION (276827@main): BitmapImageSource may outlive its creator BitmapImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=272486">https://bugs.webkit.org/show_bug.cgi?id=272486</a>
<a href="https://rdar.apple.com/126113651">rdar://126113651</a>

Reviewed by Simon Fraser.

Before 276827@main ImageSource used to hold a raw pointer BitmapImage and it had
function to clear this pointer when BitmapImage is destroyed.
Moreover ImageSource methods used to check the nullability of this pointer before
using it.

A similar life time relationship needs to be applied to BitmapImageSource and
BitmapImage.

* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::BitmapImageSource):
(WebCore::BitmapImageSource::decoder const):
(WebCore::BitmapImageSource::encodedDataStatusChanged):
(WebCore::BitmapImageSource::decodedSizeChanged):
(WebCore::BitmapImageSource::canDestroyDecodedData const):
(WebCore::BitmapImageSource::resetData):
(WebCore::BitmapImageSource::isAnimationAllowed const):
(WebCore::BitmapImageSource::imageFrameAtIndexAvailable):
(WebCore::BitmapImageSource::imageObserver const):
(WebCore::BitmapImageSource::mimeType const):
(WebCore::BitmapImageSource::expectedContentLength const):
(WebCore::BitmapImageSource::sourceUTF8 const):
* Source/WebCore/platform/graphics/BitmapImageSource.h:

Canonical link: <a href="https://commits.webkit.org/277375@main">https://commits.webkit.org/277375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6e1c60a88cb6c1d841b64a313577a5b6fd8804e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50106 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43471 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38605 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19928 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42038 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5466 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43766 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51983 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45908 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23729 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44945 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10466 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24519 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23447 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->