### PR TITLE
[results.webkit.org] Fetch missing range commit on dashboard

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/commit.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/commit.js
@@ -491,6 +491,25 @@ class _CommitBank {
             promises.push(this._load(this._endUuid, endUuid));
         return Promise.all(promises);
     }
+    addCommit(ref) {
+        const query = paramsToQuery({
+            branch: [...this._branches],
+            ref: [ref],
+        });
+
+        return fetch(`api/commits?${query}`).then(response => {
+            let self = this;
+            response.json().then(json => {
+                for (const commit of json) {
+                    const uuid = commit.timestamp * 100 + commit.order;
+                    self.add(uuid, uuid);
+                }
+            });
+        }).catch(error => {
+            // If the load fails, log the error and continue
+            console.error(JSON.stringify(error, null, 4));
+        });
+    }
     reload() {
         let needReload = false;
         const params = queryToParams(document.URL.split('?')[1]);

--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js
@@ -360,12 +360,16 @@ class Dashboard {
             let commit_bank = CommitBank;
             if (Object.hasOwn(globalParams, 'branch'))
                 commit_bank = CommitBank.forBranch(globalParams.branch);
-            for (const commit of CommitBank.commits) {
-                if (commit.identifier == globalParams.before_ref[0] || commit.revision == globalParams.before_ref[0] || commit.hash == globalParams.before_ref[0]) {
+            let doesContain = false;
+            for (const commit of commit_bank.commits) {
+                if (commit.identifier == globalParams.before_ref[0] || commit.revision == globalParams.before_ref[0] || commit.hash.startsWith(globalParams.before_ref[0])) {
                     now = Math.min(now, commit.timestamp);
+                    doesContain = true;
                     break;
                 }
             }
+            if (!doesContain && commit_bank.commits)
+                commit_bank.addCommit(globalParams.before_ref[0])
         }
 
         let oldestUuid = now * 100;


### PR DESCRIPTION
#### a71b5c17fafca668fae8fa0e6bb7d63d7b60fd5c
<pre>
[results.webkit.org] Fetch missing range commit on dashboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=272529">https://bugs.webkit.org/show_bug.cgi?id=272529</a>
<a href="https://rdar.apple.com/126275308">rdar://126275308</a>

Reviewed by Dewei Zhu.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/commit.js:
(prototype.addCommit): Fetch a commit by ref, and ensure that commit&apos;s UUID is contained
in the range for this CommitBank.
* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/dashboard.js:
(Dashboard.prototype.setTilesFromData): If we can&apos;t find before_ref in a CommitBank, specifically
request that ref.

Canonical link: <a href="https://commits.webkit.org/278202@main">https://commits.webkit.org/278202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5be38a1c2dfbe2f6dfcc33a6217799264dc5193d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43506 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38645 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19959 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/47321 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42070 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5501 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43802 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52019 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18818 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45942 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/47494 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23764 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44980 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24554 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7179 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->