### PR TITLE
[svg] WPT test `svg/path/property/serialization.svg` fails to test computed style converts relative commands to  absolute commands in one subtest

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/serialization-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/serialization-expected.txt
@@ -2,7 +2,7 @@
 PASS e.style['d'] = "path(\"m 10 20 q 30 60 40 50 q 100 70 90 80\")" should set the property value
 PASS Property d value 'path("m 10 20 q 30 60 40 50 q 100 70 90 80")'
 PASS e.style['d'] = "path(\"M 0 0 L 100 100 m 0 100 l 100 0 Z l 160 20 Z\")" should set the property value
-FAIL Property d value 'path("M 0 0 L 100 100 m 0 100 l 100 0 Z l 160 20 Z")' assert_equals: expected "path(\"M 0 0 L 100 100 m 0 100 l 100 0 Z l 160 20 Z\")" but got "path(\"M 0 0 L 100 100 M 100 200 L 200 200 Z L 260 220 Z\")"
+PASS Property d value 'path("M 0 0 L 100 100 m 0 100 l 100 0 Z l 160 20 Z")'
 PASS e.style['d'] = "path(\"m 10 20   l 20 30   Z   l 50 60   Z   m 70 80   l 90 60   Z   t 70 120\")" should set the property value
 PASS Property d value 'path("m 10 20   l 20 30   Z   l 50 60   Z   m 70 80   l 90 60   Z   t 70 120")'
 PASS e.style['d'] = "path(\"m 10.0 170.0 h 90.00 v 30.00 m 0 0 s 1 2 3 4 z c 9 8 7 6 5 4\")" should set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/serialization.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/serialization.svg
@@ -17,7 +17,7 @@
 
   let test2 = 'path("M 0 0 L 100 100 m 0 100 l 100 0 Z l 160 20 Z")';
   test_valid_value('d', test2);
-  test_computed_value('d', test2);
+  test_computed_value('d', test2, 'path("M 0 0 L 100 100 M 100 200 L 200 200 Z L 260 220 Z")');
 
   let test3 = 'path("m 10 20   l 20 30   Z   l 50 60   Z   m 70 80   l 90 60   Z   t 70 120")';
   test_valid_value('d', test3, 'path("m 10 20 l 20 30 Z l 50 60 Z m 70 80 l 90 60 Z t 70 120")');


### PR DESCRIPTION
#### 0a59024e40c4745f8182a5b7ad31fd3c6ca89cad
<pre>
[svg] WPT test `svg/path/property/serialization.svg` fails to test computed style converts relative commands to  absolute commands in one subtest
<a href="https://bugs.webkit.org/show_bug.cgi?id=272517">https://bugs.webkit.org/show_bug.cgi?id=272517</a>
<a href="https://rdar.apple.com/126262327">rdar://126262327</a>

Reviewed by Anne van Kesteren and Antti Koivisto.

The purpose of `svg/path/property/serialization.svg` is to check that relative commands are converted
to absolute commands when serializing through the computed style. Yet, one of the subtests failed to
do just that.

* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/serialization-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/serialization.svg:

Canonical link: <a href="https://commits.webkit.org/277380@main">https://commits.webkit.org/277380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27e849e80d649169c9c94055c74cd6a6badb85b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50121 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43486 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38616 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42051 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5481 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43777 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/51998 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22472 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18800 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45918 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23744 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44955 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24534 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6683 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->