### PR TITLE
[svg] WPT test svg/animations/animateMotion-keyPoints-001.html fails in WebKit only

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-keyPoints-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-keyPoints-001-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL 'calcMode' paced and 'keyPoints' on <animateMotion> with 'path' assert_equals: y position expected 0 but got -50
+PASS 'calcMode' paced and 'keyPoints' on <animateMotion> with 'path'
 

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -426,10 +426,10 @@ float SVGAnimationElement::calculatePercentForSpline(float percent, unsigned spl
 
 float SVGAnimationElement::calculatePercentFromKeyPoints(float percent) const
 {
-    const auto& keyTimes = this->keyTimes();
+    const auto& keyTimes = m_keyTimesFromAttribute;
 
     ASSERT(!m_keyPoints.isEmpty());
-    ASSERT(calcMode() != CalcMode::Paced);
+    ASSERT(calcMode() != CalcMode::Paced || animationMode() == AnimationMode::Path);
     ASSERT(keyTimes.size() > 1);
     ASSERT(m_keyPoints.size() == keyTimes.size());
 
@@ -543,11 +543,11 @@ void SVGAnimationElement::startedActiveInterval()
     if (!hasValidAttributeType())
         return;
 
-    const auto& keyTimes = this->keyTimes();
-
     // These validations are appropriate for all animation modes.
-    if (hasAttributeWithoutSynchronization(SVGNames::keyPointsAttr) && m_keyPoints.size() != keyTimes.size())
+    if (hasAttributeWithoutSynchronization(SVGNames::keyPointsAttr) && m_keyPoints.size() != m_keyTimesFromAttribute.size())
         return;
+
+    const auto& keyTimes = this->keyTimes();
 
     AnimationMode animationMode = this->animationMode();
     CalcMode calcMode = this->calcMode();
@@ -611,7 +611,7 @@ void SVGAnimationElement::updateAnimation(float percent, unsigned repeatCount)
             m_lastValuesAnimationFrom = from;
             m_lastValuesAnimationTo = to;
         }
-    } else if (!m_keyPoints.isEmpty() && calcMode != CalcMode::Paced)
+    } else if (!m_keyPoints.isEmpty() && (calcMode != CalcMode::Paced || animationMode == AnimationMode::Path))
         effectivePercent = calculatePercentFromKeyPoints(percent);
     else if (m_keyPoints.isEmpty() && calcMode == CalcMode::Spline && keyTimes().size() > 1)
         effectivePercent = calculatePercentForSpline(percent, calculateKeyTimesIndex(percent));


### PR DESCRIPTION
#### fcaf706998523701858ebe0ba15da4bcb372ddf1
<pre>
[svg] WPT test svg/animations/animateMotion-keyPoints-001.html fails in WebKit only
<a href="https://bugs.webkit.org/show_bug.cgi?id=272602">https://bugs.webkit.org/show_bug.cgi?id=272602</a>

Reviewed by Dean Jackson.

The SVG Animations spec says [0] that &quot;the default value for the `calcMode` for `animateMotion`
is `paced`&quot;. Further, on this `paced` value, the spec says [1] &quot;if `paced` is specified, any
`keyTimes` or `keySplines` will be ignored&quot;.

I believe that based on this, our implementation always disregarded `keyTimes` when resolving
animations for `&lt;animationMotion&gt;`. However, `svg/animations/animateMotion-keyPoints-001.html`
has both `keyPoints` and `keyTimes` attributes and so WebKit ignores them. But the spec also
says [2] &quot;SVG adds a `keyPoints` attribute to the `animateMotion` to provide precise control
of the velocity of motion path animations&quot;.

While the spec is convoluted in this area, it would make little sense to ignore `keyPoints`
for `&lt;animationMotion&gt;` when it&apos;s been expressly added for the purpose of this animation type,
even though its `calcMode` is `paced` and `keyTimes` ought to be ignored. And in fact, Chrome
and Firefox both respect those attributes and passes this test.

So we change our implementation to use the `keyTimes` as specified via the attribute in
`startedActiveInterval()` to determine whether the animation is valid and then, in `updateAnimation()`,
call `calculatePercentFromKeyPoints()` to respect the `keyPoints` value in the case of an
`&lt;animateMotion&gt;` element.

This will also be required to pass the WPT test `svg/path/property/mpath.svg` (see bug 272416)
which also uses an `&lt;animateMotion&gt;` element with a `keyPoints`/`keyTimes` attribute combination.

[0] <a href="https://svgwg.org/specs/animations/#AnimateMotionElement">https://svgwg.org/specs/animations/#AnimateMotionElement</a>
[1] <a href="https://svgwg.org/specs/animations/#CalcModeAttribute">https://svgwg.org/specs/animations/#CalcModeAttribute</a>
[2] <a href="https://svgwg.org/specs/animations/#RelationshipToSMILAnimation">https://svgwg.org/specs/animations/#RelationshipToSMILAnimation</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/animateMotion-keyPoints-001-expected.txt:
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::calculatePercentFromKeyPoints const):
(WebCore::SVGAnimationElement::startedActiveInterval):
(WebCore::SVGAnimationElement::updateAnimation):

Canonical link: <a href="https://commits.webkit.org/277450@main">https://commits.webkit.org/277450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5957ae27bdcbcd673428116657a0d67f92f6559b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26803 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50298 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43665 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24267 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38768 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Skipped layout-tests; 28 flakes 81 failures; Uploaded test results; 23 flakes 52 failures; Running compile-webkit-without-change") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20068 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21904 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42218 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5658 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43954 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52183 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22652 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/18985 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46075 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Running layout-tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23924 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45111 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24712 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6733 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23644 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->