### PR TITLE
UBSAN: runtime error: negation of -2147483648 cannot be represented in type 'int'; cast to an unsigned type to negate this value to itself

### DIFF
--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 Caio Lima <ticaiolima@gmail.com>
- * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -496,12 +496,12 @@ public:
         ASSERT_UNUSED(i, i < length());
 #if CPU(REGISTER64)
         if (sign())
-            return static_cast<JSBigInt::Digit>(WTF::negate(m_value));
+            return static_cast<JSBigInt::Digit>(WTF::negate(static_cast<int64_t>(m_value)));
         return m_value;
 #else
         static_assert(sizeof(JSBigInt::Digit) == 4);
         if (sign())
-            return static_cast<JSBigInt::Digit>(WTF::negate(m_value) >> (32 * i));
+            return static_cast<JSBigInt::Digit>(WTF::negate(static_cast<int64_t>(m_value)) >> (32 * i));
         return static_cast<JSBigInt::Digit>(m_value >> (32 * i));
 #endif
     }

--- a/Source/WTF/wtf/MathExtras.h
+++ b/Source/WTF/wtf/MathExtras.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -782,9 +782,10 @@ template<typename T> constexpr T fabsConstExpr(T value)
 }
 
 // For use in places where we could negate std::numeric_limits<T>::min and would like to avoid UB.
