### PR TITLE
[InteractionRegions] Consolidation rules from 266230@main can cause false positive

### DIFF
--- a/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
+++ b/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
@@ -1,6 +1,6 @@
 Nested  Nested  Nested Secondary
 Tappable! Secondary
-labels y aligned Secondary
+labels y aligned Secondarysub-link
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 613.00)
@@ -29,6 +29,8 @@ labels y aligned Secondary
         (interaction (253.50,151) width=67.50 height=20)
         (cornerRadius 5.00),
         (interaction (0,500) width=240 height=100),
+        (interaction (120.41,536) width=60.45 height=27)
+        (cornerRadius 8.00),
         (interaction (172.50,500) width=67.50 height=20)
         (cornerRadius 5.00)])
       )

--- a/LayoutTests/interaction-region/consolidated-nested-regions.html
+++ b/LayoutTests/interaction-region/consolidated-nested-regions.html
@@ -14,6 +14,7 @@
         right: 0;
         border-radius: 5px;
         background: blue;
+        color: white;
     }
     .tappable-container {
         position: relative;
@@ -41,19 +42,17 @@
         height: 120px;
         border: 1px blue dotted;
     }
-    .tap-and-hover {
+    button {
         position: relative;
-        cursor: pointer;
-        width: 200px;
-        height: 60px;
-        padding: 20px;
+        width: 240px;
+        height: 100px;
         background: lightblue;
-    }
-    .tap-and-hover:hover {
-        background: blue;
-    }
-    .tap-and-hover span {
-        line-height: 60px;
+        border: none;
+        border-radius: 0;
+        padding: 20px;
+        text-align: left;
+        font: inherit;
+        appearance: none;
     }
 </style>
 <body>
@@ -95,12 +94,13 @@
         </div>
     </div>
 </div>
-<div class="tap-and-hover">
+<button class="tap-and-hover">
     <span>labels</span>
     <span>y</span>
     <span>aligned</span>
     <a href="#" class="secondary">Secondary</a>
-</div>
+    <a href="#">sub-link</a>
+</button>
 
 <pre id="results"></pre>
 <script>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -125,7 +125,7 @@ static bool shouldAllowAccessibilityRoleAsPointerCursorReplacement(const Element
     }
 }
 
-bool elementMatchesHoverRules(Element& element)
+static bool elementMatchesHoverRules(Element& element)
 {
     bool foundHoverRules = false;
     bool initialValue = element.isUserActionElement() && element.document().userActionElements().isHovered(element);

--- a/Source/WebCore/page/InteractionRegion.h
+++ b/Source/WebCore/page/InteractionRegion.h
@@ -79,7 +79,6 @@ inline bool operator==(const InteractionRegion& a, const InteractionRegion& b)
 }
 
 WEBCORE_EXPORT std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject&, const FloatRect&);
-WEBCORE_EXPORT bool elementMatchesHoverRules(Element&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const InteractionRegion&);
 

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -60,7 +60,7 @@ public:
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     void uniteInteractionRegions(RenderObject&, const FloatRect&);
-    bool shouldConsolidateInteractionRegion(RenderObject&, const IntRect&);
+    bool shouldConsolidateInteractionRegion(RenderObject&, const IntRect&, const ElementIdentifier&);
     void removeSuperfluousInteractionRegions();
     void shrinkWrapInteractionRegions();
     void copyInteractionRegionsToEventRegion();


### PR DESCRIPTION
#### 414ef157946ae3c45b268c4d7040006d69288eba
<pre>
[InteractionRegions] Consolidation rules from 266230@main can cause false positive
<a href="https://bugs.webkit.org/show_bug.cgi?id=272592">https://bugs.webkit.org/show_bug.cgi?id=272592</a>
&lt;<a href="https://rdar.apple.com/123918512">rdar://123918512</a>&gt;

Reviewed by Mike Wyrzykowski.

The new consolidation rule introduced in 266230@main was too eager and
caused some missing regions.

Instead of using the presence of hover styles + axis alignment as a
heuristic, we now look at the element that was matched.
When we find an enclosing ancestor with a region that shares the same
ElementIdentifier we can safely consolidate.

This new heuristic is simpler: no need to inspect hover styles.
And more reliable: regions sharing a ElementIdentifier would be
configured as a group anyway on the UI-side.

This change doesn&apos;t regress the original bug, but the test had to be
updated to use an enclosing `&lt;button&gt;` instead of a hover style.

* Source/WebCore/page/InteractionRegion.h:
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::elementMatchesHoverRules):
No need to expose `elementMatchesHoverRules` anymore.

* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::uniteInteractionRegions):
Prevent regions with a custom ContentHint from being consolidated. We
would otherwise regress the content hint test.
(WebCore::EventRegionContext::shouldConsolidateInteractionRegion):
Update the consolidation rule.

* LayoutTests/interaction-region/consolidated-nested-regions-expected.txt:
* LayoutTests/interaction-region/consolidated-nested-regions.html:
Update the test to cover the new rule and the scenario that was
originally missed (sub links / buttons).

Canonical link: <a href="https://commits.webkit.org/277617@main">https://commits.webkit.org/277617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/968423ca72bc6e30de34e22de30c1283ef12e83d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26779 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50263 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50275 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43642 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38753 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24398 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/50263 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Running compile-webkit") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20052 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; 1 api test failed or timed out; Running re-run-api-tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21887 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/50263 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5635 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43926 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/50263 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52159 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22627 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18958 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46059 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23900 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/50263 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Running apply-patch; Checked out pull request; Running compile-webkit") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45086 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10617 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24689 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23619 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | 
<!--EWS-Status-Bubble-End-->