### PR TITLE
GraphicsContextGL::bindExternalImage cannot unbind images

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -703,10 +703,13 @@ GCGLExternalImage GraphicsContextGLCocoa::createExternalImage(ExternalImageSourc
 
 void GraphicsContextGLCocoa::bindExternalImage(GCGLenum target, GCGLExternalImage image)
 {
-    auto* eglImage = m_eglImages.get(image);
-    if (!eglImage) {
-        addError(GCGLErrorCode::InvalidOperation);
-        return;
+    EGLImage eglImage = EGL_NO_IMAGE_KHR;
+    if (image) {
+        eglImage = m_eglImages.get(image);
+        if (!eglImage) {
+            addError(GCGLErrorCode::InvalidOperation);
+            return;
+        }
     }
     if (target == RENDERBUFFER)
         GL_EGLImageTargetRenderbufferStorageOES(RENDERBUFFER, eglImage);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -33,38 +33,45 @@
     void attachShader(uint32_t program, uint32_t shader)
     {
         assertIsCurrent(workQueue());
-        program = m_objectNames.get(program);
-        shader = m_objectNames.get(shader);
+        if (program)
+            program = m_objectNames.get(program);
+        if (shader)
+            shader = m_objectNames.get(shader);
         m_context->attachShader(program, shader);
     }
     void bindAttribLocation(uint32_t arg0, uint32_t index, String&& name)
     {
         assertIsCurrent(workQueue());
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         m_context->bindAttribLocation(arg0, index, name);
     }
     void bindBuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
-        arg1 = m_objectNames.get(arg1);
+        if (arg1)
+            arg1 = m_objectNames.get(arg1);
         m_context->bindBuffer(target, arg1);
     }
     void bindFramebuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
-        arg1 = m_objectNames.get(arg1);
+        if (arg1)
+            arg1 = m_objectNames.get(arg1);
         m_context->bindFramebuffer(target, arg1);
     }
     void bindRenderbuffer(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
-        arg1 = m_objectNames.get(arg1);
+        if (arg1)
+            arg1 = m_objectNames.get(arg1);
         m_context->bindRenderbuffer(target, arg1);
     }
     void bindTexture(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
-        arg1 = m_objectNames.get(arg1);
+        if (arg1)
+            arg1 = m_objectNames.get(arg1);
         m_context->bindTexture(target, arg1);
     }
     void blendColor(float red, float green, float blue, float alpha)
@@ -127,7 +134,8 @@
     void compileShader(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         m_context->compileShader(arg0);
     }
     void copyTexImage2D(uint32_t target, int32_t level, uint32_t internalformat, int32_t x, int32_t y, int32_t width, int32_t height, int32_t border)
@@ -190,36 +198,48 @@
     void deleteBuffer(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!arg0))
+            return;
         arg0 = m_objectNames.take(arg0);
         m_context->deleteBuffer(arg0);
     }
     void deleteFramebuffer(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!arg0))
+            return;
         arg0 = m_objectNames.take(arg0);
         m_context->deleteFramebuffer(arg0);
     }
     void deleteProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!arg0))
+            return;
         arg0 = m_objectNames.take(arg0);
         m_context->deleteProgram(arg0);
     }
     void deleteRenderbuffer(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!arg0))
+            return;
         arg0 = m_objectNames.take(arg0);
         m_context->deleteRenderbuffer(arg0);
     }
     void deleteShader(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!arg0))
+            return;
         arg0 = m_objectNames.take(arg0);
         m_context->deleteShader(arg0);
     }
     void deleteTexture(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!arg0))
+            return;
         arg0 = m_objectNames.take(arg0);
         m_context->deleteTexture(arg0);
     }
@@ -241,8 +261,10 @@
     void detachShader(uint32_t arg0, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
-        arg0 = m_objectNames.get(arg0);
-        arg1 = m_objectNames.get(arg1);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
+        if (arg1)
+            arg1 = m_objectNames.get(arg1);
         m_context->detachShader(arg0, arg1);
     }
     void disable(uint32_t cap)
