### PR TITLE
[Skia] Add initial support for accelerated filters

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4279,6 +4279,10 @@ OptionSet<FilterRenderingMode> Page::preferredFilterRenderingModes() const
     if (settings().acceleratedFiltersEnabled())
         modes.add(FilterRenderingMode::Accelerated);
 #endif
+#if USE(SKIA)
+    if (settings().acceleratedCompositingEnabled())
+        modes.add(FilterRenderingMode::Accelerated);
+#endif
 #if USE(GRAPHICS_CONTEXT_FILTERS)
     if (settings().graphicsContextFiltersEnabled())
         modes.add(FilterRenderingMode::GraphicsContext);

--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -1,5 +1,6 @@
 list(APPEND WebCore_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBCORE_DIR}/platform/graphics/harfbuzz"
+    "${WEBCORE_DIR}/platform/graphics/filters/skia"
     "${WEBCORE_DIR}/platform/graphics/skia"
 )
 

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -23,10 +23,15 @@
 
 page/skia/MemoryReleaseSkia.cpp
 
+platform/graphics/filters/skia/FEColorMatrixSkiaApplier.cpp
+platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp
+platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp
+
 platform/graphics/skia/TransformationMatrixSkia.cpp
 platform/graphics/skia/ColorSkia.cpp
 platform/graphics/skia/ComplexTextControllerSkia.cpp
 platform/graphics/skia/DrawGlyphsRecorderSkia.cpp
+platform/graphics/skia/FilterImageSkia.cpp
 platform/graphics/skia/FloatRectSkia.cpp
 platform/graphics/skia/FloatRoundedRectSkia.cpp
 platform/graphics/skia/FontCacheSkia.cpp

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
@@ -33,6 +33,10 @@
 #include "FEColorMatrixCoreImageApplier.h"
 #endif
 
