### PR TITLE
Disable OffscreenCanvasRenderingContext2D's commit() method by default

### DIFF
--- a/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-full-expected.txt
+++ b/LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-full-expected.txt
@@ -791,10 +791,4 @@ frames:
         0: roundRect
         1: (anonymous function)
         2: executeFrameFunction
-  61: (duration)
-    0: commit()
-      trace:
-        0: commit
-        1: (anonymous function)
-        2: executeFrameFunction
 

--- a/LayoutTests/inspector/canvas/resources/recording-2d.js
+++ b/LayoutTests/inspector/canvas/resources/recording-2d.js
@@ -400,9 +400,11 @@ function performActions() {
             ctx.roundRect(0, 0, 50, 50, [23]);
             ctx.roundRect(0, 0, 150, 150, [{x: 24, y: 42}]);
         },
+        /* FIXME: Disabled as per webkit.org/b/272591. Should be fully removed if we manage to remove this method.
         () => {
             ctx.commit?.();
         },
+        */
         () => {
             TestPage.dispatchEventToFrontend("LastFrame");
         },

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4707,6 +4707,21 @@ NotificationsEnabled:
       "PLATFORM(IOS_FAMILY)": false
       default: true
 
+OffscreenCanvasDeprecatedCommitEnabled:
+  type: bool
+  status: testable
+  category: dom
+  humanReadableName: "OffscreenCanvasRenderingContext2D's deprecated commit() method"
+  humanReadableDescription: "Support for OffscreenCanvasRenderingContext2D's deprecated commit() method"
+  condition: ENABLE(OFFSCREEN_CANVAS)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 OffscreenCanvasEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl
@@ -36,7 +36,7 @@
     CallTracer=InspectorCanvasCallTracer,
 ] interface OffscreenCanvasRenderingContext2D {
     readonly attribute OffscreenCanvas canvas;
-    undefined commit();
+    [EnabledBySetting=OffscreenCanvasDeprecatedCommitEnabled] undefined commit();
 };
 
 OffscreenCanvasRenderingContext2D includes CanvasState;


### PR DESCRIPTION
#### f8cecb9d26e94ed6f13b6b2a4feeb7b0bcc1becd
<pre>
Disable OffscreenCanvasRenderingContext2D&apos;s commit() method by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=272591">https://bugs.webkit.org/show_bug.cgi?id=272591</a>
<a href="https://rdar.apple.com/126758254">rdar://126758254</a>

Reviewed by Matt Woodrow.

This puts OffscreenCanvasRenderingContext2D&apos;s commit() behind a runtime
setting marked testable (OffscreenCanvasDeprecatedCommitEnabled). This
ensures this method continues to be tested for the time being and can
be re-enabled should there be a need.

The goal is to remove this method and underlying implementation
completely as discussed here:
<a href="https://github.com/whatwg/html/pull/9979">https://github.com/whatwg/html/pull/9979</a>

* LayoutTests/inspector/canvas/recording-offscreen-canvas-2d-full-expected.txt:
* LayoutTests/inspector/canvas/resources/recording-2d.js:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.idl:

Canonical link: <a href="https://commits.webkit.org/278047@main">https://commits.webkit.org/278047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cb3f4bb679f63bfd156e0b1b211cdb023be54ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52153 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/45411 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34604 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26210 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40283 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21404 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43654 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7675 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/42610 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54056 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/48797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47600 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46595 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26501 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56292 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7082 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25385 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11561 "Passed tests") | 
<!--EWS-Status-Bubble-End-->