### PR TITLE
[git-webkit] Remove resolve-ChangeLog merge driver

### DIFF
--- a/Tools/Scripts/git-webkit
+++ b/Tools/Scripts/git-webkit
@@ -48,25 +48,6 @@ def is_webkit_filter(to_return):
     return callback
 
 
-def additional_setup(args, repository):
-    if not isinstance(repository, local.Git):
-        return 0
-
-    log.info('Setting merging behavior for changelogs...')
-    if run([
-        repository.executable(),
-        'config', 'merge.changelog.driver',
-        'perl {} --merge-driver -c %O %A %B'.format(os.path.join(
-            os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
-            'Tools', 'Scripts', 'resolve-ChangeLogs',
-        )),
-    ], capture_output=True, cwd=repository.root_path).returncode:
-        sys.stderr.write('Failed to set the git merging behaivor for changelogs...\n')
-        return 1
-    log.info('Set merging behavior for changelogs!')
-    return 0
-
-
 def classifier():
     from webkitscmpy import CommitClassifier
 
@@ -82,7 +63,6 @@ if '__main__' == __name__:
     sys.exit(program.main(
         identifier_template=is_webkit_filter('Canonical link: https://commits.webkit.org/{}'),
         subversion=is_webkit_filter('https://svn.webkit.org/repository/webkit'),
-        additional_setup=is_webkit_filter(additional_setup),
         hooks=os.path.join(os.path.abspath(os.path.join(os.path.dirname(__file__))), 'hooks'),
         classifier=is_webkit_filter(classifier()),
     ))


### PR DESCRIPTION
#### 5a68ed028d1f1bee462f2e98fe0aee24f21ae340
<pre>
[git-webkit] Remove resolve-ChangeLog merge driver
<a href="https://bugs.webkit.org/show_bug.cgi?id=272539">https://bugs.webkit.org/show_bug.cgi?id=272539</a>
<a href="https://rdar.apple.com/126287638">rdar://126287638</a>

Reviewed by Elliott Williams.

* Tools/Scripts/git-webkit:
(additional_setup): Deleted.

Canonical link: <a href="https://commits.webkit.org/277637@main">https://commits.webkit.org/277637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e044713837b1458b9045d48dfb46f13bd58a8160

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50157 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43522 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38649 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40913 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19970 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42082 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5517 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/43817 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52035 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22508 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45952 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23780 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44991 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24570 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6842 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->