+#if USE(SKIA)
+#include "FEColorMatrixSkiaApplier.h"
+#endif
+
 namespace WebCore {
 
 Ref<FEColorMatrix> FEColorMatrix::create(ColorMatrixType type, Vector<float>&& values, DestinationColorSpace colorSpace)
@@ -124,6 +128,9 @@ OptionSet<FilterRenderingMode> FEColorMatrix::supportedFilterRenderingModes() co
     if (FEColorMatrixCoreImageApplier::supportsCoreImageRendering(*this))
         modes.add(FilterRenderingMode::Accelerated);
 #endif
+#if USE(SKIA)
+    modes.add(FilterRenderingMode::Accelerated);
+#endif
 #if HAVE(CGSTYLE_COLORMATRIX_BLUR)
     if (m_type == ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX)
         modes.add(FilterRenderingMode::GraphicsContext);
@@ -135,6 +142,8 @@ std::unique_ptr<FilterEffectApplier> FEColorMatrix::createAcceleratedApplier() c
 {
 #if USE(CORE_IMAGE)
     return FilterEffectApplier::create<FEColorMatrixCoreImageApplier>(*this);
+#elif USE(SKIA)
+    return FilterEffectApplier::create<FEColorMatrixSkiaApplier>(*this);
 #else
     return nullptr;
 #endif
@@ -142,7 +151,11 @@ std::unique_ptr<FilterEffectApplier> FEColorMatrix::createAcceleratedApplier() c
 
 std::unique_ptr<FilterEffectApplier> FEColorMatrix::createSoftwareApplier() const
 {
+#if USE(SKIA)
+    return FilterEffectApplier::create<FEColorMatrixSkiaApplier>(*this);
+#else
     return FilterEffectApplier::create<FEColorMatrixSoftwareApplier>(*this);
+#endif
 }
 
 std::optional<GraphicsStyle> FEColorMatrix::createGraphicsStyle(const Filter&) const

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
@@ -59,6 +59,7 @@ private:
 
     OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
 
+    std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
     std::optional<GraphicsStyle> createGraphicsStyle(const Filter&) const override;
 

--- a/Source/WebCore/platform/graphics/filters/FilterImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.cpp
@@ -103,6 +103,9 @@ size_t FilterImage::memoryCost() const
 #if USE(CORE_IMAGE)
     if (m_ciImage)
         memoryCost += memoryCostOfCIImage();
+#elif USE(SKIA)
+    if (m_skPicture)
+        memoryCost += memoryCostOfSkPicture();
 #endif
 
     return memoryCost;
@@ -113,6 +116,9 @@ ImageBuffer* FilterImage::imageBuffer()
 #if USE(CORE_IMAGE)
     if (m_ciImage)
         return imageBufferFromCIImage();
+#elif USE(SKIA)
+    if (m_skPicture)
+        return imageBufferFromSkPicture();
 #endif
     return imageBufferFromPixelBuffer();
 }

--- a/Source/WebCore/platform/graphics/filters/FilterImage.h
+++ b/Source/WebCore/platform/graphics/filters/FilterImage.h
@@ -37,6 +37,11 @@
 OBJC_CLASS CIImage;
 #endif
 
+#if USE(SKIA)
+#include <skia/core/SkPicture.h>
+#include <skia/core/SkPictureRecorder.h>
+#endif
+
 namespace WebCore {
 
 class Filter;
@@ -80,6 +85,12 @@ public:
     size_t memoryCostOfCIImage() const;
 #endif
 
+#if USE(SKIA)
+    SkCanvas* beginRecording();
+    void finishRecording();
+    size_t memoryCostOfSkPicture() const;
+#endif
+
 private:
     FilterImage(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, bool isAlphaImage, bool isValidPremultiplied, RenderingMode, const DestinationColorSpace&, ImageBufferAllocator&);
     FilterImage(const FloatRect& primitiveSubregion, const FloatRect& imageRect, const IntRect& absoluteImageRect, Ref<ImageBuffer>&&, ImageBufferAllocator&);
@@ -90,6 +101,10 @@ private:
 
 #if USE(CORE_IMAGE)
     ImageBuffer* imageBufferFromCIImage();
+#endif
+
+#if USE(SKIA)
+    ImageBuffer* imageBufferFromSkPicture();
 #endif
 
     bool requiresPixelBufferColorSpaceConversion(std::optional<DestinationColorSpace>) const;
@@ -109,6 +124,11 @@ private:
 
 #if USE(CORE_IMAGE)
     RetainPtr<CIImage> m_ciImage;
+#endif
+
+#if USE(SKIA)
+    SkPictureRecorder m_pictureRecorder;
+    sk_sp<SkPicture> m_skPicture;
 #endif
 
     ImageBufferAllocator& m_allocator;

--- a/Source/WebCore/platform/graphics/filters/SourceGraphic.cpp
+++ b/Source/WebCore/platform/graphics/filters/SourceGraphic.cpp
@@ -29,6 +29,10 @@
 #include "SourceGraphicCoreImageApplier.h"
 #endif
 
+#if USE(SKIA)
+#include "SourceGraphicSkiaApplier.h"
+#endif
+
 namespace WebCore {
 
 Ref<SourceGraphic> SourceGraphic::create(DestinationColorSpace colorSpace)
@@ -44,7 +48,7 @@ SourceGraphic::SourceGraphic(DestinationColorSpace colorSpace)
 OptionSet<FilterRenderingMode> SourceGraphic::supportedFilterRenderingModes() const
 {
     OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;
-#if USE(CORE_IMAGE)
+#if USE(CORE_IMAGE) || USE(SKIA)
     modes.add(FilterRenderingMode::Accelerated);
 #endif
 #if USE(GRAPHICS_CONTEXT_FILTERS)
@@ -57,6 +61,8 @@ std::unique_ptr<FilterEffectApplier> SourceGraphic::createAcceleratedApplier() c
 {
 #if USE(CORE_IMAGE)
     return FilterEffectApplier::create<SourceGraphicCoreImageApplier>(*this);
+#elif USE(SKIA)
+    return FilterEffectApplier::create<SourceGraphicSkiaApplier>(*this);
 #else
     return nullptr;
 #endif
@@ -64,7 +70,11 @@ std::unique_ptr<FilterEffectApplier> SourceGraphic::createAcceleratedApplier() c
 
 std::unique_ptr<FilterEffectApplier> SourceGraphic::createSoftwareApplier() const
 {
+#if USE(SKIA)
+    return FilterEffectApplier::create<SourceGraphicSkiaApplier>(*this);
+#else
     return FilterEffectApplier::create<SourceGraphicSoftwareApplier>(*this);
+#endif
 }
 
 TextStream& SourceGraphic::externalRepresentation(TextStream& ts, FilterRepresentation) const

--- a/Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FEColorMatrixSkiaApplier.h"
+
+#if USE(SKIA)
+
+#include "FEColorMatrix.h"
+#include "FilterImage.h"
+#include "ImageBuffer.h"
+#include "NativeImage.h"
+#include <skia/core/SkCanvas.h>
+#include <skia/core/SkColorFilter.h>
+
+namespace WebCore {
+
+bool FEColorMatrixSkiaApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+{
+    ASSERT(inputs.size() == 1);
+    auto& input = inputs[0].get();
+
+    auto sourceImage = input.imageBuffer();
+    if (!sourceImage)
+        return false;
+
+    auto nativeImage = sourceImage->copyNativeImage();
+    if (!nativeImage || !nativeImage->platformImage())
+        return false;
+
+    auto values = FEColorMatrix::normalizedFloats(m_effect.values());
+    Vector<float> matrix;
+    float components[9];
+
+    switch (m_effect.type()) {
+    case ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX:
+        matrix = values;
+        break;
+
+    case ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE:
+        FEColorMatrix::calculateSaturateComponents(components, values[0]);
+        matrix = Vector<float>({
+            components[0], components[1], components[2], 0.0, 0.0,
+            components[3], components[4], components[5], 0.0, 0.0,
+            components[6], components[7], components[8], 0.0, 0.0,
+            0.0, 0.0, 0.0, 1.0, 0.0,
+        });
+        break;
+
+    case ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE:
+        FEColorMatrix::calculateHueRotateComponents(components, values[0]);
+        matrix = Vector<float>({
+            components[0], components[1], components[2], 0.0, 0.0,
+            components[3], components[4], components[5], 0.0, 0.0,
+            components[6], components[7], components[8], 0.0, 0.0,
+            0.0, 0.0, 0.0, 1.0, 0.0,
+        });
+        break;
+
+    case ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA:
+        matrix = Vector<float>({
+            0.0,    0.0,    0.0,    0.0, 0.0,
+            0.0,    0.0,    0.0,    0.0, 0.0,
+            0.0,    0.0,    0.0,    0.0, 0.0,
+            0.2125, 0.7154, 0.0721, 0.0, 0.0,
+        });
+        break;
+
+    case ColorMatrixType::FECOLORMATRIX_TYPE_UNKNOWN:
+        return false;
+    }
+
+    SkPaint paint;
+    paint.setColorFilter(SkColorFilters::Matrix(matrix.data()));
+
+    auto* canvas = result.beginRecording();
+    canvas->drawImage(nativeImage->platformImage(), 0, 0, { }, &paint);
+    result.finishRecording();
+
+    return true;
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.h
+++ b/Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(SKIA)
+
+#include "FilterEffectApplier.h"
+
+namespace WebCore {
+
+class FEColorMatrix;
+
+class FEColorMatrixSkiaApplier final : public FilterEffectConcreteApplier<FEColorMatrix> {
+    WTF_MAKE_FAST_ALLOCATED;
+    using Base = FilterEffectConcreteApplier<FEColorMatrix>;
+
+public:
+    using Base::Base;
+
+private:
+    bool apply(const Filter&, const FilterImageVector&, FilterImage&) const final;
+};
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FEGaussianBlurSkiaApplier.h"
+
+#if USE(SKIA)
+
+#include "FEGaussianBlur.h"
+#include "Filter.h"
+#include "FilterImage.h"
+#include "NativeImage.h"
+#include <skia/core/SkCanvas.h>
+#include <skia/effects/SkImageFilters.h>
+
+namespace WebCore {
+
+bool FEGaussianBlurSkiaApplier::apply(const Filter& filter, const FilterImageVector& inputs, FilterImage& result) const
+{
+    ASSERT(inputs.size() == 1);
+    auto& input = inputs[0].get();
+
+    auto sourceImage = input.imageBuffer();
+    if (!sourceImage)
+        return false;
+
+    auto nativeImage = sourceImage->copyNativeImage();
+    if (!nativeImage || !nativeImage->platformImage())
+        return false;
+
+    FloatSize sigma = FloatSize(m_effect.stdDeviationX(), m_effect.stdDeviationY()) * filter.filterScale();
+
+    SkPaint paint;
+    paint.setImageFilter(SkImageFilters::Blur(sigma.width(), sigma.height(), nullptr));
+
+    auto outsetSize = m_effect.calculateOutsetSize(sigma);
+
+    auto* canvas = result.beginRecording();
+    canvas->drawImage(nativeImage->platformImage(), outsetSize.width(), outsetSize.height(), { }, &paint);
+    result.finishRecording();
+
+    return true;
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.h
+++ b/Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FilterEffectApplier.h"
+
+namespace WebCore {
+
+class FEGaussianBlur;
+
+class FEGaussianBlurSkiaApplier final : public FilterEffectConcreteApplier<FEGaussianBlur> {
+    WTF_MAKE_FAST_ALLOCATED;
+    using Base = FilterEffectConcreteApplier<FEGaussianBlur>;
+
+public:
+    using Base::Base;
+
+private:
+    bool apply(const Filter&, const FilterImageVector&, FilterImage&) const final;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SourceGraphicSkiaApplier.h"
+
+#if USE(SKIA)
+
+#include "Filter.h"
+#include "FilterImage.h"
+#include "ImageBuffer.h"
+#include "NativeImage.h"
+#include <skia/core/SkCanvas.h>
+
+namespace WebCore {
+
+bool SourceGraphicSkiaApplier::apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const
+{
+    auto& input = inputs[0].get();
+
+    auto sourceImage = input.imageBuffer();
+    if (!sourceImage)
+        return false;
+
+    auto nativeImage = sourceImage->copyNativeImage();
+    if (!nativeImage || !nativeImage->platformImage())
+        return false;
+
+    auto* canvas = result.beginRecording();
+    canvas->drawImage(nativeImage->platformImage(), 0, 0);
+    result.finishRecording();
+
+    return true;
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.h
+++ b/Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(SKIA)
+
+#include "FilterEffectApplier.h"
+
+namespace WebCore {
+
+class SourceGraphic;
+
+class SourceGraphicSkiaApplier final : public FilterEffectConcreteApplier<SourceGraphic> {
+    WTF_MAKE_FAST_ALLOCATED;
+    using Base = FilterEffectConcreteApplier<SourceGraphic>;
+
+public:
+    using Base::Base;
+
+private:
+    bool apply(const Filter&, const FilterImageVector&, FilterImage&) const final;
+};
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/FilterImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FilterImageSkia.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FilterImage.h"
+
+#if USE(SKIA)
+
+#include "ImageBufferSkiaAcceleratedBackend.h"
+#include "ImageBufferSkiaUnacceleratedBackend.h"
+#include <skia/core/SkColorSpace.h>
+#include <skia/core/SkPicture.h>
+
+namespace WebCore {
+
+
+SkCanvas* FilterImage::beginRecording()
+{
+    ASSERT(!m_pictureRecorder.getRecordingCanvas());
+
+    return m_pictureRecorder.beginRecording(SkRect(m_absoluteImageRect.width(), m_absoluteImageRect.height()));
+}
+
+void FilterImage::finishRecording()
+{
+    ASSERT(m_pictureRecorder.getRecordingCanvas());
+
+    m_skPicture = m_pictureRecorder.finishRecordingAsPicture();
+}
+
+size_t FilterImage::memoryCostOfSkPicture() const
+{
+    ASSERT(m_skPicture);
+    return m_skPicture->approximateBytesUsed();
+}
+
+ImageBuffer* FilterImage::imageBufferFromSkPicture()
+{
+    ASSERT(m_skPicture);
+
+    if (m_imageBuffer)
+        return m_imageBuffer.get();
+
+    if (m_renderingMode == RenderingMode::Accelerated)
+        m_imageBuffer = ImageBuffer::create<ImageBufferSkiaAcceleratedBackend>(m_absoluteImageRect.size(), 1, m_colorSpace, PixelFormat::BGRA8, RenderingPurpose::Unspecified, { });
+
+    if (!m_imageBuffer)
+        m_imageBuffer = ImageBuffer::create<ImageBufferSkiaUnacceleratedBackend>(m_absoluteImageRect.size(), 1, m_colorSpace, PixelFormat::BGRA8, RenderingPurpose::Unspecified, { });
+
+    if (!m_imageBuffer)
+        return nullptr;
+
+    m_imageBuffer->context().platformContext()->drawPicture(m_skPicture);
+
+    return m_imageBuffer.get();
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)


### PR DESCRIPTION
#### f8c0fe750d94b7db23d193c0b1f31858c2537620
<pre>
[Skia] Add initial support for accelerated filters
<a href="https://bugs.webkit.org/show_bug.cgi?id=272535">https://bugs.webkit.org/show_bug.cgi?id=272535</a>

Reviewed by Carlos Garcia Campos.

This changeset enables accelerated filters on Skia builds.

Make WebCore::Page report FilterRenderingMode::Accelerated on Skia
builds if accelerated compositing is enabled.

Create Skia filters both in accelerated and software-based code paths,
since Skia is able to handle unaccelerated buffers transparently.

Add Skia-specific code to WebCore::FilterImage. The idea is that Skia
filters acquire a SkCanvas with WebCore::FilterImage::beginRecording(),
render the source image however they want, and finish the operation with
WebCore::FilterImage::finishRecording(). This generates a SkPicture
which is then used to paint on the resulting image buffer.

The memory cost is estimated using SkPicture. It&apos;s not an accurate
measure though.

Implement 3 filters as an exercise of usage of this new code:

 * SourceGraphicSkiaApplier, which merely copies the source image
 * FEColorMatrixSkiaApplier, for CSS and SVG filters like saturate(),
   greyscale(), contrast(), and others
 * FEGaussianBlurSkiaApplier, for the blur() filter

More filters will be added in follow up commits, as needed.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::preferredFilterRenderingModes const):
* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp:
(WebCore::FEColorMatrix::supportedFilterRenderingModes const):
(WebCore::FEColorMatrix::createAcceleratedApplier const):
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp:
(WebCore::FEGaussianBlur::supportedFilterRenderingModes const):
(WebCore::FEGaussianBlur::createAcceleratedApplier const):
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.h:
* Source/WebCore/platform/graphics/filters/FilterImage.cpp:
(WebCore::FilterImage::memoryCost const):
(WebCore::FilterImage::imageBuffer):
* Source/WebCore/platform/graphics/filters/FilterImage.h:
* Source/WebCore/platform/graphics/filters/SourceGraphic.cpp:
(WebCore::SourceGraphic::supportedFilterRenderingModes const):
(WebCore::SourceGraphic::createAcceleratedApplier const):
* Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.cpp: Added.
(WebCore::FEColorMatrixSkiaApplier::apply const):
* Source/WebCore/platform/graphics/filters/skia/FEColorMatrixSkiaApplier.h: Added.
* Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.cpp: Added.
(WebCore::FEGaussianBlurSkiaApplier::apply const):
* Source/WebCore/platform/graphics/filters/skia/FEGaussianBlurSkiaApplier.h: Added.
* Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.cpp: Added.
(WebCore::SourceGraphicSkiaApplier::apply const):
* Source/WebCore/platform/graphics/filters/skia/SourceGraphicSkiaApplier.h: Added.
* Source/WebCore/platform/graphics/skia/FilterImageSkia.cpp: Added.
(WebCore::FilterImage::beginRecording):
(WebCore::FilterImage::finishRecording):
(WebCore::FilterImage::memoryCostOfSkPicture const):
(WebCore::FilterImage::imageBufferFromSkPicture):

Canonical link: <a href="https://commits.webkit.org/277690@main">https://commits.webkit.org/277690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a39406f9aba1a85a6cca33ab0a34310369c2f5fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50957 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44334 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39430 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41702 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20580 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22655 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6325 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43336 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52861 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46767 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45691 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10655 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24304 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->