### PR TITLE
FindString should not be sent twice if a webpage has no iframe processes

### DIFF
--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -204,4 +204,10 @@ void BrowsingContextGroup::transitionPageToRemotePage(WebPageProxy& page, const 
     set.add(WTFMove(newRemotePage));
 }
 
+bool BrowsingContextGroup::hasRemotePages(const WebPageProxy& page)
+{
+    auto it = m_remotePages.find(page);
+    return it != m_remotePages.end() && !it->value.isEmpty();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -63,6 +63,8 @@ public:
     std::unique_ptr<RemotePageProxy> takeRemotePageInProcessForProvisionalPage(const WebPageProxy&, const WebCore::RegistrableDomain&);
     void transitionPageToRemotePage(WebPageProxy&, const WebCore::RegistrableDomain& openerDomain);
 
+    bool hasRemotePages(const WebPageProxy&);
+
 private:
     BrowsingContextGroup();
 


### PR DESCRIPTION
#### 292927b976641ccbaa30c5fd67d256589f7fc306
<pre>
FindString should not be sent twice if a webpage has no iframe processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=271029">https://bugs.webkit.org/show_bug.cgi?id=271029</a>
<a href="https://rdar.apple.com/124652108">rdar://124652108</a>

Reviewed by Alex Christensen.

With site isolation, we need to search all web processes initially without setting selection because we
do not know which frame should receive selection until we know which frames have matches. If a webpage
has no iframe processes, or site isolation is disabled, we don’t need to do this because we can
synchronously search all frames in the web process. So we should just send one FindString message in
this situation.

* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::hasRemotePages):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::findString):

Canonical link: <a href="https://commits.webkit.org/277474@main">https://commits.webkit.org/277474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d365a2933558092476aebef622f5f961c5e4d867

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43715 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24314 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38800 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48242 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20097 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21979 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5709 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43999 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52235 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46103 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23968 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45134 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24756 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6746 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->