@@ -288,13 +310,15 @@
     void framebufferRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
     {
         assertIsCurrent(workQueue());
-        arg3 = m_objectNames.get(arg3);
+        if (arg3)
+            arg3 = m_objectNames.get(arg3);
         m_context->framebufferRenderbuffer(target, attachment, renderbuffertarget, arg3);
     }
     void framebufferTexture2D(uint32_t target, uint32_t attachment, uint32_t textarget, uint32_t arg3, int32_t level)
     {
         assertIsCurrent(workQueue());
-        arg3 = m_objectNames.get(arg3);
+        if (arg3)
+            arg3 = m_objectNames.get(arg3);
         m_context->framebufferTexture2D(target, attachment, textarget, arg3, level);
     }
     void frontFace(uint32_t mode)
@@ -311,7 +335,8 @@
     {
         assertIsCurrent(workQueue());
         bool returnValue = { };
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         struct WebCore::GraphicsContextGLActiveInfo arg2 { };
         returnValue = m_context->getActiveAttrib(program, index, arg2);
         completionHandler(returnValue, WTFMove(arg2));
@@ -320,7 +345,8 @@
     {
         assertIsCurrent(workQueue());
         bool returnValue = { };
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         struct WebCore::GraphicsContextGLActiveInfo arg2 { };
         returnValue = m_context->getActiveUniform(program, index, arg2);
         completionHandler(returnValue, WTFMove(arg2));
@@ -329,7 +355,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getAttribLocation(arg0, name);
         completionHandler(returnValue);
     }
@@ -386,7 +413,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         returnValue = m_context->getProgrami(program, pname);
         completionHandler(returnValue);
     }
@@ -408,7 +436,8 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getProgramInfoLog(arg0);
         completionHandler(WTFMove(returnValue));
     }
@@ -423,7 +452,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getShaderi(arg0, pname);
         completionHandler(returnValue);
     }
@@ -431,7 +461,8 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getShaderInfoLog(arg0);
         completionHandler(WTFMove(returnValue));
     }
@@ -447,7 +478,8 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getShaderSource(arg0);
         completionHandler(WTFMove(returnValue));
     }
@@ -468,7 +500,8 @@
     void getUniformfv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const float>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         Vector<GCGLfloat, 16> value(valueSize, 0);
         m_context->getUniformfv(program, location, value);
         completionHandler(std::span<const float>(reinterpret_cast<const float*>(value.data()), value.size()));
@@ -476,7 +509,8 @@
     void getUniformiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         Vector<GCGLint, 4> value(valueSize, 0);
         m_context->getUniformiv(program, location, value);
         completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(value.data()), value.size()));
