### PR TITLE
[svg] make `d` a presentation attribute

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7445,10 +7445,7 @@ imported/w3c/web-platform-tests/svg/painting/reftests/markers-orient-002.svg [ I
 imported/w3c/web-platform-tests/svg/painting/reftests/paint-context-001.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/paint-context-002.svg [ ImageOnlyFailure ]
 
-# tests added with webkit.org/b/272414
-webkit.org/b/272415 imported/w3c/web-platform-tests/svg/path/property/marker-path.svg [ ImageOnlyFailure ]
 webkit.org/b/272416 imported/w3c/web-platform-tests/svg/path/property/mpath.svg [ ImageOnlyFailure ]
-webkit.org/b/272417 imported/w3c/web-platform-tests/svg/path/property/priority.svg [ ImageOnlyFailure ]
 
 # re-import css/css-align WPT failure
 webkit.org/b/271692 imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-break-overflow-020.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/getComputedStyle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/getComputedStyle-expected.txt
@@ -1,7 +1,7 @@
 
 PASS d property of g0 should be none.
 PASS d property of p1 should be none.
-FAIL d property of p2 should be path("M 10 2 H 20"). assert_equals: expected "path(\"M 10 2 H 20\")" but got "none"
+PASS d property of p2 should be path("M 10 2 H 20").
 PASS d property of p3 should be path("M 10 3 H 30").
 PASS d property of p4 should be path("M 10 4 H 40").
 PASS d property of g5 should be path("M 10 5 H 50").

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/test_style_flush_on_dom_api_with_d_property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/test_style_flush_on_dom_api_with_d_property-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL getTotalLength() with d property assert_equals: the total length expected 10 but got 0
 FAIL getPointAtLength() with d property assert_equals: x-axis position expected 10 but got 0
-FAIL isPointInFill() with d property assert_equals: expected true but got false
-FAIL isPointInStroke() with d property assert_equals: expected true but got false
+PASS isPointInFill() with d property
+PASS isPointInStroke() with d property
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-relevant-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-relevant-expected.txt
@@ -11,7 +11,7 @@ PASS cx presentation attribute supported on a relevant element
 PASS cy presentation attribute supported on a relevant element
 PASS direction presentation attribute supported on a relevant element
 PASS display presentation attribute supported on a relevant element
-FAIL d presentation attribute supported on a relevant element assert_true: Presentation attribute d="M0,0 L1,1" should be supported on path element expected true got false
+PASS d presentation attribute supported on a relevant element
 PASS dominant-baseline presentation attribute supported on a relevant element
 PASS fill presentation attribute supported on a relevant element
 PASS fill-opacity presentation attribute supported on a relevant element

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases-expected.txt
@@ -10,7 +10,7 @@ PASS x, y, width, and height presentation attributes supported on use element
 PASS r presentation attribute supported on circle element
 PASS rx and ry presentation attributes supported on ellipse element
 PASS rx and ry presentation attributes supported on rect element
-FAIL d presentation attribute supported on path element assert_true: Presentation attribute d="M0,0 L1,1" should be supported on path element expected true got false
+PASS d presentation attribute supported on path element
 FAIL cx and cy presentation attributes not supported on other elements assert_false: Presentation attribute cx="1" should not be supported on g element expected false got true
 FAIL x, y, width, and height presentation attributes not supported on other elements assert_false: Presentation attribute x="1" should not be supported on g element expected false got true
 FAIL r presentation attribute not supported on other elements assert_false: Presentation attribute r="1" should not be supported on g element expected false got true

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -382,4 +382,9 @@ void StyledElement::addPropertyToPresentationalHintStyle(MutableStyleProperties&
     style.setProperty(propertyID, value, false, CSSParserContext(document()));
 }
 
+void StyledElement::addPropertyToPresentationalHintStyle(MutableStyleProperties& style, CSSPropertyID propertyID, RefPtr<CSSValue>&& value)
+{
+    style.setProperty(propertyID, WTFMove(value), false);
+}
+
 }

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -84,6 +84,7 @@ protected:
     void addPropertyToPresentationalHintStyle(MutableStyleProperties&, CSSPropertyID, CSSValueID identifier);
     void addPropertyToPresentationalHintStyle(MutableStyleProperties&, CSSPropertyID, double value, CSSUnitType);
     void addPropertyToPresentationalHintStyle(MutableStyleProperties&, CSSPropertyID, const String& value);
+    void addPropertyToPresentationalHintStyle(MutableStyleProperties&, CSSPropertyID, RefPtr<CSSValue>&&);
 
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const override;
     Attribute replaceURLsInAttributeValue(const Attribute&, const HashMap<String, String>&) const override;

--- a/Source/WebCore/rendering/style/BasicShapes.h
+++ b/Source/WebCore/rendering/style/BasicShapes.h
@@ -314,6 +314,8 @@ public:
     const SVGPathByteStream* pathData() const { return m_byteStream.get(); }
     const std::unique_ptr<SVGPathByteStream>& byteStream() const { return m_byteStream; }
 
+    const Path& path(const FloatRect&) final;
+
     bool canBlend(const BasicShape&) const final;
     Ref<BasicShape> blend(const BasicShape& from, const BlendingContext&) const final;
 
@@ -322,8 +324,6 @@ private:
     BasicShapePath(std::unique_ptr<SVGPathByteStream>&&, float zoom, WindRule);
 
     Type type() const final { return Type::Path; }
