### PR TITLE
Digital Credentials: DigitalCredential's data attribute should be a Uint8Array

### DIFF
--- a/LayoutTests/http/wpt/identity/idl.https.html
+++ b/LayoutTests/http/wpt/identity/idl.https.html
@@ -24,7 +24,7 @@ dictionary IdentityRequestProvider {
 [Exposed=Window, SecureContext]
 interface DigitalCredential : Credential {
     readonly attribute DOMString protocol;
-    readonly attribute DOMString data;
+    readonly attribute Uint8Array data;
 };
 </script>
 <script>

--- a/Source/WebCore/Modules/identity/DigitalCredential.cpp
+++ b/Source/WebCore/Modules/identity/DigitalCredential.cpp
@@ -32,14 +32,14 @@
 
 namespace WebCore {
 
-Ref<DigitalCredential> DigitalCredential::create(Ref<ArrayBuffer>&& data, IdentityCredentialProtocol protocol)
+Ref<DigitalCredential> DigitalCredential::create(Ref<Uint8Array>&& data, IdentityCredentialProtocol protocol)
 {
     return adoptRef(*new DigitalCredential(WTFMove(data), protocol));
 }
 
 DigitalCredential::~DigitalCredential() = default;
 
-DigitalCredential::DigitalCredential(Ref<ArrayBuffer>&& data, IdentityCredentialProtocol protocol)
+DigitalCredential::DigitalCredential(Ref<Uint8Array>&& data, IdentityCredentialProtocol protocol)
     : BasicCredential(base64URLEncodeToString(data->data(), data->byteLength()), Type::DigitalCredential, Discovery::CredentialStore)
     , m_protocol(protocol)
     , m_data(WTFMove(data))

--- a/Source/WebCore/Modules/identity/DigitalCredential.h
+++ b/Source/WebCore/Modules/identity/DigitalCredential.h
@@ -30,7 +30,6 @@
 #include "BasicCredential.h"
 #include "IDLTypes.h"
 #include "IdentityCredentialProtocol.h"
-#include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 
@@ -43,11 +42,11 @@ using DigitalCredentialPromise = DOMPromiseDeferred<IDLInterface<DigitalCredenti
 
 class DigitalCredential final : public BasicCredential {
 public:
-    static Ref<DigitalCredential> create(Ref<ArrayBuffer>&& data, IdentityCredentialProtocol);
+    static Ref<DigitalCredential> create(Ref<Uint8Array>&& data, IdentityCredentialProtocol);
 
     virtual ~DigitalCredential();
 
-    ArrayBuffer* data() const
+    Uint8Array* data() const
     {
         return m_data.get();
     };
@@ -58,12 +57,12 @@ public:
     }
 
 private:
-    DigitalCredential(Ref<ArrayBuffer>&& data, IdentityCredentialProtocol);
+    DigitalCredential(Ref<Uint8Array>&& data, IdentityCredentialProtocol);
 
     Type credentialType() const final { return Type::DigitalCredential; }
 
     IdentityCredentialProtocol m_protocol;
-    RefPtr<ArrayBuffer> m_data;
+    RefPtr<Uint8Array> m_data;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/identity/DigitalCredential.idl
+++ b/Source/WebCore/Modules/identity/DigitalCredential.idl
@@ -29,6 +29,6 @@
     EnabledBySetting=DigitalCredentialsEnabled,
     Conditional=WEB_AUTHN,
 ] interface DigitalCredential : BasicCredential {
-    [SameObject] readonly attribute ArrayBuffer data;
+    [SameObject] readonly attribute Uint8Array data;
     readonly attribute IdentityCredentialProtocol protocol;
 };


### PR DESCRIPTION
#### 24aaf367721d694e417a77f864c95533382d8de7
<pre>
Digital Credentials: DigitalCredential&apos;s data attribute should be a Uint8Array
<a href="https://bugs.webkit.org/show_bug.cgi?id=272444">https://bugs.webkit.org/show_bug.cgi?id=272444</a>
<a href="https://rdar.apple.com/126244545">rdar://126244545</a>

Reviewed by Anne van Kesteren.

Changed DigitalCredential&apos;s data attribute to Uint8Array.

* LayoutTests/http/wpt/identity/idl.https.html:
* Source/WebCore/Modules/identity/DigitalCredential.cpp:
(WebCore::DigitalCredential::create):
(WebCore::DigitalCredential::DigitalCredential):
* Source/WebCore/Modules/identity/DigitalCredential.h:
* Source/WebCore/Modules/identity/DigitalCredential.idl:

Canonical link: <a href="https://commits.webkit.org/277379@main">https://commits.webkit.org/277379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efb432c7daedd3c2f416b621267d0c98687ab6f0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50061 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50090 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43455 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24047 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38592 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19912 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21558 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42027 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5450 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42436 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51967 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18778 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45892 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44925 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10471 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24502 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->