### PR TITLE
[GTK][WPE] Make GLFence usable with ANGLE EGL contexts

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -53,6 +53,7 @@ public:
 
     static GLContext* current();
     static bool isExtensionSupported(const char* extensionList, const char* extension);
+    static unsigned versionFromString(const char* versionString);
 
     static const char* errorString(int statusCode);
     static const char* lastErrorString();

--- a/Source/WebCore/platform/graphics/egl/GLFence.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLFence.cpp
@@ -31,13 +31,32 @@
 
 namespace WebCore {
 
+bool isGLFenceSyncSupported()
+{
+    static std::once_flag onceFlag;
+    static bool supported = false;
+
+    std::call_once(onceFlag, [&]() {
+        auto version = GLContext::versionFromString(reinterpret_cast<const char*>(glGetString(GL_VERSION)));
+        if (version >= 300) {
+            supported = true;
+            return;
+        }
+
+        const char* extensionsString = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
+        if (GLContext::isExtensionSupported(extensionsString, "GL_APPLE_sync"))
+            supported = true;
+    });
+
+    return supported;
+}
+
 std::unique_ptr<GLFence> GLFence::create()
 {
-    auto* context = GLContext::current();
-    if (!context)
+    if (!GLContextWrapper::currentContext())
         return nullptr;
 
-    if (context->version() >= 300 || context->glExtensions().APPLE_sync) {
+    if (isGLFenceSyncSupported()) {
         if (auto* sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)) {
             glFlush();
             return makeUnique<GLFence>(sync);


### PR DESCRIPTION
#### 904f76a8f8a60978baef2a1fb255a330e61fbdf2
<pre>
[GTK][WPE] Make GLFence usable with ANGLE EGL contexts
<a href="https://bugs.webkit.org/show_bug.cgi?id=272581">https://bugs.webkit.org/show_bug.cgi?id=272581</a>

Reviewed by Carlos Garcia Campos.

Adapt GLFence to use only EGL/GL calls so it doesn&apos;t require a
current GLContext. Also, take advantage of the static methods
in GLContext to parse the version and extension strings.

* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::versionFromString):
(WebCore::GLContext::version):
* Source/WebCore/platform/graphics/egl/GLContext.h:
* Source/WebCore/platform/graphics/egl/GLFence.cpp:
(WebCore::isGLFenceSyncSupported):
(WebCore::GLFence::create):

Canonical link: <a href="https://commits.webkit.org/277489@main">https://commits.webkit.org/277489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6420d2dcae1606dea99d66439a1b9896dc84fb21

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50254 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43620 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38729 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/40985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20032 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21846 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42162 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5614 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52146 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46043 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23879 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45073 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24667 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6756 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->