### PR TITLE
[WebXR] Enable WebXR-specific GraphicsContextGL extensions only when needed

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1519,17 +1519,23 @@ public:
     using EGLImageSourceIOSurfaceHandle = GraphicsContextGLExternalImageSourceIOSurfaceHandle;
     using EGLImageSourceMTLSharedTextureHandle = GraphicsContextGLExternalImageSourceMTLSharedTextureHandle;
 #endif
+#if ENABLE(WEBXR)
     virtual bool addFoveation(IntSize, IntSize, IntSize, std::span<const GCGLfloat>, std::span<const GCGLfloat>, std::span<const GCGLfloat>) = 0;
     virtual void enableFoveation(GCGLuint) = 0;
     virtual void disableFoveation() = 0;
+#endif
 
     using ExternalImageSource = GraphicsContextGLExternalImageSource;
+#if ENABLE(WEBXR)
     virtual GCGLExternalImage createExternalImage(ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) = 0;
     virtual void deleteExternalImage(GCGLExternalImage) = 0;
     virtual void bindExternalImage(GCGLenum target, GCGLExternalImage) = 0;
+#endif
 
     using ExternalSyncSource = GraphicsContextGLExternalSyncSource;
+#if ENABLE(WEBXR)
     virtual GCGLExternalSync createExternalSync(ExternalSyncSource&&) = 0;
+#endif
     virtual void deleteExternalSync(GCGLExternalSync) = 0;
 
     // ========== Extension related entry points.
@@ -1550,7 +1556,9 @@ public:
     // Has no other side-effects.
     virtual bool isExtensionEnabled(const String&) = 0;
 
+#if ENABLE(WEBXR)
     virtual bool enableRequiredWebXRExtensions() { return false; }
+#endif
 
     // GL_ANGLE_translated_shader_source
     virtual String getTranslatedShaderSourceANGLE(PlatformGLObject) = 0;
@@ -1744,7 +1752,9 @@ private:
 using GCGLOwnedFramebuffer = GCGLOwned<PlatformGLObject, &GraphicsContextGL::deleteFramebuffer>;
 using GCGLOwnedRenderbuffer = GCGLOwned<PlatformGLObject, &GraphicsContextGL::deleteRenderbuffer>;
 using GCGLOwnedTexture = GCGLOwned<PlatformGLObject, &GraphicsContextGL::deleteTexture>;
+#if ENABLE(WEBXR)
 using GCGLOwnedExternalImage = GCGLOwned<GCGLExternalImage, &GraphicsContextGL::deleteExternalImage>;
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -2851,6 +2851,7 @@ void GraphicsContextGLANGLE::getActiveUniformBlockiv(PlatformGLObject program, G
     GL_GetActiveUniformBlockivRobustANGLE(program, uniformBlockIndex, pname, params.size(), nullptr, params.data());
 }
 
+#if ENABLE(WEBXR)
 GCGLExternalImage GraphicsContextGLANGLE::createExternalImage(ExternalImageSource&&, GCGLenum, GCGLint)
 {
     notImplemented();
@@ -2882,6 +2883,7 @@ GCGLExternalSync GraphicsContextGLANGLE::createExternalSync(ExternalSyncSource&&
     notImplemented();
     return { };
 }
+#endif
 
 void GraphicsContextGLANGLE::deleteExternalSync(GCGLExternalSync sync)
 {

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -289,10 +289,12 @@ public:
     String getActiveUniformBlockName(PlatformGLObject program, GCGLuint uniformBlockIndex) final;
     void uniformBlockBinding(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLuint uniformBlockBinding) final;
     void getActiveUniformBlockiv(PlatformGLObject program, GCGLuint uniformBlockIndex, GCGLenum pname, std::span<GCGLint> params) final;
+#if ENABLE(WEBXR)
     GCGLExternalImage createExternalImage(ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) override;
     void deleteExternalImage(GCGLExternalImage) final;
     void bindExternalImage(GCGLenum target, GCGLExternalImage) override;
     GCGLExternalSync createExternalSync(ExternalSyncSource&&) override;
+#endif
     void deleteExternalSync(GCGLExternalSync) final;
     void multiDrawArraysANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLint, const GCGLsizei> firstsAndCounts) final;
     void multiDrawArraysInstancedANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLint, const GCGLsizei, const GCGLsizei> firstsCountsAndInstanceCounts) final;

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -76,6 +76,7 @@ public:
     void* createPbufferAndAttachIOSurface(GCGLenum target, PbufferAttachmentUsage, GCGLenum internalFormat, GCGLsizei width, GCGLsizei height, GCGLenum type, IOSurfaceRef, GCGLuint plane);
     void destroyPbufferAndDetachIOSurface(void* handle);
 
