### PR TITLE
[WebAuthn] Reject empty appid extension

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid-silent.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid-silent.https-expected.txt
@@ -3,4 +3,5 @@ PASS PublicKeyCredential's [[get]] with malicious payload in a mock hid authenti
 PASS PublicKeyCredential's [[get]] with invalid credential in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with authenticator downgrade in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with authenticator downgrade in a mock hid authenticator. 2
+PASS PublicKeyCredential's [[get]] with empty appid in create
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid-silent.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid-silent.https.html
@@ -47,7 +47,6 @@
         const options = {
             publicKey: {
                 challenge: asciiToUint8Array("123456"),
-                extensions: { appid: "" },
                 timeout: 10
             }
         };
@@ -56,4 +55,18 @@
             internals.setMockWebAuthenticationConfiguration({ silentFailure: true, hid: { stage: "request", subStage: "msg", error: "malicious-payload", canDowngrade: true, payloadBase64: [testCtapErrInvalidCredentialResponseBase64] } });
         return promiseRejects(t, "NotAllowedError", navigator.credentials.get(options), "Operation timed out.");
     }, "PublicKeyCredential's [[get]] with authenticator downgrade in a mock hid authenticator. 2");
+
+    promise_test(function(t) {
+        const options = {
+            publicKey: {
+                challenge: asciiToUint8Array("123456"),
+                extensions: { appid: "" },
+                timeout: 10
+            }
+        };
+
+        if (window.internals)
+            internals.setMockWebAuthenticationConfiguration({ silentFailure: true, hid: { stage: "request", subStage: "msg", error: "malicious-payload", canDowngrade: true, payloadBase64: [testCtapErrInvalidCredentialResponseBase64] } });
+        return promiseRejects(t, "NotAllowedError", navigator.credentials.get(options), "Empty appid in create request.");
+    }, "PublicKeyCredential's [[get]] with empty appid in create");
 </script>

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https-expected.txt
@@ -2,6 +2,5 @@
 PASS PublicKeyCredential's [[get]] with malformed sign response in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with no matched allow credentials in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with no matched allow credentials in a mock hid authenticator. 2
-PASS PublicKeyCredential's [[get]] with no matched allow credentials in a mock hid authenticator. (AppID)
-PASS PublicKeyCredential's [[get]] with no matched allow credentials in a mock hid authenticator. 2 (AppID)
+PASS PublicKeyCredential's [[get]] with empty appid
 

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https.html
@@ -43,32 +43,17 @@
         return promiseRejects(t, "NotAllowedError", navigator.credentials.get(options), "No credentials from the allowCredentials list is found in the authenticator.");
     }, "PublicKeyCredential's [[get]] with no matched allow credentials in a mock hid authenticator. 2");
 
-    // With AppID extension
-    promise_test(function(t) {
+    promise_test(t => {
         const options = {
             publicKey: {
-                challenge: asciiToUint8Array("123456"),
-                allowCredentials: [{ type: "public-key", id: Base64URL.parse(testCredentialIdBase64) }],
+                challenge: Base64URL.parse("MTIzNDU2"),
+                allowCredentials: [{ type: "public-key", id: Base64URL.parse(testU2fCredentialIdBase64) }],
                 extensions: { appid: "" }
             }
         };
 
         if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fApduNoErrorOnlyResponseBase64] } });
-        return promiseRejects(t, "NotAllowedError", navigator.credentials.get(options), "No credentials from the allowCredentials list is found in the authenticator.");
-    }, "PublicKeyCredential's [[get]] with no matched allow credentials in a mock hid authenticator. (AppID)");
-
-    promise_test(function(t) {
-        const options = {
-            publicKey: {
-                challenge: asciiToUint8Array("123456"),
-                allowCredentials: [{ type: "public-key", id: Base64URL.parse(testCredentialIdBase64) }, { type: "public-key", id: Base64URL.parse(testCredentialIdBase64) }],
-                extensions: { appid: "" }
-            }
-        };
-
-        if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fApduNoErrorOnlyResponseBase64] } });
-        return promiseRejects(t, "NotAllowedError", navigator.credentials.get(options), "No credentials from the allowCredentials list is found in the authenticator.");
-    }, "PublicKeyCredential's [[get]] with no matched allow credentials in a mock hid authenticator. 2 (AppID)");
+            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "malicious-payload", isU2f: true, payloadBase64: [testU2fSignResponse] } });
+        return promiseRejects(t, "NotAllowedError", navigator.credentials.get(options), "Empty appid in create request.");
+        }, "PublicKeyCredential's [[get]] with empty appid");
 </script>

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -151,7 +151,7 @@ void AuthenticatorCoordinator::create(const Document& document, CredentialCreati
     ASSERT(options.rp.id);
 
     AuthenticationExtensionsClientInputs extensionInputs = {
-        String(),
+        nullString(),
         false,
         std::nullopt,
         std::nullopt
@@ -255,6 +255,10 @@ void AuthenticatorCoordinator::discoverFromExternalSource(const Document& docume
     // Only FIDO AppID Extension is supported.
     if (options.extensions && !options.extensions->appid.isNull()) {
         // The following implements https://www.w3.org/TR/webauthn/#sctn-appid-extension as of 4 March 2019.
+        if (options.extensions->appid.isEmpty()) {
+            promise.reject(Exception { ExceptionCode::NotAllowedError, "Empty appid in create request."_s });
+            return;
+        }
         auto appid = processAppIdExtension(callerOrigin, options.extensions->appid);
         if (!appid) {
             promise.reject(Exception { ExceptionCode::SecurityError, "The origin of the document is not authorized for the provided App ID."_s });


### PR DESCRIPTION
#### 2d34e99f4cc7519b2eab94842591b2b4df6ab653
<pre>
[WebAuthn] Reject empty appid extension
<a href="https://bugs.webkit.org/show_bug.cgi?id=272531">https://bugs.webkit.org/show_bug.cgi?id=272531</a>
<a href="https://rdar.apple.com/90281712">rdar://90281712</a>

Reviewed by Pascoe.

Return a NotSupportedError when appid extension is empty, to match WPT test expectations

* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid-silent.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-hid-silent.https.html:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-failure-u2f.https.html:
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::create):
(WebCore::AuthenticatorCoordinator::discoverFromExternalSource):

Canonical link: <a href="https://commits.webkit.org/279285@main">https://commits.webkit.org/279285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/430ef3c1004202dddf89555efa77e061e36bc663

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/52902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56181 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3625 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/38986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3350 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/42920 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2334 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/29950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24038 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27025 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/2981 "Found 1 new test failure: imported/w3c/web-platform-tests/shadow-dom/focus/focus-shadowhost-display-none.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/1784 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/48885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/57774 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50314 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/45874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49601 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11572 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->