### PR TITLE
Add support for specifying required recipient contact fields for Disbursement requests

### DIFF
--- a/LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementPaymentRequest.https-expected.txt
+++ b/LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementPaymentRequest.https-expected.txt
@@ -1,4 +1,6 @@
 
 PASS Should have a feature for `disbursementPaymentRequest`.
 PASS Should propagate all data as part of the request.
+PASS Should propagate recipient contact information as part of the request.
+PASS Should error when incorrect `requiredRecipientContactFields` are provided as part of the request.
 

--- a/LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementPaymentRequest.https.html
+++ b/LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementPaymentRequest.https.html
@@ -15,8 +15,14 @@
 
         test((test) => {
             const method = validPaymentMethod();
-            method.data.features = ["paymentRequestDisbursements"];
-            new PaymentRequest([method], validPaymentDetails());
+            try {
+                method.data.features = ["invalidFeatureThatsNotDisbursements"];
+                new PaymentRequest([method], validPaymentDetails());
+                assert_unreached("Should have thrown with an invalid feature");
+            } catch {
+                method.data.features = ["paymentRequestDisbursements"];
+                new PaymentRequest([method], validPaymentDetails());
+            }
         }, "Should have a feature for `disbursementPaymentRequest`.");
 
         const RESOLVED_PROMISE = Promise.resolve({});
@@ -111,7 +117,45 @@
                     expectedDisbursementPaymentRequest,
                     "check that the `DisbursementPaymentRequest` matches"
                 );
-                await response.compconste("success");
+                await response.complete("success");
+            }, description + " as part of the request.");
+        }
+
+        function testInvalidDisbursementPaymentRequest(
+            description,
+            { disbursementPaymentRequest, expectedErrorType }
+        ) {
+            user_activation_test(async (test) => {
+                const detailsInit = {
+                    total: {
+                        label: "Disbursement",
+                        amount: {
+                            value: "14.85",
+                            currency: "USD",
+                        },
+                    },
+                };
+
+                if (disbursementPaymentRequest) {
+                    detailsInit.modifiers = modifiersWithData(
+                        { disbursementPaymentRequest },
+                        validLineItems
+                    );
+                }
+
+                const request = new PaymentRequest(
+                    [validPaymentMethod()],
+                    detailsInit
+                );
+
+                try {
+                    await request.show();
+                } catch (e) {
+                    assert_true(
+                        e instanceof expectedErrorType,
+                        `Expected ${expectedErrorType}`
+                    );
+                }
             }, description + " as part of the request.");
         }
 
@@ -119,6 +163,28 @@
             initialDisbursementPaymentRequest: {},
             expectedDisbursementPaymentRequest: {},
         });
+
+        testValidDisbursementPaymentRequest(
+            "Should propagate recipient contact information",
+            {
+                initialDisbursementPaymentRequest: {
+                    requiredRecipientContactFields: ["email", "name"],
+                },
+                expectedDisbursementPaymentRequest: {
+                    requiredRecipientContactFields: ["email", "name"],
+                },
+            }
+        );
+
+        testInvalidDisbursementPaymentRequest(
+            "Should error when incorrect `requiredRecipientContactFields` are provided",
+            {
+                disbursementPaymentRequest: {
+                    requiredRecipientContactFields: ["invalid1", "invalid2"],
+                },
+                expectedErrorType: TypeError,
+            }
+        );
 
         // We don't need invalidation tests since a disbursement request is an empty dictionary.
 

--- a/Source/WebCore/Modules/applepay/ApplePayContactField.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePayContactField.cpp
@@ -25,14 +25,15 @@
 
 #include "config.h"
 #include "ApplePayContactField.h"
