### PR TITLE
Digital Credentials: IdentityRequestProvider's request should be an object

### DIFF
--- a/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html
+++ b/LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html
@@ -43,7 +43,7 @@
             t,
             TypeError,
             navigator.identity.get({
-                digital: { providers: [{ protocol: "bogus protocol" }] },
+                digital: { providers: [{ protocol: "bogus protocol", request: {} }] },
             }),
             "navigator.identity.get() with a provider with unknown protocol"
         );
@@ -61,7 +61,7 @@
 
         assert_equals(
             await navigator.identity.get({
-                digital: { providers: [{ protocol: "mdoc" }] },
+                digital: { providers: [{ protocol: "mdoc", request: {} }] },
             }),
             null,
             "navigator.identity.get() with a valid provider"

--- a/LayoutTests/http/wpt/identity/idl.https.html
+++ b/LayoutTests/http/wpt/identity/idl.https.html
@@ -18,7 +18,7 @@ dictionary DigitalCredentialRequestOptions {
 
 dictionary IdentityRequestProvider {
     required DOMString protocol;
-    required DOMString request;
+    required object request;
 };
 
 [Exposed=Window, SecureContext]

--- a/Source/WebCore/Modules/identity/IdentityRequestProvider.h
+++ b/Source/WebCore/Modules/identity/IdentityRequestProvider.h
@@ -26,11 +26,14 @@
 #pragma once
 
 #include "IdentityCredentialProtocol.h"
+#include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/Strong.h>
 
 namespace WebCore {
 
 struct IdentityRequestProvider {
     IdentityCredentialProtocol protocol;
+    JSC::Strong<JSC::JSObject> request;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/IdentityRequestProvider.idl
+++ b/Source/WebCore/Modules/identity/IdentityRequestProvider.idl
@@ -25,4 +25,5 @@
 
 dictionary IdentityRequestProvider {
     required IdentityCredentialProtocol protocol;
+    required object request;
 };


### PR DESCRIPTION
#### 0ad7f8d69556cdbc2a8fa57775dfcf1c5e5cffe5
<pre>
Digital Credentials: IdentityRequestProvider&apos;s request should be an object
<a href="https://bugs.webkit.org/show_bug.cgi?id=272443">https://bugs.webkit.org/show_bug.cgi?id=272443</a>
<a href="https://rdar.apple.com/126244307">rdar://126244307</a>

Reviewed by Abrar Rahman Protyasha.

Changed IdentityRequestProvider&apos;s request member to an object.
Spec change:
<a href="https://github.com/WICG/digital-identities/pull/97/">https://github.com/WICG/digital-identities/pull/97/</a>

* LayoutTests/http/wpt/identity/identitycredentialscontainer-get-basics.https.html:
* LayoutTests/http/wpt/identity/idl.https.html:
* Source/WebCore/Modules/identity/IdentityRequestProvider.h:
* Source/WebCore/Modules/identity/IdentityRequestProvider.idl:

Canonical link: <a href="https://commits.webkit.org/277472@main">https://commits.webkit.org/277472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/daddd57c1bc9e8d486e74be5ad79d739152c5893

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50241 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43607 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24203 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38720 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 44 flakes 76 failures; Uploaded test results; 18 flakes 55 failures; Running compile-webkit-without-change") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48141 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24349 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Running apply-patch; Checked out pull request; Passed layout tests; Running layout-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40982 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20023 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42159 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5601 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52121 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22593 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18917 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Running apply-patch; Checked out pull request; Passed layout tests; 9 flakes 1 failures; Uploaded test results; Running re-run-layout-tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46025 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 26 flakes 80 failures; Uploaded test results; 5 flakes 74 failures; Running compile-webkit-without-change") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41130 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45054 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10530 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24654 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->