-template<typename T> constexpr typename std::enable_if_t<std::is_integral_v<T>, T> negate(T v)
+template<typename T> constexpr typename std::enable_if_t<std::is_integral_v<T> && std::is_signed_v<T>, std::make_unsigned_t<T>> negate(T v)
 {
-    return ~static_cast<std::make_unsigned_t<T>>(v) + 1;
+    ASSERT(v <= 0);
+    return ~static_cast<std::make_unsigned_t<T>>(v) + 1U;
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/IntegerToStringConversion.h
+++ b/Source/WTF/wtf/text/IntegerToStringConversion.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2020 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2012-2024 Apple Inc. All Rights Reserved.
  * Copyright (C) 2012 Patrick Gansterer <paroga@paroga.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -25,6 +25,7 @@
 #include <span>
 #include <string>
 #include <wtf/Forward.h>
+#include <wtf/MathExtras.h>
 #include <wtf/text/LChar.h>
 
 namespace WTF {
@@ -93,7 +94,7 @@ inline void writeIntegerToBuffer(IntegerType integer, CharacterType* destination
         return writeIntegerToBufferImpl<CharacterType, uint8_t, PositiveNumber>(integer ? 1 : 0, destination);
     else if constexpr (std::is_signed_v<IntegerType>) {
         if (integer < 0)
-            return writeIntegerToBufferImpl<CharacterType, typename std::make_unsigned_t<IntegerType>, NegativeNumber>(std::make_unsigned_t<IntegerType>(-integer), destination);
+            return writeIntegerToBufferImpl<CharacterType, typename std::make_unsigned_t<IntegerType>, NegativeNumber>(WTF::negate(integer), destination);
         return writeIntegerToBufferImpl<CharacterType, typename std::make_unsigned_t<IntegerType>, PositiveNumber>(std::make_unsigned_t<IntegerType>(integer), destination);
     } else
         return writeIntegerToBufferImpl<CharacterType, IntegerType, PositiveNumber>(integer, destination);
@@ -125,7 +126,7 @@ constexpr unsigned lengthOfIntegerAsString(IntegerType integer)
     }
     else if constexpr (std::is_signed_v<IntegerType>) {
         if (integer < 0)
-            return lengthOfIntegerAsStringImpl<typename std::make_unsigned_t<IntegerType>, NegativeNumber>(std::make_unsigned_t<IntegerType>(-integer));
+            return lengthOfIntegerAsStringImpl<typename std::make_unsigned_t<IntegerType>, NegativeNumber>(WTF::negate(integer));
         return lengthOfIntegerAsStringImpl<typename std::make_unsigned_t<IntegerType>, PositiveNumber>(std::make_unsigned_t<IntegerType>(integer));
     } else
         return lengthOfIntegerAsStringImpl<IntegerType, PositiveNumber>(integer);

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -234,7 +234,7 @@ ExceptionOr<Ref<CSSNumericValue>> CSSNumericValue::add(FixedVector<CSSNumberish>
 ExceptionOr<Ref<CSSNumericValue>> CSSNumericValue::sub(FixedVector<CSSNumberish>&& values)
 {
     return addInternal(WTF::map(WTFMove(values), [] (CSSNumberish&& numberish) {
-        return negate(rectifyNumberish(WTFMove(numberish)));
+        return WebCore::negate(rectifyNumberish(WTFMove(numberish)));
     }));
 }
 

--- a/Source/WebCore/platform/LayoutUnit.h
+++ b/Source/WebCore/platform/LayoutUnit.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012-2017, Google Inc. All rights reserved.
- * Copyright (c) 2012-2023, Apple Inc. All rights reserved.
+ * Copyright (c) 2012-2024, Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -783,7 +783,7 @@ inline float roundToDevicePixel(LayoutUnit value, float pixelSnappingFactor, boo
     // This adjusts directional rounding on negative halfway values. It produces the same direction for both negative and positive values.
     // Instead of rounding negative halfway cases away from zero, we translate them to positive values before rounding.
     // It helps snapping relative negative coordinates to the same position as if they were positive absolute coordinates.
-    unsigned translateOrigin = -value.rawValue();
+    unsigned translateOrigin = WTF::negate(value.rawValue());
     return (round((valueToRound + translateOrigin) * pixelSnappingFactor) / pixelSnappingFactor) - translateOrigin;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Intel Corporation
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 
 #include "config.h"
 
+#include <type_traits>
 #include <wtf/MathExtras.h>
 
 namespace TestWebKitAPI {
@@ -638,6 +639,41 @@ TEST(WTF, fastLog2)
     EXPECT_EQ(WTF::fastLog2(std::numeric_limits<uint32_t>::max() - 2u), 32u);
     EXPECT_EQ(WTF::fastLog2(std::numeric_limits<uint32_t>::max() - 1u), 32u);
     EXPECT_EQ(WTF::fastLog2(std::numeric_limits<uint32_t>::max()), 32u);
+}
+
+TEST(WTF, negate)
+{
+    auto expected_uint8_t = WTF::negate<int8_t>(0);
+    EXPECT_TRUE((std::is_same_v<uint8_t, decltype(expected_uint8_t)>));
+    auto expected_uint16_t = WTF::negate<int16_t>(0);
+    EXPECT_TRUE((std::is_same_v<uint16_t, decltype(expected_uint16_t)>));
+    auto expected_uint32_t = WTF::negate<int32_t>(0);
+    EXPECT_TRUE((std::is_same_v<uint32_t, decltype(expected_uint32_t)>));
+    auto expected_uint64_t = WTF::negate<int64_t>(0);
+    EXPECT_TRUE((std::is_same_v<uint64_t, decltype(expected_uint64_t)>));
+    auto expected_unsigned_long_long = WTF::negate<long long>(0);
+    EXPECT_TRUE((std::is_same_v<unsigned long long, decltype(expected_unsigned_long_long)>));
+
+    EXPECT_EQ(WTF::negate<int8_t>(std::numeric_limits<int8_t>::min()), static_cast<uint8_t>(std::numeric_limits<int8_t>::max()) + 1U);
+    EXPECT_EQ(WTF::negate<int8_t>(std::numeric_limits<int8_t>::min() + 1), static_cast<uint8_t>(std::numeric_limits<int8_t>::max()));
+    EXPECT_EQ(WTF::negate<int8_t>(-1), 1U);
+    EXPECT_EQ(WTF::negate<int8_t>(0), 0U);
+    EXPECT_EQ(WTF::negate<int16_t>(std::numeric_limits<int16_t>::min()), static_cast<uint16_t>(std::numeric_limits<int16_t>::max()) + 1U);
+    EXPECT_EQ(WTF::negate<int16_t>(std::numeric_limits<int16_t>::min() + 1), static_cast<uint16_t>(std::numeric_limits<int16_t>::max()));
+    EXPECT_EQ(WTF::negate<int16_t>(-1), 1U);
+    EXPECT_EQ(WTF::negate<int16_t>(0), 0U);
+    EXPECT_EQ(WTF::negate<int32_t>(std::numeric_limits<int32_t>::min()), static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) + 1U);
+    EXPECT_EQ(WTF::negate<int32_t>(std::numeric_limits<int32_t>::min() + 1), static_cast<uint32_t>(std::numeric_limits<int32_t>::max()));
+    EXPECT_EQ(WTF::negate<int32_t>(-1), 1U);
+    EXPECT_EQ(WTF::negate<int32_t>(0), 0U);
+    EXPECT_EQ(WTF::negate<int64_t>(std::numeric_limits<int64_t>::min()), static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1UL);
+    EXPECT_EQ(WTF::negate<int64_t>(std::numeric_limits<int64_t>::min() + 1L), static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+    EXPECT_EQ(WTF::negate<int64_t>(-1L), 1UL);
+    EXPECT_EQ(WTF::negate<int64_t>(0L), 0UL);
+    EXPECT_EQ(WTF::negate<long long>(std::numeric_limits<long long>::min()), static_cast<unsigned long long>(std::numeric_limits<long long>::max()) + 1ULL);
+    EXPECT_EQ(WTF::negate<long long>(std::numeric_limits<long long>::min() + 1LL), static_cast<unsigned long long>(std::numeric_limits<long long>::max()));
+    EXPECT_EQ(WTF::negate<long long>(-1LL), 1ULL);
+    EXPECT_EQ(WTF::negate<long long>(0LL), 0ULL);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 715c3124843bb2b5ba39d245b9a8dcc52df00e81
<pre>
UBSAN: runtime error: negation of -2147483648 cannot be represented in type &apos;int&apos;; cast to an unsigned type to negate this value to itself
<a href="https://bugs.webkit.org/show_bug.cgi?id=272533">https://bugs.webkit.org/show_bug.cgi?id=272533</a>
&lt;<a href="https://rdar.apple.com/126277702">rdar://126277702</a>&gt;

Reviewed by Justin Michaud.

Change WTF::negate() to require a signed type as input, and to always
return an unsigned value since that&apos;s how it&apos;s used. Also add a Debug
assert that the value being negated is negative since this function was
never designed to negate positive, signed integers.

Tests for WTF::negate():  TestWTF.WTF.negate

Layout tests covering WebCore changes:
    fast/css/border-image-scale-crash.html
    fast/forms/datalist/datalist-dropdown-transformed-element-crash.html
    fast/selectors/nth-child-bounds.html

* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::Int64BigIntImpl::digit):
- Cast back to signed type before calling WTF::negate().

* Source/WTF/wtf/MathExtras.h:
(WTF::negate):
- Tighten up function to always return an unsigned integer type and to
  require `T` to be a signed integer type.
- Add Debug assert that `v` is negative as this function is not intended
  for use with positive integer values.
* Source/WTF/wtf/text/IntegerToStringConversion.h:
(WTF::writeIntegerToBuffer):
(WTF::lengthOfIntegerAsString):
- Make use of WTF::negate() to avoid undefined behavior.
- Remove use of std::make_unsigned_t&lt;&gt;() since WTF::negate() does this
  for us.

* Source/WebCore/css/typedom/CSSNumericValue.cpp:
(WebCore::CSSNumericValue::sub):
- Specify WebCore::negate() as workaround for MSVC++ and older clang.
* Source/WebCore/platform/LayoutUnit.h:
(WebCore::roundToDevicePixel):
- Make use of WTF::negate() to avoid undefined behavior.

* Tools/TestWebKitAPI/Tests/WTF/MathExtras.cpp:
(TestWebKitAPI::TEST(WTF, negate)):
- Add tests for WTF::negate().  Verify the return type of the template
  function as well as interesting values.

Canonical link: <a href="https://commits.webkit.org/277431@main">https://commits.webkit.org/277431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f523f973424b332fac0dc6eda112a38bb00e722d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50236 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43602 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38721 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20024 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42153 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5596 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40835 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43880 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52116 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47044 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46022 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23861 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45051 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24649 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54544 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6718 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23580 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11183 "Passed tests") | 
<!--EWS-Status-Bubble-End-->