### PR TITLE
Implement case sensitive modifier (s) in attribute selector

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/cssom-expected.txt
@@ -39,36 +39,36 @@ PASS [*|foo="bar" i] insertRule in @media
 PASS [*|foo="bar" i] getting CSSRule#cssText in @media
 PASS [*|foo="bar" i] getting CSSStyleRule#selectorText in @media
 PASS [*|foo="bar" i] setting CSSStyleRule#selectorText in @media
-FAIL [foo="bar" s] insertRule The string did not match the expected pattern.
-FAIL [foo="bar" s] getting CSSRule#cssText The string did not match the expected pattern.
-FAIL [foo="bar" s] getting CSSStyleRule#selectorText The string did not match the expected pattern.
-FAIL [foo="bar" s] setting CSSStyleRule#selectorText assert_equals: expected "[foo=\"bar\" s]" but got "foobar"
-FAIL [foo="bar" s] insertRule in @media The string did not match the expected pattern.
-FAIL [foo="bar" s] getting CSSRule#cssText in @media The string did not match the expected pattern.
-FAIL [foo="bar" s] getting CSSStyleRule#selectorText in @media The string did not match the expected pattern.
-FAIL [foo="bar" s] setting CSSStyleRule#selectorText in @media assert_equals: expected "[foo=\"bar\" s]" but got "foobar"
-FAIL [foo="bar" /**/ s] insertRule The string did not match the expected pattern.
-FAIL [foo="bar" /**/ s] getting CSSRule#cssText The string did not match the expected pattern.
-FAIL [foo="bar" /**/ s] getting CSSStyleRule#selectorText The string did not match the expected pattern.
-FAIL [foo="bar" /**/ s] setting CSSStyleRule#selectorText assert_equals: expected "[foo=\"bar\" s]" but got "foobar"
-FAIL [foo="bar" /**/ s] insertRule in @media The string did not match the expected pattern.
-FAIL [foo="bar" /**/ s] getting CSSRule#cssText in @media The string did not match the expected pattern.
-FAIL [foo="bar" /**/ s] getting CSSStyleRule#selectorText in @media The string did not match the expected pattern.
-FAIL [foo="bar" /**/ s] setting CSSStyleRule#selectorText in @media assert_equals: expected "[foo=\"bar\" s]" but got "foobar"
-FAIL [foo="bar"/**/s] insertRule The string did not match the expected pattern.
-FAIL [foo="bar"/**/s] getting CSSRule#cssText The string did not match the expected pattern.
-FAIL [foo="bar"/**/s] getting CSSStyleRule#selectorText The string did not match the expected pattern.
-FAIL [foo="bar"/**/s] setting CSSStyleRule#selectorText assert_equals: expected "[foo=\"bar\" s]" but got "foobar"
-FAIL [foo="bar"/**/s] insertRule in @media The string did not match the expected pattern.
-FAIL [foo="bar"/**/s] getting CSSRule#cssText in @media The string did not match the expected pattern.
-FAIL [foo="bar"/**/s] getting CSSStyleRule#selectorText in @media The string did not match the expected pattern.
-FAIL [foo="bar"/**/s] setting CSSStyleRule#selectorText in @media assert_equals: expected "[foo=\"bar\" s]" but got "foobar"
-FAIL [*|foo="bar" s] insertRule The string did not match the expected pattern.
-FAIL [*|foo="bar" s] getting CSSRule#cssText The string did not match the expected pattern.
-FAIL [*|foo="bar" s] getting CSSStyleRule#selectorText The string did not match the expected pattern.
-FAIL [*|foo="bar" s] setting CSSStyleRule#selectorText assert_equals: expected "[*|foo=\"bar\" s]" but got "foobar"
-FAIL [*|foo="bar" s] insertRule in @media The string did not match the expected pattern.
-FAIL [*|foo="bar" s] getting CSSRule#cssText in @media The string did not match the expected pattern.
-FAIL [*|foo="bar" s] getting CSSStyleRule#selectorText in @media The string did not match the expected pattern.
-FAIL [*|foo="bar" s] setting CSSStyleRule#selectorText in @media assert_equals: expected "[*|foo=\"bar\" s]" but got "foobar"
+PASS [foo="bar" s] insertRule
+FAIL [foo="bar" s] getting CSSRule#cssText assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"] {"
+FAIL [foo="bar" s] getting CSSStyleRule#selectorText assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"]"
+FAIL [foo="bar" s] setting CSSStyleRule#selectorText assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"]"
+PASS [foo="bar" s] insertRule in @media
+FAIL [foo="bar" s] getting CSSRule#cssText in @media assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"] {"
+FAIL [foo="bar" s] getting CSSStyleRule#selectorText in @media assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"]"
+FAIL [foo="bar" s] setting CSSStyleRule#selectorText in @media assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"]"
+PASS [foo="bar" /**/ s] insertRule
+FAIL [foo="bar" /**/ s] getting CSSRule#cssText assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"] {"
+FAIL [foo="bar" /**/ s] getting CSSStyleRule#selectorText assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"]"
+FAIL [foo="bar" /**/ s] setting CSSStyleRule#selectorText assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"]"
+PASS [foo="bar" /**/ s] insertRule in @media
+FAIL [foo="bar" /**/ s] getting CSSRule#cssText in @media assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"] {"
+FAIL [foo="bar" /**/ s] getting CSSStyleRule#selectorText in @media assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"]"
+FAIL [foo="bar" /**/ s] setting CSSStyleRule#selectorText in @media assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"]"
+PASS [foo="bar"/**/s] insertRule
+FAIL [foo="bar"/**/s] getting CSSRule#cssText assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"] {"
+FAIL [foo="bar"/**/s] getting CSSStyleRule#selectorText assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"]"
+FAIL [foo="bar"/**/s] setting CSSStyleRule#selectorText assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"]"
+PASS [foo="bar"/**/s] insertRule in @media
+FAIL [foo="bar"/**/s] getting CSSRule#cssText in @media assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"] {"
+FAIL [foo="bar"/**/s] getting CSSStyleRule#selectorText in @media assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"]"
+FAIL [foo="bar"/**/s] setting CSSStyleRule#selectorText in @media assert_equals: expected "[foo=\"bar\" s]" but got "[foo=\"bar\"]"
+PASS [*|foo="bar" s] insertRule
+FAIL [*|foo="bar" s] getting CSSRule#cssText assert_equals: expected "[*|foo=\"bar\" s]" but got "[*|foo=\"bar\"] {"
+FAIL [*|foo="bar" s] getting CSSStyleRule#selectorText assert_equals: expected "[*|foo=\"bar\" s]" but got "[*|foo=\"bar\"]"
+FAIL [*|foo="bar" s] setting CSSStyleRule#selectorText assert_equals: expected "[*|foo=\"bar\" s]" but got "[*|foo=\"bar\"]"
+PASS [*|foo="bar" s] insertRule in @media
+FAIL [*|foo="bar" s] getting CSSRule#cssText in @media assert_equals: expected "[*|foo=\"bar\" s]" but got "[*|foo=\"bar\"] {"
+FAIL [*|foo="bar" s] getting CSSStyleRule#selectorText in @media assert_equals: expected "[*|foo=\"bar\" s]" but got "[*|foo=\"bar\"]"
+FAIL [*|foo="bar" s] setting CSSStyleRule#selectorText in @media assert_equals: expected "[*|foo=\"bar\" s]" but got "[*|foo=\"bar\"]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/semantics-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/semantics-expected.txt
@@ -57,39 +57,39 @@ PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> in standards mode
 PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> with querySelector in standards mode
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> in standards mode
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> with querySelector in standards mode
-FAIL [foo='bar' s] <div foo="bar"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="bar"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='' s] <div foo=""> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo=""> with querySelector in standards mode '[foo='' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in standards mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in standards mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [align='left' s] <div align="left"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="left"> with querySelector in standards mode '[align='left' s]' is not a valid selector.
-FAIL [align='LEFT' s] <div align="LEFT"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="LEFT"> with querySelector in standards mode '[align='LEFT' s]' is not a valid selector.
-FAIL [class~='a' s] <div class="x a b"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="x a b"> with querySelector in standards mode '[class~='a' s]' is not a valid selector.
-FAIL [class~='A' s] <div class="X A B"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="X A B"> with querySelector in standards mode '[class~='A' s]' is not a valid selector.
-FAIL [id^='a' s] <div id="ab"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="ab"> with querySelector in standards mode '[id^='a' s]' is not a valid selector.
-FAIL [id$='A' s] <div id="XA"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="XA"> with querySelector in standards mode '[id$='A' s]' is not a valid selector.
-FAIL [lang|='a' s] <div lang="a-b"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="a-b"> with querySelector in standards mode '[lang|='a' s]' is not a valid selector.
-FAIL [lang*='A' s] <div lang="XAB"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="XAB"> with querySelector in standards mode '[lang*='A' s]' is not a valid selector.
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in standards mode '[*|lang='a' s]' is not a valid selector.
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in standards mode '[*|lang='A' s]' is not a valid selector.
-FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in standards mode '[foo='BAR' s][foo='BAR' s]' is not a valid selector.
+PASS [foo='bar' s] <div foo="bar"> in standards mode
+PASS [foo='bar' s] <div foo="bar"> with querySelector in standards mode
+PASS [foo='' s] <div foo=""> in standards mode
+PASS [foo='' s] <div foo=""> with querySelector in standards mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in standards mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in standards mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in standards mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in standards mode
+PASS [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in standards mode
+PASS [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in standards mode
+PASS [align='left' s] <div align="left"> in standards mode
+PASS [align='left' s] <div align="left"> with querySelector in standards mode
+PASS [align='LEFT' s] <div align="LEFT"> in standards mode
+PASS [align='LEFT' s] <div align="LEFT"> with querySelector in standards mode
+PASS [class~='a' s] <div class="x a b"> in standards mode
+PASS [class~='a' s] <div class="x a b"> with querySelector in standards mode
+PASS [class~='A' s] <div class="X A B"> in standards mode
+PASS [class~='A' s] <div class="X A B"> with querySelector in standards mode
+PASS [id^='a' s] <div id="ab"> in standards mode
+PASS [id^='a' s] <div id="ab"> with querySelector in standards mode
+PASS [id$='A' s] <div id="XA"> in standards mode
+PASS [id$='A' s] <div id="XA"> with querySelector in standards mode
+PASS [lang|='a' s] <div lang="a-b"> in standards mode
+PASS [lang|='a' s] <div lang="a-b"> with querySelector in standards mode
+PASS [lang*='A' s] <div lang="XAB"> in standards mode
+PASS [lang*='A' s] <div lang="XAB"> with querySelector in standards mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in standards mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in standards mode
+PASS @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode
+PASS [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in standards mode
+PASS [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in standards mode
 PASS [align='left'] /* sanity check (match HTML) */ <div align="LEFT"> in standards mode
 PASS [align='left'] /* sanity check (match HTML) */ <div align="LEFT"> with querySelector in standards mode
 PASS [align='LEFT'] /* sanity check (match HTML) */ <div align="left"> in standards mode
@@ -205,121 +205,121 @@ PASS [foo*='É' i] <div foo="é"> in standards mode
 PASS [foo*='É' i] <div foo="é"> with querySelector in standards mode
 PASS [foo|='É' i] <div foo="é"> in standards mode
 PASS [foo|='É' i] <div foo="é"> with querySelector in standards mode
-FAIL [foo='' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo="BAR"> with querySelector in standards mode '[foo='' s]' is not a valid selector.
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in standards mode '[foo='\0' s] /* \0 in selector */' is not a valid selector.
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in standards mode '[foo='' s] /* \0 in attribute */' is not a valid selector.
-FAIL [foo='ä' s] <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] <div foo="Ä"> with querySelector in standards mode '[foo='ä' s]' is not a valid selector.
-FAIL [foo='Ä' s] <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] <div foo="ä"> with querySelector in standards mode '[foo='Ä' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in standards mode '[foo~='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in standards mode '[foo^='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in standards mode '[foo$='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode '[foo*='ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode '[foo|='ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='i' s] <div foo="İ"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="İ"> with querySelector in standards mode '[foo='i' s]' is not a valid selector.
-FAIL [foo='i' s] <div foo="ı"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="ı"> with querySelector in standards mode '[foo='i' s]' is not a valid selector.
-FAIL [foo='I' s] <div foo="İ"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="İ"> with querySelector in standards mode '[foo='I' s]' is not a valid selector.
-FAIL [foo='I' s] <div foo="ı"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="ı"> with querySelector in standards mode '[foo='I' s]' is not a valid selector.
-FAIL [foo='İ' s] <div foo="i"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="i"> with querySelector in standards mode '[foo='İ' s]' is not a valid selector.
-FAIL [foo='ı' s] <div foo="i"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="i"> with querySelector in standards mode '[foo='ı' s]' is not a valid selector.
-FAIL [foo='İ' s] <div foo="I"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="I"> with querySelector in standards mode '[foo='İ' s]' is not a valid selector.
-FAIL [foo='ı' s] <div foo="I"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="I"> with querySelector in standards mode '[foo='ı' s]' is not a valid selector.
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in standards mode '[|foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s] <div FOO="bar"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div FOO="bar"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in standards mode '[foo='	' s] /* tab in selector */' is not a valid selector.
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in standards mode '[foo=' ' s] /* tab in attribute */' is not a valid selector.
-FAIL @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in standards mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in standards mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in standards mode '[foo='bar' s][foo='bar']' is not a valid selector.
-FAIL [foo='bar' s] <div baz="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div baz="BAR"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="BAR"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in standards mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in standards mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [align='left' s] <div align="LEFT"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="LEFT"> with querySelector in standards mode '[align='left' s]' is not a valid selector.
-FAIL [align='LEFT' s] <div align="left"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="left"> with querySelector in standards mode '[align='LEFT' s]' is not a valid selector.
-FAIL [class~='a' s] <div class="X A B"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="X A B"> with querySelector in standards mode '[class~='a' s]' is not a valid selector.
-FAIL [class~='A' s] <div class="x a b"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="x a b"> with querySelector in standards mode '[class~='A' s]' is not a valid selector.
-FAIL [id^='a' s] <div id="AB"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="AB"> with querySelector in standards mode '[id^='a' s]' is not a valid selector.
-FAIL [id$='A' s] <div id="xa"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="xa"> with querySelector in standards mode '[id$='A' s]' is not a valid selector.
-FAIL [lang|='a' s] <div lang="A-B"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="A-B"> with querySelector in standards mode '[lang|='a' s]' is not a valid selector.
-FAIL [lang*='A' s] <div lang="xab"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="xab"> with querySelector in standards mode '[lang*='A' s]' is not a valid selector.
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in standards mode '[*|lang='a' s]' is not a valid selector.
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in standards mode '[*|lang='A' s]' is not a valid selector.
-FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in standards mode '[foo='bar' s][foo='bar' s]' is not a valid selector.
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in standards mode '[foo='BAR' s][foo='bar']' is not a valid selector.
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in standards mode '[foo='bar'][foo='BAR' s]' is not a valid selector.
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in standards mode '[foo='BAR'][foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in standards mode '[foo='bar' s][foo='BAR']' is not a valid selector.
+PASS [foo='' s] <div foo="BAR"> in standards mode
+PASS [foo='' s] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='\0' s] /* \0 in selector */ <div foo=""> in standards mode
+PASS [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in standards mode
+PASS [foo='' s] /* \0 in attribute */ <div foo="\0"> in standards mode
+PASS [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in standards mode
+PASS [foo='ä' s] <div foo="Ä"> in standards mode
+PASS [foo='ä' s] <div foo="Ä"> with querySelector in standards mode
+PASS [foo='Ä' s] <div foo="ä"> in standards mode
+PASS [foo='Ä' s] <div foo="ä"> with querySelector in standards mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in standards mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in standards mode
+PASS [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in standards mode
+PASS [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in standards mode
+PASS [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in standards mode
+PASS [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in standards mode
+PASS [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode
+PASS [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode
+PASS [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode
+PASS [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in standards mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in standards mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in standards mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in standards mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in standards mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in standards mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in standards mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in standards mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo='i' s] <div foo="İ"> in standards mode
+PASS [foo='i' s] <div foo="İ"> with querySelector in standards mode
+PASS [foo='i' s] <div foo="ı"> in standards mode
+PASS [foo='i' s] <div foo="ı"> with querySelector in standards mode
+PASS [foo='I' s] <div foo="İ"> in standards mode
+PASS [foo='I' s] <div foo="İ"> with querySelector in standards mode
+PASS [foo='I' s] <div foo="ı"> in standards mode
+PASS [foo='I' s] <div foo="ı"> with querySelector in standards mode
+PASS [foo='İ' s] <div foo="i"> in standards mode
+PASS [foo='İ' s] <div foo="i"> with querySelector in standards mode
+PASS [foo='ı' s] <div foo="i"> in standards mode
+PASS [foo='ı' s] <div foo="i"> with querySelector in standards mode
+PASS [foo='İ' s] <div foo="I"> in standards mode
+PASS [foo='İ' s] <div foo="I"> with querySelector in standards mode
+PASS [foo='ı' s] <div foo="I"> in standards mode
+PASS [foo='ı' s] <div foo="I"> with querySelector in standards mode
+PASS [foo='bar' s] <div foo="x" {a}foo="BAR"> in standards mode
+PASS [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in standards mode
+PASS [|foo='bar' s] <div foo="x" {a}foo="BAR"> in standards mode
+PASS [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in standards mode
+PASS [foo='bar' s] <div FOO="bar"> in standards mode
+PASS [foo='bar' s] <div FOO="bar"> with querySelector in standards mode
+PASS [foo='	' s] /* tab in selector */ <div foo=" "> in standards mode
+PASS [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in standards mode
+PASS [foo=' ' s] /* tab in attribute */ <div foo="	"> in standards mode
+PASS [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in standards mode
+PASS @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in standards mode
+PASS @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in standards mode
+PASS [foo='bar' s][foo='bar'] <div foo="BAR"> in standards mode
+PASS [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='bar' s] <div baz="BAR"> in standards mode
+PASS [foo='bar' s] <div baz="BAR"> with querySelector in standards mode
+PASS [foo='bar' s] <div foo="BAR"> in standards mode
+PASS [foo='bar' s] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in standards mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in standards mode
+PASS [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in standards mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in standards mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in standards mode
+PASS [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in standards mode
+PASS [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in standards mode
+FAIL [align='left' s] <div align="LEFT"> in standards mode assert_equals: selector matched expected "visible" but got "hidden"
+FAIL [align='left' s] <div align="LEFT"> with querySelector in standards mode assert_equals: selector matched expected null but got Element node <div align="LEFT"></div>
+FAIL [align='LEFT' s] <div align="left"> in standards mode assert_equals: selector matched expected "visible" but got "hidden"
+FAIL [align='LEFT' s] <div align="left"> with querySelector in standards mode assert_equals: selector matched expected null but got Element node <div align="left"></div>
+PASS [class~='a' s] <div class="X A B"> in standards mode
+PASS [class~='a' s] <div class="X A B"> with querySelector in standards mode
+PASS [class~='A' s] <div class="x a b"> in standards mode
+PASS [class~='A' s] <div class="x a b"> with querySelector in standards mode
+PASS [id^='a' s] <div id="AB"> in standards mode
+PASS [id^='a' s] <div id="AB"> with querySelector in standards mode
+PASS [id$='A' s] <div id="xa"> in standards mode
+PASS [id$='A' s] <div id="xa"> with querySelector in standards mode
+FAIL [lang|='a' s] <div lang="A-B"> in standards mode assert_equals: selector matched expected "visible" but got "hidden"
+FAIL [lang|='a' s] <div lang="A-B"> with querySelector in standards mode assert_equals: selector matched expected null but got Element node <div lang="A-B"></div>
+FAIL [lang*='A' s] <div lang="xab"> in standards mode assert_equals: selector matched expected "visible" but got "hidden"
+FAIL [lang*='A' s] <div lang="xab"> with querySelector in standards mode assert_equals: selector matched expected null but got Element node <div lang="xab"></div>
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in standards mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in standards mode
+PASS @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode
+PASS [foo='bar' s][foo='bar' s] <div foo="BAR"> in standards mode
+PASS [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='BAR' s][foo='bar'] <div foo="BAR"> in standards mode
+PASS [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='bar'][foo='BAR' s] <div foo="BAR"> in standards mode
+PASS [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='BAR'][foo='bar' s] <div foo="BAR"> in standards mode
+PASS [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='bar' s][foo='BAR'] <div foo="bar"> in standards mode
+PASS [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in standards mode
 PASS [foo='BAR'] /* sanity check (match) */ <div foo="BAR"> in quirks mode
 PASS [foo='BAR'] /* sanity check (match) */ <div foo="BAR"> with querySelector in quirks mode
 PASS [foo='bar'] /* sanity check (match) */ <div foo="bar"> in quirks mode
@@ -378,39 +378,39 @@ PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> in quirks mode
 PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> with querySelector in quirks mode
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> in quirks mode
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> with querySelector in quirks mode
-FAIL [foo='bar' s] <div foo="bar"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="bar"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='' s] <div foo=""> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo=""> with querySelector in quirks mode '[foo='' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in quirks mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in quirks mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [align='left' s] <div align="left"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="left"> with querySelector in quirks mode '[align='left' s]' is not a valid selector.
-FAIL [align='LEFT' s] <div align="LEFT"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="LEFT"> with querySelector in quirks mode '[align='LEFT' s]' is not a valid selector.
-FAIL [class~='a' s] <div class="x a b"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="x a b"> with querySelector in quirks mode '[class~='a' s]' is not a valid selector.
-FAIL [class~='A' s] <div class="X A B"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="X A B"> with querySelector in quirks mode '[class~='A' s]' is not a valid selector.
-FAIL [id^='a' s] <div id="ab"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="ab"> with querySelector in quirks mode '[id^='a' s]' is not a valid selector.
-FAIL [id$='A' s] <div id="XA"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="XA"> with querySelector in quirks mode '[id$='A' s]' is not a valid selector.
-FAIL [lang|='a' s] <div lang="a-b"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="a-b"> with querySelector in quirks mode '[lang|='a' s]' is not a valid selector.
-FAIL [lang*='A' s] <div lang="XAB"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="XAB"> with querySelector in quirks mode '[lang*='A' s]' is not a valid selector.
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in quirks mode '[*|lang='a' s]' is not a valid selector.
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in quirks mode '[*|lang='A' s]' is not a valid selector.
-FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in quirks mode '[foo='BAR' s][foo='BAR' s]' is not a valid selector.
+PASS [foo='bar' s] <div foo="bar"> in quirks mode
+PASS [foo='bar' s] <div foo="bar"> with querySelector in quirks mode
+PASS [foo='' s] <div foo=""> in quirks mode
+PASS [foo='' s] <div foo=""> with querySelector in quirks mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in quirks mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in quirks mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in quirks mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in quirks mode
+PASS [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in quirks mode
+PASS [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in quirks mode
+PASS [align='left' s] <div align="left"> in quirks mode
+PASS [align='left' s] <div align="left"> with querySelector in quirks mode
+PASS [align='LEFT' s] <div align="LEFT"> in quirks mode
+PASS [align='LEFT' s] <div align="LEFT"> with querySelector in quirks mode
+PASS [class~='a' s] <div class="x a b"> in quirks mode
+PASS [class~='a' s] <div class="x a b"> with querySelector in quirks mode
+PASS [class~='A' s] <div class="X A B"> in quirks mode
+PASS [class~='A' s] <div class="X A B"> with querySelector in quirks mode
+PASS [id^='a' s] <div id="ab"> in quirks mode
+PASS [id^='a' s] <div id="ab"> with querySelector in quirks mode
+PASS [id$='A' s] <div id="XA"> in quirks mode
+PASS [id$='A' s] <div id="XA"> with querySelector in quirks mode
+PASS [lang|='a' s] <div lang="a-b"> in quirks mode
+PASS [lang|='a' s] <div lang="a-b"> with querySelector in quirks mode
+PASS [lang*='A' s] <div lang="XAB"> in quirks mode
+PASS [lang*='A' s] <div lang="XAB"> with querySelector in quirks mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in quirks mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in quirks mode
+PASS @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode
+PASS [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in quirks mode
+PASS [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in quirks mode
 PASS [align='left'] /* sanity check (match HTML) */ <div align="LEFT"> in quirks mode
 PASS [align='left'] /* sanity check (match HTML) */ <div align="LEFT"> with querySelector in quirks mode
 PASS [align='LEFT'] /* sanity check (match HTML) */ <div align="left"> in quirks mode
@@ -526,121 +526,121 @@ PASS [foo*='É' i] <div foo="é"> in quirks mode
 PASS [foo*='É' i] <div foo="é"> with querySelector in quirks mode
 PASS [foo|='É' i] <div foo="é"> in quirks mode
 PASS [foo|='É' i] <div foo="é"> with querySelector in quirks mode
-FAIL [foo='' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo="BAR"> with querySelector in quirks mode '[foo='' s]' is not a valid selector.
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in quirks mode '[foo='\0' s] /* \0 in selector */' is not a valid selector.
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in quirks mode '[foo='' s] /* \0 in attribute */' is not a valid selector.
-FAIL [foo='ä' s] <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] <div foo="Ä"> with querySelector in quirks mode '[foo='ä' s]' is not a valid selector.
-FAIL [foo='Ä' s] <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] <div foo="ä"> with querySelector in quirks mode '[foo='Ä' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in quirks mode '[foo~='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in quirks mode '[foo^='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in quirks mode '[foo$='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode '[foo*='ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode '[foo|='ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='i' s] <div foo="İ"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="İ"> with querySelector in quirks mode '[foo='i' s]' is not a valid selector.
-FAIL [foo='i' s] <div foo="ı"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="ı"> with querySelector in quirks mode '[foo='i' s]' is not a valid selector.
-FAIL [foo='I' s] <div foo="İ"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="İ"> with querySelector in quirks mode '[foo='I' s]' is not a valid selector.
-FAIL [foo='I' s] <div foo="ı"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="ı"> with querySelector in quirks mode '[foo='I' s]' is not a valid selector.
-FAIL [foo='İ' s] <div foo="i"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="i"> with querySelector in quirks mode '[foo='İ' s]' is not a valid selector.
-FAIL [foo='ı' s] <div foo="i"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="i"> with querySelector in quirks mode '[foo='ı' s]' is not a valid selector.
-FAIL [foo='İ' s] <div foo="I"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="I"> with querySelector in quirks mode '[foo='İ' s]' is not a valid selector.
-FAIL [foo='ı' s] <div foo="I"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="I"> with querySelector in quirks mode '[foo='ı' s]' is not a valid selector.
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in quirks mode '[|foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s] <div FOO="bar"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div FOO="bar"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in quirks mode '[foo='	' s] /* tab in selector */' is not a valid selector.
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in quirks mode '[foo=' ' s] /* tab in attribute */' is not a valid selector.
-FAIL @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in quirks mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in quirks mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in quirks mode '[foo='bar' s][foo='bar']' is not a valid selector.
-FAIL [foo='bar' s] <div baz="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div baz="BAR"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="BAR"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in quirks mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in quirks mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [align='left' s] <div align="LEFT"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="LEFT"> with querySelector in quirks mode '[align='left' s]' is not a valid selector.
-FAIL [align='LEFT' s] <div align="left"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="left"> with querySelector in quirks mode '[align='LEFT' s]' is not a valid selector.
-FAIL [class~='a' s] <div class="X A B"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="X A B"> with querySelector in quirks mode '[class~='a' s]' is not a valid selector.
-FAIL [class~='A' s] <div class="x a b"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="x a b"> with querySelector in quirks mode '[class~='A' s]' is not a valid selector.
-FAIL [id^='a' s] <div id="AB"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="AB"> with querySelector in quirks mode '[id^='a' s]' is not a valid selector.
-FAIL [id$='A' s] <div id="xa"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="xa"> with querySelector in quirks mode '[id$='A' s]' is not a valid selector.
-FAIL [lang|='a' s] <div lang="A-B"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="A-B"> with querySelector in quirks mode '[lang|='a' s]' is not a valid selector.
-FAIL [lang*='A' s] <div lang="xab"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="xab"> with querySelector in quirks mode '[lang*='A' s]' is not a valid selector.
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in quirks mode '[*|lang='a' s]' is not a valid selector.
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in quirks mode '[*|lang='A' s]' is not a valid selector.
-FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in quirks mode '[foo='bar' s][foo='bar' s]' is not a valid selector.
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in quirks mode '[foo='BAR' s][foo='bar']' is not a valid selector.
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in quirks mode '[foo='bar'][foo='BAR' s]' is not a valid selector.
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in quirks mode '[foo='BAR'][foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in quirks mode '[foo='bar' s][foo='BAR']' is not a valid selector.
+PASS [foo='' s] <div foo="BAR"> in quirks mode
+PASS [foo='' s] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='\0' s] /* \0 in selector */ <div foo=""> in quirks mode
+PASS [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in quirks mode
+PASS [foo='' s] /* \0 in attribute */ <div foo="\0"> in quirks mode
+PASS [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in quirks mode
+PASS [foo='ä' s] <div foo="Ä"> in quirks mode
+PASS [foo='ä' s] <div foo="Ä"> with querySelector in quirks mode
+PASS [foo='Ä' s] <div foo="ä"> in quirks mode
+PASS [foo='Ä' s] <div foo="ä"> with querySelector in quirks mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in quirks mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in quirks mode
+PASS [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in quirks mode
+PASS [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in quirks mode
+PASS [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in quirks mode
+PASS [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in quirks mode
+PASS [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode
+PASS [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode
+PASS [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode
+PASS [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in quirks mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in quirks mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in quirks mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in quirks mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in quirks mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in quirks mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in quirks mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in quirks mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo='i' s] <div foo="İ"> in quirks mode
+PASS [foo='i' s] <div foo="İ"> with querySelector in quirks mode
+PASS [foo='i' s] <div foo="ı"> in quirks mode
+PASS [foo='i' s] <div foo="ı"> with querySelector in quirks mode
+PASS [foo='I' s] <div foo="İ"> in quirks mode
+PASS [foo='I' s] <div foo="İ"> with querySelector in quirks mode
+PASS [foo='I' s] <div foo="ı"> in quirks mode
+PASS [foo='I' s] <div foo="ı"> with querySelector in quirks mode
+PASS [foo='İ' s] <div foo="i"> in quirks mode
+PASS [foo='İ' s] <div foo="i"> with querySelector in quirks mode
+PASS [foo='ı' s] <div foo="i"> in quirks mode
+PASS [foo='ı' s] <div foo="i"> with querySelector in quirks mode
+PASS [foo='İ' s] <div foo="I"> in quirks mode
+PASS [foo='İ' s] <div foo="I"> with querySelector in quirks mode
+PASS [foo='ı' s] <div foo="I"> in quirks mode
+PASS [foo='ı' s] <div foo="I"> with querySelector in quirks mode
+PASS [foo='bar' s] <div foo="x" {a}foo="BAR"> in quirks mode
+PASS [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in quirks mode
+PASS [|foo='bar' s] <div foo="x" {a}foo="BAR"> in quirks mode
+PASS [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in quirks mode
+PASS [foo='bar' s] <div FOO="bar"> in quirks mode
+PASS [foo='bar' s] <div FOO="bar"> with querySelector in quirks mode
+PASS [foo='	' s] /* tab in selector */ <div foo=" "> in quirks mode
+PASS [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in quirks mode
+PASS [foo=' ' s] /* tab in attribute */ <div foo="	"> in quirks mode
+PASS [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in quirks mode
+PASS @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in quirks mode
+PASS @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in quirks mode
+PASS [foo='bar' s][foo='bar'] <div foo="BAR"> in quirks mode
+PASS [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='bar' s] <div baz="BAR"> in quirks mode
+PASS [foo='bar' s] <div baz="BAR"> with querySelector in quirks mode
+PASS [foo='bar' s] <div foo="BAR"> in quirks mode
+PASS [foo='bar' s] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in quirks mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in quirks mode
+PASS [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in quirks mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in quirks mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in quirks mode
+PASS [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in quirks mode
+PASS [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in quirks mode
+FAIL [align='left' s] <div align="LEFT"> in quirks mode assert_equals: selector matched expected "visible" but got "hidden"
+FAIL [align='left' s] <div align="LEFT"> with querySelector in quirks mode assert_equals: selector matched expected null but got Element node <div align="LEFT"></div>
+FAIL [align='LEFT' s] <div align="left"> in quirks mode assert_equals: selector matched expected "visible" but got "hidden"
+FAIL [align='LEFT' s] <div align="left"> with querySelector in quirks mode assert_equals: selector matched expected null but got Element node <div align="left"></div>
+PASS [class~='a' s] <div class="X A B"> in quirks mode
+PASS [class~='a' s] <div class="X A B"> with querySelector in quirks mode
+PASS [class~='A' s] <div class="x a b"> in quirks mode
+PASS [class~='A' s] <div class="x a b"> with querySelector in quirks mode
+PASS [id^='a' s] <div id="AB"> in quirks mode
+PASS [id^='a' s] <div id="AB"> with querySelector in quirks mode
+PASS [id$='A' s] <div id="xa"> in quirks mode
+PASS [id$='A' s] <div id="xa"> with querySelector in quirks mode
+FAIL [lang|='a' s] <div lang="A-B"> in quirks mode assert_equals: selector matched expected "visible" but got "hidden"
+FAIL [lang|='a' s] <div lang="A-B"> with querySelector in quirks mode assert_equals: selector matched expected null but got Element node <div lang="A-B"></div>
+FAIL [lang*='A' s] <div lang="xab"> in quirks mode assert_equals: selector matched expected "visible" but got "hidden"
+FAIL [lang*='A' s] <div lang="xab"> with querySelector in quirks mode assert_equals: selector matched expected null but got Element node <div lang="xab"></div>
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in quirks mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in quirks mode
+PASS @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode
+PASS [foo='bar' s][foo='bar' s] <div foo="BAR"> in quirks mode
+PASS [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='BAR' s][foo='bar'] <div foo="BAR"> in quirks mode
+PASS [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='bar'][foo='BAR' s] <div foo="BAR"> in quirks mode
+PASS [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='BAR'][foo='bar' s] <div foo="BAR"> in quirks mode
+PASS [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='bar' s][foo='BAR'] <div foo="bar"> in quirks mode
+PASS [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in quirks mode
 PASS [foo='BAR'] /* sanity check (match) */ <div foo="BAR"> in XML
 PASS [foo='BAR'] /* sanity check (match) */ <div foo="BAR"> with querySelector in XML
 PASS [foo='bar'] /* sanity check (match) */ <div foo="bar"> in XML
@@ -699,39 +699,39 @@ PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> in XML
 PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> with querySelector in XML
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> in XML
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> with querySelector in XML
-FAIL [foo='bar' s] <div foo="bar"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="bar"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
-FAIL [foo='' s] <div foo=""> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo=""> with querySelector in XML '[foo='' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in XML '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in XML '[*|foo='bar' s]' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in XML '[*|foo='bar' s]' is not a valid selector.
-FAIL [align='left' s] <div align="left"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="left"> with querySelector in XML '[align='left' s]' is not a valid selector.
-FAIL [align='LEFT' s] <div align="LEFT"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="LEFT"> with querySelector in XML '[align='LEFT' s]' is not a valid selector.
-FAIL [class~='a' s] <div class="x a b"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="x a b"> with querySelector in XML '[class~='a' s]' is not a valid selector.
-FAIL [class~='A' s] <div class="X A B"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="X A B"> with querySelector in XML '[class~='A' s]' is not a valid selector.
-FAIL [id^='a' s] <div id="ab"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="ab"> with querySelector in XML '[id^='a' s]' is not a valid selector.
-FAIL [id$='A' s] <div id="XA"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="XA"> with querySelector in XML '[id$='A' s]' is not a valid selector.
-FAIL [lang|='a' s] <div lang="a-b"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="a-b"> with querySelector in XML '[lang|='a' s]' is not a valid selector.
-FAIL [lang*='A' s] <div lang="XAB"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="XAB"> with querySelector in XML '[lang*='A' s]' is not a valid selector.
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in XML '[*|lang='a' s]' is not a valid selector.
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in XML '[*|lang='A' s]' is not a valid selector.
-FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in XML '[foo='BAR' s][foo='BAR' s]' is not a valid selector.
+PASS [foo='bar' s] <div foo="bar"> in XML
+PASS [foo='bar' s] <div foo="bar"> with querySelector in XML
+PASS [foo='' s] <div foo=""> in XML
+PASS [foo='' s] <div foo=""> with querySelector in XML
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in XML
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in XML
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in XML
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in XML
+PASS [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in XML
+PASS [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in XML
+PASS [align='left' s] <div align="left"> in XML
+PASS [align='left' s] <div align="left"> with querySelector in XML
+PASS [align='LEFT' s] <div align="LEFT"> in XML
+PASS [align='LEFT' s] <div align="LEFT"> with querySelector in XML
+PASS [class~='a' s] <div class="x a b"> in XML
+PASS [class~='a' s] <div class="x a b"> with querySelector in XML
+PASS [class~='A' s] <div class="X A B"> in XML
+PASS [class~='A' s] <div class="X A B"> with querySelector in XML
+PASS [id^='a' s] <div id="ab"> in XML
+PASS [id^='a' s] <div id="ab"> with querySelector in XML
+PASS [id$='A' s] <div id="XA"> in XML
+PASS [id$='A' s] <div id="XA"> with querySelector in XML
+PASS [lang|='a' s] <div lang="a-b"> in XML
+PASS [lang|='a' s] <div lang="a-b"> with querySelector in XML
+PASS [lang*='A' s] <div lang="XAB"> in XML
+PASS [lang*='A' s] <div lang="XAB"> with querySelector in XML
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in XML
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in XML
+PASS @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML
+PASS [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in XML
+PASS [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in XML
 PASS [missingattr] /* sanity check (no match) */ <div foo="BAR"> in XML
 PASS [missingattr] /* sanity check (no match) */ <div foo="BAR"> with querySelector in XML
 PASS [foo='bar'] /* sanity check (no match) */ <div foo="BAR"> in XML
@@ -839,120 +839,120 @@ PASS [foo*='É' i] <div foo="é"> in XML
 PASS [foo*='É' i] <div foo="é"> with querySelector in XML
 PASS [foo|='É' i] <div foo="é"> in XML
 PASS [foo|='É' i] <div foo="é"> with querySelector in XML
-FAIL [foo='' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo="BAR"> with querySelector in XML '[foo='' s]' is not a valid selector.
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in XML '[foo='\0' s] /* \0 in selector */' is not a valid selector.
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in XML '[foo='' s] /* \0 in attribute */' is not a valid selector.
-FAIL [foo='ä' s] <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] <div foo="Ä"> with querySelector in XML '[foo='ä' s]' is not a valid selector.
-FAIL [foo='Ä' s] <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] <div foo="ä"> with querySelector in XML '[foo='Ä' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in XML '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in XML '[foo~='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in XML '[foo^='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in XML '[foo$='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML '[foo*='ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML '[foo|='ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in XML '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in XML '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in XML '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in XML '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='i' s] <div foo="İ"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="İ"> with querySelector in XML '[foo='i' s]' is not a valid selector.
-FAIL [foo='i' s] <div foo="ı"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="ı"> with querySelector in XML '[foo='i' s]' is not a valid selector.
-FAIL [foo='I' s] <div foo="İ"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="İ"> with querySelector in XML '[foo='I' s]' is not a valid selector.
-FAIL [foo='I' s] <div foo="ı"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="ı"> with querySelector in XML '[foo='I' s]' is not a valid selector.
-FAIL [foo='İ' s] <div foo="i"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="i"> with querySelector in XML '[foo='İ' s]' is not a valid selector.
-FAIL [foo='ı' s] <div foo="i"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="i"> with querySelector in XML '[foo='ı' s]' is not a valid selector.
-FAIL [foo='İ' s] <div foo="I"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="I"> with querySelector in XML '[foo='İ' s]' is not a valid selector.
-FAIL [foo='ı' s] <div foo="I"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="I"> with querySelector in XML '[foo='ı' s]' is not a valid selector.
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in XML '[|foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s] <div FOO="bar"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div FOO="bar"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in XML '[foo='	' s] /* tab in selector */' is not a valid selector.
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in XML '[foo=' ' s] /* tab in attribute */' is not a valid selector.
-FAIL @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in XML assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in XML assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in XML '[foo='bar' s][foo='bar']' is not a valid selector.
-FAIL [foo='bar' s] <div baz="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div baz="BAR"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="BAR"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in XML '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in XML '[foo='Ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in XML '[*|foo='bar' s]' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in XML '[*|foo='bar' s]' is not a valid selector.
-FAIL [align='left' s] <div align="LEFT"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="LEFT"> with querySelector in XML '[align='left' s]' is not a valid selector.
-FAIL [align='LEFT' s] <div align="left"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="left"> with querySelector in XML '[align='LEFT' s]' is not a valid selector.
-FAIL [class~='a' s] <div class="X A B"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="X A B"> with querySelector in XML '[class~='a' s]' is not a valid selector.
-FAIL [class~='A' s] <div class="x a b"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="x a b"> with querySelector in XML '[class~='A' s]' is not a valid selector.
-FAIL [id^='a' s] <div id="AB"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="AB"> with querySelector in XML '[id^='a' s]' is not a valid selector.
-FAIL [id$='A' s] <div id="xa"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="xa"> with querySelector in XML '[id$='A' s]' is not a valid selector.
-FAIL [lang|='a' s] <div lang="A-B"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="A-B"> with querySelector in XML '[lang|='a' s]' is not a valid selector.
-FAIL [lang*='A' s] <div lang="xab"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="xab"> with querySelector in XML '[lang*='A' s]' is not a valid selector.
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in XML '[*|lang='a' s]' is not a valid selector.
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in XML '[*|lang='A' s]' is not a valid selector.
-FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in XML '[foo='bar' s][foo='bar' s]' is not a valid selector.
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in XML '[foo='BAR' s][foo='bar']' is not a valid selector.
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in XML '[foo='bar'][foo='BAR' s]' is not a valid selector.
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in XML '[foo='BAR'][foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in XML '[foo='bar' s][foo='BAR']' is not a valid selector.
+PASS [foo='' s] <div foo="BAR"> in XML
+PASS [foo='' s] <div foo="BAR"> with querySelector in XML
+PASS [foo='\0' s] /* \0 in selector */ <div foo=""> in XML
+PASS [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in XML
+PASS [foo='' s] /* \0 in attribute */ <div foo="\0"> in XML
+PASS [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in XML
+PASS [foo='ä' s] <div foo="Ä"> in XML
+PASS [foo='ä' s] <div foo="Ä"> with querySelector in XML
+PASS [foo='Ä' s] <div foo="ä"> in XML
+PASS [foo='Ä' s] <div foo="ä"> with querySelector in XML
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in XML
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in XML
+PASS [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in XML
+PASS [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in XML
+PASS [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in XML
+PASS [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in XML
+PASS [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in XML
+PASS [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in XML
+PASS [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in XML
+PASS [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML
+PASS [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in XML
+PASS [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in XML
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in XML
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in XML
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in XML
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in XML
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in XML
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in XML
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in XML
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in XML
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in XML
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in XML
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in XML
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in XML
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in XML
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML
+PASS [foo='i' s] <div foo="İ"> in XML
+PASS [foo='i' s] <div foo="İ"> with querySelector in XML
+PASS [foo='i' s] <div foo="ı"> in XML
+PASS [foo='i' s] <div foo="ı"> with querySelector in XML
+PASS [foo='I' s] <div foo="İ"> in XML
+PASS [foo='I' s] <div foo="İ"> with querySelector in XML
+PASS [foo='I' s] <div foo="ı"> in XML
+PASS [foo='I' s] <div foo="ı"> with querySelector in XML
+PASS [foo='İ' s] <div foo="i"> in XML
+PASS [foo='İ' s] <div foo="i"> with querySelector in XML
+PASS [foo='ı' s] <div foo="i"> in XML
+PASS [foo='ı' s] <div foo="i"> with querySelector in XML
+PASS [foo='İ' s] <div foo="I"> in XML
+PASS [foo='İ' s] <div foo="I"> with querySelector in XML
+PASS [foo='ı' s] <div foo="I"> in XML
+PASS [foo='ı' s] <div foo="I"> with querySelector in XML
+PASS [foo='bar' s] <div foo="x" {a}foo="BAR"> in XML
+PASS [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in XML
+PASS [|foo='bar' s] <div foo="x" {a}foo="BAR"> in XML
+PASS [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in XML
+PASS [foo='bar' s] <div FOO="bar"> in XML
+PASS [foo='bar' s] <div FOO="bar"> with querySelector in XML
+PASS [foo='	' s] /* tab in selector */ <div foo=" "> in XML
+PASS [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in XML
+PASS [foo=' ' s] /* tab in attribute */ <div foo="	"> in XML
+PASS [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in XML
+PASS @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in XML
+PASS @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in XML
+PASS [foo='bar' s][foo='bar'] <div foo="BAR"> in XML
+PASS [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in XML
+PASS [foo='bar' s] <div baz="BAR"> in XML
+PASS [foo='bar' s] <div baz="BAR"> with querySelector in XML
+PASS [foo='bar' s] <div foo="BAR"> in XML
+PASS [foo='bar' s] <div foo="BAR"> with querySelector in XML
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in XML
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in XML
+PASS [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in XML
+PASS [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in XML
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in XML
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in XML
+PASS [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in XML
+PASS [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in XML
+PASS [align='left' s] <div align="LEFT"> in XML
+PASS [align='left' s] <div align="LEFT"> with querySelector in XML
+PASS [align='LEFT' s] <div align="left"> in XML
+PASS [align='LEFT' s] <div align="left"> with querySelector in XML
+PASS [class~='a' s] <div class="X A B"> in XML
+PASS [class~='a' s] <div class="X A B"> with querySelector in XML
+PASS [class~='A' s] <div class="x a b"> in XML
+PASS [class~='A' s] <div class="x a b"> with querySelector in XML
+PASS [id^='a' s] <div id="AB"> in XML
+PASS [id^='a' s] <div id="AB"> with querySelector in XML
+PASS [id$='A' s] <div id="xa"> in XML
+PASS [id$='A' s] <div id="xa"> with querySelector in XML
+PASS [lang|='a' s] <div lang="A-B"> in XML
+PASS [lang|='a' s] <div lang="A-B"> with querySelector in XML
+PASS [lang*='A' s] <div lang="xab"> in XML
+PASS [lang*='A' s] <div lang="xab"> with querySelector in XML
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in XML
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in XML
+PASS @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML
+PASS [foo='bar' s][foo='bar' s] <div foo="BAR"> in XML
+PASS [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in XML
+PASS [foo='BAR' s][foo='bar'] <div foo="BAR"> in XML
+PASS [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in XML
+PASS [foo='bar'][foo='BAR' s] <div foo="BAR"> in XML
+PASS [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in XML
+PASS [foo='BAR'][foo='bar' s] <div foo="BAR"> in XML
+PASS [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in XML
+PASS [foo='bar' s][foo='BAR'] <div foo="bar"> in XML
+PASS [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in XML
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/syntax-expected.txt
@@ -55,60 +55,58 @@ PASS [|foo='bar' i] in standards mode
 PASS [|foo='bar' i] with querySelector in standards mode
 PASS [*|foo='bar' i] in standards mode
 PASS [*|foo='bar' i] with querySelector in standards mode
-FAIL [baz='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s] with querySelector in standards mode '[baz='quux' s]' is not a valid selector.
-FAIL [baz='quux' S] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' S] with querySelector in standards mode '[baz='quux' S]' is not a valid selector.
-FAIL [baz=quux s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux s] with querySelector in standards mode '[baz=quux s]' is not a valid selector.
-FAIL [baz="quux" s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz="quux" s] with querySelector in standards mode '[baz="quux" s]' is not a valid selector.
-FAIL [baz='quux's] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's] with querySelector in standards mode '[baz='quux's]' is not a valid selector.
-FAIL [baz='quux's ] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's ] with querySelector in standards mode '[baz='quux's ]' is not a valid selector.
-FAIL [baz='quux' s ] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s ] with querySelector in standards mode '[baz='quux' s ]' is not a valid selector.
-FAIL [baz='quux' /**/ s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' /**/ s] with querySelector in standards mode '[baz='quux' /**/ s]' is not a valid selector.
-FAIL [baz='quux' s /**/ ] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s /**/ ] with querySelector in standards mode '[baz='quux' s /**/ ]' is not a valid selector.
-FAIL [baz='quux'/**/s/**/] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'/**/s/**/] with querySelector in standards mode '[baz='quux'/**/s/**/]' is not a valid selector.
-FAIL [baz=quux/**/s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux/**/s] with querySelector in standards mode '[baz=quux/**/s]' is not a valid selector.
-FAIL [baz='quux'	s	] /* \t */ in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'	s	] /* \t */ with querySelector in standards mode '[baz='quux'	s	] /* \t */' is not a valid selector.
-FAIL [baz='quux'
+PASS [baz='quux' s] in standards mode
+PASS [baz='quux' s] with querySelector in standards mode
+PASS [baz='quux' S] in standards mode
+PASS [baz='quux' S] with querySelector in standards mode
+PASS [baz=quux s] in standards mode
+PASS [baz=quux s] with querySelector in standards mode
+PASS [baz="quux" s] in standards mode
+PASS [baz="quux" s] with querySelector in standards mode
+PASS [baz='quux's] in standards mode
+PASS [baz='quux's] with querySelector in standards mode
+PASS [baz='quux's ] in standards mode
+PASS [baz='quux's ] with querySelector in standards mode
+PASS [baz='quux' s ] in standards mode
+PASS [baz='quux' s ] with querySelector in standards mode
+PASS [baz='quux' /**/ s] in standards mode
+PASS [baz='quux' /**/ s] with querySelector in standards mode
+PASS [baz='quux' s /**/ ] in standards mode
+PASS [baz='quux' s /**/ ] with querySelector in standards mode
+PASS [baz='quux'/**/s/**/] in standards mode
+PASS [baz='quux'/**/s/**/] with querySelector in standards mode
+PASS [baz=quux/**/s] in standards mode
+PASS [baz=quux/**/s] with querySelector in standards mode
+PASS [baz='quux'	s	] /* \t */ in standards mode
+PASS [baz='quux'	s	] /* \t */ with querySelector in standards mode
+PASS [baz='quux'
 s
-] /* \n */ in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'
+] /* \n */ in standards mode
+PASS [baz='quux'
 s
-] /* \n */ with querySelector in standards mode '[baz='quux'
-s
-] /* \n */' is not a valid selector.
-FAIL [baz='quux'\rs\r] /* \r */ in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'\rs\r] /* \r */ with querySelector in standards mode '[baz='quux'\rs\r] /* \r */' is not a valid selector.
-FAIL [baz='quux' \s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \s] with querySelector in standards mode '[baz='quux' \s]' is not a valid selector.
-FAIL [baz='quux' \73] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \73] with querySelector in standards mode '[baz='quux' \73]' is not a valid selector.
-FAIL [baz='quux' \53] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \53] with querySelector in standards mode '[baz='quux' \53]' is not a valid selector.
-FAIL [baz~='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz~='quux' s] with querySelector in standards mode '[baz~='quux' s]' is not a valid selector.
-FAIL [baz^='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz^='quux' s] with querySelector in standards mode '[baz^='quux' s]' is not a valid selector.
-FAIL [baz$='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz$='quux' s] with querySelector in standards mode '[baz$='quux' s]' is not a valid selector.
-FAIL [baz*='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz*='quux' s] with querySelector in standards mode '[baz*='quux' s]' is not a valid selector.
-FAIL [baz|='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz|='quux' s] with querySelector in standards mode '[baz|='quux' s]' is not a valid selector.
-FAIL [|baz='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|baz='quux' s] with querySelector in standards mode '[|baz='quux' s]' is not a valid selector.
-FAIL [*|baz='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|baz='quux' s] with querySelector in standards mode '[*|baz='quux' s]' is not a valid selector.
+] /* \n */ with querySelector in standards mode
+PASS [baz='quux'\rs\r] /* \r */ in standards mode
+PASS [baz='quux'\rs\r] /* \r */ with querySelector in standards mode
+PASS [baz='quux' \s] in standards mode
+PASS [baz='quux' \s] with querySelector in standards mode
+PASS [baz='quux' \73] in standards mode
+PASS [baz='quux' \73] with querySelector in standards mode
+PASS [baz='quux' \53] in standards mode
+PASS [baz='quux' \53] with querySelector in standards mode
+PASS [baz~='quux' s] in standards mode
+PASS [baz~='quux' s] with querySelector in standards mode
+PASS [baz^='quux' s] in standards mode
+PASS [baz^='quux' s] with querySelector in standards mode
+PASS [baz$='quux' s] in standards mode
+PASS [baz$='quux' s] with querySelector in standards mode
+PASS [baz*='quux' s] in standards mode
+PASS [baz*='quux' s] with querySelector in standards mode
+PASS [baz|='quux' s] in standards mode
+PASS [baz|='quux' s] with querySelector in standards mode
+PASS [|baz='quux' s] in standards mode
+PASS [|baz='quux' s] with querySelector in standards mode
+PASS [*|baz='quux' s] in standards mode
+PASS [*|baz='quux' s] with querySelector in standards mode
 PASS [foo[ /* sanity check (invalid) */ in standards mode
 PASS [foo[ /* sanity check (invalid) */ with querySelector in standards mode
 PASS [foo='bar' i i] in standards mode
@@ -241,60 +239,58 @@ PASS [|foo='bar' i] in quirks mode
 PASS [|foo='bar' i] with querySelector in quirks mode
 PASS [*|foo='bar' i] in quirks mode
 PASS [*|foo='bar' i] with querySelector in quirks mode
-FAIL [baz='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s] with querySelector in quirks mode '[baz='quux' s]' is not a valid selector.
-FAIL [baz='quux' S] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' S] with querySelector in quirks mode '[baz='quux' S]' is not a valid selector.
-FAIL [baz=quux s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux s] with querySelector in quirks mode '[baz=quux s]' is not a valid selector.
-FAIL [baz="quux" s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz="quux" s] with querySelector in quirks mode '[baz="quux" s]' is not a valid selector.
-FAIL [baz='quux's] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's] with querySelector in quirks mode '[baz='quux's]' is not a valid selector.
-FAIL [baz='quux's ] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's ] with querySelector in quirks mode '[baz='quux's ]' is not a valid selector.
-FAIL [baz='quux' s ] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s ] with querySelector in quirks mode '[baz='quux' s ]' is not a valid selector.
-FAIL [baz='quux' /**/ s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' /**/ s] with querySelector in quirks mode '[baz='quux' /**/ s]' is not a valid selector.
-FAIL [baz='quux' s /**/ ] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s /**/ ] with querySelector in quirks mode '[baz='quux' s /**/ ]' is not a valid selector.
-FAIL [baz='quux'/**/s/**/] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'/**/s/**/] with querySelector in quirks mode '[baz='quux'/**/s/**/]' is not a valid selector.
-FAIL [baz=quux/**/s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux/**/s] with querySelector in quirks mode '[baz=quux/**/s]' is not a valid selector.
-FAIL [baz='quux'	s	] /* \t */ in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'	s	] /* \t */ with querySelector in quirks mode '[baz='quux'	s	] /* \t */' is not a valid selector.
-FAIL [baz='quux'
+PASS [baz='quux' s] in quirks mode
+PASS [baz='quux' s] with querySelector in quirks mode
+PASS [baz='quux' S] in quirks mode
+PASS [baz='quux' S] with querySelector in quirks mode
+PASS [baz=quux s] in quirks mode
+PASS [baz=quux s] with querySelector in quirks mode
+PASS [baz="quux" s] in quirks mode
+PASS [baz="quux" s] with querySelector in quirks mode
+PASS [baz='quux's] in quirks mode
+PASS [baz='quux's] with querySelector in quirks mode
+PASS [baz='quux's ] in quirks mode
+PASS [baz='quux's ] with querySelector in quirks mode
+PASS [baz='quux' s ] in quirks mode
+PASS [baz='quux' s ] with querySelector in quirks mode
+PASS [baz='quux' /**/ s] in quirks mode
+PASS [baz='quux' /**/ s] with querySelector in quirks mode
+PASS [baz='quux' s /**/ ] in quirks mode
+PASS [baz='quux' s /**/ ] with querySelector in quirks mode
+PASS [baz='quux'/**/s/**/] in quirks mode
+PASS [baz='quux'/**/s/**/] with querySelector in quirks mode
+PASS [baz=quux/**/s] in quirks mode
+PASS [baz=quux/**/s] with querySelector in quirks mode
+PASS [baz='quux'	s	] /* \t */ in quirks mode
+PASS [baz='quux'	s	] /* \t */ with querySelector in quirks mode
+PASS [baz='quux'
 s
-] /* \n */ in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'
+] /* \n */ in quirks mode
+PASS [baz='quux'
 s
-] /* \n */ with querySelector in quirks mode '[baz='quux'
-s
-] /* \n */' is not a valid selector.
-FAIL [baz='quux'\rs\r] /* \r */ in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'\rs\r] /* \r */ with querySelector in quirks mode '[baz='quux'\rs\r] /* \r */' is not a valid selector.
-FAIL [baz='quux' \s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \s] with querySelector in quirks mode '[baz='quux' \s]' is not a valid selector.
-FAIL [baz='quux' \73] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \73] with querySelector in quirks mode '[baz='quux' \73]' is not a valid selector.
-FAIL [baz='quux' \53] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \53] with querySelector in quirks mode '[baz='quux' \53]' is not a valid selector.
-FAIL [baz~='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz~='quux' s] with querySelector in quirks mode '[baz~='quux' s]' is not a valid selector.
-FAIL [baz^='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz^='quux' s] with querySelector in quirks mode '[baz^='quux' s]' is not a valid selector.
-FAIL [baz$='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz$='quux' s] with querySelector in quirks mode '[baz$='quux' s]' is not a valid selector.
-FAIL [baz*='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz*='quux' s] with querySelector in quirks mode '[baz*='quux' s]' is not a valid selector.
-FAIL [baz|='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz|='quux' s] with querySelector in quirks mode '[baz|='quux' s]' is not a valid selector.
-FAIL [|baz='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|baz='quux' s] with querySelector in quirks mode '[|baz='quux' s]' is not a valid selector.
-FAIL [*|baz='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|baz='quux' s] with querySelector in quirks mode '[*|baz='quux' s]' is not a valid selector.
+] /* \n */ with querySelector in quirks mode
+PASS [baz='quux'\rs\r] /* \r */ in quirks mode
+PASS [baz='quux'\rs\r] /* \r */ with querySelector in quirks mode
+PASS [baz='quux' \s] in quirks mode
+PASS [baz='quux' \s] with querySelector in quirks mode
+PASS [baz='quux' \73] in quirks mode
+PASS [baz='quux' \73] with querySelector in quirks mode
+PASS [baz='quux' \53] in quirks mode
+PASS [baz='quux' \53] with querySelector in quirks mode
+PASS [baz~='quux' s] in quirks mode
+PASS [baz~='quux' s] with querySelector in quirks mode
+PASS [baz^='quux' s] in quirks mode
+PASS [baz^='quux' s] with querySelector in quirks mode
+PASS [baz$='quux' s] in quirks mode
+PASS [baz$='quux' s] with querySelector in quirks mode
+PASS [baz*='quux' s] in quirks mode
+PASS [baz*='quux' s] with querySelector in quirks mode
+PASS [baz|='quux' s] in quirks mode
+PASS [baz|='quux' s] with querySelector in quirks mode
+PASS [|baz='quux' s] in quirks mode
+PASS [|baz='quux' s] with querySelector in quirks mode
+PASS [*|baz='quux' s] in quirks mode
+PASS [*|baz='quux' s] with querySelector in quirks mode
 PASS [foo[ /* sanity check (invalid) */ in quirks mode
 PASS [foo[ /* sanity check (invalid) */ with querySelector in quirks mode
 PASS [foo='bar' i i] in quirks mode
@@ -427,60 +423,58 @@ PASS [|foo='bar' i] in XML
 PASS [|foo='bar' i] with querySelector in XML
 PASS [*|foo='bar' i] in XML
 PASS [*|foo='bar' i] with querySelector in XML
-FAIL [baz='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s] with querySelector in XML '[baz='quux' s]' is not a valid selector.
-FAIL [baz='quux' S] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' S] with querySelector in XML '[baz='quux' S]' is not a valid selector.
-FAIL [baz=quux s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux s] with querySelector in XML '[baz=quux s]' is not a valid selector.
-FAIL [baz="quux" s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz="quux" s] with querySelector in XML '[baz="quux" s]' is not a valid selector.
-FAIL [baz='quux's] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's] with querySelector in XML '[baz='quux's]' is not a valid selector.
-FAIL [baz='quux's ] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's ] with querySelector in XML '[baz='quux's ]' is not a valid selector.
-FAIL [baz='quux' s ] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s ] with querySelector in XML '[baz='quux' s ]' is not a valid selector.
-FAIL [baz='quux' /**/ s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' /**/ s] with querySelector in XML '[baz='quux' /**/ s]' is not a valid selector.
-FAIL [baz='quux' s /**/ ] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s /**/ ] with querySelector in XML '[baz='quux' s /**/ ]' is not a valid selector.
-FAIL [baz='quux'/**/s/**/] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'/**/s/**/] with querySelector in XML '[baz='quux'/**/s/**/]' is not a valid selector.
-FAIL [baz=quux/**/s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux/**/s] with querySelector in XML '[baz=quux/**/s]' is not a valid selector.
-FAIL [baz='quux'	s	] /* \t */ in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'	s	] /* \t */ with querySelector in XML '[baz='quux'	s	] /* \t */' is not a valid selector.
-FAIL [baz='quux'
+PASS [baz='quux' s] in XML
+PASS [baz='quux' s] with querySelector in XML
+PASS [baz='quux' S] in XML
+PASS [baz='quux' S] with querySelector in XML
+PASS [baz=quux s] in XML
+PASS [baz=quux s] with querySelector in XML
+PASS [baz="quux" s] in XML
+PASS [baz="quux" s] with querySelector in XML
+PASS [baz='quux's] in XML
+PASS [baz='quux's] with querySelector in XML
+PASS [baz='quux's ] in XML
+PASS [baz='quux's ] with querySelector in XML
+PASS [baz='quux' s ] in XML
+PASS [baz='quux' s ] with querySelector in XML
+PASS [baz='quux' /**/ s] in XML
+PASS [baz='quux' /**/ s] with querySelector in XML
+PASS [baz='quux' s /**/ ] in XML
+PASS [baz='quux' s /**/ ] with querySelector in XML
+PASS [baz='quux'/**/s/**/] in XML
+PASS [baz='quux'/**/s/**/] with querySelector in XML
+PASS [baz=quux/**/s] in XML
+PASS [baz=quux/**/s] with querySelector in XML
+PASS [baz='quux'	s	] /* \t */ in XML
+PASS [baz='quux'	s	] /* \t */ with querySelector in XML
+PASS [baz='quux'
 s
-] /* \n */ in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'
+] /* \n */ in XML
+PASS [baz='quux'
 s
-] /* \n */ with querySelector in XML '[baz='quux'
-s
-] /* \n */' is not a valid selector.
-FAIL [baz='quux'\rs\r] /* \r */ in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'\rs\r] /* \r */ with querySelector in XML '[baz='quux'\rs\r] /* \r */' is not a valid selector.
-FAIL [baz='quux' \s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \s] with querySelector in XML '[baz='quux' \s]' is not a valid selector.
-FAIL [baz='quux' \73] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \73] with querySelector in XML '[baz='quux' \73]' is not a valid selector.
-FAIL [baz='quux' \53] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \53] with querySelector in XML '[baz='quux' \53]' is not a valid selector.
-FAIL [baz~='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz~='quux' s] with querySelector in XML '[baz~='quux' s]' is not a valid selector.
-FAIL [baz^='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz^='quux' s] with querySelector in XML '[baz^='quux' s]' is not a valid selector.
-FAIL [baz$='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz$='quux' s] with querySelector in XML '[baz$='quux' s]' is not a valid selector.
-FAIL [baz*='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz*='quux' s] with querySelector in XML '[baz*='quux' s]' is not a valid selector.
-FAIL [baz|='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz|='quux' s] with querySelector in XML '[baz|='quux' s]' is not a valid selector.
-FAIL [|baz='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|baz='quux' s] with querySelector in XML '[|baz='quux' s]' is not a valid selector.
-FAIL [*|baz='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|baz='quux' s] with querySelector in XML '[*|baz='quux' s]' is not a valid selector.
+] /* \n */ with querySelector in XML
+PASS [baz='quux'\rs\r] /* \r */ in XML
+PASS [baz='quux'\rs\r] /* \r */ with querySelector in XML
+PASS [baz='quux' \s] in XML
+PASS [baz='quux' \s] with querySelector in XML
+PASS [baz='quux' \73] in XML
+PASS [baz='quux' \73] with querySelector in XML
+PASS [baz='quux' \53] in XML
+PASS [baz='quux' \53] with querySelector in XML
+PASS [baz~='quux' s] in XML
+PASS [baz~='quux' s] with querySelector in XML
+PASS [baz^='quux' s] in XML
+PASS [baz^='quux' s] with querySelector in XML
+PASS [baz$='quux' s] in XML
+PASS [baz$='quux' s] with querySelector in XML
+PASS [baz*='quux' s] in XML
+PASS [baz*='quux' s] with querySelector in XML
+PASS [baz|='quux' s] in XML
+PASS [baz|='quux' s] with querySelector in XML
+PASS [|baz='quux' s] in XML
+PASS [|baz='quux' s] with querySelector in XML
+PASS [*|baz='quux' s] in XML
+PASS [*|baz='quux' s] with querySelector in XML
 PASS [foo[ /* sanity check (invalid) */ in XML
 PASS [foo[ /* sanity check (invalid) */ with querySelector in XML
 PASS [foo='bar' i i] in XML

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -976,6 +976,8 @@ CSSSelector::AttributeMatchType CSSSelectorParser::consumeAttributeFlags(CSSPars
     const CSSParserToken& flag = range.consumeIncludingWhitespace();
     if (equalLettersIgnoringASCIICase(flag.value(), "i"_s))
         return CSSSelector::CaseInsensitive;
+    if (equalLettersIgnoringASCIICase(flag.value(), "s"_s))
+        return CSSSelector::CaseSensitive;
     m_failedParsing = true;
     return CSSSelector::CaseSensitive;
 }


### PR DESCRIPTION
#### 62796751e19c8dad35440b829ebcf3b36834ec3d
<pre>
Implement case sensitive modifier (s) in attribute selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=272573">https://bugs.webkit.org/show_bug.cgi?id=272573</a>
<a href="https://rdar.apple.com/126331481">rdar://126331481</a>

Reviewed by NOBODY (OOPS!).

This is fixing a couple of WPT tests relative to attribute selector case
sensitivity aka adding the value &quot;s&quot; for case sensitive in rules with
this pattern: [attribute=&quot;Value&quot; s]

It doesn&apos;t fix yet some of the cases when
1. getting CSSRule#cssText
2. getting CSSStyleRule#selectorText
3. setting CSSStyleRule#selectorText

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/semantics-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/syntax-expected.txt:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeAttributeFlags):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62796751e19c8dad35440b829ebcf3b36834ec3d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50252 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43618 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38727 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48152 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20030 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42172 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5612 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43901 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52132 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46029 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23877 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45059 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23596 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->