### PR TITLE
Optimize CachedResource::didAccessDecodedData()

### DIFF
--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -737,10 +737,7 @@ void CachedResource::didAccessDecodedData(MonotonicTime timeStamp)
     
     if (allowsCaching() && inCache()) {
         auto& memoryCache = MemoryCache::singleton();
-        if (memoryCache.inLiveDecodedResourcesList(*this)) {
-            memoryCache.removeFromLiveDecodedResourcesList(*this);
-            memoryCache.insertInLiveDecodedResourcesList(*this);
-        }
+        memoryCache.moveToEndOfLiveDecodedResourcesListIfPresent(*this);
         memoryCache.pruneSoon();
     }
 }

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -648,6 +648,12 @@ void MemoryCache::removeFromLiveDecodedResourcesList(CachedResource& resource)
     m_liveDecodedResources.remove(resource);
 }
 
+void MemoryCache::moveToEndOfLiveDecodedResourcesListIfPresent(CachedResource& resource)
+{
+    RELEASE_ASSERT(isMainThread());
+    m_liveDecodedResources.moveToLastIfPresent(resource);
+}
+
 void MemoryCache::insertInLiveDecodedResourcesList(CachedResource& resource)
 {
     RELEASE_ASSERT(isMainThread());
@@ -796,9 +802,9 @@ void MemoryCache::prune()
 void MemoryCache::pruneSoon()
 {
     RELEASE_ASSERT(isMainThread());
-    if (m_pruneTimer.isActive())
-        return;
     if (!needsPruning())
+        return;
+    if (m_pruneTimer.isActive())
         return;
     m_pruneTimer.startOneShot(0_s);
 }

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -140,6 +140,7 @@ public:
     // Track decoded resources that are in the cache and referenced by a Web page.
     void insertInLiveDecodedResourcesList(CachedResource&);
     void removeFromLiveDecodedResourcesList(CachedResource&);
+    void moveToEndOfLiveDecodedResourcesListIfPresent(CachedResource&);
 
     void addToLiveResourcesSize(CachedResource&);
     void removeFromLiveResourcesSize(CachedResource&);


### PR DESCRIPTION
#### bfb4040b247ba36137d829e0ae38981d4c6d2cf5
<pre>
Optimize CachedResource::didAccessDecodedData()
<a href="https://bugs.webkit.org/show_bug.cgi?id=272499">https://bugs.webkit.org/show_bug.cgi?id=272499</a>
<a href="https://rdar.apple.com/126244115">rdar://126244115</a>

Reviewed by Ryosuke Niwa and Chris Dumez.

LRUList has a `moveToLastIfPresent()` so use that instead of removing and re-adding just to get
something to the end of the LRU list.

* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::didAccessDecodedData):
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::moveToEndOfLiveDecodedResourcesListIfPresent):
(WebCore::MemoryCache::pruneSoon):
* Source/WebCore/loader/cache/MemoryCache.h:

Canonical link: <a href="https://commits.webkit.org/277358@main">https://commits.webkit.org/277358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96414595b22c9284acc4fc8355da28977ab3860d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26587 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50059 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50088 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43453 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49712 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24045 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38593 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19913 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42015 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5448 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51965 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22437 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45889 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23710 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/44941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10457 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->