### PR TITLE
Expand use of WKBundlePagePostMessageWithAsyncReply in WebKitTestRunner

### DIFF
--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -279,5 +279,6 @@ template<typename T> void postSynchronousPageMessage(const char* name, const WKR
 
 void asyncReplyHandler(WKTypeRef reply, void* context);
 void postMessageWithAsyncReply(const char* messageName, JSValueRef callback);
+JSValueRef stringArrayToJS(JSContextRef, WKArrayRef);
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -497,7 +497,6 @@ public:
 
     // Storage Access API
     void getAllStorageAccessEntries(JSValueRef callback);
-    void callDidReceiveAllStorageAccessEntriesCallback(Vector<String>& domains);
     void setRequestStorageAccessThrowsExceptionUntilReload(bool enabled);
 
     // Open panel

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -278,7 +278,7 @@ public:
 
     void removeAllCookies();
 
-    void getAllStorageAccessEntries();
+    void getAllStorageAccessEntries(CompletionHandler<void(WKTypeRef)>&&);
     void setRequestStorageAccessThrowsExceptionUntilReload(bool enabled);
     void loadedSubresourceDomains();
     void clearLoadedSubresourceDomains();
@@ -512,6 +512,9 @@ private:
     // WKPageInjectedBundleClient
     static void didReceivePageMessageFromInjectedBundle(WKPageRef, WKStringRef messageName, WKTypeRef messageBody, const void*);
     static void didReceiveSynchronousPageMessageFromInjectedBundleWithListener(WKPageRef, WKStringRef messageName, WKTypeRef messageBody, WKMessageListenerRef, const void*);
+    static void didReceiveAsyncPageMessageFromInjectedBundleWithListener(WKPageRef, WKStringRef, WKTypeRef, WKMessageListenerRef, const void*);
+    void didReceiveAsyncMessageFromInjectedBundle(WKStringRef, WKTypeRef, WKMessageListenerRef);
+
     void didReceiveMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody);
     void didReceiveSynchronousMessageFromInjectedBundle(WKStringRef messageName, WKTypeRef messageBody, WKMessageListenerRef);
     WKRetainPtr<WKTypeRef> getInjectedBundleInitializationUserData();

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -839,11 +839,6 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         return;
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "GetAllStorageAccessEntries")) {
-        TestController::singleton().getAllStorageAccessEntries();
-        return;
-    }
-
     if (WKStringIsEqualToUTF8CString(messageName, "RemoveAllSessionCredentials")) {
         TestController::singleton().removeAllSessionCredentials();
         return;
@@ -1772,14 +1767,6 @@ void TestInvocation::didSetHasHadUserInteraction()
 void TestInvocation::didRemoveAllCookies()
 {
     postPageMessage("CallDidRemoveAllCookies");
-}
-
-void TestInvocation::didReceiveAllStorageAccessEntries(Vector<String>&& domains)
-{
-    auto messageBody = adoptWK(WKMutableArrayCreate());
-    for (auto& domain : domains)
-        WKArrayAppendItem(messageBody.get(), toWK(domain).get());
-    postPageMessage("CallDidReceiveAllStorageAccessEntries", messageBody);
 }
 
 void TestInvocation::didReceiveLoadedSubresourceDomains(Vector<String>&& domains)

--- a/Tools/WebKitTestRunner/TestInvocation.h
+++ b/Tools/WebKitTestRunner/TestInvocation.h
@@ -90,7 +90,6 @@ public:
     void didSetPrevalentResource();
     void didSetVeryPrevalentResource();
     void didSetHasHadUserInteraction();
-    void didReceiveAllStorageAccessEntries(Vector<String>&& domains);
     void didReceiveLoadedSubresourceDomains(Vector<String>&& domains);
     void didRemoveAllCookies();
 

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -512,17 +512,6 @@ void TestController::removeAllSessionCredentials()
     }];
 }
 
-void TestController::getAllStorageAccessEntries()
-{
-    auto* parentView = mainWebView();
-    if (!parentView)
-        return;
-
-    [[globalWebViewConfiguration() websiteDataStore] _getAllStorageAccessEntriesFor:parentView->platformView() completionHandler:^(NSArray<NSString *> *domains) {
-        m_currentInvocation->didReceiveAllStorageAccessEntries(makeVector<String>(domains));
-    }];
-}
-
 void TestController::loadedSubresourceDomains()
 {
     auto* parentView = mainWebView();


### PR DESCRIPTION
#### 453783344f766c0d7498541a692c0e9a1951f5fc
<pre>
Expand use of WKBundlePagePostMessageWithAsyncReply in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=272593">https://bugs.webkit.org/show_bug.cgi?id=272593</a>
<a href="https://rdar.apple.com/126361971">rdar://126361971</a>

Reviewed by Sihui Liu and Charlie Wolfe.

This makes tests work better with site isolation because the reply is sent to the
process that made the request, instead of always sending the reply to the main frame&apos;s process.

Most of this PR is just plumbing to get the call in the UI process, get the reply, send it
to the web process, and process it into a form that JS can receive in the web process.  I also
reduced duplicate implementations of TestController::getAllStorageAccessEntries.

I verified this works correctly by running the 1 test that uses getAllStorageAccessEntries:
http/tests/storageAccess/request-and-grant-access-then-detach-should-not-have-access.html

* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::didReceiveMessageToPage):
(WTR::asyncReplyHandler):
(WTR::postMessageWithAsyncReply):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::stringArrayToJS):
(WTR::TestRunner::getAllStorageAccessEntries):
(WTR::TestRunner::callDidReceiveAllStorageAccessEntriesCallback): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::createOtherPlatformWebView):
(WTR::TestController::createWebViewWithOptions):
(WTR::TestController::didReceiveAsyncMessageFromInjectedBundle):
(WTR::getAllStorageAccessEntriesCallback):
(WTR::TestController::getAllStorageAccessEntries):
(WTR::GetAllStorageAccessEntriesCallbackContext::GetAllStorageAccessEntriesCallbackContext): Deleted.
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):
(WTR::TestInvocation::didReceiveAllStorageAccessEntries): Deleted.
* Tools/WebKitTestRunner/TestInvocation.h:
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::getAllStorageAccessEntries): Deleted.

Canonical link: <a href="https://commits.webkit.org/277505@main">https://commits.webkit.org/277505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e852f89d055a62f98342ea5eab818abf2affb4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50495 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43867 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24492 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38914 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48395 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/24681 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20206 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/22159 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5861 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52389 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19202 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24121 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45259 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/24911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6762 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->