### PR TITLE
run-webkit-tests should start http server when running tests in cross-origin iframe

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py
@@ -261,10 +261,16 @@ class LayoutTestRunner(object):
                         TestExpectations.EXPECTATION_DESCRIPTION[new_result.type], 'expected' if now_expected else 'unexpected'))
                 self._current_run_results.change_result_to_failure(existing_result, new_result, was_expected, now_expected)
 
+    def _additional_dirs_for_http_server(self):
+        if not self._options.load_in_cross_origin_iframe:
+            return {}
+
+        return {"root": "."}
+
     def start_servers(self):
         if self._needs_http and not self._did_start_http_server and not self._port.is_http_server_running():
             self.printer.write_update('Starting HTTP server ...')
-            self._port.start_http_server()
+            self._port.start_http_server(self._additional_dirs_for_http_server())
             self._did_start_http_server = True
         if self._needs_websockets and not self._did_start_websocket_server and not self._port.is_websocket_server_running():
             self.printer.write_update('Starting WebSocket server ...')

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py
@@ -173,7 +173,7 @@ class LayoutTestRunnerTests(unittest.TestCase):
 
     def test_servers_started(self):
 
-        def start_http_server():
+        def start_http_server(additional_dirs=None):
             self.http_started = True
 
         def start_websocket_server():

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -377,7 +377,7 @@ class Manager(object):
         # Create the output directory if it doesn't already exist.
         self._port.host.filesystem.maybe_make_directory(self._results_directory)
 
-        needs_http = any(test.needs_http_server for tests in itervalues(tests_to_run_by_device) for test in tests)
+        needs_http = (any(test.needs_http_server for tests in itervalues(tests_to_run_by_device) for test in tests) or self._options.load_in_cross_origin_iframe)
         needs_web_platform_test_server = any(test.needs_wpt_server for tests in itervalues(tests_to_run_by_device) for test in tests)
         needs_websockets = any(test.needs_websocket_server for tests in itervalues(tests_to_run_by_device) for test in tests)
         self._runner = LayoutTestRunner(self._options, self._port, self._printer, self._results_directory,

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -357,6 +357,9 @@ def parse_args(args):
             "--site-isolation", action="store_true", default=False,
             help=("Run each test in a cross origin iframe with and without site isolation enabled and compare the results. Uses site-isolation test expectations")),
         optparse.make_option(
+            "--load-in-cross-origin-iframe", action="store_true", default=False,
+            help=("Run each test in a cross origin iframe.")),
+        optparse.make_option(
             "--no-use-gpu-process", action="store_true", default=False,
             help=("Disable GPU process for DOM rendering.")),
         optparse.make_option(
@@ -477,8 +480,15 @@ def _set_up_derived_options(port, options):
             options.additional_platform_directory = []
         options.additional_platform_directory.insert(0, port.host.filesystem.join(host.scm().checkout_root, 'LayoutTests/platform/mac-gpup'))
 
-    if port.port_name == "mac" and options.site_isolation:
+    if options.site_isolation:
+        if not options.load_in_cross_origin_iframe:
+            _log.warning("Option --site-isolation will set --load-in-cross-origin-iframe")
+        options.load_in_cross_origin_iframe = True
+
+    if options.load_in_cross_origin_iframe:
         options.additional_header = 'runInCrossOriginFrame=true'
+
+    if port.port_name == "mac" and options.site_isolation:
         host = Host()
         host.initialize_scm()
         options.additional_expectations.insert(0, port.host.filesystem.join(host.scm().checkout_root, 'LayoutTests/platform/mac-site-isolation/TestExpectations'))

--- a/Tools/Scripts/webkitpy/layout_tests/servers/apache_http_server.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/apache_http_server.py
@@ -138,6 +138,8 @@ class LayoutTestApacheHttpd(http_server_base.HttpServerBase):
 
         if additional_dirs:
             for alias, path in iteritems(additional_dirs):
+                if path == '.':
+                    path = self.tests_dir
                 start_cmd += ['-c', 'Alias %s "%s"' % (alias, path),
                         # Disable CGI handler for additional dirs.
                         '-c', '<Location %s>' % alias,


### PR DESCRIPTION
#### f17d14686a19dea8c14cc12ecb7169046057db7f
<pre>
run-webkit-tests should start http server when running tests in cross-origin iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=272595">https://bugs.webkit.org/show_bug.cgi?id=272595</a>
<a href="https://rdar.apple.com/problem/126363405">rdar://problem/126363405</a>

Reviewed by Charlie Wolfe.

`--site-isolation` intends to run test in cross-origin iframe with host &quot;127.0.0.1&quot; but it does not start http server.
This patch fixes that by starting http server and setting correct root path for the server and introduces a new option
`load-in-cross-origin-iframe` for testing.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner.py:
(LayoutTestRunner._additional_dirs_for_http_server):
(LayoutTestRunner.start_servers):
* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_runner_unittest.py:
(LayoutTestRunnerTests.test_servers_started.start_http_server):
* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager.run):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args):
(_set_up_derived_options):
* Tools/Scripts/webkitpy/layout_tests/servers/apache_http_server.py:
(LayoutTestApacheHttpd.__init__):

Canonical link: <a href="https://commits.webkit.org/277445@main">https://commits.webkit.org/277445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b70aa9516dd0a3de1d317f00dbbe20e2246953c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50293 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43660 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38764 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48193 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24408 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41020 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20063 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/47473 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42225 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5653 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43946 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42626 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52177 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22647 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18975 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46068 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23919 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45095 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10520 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23639 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->