### PR TITLE
Missing result from Web Extension storage get() with empty string key.

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -97,14 +97,8 @@ void WebExtensionAPIStorageArea::get(WebPage& page, id items, Ref<WebExtensionCa
         keysVector = makeVector<String>(keys);
     }
 
-    if (NSString *key = dynamic_objc_cast<NSString>(items)) {
-        if (!key.length) {
-            callback->call(@{ });
-            return;
-        }
-
+    if (NSString *key = dynamic_objc_cast<NSString>(items))
         keysVector = { key };
-    }
 
     WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::StorageGet(page.webPageProxyIdentifier(), m_type, keysVector), [keysWithDefaultValues, protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<String, WebExtensionError>&& result) {
         if (!result) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm
@@ -265,7 +265,7 @@ TEST(WKWebExtensionAPIStorage, SetCustomObject)
 TEST(WKWebExtensionAPIStorage, Get)
 {
     auto *backgroundScript = Util::constructScript(@[
-        @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'], 'null': null, 'nan': NaN }",
+        @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'], 'null': null, 'nan': NaN, '': 'empty' }",
         @"await browser?.storage?.local?.set(data)",
 
         @"var result = await browser?.storage?.local?.get()",
@@ -277,8 +277,11 @@ TEST(WKWebExtensionAPIStorage, Get)
         @"result = await browser?.storage?.local?.get('nan')",
         @"browser.test.assertEq(result?.nan, null)",
 
-        @"result = await browser?.storage?.local?.get([ 'string', 'number' ])",
-        @"browser.test.assertDeepEq({ 'string': 'string', 'number': 1 }, result)",
+        @"result = await browser?.storage?.local?.get('')",
+        @"browser.test.assertEq(result?.[''], 'empty')",
+
+        @"result = await browser?.storage?.local?.get([ 'string', 'number', 'boolean', 'dictionary', 'array', 'null', 'nan', '' ])",
+        @"browser.test.assertDeepEq(data, result)",
 
         @"result = await browser?.storage?.local?.get({ 'boolean': false, 'unrecognized_key': 'default_value', 'array': [1, true, 'string'], 'null': 42 })",
         @"browser.test.assertDeepEq({ 'boolean': true, 'unrecognized_key': 'default_value', 'array': [1, true, 'string'], 'null': null }, result)",


### PR DESCRIPTION
#### 28ec4a08ef0a78d852aad9a1a6b7392c3c9dd3c5
<pre>
Missing result from Web Extension storage get() with empty string key.
<a href="https://webkit.org/b/272542">https://webkit.org/b/272542</a>
<a href="https://rdar.apple.com/problem/126290503">rdar://problem/126290503</a>

Reviewed by Brian Weinstein.

Allow getting an empty key from storage, we already allowed setting it. It was also working
when using an array of keys, but not a string key.

Bug details: <a href="https://github.com/lapcat/SafariExtensions/issues/12">https://github.com/lapcat/SafariExtensions/issues/12</a>

* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::get): Don&apos;t return early if the key is empty.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIStorage.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, Get)): Add tests for empty key.

Canonical link: <a href="https://commits.webkit.org/277401@main">https://commits.webkit.org/277401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0f573e65f0c0102d2423c7440df5cb55f1f7649

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50165 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43530 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38651 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40925 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19972 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21730 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42094 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5525 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42508 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52043 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18838 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45954 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23788 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24578 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6694 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23506 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->