### PR TITLE
[svg] fix remaining failures in svg/path/property/d-interpolation-relative-absolute.html and svg/path/property/d-interpolation-single.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-relative-absolute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-relative-absolute-expected.txt
@@ -49,7 +49,7 @@ PASS Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "pa
 PASS Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress 1
 PASS Animation between "path("m 10 20 h 30 v 60 h 10 v -10 l 110 60 Z")" and "path("M 130 140 H 120 V 160 H 130 V 150 L 200 170 Z")" at progress 2
 PASS "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" are valid d values
-FAIL Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress -1 assert_equals: expected "path(\"M 2 28 A -30 -60 -10 1 0 10 30 A 70 80 -10 1 1 310 160\")" but got "path(\"M 2 28 A 30 60 -10 1 0 10 30 A 70 80 -10 1 1 310 160\")"
+PASS Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress -1
 PASS Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress 0
 PASS Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress 0.125
 PASS Animation between "path("m 10 20 a 10 20 30 1 0 40 50 a 110 120 30 1 1 140 50")" and "path("M 18 12 A 50 100 70 0 1 90 110 A 150 160 70 0 1 70 80")" at progress 0.875

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-single-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-single-expected.txt
@@ -56,14 +56,14 @@ PASS Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 2
 PASS Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress 1
 PASS Animation between "path("m 20 10 q 12 32 100 2190")" and "path("m 20 10 q 20 40 180 2990")" at progress 2
 PASS "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" are valid d values
-FAIL Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress -1 assert_equals: expected "path(\"M -100 600 A -30 -20 -10 1 0 -100 610\")" but got "path(\"M -100 600 A 30 20 -10 1 0 -100 610\")"
+PASS Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress -1
 PASS Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 0
 PASS Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 0.125
 PASS Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 0.875
 PASS Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 1
 PASS Animation between "path("M 100 400 A 10 20 30 1 0 140 450")" and "path("M 300 200 A 50 60 70 0 1 380 290")" at progress 2
 PASS "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" are valid d values
-FAIL Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress -1 assert_equals: expected "path(\"M -100 600 A -30 -20 -10 1 0 -100 610\")" but got "path(\"M -100 600 A 30 20 -10 1 0 -100 610\")"
+PASS Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress -1
 PASS Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress 0
 PASS Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress 0.125
 PASS Animation between "path("m 100 400 a 10 20 30 1 0 40 50")" and "path("m 300 200 a 50 60 70 0 1 80 90")" at progress 0.875

--- a/Source/WebCore/svg/SVGPathParser.cpp
+++ b/Source/WebCore/svg/SVGPathParser.cpp
@@ -268,10 +268,10 @@ bool SVGPathParser::parseArcToSegment()
     // http://www.w3.org/TR/SVG/implnote.html#ArcOutOfRangeParameters
     // If the current point and target point for the arc are identical, it should be treated as a zero length
     // path. This ensures continuity in animations.
-    result->rx = std::abs(result->rx);
-    result->ry = std::abs(result->ry);
     bool arcIsZeroLength = false;
     if (m_pathParsingMode == NormalizedParsing) {
+        result->rx = std::abs(result->rx);
+        result->ry = std::abs(result->ry);
         if (m_mode == RelativeCoordinates)
             arcIsZeroLength = result->targetPoint == FloatPoint::zero();
         else


### PR DESCRIPTION
#### 712ee8ac74c4a7b9a1af01ea8a5bf42a93da6f6c
<pre>
[svg] fix remaining failures in svg/path/property/d-interpolation-relative-absolute.html and svg/path/property/d-interpolation-single.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=272507">https://bugs.webkit.org/show_bug.cgi?id=272507</a>

Reviewed by Antti Koivisto.

When parsing SVG path data, we mistakenly applied the normalization rules for the `rx` and `ry` parameters
to the arc commands no matter the parsing mode. Now we only do so when asked to normalize such that values
resulting from interpolation are not affected. This fixes the remaining failures in the interpolation tests
under the WPT `svg/path/property` directory.

* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-relative-absolute-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-single-expected.txt:
* Source/WebCore/svg/SVGPathParser.cpp:
(WebCore::SVGPathParser::parseArcToSegment):

Canonical link: <a href="https://commits.webkit.org/277372@main">https://commits.webkit.org/277372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9cf5a37dd92ef070033a6c673208bc5d3b4c357

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50111 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43476 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38607 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40871 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19930 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42042 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5471 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43769 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51988 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45909 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23734 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44946 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24524 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6680 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23452 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->