+#if ENABLE(WEBXR)
     GCGLExternalImage createExternalImage(ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) final;
     void bindExternalImage(GCGLenum target, GCGLExternalImage) final;
 
@@ -85,10 +86,12 @@ public:
 
     RetainPtr<id> newSharedEventWithMachPort(mach_port_t);
     GCGLExternalSync createExternalSync(ExternalSyncSource&&) final;
-    // Short term support for in-process WebGL.
+#endif
     GCGLExternalSync createExternalSync(id, uint64_t);
 
+#if ENABLE(WEBXR)
     bool enableRequiredWebXRExtensions() final;
+#endif
 
     void waitUntilWorkScheduled();
 

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -626,6 +626,7 @@ void GraphicsContextGLCocoa::destroyPbufferAndDetachIOSurface(void* handle)
     WebCore::destroyPbufferAndDetachIOSurface(m_displayObj, handle);
 }
 
+#if ENABLE(WEBXR)
 GCGLExternalImage GraphicsContextGLCocoa::createExternalImage(ExternalImageSource&& source, GCGLenum internalFormat, GCGLint layer)
 {
     EGLDeviceEXT eglDevice = EGL_NO_DEVICE_EXT;
@@ -719,23 +720,13 @@ void GraphicsContextGLCocoa::bindExternalImage(GCGLenum target, GCGLExternalImag
 
 bool GraphicsContextGLCocoa::addFoveation(IntSize physicalSizeLeft, IntSize physicalSizeRight, IntSize screenSize, std::span<const GCGLfloat> horizontalSamplesLeft, std::span<const GCGLfloat> verticalSamplesLeft, std::span<const GCGLfloat> horizontalSamplesRight)
 {
-#if ENABLE(WEBXR)
     m_rasterizationRateMap[PlatformXR::Layout::Shared] = newRasterizationRateMap(m_displayObj, physicalSizeLeft, physicalSizeRight, screenSize, horizontalSamplesLeft, verticalSamplesLeft, horizontalSamplesRight);
     return m_rasterizationRateMap[PlatformXR::Layout::Shared];
-#else
-    UNUSED_PARAM(physicalSizeLeft);
-    UNUSED_PARAM(physicalSizeRight);
-    UNUSED_PARAM(screenSize);
-    UNUSED_PARAM(horizontalSamplesLeft);
-    UNUSED_PARAM(verticalSamplesLeft);
-    UNUSED_PARAM(horizontalSamplesRight);
-    return false;
-#endif
 }
 
 void GraphicsContextGLCocoa::enableFoveation(GCGLuint fbo)
 {
-#if ENABLE(WEBXR) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#if !PLATFORM(IOS_FAMILY_SIMULATOR)
     GL_BindMetalRasterizationRateMapANGLE(fbo, m_rasterizationRateMap[PlatformXR::Layout::Shared].get());
     GL_Enable(GL::VARIABLE_RASTERIZATION_RATE_ANGLE);
 #else
@@ -745,7 +736,7 @@ void GraphicsContextGLCocoa::enableFoveation(GCGLuint fbo)
 
 void GraphicsContextGLCocoa::disableFoveation()
 {
-#if ENABLE(WEBXR) && !PLATFORM(IOS_FAMILY_SIMULATOR)
+#if !PLATFORM(IOS_FAMILY_SIMULATOR)
     GL_Disable(GL::VARIABLE_RASTERIZATION_RATE_ANGLE);
     GL_BindMetalRasterizationRateMapANGLE(0, nullptr);
 #endif
@@ -770,16 +761,13 @@ GCGLExternalSync GraphicsContextGLCocoa::createExternalSync(ExternalSyncSource&&
 
 bool GraphicsContextGLCocoa::enableRequiredWebXRExtensions()
 {
-#if ENABLE(WEBXR)
     if (!makeContextCurrent())
         return false;
     if (enableRequiredWebXRExtensionsImpl())
         return true;
-#endif
     return false;
 }
 
-#if ENABLE(WEBXR)
 bool GraphicsContextGLCocoa::enableRequiredWebXRExtensionsImpl()
 {
     return enableExtension("GL_ANGLE_framebuffer_multisample"_s)

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -293,16 +293,20 @@ void GraphicsContextGLGBM::allocateDrawBufferObject()
     GL_EGLImageTargetTexture2DOES(textureTarget, result.iterator->value);
 }
 
+#if ENABLE(WEBXR)
 bool GraphicsContextGLGBM::addFoveation(IntSize, IntSize, IntSize, std::span<const GCGLfloat>, std::span<const GCGLfloat>, std::span<const GCGLfloat>)
 {
     return false;
 }
+
 void GraphicsContextGLGBM::enableFoveation(GCGLuint)
 {
 }
+
 void GraphicsContextGLGBM::disableFoveation()
 {
 }
+#endif
 
 GraphicsContextGLGBM::Swapchain::Swapchain(GCGLDisplay platformDisplay)
     : platformDisplay(platformDisplay)

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
@@ -69,9 +69,11 @@ public:
     bool platformInitializeExtensions() override;
 
     bool reshapeDrawingBuffer() override;
+#if ENABLE(WEBXR)
     bool addFoveation(IntSize, IntSize, IntSize, std::span<const GCGLfloat>, std::span<const GCGLfloat>, std::span<const GCGLfloat>) override;
     void enableFoveation(GCGLuint) override;
     void disableFoveation() override;
+#endif
 
     struct Swapchain {
         Swapchain() = default;

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -385,6 +385,7 @@ bool GraphicsContextGLTextureMapperANGLE::unmakeCurrentImpl()
     return !!EGL_MakeCurrent(m_displayObj, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 }
 
+#if ENABLE(WEBXR)
 bool GraphicsContextGLTextureMapperANGLE::addFoveation(IntSize, IntSize, IntSize, std::span<const GCGLfloat>, std::span<const GCGLfloat>, std::span<const GCGLfloat>)
 {
     return false;
@@ -397,6 +398,7 @@ void GraphicsContextGLTextureMapperANGLE::enableFoveation(GCGLuint)
 void GraphicsContextGLTextureMapperANGLE::disableFoveation()
 {
 }
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -62,9 +62,11 @@ public:
     void setContextVisibility(bool) final;
     bool reshapeDrawingBuffer() final;
     void prepareForDisplay() final;
+#if ENABLE(WEBXR)
     bool addFoveation(IntSize, IntSize, IntSize, std::span<const GCGLfloat>, std::span<const GCGLfloat>, std::span<const GCGLfloat>) final;
     void enableFoveation(GCGLuint) final;
     void disableFoveation() final;
+#endif
 
 private:
     GraphicsContextGLTextureMapperANGLE(WebCore::GraphicsContextGLAttributes&&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -322,15 +322,19 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void GetInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, size_t paramsSize) -> (std::span<const int32_t> params) Synchronous
     void SetDrawingBufferColorSpace(WebCore::DestinationColorSpace arg0)
     void DrawingBufferToPixelBuffer(enum:bool WebCore::GraphicsContextGLFlipY arg0) -> (RefPtr<WebCore::PixelBuffer> returnValue) Synchronous
-    void CreateExternalImage(uint32_t externalImage, WebCore::GraphicsContextGL::ExternalImageSource arg0, uint32_t internalFormat, int32_t layer) NotStreamEncodable
-    void DeleteExternalImage(uint32_t handle)
-    void BindExternalImage(uint32_t target, uint32_t arg1)
-    void CreateExternalSync(uint32_t externalSync, WebCore::GraphicsContextGL::ExternalSyncSource arg0) NotStreamEncodable
-    void DeleteExternalSync(uint32_t arg0)
+#if ENABLE(WEBXR)
+    [EnabledIf='webXREnabled()'] void CreateExternalImage(uint32_t externalImage, WebCore::GraphicsContextGL::ExternalImageSource arg0, uint32_t internalFormat, int32_t layer) NotStreamEncodable
+    [EnabledIf='webXREnabled()'] void DeleteExternalImage(uint32_t handle)
+    [EnabledIf='webXREnabled()'] void BindExternalImage(uint32_t target, uint32_t arg1)
+    [EnabledIf='webXREnabled()'] void CreateExternalSync(uint32_t externalSync, WebCore::GraphicsContextGL::ExternalSyncSource arg0) NotStreamEncodable
+#endif
+    [EnabledIf='webXREnabled()'] void DeleteExternalSync(uint32_t arg0)
+#if ENABLE(WEBXR)
     [EnabledIf='webXREnabled()'] void EnableRequiredWebXRExtensions() -> (bool returnValue) Synchronous
     [EnabledIf='webXREnabled()'] void AddFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const float> horizontalSamplesLeft, std::span<const float> verticalSamples, std::span<const float> horizontalSamplesRight) -> (bool returnValue) Synchronous
     [EnabledIf='webXREnabled()'] void EnableFoveation(uint32_t arg0)
     [EnabledIf='webXREnabled()'] void DisableFoveation()
+#endif
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -1652,6 +1652,7 @@
         returnValue = m_context->drawingBufferToPixelBuffer(arg0);
         completionHandler(WTFMove(returnValue));
     }
+#if ENABLE(WEBXR)
     void createExternalImage(uint32_t name, WebCore::GraphicsContextGL::ExternalImageSource&& arg0, uint32_t internalFormat, int32_t layer)
     {
         assertIsCurrent(workQueue());
@@ -1681,6 +1682,7 @@
         if (result)
             m_objectNames.add(name, result);
     }
+#endif
     void deleteExternalSync(uint32_t arg0)
     {
         assertIsCurrent(workQueue());
@@ -1689,6 +1691,7 @@
         arg0 = m_objectNames.take(arg0);
         m_context->deleteExternalSync(arg0);
     }
+#if ENABLE(WEBXR)
     void enableRequiredWebXRExtensions(CompletionHandler<void(bool)>&& completionHandler)
     {
         assertIsCurrent(workQueue());
@@ -1713,4 +1716,5 @@
         assertIsCurrent(workQueue());
         m_context->disableFoveation();
     }
+#endif
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -364,17 +364,21 @@ public:
     void getInternalformativ(GCGLenum target, GCGLenum internalformat, GCGLenum pname, std::span<GCGLint> params) final;
     void setDrawingBufferColorSpace(const WebCore::DestinationColorSpace&) final;
     RefPtr<WebCore::PixelBuffer> drawingBufferToPixelBuffer(WebCore::GraphicsContextGLFlipY) final;
-    GCGLExternalImage createExternalImage(WebCore::GraphicsContextGL::ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) final;
-    void deleteExternalImage(GCGLExternalImage handle) final;
-    void bindExternalImage(GCGLenum target, GCGLExternalImage) final;
-    GCGLExternalSync createExternalSync(WebCore::GraphicsContextGL::ExternalSyncSource&&) final;
-    void deleteExternalSync(GCGLExternalSync) final;
 
+#if ENABLE(WEBXR)
+    GCGLExternalImage createExternalImage(WebCore::GraphicsContextGL::ExternalImageSource&&, GCGLenum internalFormat, GCGLint layer) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
+    void deleteExternalImage(GCGLExternalImage handle) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
+    void bindExternalImage(GCGLenum target, GCGLExternalImage) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
+    GCGLExternalSync createExternalSync(WebCore::GraphicsContextGL::ExternalSyncSource&&) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
+#endif
+    void deleteExternalSync(GCGLExternalSync) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
+
+#if ENABLE(WEBXR)
     bool enableRequiredWebXRExtensions() IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
     bool addFoveation(WebCore::IntSize physicalSizeLeft, WebCore::IntSize physicalSizeRight, WebCore::IntSize screenSize, std::span<const GCGLfloat> horizontalSamplesLeft, std::span<const GCGLfloat> verticalSamples, std::span<const GCGLfloat> horizontalSamplesRight) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
     void enableFoveation(GCGLuint) IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
     void disableFoveation() IPC_MESSAGE_ATTRIBUTE(EnabledIf='webXREnabled()') final;
-
+#endif
     // End of list used by generate-gpup-webgl script.
 
     static bool handleMessageToRemovedDestination(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -3073,6 +3073,7 @@ RefPtr<WebCore::PixelBuffer> RemoteGraphicsContextGLProxy::drawingBufferToPixelB
     return returnValue;
 }
 
+#if ENABLE(WEBXR)
 GCGLExternalImage RemoteGraphicsContextGLProxy::createExternalImage(WebCore::GraphicsContextGL::ExternalImageSource&& arg0, GCGLenum internalFormat, GCGLint layer)
 {
     if (isContextLost())
@@ -3120,6 +3121,7 @@ GCGLExternalSync RemoteGraphicsContextGLProxy::createExternalSync(WebCore::Graph
     }
     return name;
 }
+#endif
 
 void RemoteGraphicsContextGLProxy::deleteExternalSync(GCGLExternalSync arg0)
 {
@@ -3132,6 +3134,7 @@ void RemoteGraphicsContextGLProxy::deleteExternalSync(GCGLExternalSync arg0)
     }
 }
 
+#if ENABLE(WEBXR)
 bool RemoteGraphicsContextGLProxy::enableRequiredWebXRExtensions()
 {
     if (isContextLost())
@@ -3179,6 +3182,7 @@ void RemoteGraphicsContextGLProxy::disableFoveation()
         return;
     }
 }
+#endif
 
 }
 

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -457,13 +457,15 @@ class cpp_func(object):
     args: cpp_arg_list
     return_type: cpp_type
     attr: str
+    cond: str
     overload_suffix: str
 
-    def __init__(self, name: str, return_type: cpp_type, args: cpp_arg_list, attr: str):
+    def __init__(self, name: str, return_type: cpp_type, args: cpp_arg_list, attr: str, cond: str):
         self.name = name
         self.return_type = return_type
         self.args = args
         self.attr = attr
+        self.cond = cond
         self.overload_suffix = ""
 
     def __str__(self):
@@ -606,6 +608,7 @@ non_stream_types = set({"WebCore::GraphicsContextGL::ExternalImageSource&&", "We
 
 
 class webkit_ipc_msg(object):
+    cond: str
     attr: str
     name: str
     in_args: cpp_arg_list
@@ -613,6 +616,7 @@ class webkit_ipc_msg(object):
 
     def __init__(self, func: cpp_func):
         self.attr = func.attr
+        self.cond = func.cond
         self.name = webkit_ipc_msg_name(func)
         in_args, out_args = func.get_args_categories()
         ipc_in_args = [cpp_arg(webkit_ipc_msg_arg_type(a.type), a.name) for a in in_args]
@@ -641,6 +645,7 @@ class webkit_ipc_msg(object):
 
 
 class webkit_ipc_cpp_proxy_impl(object):
+    cond: str
     name: str
     is_create: bool
     msg_name: str
@@ -655,6 +660,7 @@ class webkit_ipc_cpp_proxy_impl(object):
     out_exprs: List[cpp_expr]
 
     def __init__(self, cpp_func: cpp_func):
+        self.cond = cpp_func.cond
         self.name = cpp_func.name
         self.is_create = is_create_func(cpp_func)
         self.msg_name = webkit_ipc_msg_name(cpp_func)
@@ -801,13 +807,29 @@ class context_proxy_cpp_webkit_ipc_generator(object):
     "RemoteGraphicsContextGLProxy C++ implementation generator."
     impls: List[webkit_ipc_cpp_proxy_impl]
     unimpls: List[webkit_ipc_cpp_proxy_placeholder]
+    cond: str
 
     def __init__(self, funcs: Iterable[cpp_func], unimplemented: Iterable[cpp_func]):
         self.impls = [webkit_ipc_cpp_proxy_impl(f) for f in funcs]
         self.unimpls = [webkit_ipc_cpp_proxy_placeholder(f) for f in unimplemented]
+        self.cond = ""
+
+    def open_cond(self, impl):
+        if self.cond != impl.cond:
+            close_cond = "#endif\n" if self.cond else ""
+            open_cond = f"\n#if {impl.cond}" if impl.cond else ""
+            self.cond = impl.cond
+            return f"{close_cond}{open_cond}"
+        return ""
+
+    def close_cond(self):
+        if self.cond:
+            self.cond = ""
+            return "\n#endif"
+        return ""
 
     def get_functions(self):
-        return "\n".join(str(i) for i in self.impls + self.unimpls)
+        return "\n".join(f"{self.open_cond(i)}{i}" for i in self.impls) + self.close_cond() + "\n".join(str(i) for i in self.unimpls)
 
     def generate(self):
         write_file(
@@ -820,6 +842,7 @@ named_object_types = set(["PlatformGLObject", "GCGLExternalImage", "GCGLExternal
 
 
 class webkit_ipc_cpp_impl(object):
+    cond: str
     name: str
     args: cpp_arg_list
     pre_call_stmts: List[str]
@@ -830,6 +853,7 @@ class webkit_ipc_cpp_impl(object):
     return_value_expr: Optional[cpp_expr]
 
     def __init__(self, cpp_func: cpp_func):
+        self.cond = cpp_func.cond
         self.name = cpp_func.name
         self.is_create = is_create_func(cpp_func)
         self.is_delete = is_delete_func(cpp_func)
@@ -966,12 +990,28 @@ def webkit_ipc_resolve_overload_suffix(funcs: Iterable[cpp_func]):
 class context_cpp_webkit_ipc_generator(object):
     "RemoteGraphicsContextGL C++ implementation generator."
     impls: List[webkit_ipc_cpp_impl]
+    cond: str
 
     def __init__(self, funcs: Iterable[cpp_func]):
         self.impls = [webkit_ipc_cpp_impl(f) for f in funcs]
+        self.cond = ""
+
+    def open_cond(self, impl):
+        if self.cond != impl.cond:
+            close_cond = "#endif\n" if self.cond else ""
+            open_cond = f"#if {impl.cond}\n" if impl.cond else ""
+            self.cond = impl.cond
+            return f"{close_cond}{open_cond}"
+        return ""
+
+    def close_cond(self):
+        if self.cond:
+            self.cond = ""
+            return "\n#endif"
+        return ""
 
     def get_functions(self):
-        return "\n".join(str(i) for i in self.impls)
+        return "\n".join(f"{self.open_cond(i)}{i}" for i in self.impls) + self.close_cond()
 
     def generate(self):
         write_file(
@@ -983,12 +1023,28 @@ class context_cpp_webkit_ipc_generator(object):
 class context_msg_webkit_ipc_generator(object):
     "RemoteGraphicsContextGL WebKit IPC message definition generator."
     msgs: List[webkit_ipc_msg]
+    cond: str
 
     def __init__(self, funcs: Iterable[cpp_func]):
         self.msgs = [webkit_ipc_msg(f) for f in funcs]
+        self.cond = ""
+
+    def open_cond(self, msg):
+        if self.cond != msg.cond:
+            close_cond = "\n#endif" if self.cond else ""
+            open_cond = f"\n#if {msg.cond}" if msg.cond else ""
+            self.cond = msg.cond
+            return f"{close_cond}{open_cond}"
+        return ""
+
+    def close_cond(self):
+        if self.cond:
+            self.cond = ""
+            return "\n#endif"
+        return ""
 
     def get_messages(self):
-        return "".join(str(m) for m in self.msgs)
+        return "".join(f"{self.open_cond(m)}{m}" for m in self.msgs) + self.close_cond()
 
     def generate(self):
         write_file(context_messages_fn, context_messages_template.format(self.get_messages()))
@@ -1011,8 +1067,8 @@ def create_cpp_arg_list(args_specs: Iterable[str]):
     return cpp_arg_list([create_cpp_arg(arg_spec=e, arg_index=i) for i, e in enumerate(args_specs)])
 
 
-def create_cpp_func(name: str, return_spec: str, args_specs: List[str], attr: str):
-    return cpp_func(name=name, return_type=get_cpp_type(return_spec), args=create_cpp_arg_list(args_specs), attr=attr)
+def create_cpp_func(name: str, return_spec: str, args_specs: List[str], attr: str, cond: str):
+    return cpp_func(name=name, return_type=get_cpp_type(return_spec), args=create_cpp_arg_list(args_specs), attr=attr, cond=cond)
 
 
 def read_lines_until(lines: Iterable[str], match: str) -> Generator[str, None, None]:
@@ -1031,6 +1087,7 @@ def main():
 
     funcs = []
     unimplemented = []
+    cond = ""
     for fn in functions_input_fns:
         with open(fn) as f:
             lines = iter(f.readlines())
@@ -1038,6 +1095,15 @@ def main():
                 pass
 
             for line in read_lines_until(lines, "// End of list used by generate-gpup-webgl script."):
+                m = re.match(r"\s*#\s*if\s+(.*\S)\s*$", line)
+                if m:
+                    # FIXME: Nested conditions are not handled
+                    cond=m[1]
+                    continue
+                m = re.match(r"\s*#\s*endif", line)
+                if m:
+                    cond=""
+                    continue
                 m = re.match(r"\s*(\S+)\s+(\w+)\((.*?)\)\s+(IPC_MESSAGE_ATTRIBUTE\((\S+?)\)\s+)?final;", line)
                 if m:
                     func_name = m[2]
@@ -1045,7 +1111,8 @@ def main():
                         name=func_name,
                         return_spec=m[1],
                         args_specs=cpp_split_args_specs(m[3]),
-                        attr=m[5]
+                        attr=m[5],
+                        cond=cond
                     )
                     if func.is_implemented():
                         funcs.append(func)


### PR DESCRIPTION
#### 11a40e5a9e192bce547842012880e22a047f5a26
<pre>
[WebXR] Enable WebXR-specific GraphicsContextGL extensions only when needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=272641">https://bugs.webkit.org/show_bug.cgi?id=272641</a>
<a href="https://rdar.apple.com/126432404">rdar://126432404</a>

Reviewed by Kimmo Kinnunen.

Only compile in WebXR-specific GraphicsContextGL extensions when ENABLE(WEBXR).
When ENABLE(WEBXR), only enable WebXR-specific GraphicsContextGL extensions IPC
endpoints when WebXR feature is enabled via preferences.

* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::addFoveation):
(WebCore::GraphicsContextGLCocoa::enableFoveation):
(WebCore::GraphicsContextGLCocoa::disableFoveation):
(WebCore::GraphicsContextGLCocoa::enableRequiredWebXRExtensions):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
* Tools/Scripts/generate-gpup-webgl:
(cpp_func):
(cpp_func.__init__):
(webkit_ipc_msg):
(webkit_ipc_msg.__init__):
(webkit_ipc_msg.__str__):
(webkit_ipc_cpp_proxy_impl):
(webkit_ipc_cpp_proxy_impl.__init__):
(webkit_ipc_cpp_proxy_impl.__str__):
(webkit_ipc_cpp_impl):
(webkit_ipc_cpp_impl.__init__):
(webkit_ipc_cpp_impl.__str__):
(create_cpp_arg_list):
(create_cpp_func):
(main):

Canonical link: <a href="https://commits.webkit.org/277607@main">https://commits.webkit.org/277607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0241d4d3a5cdd80fa10940f8a8efa4e19f1e46b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50786 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44162 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24807 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24988 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20432 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22464 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6154 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52685 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19505 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41759 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45525 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10614 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25214 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->