### PR TITLE
[WebGPU] Queue.submit attempts to commit each CommandBuffer twice

### DIFF
--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -60,6 +60,7 @@ public:
 
     Device& device() const { return m_device; }
     void makeInvalid(NSString*);
+    void makeInvalidWithoutCommit();
     void setBufferMapCount(int);
     int bufferMapCount() const;
     NSString* lastError() const;

--- a/Source/WebGPU/WebGPU/CommandBuffer.mm
+++ b/Source/WebGPU/WebGPU/CommandBuffer.mm
@@ -55,6 +55,12 @@ void CommandBuffer::makeInvalid(NSString* lastError)
     m_commandBuffer = nil;
 }
 
+void CommandBuffer::makeInvalidWithoutCommit()
+{
+    m_lastErrorString = @"command buffer submitted";
+    m_commandBuffer = nil;
+}
+
 NSString* CommandBuffer::lastError() const
 {
     return m_lastErrorString;

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -255,7 +255,7 @@ void Queue::submit(Vector<std::reference_wrapper<CommandBuffer>>&& commands)
             device->generateAValidationError(command.lastError() ?: @"Command buffer appears twice.");
             return;
         }
-        command.makeInvalid(@"command buffer was submitted");
+        command.makeInvalidWithoutCommit();
     }
 
     for (id<MTLCommandBuffer> commandBuffer in commandBuffersToSubmit)


### PR DESCRIPTION
#### 098fa851202efd6849ae516d7683f4d8438fb057
<pre>
[WebGPU] Queue.submit attempts to commit each CommandBuffer twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=272540">https://bugs.webkit.org/show_bug.cgi?id=272540</a>
&lt;radar://126287846&gt;

Reviewed by NOBODY (OOPS!).

Normally we need to commit invalid CommandBuffers otherwise the
MTLQueue will run out of available command buffers. However, we
don&apos;t want to commit in Queue::submit because we will commit
them all together at the end of the validation logic, specifically
on line 262.

* Source/WebGPU/WebGPU/CommandBuffer.h:
* Source/WebGPU/WebGPU/CommandBuffer.mm:
(WebGPU::CommandBuffer::makeInvalidWithoutCommit):
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::submit):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/098fa851202efd6849ae516d7683f4d8438fb057

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50160 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43525 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24119 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38652 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24274 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19973 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21725 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5520 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43822 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52038 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18836 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45955 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23783 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/44994 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24573 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23501 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->