### PR TITLE
[Site Isolation] http/tests/navigation/page-cache-shared-worker.html crashes

### DIFF
--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -459,7 +459,6 @@ workers [ Skip ]
 ####################
 # Tests that crash #
 ####################
-http/tests/navigation/page-cache-shared-worker.html [ Skip ]
 http/tests/security/beforeload-iframe-server-redirect.html [ Skip ]
 http/tests/security/cross-frame-access-call.html [ Skip ]
 http/tests/security/cross-frame-access-custom.html [ Skip ]

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -102,7 +102,7 @@ ExceptionOr<Ref<SharedWorker>> SharedWorker::create(Document& document, String&&
     auto channel = MessageChannel::create(document);
     auto transferredPort = channel->port2().disentangle();
 
-    ClientOrigin clientOrigin { document.topDocument().securityOrigin().data(), document.securityOrigin().data() };
+    ClientOrigin clientOrigin { document.topOrigin().data(), document.securityOrigin().data() };
     SharedWorkerKey key { clientOrigin, url, options.name };
 
     auto sharedWorker = adoptRef(*new SharedWorker(document, key, channel->port1()));


### PR DESCRIPTION
#### b573c0f764bf00fce735c35624ce2e7e0d36d922
<pre>
[Site Isolation] http/tests/navigation/page-cache-shared-worker.html crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=272557">https://bugs.webkit.org/show_bug.cgi?id=272557</a>
<a href="https://rdar.apple.com/126300675">rdar://126300675</a>

Reviewed by Sihui Liu and Alex Christensen.

`topDocument()` will use the document of the root frame when site isolation is enabled, so we fail an
allowsFirstPartyForCookies check in the network process. Use `Document::topOrigin()` instead.

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::create):

Canonical link: <a href="https://commits.webkit.org/277418@main">https://commits.webkit.org/277418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c029bdb2ce0c626a1d03a57fe0e9fcff3690f63b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50190 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49814 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38672 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/19993 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42113 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5550 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52068 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/45975 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23813 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45017 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24603 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6706 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23532 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->