### PR TITLE
Potential crash related to WKWindowVisibilityObserver

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -887,6 +887,7 @@ private:
     bool m_shouldDeferViewInWindowChanges { false };
     bool m_viewInWindowChangeWasDeferred { false };
     bool m_isPreparingToUnparentView { false };
+    bool m_isObservingWindow { false };
     RetainPtr<NSWindow> m_targetWindowForMovePreparation;
 
     id m_flagsChangedEventMonitor { nullptr };

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1292,8 +1292,8 @@ WebViewImpl::~WebViewImpl()
 #endif
 #endif
 
-    if (m_targetWindowForMovePreparation) {
-        [m_windowVisibilityObserver stopObserving:m_targetWindowForMovePreparation.get()];
+    if (m_isObservingWindow) {
+        [m_windowVisibilityObserver stopObserving:m_targetWindowForMovePreparation.get() ?: [m_view window]];
         m_targetWindowForMovePreparation = nil;
     }
 
@@ -2169,6 +2169,7 @@ void WebViewImpl::viewWillMoveToWindowImpl(NSWindow *window)
         NSWindow *stopObservingWindow = m_targetWindowForMovePreparation.get() ?: [m_view window];
         [m_windowVisibilityObserver stopObserving:stopObservingWindow];
         [m_windowVisibilityObserver startObserving:window];
+        m_isObservingWindow = true;
     }
 
 #if HAVE(NSSCROLLVIEW_SEPARATOR_TRACKING_ADAPTER)


### PR DESCRIPTION
#### e2e4c3958516196edd70eda7b74e5078ff1bd95a
<pre>
Potential crash related to WKWindowVisibilityObserver
<a href="https://bugs.webkit.org/show_bug.cgi?id=272559">https://bugs.webkit.org/show_bug.cgi?id=272559</a>

Reviewed by Wenson Hsieh.

Be sure to always stop observing the window when destroying WebViewImpl.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::~WebViewImpl):
(WebKit::WebViewImpl::viewWillMoveToWindowImpl):

Canonical link: <a href="https://commits.webkit.org/277414@main">https://commits.webkit.org/277414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e5007833d47b8ce4feda4687f0b850bbab79e80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26706 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50184 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50205 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43570 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38699 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20004 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21775 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5565 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52084 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46003 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23828 "Built successfully") | | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45029 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (failure); Running re-run-api-tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24618 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6705 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23547 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->