### PR TITLE
[JSC] Remove loopOSREntryBytecodeIndex in Baseline JIT

### DIFF
--- a/Source/JavaScriptCore/jit/BaselineJITPlan.cpp
+++ b/Source/JavaScriptCore/jit/BaselineJITPlan.cpp
@@ -32,9 +32,8 @@
 
 namespace JSC {
 
-BaselineJITPlan::BaselineJITPlan(CodeBlock* codeBlock, BytecodeIndex loopOSREntryBytecodeIndex)
+BaselineJITPlan::BaselineJITPlan(CodeBlock* codeBlock)
     : JITPlan(JITCompilationMode::Baseline, codeBlock)
-    , m_loopOSREntryBytecodeIndex(loopOSREntryBytecodeIndex)
 {
     JIT::doMainThreadPreparationBeforeCompile(codeBlock->vm());
 }
@@ -48,7 +47,7 @@ auto BaselineJITPlan::compileInThreadImpl(JITCompilationEffort effort) -> Compil
         Safepoint safepoint(*this, result);
         safepoint.begin();
 
-        JIT jit(*m_vm, *this, m_codeBlock, m_loopOSREntryBytecodeIndex);
+        JIT jit(*m_vm, *this, m_codeBlock);
         auto jitCode = jit.compileAndLinkWithoutFinalizing(effort);
         m_jitCode = WTFMove(jitCode);
     }

--- a/Source/JavaScriptCore/jit/BaselineJITPlan.h
+++ b/Source/JavaScriptCore/jit/BaselineJITPlan.h
@@ -39,7 +39,7 @@ class BaselineJITPlan final : public JITPlan {
     using Base = JITPlan;
 
 public:
-    BaselineJITPlan(CodeBlock*, BytecodeIndex loopOSREntryBytecodeIndex);
+    BaselineJITPlan(CodeBlock*);
 
     CompilationPath compileInThreadImpl() final;
     size_t codeSize() const final;
@@ -53,8 +53,6 @@ public:
 private:
     CompilationPath compileInThreadImpl(JITCompilationEffort);
 
-
-    BytecodeIndex m_loopOSREntryBytecodeIndex;
     RefPtr<BaselineJITCode> m_jitCode;
 };
 

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -67,14 +67,13 @@ Seconds totalFTLCompileTime;
 Seconds totalFTLDFGCompileTime;
 Seconds totalFTLB3CompileTime;
 
-JIT::JIT(VM& vm, BaselineJITPlan& plan, CodeBlock* codeBlock, BytecodeIndex loopOSREntryBytecodeIndex)
+JIT::JIT(VM& vm, BaselineJITPlan& plan, CodeBlock* codeBlock)
     : JSInterfaceJIT(&vm, nullptr)
     , m_plan(plan)
     , m_labels(codeBlock ? codeBlock->instructions().size() : 0)
     , m_pcToCodeOriginMapBuilder(vm)
     , m_canBeOptimized(false)
     , m_shouldEmitProfiling(false)
-    , m_loopOSREntryBytecodeIndex(loopOSREntryBytecodeIndex)
     , m_profiledCodeBlock(codeBlock)
     , m_unlinkedCodeBlock(codeBlock->unlinkedCodeBlock())
 {
@@ -1040,7 +1039,7 @@ CompilationResult JIT::finalizeOnMainThread(CodeBlock* codeBlock, BaselineJITPla
 
 CompilationResult JIT::compileSync(VM&, CodeBlock* codeBlock, JITCompilationEffort effort)
 {
-    auto plan = adoptRef(*new BaselineJITPlan(codeBlock, BytecodeIndex(0)));
+    auto plan = adoptRef(*new BaselineJITPlan(codeBlock));
     plan->compileSync(effort);
     return plan->finalize();
 }

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -164,7 +164,7 @@ namespace JSC {
         using Base = JSInterfaceJIT;
 
     public:
-        JIT(VM&, BaselineJITPlan&, CodeBlock*, BytecodeIndex loopOSREntryBytecodeOffset);
+        JIT(VM&, BaselineJITPlan&, CodeBlock*);
         ~JIT();
 
         VM& vm() { return *JSInterfaceJIT::vm(); }
@@ -948,7 +948,6 @@ namespace JSC {
 
         bool m_canBeOptimized;
         bool m_shouldEmitProfiling;
-        BytecodeIndex m_loopOSREntryBytecodeIndex;
 
         CodeBlock* const m_profiledCodeBlock { nullptr };
         UnlinkedCodeBlock* const m_unlinkedCodeBlock { nullptr };


### PR DESCRIPTION
#### be01d8c2290dfee4ed9b04856e29616dec96b35d
<pre>
[JSC] Remove loopOSREntryBytecodeIndex in Baseline JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=272566">https://bugs.webkit.org/show_bug.cgi?id=272566</a>
<a href="https://rdar.apple.com/126323904">rdar://126323904</a>

Reviewed by Justin Michaud.

Originally loopOSREntryBytecodeIndex was introduced not to compile whole code for global code etc., but since Baseline JIT is now unlinked,
we need to compile whole program to make it reusable later even for global code. As a result, after making Baseline JIT unlinked,
we no longer use loopOSREntryBytecodeIndex in Baseline JIT. So this patch just removes it.

* Source/JavaScriptCore/jit/BaselineJITPlan.cpp:
(JSC::BaselineJITPlan::BaselineJITPlan):
(JSC::BaselineJITPlan::compileInThreadImpl):
* Source/JavaScriptCore/jit/BaselineJITPlan.h:
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::JIT):
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::jitCompileAndSetHeuristics):
(JSC::LLInt::LLINT_SLOW_PATH_DECL):

Canonical link: <a href="https://commits.webkit.org/277412@main">https://commits.webkit.org/277412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e39d7d4c39d0cf689ec5f7ecfab9e6f6625d2800

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26733 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/50213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/50232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43598 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/32443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24194 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/50232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48132 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/32443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/50213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/50232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/32443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/50213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-skia~~](https://ews-build.webkit.org/#/builders/52/builds/5592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/40831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/32443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/50213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52112 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/47040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/22584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/18913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23857 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/50213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54540 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6702 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/23576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11181 "Passed tests") | 
<!--EWS-Status-Bubble-End-->