### PR TITLE
[GTK][WPE] Show DRM version and buffer information in webkit://gpu

### DIFF
--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -514,7 +514,7 @@ def types_that_cannot_be_forward_declared():
 
 def conditions_for_header(header):
     conditions = {
-        '"DMABufRendererBufferFormat.h"': ["USE(GBM)"],
+        '"DMABufRendererBufferFormat.h"': ["PLATFORM(GTK)", "PLATFORM(WPE)"],
         '"GestureTypes.h"': ["PLATFORM(IOS_FAMILY)"],
         '"InputMethodState.h"': ["PLATFORM(GTK)", "PLATFORM(WPE)"],
         '"MediaPlaybackTargetContextSerialized.h"': ["ENABLE(WIRELESS_PLAYBACK_TARGET)"],

--- a/Source/WebKit/Shared/glib/DMABufRendererBufferFormat.serialization.in
+++ b/Source/WebKit/Shared/glib/DMABufRendererBufferFormat.serialization.in
@@ -22,18 +22,14 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-#if USE(GBM)
-
 struct WebKit::DMABufRendererBufferFormat {
     WebKit::DMABufRendererBufferFormat::Usage usage;
     uint32_t fourcc;
     Vector<uint64_t, 1> modifiers;
-};
+}
 
-[Nested] enum class WebKit::DMABufRendererBufferFormatUsage : uint8_t {
+enum class WebKit::DMABufRendererBufferFormatUsage : uint8_t {
     Rendering,
     Mapping,
     Scanout
-};
-
-#endif
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -3052,6 +3052,17 @@ void webkitWebViewPermissionStateQuery(WebKitWebView* webView, WebKitPermissionS
     g_signal_emit(webView, signals[QUERY_PERMISSION_STATE], 0, query, &result);
 }
 
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+RendererBufferFormat webkitWebViewGetRendererBufferFormat(WebKitWebView* webView)
+{
+#if PLATFORM(GTK)
+    return webkitWebViewBaseGetRendererBufferFormat(WEBKIT_WEB_VIEW_BASE(webView));
+#elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+    return webView->priv->view->renderBufferFormat();
+#endif
+}
+#endif
+
 #if PLATFORM(WPE)
 /**
  * webkit_web_view_get_backend:

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h
@@ -28,6 +28,7 @@
 
 #include "APIPageConfiguration.h"
 #include "EditingRange.h"
+#include "RendererBufferFormat.h"
 #include "UserMessage.h"
 #include "WebContextMenuItemData.h"
 #include "WebEvent.h"
@@ -127,3 +128,7 @@ void webkitWebViewSetIsWebProcessResponsive(WebKitWebView*, bool);
 
 guint createShowOptionMenuSignal(WebKitWebViewClass*);
 guint createContextMenuSignal(WebKitWebViewClass*);
+
+#if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
+WebKit::RendererBufferFormat webkitWebViewGetRendererBufferFormat(WebKitWebView*);
+#endif

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -3493,3 +3493,12 @@ void webkitWebViewBaseSetPlugID(WebKitWebViewBase* webViewBase, const String& pl
 #endif // GTK_ACCESSIBILITY_ATSPI
 }
 #endif
+
+RendererBufferFormat webkitWebViewBaseGetRendererBufferFormat(WebKitWebViewBase* webViewBase)
+{
+    auto* drawingArea = static_cast<DrawingAreaProxyCoordinatedGraphics*>(webViewBase->priv->pageProxy->drawingArea());
+    if (!drawingArea || !drawingArea->isInAcceleratedCompositingMode())
+        return { };
+
+    return webViewBase->priv->acceleratedBackingStore->bufferFormat();
+}

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -29,6 +29,7 @@
 
 #include "APIPageConfiguration.h"
 #include "InputMethodState.h"
+#include "RendererBufferFormat.h"
 #include "SameDocumentNavigationType.h"
 #include "ViewGestureController.h"
 #include "ViewSnapshotStore.h"
@@ -145,3 +146,5 @@ void webkitWebViewBaseCallAfterNextPresentationUpdate(WebKitWebViewBase*, Comple
 #if USE(GTK4)
 void webkitWebViewBaseSetPlugID(WebKitWebViewBase*, const String&);
 #endif
+
+WebKit::RendererBufferFormat webkitWebViewBaseGetRendererBufferFormat(WebKitWebViewBase*);

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
@@ -785,6 +785,14 @@ void View::updateAcceleratedSurface(uint64_t surfaceID)
         m_backingStore->updateSurfaceID(surfaceID);
 }
 
+RendererBufferFormat View::renderBufferFormat() const
+{
+    if (!m_backingStore)
+        return { };
+
+    return m_backingStore->bufferFormat();
+}
+
 void View::updateDisplayID()
 {
     auto* monitor = wpe_view_get_monitor(m_wpeView.get());

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
@@ -30,6 +30,7 @@
 #include "InputMethodFilter.h"
 #include "KeyAutoRepeatHandler.h"
 #include "PageClientImpl.h"
+#include "RendererBufferFormat.h"
 #include "WebFullScreenManagerProxy.h"
 #include "WebKitWebViewAccessible.h"
 #include "WebPageProxy.h"
@@ -142,6 +143,7 @@ public:
 
 #if ENABLE(WPE_PLATFORM)
     void updateAcceleratedSurface(uint64_t);
+    WebKit::RendererBufferFormat renderBufferFormat() const;
 #endif
 
     void setCursor(const WebCore::Cursor&);

--- a/Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in
+++ b/Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in
@@ -22,7 +22,7 @@
 
 #if USE(EGL)
 messages -> AcceleratedBackingStoreDMABuf NotRefCounted {
-    DidCreateBuffer(uint64_t id, WebCore::IntSize size, uint32_t format, Vector<UnixFileDescriptor> fds, Vector<uint32_t> offsets, Vector<uint32_t> strides, uint64_t modifier)
+    DidCreateBuffer(uint64_t id, WebCore::IntSize size, uint32_t format, Vector<UnixFileDescriptor> fds, Vector<uint32_t> offsets, Vector<uint32_t> strides, uint64_t modifier, WebKit::DMABufRendererBufferFormat::Usage usage)
     DidCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle handle)
     DidDestroyBuffer(uint64_t id)
     Frame(uint64_t id)

--- a/Source/WebKit/UIProcess/glib/RendererBufferFormat.h
+++ b/Source/WebKit/UIProcess/glib/RendererBufferFormat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,26 +25,17 @@
 
 #pragma once
 
-#include <wtf/Vector.h>
+#include "DMABufRendererBufferFormat.h"
 
 namespace WebKit {
 
-enum class DMABufRendererBufferFormatUsage : uint8_t {
-    Rendering,
-    Mapping,
-    Scanout
-};
+struct RendererBufferFormat {
+    enum class Type : bool { DMABuf, SharedMemory };
 
-struct DMABufRendererBufferFormat {
-    bool operator==(const DMABufRendererBufferFormat& other) const
-    {
-        return usage == other.usage && fourcc == other.fourcc && modifiers == other.modifiers;
-    }
-
-    using Usage = DMABufRendererBufferFormatUsage;
-    Usage usage { Usage::Rendering };
+    Type type { Type::DMABuf };
+    DMABufRendererBufferFormat::Usage usage { DMABufRendererBufferFormat::Usage::Rendering };
     uint32_t fourcc { 0 };
-    Vector<uint64_t, 1> modifiers;
+    uint64_t modifier { 0 };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "RendererBufferFormat.h"
 #include <wtf/Noncopyable.h>
 
 typedef struct _cairo cairo_t;
@@ -59,6 +60,7 @@ public:
     virtual void realize() { };
     virtual void unrealize() { };
     virtual int renderHostFileDescriptor() { return -1; }
+    virtual RendererBufferFormat bufferFormat() const { return { }; }
 
 protected:
     AcceleratedBackingStore(WebPageProxy&);

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -147,15 +147,16 @@ AcceleratedBackingStoreDMABuf::~AcceleratedBackingStoreDMABuf()
     }
 }
 
-AcceleratedBackingStoreDMABuf::Buffer::Buffer(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor)
+AcceleratedBackingStoreDMABuf::Buffer::Buffer(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, DMABufRendererBufferFormat::Usage usage)
     : m_id(id)
     , m_size(size)
     , m_deviceScaleFactor(deviceScaleFactor)
+    , m_usage(usage)
 {
 }
 
 #if GTK_CHECK_VERSION(4, 13, 4)
-RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferDMABuf::create(uint64_t id, GdkDisplay* display, const WebCore::IntSize& size, float deviceScaleFactor, uint32_t format, Vector<UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier)
+RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferDMABuf::create(uint64_t id, GdkDisplay* display, const WebCore::IntSize& size, float deviceScaleFactor, DMABufRendererBufferFormat::Usage usage, uint32_t format, Vector<UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier)
 {
     GRefPtr<GdkDmabufTextureBuilder> builder = adoptGRef(gdk_dmabuf_texture_builder_new());
     gdk_dmabuf_texture_builder_set_display(builder.get(), display);
@@ -171,11 +172,11 @@ RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::Buf
         gdk_dmabuf_texture_builder_set_offset(builder.get(), i, offsets[i]);
     }
 
-    return adoptRef(*new BufferDMABuf(id, size, deviceScaleFactor, WTFMove(fds), WTFMove(builder)));
+    return adoptRef(*new BufferDMABuf(id, size, deviceScaleFactor, usage, WTFMove(fds), WTFMove(builder)));
 }
 
-AcceleratedBackingStoreDMABuf::BufferDMABuf::BufferDMABuf(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, Vector<UnixFileDescriptor>&& fds, GRefPtr<GdkDmabufTextureBuilder>&& builder)
-    : Buffer(id, size, deviceScaleFactor)
+AcceleratedBackingStoreDMABuf::BufferDMABuf::BufferDMABuf(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, DMABufRendererBufferFormat::Usage usage, Vector<UnixFileDescriptor>&& fds, GRefPtr<GdkDmabufTextureBuilder>&& builder)
+    : Buffer(id, size, deviceScaleFactor, usage)
     , m_fds(WTFMove(fds))
     , m_builder(WTFMove(builder))
 {
@@ -188,9 +189,14 @@ void AcceleratedBackingStoreDMABuf::BufferDMABuf::didUpdateContents()
     if (!m_texture)
         WTFLogAlways("Failed to create DMA-BUF texture of size %dx%d: %s", m_size.width(), m_size.height(), error->message);
 }
+
+RendererBufferFormat AcceleratedBackingStoreDMABuf::BufferDMABuf::format() const
+{
+    return { RendererBufferFormat::Type::DMABuf, m_usage, gdk_dmabuf_texture_builder_get_fourcc(m_builder.get()), gdk_dmabuf_texture_builder_get_modifier(m_builder.get()) };
+}
 #endif
 
-RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferEGLImage::create(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, uint32_t format, Vector<UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier)
+RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferEGLImage::create(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, DMABufRendererBufferFormat::Usage usage, uint32_t format, Vector<UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier)
 {
     auto& display = WebCore::PlatformDisplay::sharedDisplay();
     Vector<EGLAttrib> attributes = {
@@ -235,13 +241,15 @@ RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::Buf
         return nullptr;
     }
 
-    return adoptRef(*new BufferEGLImage(id, size, deviceScaleFactor, WTFMove(fds), image));
+    return adoptRef(*new BufferEGLImage(id, size, deviceScaleFactor, usage, format, WTFMove(fds), modifier, image));
 }
 
-AcceleratedBackingStoreDMABuf::BufferEGLImage::BufferEGLImage(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, Vector<UnixFileDescriptor>&& fds, EGLImage image)
-    : Buffer(id, size, deviceScaleFactor)
+AcceleratedBackingStoreDMABuf::BufferEGLImage::BufferEGLImage(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, DMABufRendererBufferFormat::Usage usage, uint32_t format, Vector<UnixFileDescriptor>&& fds, uint64_t modifier, EGLImage image)
+    : Buffer(id, size, deviceScaleFactor, usage)
     , m_fds(WTFMove(fds))
     , m_image(image)
+    , m_fourcc(format)
+    , m_modifier(modifier)
 {
 }
 
@@ -303,8 +311,13 @@ void AcceleratedBackingStoreDMABuf::BufferEGLImage::didUpdateContents()
 }
 #endif
 
+RendererBufferFormat AcceleratedBackingStoreDMABuf::BufferEGLImage::format() const
+{
+    return { RendererBufferFormat::Type::DMABuf, m_usage, m_fourcc, m_modifier };
+}
+
 #if USE(GBM)
-RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferGBM::create(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, uint32_t format, UnixFileDescriptor&& fd, uint32_t stride)
+RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferGBM::create(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, DMABufRendererBufferFormat::Usage usage, uint32_t format, UnixFileDescriptor&& fd, uint32_t stride)
 {
     auto* device = WebCore::PlatformDisplay::sharedDisplay().gbmDevice();
     if (!device) {
@@ -319,11 +332,11 @@ RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::Buf
         return nullptr;
     }
 
-    return adoptRef(*new BufferGBM(id, size, deviceScaleFactor, WTFMove(fd), buffer));
+    return adoptRef(*new BufferGBM(id, size, deviceScaleFactor, usage, WTFMove(fd), buffer));
 }
 
-AcceleratedBackingStoreDMABuf::BufferGBM::BufferGBM(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, UnixFileDescriptor&& fd, struct gbm_bo* buffer)
-    : Buffer(id, size, deviceScaleFactor)
+AcceleratedBackingStoreDMABuf::BufferGBM::BufferGBM(uint64_t id, const WebCore::IntSize& size, float deviceScaleFactor, DMABufRendererBufferFormat::Usage usage, UnixFileDescriptor&& fd, struct gbm_bo* buffer)
+    : Buffer(id, size, deviceScaleFactor, usage)
     , m_fd(WTFMove(fd))
     , m_buffer(buffer)
 {
@@ -357,6 +370,11 @@ void AcceleratedBackingStoreDMABuf::BufferGBM::didUpdateContents()
         gbm_bo_unmap(bufferData->buffer->m_buffer, bufferData->data);
     });
 }
+
+RendererBufferFormat AcceleratedBackingStoreDMABuf::BufferGBM::format() const
+{
+    return { RendererBufferFormat::Type::DMABuf, m_usage, gbm_bo_get_format(m_buffer), gbm_bo_get_modifier(m_buffer) };
+}
 #endif
 
 RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::BufferSHM::create(uint64_t id, RefPtr<WebCore::ShareableBitmap>&& bitmap, float deviceScaleFactor)
@@ -368,7 +386,7 @@ RefPtr<AcceleratedBackingStoreDMABuf::Buffer> AcceleratedBackingStoreDMABuf::Buf
 }
 
 AcceleratedBackingStoreDMABuf::BufferSHM::BufferSHM(uint64_t id, RefPtr<WebCore::ShareableBitmap>&& bitmap, float deviceScaleFactor)
-    : Buffer(id, bitmap->size(), deviceScaleFactor)
+    : Buffer(id, bitmap->size(), deviceScaleFactor, DMABufRendererBufferFormat::Usage::Rendering)
     , m_bitmap(WTFMove(bitmap))
 {
 }
@@ -386,6 +404,15 @@ void AcceleratedBackingStoreDMABuf::BufferSHM::didUpdateContents()
     });
 #endif
     cairo_surface_set_device_scale(m_surface.get(), m_deviceScaleFactor, m_deviceScaleFactor);
+}
+
+RendererBufferFormat AcceleratedBackingStoreDMABuf::BufferSHM::format() const
+{
+#if USE(LIBDRM)
+    return { RendererBufferFormat::Type::SharedMemory, m_usage, DRM_FORMAT_ARGB8888, 0 };
+#else
+    return { };
+#endif
 }
 
 #if USE(GTK4)
@@ -464,25 +491,25 @@ void AcceleratedBackingStoreDMABuf::Renderer::paint(GtkWidget* widget, cairo_t* 
 }
 #endif
 
-void AcceleratedBackingStoreDMABuf::didCreateBuffer(uint64_t id, const WebCore::IntSize& size, uint32_t format, Vector<WTF::UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier)
+void AcceleratedBackingStoreDMABuf::didCreateBuffer(uint64_t id, const WebCore::IntSize& size, uint32_t format, Vector<WTF::UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage usage)
 {
 #if USE(GBM)
     if (!WebCore::PlatformDisplay::sharedDisplay().gtkEGLDisplay()) {
         ASSERT(fds.size() == 1 && strides.size() == 1);
-        if (auto buffer = BufferGBM::create(id, size, m_webPage.deviceScaleFactor(), format, WTFMove(fds[0]), strides[0]))
+        if (auto buffer = BufferGBM::create(id, size, m_webPage.deviceScaleFactor(), usage, format, WTFMove(fds[0]), strides[0]))
             m_buffers.add(id, WTFMove(buffer));
         return;
     }
 #endif
 
 #if GTK_CHECK_VERSION(4, 13, 4)
-    if (auto buffer = BufferDMABuf::create(id, gtk_widget_get_display(m_webPage.viewWidget()), size, m_webPage.deviceScaleFactor(), format, WTFMove(fds), WTFMove(offsets), WTFMove(strides), modifier)) {
+    if (auto buffer = BufferDMABuf::create(id, gtk_widget_get_display(m_webPage.viewWidget()), size, m_webPage.deviceScaleFactor(), usage, format, WTFMove(fds), WTFMove(offsets), WTFMove(strides), modifier)) {
         m_buffers.add(id, WTFMove(buffer));
         return;
     }
 #endif
 
-    if (auto buffer = BufferEGLImage::create(id, size, m_webPage.deviceScaleFactor(), format, WTFMove(fds), WTFMove(offsets), WTFMove(strides), modifier))
+    if (auto buffer = BufferEGLImage::create(id, size, m_webPage.deviceScaleFactor(), usage, format, WTFMove(fds), WTFMove(offsets), WTFMove(strides), modifier))
         m_buffers.add(id, WTFMove(buffer));
 }
 
@@ -617,6 +644,12 @@ bool AcceleratedBackingStoreDMABuf::paint(cairo_t* cr, const WebCore::IntRect& c
     return true;
 }
 #endif
+
+RendererBufferFormat AcceleratedBackingStoreDMABuf::bufferFormat() const
+{
+    auto* buffer = m_committedBuffer ? m_committedBuffer.get() : m_pendingBuffer.get();
+    return buffer ? buffer->format() : RendererBufferFormat { };
+}
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
@@ -36,6 +36,10 @@
 #include <wpe/wpe-platform.h>
 #include <wtf/glib/GUniquePtr.h>
 
+#if USE(LIBDRM)
+#include <drm_fourcc.h>
+#endif
+
 namespace WebKit {
 
 std::unique_ptr<AcceleratedBackingStoreDMABuf> AcceleratedBackingStoreDMABuf::create(WebPageProxy& webPage, WPEView* view)
@@ -83,13 +87,14 @@ void AcceleratedBackingStoreDMABuf::updateSurfaceID(uint64_t surfaceID)
 
 }
 
-void AcceleratedBackingStoreDMABuf::didCreateBuffer(uint64_t id, const WebCore::IntSize& size, uint32_t format, Vector<WTF::UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier)
+void AcceleratedBackingStoreDMABuf::didCreateBuffer(uint64_t id, const WebCore::IntSize& size, uint32_t format, Vector<WTF::UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage usage)
 {
     Vector<int> fileDescriptors;
     fileDescriptors.reserveInitialCapacity(fds.size());
     for (auto& fd : fds)
         fileDescriptors.append(fd.release());
     GRefPtr<WPEBuffer> buffer = adoptGRef(WPE_BUFFER(wpe_buffer_dma_buf_new(m_wpeView.get(), size.width(), size.height(), format, fds.size(), fileDescriptors.data(), offsets.data(), strides.data(), modifier)));
+    g_object_set_data(G_OBJECT(buffer.get()), "wk-buffer-format-usage", GUINT_TO_POINTER(usage));
     m_bufferIDs.add(buffer.get(), id);
     m_buffers.add(id, WTFMove(buffer));
 }
@@ -144,13 +149,41 @@ void AcceleratedBackingStoreDMABuf::frameDone()
 void AcceleratedBackingStoreDMABuf::bufferRendered()
 {
     frameDone();
-    m_pendingBuffer = nullptr;
+    m_committedBuffer = WTFMove(m_pendingBuffer);
 }
 
 void AcceleratedBackingStoreDMABuf::bufferReleased(WPEBuffer* buffer)
 {
     if (auto id = m_bufferIDs.get(buffer))
         m_webPage.process().send(Messages::AcceleratedSurfaceDMABuf::ReleaseBuffer(id), m_surfaceID);
+}
+
+RendererBufferFormat AcceleratedBackingStoreDMABuf::bufferFormat() const
+{
+    RendererBufferFormat format;
+    auto* buffer = m_committedBuffer ? m_committedBuffer.get() : m_pendingBuffer.get();
+    if (!buffer)
+        return format;
+
+    if (WPE_IS_BUFFER_DMA_BUF(buffer)) {
+        auto* dmabuf = WPE_BUFFER_DMA_BUF(buffer);
+        format.type = RendererBufferFormat::Type::DMABuf;
+        format.fourcc = wpe_buffer_dma_buf_get_format(dmabuf);
+        format.modifier = wpe_buffer_dma_buf_get_modifier(dmabuf);
+        format.usage = static_cast<DMABufRendererBufferFormat::Usage>(GPOINTER_TO_UINT(g_object_get_data(G_OBJECT(buffer), "wk-buffer-format-usage")));
+    } else if (WPE_IS_BUFFER_SHM(buffer)) {
+        format.type = RendererBufferFormat::Type::SharedMemory;
+        switch (wpe_buffer_shm_get_format(WPE_BUFFER_SHM(buffer))) {
+        case WPE_PIXEL_FORMAT_ARGB8888:
+#if USE(LIBDRM)
+            format.fourcc = DRM_FORMAT_ARGB8888;
+#endif
+            break;
+        }
+        format.usage = DMABufRendererBufferFormat::Usage::Rendering;
+    }
+
+    return format;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WPE_PLATFORM)
 #include "MessageReceiver.h"
+#include "RendererBufferFormat.h"
 #include <WebCore/IntSize.h>
 #include <wtf/HashMap.h>
 #include <wtf/glib/GRefPtr.h>
@@ -56,13 +57,15 @@ public:
 
     void updateSurfaceID(uint64_t);
 
+    RendererBufferFormat bufferFormat() const;
+
 private:
     AcceleratedBackingStoreDMABuf(WebPageProxy&, WPEView*);
 
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    void didCreateBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier);
+    void didCreateBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage);
     void didCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle&&);
     void didDestroyBuffer(uint64_t id);
     void frame(uint64_t bufferID);
@@ -74,6 +77,7 @@ private:
     GRefPtr<WPEView> m_wpeView;
     uint64_t m_surfaceID { 0 };
     GRefPtr<WPEBuffer> m_pendingBuffer;
+    GRefPtr<WPEBuffer> m_committedBuffer;
     HashMap<uint64_t, GRefPtr<WPEBuffer>> m_buffers;
     HashMap<WPEBuffer*, uint64_t> m_bufferIDs;
 };

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h
@@ -29,13 +29,13 @@
 
 #include "AcceleratedSurface.h"
 
+#include "DMABufRendererBufferFormat.h"
 #include "MessageReceiver.h"
 #include <wtf/Noncopyable.h>
 #include <wtf/RunLoop.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
 #if USE(GBM)
-#include "DMABufRendererBufferFormat.h"
 #include <atomic>
 #include <wtf/Lock.h>
 typedef void *EGLImage;
@@ -124,7 +124,7 @@ private:
     class RenderTargetEGLImage final : public RenderTargetColorBuffer {
     public:
         static std::unique_ptr<RenderTarget> create(uint64_t, const WebCore::IntSize&, const DMABufRendererBufferFormat&);
-        RenderTargetEGLImage(uint64_t, const WebCore::IntSize&, EGLImage, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier);
+        RenderTargetEGLImage(uint64_t, const WebCore::IntSize&, EGLImage, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage);
         ~RenderTargetEGLImage();
 
     private:

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -129,9 +129,16 @@ static gboolean wpeViewEventCallback(WPEView* view, WPEEvent* event, WebKitWebVi
     auto modifiers = wpe_event_get_modifiers(event);
     auto keyval = wpe_event_keyboard_get_keyval(event);
 
-    if (modifiers & WPE_MODIFIER_KEYBOARD_CONTROL && keyval == WPE_KEY_q) {
-        g_application_quit(g_application_get_default());
-        return TRUE;
+    if (modifiers & WPE_MODIFIER_KEYBOARD_CONTROL) {
+        if (keyval == WPE_KEY_q) {
+            g_application_quit(g_application_get_default());
+            return TRUE;
+        }
+
+        if (keyval == WPE_KEY_r) {
+            webkit_web_view_reload(webView);
+            return TRUE;
+        }
     }
 
     if (modifiers & WPE_MODIFIER_KEYBOARD_ALT) {


### PR DESCRIPTION
#### 42b12bb9542db3b2b48daf0eac4efb0073582708
<pre>
[GTK][WPE] Show DRM version and buffer information in webkit://gpu
<a href="https://bugs.webkit.org/show_bug.cgi?id=272518">https://bugs.webkit.org/show_bug.cgi?id=272518</a>

Reviewed by Alejandro G. Castro.

This changes the DidCreateBuffer message to also include the usage flags
used when creating the buffer, since that&apos;s also useful information to
show in webkit://gpu.

* Source/WebKit/Scripts/webkit/messages.py:
(conditions_for_header):
* Source/WebKit/Shared/glib/DMABufRendererBufferFormat.h:
* Source/WebKit/Shared/glib/DMABufRendererBufferFormat.serialization.in:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::renderBufferFormat):
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewGetRendererBufferFormat):
* Source/WebKit/UIProcess/API/glib/WebKitWebViewPrivate.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseGetRendererBufferFormat):
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h:
* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::View::renderBufferFormat const):
* Source/WebKit/UIProcess/API/wpe/WPEWebView.h:
* Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in:
* Source/WebKit/UIProcess/glib/RendererBufferFormat.h: Copied from Source/WebKit/Shared/glib/DMABufRendererBufferFormat.h.
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.h:
(WebKit::AcceleratedBackingStore::bufferFormat const):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::Buffer::Buffer):
(WebKit::AcceleratedBackingStoreDMABuf::BufferDMABuf::create):
(WebKit::AcceleratedBackingStoreDMABuf::BufferDMABuf::BufferDMABuf):
(WebKit::AcceleratedBackingStoreDMABuf::BufferDMABuf::format const):
(WebKit::AcceleratedBackingStoreDMABuf::BufferEGLImage::create):
(WebKit::AcceleratedBackingStoreDMABuf::BufferEGLImage::BufferEGLImage):
(WebKit::AcceleratedBackingStoreDMABuf::BufferEGLImage::format const):
(WebKit::AcceleratedBackingStoreDMABuf::BufferGBM::create):
(WebKit::AcceleratedBackingStoreDMABuf::BufferGBM::BufferGBM):
(WebKit::AcceleratedBackingStoreDMABuf::BufferGBM::format const):
(WebKit::AcceleratedBackingStoreDMABuf::BufferSHM::BufferSHM):
(WebKit::AcceleratedBackingStoreDMABuf::BufferSHM::format const):
(WebKit::AcceleratedBackingStoreDMABuf::didCreateBuffer):
(WebKit::AcceleratedBackingStoreDMABuf::bufferFormat const):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::didCreateBuffer):
(WebKit::AcceleratedBackingStoreDMABuf::bufferRendered):
(WebKit::AcceleratedBackingStoreDMABuf::bufferFormat const):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::create):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::RenderTargetEGLImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetTexture::RenderTargetTexture):
(WebKit::AcceleratedSurfaceDMABuf::SwapChain::setupBufferFormat):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:
* Tools/MiniBrowser/wpe/main.cpp:

Canonical link: <a href="https://commits.webkit.org/277428@main">https://commits.webkit.org/277428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0f7fe4ecf9fe83dc5beb0bca4c5299f4a805115

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50137 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43502 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38631 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19954 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/47317 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42066 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5497 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43793 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52014 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18814 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45935 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23760 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44974 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10501 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->