@@ -484,7 +518,8 @@
     void getUniformuiv(uint32_t program, int32_t location, size_t valueSize, CompletionHandler<void(std::span<const uint32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         Vector<GCGLuint, 4> value(valueSize, 0);
         m_context->getUniformuiv(program, location, value);
         completionHandler(std::span<const uint32_t>(reinterpret_cast<const uint32_t*>(value.data()), value.size()));
@@ -493,7 +528,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getUniformLocation(arg0, name);
         completionHandler(returnValue);
     }
@@ -513,7 +549,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isBuffer(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
@@ -528,7 +565,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isFramebuffer(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
@@ -536,7 +574,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isProgram(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
@@ -544,7 +583,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isRenderbuffer(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
@@ -552,7 +592,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isShader(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
@@ -560,7 +601,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isTexture(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
@@ -572,7 +614,8 @@
     void linkProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         m_context->linkProgram(arg0);
     }
     void pixelStorei(uint32_t pname, int32_t param)
@@ -603,7 +646,8 @@
     void shaderSource(uint32_t arg0, String&& arg1)
     {
         assertIsCurrent(workQueue());
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         m_context->shaderSource(arg0, arg1);
     }
     void stencilFunc(uint32_t func, int32_t ref, uint32_t mask)
@@ -744,13 +788,15 @@
     void useProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         m_context->useProgram(arg0);
     }
     void validateProgram(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         m_context->validateProgram(arg0);
     }
     void vertexAttrib1f(uint32_t index, float x)
@@ -888,6 +934,8 @@
     void deleteVertexArray(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!arg0))
+            return;
         arg0 = m_objectNames.take(arg0);
         m_context->deleteVertexArray(arg0);
     }
@@ -895,14 +943,16 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->isVertexArray(arg0);
         completionHandler(static_cast<bool>(returnValue));
     }
     void bindVertexArray(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         m_context->bindVertexArray(arg0);
     }
     void copyBufferSubData(uint32_t readTarget, uint32_t writeTarget, uint64_t readOffset, uint64_t writeOffset, uint64_t arg4)
@@ -925,7 +975,8 @@
     void framebufferTextureLayer(uint32_t target, uint32_t attachment, uint32_t texture, int32_t level, int32_t layer)
     {
         assertIsCurrent(workQueue());
-        texture = m_objectNames.get(texture);
+        if (texture)
+            texture = m_objectNames.get(texture);
         m_context->framebufferTextureLayer(target, attachment, texture, level, layer);
     }
     void invalidateFramebuffer(uint32_t target, std::span<const uint32_t>&& attachments)
@@ -1007,7 +1058,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         returnValue = m_context->getFragDataLocation(program, name);
         completionHandler(returnValue);
     }
@@ -1146,6 +1198,8 @@
     void deleteQuery(uint32_t query)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!query))
+            return;
         query = m_objectNames.take(query);
         m_context->deleteQuery(query);
     }
@@ -1153,14 +1207,16 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        query = m_objectNames.get(query);
+        if (query)
+            query = m_objectNames.get(query);
         returnValue = m_context->isQuery(query);
         completionHandler(static_cast<bool>(returnValue));
     }
     void beginQuery(uint32_t target, uint32_t query)
     {
         assertIsCurrent(workQueue());
-        query = m_objectNames.get(query);
+        if (query)
+            query = m_objectNames.get(query);
         m_context->beginQuery(target, query);
     }
     void endQuery(uint32_t target)
@@ -1179,7 +1235,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLuint returnValue = { };
-        query = m_objectNames.get(query);
+        if (query)
+            query = m_objectNames.get(query);
         returnValue = m_context->getQueryObjectui(query, pname);
         completionHandler(returnValue);
     }
@@ -1193,6 +1250,8 @@
     void deleteSampler(uint32_t sampler)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!sampler))
+            return;
         sampler = m_objectNames.take(sampler);
         m_context->deleteSampler(sampler);
     }
@@ -1200,33 +1259,38 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        sampler = m_objectNames.get(sampler);
+        if (sampler)
+            sampler = m_objectNames.get(sampler);
         returnValue = m_context->isSampler(sampler);
         completionHandler(static_cast<bool>(returnValue));
     }
     void bindSampler(uint32_t unit, uint32_t sampler)
     {
         assertIsCurrent(workQueue());
-        sampler = m_objectNames.get(sampler);
+        if (sampler)
+            sampler = m_objectNames.get(sampler);
         m_context->bindSampler(unit, sampler);
     }
     void samplerParameteri(uint32_t sampler, uint32_t pname, int32_t param)
     {
         assertIsCurrent(workQueue());
-        sampler = m_objectNames.get(sampler);
+        if (sampler)
+            sampler = m_objectNames.get(sampler);
         m_context->samplerParameteri(sampler, pname, param);
     }
     void samplerParameterf(uint32_t sampler, uint32_t pname, float param)
     {
         assertIsCurrent(workQueue());
-        sampler = m_objectNames.get(sampler);
+        if (sampler)
+            sampler = m_objectNames.get(sampler);
         m_context->samplerParameterf(sampler, pname, param);
     }
     void getSamplerParameterf(uint32_t sampler, uint32_t pname, CompletionHandler<void(float)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         GCGLfloat returnValue = { };
-        sampler = m_objectNames.get(sampler);
+        if (sampler)
+            sampler = m_objectNames.get(sampler);
         returnValue = m_context->getSamplerParameterf(sampler, pname);
         completionHandler(returnValue);
     }
