### PR TITLE
GeolocationPosition should expose a Default .toJSON() method

### DIFF
--- a/LayoutTests/fast/dom/Geolocation/position-interface-toJSON-expected.txt
+++ b/LayoutTests/fast/dom/Geolocation/position-interface-toJSON-expected.txt
@@ -1,0 +1,19 @@
+Test GeolocationPosition toJSON() method
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typeof window.positionJson === 'object' is true
+PASS typeof window.positionJson.coords === 'object' is true
+PASS window.positionJson.timestamp is window.position.timestamp
+PASS window.positionJson.coords.latitude is window.expectedCoords.latitude
+PASS window.positionJson.coords.longitude is window.expectedCoords.longitude
+PASS window.positionJson.coords.accuracy is window.expectedCoords.accuracy
+PASS window.positionJson.coords.altitude is window.expectedCoords.altitude
+PASS window.positionJson.coords.altitudeAccuracy is window.expectedCoords.altitudeAccuracy
+PASS window.positionJson.coords.heading is window.expectedCoords.heading
+PASS window.positionJson.coords.speed is window.expectedCoords.speed
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/Geolocation/position-interface-toJSON.html
+++ b/LayoutTests/fast/dom/Geolocation/position-interface-toJSON.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+  <head>
+    <script src="../../../resources/js-test-pre.js"></script>
+  </head>
+  <body>
+    <script>
+      description("Test GeolocationPosition toJSON() method");
+
+      testRunner.setGeolocationPermission(true);
+
+      window.jsTestIsAsync = true;
+
+      const baseExpected = {
+        altitude: null,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null,
+        floorLevel: null,
+      };
+
+      const testData = [
+        [
+          {
+            latitude: 5,
+            longitude: 6,
+            accuracy: 7,
+            altitude: 8,
+            altitudeAccuracy: 9,
+            heading: 10,
+            speed: 11,
+          },
+          {
+            ...baseExpected,
+            latitude: 5,
+            longitude: 6,
+            accuracy: 7,
+            altitude: 8,
+            altitudeAccuracy: 9,
+            heading: 10,
+            speed: 11,
+          },
+        ],
+      ];
+
+      async function runNextTest() {
+        for (const [actualCoords, expectedCoords] of testData) {
+          window.expectedCoords = expectedCoords;
+          const {
+            latitude,
+            longitude,
+            accuracy,
+            altitude,
+            altitudeAccuracy,
+            heading,
+            speed,
+            floorLevel,
+          } = actualCoords;
+
+          testRunner.setMockGeolocationPosition(
+            latitude,
+            longitude,
+            accuracy,
+            altitude,
+            altitudeAccuracy,
+            heading,
+            speed,
+            floorLevel
+          );
+
+          const position = await new Promise((resolve, reject) =>
+            navigator.geolocation.getCurrentPosition(resolve, reject)
+          );
+
+          window.position = position;
+          window.positionJson = position.toJSON();
+
+          shouldBeTrue(`typeof window.positionJson === 'object'`);
+          shouldBeTrue(`typeof window.positionJson.coords === 'object'`);
+          shouldBe(`window.positionJson.timestamp`, `window.position.timestamp`);
+
+          // check coords got converted correctly
+          for (const key in actualCoords) {
+            shouldBe(`window.positionJson.coords.${key}`, `window.expectedCoords.${key}`);
+          }
+        }
+      }
+
+      runNextTest().finally(finishJSTest);
+    </script>
+    <script src="../../../resources/js-test-post.js"></script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/geolocation/GeolocationPosition.idl
+++ b/Source/WebCore/Modules/geolocation/GeolocationPosition.idl
@@ -31,4 +31,5 @@
 ] interface GeolocationPosition {
     readonly attribute GeolocationCoordinates coords;
     readonly attribute EpochTimeStamp timestamp;
+    [Default] object toJSON();
 };


### PR DESCRIPTION
#### b4a5c2c90fb4f7aae5dba8310145b4c41f419817
<pre>
GeolocationPosition should expose a Default .toJSON() method
<a href="https://bugs.webkit.org/show_bug.cgi?id=272501">https://bugs.webkit.org/show_bug.cgi?id=272501</a>
<a href="https://rdar.apple.com/problem/126247408">rdar://problem/126247408</a>

Reviewed by Ryosuke Niwa.

Implements .toJSON() method on GeolocationPosition, as per spec change:
<a href="https://github.com/w3c/geolocation-api/pull/147">https://github.com/w3c/geolocation-api/pull/147</a>

* LayoutTests/fast/dom/Geolocation/position-interface-toJSON-expected.txt: Added.
* LayoutTests/fast/dom/Geolocation/position-interface-toJSON.html: Added.
* Source/WebCore/Modules/geolocation/GeolocationPosition.idl:

Canonical link: <a href="https://commits.webkit.org/277413@main">https://commits.webkit.org/277413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef7a062983b02cf7102cc9f70b3efc6f33806f68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50097 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43462 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38597 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40859 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19918 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42030 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5457 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51974 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18775 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45902 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44938 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10486 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24509 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23438 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->