### PR TITLE
[visionOS] Element fullscreen window is hidden before LinearMediaPlayer scene swap occurs

### DIFF
--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -34,6 +34,7 @@
 #import "WKSLinearMediaTypes.h"
 #import <UIKit/UIKit.h>
 #import <WebCore/WebAVPlayerLayerView.h>
+#import <wtf/BlockPtr.h>
 
 namespace WebKit {
 
@@ -77,16 +78,14 @@ void VideoPresentationInterfaceLMK::invalidatePlayerViewController()
 
 void VideoPresentationInterfaceLMK::presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
 {
-    [linearMediaPlayer() enterFullscreen];
     playbackSessionInterface().startObservingNowPlayingMetadata();
-    completionHandler(YES, nil);
+    [linearMediaPlayer() enterFullscreenWithCompletionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
 }
 
 void VideoPresentationInterfaceLMK::dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)
 {
-    [linearMediaPlayer() exitFullscreen];
     playbackSessionInterface().stopObservingNowPlayingMetadata();
-    completionHandler(YES, nil);
+    [linearMediaPlayer() exitFullscreenWithCompletionHandler:makeBlockPtr(WTFMove(completionHandler)).get()];
 }
 
 UIViewController *VideoPresentationInterfaceLMK::playerViewController() const

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -796,14 +796,6 @@ void PlaybackSessionManagerProxy::setVideoReceiverEndpoint(PlaybackSessionContex
     if (!xpcConnection)
         return;
 
-    // FIXME 125816935: element fullscreen is expected to exit when switching to LinearMediaPlayer
-    // fullscreen, but in order to do so in a way that's not visible to the user we need an API
-    // from LinearMediaKit to know when its scene swap transition has occurred. For now we just
-    // exit element fullscreen when we receive the video receiver endpoint, but this causes the
-    // element fullscreen window to close before the LinearMediaKit scene is visible.
-    if (endpoint && m_page->fullScreenManager() && m_page->fullScreenManager()->isFullScreen())
-        m_page->fullScreenManager()->requestExitFullScreen();
-
     VideoReceiverEndpointMessage endpointMessage(WTFMove(processIdentifier), WTFMove(playerIdentifier), endpoint);
     xpc_connection_send_message(xpcConnection.get(), endpointMessage.encode().get());
 #else

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -40,6 +40,7 @@
 #import "VideoPresentationManagerMessages.h"
 #import "VideoPresentationManagerProxyMessages.h"
 #import "WKVideoView.h"
+#import "WebFullScreenManagerProxy.h"
 #import "WebPageProxy.h"
 #import "WebProcessPool.h"
 #import "WebProcessProxy.h"
@@ -1313,8 +1314,17 @@ void VideoPresentationManagerProxy::setVideoLayerGravity(PlaybackSessionContextI
 
 void VideoPresentationManagerProxy::fullscreenModeChanged(PlaybackSessionContextIdentifier contextId, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
-    if (m_page)
-        m_page->send(Messages::VideoPresentationManager::FullscreenModeChanged(contextId, mode));
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    // FIXME: return to element fullscreen when exiting standard fullscreen
+    if (mode == HTMLMediaElementEnums::VideoFullscreenModeStandard && page->fullScreenManager() && page->fullScreenManager()->isFullScreen())
+        m_page->fullScreenManager()->requestExitFullScreen();
+#endif
+
+    page->send(Messages::VideoPresentationManager::FullscreenModeChanged(contextId, mode));
 }
 
 void VideoPresentationManagerProxy::fullscreenMayReturnToInline(PlaybackSessionContextIdentifier contextId)

--- a/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h
@@ -80,9 +80,7 @@ API_AVAILABLE(visionos(1.0))
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player updateViewingMode:(WKSLinearMediaViewingMode)viewingMode;
 - (void)linearMediaPlayerTogglePip:(WKSLinearMediaPlayer *)player;
 - (void)linearMediaPlayerEnterFullscreen:(WKSLinearMediaPlayer *)player;
-- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player didEnterFullscreenWithError:(NSError * _Nullable)error;
 - (void)linearMediaPlayerExitFullscreen:(WKSLinearMediaPlayer *)player;
-- (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player didExitFullscreenWithError:(NSError * _Nullable)error;
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setTimeResolverInterval:(NSTimeInterval)interval;
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setTimeResolverResolution:(NSTimeInterval)resolution;
 - (void)linearMediaPlayer:(WKSLinearMediaPlayer *)player setThumbnailSize:(CGSize)size;
@@ -152,8 +150,8 @@ API_AVAILABLE(visionos(1.0))
 @property (nonatomic, strong, nullable) NSDate *endDate;
 
 - (LMPlayableViewController *)makeViewController;
-- (void)enterFullscreen;
-- (void)exitFullscreen;
+- (void)enterFullscreenWithCompletionHandler:(void (^)(BOOL, NSError * _Nullable))completionHandler;
+- (void)exitFullscreenWithCompletionHandler:(void (^)(BOOL, NSError * _Nullable))completionHandler;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### 9709bbc7e533fda34aa91ba2ff14757156470f10
<pre>
[visionOS] Element fullscreen window is hidden before LinearMediaPlayer scene swap occurs
<a href="https://bugs.webkit.org/show_bug.cgi?id=272504">https://bugs.webkit.org/show_bug.cgi?id=272504</a>
<a href="https://rdar.apple.com/126250840">rdar://126250840</a>

Reviewed by NOBODY (OOPS!).

TBA

* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::presentFullscreen):
(WebKit::VideoPresentationInterfaceLMK::dismissFullscreen):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::setVideoReceiverEndpoint):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::fullscreenModeChanged):
* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
(WKSLinearMediaPlayer.enterFullscreenCompletionHandler):
(WKSLinearMediaPlayer.exitFullscreenCompletionHandler):
(WKSLinearMediaPlayer.enterFullscreen(_:Error:)):
(WKSLinearMediaPlayer.exitFullscreen(_:Error:)):
(WKSLinearMediaPlayer.didCompleteEnterFullscreen(_:Error:)):
(WKSLinearMediaPlayer.didCompleteExitFullscreen(_:Error:)):
(WKSLinearMediaPlayer.enterFullscreen): Deleted.
(WKSLinearMediaPlayer.exitFullscreen): Deleted.
* Source/WebKit/WebKitSwift/LinearMediaKit/WKSLinearMediaPlayer.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9709bbc7e533fda34aa91ba2ff14757156470f10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26598 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50073 "Hash 9709bbc7 for PR 27129 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50099 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43464 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38598 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/47997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24137 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/50073 "Hash 9709bbc7 for PR 27129 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19919 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21574 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/50073 "Hash 9709bbc7 for PR 27129 does not build (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5459 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43757 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/50073 "Hash 9709bbc7 for PR 27129 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51976 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22448 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45899 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23722 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/50073 "Hash 9709bbc7 for PR 27129 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44933 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->