### PR TITLE
[Buildstream SDK] Update to GStreamer 1.24.2 and mold 2.30 releases

### DIFF
--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -13,7 +13,7 @@ sources:
 - kind: patch
   path: patches/fdo-0004-gst-plugins-ugly-Enable-x264-encoder.patch
 - kind: patch
-  path: patches/fdo-0005-GStreamer-Bump-to-1.24.1.patch
+  path: patches/fdo-0005-GStreamer-Bump-to-1.24.2.patch
 - kind: patch
   path: patches/fdo-0006-gst-plugins-bad-Enable-soundtouch.patch
 - kind: patch

--- a/Tools/buildstream/elements/sdk/mold.bst
+++ b/Tools/buildstream/elements/sdk/mold.bst
@@ -22,7 +22,7 @@ sources:
 - kind: git_repo
   url: github_com:rui314/mold.git
   track: v2.*
-  ref: v2.3.1-0-g34c53777fbb4fe6bff59ed745321d92dbf7e4fab
+  ref: v2.30.0-0-gc7f6a91da512ef8a2634a1bef5d4ba82104659fe
 public:
   bst:
     integration-commands:

--- a/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.24.2.patch
+++ b/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.24.2.patch
@@ -89,7 +89,7 @@ index f36b91e..2d73091 100644
    url: freedesktop:gstreamer/gstreamer.git
    track: 1.*[02468].*
 -  ref: 1.22.5-0-gbf6ce1d64a0697e7910826147b48f8f658366a5a
-+  ref: 1.24.1-0-g0d0a1d9d16d1eb0f5355202c9f8f3ae6df19cf3b
++  ref: 1.24.2-0-g2d8273151571fcab887cc81de48e87aeb61b5c06
  - kind: patch_queue
    path: patches/gstreamer
 diff --git a/patches/gstreamer/graceful-error-noopenh264.patch b/patches/gstreamer/graceful-error-noopenh264.patch


### PR DESCRIPTION
#### 421a0ae008d1039a57dc1a324dc37674c32353ee
<pre>
[Buildstream SDK] Update to GStreamer 1.24.2 and mold 2.30 releases
<a href="https://bugs.webkit.org/show_bug.cgi?id=272515">https://bugs.webkit.org/show_bug.cgi?id=272515</a>

Reviewed by Adrian Perez de Castro.

* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/elements/sdk/mold.bst:
* Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.24.2.patch: Renamed from Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.24.1.patch.

Canonical link: <a href="https://commits.webkit.org/277422@main">https://commits.webkit.org/277422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a93d18e59886c341612c0892492c26e91eef1fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50126 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43491 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38620 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24191 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19943 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42053 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5486 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43778 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42468 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52003 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45923 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23749 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44967 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/10502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24539 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6710 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23467 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->