### PR TITLE
Cache preferences updated while child process was suspended

### DIFF
--- a/Source/WebKit/Shared/AuxiliaryProcess.h
+++ b/Source/WebKit/Shared/AuxiliaryProcess.h
@@ -106,6 +106,7 @@ public:
 
 #if ENABLE(CFPREFS_DIRECT_MODE)
     virtual void preferenceDidUpdate(const String& domain, const String& key, const std::optional<String>& encodedValue);
+    void preferencesDidUpdate(HashMap<std::pair<String, String>, std::optional<String>>);
 #endif
 
 protected:

--- a/Source/WebKit/Shared/AuxiliaryProcess.messages.in
+++ b/Source/WebKit/Shared/AuxiliaryProcess.messages.in
@@ -28,6 +28,7 @@ messages -> AuxiliaryProcess NotRefCounted {
 
 #if ENABLE(CFPREFS_DIRECT_MODE)
     PreferenceDidUpdate(String domain, String key, std::optional<String> encodedValue)
+    PreferencesDidUpdate(HashMap<std::pair<String, String>, std::optional<String>> preferences)
 #endif
 
 #if OS(LINUX)

--- a/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm
@@ -210,6 +210,14 @@ void AuxiliaryProcess::preferenceDidUpdate(const String& domain, const String& k
     handlePreferenceChange(domain, key, value);
 }
 
+#if ENABLE(CFPREFS_DIRECT_MODE)
+void AuxiliaryProcess::preferencesDidUpdate(HashMap<std::pair<String, String>, std::optional<String>> preferences)
+{
+    for (auto& [key, value] : preferences)
+        preferenceDidUpdate(key.first, key.second, value);
+}
+#endif
+
 #if !HAVE(UPDATE_WEB_ACCESSIBILITY_SETTINGS) && PLATFORM(IOS_FAMILY)
 static const WTF::String& increaseContrastPreferenceKey()
 {

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -571,4 +571,16 @@ bool AuxiliaryProcessProxy::runningBoardThrottlingEnabled()
 }
 #endif
 
+void AuxiliaryProcessProxy::didChangeThrottleState(ProcessThrottleState state)
+{
+    bool isNowSuspended = state == ProcessThrottleState::Suspended;
+    if (m_isSuspended == isNowSuspended)
+        return;
+    m_isSuspended = isNowSuspended;
+#if ENABLE(CFPREFS_DIRECT_MODE)
+    if (!m_isSuspended && !m_preferencesUpdatedWhileSuspended.isEmpty())
+        send(Messages::AuxiliaryProcess::PreferencesDidUpdate(std::exchange(m_preferencesUpdatedWhileSuspended, { })), 0);
+#endif
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -223,7 +223,7 @@ public:
     enum ResumeReason : bool { ForegroundActivity, BackgroundActivity };
     virtual void sendPrepareToSuspend(IsSuspensionImminent, double remainingRunTime, CompletionHandler<void()>&&) = 0;
     virtual void sendProcessDidResume(ResumeReason) = 0;
-    virtual void didChangeThrottleState(ProcessThrottleState) { };
+    virtual void didChangeThrottleState(ProcessThrottleState);
     virtual ASCIILiteral clientName() const = 0;
     virtual String environmentIdentifier() const { return emptyString(); }
     virtual void prepareToDropLastAssertion(CompletionHandler<void()>&& completionHandler) { completionHandler(); }
@@ -279,6 +279,7 @@ private:
     IPC::MessageReceiverMap m_messageReceiverMap;
     bool m_alwaysRunsAtBackgroundPriority { false };
     bool m_didBeginResponsivenessChecks { false };
+    bool m_isSuspended { false };
     const WebCore::ProcessIdentifier m_processIdentifier { WebCore::ProcessIdentifier::generate() };
     std::optional<UseLazyStop> m_delayedResponsivenessCheck;
     MonotonicTime m_processStart;
@@ -292,6 +293,9 @@ private:
 #endif
 #if ENABLE(EXTENSION_CAPABILITIES)
     ExtensionCapabilityGrantMap m_extensionCapabilityGrants;
+#endif
+#if ENABLE(CFPREFS_DIRECT_MODE)
+    HashMap<std::pair<String /* domain */, String /* key */>, std::optional<String>> m_preferencesUpdatedWhileSuspended;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
@@ -145,7 +145,10 @@ std::optional<AuxiliaryProcessProxy::TaskInfo> AuxiliaryProcessProxy::taskInfo()
 #if ENABLE(CFPREFS_DIRECT_MODE)
 void AuxiliaryProcessProxy::notifyPreferencesChanged(const String& domain, const String& key, const std::optional<String>& encodedValue)
 {
-    send(Messages::AuxiliaryProcess::PreferenceDidUpdate(domain, key, encodedValue), 0);
+    if (m_isSuspended)
+        m_preferencesUpdatedWhileSuspended.set(std::pair { domain, key }, encodedValue);
+    else
+        send(Messages::AuxiliaryProcess::PreferenceDidUpdate(domain, key, encodedValue), 0);
 }
 #endif
 


### PR DESCRIPTION
#### c626fbfed63e03e52037b6afd26141ca78608063
<pre>
Cache preferences updated while child process was suspended
<a href="https://bugs.webkit.org/show_bug.cgi?id=272572">https://bugs.webkit.org/show_bug.cgi?id=272572</a>

Reviewed by Per Arne Vollan.

Whenever system preferences change, the UIProcess detects this and broadcasts
the changes to every child process via IPC. A lot of these processes are often
suspended, which means that they&apos;re not processing incoming IPC and the IPC
queue will grow, using more and more memory.

To reduce memory usage in such cases, I am now caching preference updates
happening during suspension in a HashMap. This saves memory because there is no
IPC overhead. Also, when the same preferences changes several times, we just
overwrite it in the map, instead of queuing a new IPC message. Once the process
resumes, we send all updated preferences in a single IPC instead of one per
preference change.

* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/AuxiliaryProcess.messages.in:
* Source/WebKit/Shared/Cocoa/AuxiliaryProcessCocoa.mm:
(WebKit::AuxiliaryProcess::preferencesDidUpdate):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::didChangeThrottleState):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::didChangeThrottleState): Deleted.
* Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm:
(WebKit::AuxiliaryProcessProxy::notifyPreferencesChanged):

Canonical link: <a href="https://commits.webkit.org/277427@main">https://commits.webkit.org/277427@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14c13ad8646e7869ac8e5629bc1bd79f8f5c252d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50237 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43603 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24199 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38724 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 21 flakes 75 failures; Uploaded test results; 15 flakes 58 failures; Running compile-webkit-without-change") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24340 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40980 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; Running re-run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20027 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21804 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5597 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43879 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Running apply-patch; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52117 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22589 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46023 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23862 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45052 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24650 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6717 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->