@@ -1234,7 +1298,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        sampler = m_objectNames.get(sampler);
+        if (sampler)
+            sampler = m_objectNames.get(sampler);
         returnValue = m_context->getSamplerParameteri(sampler, pname);
         completionHandler(returnValue);
     }
@@ -1286,6 +1351,8 @@
     void deleteTransformFeedback(uint32_t id)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!id))
+            return;
         id = m_objectNames.take(id);
         m_context->deleteTransformFeedback(id);
     }
@@ -1293,14 +1360,16 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        id = m_objectNames.get(id);
+        if (id)
+            id = m_objectNames.get(id);
         returnValue = m_context->isTransformFeedback(id);
         completionHandler(static_cast<bool>(returnValue));
     }
     void bindTransformFeedback(uint32_t target, uint32_t id)
     {
         assertIsCurrent(workQueue());
-        id = m_objectNames.get(id);
+        if (id)
+            id = m_objectNames.get(id);
         m_context->bindTransformFeedback(target, id);
     }
     void beginTransformFeedback(uint32_t primitiveMode)
@@ -1316,13 +1385,15 @@
     void transformFeedbackVaryings(uint32_t program, Vector<String>&& varyings, uint32_t bufferMode)
     {
         assertIsCurrent(workQueue());
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         m_context->transformFeedbackVaryings(program, varyings, bufferMode);
     }
     void getTransformFeedbackVarying(uint32_t program, uint32_t index, CompletionHandler<void(struct WebCore::GraphicsContextGLActiveInfo&&)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         struct WebCore::GraphicsContextGLActiveInfo arg2 { };
         m_context->getTransformFeedbackVarying(program, index, arg2);
         completionHandler(WTFMove(arg2));
@@ -1340,20 +1411,23 @@
     void bindBufferBase(uint32_t target, uint32_t index, uint32_t buffer)
     {
         assertIsCurrent(workQueue());
-        buffer = m_objectNames.get(buffer);
+        if (buffer)
+            buffer = m_objectNames.get(buffer);
         m_context->bindBufferBase(target, index, buffer);
     }
     void bindBufferRange(uint32_t target, uint32_t index, uint32_t buffer, uint64_t offset, uint64_t arg4)
     {
         assertIsCurrent(workQueue());
-        buffer = m_objectNames.get(buffer);
+        if (buffer)
+            buffer = m_objectNames.get(buffer);
         m_context->bindBufferRange(target, index, buffer, static_cast<GCGLintptr>(offset), static_cast<GCGLsizeiptr>(arg4));
     }
     void getUniformIndices(uint32_t program, Vector<String>&& uniformNames, CompletionHandler<void(Vector<uint32_t>&&)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
         Vector<GCGLuint> returnValue = { };
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         returnValue = m_context->getUniformIndices(program, uniformNames);
         completionHandler(WTFMove(returnValue));
     }
@@ -1361,7 +1435,8 @@
     {
         assertIsCurrent(workQueue());
         Vector<GCGLint> returnValue = { };
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         returnValue = m_context->getActiveUniforms(program, uniformIndices, pname);
         completionHandler(WTFMove(returnValue));
     }
@@ -1369,7 +1444,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLuint returnValue = { };
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         returnValue = m_context->getUniformBlockIndex(program, uniformBlockName);
         completionHandler(returnValue);
     }
@@ -1377,20 +1453,23 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         returnValue = m_context->getActiveUniformBlockName(program, uniformBlockIndex);
         completionHandler(WTFMove(returnValue));
     }
     void uniformBlockBinding(uint32_t program, uint32_t uniformBlockIndex, uint32_t uniformBlockBinding)
     {
         assertIsCurrent(workQueue());
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         m_context->uniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
     }
     void getActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, size_t paramsSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