+#include "ApplePaySessionPaymentRequest.h"
 
 #if ENABLE(APPLE_PAY)
 
 namespace WebCore {
 
-ExceptionOr<ApplePaySessionPaymentRequest::ContactFields> convertAndValidate(unsigned version, const Vector<ApplePayContactField>& contactFields)
+ExceptionOr<ApplePaySessionPaymentRequestContactFields> convertAndValidate(unsigned version, const Vector<ApplePayContactField>& contactFields)
 {
-    ApplePaySessionPaymentRequest::ContactFields result;
+    ApplePaySessionPaymentRequestContactFields result;
 
     for (auto& contactField : contactFields) {
         switch (contactField) {

--- a/Source/WebCore/Modules/applepay/ApplePayContactField.h
+++ b/Source/WebCore/Modules/applepay/ApplePayContactField.h
@@ -27,12 +27,13 @@
 
 #if ENABLE(APPLE_PAY)
 
-#include "ApplePaySessionPaymentRequest.h"
 #include "ExceptionOr.h"
 
 namespace WebCore {
 
-enum class ApplePayContactField {
+struct ApplePaySessionPaymentRequestContactFields;
+
+enum class ApplePayContactField : uint8_t {
     Email,
     Name,
     PhoneticName,
@@ -40,7 +41,7 @@ enum class ApplePayContactField {
     PostalAddress,
 };
 
-ExceptionOr<ApplePaySessionPaymentRequest::ContactFields> convertAndValidate(unsigned version, const Vector<ApplePayContactField>&);
+ExceptionOr<ApplePaySessionPaymentRequestContactFields> convertAndValidate(unsigned version, const Vector<ApplePayContactField>&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/applepay/ApplePayDisbursementPaymentRequest.h
+++ b/Source/WebCore/Modules/applepay/ApplePayDisbursementPaymentRequest.h
@@ -33,9 +33,13 @@
 
 namespace WebCore {
 
+enum class ApplePayContactField : uint8_t;
+
 template<typename> class ExceptionOr;
 
 struct ApplePayDisbursementPaymentRequest final {
+    std::optional<Vector<ApplePayContactField>> requiredRecipientContactFields;
+
     ExceptionOr<void> validate() const;
     ExceptionOr<ApplePayDisbursementPaymentRequest> convertAndValidate() &&;
 };

--- a/Source/WebCore/Modules/applepay/ApplePayDisbursementPaymentRequest.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayDisbursementPaymentRequest.idl
@@ -28,4 +28,5 @@
     ExportMacro=WEBCORE_EXPORT,
     JSGenerateToJSObject,
 ] dictionary ApplePayDisbursementPaymentRequest {
+    sequence<ApplePayContactField> requiredRecipientContactFields;
 };

--- a/Source/WebCore/Modules/applepay/ApplePaySessionPaymentRequest.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySessionPaymentRequest.h
@@ -52,6 +52,14 @@ enum class ApplePaySessionPaymentRequestShippingType : uint8_t {
     ServicePickup,
 };
 
+struct ApplePaySessionPaymentRequestContactFields {
+    bool postalAddress { false };
+    bool phone { false };
+    bool email { false };
+    bool name { false };
+    bool phoneticName { false };
+};
+
 class ApplePaySessionPaymentRequest {
 public:
     WEBCORE_EXPORT ApplePaySessionPaymentRequest();
@@ -66,13 +74,7 @@ public:
     const String& currencyCode() const { return m_currencyCode; }
     void setCurrencyCode(const String& currencyCode) { m_currencyCode = currencyCode; }
 
-    struct ContactFields {
-        bool postalAddress { false };
-        bool phone { false };
-        bool email { false };
-        bool name { false };
-        bool phoneticName { false };
-    };
+    using ContactFields = ApplePaySessionPaymentRequestContactFields;
 
     const ContactFields& requiredBillingContactFields() const { return m_requiredBillingContactFields; }
     void setRequiredBillingContactFields(const ContactFields& requiredBillingContactFields) { m_requiredBillingContactFields = requiredBillingContactFields; }

--- a/Source/WebKit/Shared/ApplePay/DisbursementPaymentRequest.h
+++ b/Source/WebKit/Shared/ApplePay/DisbursementPaymentRequest.h
@@ -33,11 +33,12 @@ OBJC_CLASS PKDisbursementPaymentRequest;
 
 namespace WebCore {
 class ApplePaySessionPaymentRequest;
+enum class ApplePayContactField : uint8_t;
 }
 
 namespace WebKit {
 
-RetainPtr<PKDisbursementPaymentRequest> platformDisbursementPaymentRequest(const WebCore::ApplePaySessionPaymentRequest&, const URL& originatingURL);
+RetainPtr<PKDisbursementPaymentRequest> platformDisbursementPaymentRequest(const WebCore::ApplePaySessionPaymentRequest&, const URL& originatingURL, const std::optional<Vector<WebCore::ApplePayContactField>>& requiredrecipientContactFields);
 
 } // namespace WebKit
 

--- a/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
+++ b/Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm
@@ -52,7 +52,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
 #if HAVE(PASSKIT_DISBURSEMENTS)
     std::optional<ApplePayDisbursementPaymentRequest> webDisbursementPaymentRequest = request.disbursementPaymentRequest();
     if (webDisbursementPaymentRequest) {
-        auto disbursementRequest = platformDisbursementPaymentRequest(request, originatingURL);
+        auto disbursementRequest = platformDisbursementPaymentRequest(request, originatingURL, webDisbursementPaymentRequest->requiredRecipientContactFields);
         paymentRequest = RetainPtr<PKPaymentRequest>((PKPaymentRequest *)disbursementRequest);
     } else
 #endif

--- a/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
+++ b/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
@@ -68,7 +68,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
 #if HAVE(PASSKIT_DISBURSEMENTS)
     std::optional<ApplePayDisbursementPaymentRequest> webDisbursementPaymentRequest = request.disbursementPaymentRequest();
     if (webDisbursementPaymentRequest) {
-        auto disbursementRequest = platformDisbursementPaymentRequest(request, originatingURL);
+        auto disbursementRequest = platformDisbursementPaymentRequest(request, originatingURL, webDisbursementPaymentRequest->requiredRecipientContactFields);
         paymentRequest = RetainPtr<PKPaymentRequest>((PKPaymentRequest *)disbursementRequest);
     } else
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -40,6 +40,7 @@ header: <WebCore/DOMCacheEngine.h>
 
 #if ENABLE(APPLE_PAY)
 header: <WebCore/ApplePayFeature.h>
+header: <WebCore/ApplePayContactField.h>
 enum class WebCore::ApplePayFeature : uint8_t {
 #if ENABLE(APPLE_PAY_LATER)
     ApplePayLater,
@@ -1046,11 +1047,6 @@ struct WebCore::ApplePayDeferredPaymentRequest {
 };
 #endif
 
-#if ENABLE(APPLE_PAY_DISBURSEMENTS)
-struct WebCore::ApplePayDisbursementPaymentRequest {
-};
-#endif
-
 #if ENABLE(APPLE_PAY_PAYMENT_ORDER_DETAILS)
 struct WebCore::ApplePayPaymentOrderDetails {
     String orderTypeIdentifier
@@ -1217,6 +1213,14 @@ enum class WebCore::ApplePayErrorContactField : uint8_t {
     CountryCode,
 };
 
+enum class WebCore::ApplePayContactField : uint8_t {
+    Email,
+    Name,
+    PhoneticName,
+    Phone,
+    PostalAddress,
+};
+
 enum class WebCore::ApplePayErrorCode : uint8_t {
     Unknown,
     ShippingContactInvalid,
@@ -1228,6 +1232,12 @@ enum class WebCore::ApplePayErrorCode : uint8_t {
 #endif
 };
 #endif // ENABLE(APPLE_PAY)
+
+#if ENABLE(APPLE_PAY_DISBURSEMENTS)
+struct WebCore::ApplePayDisbursementPaymentRequest {
+    std::optional<Vector<WebCore::ApplePayContactField>> requiredRecipientContactFields
+};
+#endif
 
 #if ENABLE(APPLE_PAY_INSTALLMENTS)
 header: <WebCore/ApplePayInstallmentConfigurationWebCore.h>


### PR DESCRIPTION
#### 0feced788ade150bbdb6a80e0934add69b4a30dd
<pre>
Add support for specifying required recipient contact fields for Disbursement requests

<a href="https://bugs.webkit.org/show_bug.cgi?id=272526">https://bugs.webkit.org/show_bug.cgi?id=272526</a>
<a href="https://rdar.apple.com/115776112">rdar://115776112</a>
Reviewed by Abrar Rahman Protyasha.

We add support for the requisite types to specify recipient contact information in a DisbursementRequest

* LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementPaymentRequest.https-expected.txt:
* LayoutTests/http/tests/paymentrequest/ApplePayModifier-disbursementPaymentRequest.https.html:
* Source/WebCore/Modules/applepay/ApplePayContactField.cpp:
(WebCore::convertAndValidate):
* Source/WebCore/Modules/applepay/ApplePayContactField.h:
* Source/WebCore/Modules/applepay/ApplePayDisbursementPaymentRequest.h:
* Source/WebCore/Modules/applepay/ApplePayDisbursementPaymentRequest.idl:
* Source/WebCore/Modules/applepay/ApplePaySessionPaymentRequest.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/Shared/ApplePay/DisbursementPaymentRequest.h:
* Source/WebKit/Shared/ApplePay/cocoa/DisbursementPaymentRequestCocoa.mm:
(WebKit::platformDisbursementPaymentRequest):
* Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm:
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
* Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm:
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/277953@main">https://commits.webkit.org/277953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08acaadb8d3cba7c3b50db44c173282d364d206c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51688 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45070 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51305 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40058 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/50035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25859 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21166 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43418 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7055 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53598 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47368 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46346 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10791 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26123 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25034 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->