### PR TITLE
[WebGPU] GPUQueueDescriptor.idl is missing

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1822,6 +1822,7 @@ list(APPEND WebCore_NON_SVG_IDL_FILES
     Modules/WebGPU/GPUQuerySetDescriptor.idl
     Modules/WebGPU/GPUQueryType.idl
     Modules/WebGPU/GPUQueue.idl
+    Modules/WebGPU/GPUQueueDescriptor.idl
     Modules/WebGPU/GPURenderBundle.idl
     Modules/WebGPU/GPURenderBundleDescriptor.idl
     Modules/WebGPU/GPURenderBundleEncoder.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -138,6 +138,7 @@ $(PROJECT_DIR)/Modules/WebGPU/GPUQuerySet.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUQuerySetDescriptor.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUQueryType.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUQueue.idl
+$(PROJECT_DIR)/Modules/WebGPU/GPUQueueDescriptor.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPURenderBundle.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPURenderBundleDescriptor.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPURenderBundleEncoder.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1283,6 +1283,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUQueryType.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUQueryType.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUQueue.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUQueue.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUQueueDescriptor.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUQueueDescriptor.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPURenderBundle.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPURenderBundle.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPURenderBundleDescriptor.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -149,6 +149,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/WebGPU/GPUQuerySetDescriptor.idl \
     $(WebCore)/Modules/WebGPU/GPUQueryType.idl \
     $(WebCore)/Modules/WebGPU/GPUQueue.idl \
+    $(WebCore)/Modules/WebGPU/GPUQueueDescriptor.idl \
     $(WebCore)/Modules/WebGPU/GPURenderBundle.idl \
     $(WebCore)/Modules/WebGPU/GPURenderBundleDescriptor.idl \
     $(WebCore)/Modules/WebGPU/GPURenderBundleEncoder.idl \

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
@@ -113,7 +113,8 @@ void GPUAdapter::requestDevice(ScriptExecutionContext& scriptExecutionContext, c
         if (!device.get())
             promise.reject(Exception(ExceptionCode::OperationError));
         else {
-            Ref<GPUDevice> gpuDevice = GPUDevice::create(scriptExecutionContextRef.ptr(), device.releaseNonNull());
+            auto queueLabel = deviceDescriptor->defaultQueue.label;
+            Ref<GPUDevice> gpuDevice = GPUDevice::create(scriptExecutionContextRef.ptr(), device.releaseNonNull(), deviceDescriptor ? WTFMove(queueLabel) : ""_s);
             gpuDevice->suspendIfNeeded();
             promise.resolve(WTFMove(gpuDevice));
         }

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -76,13 +76,14 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(GPUDevice);
 
-GPUDevice::GPUDevice(ScriptExecutionContext* scriptExecutionContext, Ref<WebGPU::Device>&& backing)
+GPUDevice::GPUDevice(ScriptExecutionContext* scriptExecutionContext, Ref<WebGPU::Device>&& backing, String&& queueLabel)
     : ActiveDOMObject { scriptExecutionContext }
     , m_lostPromise(makeUniqueRef<LostPromise>())
     , m_backing(WTFMove(backing))
     , m_queue(GPUQueue::create(Ref { m_backing->queue() }))
     , m_autoPipelineLayout(createAutoPipelineLayout())
 {
+    m_queue->setLabel(WTFMove(queueLabel));
 }
 
 GPUDevice::~GPUDevice() = default;

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -82,9 +82,9 @@ struct GPUTextureDescriptor;
 class GPUDevice : public RefCounted<GPUDevice>, public ActiveDOMObject, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(GPUDevice);
 public:
-    static Ref<GPUDevice> create(ScriptExecutionContext* scriptExecutionContext, Ref<WebGPU::Device>&& backing)
+    static Ref<GPUDevice> create(ScriptExecutionContext* scriptExecutionContext, Ref<WebGPU::Device>&& backing, String&& queueLabel)
     {
-        return adoptRef(*new GPUDevice(scriptExecutionContext, WTFMove(backing)));
+        return adoptRef(*new GPUDevice(scriptExecutionContext, WTFMove(backing), WTFMove(queueLabel)));
     }
 
     virtual ~GPUDevice();
@@ -143,7 +143,7 @@ public:
     WeakPtr<GPUExternalTexture> takeExternalTextureForVideoElement(const HTMLVideoElement&);
 
 private:
-    GPUDevice(ScriptExecutionContext*, Ref<WebGPU::Device>&&);
+    GPUDevice(ScriptExecutionContext*, Ref<WebGPU::Device>&&, String&& queueLabel);
 
     // FIXME: We probably need to override more methods to make this work properly.
     RefPtr<GPUPipelineLayout> createAutoPipelineLayout();

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceDescriptor.h
@@ -27,6 +27,7 @@
 
 #include "GPUFeatureName.h"
 #include "GPUObjectDescriptorBase.h"
+#include "GPUQueueDescriptor.h"
 #include "WebGPUDeviceDescriptor.h"
 #include <cstdint>
 #include <wtf/HashMap.h>
@@ -50,6 +51,7 @@ struct GPUDeviceDescriptor : public GPUObjectDescriptorBase {
 
     Vector<GPUFeatureName> requiredFeatures;
     Vector<KeyValuePair<String, uint64_t>> requiredLimits;
+    GPUQueueDescriptor defaultQueue;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceDescriptor.idl
@@ -33,4 +33,5 @@ typedef [EnforceRange] unsigned long long GPUSize64;
 dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
     sequence<GPUFeatureName> requiredFeatures = [];
     record<DOMString, GPUSize64> requiredLimits;
+    GPUQueueDescriptor defaultQueue = {};
 };

--- a/Source/WebCore/Modules/WebGPU/GPUQueueDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUQueueDescriptor.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "GPUObjectDescriptorBase.h"
+
+namespace WebCore {
+
+struct GPUQueueDescriptor : public GPUObjectDescriptorBase {
+};
+
+}

--- a/Source/WebCore/Modules/WebGPU/GPUQueueDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQueueDescriptor.idl
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://gpuweb.github.io/gpuweb/#dictdef-gpuqueuedescriptor
+
+[
+    EnabledBySetting=WebGPUEnabled
+]
+dictionary GPUQueueDescriptor : GPUObjectDescriptorBase {
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3688,6 +3688,7 @@ JSGPUQuerySet.cpp
 JSGPUQuerySetDescriptor.cpp
 JSGPUQueryType.cpp
 JSGPUQueue.cpp
+JSGPUQueueDescriptor.cpp
 JSGPURenderBundle.cpp
 JSGPURenderBundleDescriptor.cpp
 JSGPURenderBundleEncoder.cpp


### PR DESCRIPTION
#### d7291479188e96a6d65ccfcd622d1931a3e95e6a
<pre>
[WebGPU] GPUQueueDescriptor.idl is missing
<a href="https://bugs.webkit.org/show_bug.cgi?id=272554">https://bugs.webkit.org/show_bug.cgi?id=272554</a>
&lt;radar://126298421&gt;

Reviewed by Tadeu Zagallo.

Add GPUQueueDescriptor which simply sets the label on the GPUQueue.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/WebGPU/GPUDeviceDescriptor.h:
* Source/WebCore/Modules/WebGPU/GPUDeviceDescriptor.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:

* Source/WebCore/Modules/WebGPU/GPUQueueDescriptor.h: Added.
* Source/WebCore/Modules/WebGPU/GPUQueueDescriptor.idl: Added.

Canonical link: <a href="https://commits.webkit.org/278365@main">https://commits.webkit.org/278365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83a256e025e98de75580edf983801bc15869c653

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/50319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/29612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/2616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/53578 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/1009 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/52622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/35841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/657 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/41046 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/52418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/27270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/43313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/22150 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/24680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/567 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/8697 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/46665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/55164 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/25415 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/48450 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/26678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/43496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/47482 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11038 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/27540 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/26408 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->