### PR TITLE
[JSC] Simplify DFG finalization in the main thread more

### DIFF
--- a/Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.cpp
+++ b/Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.cpp
@@ -47,7 +47,7 @@ void AdaptiveInferredPropertyValueWatchpointBase::initialize(const ObjectPropert
 
 void AdaptiveInferredPropertyValueWatchpointBase::install(VM& vm)
 {
-    RELEASE_ASSERT(m_key.isWatchable(PropertyCondition::MakeNoChanges));
+    ASSERT(m_key.isWatchable(PropertyCondition::MakeNoChanges)); // This is really costly.
 
     Structure* structure = m_key.object()->structure();
 

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3628,7 +3628,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case GetCallee:
         if (FunctionExecutable* executable = jsDynamicCast<FunctionExecutable*>(m_codeBlock->ownerExecutable())) {
             if (JSFunction* function = executable->singleton().inferredValue()) {
-                m_graph.watchpoints().addLazily(executable);
+                m_graph.watchpoints().addLazily(m_graph, executable);
                 setConstant(node, *m_graph.freeze(function));
                 break;
             }

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -376,7 +376,7 @@ private:
             // case if the function is a singleton then we already know it.
             if (FunctionExecutable* executable = jsDynamicCast<FunctionExecutable*>(m_codeBlock->ownerExecutable())) {
                 if (JSFunction* function = executable->singleton().inferredValue()) {
-                    m_graph.watchpoints().addLazily(executable);
+                    m_graph.watchpoints().addLazily(m_graph, executable);
                     return weakJSConstant(function);
                 }
             }
@@ -8558,7 +8558,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
 
                 if (symbolTable) {
                     if (JSScope* scope = symbolTable->singleton().inferredValue()) {
-                        m_graph.watchpoints().addLazily(symbolTable);
+                        m_graph.watchpoints().addLazily(m_graph, symbolTable);
                         set(bytecode.m_dst, weakJSConstant(scope));
                         break;
                     }

--- a/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp
@@ -41,10 +41,7 @@ bool ArrayBufferViewWatchpointAdaptor::add(CodeBlock* codeBlock, JSArrayBufferVi
             return false;
 
         // view is already frozen. If it is deallocated, jettisoning happens.
-        {
-            ConcurrentJSLocker locker(codeBlock->m_lock);
-            watchpoint.initialize(codeBlock);
-        }
+        watchpoint.initialize(codeBlock);
         ArrayBuffer* arrayBuffer = view->possiblySharedBuffer();
         if (!arrayBuffer) {
             watchpoint.fire(codeBlock->vm(), StringFireDetail("ArrayBuffer could not be allocated, probably because of OOM."));
@@ -64,11 +61,8 @@ bool SymbolTableAdaptor::add(CodeBlock* codeBlock, SymbolTable* symbolTable, Wat
         if (hasBeenInvalidated(symbolTable))
             return false;
 
-        {
-            ConcurrentJSLocker locker(codeBlock->m_lock);
-            watchpoint.initialize(codeBlock);
-        }
-        codeBlock->addConstant(ConcurrentJSLocker(codeBlock->m_lock), symbolTable); // For common users, it doesn't really matter if it's weak or not. If references to it go away, we go away, too.
+        // symbolTable is already frozen strongly.
+        watchpoint.initialize(codeBlock);
         symbolTable->singleton().add(&watchpoint);
         return true;
     });
@@ -80,11 +74,8 @@ bool FunctionExecutableAdaptor::add(CodeBlock* codeBlock, FunctionExecutable* ex
         if (hasBeenInvalidated(executable))
             return false;
 
-        {
-            ConcurrentJSLocker locker(codeBlock->m_lock);
-            watchpoint.initialize(codeBlock);
-        }
-        codeBlock->addConstant(ConcurrentJSLocker(codeBlock->m_lock), executable); // For common users, it doesn't really matter if it's weak or not. If references to it go away, we go away, too.
+        // executable is already frozen strongly.
+        watchpoint.initialize(codeBlock);
         executable->singleton().add(&watchpoint);
 
         return true;
@@ -100,10 +91,7 @@ bool AdaptiveStructureWatchpointAdaptor::add(CodeBlock* codeBlock, const ObjectP
             if (hasBeenInvalidated(key))
                 return false;
 
-            {
-                ConcurrentJSLocker locker(codeBlock->m_lock);
-                watchpoint.initialize(key, codeBlock);
-            }
+            watchpoint.initialize(key, codeBlock);
             watchpoint.install(vm);
             return true;
         });
@@ -112,10 +100,8 @@ bool AdaptiveStructureWatchpointAdaptor::add(CodeBlock* codeBlock, const ObjectP
         return collector.addAdaptiveStructureWatchpoint([&](AdaptiveStructureWatchpoint& watchpoint) {
             if (hasBeenInvalidated(key))
                 return false;
-            {
-                ConcurrentJSLocker locker(codeBlock->m_lock);
-                watchpoint.initialize(key, codeBlock);
-            }
+
+            watchpoint.initialize(key, codeBlock);
             watchpoint.install(vm);
             return true;
         });
@@ -137,13 +123,15 @@ void DesiredWatchpoints::addLazily(InlineWatchpointSet& set)
     m_inlineSets.addLazily(&set);
 }
 
-void DesiredWatchpoints::addLazily(SymbolTable* symbolTable)
+void DesiredWatchpoints::addLazily(Graph& graph, SymbolTable* symbolTable)
 {
+    graph.freezeStrong(symbolTable); // Keep this strongly.
     m_symbolTables.addLazily(symbolTable);
 }
 
-void DesiredWatchpoints::addLazily(FunctionExecutable* executable)
+void DesiredWatchpoints::addLazily(Graph& graph, FunctionExecutable* executable)
 {
+    graph.freezeStrong(executable); // Keep this strongly.
     m_functionExecutables.addLazily(executable);
 }
 
@@ -170,9 +158,9 @@ bool DesiredWatchpoints::consider(Structure* structure)
     return true;
 }
 
-void DesiredWatchpoints::countWatchpoints(CodeBlock* codeBlock, DesiredIdentifiers& identifiers)
+void DesiredWatchpoints::countWatchpoints(CodeBlock* codeBlock, DesiredIdentifiers& identifiers, CommonData* commonData)
 {
-    WatchpointCollector collector;
+    WatchpointCollector collector(*commonData);
 
     m_sets.reallyAdd(codeBlock, collector);
     m_inlineSets.reallyAdd(codeBlock, collector);
@@ -182,14 +170,16 @@ void DesiredWatchpoints::countWatchpoints(CodeBlock* codeBlock, DesiredIdentifie
     m_adaptiveStructureSets.reallyAdd(codeBlock, collector);
     m_globalProperties.reallyAdd(codeBlock, identifiers, collector);
 
-    m_counts = collector.counts();
+    auto counts = collector.counts();
+    commonData->m_watchpoints = FixedVector<CodeBlockJettisoningWatchpoint>(counts.m_watchpointCount);
+    commonData->m_adaptiveStructureWatchpoints = FixedVector<AdaptiveStructureWatchpoint>(counts.m_adaptiveStructureWatchpointCount);
+    commonData->m_adaptiveInferredPropertyValueWatchpoints = FixedVector<AdaptiveInferredPropertyValueWatchpoint>(counts.m_adaptiveInferredPropertyValueWatchpointCount);
 }
 
 bool DesiredWatchpoints::reallyAdd(CodeBlock* codeBlock, DesiredIdentifiers& identifiers, CommonData* commonData)
 {
-    WatchpointCollector collector;
-
-    collector.materialize(m_counts);
+    WatchpointCollector collector(*commonData);
+    collector.materialize();
 
     if (!m_sets.reallyAdd(codeBlock, collector))
         return false;
@@ -212,7 +202,7 @@ bool DesiredWatchpoints::reallyAdd(CodeBlock* codeBlock, DesiredIdentifiers& ide
     if (!m_globalProperties.reallyAdd(codeBlock, identifiers, collector))
         return false;
 
-    collector.finalize(codeBlock, *commonData);
+    collector.finalize(*commonData);
 
     return true;
 }
@@ -233,14 +223,6 @@ void DesiredWatchpoints::dumpInContext(PrintStream& out, DumpContext* context) c
     out.print(prefix, "    FunctionExecutables: ", inContext(m_functionExecutables, context), "\n");
     out.print(prefix, "    Buffer views: ", inContext(m_bufferViews, context), "\n");
     out.print(prefix, "    Object property conditions: ", inContext(m_adaptiveStructureSets, context), "\n");
-}
-
-void WatchpointCollector::finalize(CodeBlock* codeBlock, CommonData& common)
-{
-    ConcurrentJSLocker locker(codeBlock->m_lock);
-    common.m_watchpoints = WTFMove(m_watchpoints);
-    common.m_adaptiveStructureWatchpoints = WTFMove(m_adaptiveStructureWatchpoints);
-    common.m_adaptiveInferredPropertyValueWatchpoints = WTFMove(m_adaptiveInferredPropertyValueWatchpoints);
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGFinalizer.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFinalizer.cpp
@@ -38,8 +38,12 @@ Finalizer::Finalizer(Plan& plan)
 {
 }
 
-Finalizer::~Finalizer()
+Finalizer::~Finalizer() = default;
+
+
+RefPtr<JSC::JITCode> Finalizer::jitCode()
 {
+    return nullptr;
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGFinalizer.h
+++ b/Source/JavaScriptCore/dfg/DFGFinalizer.h
@@ -45,6 +45,8 @@ public:
     virtual bool finalize() = 0;
     virtual bool isFailed() = 0;
 
+    virtual RefPtr<JSC::JITCode> jitCode();
+
 protected:
     Plan& m_plan;
 };

--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -210,7 +210,7 @@ JITCode* JITCode::dfg()
     return this;
 }
 
-void JITCode::shrinkToFit(const ConcurrentJSLocker&)
+void JITCode::shrinkToFit()
 {
     common.shrinkToFit();
     minifiedDFG.prepareAndShrink();

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -245,7 +245,7 @@ public:
     
     void validateReferences(const TrackedReferences&) final;
     
-    void shrinkToFit(const ConcurrentJSLocker&) final;
+    void shrinkToFit() final;
 
     RegisterSetBuilder liveRegistersToPreserveAtExceptionHandlingCallSite(CodeBlock*, CallSiteIndex) final;
 #if ENABLE(FTL_JIT)

--- a/Source/JavaScriptCore/dfg/DFGJITFinalizer.h
+++ b/Source/JavaScriptCore/dfg/DFGJITFinalizer.h
@@ -43,6 +43,8 @@ public:
     bool finalize() final;
     bool isFailed() final { return false; }
 
+    RefPtr<JSC::JITCode> jitCode() final { return m_jitCode.ptr(); }
+
 private:
     
     Ref<DFG::JITCode> m_jitCode;

--- a/Source/JavaScriptCore/dfg/DFGPlan.h
+++ b/Source/JavaScriptCore/dfg/DFGPlan.h
@@ -107,7 +107,7 @@ public:
 
 private:
     CompilationPath compileInThreadImpl() override;
-    void finalizeInThread();
+    void finalizeInThread(Ref<JSC::JITCode>);
     
     bool isStillValidCodeBlock();
     bool reallyAdd(CommonData*);

--- a/Source/JavaScriptCore/ftl/FTLJITCode.cpp
+++ b/Source/JavaScriptCore/ftl/FTLJITCode.cpp
@@ -134,7 +134,7 @@ const DFG::CommonData* JITCode::dfgCommon() const
     return &common;
 }
 
-void JITCode::shrinkToFit(const ConcurrentJSLocker&)
+void JITCode::shrinkToFit()
 {
     common.shrinkToFit();
     m_osrExit.shrinkToFit();

--- a/Source/JavaScriptCore/ftl/FTLJITCode.h
+++ b/Source/JavaScriptCore/ftl/FTLJITCode.h
@@ -68,7 +68,7 @@ public:
     DFG::CommonData* dfgCommon() override;
     const DFG::CommonData* dfgCommon() const override;
     static ptrdiff_t commonDataOffset() { return OBJECT_OFFSETOF(JITCode, common); }
-    void shrinkToFit(const ConcurrentJSLocker&) override;
+    void shrinkToFit() override;
 
     bool isUnlinked() const { return common.isUnlinked(); }
 

--- a/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
+++ b/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
@@ -62,7 +62,7 @@ bool JITFinalizer::finalize()
 
     CodeBlock* codeBlock = m_plan.codeBlock();
 
-    codeBlock->setJITCode(*jitCode);
+    codeBlock->setJITCode(*m_jitCode);
 
     if (UNLIKELY(m_plan.compilation()))
         vm.m_perBytecodeProfiler->addCompilation(codeBlock, *m_plan.compilation());

--- a/Source/JavaScriptCore/ftl/FTLJITFinalizer.h
+++ b/Source/JavaScriptCore/ftl/FTLJITFinalizer.h
@@ -45,7 +45,9 @@ public:
     bool finalize() final;
     bool isFailed() final { return false; };
 
-    RefPtr<FTL::JITCode> jitCode;
+    RefPtr<JSC::JITCode> jitCode() final { return m_jitCode; }
+
+    RefPtr<FTL::JITCode> m_jitCode;
     size_t m_codeSize { 0 };
 };
 

--- a/Source/JavaScriptCore/ftl/FTLLink.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLink.cpp
@@ -71,7 +71,7 @@ void link(State& state)
     }
 
     state.finalizer->m_codeSize = state.b3CodeLinkBuffer->size();
-    state.finalizer->jitCode = state.jitCode;
+    state.finalizer->m_jitCode = state.jitCode;
 }
 
 } } // namespace JSC::FTL

--- a/Source/JavaScriptCore/jit/JITCode.cpp
+++ b/Source/JavaScriptCore/jit/JITCode.cpp
@@ -125,7 +125,7 @@ FTL::ForOSREntryJITCode* JITCode::ftlForOSREntry()
     return nullptr;
 }
 