-        program = m_objectNames.get(program);
+        if (program)
+            program = m_objectNames.get(program);
         Vector<GCGLint, 4> params(paramsSize, 0);
         m_context->getActiveUniformBlockiv(program, uniformBlockIndex, pname, params);
         completionHandler(std::span<const int32_t>(reinterpret_cast<const int32_t*>(params.data()), params.size()));
@@ -1399,7 +1478,8 @@
     {
         assertIsCurrent(workQueue());
         String returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->getTranslatedShaderSourceANGLE(arg0);
         completionHandler(WTFMove(returnValue));
     }
@@ -1418,6 +1498,8 @@
     void deleteQueryEXT(uint32_t query)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!query))
+            return;
         query = m_objectNames.take(query);
         m_context->deleteQueryEXT(query);
     }
@@ -1425,14 +1507,16 @@
     {
         assertIsCurrent(workQueue());
         GCGLboolean returnValue = { };
-        query = m_objectNames.get(query);
+        if (query)
+            query = m_objectNames.get(query);
         returnValue = m_context->isQueryEXT(query);
         completionHandler(static_cast<bool>(returnValue));
     }
     void beginQueryEXT(uint32_t target, uint32_t query)
     {
         assertIsCurrent(workQueue());
-        query = m_objectNames.get(query);
+        if (query)
+            query = m_objectNames.get(query);
         m_context->beginQueryEXT(target, query);
     }
     void endQueryEXT(uint32_t target)
@@ -1443,7 +1527,8 @@
     void queryCounterEXT(uint32_t query, uint32_t target)
     {
         assertIsCurrent(workQueue());
-        query = m_objectNames.get(query);
+        if (query)
+            query = m_objectNames.get(query);
         m_context->queryCounterEXT(query, target);
     }
     void getQueryiEXT(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
@@ -1457,7 +1542,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLint returnValue = { };
-        query = m_objectNames.get(query);
+        if (query)
+            query = m_objectNames.get(query);
         returnValue = m_context->getQueryObjectiEXT(query, pname);
         completionHandler(returnValue);
     }
@@ -1465,7 +1551,8 @@
     {
         assertIsCurrent(workQueue());
         GCGLuint64 returnValue = { };
-        query = m_objectNames.get(query);
+        if (query)
+            query = m_objectNames.get(query);
         returnValue = m_context->getQueryObjectui64EXT(query, pname);
         completionHandler(static_cast<uint64_t>(returnValue));
     }
@@ -1580,13 +1667,16 @@
     void deleteExternalImage(uint32_t handle)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!handle))
+            return;
         handle = m_objectNames.take(handle);
         m_context->deleteExternalImage(handle);
     }
     void bindExternalImage(uint32_t target, uint32_t arg1)
     {
         assertIsCurrent(workQueue());
-        arg1 = m_objectNames.get(arg1);
+        if (arg1)
+            arg1 = m_objectNames.get(arg1);
         m_context->bindExternalImage(target, arg1);
     }
     void createExternalSync(uint32_t name, WebCore::GraphicsContextGL::ExternalSyncSource&& arg0)
@@ -1599,6 +1689,8 @@
     void deleteExternalSync(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
+        if (UNLIKELY(!arg0))
+            return;
         arg0 = m_objectNames.take(arg0);
         m_context->deleteExternalSync(arg0);
     }
@@ -1606,7 +1698,8 @@
     {
         assertIsCurrent(workQueue());
         bool returnValue = { };
-        arg0 = m_objectNames.get(arg0);
+        if (arg0)
+            arg0 = m_objectNames.get(arg0);
         returnValue = m_context->clientWaitExternalSyncWithFlush(arg0, timeout);
         completionHandler(returnValue);
     }

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -880,9 +880,16 @@ class webkit_ipc_cpp_impl(object):
             if self.is_create:
                 self.pre_call_stmts += [f"if (UNLIKELY(!{a.name})) {{", f"    ASSERT_IS_TESTING_IPC();", f"    return;", f"}}"]
             if self.is_delete:
-                self.pre_call_stmts += [f"{a.name} = m_objectNames.take({a.name});"]
+                self.pre_call_stmts += [
+                    f"if (UNLIKELY(!{a.name}))",
+                    f"    return;",
+                    f"{a.name} = m_objectNames.take({a.name});"
+                ]
             else:
-                self.pre_call_stmts += [f"{a.name} = m_objectNames.get({a.name});"]
+                self.pre_call_stmts += [
+                    f"if ({a.name})",
+                    f"    {a.name} = m_objectNames.get({a.name});"
+                ]
 
     def process_out_arg(self, a: cpp_arg):
         if a.type.is_pointer():


### PR DESCRIPTION
#### b19fbf77a19e986aa8c5c905dd728e75223d22e6
<pre>
GraphicsContextGL::bindExternalImage cannot unbind images
<a href="https://bugs.webkit.org/show_bug.cgi?id=272513">https://bugs.webkit.org/show_bug.cgi?id=272513</a>
<a href="https://rdar.apple.com/126260668">rdar://126260668</a>

Reviewed by Dan Glastonbury.

Support unbinding ExternalImage. Currently not used but might be in
the future.

Make sure ExternalSync, ExternalImage objects create errors when using
0.

When destroying any GraphicsContextGL object, follow the GL logic
ignoring calls to destroy name 0.

Avoid expected-to-fail lookup 0 -&gt; 0 in Remote implementations
for clarity.

* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::deleteExternalImage):
(WebCore::GraphicsContextGLANGLE::deleteExternalSync):
(WebCore::GraphicsContextGLANGLE::clientWaitExternalSyncWithFlush):
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::bindExternalImage):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(attachShader):
(bindAttribLocation):
(bindBuffer):
(bindFramebuffer):
(bindRenderbuffer):
(bindTexture):
(compileShader):
(deleteBuffer):
(deleteFramebuffer):
(deleteProgram):
(deleteRenderbuffer):
(deleteShader):
(deleteTexture):
(detachShader):
(framebufferRenderbuffer):
(framebufferTexture2D):
(getActiveAttrib):
(getActiveUniform):
(getAttribLocation):
(getProgrami):
(getProgramInfoLog):
(getShaderi):
(getShaderInfoLog):
(getShaderSource):
(getUniformfv):
(getUniformiv):
(getUniformuiv):
(getUniformLocation):
(isBuffer):
(isFramebuffer):
(isProgram):
(isRenderbuffer):
(isShader):
(isTexture):
(linkProgram):
(shaderSource):
(useProgram):
(validateProgram):
(deleteVertexArray):
(isVertexArray):
(bindVertexArray):
(framebufferTextureLayer):
(getFragDataLocation):
(deleteQuery):
(isQuery):
(beginQuery):
(getQueryObjectui):
(deleteSampler):
(isSampler):
(bindSampler):
(samplerParameteri):
(samplerParameterf):
(getSamplerParameterf):
(getSamplerParameteri):
(deleteTransformFeedback):
(isTransformFeedback):
(bindTransformFeedback):
(transformFeedbackVaryings):
(getTransformFeedbackVarying):
(bindBufferBase):
(bindBufferRange):
(getUniformIndices):
(getActiveUniforms):
(getUniformBlockIndex):
(getActiveUniformBlockName):
(uniformBlockBinding):
(getActiveUniformBlockiv):
(getTranslatedShaderSourceANGLE):
(deleteQueryEXT):
(isQueryEXT):
(beginQueryEXT):
(queryCounterEXT):
(getQueryObjectiEXT):
(getQueryObjectui64EXT):
(deleteExternalImage):
(bindExternalImage):
(deleteExternalSync):
(clientWaitExternalSyncWithFlush):
* Tools/Scripts/generate-gpup-webgl:
(webkit_ipc_cpp_impl.process_in_arg):

Canonical link: <a href="https://commits.webkit.org/277377@main">https://commits.webkit.org/277377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ec34be273d8cc5d15f8e8c65504bbc4f6886ec8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50119 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43484 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38618 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24185 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40880 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19941 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42050 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5479 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51996 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18799 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45916 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23742 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44953 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10468 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24532 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23460 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->