### PR TITLE
[JSC] Simplify watchpoint registration

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGDesiredGlobalProperties.h
+++ b/Source/JavaScriptCore/dfg/DFGDesiredGlobalProperties.h
@@ -50,7 +50,7 @@ public:
 
     bool isStillValidOnMainThread(VM&, DesiredIdentifiers&);
 
-    void reallyAdd(CodeBlock*, DesiredIdentifiers&, WatchpointCollector&);
+    bool reallyAdd(CodeBlock*, DesiredIdentifiers&, WatchpointCollector&);
 
 private:
     HashSet<DesiredGlobalProperty> m_set;

--- a/Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.h
+++ b/Source/JavaScriptCore/dfg/DFGDesiredWeakReferences.h
@@ -52,12 +52,16 @@ public:
     
     void reallyAdd(VM&, CommonData*);
 
+    void finalize();
+
     template<typename Visitor> void visitChildren(Visitor&);
 
 private:
     CodeBlock* m_codeBlock;
     HashSet<JSCell*> m_cells;
     HashSet<StructureID> m_structures;
+    FixedVector<WriteBarrier<JSCell>> m_finalizedCells;
+    FixedVector<StructureID> m_finalizedStructures;
 };
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGPlan.h
+++ b/Source/JavaScriptCore/dfg/DFGPlan.h
@@ -107,10 +107,10 @@ public:
 
 private:
     CompilationPath compileInThreadImpl() override;
+    void finalizeInThread();
     
-    bool isStillValidOnMainThread();
-    bool isStillValid();
-    void reallyAdd(CommonData*);
+    bool isStillValidCodeBlock();
+    bool reallyAdd(CommonData*);
 
     // These can be raw pointers because we visit them during every GC in checkLivenessAndVisitChildren.
     CodeBlock* m_profiledDFGCodeBlock;


### PR DESCRIPTION
#### 289c5e96b86f1105aa984028ed4c6fdd7bcebe5c
<pre>
[JSC] Simplify watchpoint registration
<a href="https://bugs.webkit.org/show_bug.cgi?id=272498">https://bugs.webkit.org/show_bug.cgi?id=272498</a>
<a href="https://rdar.apple.com/126243456">rdar://126243456</a>

Reviewed by Justin Michaud.

This patch makes DFG / FTL watchpoint registration simpler.

1. We should collect number of watchpoints in the compiler thread side. Not doing it in the main thread.
2. We should not iterate the same hashset twice for areStillValid and reallyAdd. Now reallyAdd can return
   whether the registration succeeded.
3. Offload weak reference vector materialization to compiler thread.

* Source/JavaScriptCore/dfg/DFGDesiredGlobalProperties.cpp:
(JSC::DFG::DesiredGlobalProperties::reallyAdd):
* Source/JavaScriptCore/dfg/DFGDesiredGlobalProperties.h:
* Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp:
(JSC::DFG::ArrayBufferViewWatchpointAdaptor::add):
(JSC::DFG::SymbolTableAdaptor::add):
(JSC::DFG::FunctionExecutableAdaptor::add):
(JSC::DFG::AdaptiveStructureWatchpointAdaptor::add):
(JSC::DFG::DesiredWatchpoints::countWatchpoints):
(JSC::DFG::DesiredWatchpoints::reallyAdd):
(JSC::DFG::DesiredWatchpoints::areStillValid const): Deleted.
* Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.h:
(JSC::DFG::SetPointerAdaptor::add):
(JSC::DFG::GenericDesiredWatchpoints::reallyAdd):
(JSC::DFG::GenericDesiredWatchpoints::areStillValid const): Deleted.
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):
(JSC::DFG::Plan::finalizeInThread):
(JSC::DFG::Plan::isStillValidCodeBlock):
(JSC::DFG::Plan::reallyAdd):
(JSC::DFG::Plan::finalize):
(JSC::DFG::Plan::isStillValid): Deleted.
(JSC::DFG::Plan::isStillValidOnMainThread): Deleted.
* Source/JavaScriptCore/dfg/DFGPlan.h:

Canonical link: <a href="https://commits.webkit.org/277400@main">https://commits.webkit.org/277400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21cc8531de0d32c8c44e4d13d65c4fe1ffb1f455

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50101 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43466 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24058 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38601 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40862 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19923 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21582 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42033 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5461 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40693 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43759 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51978 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/46908 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18782 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45903 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23724 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44939 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24513 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54406 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6693 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23442 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11165 "Passed tests") | 
<!--EWS-Status-Bubble-End-->