### PR TITLE
[WebXR] Don't create WebXRSystem when iterating all DOM objects

### DIFF
--- a/Source/WebCore/Modules/webxr/NavigatorWebXR.cpp
+++ b/Source/WebCore/Modules/webxr/NavigatorWebXR.cpp
@@ -41,6 +41,11 @@ WebXRSystem& NavigatorWebXR::xr(Navigator& navigatorObject)
     return *navigator.m_xr;
 }
 
+WebXRSystem* NavigatorWebXR::xrIfExists(Navigator& navigator)
+{
+    return NavigatorWebXR::from(navigator).m_xr.get();
+}
+
 NavigatorWebXR& NavigatorWebXR::from(Navigator& navigator)
 {
     auto* supplement = static_cast<NavigatorWebXR*>(Supplement<Navigator>::from(&navigator, supplementName()));

--- a/Source/WebCore/Modules/webxr/NavigatorWebXR.h
+++ b/Source/WebCore/Modules/webxr/NavigatorWebXR.h
@@ -40,6 +40,7 @@ class NavigatorWebXR final : public Supplement<Navigator> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT static WebXRSystem& xr(Navigator&);
+    WEBCORE_EXPORT static WebXRSystem* xrIfExists(Navigator&);
 
     WEBCORE_EXPORT static NavigatorWebXR& from(Navigator&);
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4779,7 +4779,8 @@ bool Page::hasActiveImmersiveSession() const
         if (!navigator)
             continue;
 
-        if (NavigatorWebXR::xr(*navigator).hasActiveImmersiveSession())
+        auto* xrSystem = NavigatorWebXR::xrIfExists(*navigator);
+        if (xrSystem && xrSystem->hasActiveImmersiveSession())
             return true;
     }
     return false;


### PR DESCRIPTION
#### 39ec95b06fd161d6480b867020ae4339b8f69e5e
<pre>
[WebXR] Don&apos;t create WebXRSystem when iterating all DOM objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=272564">https://bugs.webkit.org/show_bug.cgi?id=272564</a>
<a href="https://rdar.apple.com/124261374">rdar://124261374</a>

Reviewed by Cameron McCormack.

WebCore::Page::hasActiveImmersiveSession() is creating a new WebXRSystem DOM
object inside WebCore::ScriptExecutionContext::forEachActiveDOMObject(…) which
is forbidden. If there is no WebXRSystem, we should consider that there is no
active immersive session.

* Source/WebCore/Modules/webxr/NavigatorWebXR.cpp:
(WebCore::NavigatorWebXR::xrIfExists):
* Source/WebCore/Modules/webxr/NavigatorWebXR.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::hasActiveImmersiveSession const):

Canonical link: <a href="https://commits.webkit.org/277468@main">https://commits.webkit.org/277468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d935576de1be0c84a83bb7ba7c047cb6673f3327

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50383 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43755 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24367 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38825 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20122 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22023 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42370 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5749 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44044 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52275 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19067 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24008 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45161 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10528 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24796 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23728 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->