-
-    const Path& path(const FloatRect&) final;
 
     bool operator==(const BasicShape&) const final;
 

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -302,6 +302,8 @@ void SVGRenderStyle::conservativelyCollectChangedAnimatableProperties(const SVGR
             changingProperties.m_properties.set(CSSPropertyX);
         if (first.y != second.y)
             changingProperties.m_properties.set(CSSPropertyY);
+        if (first.d != second.d)
+            changingProperties.m_properties.set(CSSPropertyD);
     };
 
     auto conservativelyCollectChangedAnimatablePropertiesViaInheritedResourceData = [&](auto& first, auto& second) {

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -746,10 +746,10 @@ inline RefPtr<PathOperation> BuilderConverter::convertRayPathOperation(BuilderSt
     return RayPathOperation::create(rayValue.angle()->computeDegrees(), size, rayValue.isContaining());
 }
 
-inline RefPtr<BasicShapePath> BuilderConverter::convertSVGPath(BuilderState& builderState, const CSSValue& value)
+inline RefPtr<BasicShapePath> BuilderConverter::convertSVGPath(BuilderState&, const CSSValue& value)
 {
     if (auto* pathValue = dynamicDowncast<CSSPathValue>(value))
-        return basicShapePathForValue(*pathValue, builderState.style().usedZoom());
+        return basicShapePathForValue(*pathValue);
 
     ASSERT(is<CSSPrimitiveValue>(value));
     ASSERT(downcast<CSSPrimitiveValue>(value).valueID() == CSSValueNone);

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -869,6 +869,8 @@ CSSPropertyID SVGElement::cssPropertyIdForSVGAttributeName(const QualifiedName& 
         return CSSPropertyCx;
     case AttributeNames::cyAttr:
         return CSSPropertyCy;
+    case AttributeNames::dAttr:
+        return CSSPropertyD;
     case AttributeNames::directionAttr:
         return CSSPropertyDirection;
     case AttributeNames::displayAttr:

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -97,7 +97,7 @@ public:
     RefPtr<SVGPathSegList>& animatedPathSegList() { return m_pathSegList->animVal(); }
 
     const SVGPathByteStream& pathByteStream() const { return m_pathSegList->currentPathByteStream(); }
-    Path path() const { return m_pathSegList->currentPath(); }
+    Path path() const;
     size_t approximateMemoryCost() const final { return m_pathSegList->approximateMemoryCost(); }
 
     static void clearCache();
@@ -119,6 +119,8 @@ private:
     void removedFromAncestor(RemovalType, ContainerNode&) final;
 
     void invalidateMPathDependencies();
+
+    void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 
 private:
     Ref<SVGAnimatedPathSegList> m_pathSegList { SVGAnimatedPathSegList::create(this) };


### PR DESCRIPTION
#### 5187e475ef752de5bc38ae9570c26e03b2edbe14
<pre>
[svg] make `d` a presentation attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=272509">https://bugs.webkit.org/show_bug.cgi?id=272509</a>

Reviewed by Said Abou-Hallawa.

We now make the `d` SVG attribute map to the `d` CSS property as part of the presentation
attribute system by adding the required mapping under `SVGElement::cssPropertyIdForSVGAttributeName()`
and accounting for the path data set on the `SVGRenderStyle` in `pathFromPathElement()`.

We must also call `setPresentationalHintStyleIsDirty()` under `SVGPathElement::svgAttributeChanged()`,
matching the behavior of other SVG elements with presentation attributes.

The SVG presentation attribute system forwards the string value set on the SVG attribute to the
`MutableStyleProperties` object collecting the various matching CSS properties. But in the case
of the `d` property, path data can be large and unwieldy, so we override `collectPresentationalHintsForAttribute()`
on `SVGPathElement` and create a `CSSPathValue` with a copy of the (potentially animated)
`SVGPathByteStream` and call into a new variant of `StyledElement::addPropertyToPresentationalHintStyle()`
that takes in a `RefPtr&lt;CSSValue&gt;&amp;&amp;`.

Finally, adding support for `d` as a presentation attribute revealed a mistake in 277297@main
where we accounted for the CSS `zoom` value when converting the `CSSPathValue`, but the `zoom`
property has no bearing in SVG. This broke the following tests:

    * svg/zoom/page/zoom-coords-viewattr-01-b.svg
    * svg/zoom/page/zoom-img-preserveAspectRatio-support-1.html
    * svg/zoom/page/zoom-replaced-intrinsic-ratio-001.htm

So we modified `BuilderConverter::convertSVGPath()` accordingly.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/getComputedStyle-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/test_style_flush_on_dom_api_with_d_property-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-relevant-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases-expected.txt:
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::addPropertyToPresentationalHintStyle):
* Source/WebCore/dom/StyledElement.h:
* Source/WebCore/rendering/style/BasicShapes.h:
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
(WebCore::SVGRenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertSVGPath):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::cssPropertyIdForSVGAttributeName):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::svgAttributeChanged):
(WebCore::SVGPathElement::path const):
(WebCore::SVGPathElement::collectPresentationalHintsForAttribute):
* Source/WebCore/svg/SVGPathElement.h:

Canonical link: <a href="https://commits.webkit.org/277451@main">https://commits.webkit.org/277451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d8c7e4286a2fd9671a6e250464b7b16034a0e47

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50290 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43657 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38762 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48190 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24414 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20061 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21901 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42211 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5650 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52182 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22644 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18974 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46074 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23916 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45103 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24704 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6732 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23634 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->