### PR TITLE
[WPE] WPE Platform: WPEMonitor should return the position and size in logical coordinates

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp
@@ -159,8 +159,7 @@ static void wpe_monitor_class_init(WPEMonitorClass* monitorClass)
     /**
      * WPEMonitor:x:
      *
-     * The x coordinate of the monitor position in pixels.
-     * Note this is not device pixels, so not affected by #WPEMonitor:scale.
+     * The x coordinate of the monitor position in logical coordinates.
      */
     sObjProperties[PROP_X] =
         g_param_spec_int(
@@ -172,8 +171,7 @@ static void wpe_monitor_class_init(WPEMonitorClass* monitorClass)
     /**
      * WPEMonitor:y:
      *
-     * The y coordinate of the monitor position in pixels.
-     * Note this is not device pixels, so not affected by #WPEMonitor:scale.
+     * The y coordinate of the monitor position in logical coordinates.
      */
     sObjProperties[PROP_Y] =
         g_param_spec_int(
@@ -185,8 +183,7 @@ static void wpe_monitor_class_init(WPEMonitorClass* monitorClass)
     /**
      * WPEMonitor:width:
      *
-     * The width of the monitor in pixels.
-     * Note this is not device pixels, so not affected by #WPEMonitor:scale.
+     * The width of the monitor in logical coordinates.
      */
     sObjProperties[PROP_WIDTH] =
         g_param_spec_int(
@@ -198,8 +195,7 @@ static void wpe_monitor_class_init(WPEMonitorClass* monitorClass)
     /**
      * WPEMonitor:height:
      *
-     * The height of the monitor in pixels.
-     * Note this is not device pixels, so not affected by #WPEMonitor:scale.
+     * The height of the monitor in logical coordinates.
      */
     sObjProperties[PROP_HEIGHT] =
         g_param_spec_int(
@@ -296,7 +292,7 @@ void wpe_monitor_invalidate(WPEMonitor* monitor)
  * wpe_monitor_get_x:
  * @monitor: a #WPEMonitor
  *
- * Get the x coordinate of the @monitor position.
+ * Get the x coordinate of the @monitor position in logical coordinates.
  *
  * Returns: the x coordinate, or -1 if not available
  */
@@ -311,7 +307,7 @@ int wpe_monitor_get_x(WPEMonitor* monitor)
  * wpe_monitor_get_y:
  * @monitor: a #WPEMonitor
  *
- * Get the y coordinate of the @monitor position.
+ * Get the y coordinate of the @monitor position in logical coordinates.
  *
  * Returns: the y coordinate, or -1 if not available
  */
@@ -328,7 +324,7 @@ int wpe_monitor_get_y(WPEMonitor* monitor)
  * @x: the x coordinate, or -1
  * @y: the y coordinate, or -1
  *
- * Set the position of @monitor
+ * Set the position of @monitor in logical coordinates.
  */
 void wpe_monitor_set_position(WPEMonitor* monitor, int x, int y)
 {
@@ -351,7 +347,7 @@ void wpe_monitor_set_position(WPEMonitor* monitor, int x, int y)
  * wpe_monitor_get_width:
  * @monitor: a #WPEMonitor
  *
- * Get the width of @monitor.
+ * Get the width of @monitor in logical coordinates.
  *
  * Returns: the width of @monitor, or -1 if not available
  */
@@ -366,7 +362,7 @@ int wpe_monitor_get_width(WPEMonitor* monitor)
  * wpe_monitor_get_height:
  * @monitor: a #WPEMonitor
  *
- * Get the height of @monitor.
+ * Get the height of @monitor in logical coordinates.
  *
  * Returns: the height of @monitor, or -1 if not available
  */
@@ -383,7 +379,7 @@ int wpe_monitor_get_height(WPEMonitor* monitor)
  * @width: the width, or -1
  * @height: the height, o -1
  *
- * Set the size of @monitor.
+ * Set the size of @monitor in logical coordinates.
  */
 void wpe_monitor_set_size(WPEMonitor* monitor, int width, int height)
 {

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEMonitorDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEMonitorDRM.cpp
@@ -67,12 +67,14 @@ WPEMonitor* wpeMonitorDRMCreate(std::unique_ptr<WPE::DRM::Crtc>&& crtc, const WP
     auto* priv = WPE_MONITOR_DRM(monitor)->priv;
     priv->crtc = WTFMove(crtc);
 
-    wpe_monitor_set_position(monitor, priv->crtc->x(), priv->crtc->y());
-    wpe_monitor_set_size(monitor, priv->crtc->width(), priv->crtc->height());
-    wpe_monitor_set_physical_size(monitor, connector.widthMM(), connector.heightMM());
-
+    double scale = 1;
     if (const char* scaleString = getenv("WPE_DRM_SCALE"))
-        wpe_monitor_set_scale(monitor, g_ascii_strtod(scaleString, nullptr));
+        scale = g_ascii_strtod(scaleString, nullptr);
+
+    wpe_monitor_set_position(monitor, priv->crtc->x() / scale, priv->crtc->y() / scale);
+    wpe_monitor_set_size(monitor, priv->crtc->width() / scale, priv->crtc->height() / scale);
+    wpe_monitor_set_physical_size(monitor, connector.widthMM(), connector.heightMM());
+    wpe_monitor_set_scale(monitor, scale);
 
     if (const auto& mode = priv->crtc->currentMode())
         priv->mode = mode.value();


### PR DESCRIPTION
#### b446f6062ccc15d5911e5260df58882c5fad580e
<pre>
[WPE] WPE Platform: WPEMonitor should return the position and size in logical coordinates
<a href="https://bugs.webkit.org/show_bug.cgi?id=272580">https://bugs.webkit.org/show_bug.cgi?id=272580</a>

Reviewed by Alejandro G. Castro.

Apply the monitor scale when setting the size and position and update
the documentation to clarify we use logical coordianates.

* Source/WebKit/WPEPlatform/wpe/WPEMonitor.cpp:
(wpe_monitor_class_init):
* Source/WebKit/WPEPlatform/wpe/drm/WPEMonitorDRM.cpp:
(wpeMonitorDRMCreate):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEMonitorWayland.cpp:

Canonical link: <a href="https://commits.webkit.org/277485@main">https://commits.webkit.org/277485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2274d3537de82573489c85ef3f4d7e7193a1540

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50251 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43617 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38726 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20029 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21848 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5611 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43905 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52131 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46031 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23876 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45061 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24664 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6754 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23595 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->