-void JITCode::shrinkToFit(const ConcurrentJSLocker&)
+void JITCode::shrinkToFit()
 {
 }
 

--- a/Source/JavaScriptCore/jit/JITCode.h
+++ b/Source/JavaScriptCore/jit/JITCode.h
@@ -278,7 +278,7 @@ public:
     virtual DFG::JITCode* dfg();
     virtual FTL::JITCode* ftl();
     virtual FTL::ForOSREntryJITCode* ftlForOSREntry();
-    virtual void shrinkToFit(const ConcurrentJSLocker&);
+    virtual void shrinkToFit();
     
     virtual void validateReferences(const TrackedReferences&);
     


### PR DESCRIPTION
#### 73422ab1e1b7e6abc80c2ed414d16a337fe081f5
<pre>
[JSC] Simplify DFG finalization in the main thread more
<a href="https://bugs.webkit.org/show_bug.cgi?id=272577">https://bugs.webkit.org/show_bug.cgi?id=272577</a>
<a href="https://rdar.apple.com/126333191">rdar://126333191</a>

Reviewed by Justin Michaud.

This patch further simplifies DFG main thread finalization since it turned out this is costly.

1. AdaptiveInferredPropertyValueWatchpointBase::install&apos;s check should be ASSERT since it is huge cost.
2. Most of ConcurrentJSLock in DesiredWatchpoints are unnecessary. Removed.
3. Materialize FixedVector of watchpoints in the concurrent compiler thread instead of main thread.
4. JITCode shrinking should be done in the concurrent compiler thread.

* Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.cpp:
(JSC::AdaptiveInferredPropertyValueWatchpointBase::install):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::get):
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp:
(JSC::DFG::ArrayBufferViewWatchpointAdaptor::add):
(JSC::DFG::SymbolTableAdaptor::add):
(JSC::DFG::FunctionExecutableAdaptor::add):
(JSC::DFG::AdaptiveStructureWatchpointAdaptor::add):
(JSC::DFG::DesiredWatchpoints::addLazily):
(JSC::DFG::DesiredWatchpoints::countWatchpoints):
(JSC::DFG::DesiredWatchpoints::reallyAdd):
(JSC::DFG::WatchpointCollector::finalize): Deleted.
* Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.h:
* Source/JavaScriptCore/dfg/DFGJITCode.cpp:
(JSC::DFG::JITCode::shrinkToFit):
* Source/JavaScriptCore/dfg/DFGJITCode.h:
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::finalizeInThread):
(JSC::DFG::Plan::finalize):
* Source/JavaScriptCore/ftl/FTLJITCode.cpp:
(JSC::FTL::JITCode::shrinkToFit):
* Source/JavaScriptCore/ftl/FTLJITCode.h:
* Source/JavaScriptCore/jit/JITCode.cpp:
(JSC::JITCode::shrinkToFit):
* Source/JavaScriptCore/jit/JITCode.h:

Canonical link: <a href="https://commits.webkit.org/277457@main">https://commits.webkit.org/277457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6eb47902938a67b23a8e8f7da95c0066a87b316

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50333 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43705 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38796 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48232 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41065 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20093 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42258 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5699 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40932 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43994 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52225 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47141 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19014 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46099 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23958 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45129 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24746 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54641 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6738 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23678 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11199 "Passed tests") | 
<!--EWS-Status-Bubble-End-->