### PR TITLE
CheckedPtr should use zombie mode

### DIFF
--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -563,7 +563,7 @@ using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
     WTF_ALLOW_STRUCT_COMPACT_POINTERS; \
     WTF_MAKE_STRUCT_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(className)
 
-#else
+#else // ENABLE(MALLOC_HEAP_BREAKDOWN)
 
 #define WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER_IMPL(className) \
     WTF_MAKE_FAST_ALLOCATED_IMPL
@@ -593,4 +593,30 @@ public: \
     WTF_MAKE_FAST_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER_IMPL(className) \
 using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
 
-#endif
+#endif // ENABLE(MALLOC_HEAP_BREAKDOWN)
+
+// delete(T*, std::destroying_delete_t, size_t) is preferred over delete(void*)
+// in overload resolution, so we can use it to interpose before calling delete(void*).
+// Note: WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR must be declared in every subclass.
+#define WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(T) \
+void operator delete(T* object, std::destroying_delete_t, size_t size) { \
+    ASSERT(sizeof(T) == size); \
+    object->T::~T(); \
+    if (UNLIKELY(object->ptrCountWithoutThreadCheck())) { \
+        memset(static_cast<void*>(object), 0, size); \
+        return; \
+    } \
+    T::operator delete(object); \
+} \
+using WTFDidOverrideDeleteForCheckedPtr = int;
+
+// Note: WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR must be declared in the most derived subclass.
+#define WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ClassName) \
+public: \
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(ClassName) \
+private: \
+using __thisIsHereToForceASemicolonAfterWTFOverrideDelete UNUSED_TYPE_ALIAS = int
+
+#define WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(ClassName) \
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR_IMPL(ClassName) \
+using __thisIsHereToForceASemicolonAfterWTFOverrideDelete UNUSED_TYPE_ALIAS = int

--- a/Source/WTF/wtf/SingleThreadIntegralWrapper.h
+++ b/Source/WTF/wtf/SingleThreadIntegralWrapper.h
@@ -40,6 +40,8 @@ public:
     SingleThreadIntegralWrapper& operator++();
     SingleThreadIntegralWrapper& operator--();
 
+    IntegralType valueWithoutThreadCheck() const { return m_value; }
+
 private:
 #if ASSERT_ENABLED && !USE(WEB_THREAD)
     void assertThread() const { ASSERT(m_thread.ptr() == &Thread::current()); }

--- a/Source/WebCore/Modules/fetch/FetchLoader.h
+++ b/Source/WebCore/Modules/fetch/FetchLoader.h
@@ -43,6 +43,8 @@ class ScriptExecutionContext;
 class FragmentedSharedBuffer;
 
 class WEBCORE_EXPORT FetchLoader final : public ThreadableLoaderClient {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FetchLoader);
 public:
     FetchLoader(FetchLoaderClient&, FetchBodyConsumer*);
     ~FetchLoader() = default;

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.h
@@ -55,6 +55,8 @@ private:
     static bool resourceIsSupportedInPlatform(Resource);
 
     class ResourceLoader final : public ThreadableLoaderClient {
+        WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ResourceLoader);
     public:
         ResourceLoader(ScriptExecutionContext&, const URL&, CompletionHandler<void(ResourceLoader*, RefPtr<BitmapImage>&&)>&&);
         ~ResourceLoader();

--- a/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
+++ b/Source/WebCore/Modules/speech/SpeechRecognitionCaptureSourceImpl.h
@@ -46,11 +46,12 @@ class PlatformAudioData;
 class SpeechRecognitionUpdate;
 enum class SpeechRecognitionUpdateType : uint8_t;
 
-class SpeechRecognitionCaptureSourceImpl
+class SpeechRecognitionCaptureSourceImpl final
     : public RealtimeMediaSource::Observer
     , public RealtimeMediaSource::AudioSampleObserver
     , public CanMakeCheckedPtr<SpeechRecognitionCaptureSourceImpl> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SpeechRecognitionCaptureSourceImpl);
 public:
     using DataCallback = Function<void(const WTF::MediaTime&, const PlatformAudioData&, const AudioStreamDescription&, size_t)>;
     using StateUpdateCallback = Function<void(const SpeechRecognitionUpdate&)>;
@@ -61,6 +62,7 @@ public:
 private:
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -255,6 +255,7 @@ class AXObjectCache final : public CanMakeWeakPtr<AXObjectCache>, public CanMake
     , public AXTreeStore<AXObjectCache> {
     WTF_MAKE_NONCOPYABLE(AXObjectCache);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AXObjectCache);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AXObjectCache);
     friend class AXIsolatedTree;
     friend class AXTextMarker;
     friend WTF::TextStream& operator<<(WTF::TextStream&, AXObjectCache&);

--- a/Source/WebCore/animation/DocumentTimelinesController.h
+++ b/Source/WebCore/animation/DocumentTimelinesController.h
@@ -42,8 +42,9 @@ class DocumentTimeline;
 class WebAnimation;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DocumentTimelinesController);
-class DocumentTimelinesController : public CanMakeCheckedPtr<DocumentTimelinesController> {
+class DocumentTimelinesController final : public CanMakeCheckedPtr<DocumentTimelinesController> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(DocumentTimelinesController);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DocumentTimelinesController);
 public:
     explicit DocumentTimelinesController(Document&);
     ~DocumentTimelinesController();

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -78,8 +78,9 @@ enum class ReasonForCallingCanExecuteScripts : uint8_t {
 
 using ValueOrException = Expected<JSC::JSValue, ExceptionDetails>;
 
-class ScriptController : public CanMakeWeakPtr<ScriptController>, public CanMakeCheckedPtr<ScriptController> {
+class ScriptController final : public CanMakeWeakPtr<ScriptController>, public CanMakeCheckedPtr<ScriptController> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScriptController);
 
     using RootObjectMap = HashMap<void*, Ref<JSC::Bindings::RootObject>>;
 

--- a/Source/WebCore/dom/CustomElementDefaultARIA.h
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.h
@@ -38,8 +38,9 @@ namespace WebCore {
 class Element;
 class WeakPtrImplWithEventTargetData;
 
-class CustomElementDefaultARIA : public CanMakeCheckedPtr<CustomElementDefaultARIA> {
+class CustomElementDefaultARIA final : public CanMakeCheckedPtr<CustomElementDefaultARIA> {
     WTF_MAKE_ISO_ALLOCATED(CustomElementDefaultARIA);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CustomElementDefaultARIA);
 public:
     CustomElementDefaultARIA();
     ~CustomElementDefaultARIA();

--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -116,8 +116,9 @@ private:
     bool m_invoking { false };
 };
 
-class CustomElementReactionQueue : public CanMakeCheckedPtr<CustomElementReactionQueue> {
+class CustomElementReactionQueue final : public CanMakeCheckedPtr<CustomElementReactionQueue> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CustomElementReactionQueue);
     WTF_MAKE_NONCOPYABLE(CustomElementReactionQueue);
 public:
     CustomElementReactionQueue(JSCustomElementInterface&);

--- a/Source/WebCore/dom/DeviceMotionController.h
+++ b/Source/WebCore/dom/DeviceMotionController.h
@@ -34,8 +34,10 @@ namespace WebCore {
 class DeviceMotionClient;
 class DeviceMotionData;
 
-class DeviceMotionController final : public DeviceController {
+class DeviceMotionController : public DeviceController {
     WTF_MAKE_NONCOPYABLE(DeviceMotionController);
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceMotionController);
 public:
     explicit DeviceMotionController(DeviceMotionClient&);
     virtual ~DeviceMotionController() = default;

--- a/Source/WebCore/dom/DeviceOrientationController.h
+++ b/Source/WebCore/dom/DeviceOrientationController.h
@@ -37,6 +37,8 @@ class Page;
 
 class DeviceOrientationController final : public DeviceController {
     WTF_MAKE_NONCOPYABLE(DeviceOrientationController);
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceOrientationController);
 public:
     explicit DeviceOrientationController(DeviceOrientationClient&);
     virtual ~DeviceOrientationController() = default;

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -46,8 +46,10 @@ struct SimpleRange;
 enum class RemovePartiallyOverlappingMarker : bool { No, Yes };
 enum class FilterMarkerResult : bool { Keep, Remove };
 
-class DocumentMarkerController : public CanMakeCheckedPtr<DocumentMarkerController> {
-    WTF_MAKE_NONCOPYABLE(DocumentMarkerController); WTF_MAKE_FAST_ALLOCATED;
+class DocumentMarkerController final : public CanMakeCheckedPtr<DocumentMarkerController> {
+    WTF_MAKE_NONCOPYABLE(DocumentMarkerController);
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DocumentMarkerController);
 public:
     DocumentMarkerController(Document&);
     ~DocumentMarkerController();

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -153,9 +153,10 @@ private:
     mutable Markable<MonotonicTime> m_nextTimerFireTimeCache;
 };
 
-class EventLoopTaskGroup : public CanMakeWeakPtr<EventLoopTaskGroup>, public CanMakeCheckedPtr<EventLoopTaskGroup> {
+class EventLoopTaskGroup final : public CanMakeWeakPtr<EventLoopTaskGroup>, public CanMakeCheckedPtr<EventLoopTaskGroup> {
     WTF_MAKE_NONCOPYABLE(EventLoopTaskGroup);
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EventLoopTaskGroup);
 public:
     EventLoopTaskGroup(EventLoop& eventLoop)
         : m_eventLoop(eventLoop)

--- a/Source/WebCore/dom/ExtensionStyleSheets.cpp
+++ b/Source/WebCore/dom/ExtensionStyleSheets.cpp
@@ -57,6 +57,8 @@ ExtensionStyleSheets::ExtensionStyleSheets(Document& document)
 {
 }
 
+ExtensionStyleSheets::~ExtensionStyleSheets() = default;
+
 Ref<Document> ExtensionStyleSheets::protectedDocument() const
 {
     return const_cast<Document&>(m_document.get());

--- a/Source/WebCore/dom/ExtensionStyleSheets.h
+++ b/Source/WebCore/dom/ExtensionStyleSheets.h
@@ -51,10 +51,12 @@ class StyleSheetContents;
 class StyleSheetList;
 class WeakPtrImplWithEventTargetData;
 
-class ExtensionStyleSheets : public CanMakeCheckedPtr<ExtensionStyleSheets> {
+class ExtensionStyleSheets final : public CanMakeCheckedPtr<ExtensionStyleSheets> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ExtensionStyleSheets);
 public:
     explicit ExtensionStyleSheets(Document&);
+    ~ExtensionStyleSheets();
 
     CSSStyleSheet* pageUserSheet();
     const Vector<RefPtr<CSSStyleSheet>>& documentUserStyleSheets() const { return m_userStyleSheets; }

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -44,6 +44,7 @@ class RenderStyle;
 
 class FullscreenManager final : public CanMakeWeakPtr<FullscreenManager>, public CanMakeCheckedPtr<FullscreenManager> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FullscreenManager);
 public:
     FullscreenManager(Document&);
     ~FullscreenManager();

--- a/Source/WebCore/dom/IdTargetObserver.h
+++ b/Source/WebCore/dom/IdTargetObserver.h
@@ -35,6 +35,7 @@ class IdTargetObserverRegistry;
 
 class IdTargetObserver : public CanMakeCheckedPtr<IdTargetObserver> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IdTargetObserver);
 public:
     virtual ~IdTargetObserver();
     virtual void idTargetChanged() = 0;

--- a/Source/WebCore/dom/IdTargetObserverRegistry.cpp
+++ b/Source/WebCore/dom/IdTargetObserverRegistry.cpp
@@ -81,4 +81,8 @@ void IdTargetObserverRegistry::notifyObserversInternal(const AtomString& id)
         m_registry.remove(id);
 }
 
+IdTargetObserverRegistry::ObserverSet::ObserverSet() = default;
+
+IdTargetObserverRegistry::ObserverSet::~ObserverSet() = default;
+
 } // namespace WebCore

--- a/Source/WebCore/dom/IdTargetObserverRegistry.h
+++ b/Source/WebCore/dom/IdTargetObserverRegistry.h
@@ -37,8 +37,9 @@ namespace WebCore {
 
 class IdTargetObserver;
 
-class IdTargetObserverRegistry : public CanMakeCheckedPtr<IdTargetObserverRegistry> {
+class IdTargetObserverRegistry final : public CanMakeCheckedPtr<IdTargetObserverRegistry> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IdTargetObserverRegistry);
     friend class IdTargetObserver;
 public:
     IdTargetObserverRegistry();
@@ -51,8 +52,12 @@ private:
     void removeObserver(const AtomString& id, IdTargetObserver&);
     void notifyObserversInternal(const AtomString& id);
 
-    struct ObserverSet : public CanMakeCheckedPtr<ObserverSet> {
+    struct ObserverSet final : public CanMakeCheckedPtr<ObserverSet> {
         WTF_MAKE_STRUCT_FAST_ALLOCATED;
+        WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(ObserverSet);
+
+        ObserverSet();
+        ~ObserverSet();
         HashSet<CheckedRef<IdTargetObserver>> observers;
     };
 

--- a/Source/WebCore/dom/PendingScriptClient.h
+++ b/Source/WebCore/dom/PendingScriptClient.h
@@ -37,6 +37,7 @@ public:
 
     // CheckedPtr interface
     virtual uint32_t ptrCount() const = 0;
+    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
     virtual void incrementPtrCount() const = 0;
     virtual void decrementPtrCount() const = 0;
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/dom/RejectedPromiseTracker.h
+++ b/Source/WebCore/dom/RejectedPromiseTracker.h
@@ -45,9 +45,10 @@ class JSDOMGlobalObject;
 class ScriptExecutionContext;
 class UnhandledPromise;
 
-class RejectedPromiseTracker : public CanMakeCheckedPtr<RejectedPromiseTracker> {
-    WTF_MAKE_FAST_ALLOCATED;
+class RejectedPromiseTracker final : public CanMakeCheckedPtr<RejectedPromiseTracker> {
     WTF_MAKE_NONCOPYABLE(RejectedPromiseTracker);
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RejectedPromiseTracker);
 public:
     explicit RejectedPromiseTracker(ScriptExecutionContext&, JSC::VM&);
     ~RejectedPromiseTracker();

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -40,14 +40,17 @@ class ScriptElement;
 class LoadableScript;
 class WeakPtrImplWithEventTargetData;
 
-class ScriptRunner : public PendingScriptClient, public CanMakeCheckedPtr<ScriptRunner> {
-    WTF_MAKE_NONCOPYABLE(ScriptRunner); WTF_MAKE_FAST_ALLOCATED;
+class ScriptRunner final : public PendingScriptClient, public CanMakeCheckedPtr<ScriptRunner> {
+    WTF_MAKE_NONCOPYABLE(ScriptRunner);
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScriptRunner);
 public:
     explicit ScriptRunner(Document&);
     ~ScriptRunner();
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/dom/VisitedLinkState.h
+++ b/Source/WebCore/dom/VisitedLinkState.h
@@ -39,8 +39,9 @@ namespace WebCore {
 
 class Document;
 
-class VisitedLinkState : public CanMakeCheckedPtr<VisitedLinkState> {
+class VisitedLinkState final : public CanMakeCheckedPtr<VisitedLinkState> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VisitedLinkState);
 public:
     explicit VisitedLinkState(Document&);
 

--- a/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelRegistry.h
@@ -36,8 +36,9 @@
 
 namespace WebCore {
 
-class MessagePortChannelRegistry : public CanMakeWeakPtr<MessagePortChannelRegistry>, public CanMakeCheckedPtr<MessagePortChannelRegistry> {
+class MessagePortChannelRegistry final : public CanMakeWeakPtr<MessagePortChannelRegistry>, public CanMakeCheckedPtr<MessagePortChannelRegistry> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MessagePortChannelRegistry);
 public:
     WEBCORE_EXPORT MessagePortChannelRegistry();
 

--- a/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/WorkerMessagePortChannelProvider.h
@@ -36,6 +36,7 @@ class WorkerOrWorkletGlobalScope;
 
 class WorkerMessagePortChannelProvider final : public MessagePortChannelProvider, public CanMakeCheckedPtr<WorkerMessagePortChannelProvider> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerMessagePortChannelProvider);
 public:
     explicit WorkerMessagePortChannelProvider(WorkerOrWorkletGlobalScope&);
     ~WorkerMessagePortChannelProvider();

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -174,8 +174,9 @@ private:
     TemporarySelectionChange m_selectionChange;
 };
 
-class Editor : public CanMakeCheckedPtr<Editor> {
+class Editor final : public CanMakeCheckedPtr<Editor> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Editor);
 public:
     explicit Editor(Document&);
     ~Editor();

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -115,6 +115,7 @@ private:
 class FrameSelection final : private CaretBase, public CaretAnimationClient, public CanMakeCheckedPtr<FrameSelection> {
     WTF_MAKE_NONCOPYABLE(FrameSelection);
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameSelection);
 public:
     enum class Alteration : bool { Move, Extend };
     enum class CursorAlignOnScroll : bool { IfNeeded, Always };

--- a/Source/WebCore/editing/TextManipulationController.h
+++ b/Source/WebCore/editing/TextManipulationController.h
@@ -42,8 +42,9 @@ class Document;
 class Element;
 class VisiblePosition;
 
-class TextManipulationController : public CanMakeWeakPtr<TextManipulationController>, public CanMakeCheckedPtr<TextManipulationController> {
+class TextManipulationController final : public CanMakeWeakPtr<TextManipulationController>, public CanMakeCheckedPtr<TextManipulationController> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextManipulationController);
 public:
     TextManipulationController(Document&);
     

--- a/Source/WebCore/fileapi/FileReaderLoader.h
+++ b/Source/WebCore/fileapi/FileReaderLoader.h
@@ -52,7 +52,9 @@ class ScriptExecutionContext;
 class TextResourceDecoder;
 class ThreadableLoader;
 
-class FileReaderLoader : public ThreadableLoaderClient {
+class FileReaderLoader final : public ThreadableLoaderClient {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FileReaderLoader);
 public:
     enum ReadType {
         ReadAsArrayBuffer,

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -37,8 +37,10 @@ class BackForwardClient;
 class HistoryItem;
 class Page;
 
-class BackForwardController : public CanMakeCheckedPtr<BackForwardController> {
-    WTF_MAKE_NONCOPYABLE(BackForwardController); WTF_MAKE_FAST_ALLOCATED;
+class BackForwardController final : public CanMakeCheckedPtr<BackForwardController> {
+    WTF_MAKE_NONCOPYABLE(BackForwardController);
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(BackForwardController);
 public:
     BackForwardController(Page&, Ref<BackForwardClient>&&);
     ~BackForwardController();

--- a/Source/WebCore/history/CachedPage.h
+++ b/Source/WebCore/history/CachedPage.h
@@ -36,8 +36,9 @@ class Document;
 class DocumentLoader;
 class Page;
 
-class CachedPage : public CanMakeCheckedPtr<CachedPage> {
+class CachedPage final : public CanMakeCheckedPtr<CachedPage> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CachedPage);
 public:
     explicit CachedPage(Page&);
     WEBCORE_EXPORT ~CachedPage();

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -53,6 +53,8 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(FTPDirectoryDocument);
 using namespace HTMLNames;
     
 class FTPDirectoryDocumentParser final : public HTMLDocumentParser {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(HTMLDocumentParser);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FTPDirectoryDocumentParser);
 public:
     static Ref<FTPDirectoryDocumentParser> create(HTMLDocument& document)
     {

--- a/Source/WebCore/html/FormListedElement.cpp
+++ b/Source/WebCore/html/FormListedElement.cpp
@@ -43,6 +43,7 @@ using namespace HTMLNames;
 
 class FormAttributeTargetObserver final : private IdTargetObserver {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FormAttributeTargetObserver);
 public:
     FormAttributeTargetObserver(const AtomString& id, FormListedElement&);
 

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -99,6 +99,7 @@ using namespace HTMLNames;
 #if ENABLE(DATALIST_ELEMENT)
 class ListAttributeTargetObserver final : public IdTargetObserver {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ListAttributeTargetObserver);
 public:
     ListAttributeTargetObserver(const AtomString& id, HTMLInputElement&);
 

--- a/Source/WebCore/html/parser/HTMLDocumentParser.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.h
@@ -48,12 +48,14 @@ class PumpSession;
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HTMLDocumentParser);
 class HTMLDocumentParser : public ScriptableDocumentParser, private HTMLScriptRunnerHost, private PendingScriptClient, public CanMakeCheckedPtr<HTMLDocumentParser> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(HTMLDocumentParser);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDocumentParser);
 public:
     static Ref<HTMLDocumentParser> create(HTMLDocument&, OptionSet<ParserContentPolicy> = DefaultParserContentPolicy);
     virtual ~HTMLDocumentParser();
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/html/parser/TextDocumentParser.h
+++ b/Source/WebCore/html/parser/TextDocumentParser.h
@@ -29,6 +29,8 @@
 namespace WebCore {
 
 class TextDocumentParser final : public HTMLDocumentParser {
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(HTMLDocumentParser);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextDocumentParser);
 public:
     static Ref<TextDocumentParser> create(HTMLDocument& document)
     {

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -88,6 +88,7 @@ inline static bool hasVerticalAppearance(HTMLInputElement& input)
 // http://webkit.org/b/62535
 class RenderSliderContainer final : public RenderFlexibleBox {
     WTF_MAKE_ISO_ALLOCATED_INLINE(RenderSliderContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSliderContainer);
 public:
     RenderSliderContainer(SliderContainerElement& element, RenderStyle&& style)
         : RenderFlexibleBox(Type::SliderContainer, element, WTFMove(style))

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -103,6 +103,8 @@ namespace {
 
 class InspectorThreadableLoaderClient final : public ThreadableLoaderClient {
     WTF_MAKE_NONCOPYABLE(InspectorThreadableLoaderClient);
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InspectorThreadableLoaderClient);
 public:
     InspectorThreadableLoaderClient(RefPtr<LoadResourceCallback>&& callback)
         : m_callback(WTFMove(callback))

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
@@ -42,8 +42,9 @@ struct PaintInfo;
 
 namespace LayoutIntegration {
 
-class FlexLayout : public CanMakeCheckedPtr<FlexLayout> {
+class FlexLayout final : public CanMakeCheckedPtr<FlexLayout> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FlexLayout);
 public:
     FlexLayout(RenderFlexibleBox&);
     ~FlexLayout();

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -61,8 +61,9 @@ struct LineAdjustment;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(LayoutIntegration_LineLayout);
 
-class LineLayout : public CanMakeCheckedPtr<LineLayout> {
+class LineLayout final : public CanMakeCheckedPtr<LineLayout> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(LayoutIntegration_LineLayout);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LineLayout);
 public:
     LineLayout(RenderBlockFlow&);
     ~LineLayout();

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -45,6 +45,7 @@ class TreeBuilder;
 
 class Box : public CanMakeCheckedPtr<Box> {
     WTF_MAKE_ISO_ALLOCATED(Box);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Box);
 public:
     enum class NodeType : uint8_t {
         Text,

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.h
@@ -38,6 +38,7 @@ namespace Layout {
 
 class ElementBox : public Box {
     WTF_MAKE_ISO_ALLOCATED(ElementBox);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ElementBox);
 public:
     ElementBox(ElementAttributes&&, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr, OptionSet<BaseTypeFlag> = { ElementBoxFlag });
 

--- a/Source/WebCore/layout/layouttree/LayoutInitialContainingBlock.h
+++ b/Source/WebCore/layout/layouttree/LayoutInitialContainingBlock.h
@@ -33,6 +33,7 @@ namespace Layout {
 
 class InitialContainingBlock final : public ElementBox {
     WTF_MAKE_ISO_ALLOCATED(InitialContainingBlock);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InitialContainingBlock);
 public:
     InitialContainingBlock(RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr);
     virtual ~InitialContainingBlock() = default;

--- a/Source/WebCore/layout/layouttree/LayoutInlineTextBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutInlineTextBox.h
@@ -35,6 +35,7 @@ namespace Layout {
 
 class InlineTextBox : public Box {
     WTF_MAKE_ISO_ALLOCATED(InlineTextBox);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InlineTextBox);
 public:
     enum class ContentCharacteristic : uint8_t {
         CanUseSimplifiedContentMeasuring         = 1 << 0,

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -229,6 +229,9 @@ class EmptyDatabaseProvider final : public DatabaseProvider {
 };
 
 class EmptyDiagnosticLoggingClient final : public DiagnosticLoggingClient {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EmptyDiagnosticLoggingClient);
+
     void logDiagnosticMessage(const String&, const String&, ShouldSample) final { }
     void logDiagnosticMessageWithResult(const String&, const String&, DiagnosticLoggingResultType, ShouldSample) final { }
     void logDiagnosticMessageWithValue(const String&, const String&, double, unsigned, ShouldSample) final { }

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -310,8 +310,9 @@ private:
 };
 
 
-class FrameLoader::FrameProgressTracker : public CanMakeCheckedPtr<FrameLoader::FrameProgressTracker> {
+class FrameLoader::FrameProgressTracker final : public CanMakeCheckedPtr<FrameLoader::FrameProgressTracker> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameProgressTracker);
 public:
     explicit FrameProgressTracker(LocalFrame& frame)
         : m_frame(frame)

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -102,8 +102,9 @@ WEBCORE_EXPORT bool isReload(FrameLoadType);
 using ContentPolicyDecisionFunction = CompletionHandler<void(PolicyAction)>;
 
 class FrameLoader final : public CanMakeCheckedPtr<FrameLoader> {
-    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
     WTF_MAKE_NONCOPYABLE(FrameLoader);
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameLoader);
 public:
     FrameLoader(LocalFrame&, UniqueRef<LocalFrameLoaderClient>&&);
     ~FrameLoader();

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -43,9 +43,10 @@ enum class ShouldTreatAsContinuingLoad : uint8_t;
 
 struct StringWithDirection;
 
-class HistoryController : public CanMakeCheckedPtr<HistoryController> {
+class HistoryController final : public CanMakeCheckedPtr<HistoryController> {
     WTF_MAKE_NONCOPYABLE(HistoryController);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HistoryController);
 public:
     enum HistoryUpdateType { UpdateAll, UpdateAllExceptBackForwardList };
 

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -50,8 +50,9 @@ class SecurityOrigin;
 enum class NewLoadInProgress : bool { No, Yes };
 enum class ScheduleLocationChangeResult : uint8_t { Stopped, Completed, Started };
 
-class NavigationScheduler : public CanMakeCheckedPtr<NavigationScheduler> {
+class NavigationScheduler final : public CanMakeCheckedPtr<NavigationScheduler> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NavigationScheduler);
 public:
     explicit NavigationScheduler(Frame&);
     ~NavigationScheduler();

--- a/Source/WebCore/loader/ProgressTracker.h
+++ b/Source/WebCore/loader/ProgressTracker.h
@@ -43,9 +43,10 @@ class ResourceResponse;
 class ProgressTrackerClient;
 struct ProgressItem;
 
-class ProgressTracker : public CanMakeCheckedPtr<ProgressTracker> {
+class ProgressTracker final : public CanMakeCheckedPtr<ProgressTracker> {
     WTF_MAKE_NONCOPYABLE(ProgressTracker);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ProgressTracker);
 public:
     explicit ProgressTracker(Page&, UniqueRef<ProgressTrackerClient>&&);
     ~ProgressTracker();

--- a/Source/WebCore/loader/ThreadableLoaderClient.h
+++ b/Source/WebCore/loader/ThreadableLoaderClient.h
@@ -44,7 +44,9 @@ class ResourceTiming;
 class SharedBuffer;
 
 class ThreadableLoaderClient : public CanMakeWeakPtr<ThreadableLoaderClient>, public CanMakeThreadSafeCheckedPtr<ThreadableLoaderClient> {
-    WTF_MAKE_NONCOPYABLE(ThreadableLoaderClient); WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+    WTF_MAKE_NONCOPYABLE(ThreadableLoaderClient);
+    WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ThreadableLoaderClient);
 public:
     virtual void didSendData(unsigned long long /*bytesSent*/, unsigned long long /*totalBytesToBeSent*/) { }
 

--- a/Source/WebCore/loader/WorkerThreadableLoader.cpp
+++ b/Source/WebCore/loader/WorkerThreadableLoader.cpp
@@ -172,6 +172,8 @@ WorkerThreadableLoader::MainThreadBridge::MainThreadBridge(ThreadableLoaderClien
     });
 }
 
+WorkerThreadableLoader::MainThreadBridge::~MainThreadBridge() = default;
+
 void WorkerThreadableLoader::MainThreadBridge::destroy()
 {
     // Ensure that no more client callbacks are done in the worker context's thread.

--- a/Source/WebCore/loader/WorkerThreadableLoader.h
+++ b/Source/WebCore/loader/WorkerThreadableLoader.h
@@ -90,10 +90,14 @@ private:
     //    go through it. All tasks posted from the worker object's thread to the worker context's
     //    thread contain the RefPtr<ThreadableLoaderClientWrapper> object, so the
     //    ThreadableLoaderClientWrapper instance is there until all tasks are executed.
-    class MainThreadBridge : public ThreadableLoaderClient {
+    class MainThreadBridge final : public ThreadableLoaderClient {
+        WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MainThreadBridge);
     public:
         // All executed on the worker context's thread.
         MainThreadBridge(ThreadableLoaderClientWrapper&, WorkerLoaderProxy*, ScriptExecutionContextIdentifier, const String& taskMode, ResourceRequest&&, const ThreadableLoaderOptions&, const String& outgoingReferrer, WorkerOrWorkletGlobalScope&);
+        virtual ~MainThreadBridge();
+
         void cancel();
         void destroy();
         void computeIsDone();

--- a/Source/WebCore/page/AlternativeTextClient.h
+++ b/Source/WebCore/page/AlternativeTextClient.h
@@ -56,6 +56,7 @@ enum class AutocorrectionResponse : uint8_t {
 
 class AlternativeTextClient : public CanMakeCheckedPtr<AlternativeTextClient> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AlternativeTextClient);
 public:
     virtual ~AlternativeTextClient() = default;
 #if USE(AUTOCORRECTION_PANEL)

--- a/Source/WebCore/page/DeviceController.h
+++ b/Source/WebCore/page/DeviceController.h
@@ -40,6 +40,7 @@ class Page;
 
 class DeviceController : public Supplement<Page>, public CanMakeCheckedPtr<DeviceController> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DeviceController);
 public:
     explicit DeviceController(DeviceClient&);
     virtual ~DeviceController() = default;

--- a/Source/WebCore/page/DiagnosticLoggingClient.h
+++ b/Source/WebCore/page/DiagnosticLoggingClient.h
@@ -47,6 +47,7 @@ struct DiagnosticLoggingDictionary {
 
 class DiagnosticLoggingClient : public CanMakeCheckedPtr<DiagnosticLoggingClient> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DiagnosticLoggingClient);
 public:
     virtual void logDiagnosticMessage(const String& message, const String& description, ShouldSample) = 0;
     virtual void logDiagnosticMessageWithResult(const String& message, const String& description, DiagnosticLoggingResultType, ShouldSample) = 0;

--- a/Source/WebCore/page/EditorClient.h
+++ b/Source/WebCore/page/EditorClient.h
@@ -64,6 +64,7 @@ struct SimpleRange;
 
 class EditorClient : public CanMakeWeakPtr<EditorClient>, public CanMakeCheckedPtr<EditorClient> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EditorClient);
 public:
     virtual ~EditorClient() = default;
 

--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -45,8 +45,9 @@ namespace WebCore {
 class Document;
 class Page;
 
-class ElementTargetingController : public CanMakeCheckedPtr<ElementTargetingController> {
+class ElementTargetingController final : public CanMakeCheckedPtr<ElementTargetingController> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ElementTargetingController);
 public:
     ElementTargetingController(Page&);
 

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -133,8 +133,9 @@ enum class ImmediateActionStage : uint8_t {
     ActionCompleted
 };
 
-class EventHandler : public CanMakeCheckedPtr<EventHandler> {
+class EventHandler final : public CanMakeCheckedPtr<EventHandler> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EventHandler);
 public:
     explicit EventHandler(LocalFrame&);
     ~EventHandler();

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -48,6 +48,7 @@ class ThreadableLoader;
 
 class EventSource final : public RefCounted<EventSource>, public EventTarget, private ThreadableLoaderClient, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(EventSource);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EventSource);
 public:
     struct Init {
         bool withCredentials;

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -49,8 +49,9 @@ class TreeScope;
 
 struct FocusCandidate;
 
-class FocusController : public CanMakeCheckedPtr<FocusController> {
+class FocusController final : public CanMakeCheckedPtr<FocusController> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FocusController);
 public:
     explicit FocusController(Page&, OptionSet<ActivityState>);
 

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -33,6 +33,8 @@ class Frame;
 enum class RenderAsTextFlag : uint16_t;
 
 class FrameView : public ScrollView {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FrameView);
 public:
     enum class Type : bool { Local, Remote };
     virtual Type viewType() const = 0;

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -90,6 +90,7 @@ enum class LayoutViewportConstraint : bool { Unconstrained, ConstrainedToDocumen
 
 class LocalFrameView final : public FrameView {
     WTF_MAKE_ISO_ALLOCATED(LocalFrameView);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LocalFrameView);
 public:
     friend class Internals;
     friend class LocalFrameViewLayoutContext;

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -61,8 +61,9 @@ struct UpdateScrollInfoAfterLayoutTransaction {
     SingleThreadWeakHashSet<RenderBlock> blocks;
 };
 
-class LocalFrameViewLayoutContext : public CanMakeCheckedPtr<LocalFrameViewLayoutContext> {
+class LocalFrameViewLayoutContext final : public CanMakeCheckedPtr<LocalFrameViewLayoutContext> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LocalFrameViewLayoutContext);
 public:
     LocalFrameViewLayoutContext(LocalFrameView&);
     ~LocalFrameViewLayoutContext();

--- a/Source/WebCore/page/PageConsoleClient.h
+++ b/Source/WebCore/page/PageConsoleClient.h
@@ -50,6 +50,7 @@ class Page;
 
 class WEBCORE_EXPORT PageConsoleClient final : public JSC::ConsoleClient, public CanMakeCheckedPtr<PageConsoleClient> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PageConsoleClient);
 public:
     explicit PageConsoleClient(Page&);
     virtual ~PageConsoleClient();

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -33,6 +33,8 @@ namespace WebCore {
 class RemoteFrame;
 
 class RemoteFrameView final : public FrameView {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteFrameView);
 public:
     static Ref<RemoteFrameView> create(RemoteFrame& frame) { return adoptRef(*new RemoteFrameView(frame)); }
 

--- a/Source/WebCore/page/RenderingUpdateScheduler.h
+++ b/Source/WebCore/page/RenderingUpdateScheduler.h
@@ -36,6 +36,7 @@ class Timer;
 
 class RenderingUpdateScheduler final : public DisplayRefreshMonitorClient {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderingUpdateScheduler);
 public:
     static std::unique_ptr<RenderingUpdateScheduler> create(Page& page)
     {

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -86,8 +86,9 @@ enum class AllowTrustedTypePolicy : uint8_t {
     DisallowedDuplicateName,
 };
 
-class ContentSecurityPolicy : public CanMakeThreadSafeCheckedPtr<ContentSecurityPolicy> {
+class ContentSecurityPolicy final : public CanMakeThreadSafeCheckedPtr<ContentSecurityPolicy> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ContentSecurityPolicy);
 public:
     explicit ContentSecurityPolicy(URL&&, ScriptExecutionContext&);
     WEBCORE_EXPORT explicit ContentSecurityPolicy(URL&&, ContentSecurityPolicyClient*, ReportingClient*);

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -41,8 +41,9 @@ class ScrollingStateFrameScrollingNode;
 // will be informed and will schedule a timer that will clone the new state tree and send it over to
 // the scrolling thread, avoiding locking. 
 
-class ScrollingStateTree : public CanMakeCheckedPtr<ScrollingStateTree> {
+class ScrollingStateTree final : public CanMakeCheckedPtr<ScrollingStateTree> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollingStateTree);
     friend class ScrollingStateNode;
 public:
     WEBCORE_EXPORT static std::optional<ScrollingStateTree> createAfterReconstruction(bool, bool, RefPtr<ScrollingStateFrameScrollingNode>&&);

--- a/Source/WebCore/platform/KeyboardScrollingAnimator.h
+++ b/Source/WebCore/platform/KeyboardScrollingAnimator.h
@@ -51,8 +51,9 @@ const std::optional<KeyboardScrollingKey> keyboardScrollingKeyForKeyboardEvent(c
 const std::optional<ScrollDirection> scrollDirectionForKeyboardEvent(const KeyboardEvent&);
 const std::optional<ScrollGranularity> scrollGranularityForKeyboardEvent(const KeyboardEvent&);
 
-class KeyboardScrollingAnimator : public CanMakeWeakPtr<KeyboardScrollingAnimator>, public CanMakeCheckedPtr<KeyboardScrollingAnimator> {
+class KeyboardScrollingAnimator final : public CanMakeWeakPtr<KeyboardScrollingAnimator>, public CanMakeCheckedPtr<KeyboardScrollingAnimator> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(KeyboardScrollingAnimator);
     WTF_MAKE_NONCOPYABLE(KeyboardScrollingAnimator);
 public:
     KeyboardScrollingAnimator(ScrollableArea&);

--- a/Source/WebCore/platform/OrientationNotifier.h
+++ b/Source/WebCore/platform/OrientationNotifier.h
@@ -31,8 +31,9 @@
 
 namespace WebCore {
 
-class OrientationNotifier : public CanMakeCheckedPtr<OrientationNotifier> {
+class OrientationNotifier final : public CanMakeCheckedPtr<OrientationNotifier> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(OrientationNotifier);
 public:
     explicit OrientationNotifier(IntDegrees orientation) { m_orientation = orientation; }
     ~OrientationNotifier();

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -69,10 +69,17 @@ enum class DelegatedScrollingMode : uint8_t {
     DelegatedToWebKit,
 };
 
-class ScrollView : public Widget, public ScrollableArea {
+class ScrollView : public Widget, public ScrollableArea, public CanMakeCheckedPtr<ScrollView> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollView);
 public:
     virtual ~ScrollView();
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     using Widget::weakPtrFactory;
     using Widget::WeakValueType;

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -49,7 +49,7 @@
 
 namespace WebCore {
 
-struct SameSizeAsScrollableArea : public CanMakeWeakPtr<SameSizeAsScrollableArea>, public CanMakeCheckedPtr<SameSizeAsScrollableArea> {
+struct SameSizeAsScrollableArea final : public CanMakeWeakPtr<SameSizeAsScrollableArea> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     ~SameSizeAsScrollableArea() { }

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -71,9 +71,15 @@ inline int offsetForOrientation(ScrollOffset offset, ScrollbarOrientation orient
     return 0;
 }
 
-class ScrollableArea : public CanMakeWeakPtr<ScrollableArea>, public CanMakeCheckedPtr<ScrollableArea> {
+class ScrollableArea : public CanMakeWeakPtr<ScrollableArea> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    // CheckedPtr interface
+    virtual uint32_t ptrCount() const = 0;
+    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
+    virtual void incrementPtrCount() const = 0;
+    virtual void decrementPtrCount() const = 0;
+
     virtual bool isScrollView() const { return false; }
     virtual bool isRenderLayer() const { return false; }
     virtual bool isListBox() const { return false; }

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -136,6 +136,7 @@ public:
 
     // CheckedPtr interface
     virtual uint32_t ptrCount() const = 0;
+    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
     virtual void incrementPtrCount() const = 0;
     virtual void decrementPtrCount() const = 0;
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -104,6 +104,7 @@ public:
 
     // CheckedPtr interface
     virtual uint32_t ptrCount() const = 0;
+    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
     virtual void incrementPtrCount() const = 0;
     virtual void decrementPtrCount() const = 0;
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -57,8 +57,9 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, __AVPlayerLayerView)
 #endif
 
 namespace WebCore {
-class WebAVPlayerLayerPresentationModelClient : public VideoPresentationModelClient, public CanMakeCheckedPtr<WebAVPlayerLayerPresentationModelClient> {
+class WebAVPlayerLayerPresentationModelClient final : public VideoPresentationModelClient, public CanMakeCheckedPtr<WebAVPlayerLayerPresentationModelClient> {
     WTF_MAKE_FAST_ALLOCATED(WebAVPlayerLayerPresentationModelClient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebAVPlayerLayerPresentationModelClient);
 public:
     WebAVPlayerLayerPresentationModelClient(WebAVPlayerLayer* playerLayer)
         : m_playerLayer(playerLayer)
@@ -67,6 +68,7 @@ public:
 private:
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorClient.h
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorClient.h
@@ -40,6 +40,7 @@ struct DisplayUpdate;
 
 class DisplayRefreshMonitorClient : public CanMakeCheckedPtr<DisplayRefreshMonitorClient> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DisplayRefreshMonitorClient);
 public:
     DisplayRefreshMonitorClient();
     virtual ~DisplayRefreshMonitorClient();

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -108,8 +108,9 @@ public:
     void operator()(TextLayout*) const;
 };
 
-class FontCascade : public CanMakeWeakPtr<FontCascade>, public CanMakeCheckedPtr<FontCascade> {
+class FontCascade final : public CanMakeWeakPtr<FontCascade>, public CanMakeCheckedPtr<FontCascade> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FontCascade);
 public:
     WEBCORE_EXPORT FontCascade();
     WEBCORE_EXPORT FontCascade(FontCascadeDescription&&);

--- a/Source/WebCore/platform/graphics/TextRun.cpp
+++ b/Source/WebCore/platform/graphics/TextRun.cpp
@@ -28,8 +28,9 @@
 
 namespace WebCore {
 
-struct ExpectedTextRunSize : public CanMakeCheckedPtr<ExpectedTextRunSize> {
+struct ExpectedTextRunSize final : public CanMakeCheckedPtr<ExpectedTextRunSize> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(ExpectedTextRunSize);
 
     String text;
     TabSize tabSize;

--- a/Source/WebCore/platform/graphics/TextRun.h
+++ b/Source/WebCore/platform/graphics/TextRun.h
@@ -40,8 +40,9 @@ class Font;
 
 struct GlyphData;
 
-class TextRun : public CanMakeCheckedPtr<TextRun> {
+class TextRun final : public CanMakeCheckedPtr<TextRun> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TextRun);
     friend void add(Hasher&, const TextRun&);
 public:
     explicit TextRun(const String& text, float xpos = 0, float expansion = 0, ExpansionBehavior expansionBehavior = ExpansionBehavior::defaultBehavior(), TextDirection direction = TextDirection::LTR, bool directionalOverride = false, bool characterScanForCodePath = true)

--- a/Source/WebCore/platform/graphics/TiledBacking.h
+++ b/Source/WebCore/platform/graphics/TiledBacking.h
@@ -78,6 +78,7 @@ public:
 
 class TiledBacking : public CanMakeCheckedPtr<TiledBacking> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TiledBacking);
 public:
     virtual ~TiledBacking() = default;
 

--- a/Source/WebCore/platform/graphics/ca/LayerPool.h
+++ b/Source/WebCore/platform/graphics/ca/LayerPool.h
@@ -39,8 +39,9 @@
 
 namespace WebCore {
     
-class LayerPool : public CanMakeCheckedPtr<LayerPool> {
+class LayerPool final : public CanMakeCheckedPtr<LayerPool> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LayerPool);
     WTF_MAKE_NONCOPYABLE(LayerPool);
 public:
     WEBCORE_EXPORT LayerPool();

--- a/Source/WebCore/platform/graphics/ca/TileController.h
+++ b/Source/WebCore/platform/graphics/ca/TileController.h
@@ -52,6 +52,8 @@ const int kDefaultTileSize = 512;
 
 class TileController final : public TiledBacking {
     WTF_MAKE_NONCOPYABLE(TileController); WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(TileController);
+
     friend class TileCoverageMap;
     friend class TileGrid;
 public:

--- a/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
@@ -43,6 +43,8 @@ class NullPlaybackSessionInterface final
     : public PlaybackSessionModelClient
     , public RefCounted<NullPlaybackSessionInterface>
     , public CanMakeCheckedPtr<NullPlaybackSessionInterface> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NullPlaybackSessionInterface);
 public:
     static Ref<NullPlaybackSessionInterface> create(PlaybackSessionModel& model)
     {
@@ -76,6 +78,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
@@ -39,6 +39,8 @@ class NullVideoPresentationInterface final
     , public VideoFullscreenCaptions
     , public RefCounted<NullVideoPresentationInterface>
     , public CanMakeCheckedPtr<NullVideoPresentationInterface> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NullVideoPresentationInterface);
 public:
     static Ref<NullVideoPresentationInterface> create(NullPlaybackSessionInterface& playbackSessionInterface)
     {
@@ -90,6 +92,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -32,6 +32,8 @@
 namespace WebCore {
 
 class WEBCORE_EXPORT PlaybackSessionInterfaceAVKit final : public PlaybackSessionInterfaceIOS {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceAVKit);
 public:
     static Ref<PlaybackSessionInterfaceAVKit> create(PlaybackSessionModel&);
     ~PlaybackSessionInterfaceAVKit();

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -56,6 +56,7 @@ class WEBCORE_EXPORT PlaybackSessionInterfaceIOS
     , public RefCounted<PlaybackSessionInterfaceIOS>
     , public CanMakeCheckedPtr<PlaybackSessionInterfaceIOS> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceIOS);
 public:
     void initialize();
     virtual void invalidate();
@@ -99,9 +100,9 @@ protected:
     PlaybackSessionInterfaceIOS(PlaybackSessionModel&);
     PlaybackSessionModel* m_playbackSessionModel { nullptr };
 
-private:
     // CheckedPtr interface
     uint32_t ptrCount() const final;
+    uint32_t ptrCountWithoutThreadCheck() const final;
     void incrementPtrCount() const final;
     void decrementPtrCount() const final;
 #if CHECKED_POINTER_DEBUG
@@ -111,6 +112,7 @@ private:
     void unregisterCheckedPtr(const void* pointer) const final;
 #endif // CHECKED_POINTER_DEBUG
 
+private:
     std::optional<MediaPlayerIdentifier> m_playerIdentifier;
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String m_spatialTrackingLabel;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.mm
@@ -134,6 +134,11 @@ uint32_t PlaybackSessionInterfaceIOS::ptrCount() const
     return CanMakeCheckedPtr::ptrCount();
 }
 
+uint32_t PlaybackSessionInterfaceIOS::ptrCountWithoutThreadCheck() const
+{
+    return CanMakeCheckedPtr::ptrCountWithoutThreadCheck();
+}
+
 void PlaybackSessionInterfaceIOS::incrementPtrCount() const
 {
     CanMakeCheckedPtr::incrementPtrCount();

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h
@@ -41,6 +41,8 @@ namespace WebCore {
 class PlaybackSessionInterfaceIOS;
 
 class VideoPresentationInterfaceAVKit final : public VideoPresentationInterfaceIOS {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VideoPresentationInterfaceAVKit);
 public:
     WEBCORE_EXPORT static Ref<VideoPresentationInterfaceAVKit> create(PlaybackSessionInterfaceIOS&);
     WEBCORE_EXPORT ~VideoPresentationInterfaceAVKit();

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -64,8 +64,23 @@ class VideoPresentationInterfaceIOS
     , public VideoFullscreenCaptions
     , public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoPresentationInterfaceIOS, WTF::DestructionThread::MainRunLoop>
     , public CanMakeCheckedPtr<VideoPresentationInterfaceIOS> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VideoPresentationInterfaceIOS);
 public:
     WEBCORE_EXPORT ~VideoPresentationInterfaceIOS();
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+#if CHECKED_POINTER_DEBUG
+    void registerCheckedPtr(const void* pointer) const final { CanMakeCheckedPtr::registerCheckedPtr(pointer); };
+    void copyCheckedPtr(const void* source, const void* destination) const final { CanMakeCheckedPtr::copyCheckedPtr(source, destination); }
+    void moveCheckedPtr(const void* source, const void* destination) const final { CanMakeCheckedPtr::moveCheckedPtr(source, destination); }
+    void unregisterCheckedPtr(const void* pointer) const final { CanMakeCheckedPtr::unregisterCheckedPtr(pointer); }
+#endif // CHECKED_POINTER_DEBUG
+
     WEBCORE_EXPORT void setVideoPresentationModel(VideoPresentationModel*);
     PlaybackSessionInterfaceIOS& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
@@ -230,17 +245,6 @@ protected:
     bool m_waitingForPreparedToExit { false };
 #endif
 private:
-    // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
-#if CHECKED_POINTER_DEBUG
-    void registerCheckedPtr(const void* pointer) const final { CanMakeCheckedPtr::registerCheckedPtr(pointer); };
-    void copyCheckedPtr(const void* source, const void* destination) const final { CanMakeCheckedPtr::copyCheckedPtr(source, destination); }
-    void moveCheckedPtr(const void* source, const void* destination) const final { CanMakeCheckedPtr::moveCheckedPtr(source, destination); }
-    void unregisterCheckedPtr(const void* pointer) const final { CanMakeCheckedPtr::unregisterCheckedPtr(pointer); }
-#endif // CHECKED_POINTER_DEBUG
-
     void returnToStandby();
     void watchdogTimerFired();
 

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -104,6 +104,7 @@ class VideoFullscreenControllerContext final
     , private PlaybackSessionModelClient
     , public CanMakeCheckedPtr<VideoFullscreenControllerContext> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VideoFullscreenControllerContext);
 public:
     static Ref<VideoFullscreenControllerContext> create()
     {
@@ -123,6 +124,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -45,6 +45,8 @@ class WEBCORE_EXPORT PlaybackSessionInterfaceMac final
     : public PlaybackSessionModelClient
     , public RefCounted<PlaybackSessionInterfaceMac>
     , public CanMakeCheckedPtr<PlaybackSessionInterfaceMac> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceMac);
 public:
     static Ref<PlaybackSessionInterfaceMac> create(PlaybackSessionModel&);
     virtual ~PlaybackSessionInterfaceMac();
@@ -90,6 +92,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final;
+    uint32_t ptrCountWithoutThreadCheck() const final;
     void incrementPtrCount() const final;
     void decrementPtrCount() const final;
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -299,6 +299,11 @@ uint32_t PlaybackSessionInterfaceMac::ptrCount() const
     return CanMakeCheckedPtr::ptrCount();
 }
 
+uint32_t PlaybackSessionInterfaceMac::ptrCountWithoutThreadCheck() const
+{
+    return CanMakeCheckedPtr::ptrCountWithoutThreadCheck();
+}
+
 void PlaybackSessionInterfaceMac::incrementPtrCount() const
 {
     CanMakeCheckedPtr::incrementPtrCount();

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -49,13 +49,14 @@ class IntRect;
 class FloatSize;
 class PlaybackSessionInterfaceMac;
 
-class VideoPresentationInterfaceMac
+class VideoPresentationInterfaceMac final
     : public VideoPresentationModelClient
     , private PlaybackSessionModelClient
     , public VideoFullscreenCaptions
     , public RefCounted<VideoPresentationInterfaceMac>
     , public CanMakeCheckedPtr<VideoPresentationInterfaceMac> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VideoPresentationInterfaceMac);
 public:
     static Ref<VideoPresentationInterfaceMac> create(PlaybackSessionInterfaceMac& playbackSessionInterface)
     {
@@ -116,6 +117,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivate.h
@@ -53,8 +53,15 @@ class MediaRecorderPrivate
     , public RealtimeMediaSource::VideoFrameObserver
     , public CanMakeCheckedPtr<MediaRecorderPrivate> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaRecorderPrivate);
 public:
     ~MediaRecorderPrivate();
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     struct AudioVideoSelectedTracks {
         MediaStreamTrackPrivate* audioTrack { nullptr };
@@ -92,10 +99,6 @@ protected:
     bool shouldMuteVideo() const { return m_shouldMuteVideo; }
 
 private:
-    // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG
     void registerCheckedPtr(const void* pointer) const final { CanMakeCheckedPtr::registerCheckedPtr(pointer); };
     void copyCheckedPtr(const void* source, const void* destination) const final { CanMakeCheckedPtr::copyCheckedPtr(source, destination); }

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateAVFImpl.h
@@ -42,6 +42,7 @@ class WebAudioBufferList;
 class MediaRecorderPrivateAVFImpl final
     : public MediaRecorderPrivate {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaRecorderPrivateAVFImpl);
 public:
     static std::unique_ptr<MediaRecorderPrivateAVFImpl> create(MediaStreamPrivate&, const MediaRecorderPrivateOptions&);
     ~MediaRecorderPrivateAVFImpl();

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateGStreamer.h
@@ -93,6 +93,7 @@ private:
 
 class MediaRecorderPrivateGStreamer final : public MediaRecorderPrivate {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaRecorderPrivateGStreamer);
 public:
     static std::unique_ptr<MediaRecorderPrivateGStreamer> create(MediaStreamPrivate&, const MediaRecorderPrivateOptions&);
     explicit MediaRecorderPrivateGStreamer(Ref<MediaRecorderPrivateBackend>&&);

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateMock.h
@@ -40,6 +40,7 @@ class MediaStreamTrackPrivate;
 class WEBCORE_EXPORT MediaRecorderPrivateMock final
     : public MediaRecorderPrivate {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaRecorderPrivateMock);
 public:
     explicit MediaRecorderPrivateMock(MediaStreamPrivate&);
     ~MediaRecorderPrivateMock();

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
@@ -41,6 +41,8 @@ class AudioTrackPrivateMediaStream final
     , private RealtimeMediaSource::AudioSampleObserver
     , public CanMakeCheckedPtr<AudioTrackPrivateMediaStream> {
     WTF_MAKE_NONCOPYABLE(AudioTrackPrivateMediaStream)
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AudioTrackPrivateMediaStream);
 public:
     static Ref<AudioTrackPrivateMediaStream> create(MediaStreamTrackPrivate& streamTrack)
     {
@@ -75,6 +77,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -113,6 +113,7 @@ public:
 
         // CheckedPtr interface
         virtual uint32_t ptrCount() const = 0;
+        virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
         virtual void incrementPtrCount() const = 0;
         virtual void decrementPtrCount() const = 0;
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -139,6 +139,7 @@ class InternalSource final : public MediaStreamTrackPrivate::Observer,
     public RealtimeMediaSource::VideoFrameObserver,
     public CanMakeCheckedPtr<InternalSource> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(InternalSource);
 public:
     InternalSource(GstElement* parent, MediaStreamTrackPrivate& track, const String& padName, bool consumerIsVideoPlayer)
         : m_parent(parent)
@@ -526,6 +527,7 @@ public:
 private:
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeOutgoingAudioSourceLibWebRTC.h
@@ -43,6 +43,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 

--- a/Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.h
@@ -40,6 +40,8 @@ class MediaStreamTrackAudioSourceProviderCocoa final
     , MediaStreamTrackPrivate::Observer
     , RealtimeMediaSource::AudioSampleObserver
     , public CanMakeCheckedPtr<MediaStreamTrackAudioSourceProviderCocoa> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaStreamTrackAudioSourceProviderCocoa);
 public:
     static Ref<MediaStreamTrackAudioSourceProviderCocoa> create(MediaStreamTrackPrivate&);
     ~MediaStreamTrackAudioSourceProviderCocoa();
@@ -49,6 +51,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.h
@@ -39,6 +39,8 @@ class AudioTrackSinkInterface;
 namespace WebCore {
 
 class RealtimeOutgoingAudioSourceCocoa final : public RealtimeOutgoingAudioSource, public CanMakeCheckedPtr<RealtimeOutgoingAudioSourceCocoa> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RealtimeOutgoingAudioSourceCocoa);
 public:
     static Ref<RealtimeOutgoingAudioSourceCocoa> create(Ref<MediaStreamTrackPrivate>&& audioSource) { return adoptRef(*new RealtimeOutgoingAudioSourceCocoa(WTFMove(audioSource))); }
 
@@ -48,6 +50,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebCore/platform/network/curl/CurlMultipartHandleClient.h
+++ b/Source/WebCore/platform/network/curl/CurlMultipartHandleClient.h
@@ -33,6 +33,7 @@ class CurlMultipartHandleClient {
 public:
     // CheckedPtr interface
     virtual uint32_t ptrCount() const = 0;
+    virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
     virtual void incrementPtrCount() const = 0;
     virtual void decrementPtrCount() const = 0;
 

--- a/Source/WebCore/platform/network/curl/CurlRequest.h
+++ b/Source/WebCore/platform/network/curl/CurlRequest.h
@@ -42,9 +42,10 @@ class NetworkLoadMetrics;
 class ResourceError;
 class FragmentedSharedBuffer;
 
-class CurlRequest : public ThreadSafeRefCounted<CurlRequest>, public CurlRequestSchedulerClient, public CurlMultipartHandleClient, public CanMakeThreadSafeCheckedPtr<CurlRequest> {
+class CurlRequest final : public ThreadSafeRefCounted<CurlRequest>, public CurlRequestSchedulerClient, public CurlMultipartHandleClient, public CanMakeThreadSafeCheckedPtr<CurlRequest> {
     WTF_MAKE_NONCOPYABLE(CurlRequest);
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CurlRequest);
 public:
     enum class CaptureNetworkLoadMetrics : uint8_t {
         Basic,
@@ -84,6 +85,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeThreadSafeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeThreadSafeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeThreadSafeCheckedPtr::decrementPtrCount(); }
 

--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -49,9 +49,11 @@ class DatabaseAuthorizer;
 class SQLiteStatement;
 class SQLiteTransaction;
 
-class SQLiteDatabase : public CanMakeThreadSafeCheckedPtr<SQLiteDatabase> {
+class SQLiteDatabase final : public CanMakeThreadSafeCheckedPtr<SQLiteDatabase> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(SQLiteDatabase);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SQLiteDatabase);
+
     friend class SQLiteTransaction;
 public:
     WEBCORE_EXPORT SQLiteDatabase();

--- a/Source/WebCore/rendering/AccessibilityRegionContext.h
+++ b/Source/WebCore/rendering/AccessibilityRegionContext.h
@@ -36,7 +36,9 @@ class RenderBoxModelObject;
 class RenderText;
 class RenderView;
 
-class AccessibilityRegionContext : public RegionContext {
+class AccessibilityRegionContext final : public RegionContext {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AccessibilityRegionContext);
 public:
     AccessibilityRegionContext() = default;
     virtual ~AccessibilityRegionContext();

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -46,7 +46,9 @@ class Path;
 class RenderObject;
 class RenderStyle;
 
-class EventRegionContext : public RegionContext {
+class EventRegionContext final : public RegionContext {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EventRegionContext);
 public:
     WEBCORE_EXPORT explicit EventRegionContext(EventRegion&);
     WEBCORE_EXPORT virtual ~EventRegionContext();

--- a/Source/WebCore/rendering/LegacyRootInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.cpp
@@ -44,6 +44,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(LegacyRootInlineBox);
 
 struct SameSizeAsLegacyRootInlineBox : LegacyInlineFlowBox, CanMakeWeakPtr<LegacyRootInlineBox>, CanMakeCheckedPtr<SameSizeAsLegacyRootInlineBox> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(SameSizeAsLegacyRootInlineBox);
 
     int layoutUnits[4];
 };

--- a/Source/WebCore/rendering/LegacyRootInlineBox.h
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.h
@@ -37,6 +37,7 @@ struct GapRects;
 
 class LegacyRootInlineBox : public LegacyInlineFlowBox, public CanMakeWeakPtr<LegacyRootInlineBox>, public CanMakeCheckedPtr<LegacyRootInlineBox> {
     WTF_MAKE_ISO_ALLOCATED(LegacyRootInlineBox);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRootInlineBox);
 public:
     explicit LegacyRootInlineBox(RenderBlockFlow&);
     virtual ~LegacyRootInlineBox();

--- a/Source/WebCore/rendering/MarkedText.h
+++ b/Source/WebCore/rendering/MarkedText.h
@@ -39,6 +39,7 @@ struct TextBoxSelectableRange;
 
 struct MarkedText : public CanMakeCheckedPtr<MarkedText> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(MarkedText);
 
     // Sorted by paint order
     enum class Type : uint8_t {

--- a/Source/WebCore/rendering/RegionContext.h
+++ b/Source/WebCore/rendering/RegionContext.h
@@ -36,6 +36,7 @@ class Path;
 
 class RegionContext : public CanMakeCheckedPtr<RegionContext> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RegionContext);
 public:
     virtual ~RegionContext() = default;
 

--- a/Source/WebCore/rendering/RenderAttachment.cpp
+++ b/Source/WebCore/rendering/RenderAttachment.cpp
@@ -55,6 +55,8 @@ RenderAttachment::RenderAttachment(HTMLAttachmentElement& element, RenderStyle&&
 #endif
 }
 
+RenderAttachment::~RenderAttachment() = default;
+
 HTMLAttachmentElement& RenderAttachment::attachmentElement() const
 {
     return downcast<HTMLAttachmentElement>(nodeForNonAnonymous());

--- a/Source/WebCore/rendering/RenderAttachment.h
+++ b/Source/WebCore/rendering/RenderAttachment.h
@@ -34,8 +34,10 @@ namespace WebCore {
 
 class RenderAttachment final : public RenderReplaced {
     WTF_MAKE_ISO_ALLOCATED(RenderAttachment);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderAttachment);
 public:
     RenderAttachment(HTMLAttachmentElement&, RenderStyle&&);
+    virtual ~RenderAttachment();
 
     HTMLAttachmentElement& attachmentElement() const;
 

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -54,6 +54,7 @@ typedef unsigned TextRunFlags;
 
 class RenderBlock : public RenderBox {
     WTF_MAKE_ISO_ALLOCATED(RenderBlock);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderBlock);
 public:
     friend class LineLayoutState;
     virtual ~RenderBlock();

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -52,6 +52,7 @@ enum LineCount {
 
 class RenderBlockFlow : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderBlockFlow);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderBlockFlow);
 public:
     RenderBlockFlow(Type, Element&, RenderStyle&&, OptionSet<BlockFlowFlag> = { });
     RenderBlockFlow(Type, Document&, RenderStyle&&, OptionSet<BlockFlowFlag> = { });

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -49,6 +49,7 @@ enum class StretchingMode { Any, Explicit };
 
 class RenderBox : public RenderBoxModelObject {
     WTF_MAKE_ISO_ALLOCATED(RenderBox);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderBox);
 public:
     virtual ~RenderBox();
 

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -77,6 +77,7 @@ using BorderEdges = RectEdges<BorderEdge>;
 
 class RenderBoxModelObject : public RenderLayerModelObject {
     WTF_MAKE_ISO_ALLOCATED(RenderBoxModelObject);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderBoxModelObject);
 public:
     virtual ~RenderBoxModelObject();
     

--- a/Source/WebCore/rendering/RenderButton.h
+++ b/Source/WebCore/rendering/RenderButton.h
@@ -35,6 +35,7 @@ class RenderTextFragment;
 // to date as the button changes.
 class RenderButton final : public RenderFlexibleBox {
     WTF_MAKE_ISO_ALLOCATED(RenderButton);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderButton);
 public:
     RenderButton(HTMLFormControlElement&, RenderStyle&&);
     virtual ~RenderButton();

--- a/Source/WebCore/rendering/RenderCombineText.cpp
+++ b/Source/WebCore/rendering/RenderCombineText.cpp
@@ -41,6 +41,8 @@ RenderCombineText::RenderCombineText(Text& textNode, const String& string)
     ASSERT(isRenderCombineText());
 }
 
+RenderCombineText::~RenderCombineText() = default;
+
 void RenderCombineText::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     // FIXME: This is pretty hackish.

--- a/Source/WebCore/rendering/RenderCombineText.h
+++ b/Source/WebCore/rendering/RenderCombineText.h
@@ -28,8 +28,10 @@ namespace WebCore {
 
 class RenderCombineText final : public RenderText {
     WTF_MAKE_ISO_ALLOCATED(RenderCombineText);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderCombineText);
 public:
     RenderCombineText(Text&, const String&);
+    virtual ~RenderCombineText();
 
     Text& textNode() const { return downcast<Text>(nodeForNonAnonymous()); }
 

--- a/Source/WebCore/rendering/RenderCounter.h
+++ b/Source/WebCore/rendering/RenderCounter.h
@@ -32,6 +32,7 @@ class CounterNode;
 
 class RenderCounter final : public RenderText {
     WTF_MAKE_ISO_ALLOCATED(RenderCounter);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderCounter);
 public:
     RenderCounter(Document&, const CounterContent&);
     virtual ~RenderCounter();

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
@@ -30,6 +30,7 @@ class FlexBoxIterator;
 
 class RenderDeprecatedFlexibleBox final : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderDeprecatedFlexibleBox);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderDeprecatedFlexibleBox);
 public:
     RenderDeprecatedFlexibleBox(Element&, RenderStyle&&);
     virtual ~RenderDeprecatedFlexibleBox();

--- a/Source/WebCore/rendering/RenderDetailsMarker.cpp
+++ b/Source/WebCore/rendering/RenderDetailsMarker.cpp
@@ -43,6 +43,8 @@ RenderDetailsMarker::RenderDetailsMarker(DetailsMarkerControl& element, RenderSt
     ASSERT(isRenderDetailsMarker());
 }
 
+RenderDetailsMarker::~RenderDetailsMarker() = default;
+
 static Path createPath(const FloatPoint* path)
 {
     Path result;

--- a/Source/WebCore/rendering/RenderDetailsMarker.h
+++ b/Source/WebCore/rendering/RenderDetailsMarker.h
@@ -27,8 +27,11 @@ namespace WebCore {
 
 class RenderDetailsMarker final : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderDetailsMarker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderDetailsMarker);
 public:
     RenderDetailsMarker(DetailsMarkerControl&, RenderStyle&&);
+    virtual ~RenderDetailsMarker();
+
     DetailsMarkerControl& element() const { return static_cast<DetailsMarkerControl&>(nodeForNonAnonymous()); }
 
     enum Orientation { Up, Down, Left, Right };

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -48,6 +48,7 @@ class ElementBox;
 
 class RenderElement : public RenderObject {
     WTF_MAKE_ISO_ALLOCATED(RenderElement);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderElement);
 public:
     virtual ~RenderElement();
 

--- a/Source/WebCore/rendering/RenderEmbeddedObject.h
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.h
@@ -33,6 +33,7 @@ class TextRun;
 // For example, <embed src="foo.html"> does not invoke a plug-in.
 class RenderEmbeddedObject final : public RenderWidget {
     WTF_MAKE_ISO_ALLOCATED(RenderEmbeddedObject);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderEmbeddedObject);
 public:
     RenderEmbeddedObject(HTMLFrameOwnerElement&, RenderStyle&&);
     virtual ~RenderEmbeddedObject();

--- a/Source/WebCore/rendering/RenderFileUploadControl.h
+++ b/Source/WebCore/rendering/RenderFileUploadControl.h
@@ -32,6 +32,7 @@ class HTMLInputElement;
 
 class RenderFileUploadControl final : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderFileUploadControl);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderFileUploadControl);
 public:
     RenderFileUploadControl(HTMLInputElement&, RenderStyle&&);
     virtual ~RenderFileUploadControl();

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -44,6 +44,7 @@ class FlexLayout;
     
 class RenderFlexibleBox : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderFlexibleBox);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderFlexibleBox);
 public:
     RenderFlexibleBox(Type, Element&, RenderStyle&&);
     RenderFlexibleBox(Type, Document&, RenderStyle&&);

--- a/Source/WebCore/rendering/RenderFragmentContainer.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainer.cpp
@@ -66,6 +66,8 @@ RenderFragmentContainer::RenderFragmentContainer(Type type, Document& document, 
 {
 }
 
+RenderFragmentContainer::~RenderFragmentContainer() = default;
+
 LayoutPoint RenderFragmentContainer::mapFragmentPointIntoFragmentedFlowCoordinates(const LayoutPoint& point)
 {
     // Assuming the point is relative to the fragment block, 3 cases will be considered:

--- a/Source/WebCore/rendering/RenderFragmentContainer.h
+++ b/Source/WebCore/rendering/RenderFragmentContainer.h
@@ -44,6 +44,7 @@ class RenderFragmentedFlow;
 
 class RenderFragmentContainer : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderFragmentContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderFragmentContainer);
 public:
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;
 
@@ -122,6 +123,7 @@ public:
 protected:
     RenderFragmentContainer(Type, Element&, RenderStyle&&, RenderFragmentedFlow*);
     RenderFragmentContainer(Type, Document&, RenderStyle&&, RenderFragmentedFlow*);
+    virtual ~RenderFragmentContainer();
 
     void ensureOverflowForBox(const RenderBox&, RefPtr<RenderOverflow>&, bool) const;
 

--- a/Source/WebCore/rendering/RenderFragmentContainerSet.cpp
+++ b/Source/WebCore/rendering/RenderFragmentContainerSet.cpp
@@ -41,6 +41,8 @@ RenderFragmentContainerSet::RenderFragmentContainerSet(Type type, Document& docu
     ASSERT(is<RenderFragmentContainerSet>(*this));
 }
 
+RenderFragmentContainerSet::~RenderFragmentContainerSet() = default;
+
 void RenderFragmentContainerSet::installFragmentedFlow()
 {
     // We don't have to do anything, since we were able to connect the flow thread

--- a/Source/WebCore/rendering/RenderFragmentContainerSet.h
+++ b/Source/WebCore/rendering/RenderFragmentContainerSet.h
@@ -44,11 +44,13 @@ class RenderFragmentedFlow;
 
 class RenderFragmentContainerSet : public RenderFragmentContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderFragmentContainerSet);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderFragmentContainerSet);
 public:
     void expandToEncompassFragmentedFlowContentsIfNeeded();
 
 protected:
     RenderFragmentContainerSet(Type, Document&, RenderStyle&&, RenderFragmentedFlow&);
+    virtual ~RenderFragmentContainerSet();
 
 private:
     void installFragmentedFlow() final;

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -65,6 +65,8 @@ RenderFragmentedFlow::RenderFragmentedFlow(Type type, Document& document, Render
     ASSERT(isRenderFragmentedFlow());
 }
 
+RenderFragmentedFlow::~RenderFragmentedFlow() = default;
+
 void RenderFragmentedFlow::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     RenderBlockFlow::styleDidChange(diff, oldStyle);

--- a/Source/WebCore/rendering/RenderFragmentedFlow.h
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.h
@@ -53,10 +53,11 @@ typedef HashMap<const LegacyRootInlineBox*, SingleThreadWeakPtr<RenderFragmentCo
 // and nodeAtPoint methods to this object. Each RenderFragmentContainer will actually be a viewPort
 // of the RenderFragmentedFlow.
 
-class RenderFragmentedFlow: public RenderBlockFlow {
+class RenderFragmentedFlow : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderFragmentedFlow);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderFragmentedFlow);
 public:
-    virtual ~RenderFragmentedFlow() = default;
+    virtual ~RenderFragmentedFlow();
 
     virtual void removeFlowChildInfo(RenderElement&);
 #ifndef NDEBUG

--- a/Source/WebCore/rendering/RenderFrame.cpp
+++ b/Source/WebCore/rendering/RenderFrame.cpp
@@ -40,6 +40,8 @@ RenderFrame::RenderFrame(HTMLFrameElement& frame, RenderStyle&& style)
     ASSERT(isRenderFrame());
 }
 
+RenderFrame::~RenderFrame() = default;
+
 HTMLFrameElement& RenderFrame::frameElement() const
 {
     return downcast<HTMLFrameElement>(RenderFrameBase::frameOwnerElement());

--- a/Source/WebCore/rendering/RenderFrame.h
+++ b/Source/WebCore/rendering/RenderFrame.h
@@ -31,8 +31,10 @@ struct FrameEdgeInfo;
 
 class RenderFrame final : public RenderFrameBase {
     WTF_MAKE_ISO_ALLOCATED(RenderFrame);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderFrame);
 public:
     RenderFrame(HTMLFrameElement&, RenderStyle&&);
+    virtual ~RenderFrame();
 
     HTMLFrameElement& frameElement() const;
     FrameEdgeInfo edgeInfo() const;

--- a/Source/WebCore/rendering/RenderFrameBase.cpp
+++ b/Source/WebCore/rendering/RenderFrameBase.cpp
@@ -44,6 +44,8 @@ RenderFrameBase::RenderFrameBase(Type type, HTMLFrameElementBase& element, Rende
 {
 }
 
+RenderFrameBase::~RenderFrameBase() = default;
+
 inline bool shouldExpandFrame(LayoutUnit width, LayoutUnit height, bool hasFixedWidth, bool hasFixedHeight)
 {
     // If the size computed to zero never expand.

--- a/Source/WebCore/rendering/RenderFrameBase.h
+++ b/Source/WebCore/rendering/RenderFrameBase.h
@@ -36,8 +36,10 @@ class RenderView;
 // Base class for RenderFrame and RenderIFrame
 class RenderFrameBase : public RenderWidget {
     WTF_MAKE_ISO_ALLOCATED(RenderFrameBase);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderFrameBase);
 protected:
     RenderFrameBase(Type, HTMLFrameElementBase&, RenderStyle&&);
+    virtual ~RenderFrameBase();
 
 public:
     LocalFrameView* childView() const { return downcast<LocalFrameView>(RenderWidget::widget()); }

--- a/Source/WebCore/rendering/RenderFrameSet.h
+++ b/Source/WebCore/rendering/RenderFrameSet.h
@@ -52,6 +52,7 @@ private:
 
 class RenderFrameSet final : public RenderBox {
     WTF_MAKE_ISO_ALLOCATED(RenderFrameSet);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderFrameSet);
 public:
     RenderFrameSet(HTMLFrameSetElement&, RenderStyle&&);
     virtual ~RenderFrameSet();

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -50,6 +50,7 @@ enum class GridAxisPosition : uint8_t { GridAxisStart, GridAxisEnd, GridAxisCent
 
 class RenderGrid final : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderGrid);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderGrid);
 public:
     RenderGrid(Element&, RenderStyle&&);
     virtual ~RenderGrid();

--- a/Source/WebCore/rendering/RenderHTMLCanvas.cpp
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.cpp
@@ -55,6 +55,8 @@ RenderHTMLCanvas::RenderHTMLCanvas(HTMLCanvasElement& element, RenderStyle&& sty
     ASSERT(isRenderHTMLCanvas());
 }
 
+RenderHTMLCanvas::~RenderHTMLCanvas() = default;
+
 HTMLCanvasElement& RenderHTMLCanvas::canvasElement() const
 {
     return downcast<HTMLCanvasElement>(nodeForNonAnonymous());

--- a/Source/WebCore/rendering/RenderHTMLCanvas.h
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.h
@@ -33,8 +33,10 @@ class HTMLCanvasElement;
 
 class RenderHTMLCanvas final : public RenderReplaced {
     WTF_MAKE_ISO_ALLOCATED(RenderHTMLCanvas);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderHTMLCanvas);
 public:
     RenderHTMLCanvas(HTMLCanvasElement&, RenderStyle&&);
+    virtual ~RenderHTMLCanvas();
 
     HTMLCanvasElement& canvasElement() const;
 

--- a/Source/WebCore/rendering/RenderIFrame.cpp
+++ b/Source/WebCore/rendering/RenderIFrame.cpp
@@ -50,6 +50,8 @@ RenderIFrame::RenderIFrame(HTMLIFrameElement& element, RenderStyle&& style)
     ASSERT(isRenderIFrame());
 }
 
+RenderIFrame::~RenderIFrame() = default;
+
 HTMLIFrameElement& RenderIFrame::iframeElement() const
 {
     return downcast<HTMLIFrameElement>(RenderFrameBase::frameOwnerElement());

--- a/Source/WebCore/rendering/RenderIFrame.h
+++ b/Source/WebCore/rendering/RenderIFrame.h
@@ -33,8 +33,10 @@ class RenderView;
 
 class RenderIFrame final : public RenderFrameBase {
     WTF_MAKE_ISO_ALLOCATED(RenderIFrame);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderIFrame);
 public:
     RenderIFrame(HTMLIFrameElement&, RenderStyle&&);
+    virtual ~RenderIFrame();
 
     HTMLIFrameElement& iframeElement() const;
 

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -39,6 +39,7 @@ enum ImageSizeChangeType {
 
 class RenderImage : public RenderReplaced {
     WTF_MAKE_ISO_ALLOCATED(RenderImage);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderImage);
 public:
     RenderImage(Type, Element&, RenderStyle&&, StyleImage* = nullptr, const float imageDevicePixelRatio = 1.0f);
     RenderImage(Type, Document&, RenderStyle&&, StyleImage* = nullptr);

--- a/Source/WebCore/rendering/RenderImageResource.cpp
+++ b/Source/WebCore/rendering/RenderImageResource.cpp
@@ -42,6 +42,8 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderImageResource);
 
 RenderImageResource::RenderImageResource() = default;
 
+RenderImageResource::~RenderImageResource() = default;
+
 void RenderImageResource::initialize(RenderElement& renderer, CachedImage* styleCachedImage)
 {
     ASSERT(!m_renderer);

--- a/Source/WebCore/rendering/RenderImageResource.h
+++ b/Source/WebCore/rendering/RenderImageResource.h
@@ -39,10 +39,12 @@ class CachedImage;
 class RenderElement;
 
 class RenderImageResource : public CanMakeCheckedPtr<RenderImageResource> {
-    WTF_MAKE_NONCOPYABLE(RenderImageResource); WTF_MAKE_ISO_ALLOCATED(RenderImageResource);
+    WTF_MAKE_NONCOPYABLE(RenderImageResource);
+    WTF_MAKE_ISO_ALLOCATED(RenderImageResource);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderImageResource);
 public:
     RenderImageResource();
-    virtual ~RenderImageResource() = default;
+    virtual ~RenderImageResource();
 
     virtual void initialize(RenderElement& renderer) { initialize(renderer, nullptr); }
     virtual void shutdown();

--- a/Source/WebCore/rendering/RenderImageResourceStyleImage.h
+++ b/Source/WebCore/rendering/RenderImageResourceStyleImage.h
@@ -35,6 +35,7 @@ class RenderElement;
 
 class RenderImageResourceStyleImage final : public RenderImageResource {
     WTF_MAKE_ISO_ALLOCATED(RenderImageResourceStyleImage);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderImageResourceStyleImage);
 public:
     explicit RenderImageResourceStyleImage(StyleImage&);
 

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -76,6 +76,8 @@ RenderInline::RenderInline(Type type, Document& document, RenderStyle&& style)
     ASSERT(isRenderInline());
 }
 
+RenderInline::~RenderInline() = default;
+
 void RenderInline::willBeDestroyed()
 {
 #if ASSERT_ENABLED

--- a/Source/WebCore/rendering/RenderInline.h
+++ b/Source/WebCore/rendering/RenderInline.h
@@ -32,9 +32,11 @@ class RenderFragmentContainer;
 
 class RenderInline : public RenderBoxModelObject {
     WTF_MAKE_ISO_ALLOCATED(RenderInline);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderInline);
 public:
     RenderInline(Type, Element&, RenderStyle&&);
     RenderInline(Type, Document&, RenderStyle&&);
+    virtual ~RenderInline();
 
     LayoutUnit marginLeft() const final;
     LayoutUnit marginRight() const final;

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -151,8 +151,9 @@ struct ScrollRectToVisibleOptions {
 
 using ScrollingScope = uint64_t;
 
-class RenderLayer : public CanMakeSingleThreadWeakPtr<RenderLayer>, public CanMakeCheckedPtr<RenderLayer> {
+class RenderLayer final : public CanMakeSingleThreadWeakPtr<RenderLayer>, public CanMakeCheckedPtr<RenderLayer> {
     WTF_MAKE_ISO_ALLOCATED(RenderLayer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderLayer);
 public:
     friend class RenderReplica;
     friend class RenderLayerFilters;

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -38,6 +38,7 @@ class SVGGraphicsElement;
 
 class RenderLayerModelObject : public RenderElement {
     WTF_MAKE_ISO_ALLOCATED(RenderLayerModelObject);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderLayerModelObject);
 public:
     virtual ~RenderLayerModelObject();
 

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -51,11 +51,18 @@ namespace WebCore {
 
 class RenderMarquee;
 
-class RenderLayerScrollableArea final : public ScrollableArea {
+class RenderLayerScrollableArea final : public ScrollableArea, public CanMakeCheckedPtr<RenderLayerScrollableArea> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderLayerScrollableArea);
 public:
     explicit RenderLayerScrollableArea(RenderLayer&);
     virtual ~RenderLayerScrollableArea();
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     RenderLayer& layer() { return m_layer; }
 

--- a/Source/WebCore/rendering/RenderLineBreak.h
+++ b/Source/WebCore/rendering/RenderLineBreak.h
@@ -30,6 +30,7 @@ class Position;
 
 class RenderLineBreak final : public RenderBoxModelObject {
     WTF_MAKE_ISO_ALLOCATED(RenderLineBreak);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderLineBreak);
 public:
     RenderLineBreak(HTMLElement&, RenderStyle&&);
     virtual ~RenderLineBreak();

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -42,19 +42,22 @@ class HTMLSelectElement;
 
 class RenderListBox final : public RenderBlockFlow, public ScrollableArea {
     WTF_MAKE_ISO_ALLOCATED(RenderListBox);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderListBox);
 public:
-    // Resolve ambiguity for CanMakeCheckedPtr.
-    void incrementPtrCount() const { static_cast<const RenderBlockFlow*>(this)->incrementPtrCount(); }
-    void decrementPtrCount() const { static_cast<const RenderBlockFlow*>(this)->decrementPtrCount(); }
+    RenderListBox(HTMLSelectElement&, RenderStyle&&);
+    virtual ~RenderListBox();
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG
     void registerCheckedPtr(const void* pointer) const { static_cast<const RenderBlockFlow*>(this)->registerCheckedPtr(pointer); }
     void copyCheckedPtr(const void* source, const void* destination) const { static_cast<const RenderBlockFlow*>(this)->copyCheckedPtr(source, destination); }
     void moveCheckedPtr(const void* source, const void* destination) const { static_cast<const RenderBlockFlow*>(this)->moveCheckedPtr(source, destination); }
     void unregisterCheckedPtr(const void* pointer) const { static_cast<const RenderBlockFlow*>(this)->unregisterCheckedPtr(pointer); }
 #endif // CHECKED_POINTER_DEBUG
-
-    RenderListBox(HTMLSelectElement&, RenderStyle&&);
-    virtual ~RenderListBox();
 
     HTMLSelectElement& selectElement() const;
 

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -31,6 +31,7 @@ class HTMLOListElement;
 
 class RenderListItem final : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderListItem);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderListItem);
 public:
     RenderListItem(Element&, RenderStyle&&);
     virtual ~RenderListItem();

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -34,6 +34,7 @@ class StyleRuleCounterStyle;
 // The RenderListMarker always has to be a child of a RenderListItem.
 class RenderListMarker final : public RenderBox {
     WTF_MAKE_ISO_ALLOCATED(RenderListMarker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderListMarker);
 public:
     RenderListMarker(RenderListItem&, RenderStyle&&);
     virtual ~RenderListMarker();

--- a/Source/WebCore/rendering/RenderMedia.h
+++ b/Source/WebCore/rendering/RenderMedia.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class RenderMedia : public RenderImage {
     WTF_MAKE_ISO_ALLOCATED(RenderMedia);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMedia);
 public:
     RenderMedia(Type, HTMLMediaElement&, RenderStyle&&);
     RenderMedia(Type, HTMLMediaElement&, RenderStyle&&, const IntSize& intrinsicSize);

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -41,6 +41,7 @@ class RenderText;
 
 class RenderMenuList final : public RenderFlexibleBox, private PopupMenuClient {
     WTF_MAKE_ISO_ALLOCATED(RenderMenuList);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMenuList);
 public:
     RenderMenuList(HTMLSelectElement&, RenderStyle&&);
     virtual ~RenderMenuList();

--- a/Source/WebCore/rendering/RenderMeter.h
+++ b/Source/WebCore/rendering/RenderMeter.h
@@ -28,6 +28,7 @@ class HTMLMeterElement;
 
 class RenderMeter final : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderMeter);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMeter);
 public:
     RenderMeter(HTMLElement&, RenderStyle&&);
     virtual ~RenderMeter();

--- a/Source/WebCore/rendering/RenderModel.h
+++ b/Source/WebCore/rendering/RenderModel.h
@@ -35,6 +35,7 @@ class HTMLModelElement;
 
 class RenderModel final : public RenderReplaced {
     WTF_MAKE_ISO_ALLOCATED(RenderModel);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderModel);
 public:
     RenderModel(HTMLModelElement&, RenderStyle&&);
     virtual ~RenderModel();

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.h
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.h
@@ -35,9 +35,10 @@ class RenderMultiColumnSpannerPlaceholder;
 
 class RenderMultiColumnFlow final : public RenderFragmentedFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderMultiColumnFlow);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMultiColumnFlow);
 public:
     RenderMultiColumnFlow(Document&, RenderStyle&&);
-    ~RenderMultiColumnFlow();
+    virtual ~RenderMultiColumnFlow();
 
     RenderBlockFlow* multiColumnBlockFlow() const { return downcast<RenderBlockFlow>(parent()); }
 

--- a/Source/WebCore/rendering/RenderMultiColumnSet.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.cpp
@@ -52,6 +52,8 @@ RenderMultiColumnSet::RenderMultiColumnSet(RenderFragmentedFlow& fragmentedFlow,
     ASSERT(isRenderMultiColumnSet());
 }
 
+RenderMultiColumnSet::~RenderMultiColumnSet() = default;
+
 RenderMultiColumnSet* RenderMultiColumnSet::nextSiblingMultiColumnSet() const
 {
     for (RenderObject* sibling = nextSibling(); sibling; sibling = sibling->nextSibling()) {

--- a/Source/WebCore/rendering/RenderMultiColumnSet.h
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.h
@@ -44,8 +44,10 @@ namespace WebCore {
 // come before and after the span.
 class RenderMultiColumnSet final : public RenderFragmentContainerSet {
     WTF_MAKE_ISO_ALLOCATED(RenderMultiColumnSet);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMultiColumnSet);
 public:
     RenderMultiColumnSet(RenderFragmentedFlow&, RenderStyle&&);
+    virtual ~RenderMultiColumnSet();
 
     RenderBlockFlow* multiColumnBlockFlow() const { return downcast<RenderBlockFlow>(parent()); }
     RenderMultiColumnFlow* multiColumnFlow() const { return static_cast<RenderMultiColumnFlow*>(fragmentedFlow()); }

--- a/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp
+++ b/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.cpp
@@ -56,6 +56,8 @@ RenderMultiColumnSpannerPlaceholder::RenderMultiColumnSpannerPlaceholder(RenderM
     ASSERT(isRenderMultiColumnSpannerPlaceholder());
 }
 
+RenderMultiColumnSpannerPlaceholder::~RenderMultiColumnSpannerPlaceholder() = default;
+
 ASCIILiteral RenderMultiColumnSpannerPlaceholder::renderName() const
 {
     return "RenderMultiColumnSpannerPlaceholder"_s;

--- a/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.h
+++ b/Source/WebCore/rendering/RenderMultiColumnSpannerPlaceholder.h
@@ -36,8 +36,10 @@ namespace WebCore {
 
 class RenderMultiColumnSpannerPlaceholder final : public RenderBox {
     WTF_MAKE_ISO_ALLOCATED(RenderMultiColumnSpannerPlaceholder);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMultiColumnSpannerPlaceholder);
 public:
     static RenderPtr<RenderMultiColumnSpannerPlaceholder> createAnonymous(RenderMultiColumnFlow&, RenderBox& spanner, const RenderStyle& parentStyle);
+    virtual ~RenderMultiColumnSpannerPlaceholder();
 
     RenderBox* spanner() const { return m_spanner.get(); }
     RenderMultiColumnFlow* fragmentedFlow() const { return m_fragmentedFlow.get(); }

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -110,8 +110,9 @@ RenderObject::SetLayoutNeededForbiddenScope::~SetLayoutNeededForbiddenScope()
 
 #endif
 
-struct SameSizeAsRenderObject : public CachedImageClient, public CanMakeCheckedPtr<SameSizeAsRenderObject> {
+struct SameSizeAsRenderObject final : public CachedImageClient, public CanMakeCheckedPtr<SameSizeAsRenderObject> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(SameSizeAsRenderObject);
 
     virtual ~SameSizeAsRenderObject() = default; // Allocate vtable pointer.
 #if ASSERT_ENABLED

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -103,6 +103,7 @@ enum class RequiresFullRepaint : bool { No, Yes };
 // Base class for all rendering tree objects.
 class RenderObject : public CachedImageClient, public CanMakeCheckedPtr<RenderObject> {
     WTF_MAKE_COMPACT_ISO_ALLOCATED(RenderObject);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderObject);
     friend class RenderBlock;
     friend class RenderBlockFlow;
     friend class RenderBox;

--- a/Source/WebCore/rendering/RenderProgress.h
+++ b/Source/WebCore/rendering/RenderProgress.h
@@ -28,6 +28,7 @@ class HTMLProgressElement;
 
 class RenderProgress final : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderProgress);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderProgress);
 public:
     RenderProgress(HTMLElement&, RenderStyle&&);
     virtual ~RenderProgress();

--- a/Source/WebCore/rendering/RenderQuote.h
+++ b/Source/WebCore/rendering/RenderQuote.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class RenderQuote final : public RenderInline {
     WTF_MAKE_ISO_ALLOCATED(RenderQuote);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderQuote);
 public:
     RenderQuote(Document&, RenderStyle&&, QuoteType);
     virtual ~RenderQuote();

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -27,6 +27,7 @@ namespace WebCore {
 
 class RenderReplaced : public RenderBox {
     WTF_MAKE_ISO_ALLOCATED(RenderReplaced);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderReplaced);
 public:
     virtual ~RenderReplaced();
 

--- a/Source/WebCore/rendering/RenderReplica.h
+++ b/Source/WebCore/rendering/RenderReplica.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class RenderReplica final : public RenderBox {
     WTF_MAKE_ISO_ALLOCATED(RenderReplica);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderReplica);
 public:
     RenderReplica(Document&, RenderStyle&&);
     virtual ~RenderReplica();

--- a/Source/WebCore/rendering/RenderScrollbarPart.h
+++ b/Source/WebCore/rendering/RenderScrollbarPart.h
@@ -34,6 +34,7 @@ class RenderScrollbar;
 
 class RenderScrollbarPart final : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderScrollbarPart);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderScrollbarPart);
 public:
     RenderScrollbarPart(Document&, RenderStyle&&, RenderScrollbar* = nullptr, ScrollbarPart = NoPart);
     

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -32,6 +32,7 @@ class HTMLInputElement;
 
 class RenderSearchField final : public RenderTextControlSingleLine, private PopupMenuClient {
     WTF_MAKE_ISO_ALLOCATED(RenderSearchField);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSearchField);
 public:
     RenderSearchField(HTMLInputElement&, RenderStyle&&);
     virtual ~RenderSearchField();

--- a/Source/WebCore/rendering/RenderSlider.h
+++ b/Source/WebCore/rendering/RenderSlider.h
@@ -29,6 +29,7 @@ class MouseEvent;
 
 class RenderSlider final : public RenderFlexibleBox {
     WTF_MAKE_ISO_ALLOCATED(RenderSlider);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSlider);
 public:
     static const int defaultTrackLength;
 

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -44,6 +44,7 @@ enum class TableIntrinsics : uint8_t { ForLayout, ForKeyword };
 
 class RenderTable : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderTable);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderTable);
 public:
     RenderTable(Type, Element&, RenderStyle&&);
     RenderTable(Type, Document&, RenderStyle&&);

--- a/Source/WebCore/rendering/RenderTableCaption.h
+++ b/Source/WebCore/rendering/RenderTableCaption.h
@@ -27,6 +27,7 @@ class RenderTable;
 
 class RenderTableCaption final : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderTableCaption);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderTableCaption);
 public:
     RenderTableCaption(Element&, RenderStyle&&);
     virtual ~RenderTableCaption();

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -98,6 +98,8 @@ RenderTableCell::RenderTableCell(Document& document, RenderStyle&& style)
     ASSERT(isRenderTableCell());
 }
 
+RenderTableCell::~RenderTableCell() = default;
+
 void RenderTableCell::willBeRemovedFromTree()
 {
     RenderBlockFlow::willBeRemovedFromTree();

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -38,9 +38,11 @@ enum IncludeBorderColorOrNot { DoNotIncludeBorderColor, IncludeBorderColor };
 
 class RenderTableCell final : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderTableCell);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderTableCell);
 public:
     RenderTableCell(Element&, RenderStyle&&);
     RenderTableCell(Document&, RenderStyle&&);
+    virtual ~RenderTableCell();
     
     unsigned colSpan() const;
     unsigned rowSpan() const;

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -61,6 +61,8 @@ RenderTableCol::RenderTableCol(Document& document, RenderStyle&& style)
     ASSERT(isRenderTableCol());
 }
 
+RenderTableCol::~RenderTableCol() = default;
+
 void RenderTableCol::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     RenderBox::styleDidChange(diff, oldStyle);

--- a/Source/WebCore/rendering/RenderTableCol.h
+++ b/Source/WebCore/rendering/RenderTableCol.h
@@ -34,9 +34,11 @@ class RenderTableCell;
 
 class RenderTableCol final : public RenderBox {
     WTF_MAKE_ISO_ALLOCATED(RenderTableCol);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderTableCol);
 public:
     RenderTableCol(Element&, RenderStyle&&);
     RenderTableCol(Document&, RenderStyle&&);
+    virtual ~RenderTableCol();
 
     void clearPreferredLogicalWidthsDirtyBits();
 

--- a/Source/WebCore/rendering/RenderTableRow.cpp
+++ b/Source/WebCore/rendering/RenderTableRow.cpp
@@ -63,6 +63,8 @@ RenderTableRow::RenderTableRow(Document& document, RenderStyle&& style)
     ASSERT(isRenderTableRow());
 }
 
+RenderTableRow::~RenderTableRow() = default;
+
 void RenderTableRow::willBeRemovedFromTree()
 {
     RenderBox::willBeRemovedFromTree();

--- a/Source/WebCore/rendering/RenderTableRow.h
+++ b/Source/WebCore/rendering/RenderTableRow.h
@@ -33,9 +33,11 @@ static const unsigned maxRowIndex = 0x7FFFFFFE; // 2,147,483,646
 
 class RenderTableRow final : public RenderBox {
     WTF_MAKE_ISO_ALLOCATED(RenderTableRow);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderTableRow);
 public:
     RenderTableRow(Element&, RenderStyle&&);
     RenderTableRow(Document&, RenderStyle&&);
+    virtual ~RenderTableRow();
 
     RenderTableRow* nextRow() const;
     RenderTableRow* previousRow() const;

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -54,6 +54,7 @@ public:
 
 class RenderTableSection final : public RenderBox {
     WTF_MAKE_ISO_ALLOCATED(RenderTableSection);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderTableSection);
 public:
     RenderTableSection(Element&, RenderStyle&&);
     RenderTableSection(Document&, RenderStyle&&);

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -42,6 +42,7 @@ class LineLayout;
 
 class RenderText : public RenderObject {
     WTF_MAKE_ISO_ALLOCATED(RenderText);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderText);
 public:
     RenderText(Type, Text&, const String&);
     RenderText(Type, Document&, const String&);

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -244,4 +244,6 @@ RenderTextControlInnerContainer::RenderTextControlInnerContainer(Element& elemen
 
 }
 
+RenderTextControlInnerContainer::~RenderTextControlInnerContainer() = default;
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderTextControl.h
+++ b/Source/WebCore/rendering/RenderTextControl.h
@@ -31,6 +31,7 @@ class HTMLTextFormControlElement;
 
 class RenderTextControl : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderTextControl);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderTextControl);
 public:
     virtual ~RenderTextControl();
 
@@ -84,9 +85,10 @@ private:
 // anymore.
 class RenderTextControlInnerContainer final : public RenderFlexibleBox {
     WTF_MAKE_ISO_ALLOCATED(RenderTextControlInnerContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderTextControlInnerContainer);
 public:
     RenderTextControlInnerContainer(Element&, RenderStyle&&);
-    virtual ~RenderTextControlInnerContainer() = default;
+    virtual ~RenderTextControlInnerContainer();
 
     LayoutUnit baselinePosition(FontBaseline baseline, bool firstLine, LineDirectionMode direction, LinePositionMode position) const override
     {

--- a/Source/WebCore/rendering/RenderTextControlMultiLine.h
+++ b/Source/WebCore/rendering/RenderTextControlMultiLine.h
@@ -28,6 +28,7 @@ namespace WebCore {
 
 class RenderTextControlMultiLine final : public RenderTextControl {
     WTF_MAKE_ISO_ALLOCATED(RenderTextControlMultiLine);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderTextControlMultiLine);
 public:
     RenderTextControlMultiLine(HTMLTextAreaElement&, RenderStyle&&);
     virtual ~RenderTextControlMultiLine();

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -499,4 +499,6 @@ RenderTextControlInnerBlock::RenderTextControlInnerBlock(Element& element, Rende
     ASSERT(isRenderTextControlInnerBlock());
 }
 
+RenderTextControlInnerBlock::~RenderTextControlInnerBlock() = default;
+
 }

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.h
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class RenderTextControlSingleLine : public RenderTextControl {
     WTF_MAKE_ISO_ALLOCATED(RenderTextControlSingleLine);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderTextControlSingleLine);
 public:
     RenderTextControlSingleLine(Type, HTMLInputElement&, RenderStyle&&);
     virtual ~RenderTextControlSingleLine();
@@ -85,8 +86,10 @@ inline HTMLElement* RenderTextControlSingleLine::innerBlockElement() const
 
 class RenderTextControlInnerBlock final : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderTextControlInnerBlock);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderTextControlInnerBlock);
 public:
     RenderTextControlInnerBlock(Element&, RenderStyle&&);
+    virtual ~RenderTextControlInnerBlock();
 
 private:
     bool hasLineIfEmpty() const override { return true; }

--- a/Source/WebCore/rendering/RenderTextFragment.h
+++ b/Source/WebCore/rendering/RenderTextFragment.h
@@ -33,6 +33,7 @@ namespace WebCore {
 // the original unaltered string from our corresponding DOM node.
 class RenderTextFragment final : public RenderText {
     WTF_MAKE_ISO_ALLOCATED(RenderTextFragment);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderTextFragment);
 public:
     RenderTextFragment(Text&, const String&, int startOffset, int length);
     RenderTextFragment(Document&, const String&, int startOffset, int length);

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -97,6 +97,8 @@ RenderTheme::RenderTheme()
 {
 }
 
+RenderTheme::~RenderTheme() = default;
+
 StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, const Element* element, StyleAppearance autoAppearance) const
 {
     if (!element) {

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -54,8 +54,7 @@ class Settings;
 class RenderTheme {
 protected:
     RenderTheme();
-
-    virtual ~RenderTheme() = default;
+    virtual ~RenderTheme();
 
 public:
     // This function is to be implemented in platform-specific theme implementations to hand back the

--- a/Source/WebCore/rendering/RenderVTTCue.cpp
+++ b/Source/WebCore/rendering/RenderVTTCue.cpp
@@ -52,6 +52,8 @@ RenderVTTCue::RenderVTTCue(VTTCueBox& element, RenderStyle&& style)
     ASSERT(isRenderVTTCue());
 }
 
+RenderVTTCue::~RenderVTTCue() = default;
+
 void RenderVTTCue::layout()
 {
     StackStats::LayoutCheckPoint layoutCheckPoint;

--- a/Source/WebCore/rendering/RenderVTTCue.h
+++ b/Source/WebCore/rendering/RenderVTTCue.h
@@ -39,8 +39,10 @@ class VTTCueBox;
 
 class RenderVTTCue final : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderVTTCue);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderVTTCue);
 public:
     RenderVTTCue(VTTCueBox&, RenderStyle&&);
+    virtual ~RenderVTTCue();
 
 private:
     void layout() override;

--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class RenderVideo final : public RenderMedia {
     WTF_MAKE_ISO_ALLOCATED(RenderVideo);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderVideo);
 public:
     RenderVideo(HTMLVideoElement&, RenderStyle&&);
     virtual ~RenderVideo();

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -46,6 +46,7 @@ class LayoutState;
 
 class RenderView final : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderView);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderView);
 public:
     RenderView(Document&, RenderStyle&&);
     virtual ~RenderView();

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -38,7 +38,10 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderViewTransitionCapture);
 
 RenderViewTransitionCapture::RenderViewTransitionCapture(Type type, Document& document, RenderStyle&& style)
     : RenderReplaced(type, document, WTFMove(style), { }, ReplacedFlag::IsViewTransitionCapture)
-{ }
+{
+}
+
+RenderViewTransitionCapture::~RenderViewTransitionCapture() = default;
 
 void RenderViewTransitionCapture::setImage(RefPtr<ImageBuffer> oldImage)
 {

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -29,10 +29,12 @@
 
 namespace WebCore {
 
-class RenderViewTransitionCapture : public RenderReplaced {
+class RenderViewTransitionCapture final : public RenderReplaced {
     WTF_MAKE_ISO_ALLOCATED(RenderViewTransitionCapture);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderViewTransitionCapture);
 public:
     RenderViewTransitionCapture(Type, Document&, RenderStyle&&);
+    virtual ~RenderViewTransitionCapture();
 
     void setImage(RefPtr<ImageBuffer>);
     void setSize(const LayoutSize&, const LayoutRect& overflowRect);

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -64,6 +64,7 @@ inline void WidgetHierarchyUpdatesSuspensionScope::scheduleWidgetToMove(Widget& 
 
 class RenderWidget : public RenderReplaced, private OverlapTestRequestClient, public RefCounted<RenderWidget> {
     WTF_MAKE_ISO_ALLOCATED(RenderWidget);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderWidget);
 public:
     virtual ~RenderWidget();
 

--- a/Source/WebCore/rendering/StyledMarkedText.h
+++ b/Source/WebCore/rendering/StyledMarkedText.h
@@ -35,7 +35,10 @@ namespace WebCore {
 class RenderText;
 class RenderedDocumentMarker;
 
-struct StyledMarkedText : MarkedText {
+struct StyledMarkedText final : MarkedText {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(StyledMarkedText);
+
     struct Style {
         Color backgroundColor;
         TextPaintStyle textStyles;

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -118,6 +118,8 @@ RenderTheme& RenderTheme::singleton()
     return theme;
 }
 
+RenderThemeAdwaita::~RenderThemeAdwaita() = default;
+
 bool RenderThemeAdwaita::supportsFocusRing(const RenderStyle& style) const
 {
     switch (style.usedAppearance()) {

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class RenderThemeAdwaita : public RenderTheme {
 public:
-    virtual ~RenderThemeAdwaita() = default;
+    virtual ~RenderThemeAdwaita();
 
     void setAccentColor(const Color&);
 

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -184,7 +184,7 @@ private:
 
 private:
     RenderThemeIOS();
-    virtual ~RenderThemeIOS() = default;
+    virtual ~RenderThemeIOS();
 
 #if PLATFORM(WATCHOS)
     String extraDefaultStyleSheet() final;

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -112,6 +112,8 @@ const float ControlBaseFontSize = 11;
 
 RenderThemeIOS::RenderThemeIOS() = default;
 
+RenderThemeIOS::~RenderThemeIOS() = default;
+
 RenderTheme& RenderTheme::singleton()
 {
     static NeverDestroyed<RenderThemeIOS> theme;

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -176,6 +176,8 @@ LayoutUnit toUserUnits(const MathMLElement::Length& length, const RenderStyle& s
     }
 }
 
+RenderMathMLTable::~RenderMathMLTable() = default;
+
 std::optional<LayoutUnit> RenderMathMLTable::firstLineBaseline() const
 {
     // By default the vertical center of <mtable> is aligned on the math axis.

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.h
@@ -40,6 +40,7 @@ class MathMLPresentationElement;
 
 class RenderMathMLBlock : public RenderBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLBlock);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLBlock);
 public:
     RenderMathMLBlock(Type, MathMLPresentationElement&, RenderStyle&&);
     RenderMathMLBlock(Type, Document&, RenderStyle&&);
@@ -90,8 +91,10 @@ private:
 
 class RenderMathMLTable final : public RenderTable {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLTable);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLTable);
 public:
     inline RenderMathMLTable(MathMLElement&, RenderStyle&&);
+    virtual ~RenderMathMLTable();
 
     MathMLStyle& mathMLStyle() const { return m_mathMLStyle; }
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFenced.cpp
@@ -56,6 +56,8 @@ RenderMathMLFenced::RenderMathMLFenced(MathMLRowElement& element, RenderStyle&& 
     ASSERT(isRenderMathMLFenced());
 }
 
+RenderMathMLFenced::~RenderMathMLFenced() = default;
+
 void RenderMathMLFenced::updateFromElement()
 {
     const auto& fenced = element();

--- a/Source/WebCore/rendering/mathml/RenderMathMLFenced.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFenced.h
@@ -36,8 +36,10 @@ class MathMLRowElement;
 
 class RenderMathMLFenced final : public RenderMathMLRow {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLFenced);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLFenced);
 public:
     RenderMathMLFenced(MathMLRowElement&, RenderStyle&&);
+    virtual ~RenderMathMLFenced();
 
     StringImpl* separators() const { return m_separators.get(); }
     String openingBrace() const { return m_open; }

--- a/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.cpp
@@ -50,6 +50,8 @@ RenderMathMLFencedOperator::RenderMathMLFencedOperator(Document& document, Rende
     ASSERT(isRenderMathMLFencedOperator());
 }
 
+RenderMathMLFencedOperator::~RenderMathMLFencedOperator() = default;
+
 void RenderMathMLFencedOperator::updateOperatorContent(const String& operatorString)
 {
     m_operatorChar = MathMLOperatorElement::parseOperatorChar(operatorString);

--- a/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFencedOperator.h
@@ -35,8 +35,11 @@ namespace WebCore {
 
 class RenderMathMLFencedOperator final : public RenderMathMLOperator {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLFencedOperator);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLFencedOperator);
 public:
     RenderMathMLFencedOperator(Document&, RenderStyle&&, const String& operatorString, MathMLOperatorDictionary::Form, unsigned short flags = 0);
+    virtual ~RenderMathMLFencedOperator();
+
     void updateOperatorContent(const String&);
 
 private:

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.cpp
@@ -47,6 +47,8 @@ RenderMathMLFraction::RenderMathMLFraction(MathMLFractionElement& element, Rende
     ASSERT(isRenderMathMLFraction());
 }
 
+RenderMathMLFraction::~RenderMathMLFraction() = default;
+
 bool RenderMathMLFraction::isValid() const
 {
     // Verify whether the list of children is valid:

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.h
@@ -38,8 +38,10 @@ class MathMLFractionElement;
 
 class RenderMathMLFraction final : public RenderMathMLBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLFraction);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLFraction);
 public:
     RenderMathMLFraction(MathMLFractionElement&, RenderStyle&&);
+    virtual ~RenderMathMLFraction();
 
     LayoutUnit defaultLineThickness() const;
     LayoutUnit lineThickness() const;

--- a/Source/WebCore/rendering/mathml/RenderMathMLMath.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMath.cpp
@@ -47,6 +47,8 @@ RenderMathMLMath::RenderMathMLMath(MathMLRowElement& element, RenderStyle&& styl
     ASSERT(isRenderMathMLMath());
 }
 
+RenderMathMLMath::~RenderMathMLMath() = default;
+
 void RenderMathMLMath::centerChildren(LayoutUnit contentWidth)
 {
     auto centerBlockOffset = (logicalWidth() - contentWidth) / 2;

--- a/Source/WebCore/rendering/mathml/RenderMathMLMath.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMath.h
@@ -35,8 +35,10 @@ class MathMLRowElement;
 
 class RenderMathMLMath final : public RenderMathMLRow {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLMath);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLMath);
 public:
     RenderMathMLMath(MathMLRowElement&, RenderStyle&&);
+    virtual ~RenderMathMLMath();
 
 private:
     ASCIILiteral renderName() const final { return "RenderMathMLMath"_s; }

--- a/Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMenclose.cpp
@@ -54,6 +54,8 @@ RenderMathMLMenclose::RenderMathMLMenclose(MathMLMencloseElement& element, Rende
     ASSERT(isRenderMathMLMenclose());
 }
 
+RenderMathMLMenclose::~RenderMathMLMenclose() = default;
+
 // This arbitrary thickness value is used for the parameter \xi_8 from the MathML in HTML5 implementation note.
 // For now, we take:
 // - OverbarVerticalGap = UnderbarVerticalGap = 3\xi_8

--- a/Source/WebCore/rendering/mathml/RenderMathMLMenclose.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLMenclose.h
@@ -35,8 +35,10 @@ namespace WebCore {
 
 class RenderMathMLMenclose final : public RenderMathMLRow {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLMenclose);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLMenclose);
 public:
     RenderMathMLMenclose(MathMLMencloseElement&, RenderStyle&&);
+    virtual ~RenderMathMLMenclose();
 
 private:
     ASCIILiteral renderName() const final { return "RenderMathMLMenclose"_s; }

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
@@ -63,6 +63,8 @@ RenderMathMLOperator::RenderMathMLOperator(Type type, Document& document, Render
 {
 }
 
+RenderMathMLOperator::~RenderMathMLOperator() = default;
+
 MathMLOperatorElement& RenderMathMLOperator::element() const
 {
     return static_cast<MathMLOperatorElement&>(nodeForNonAnonymous());

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.h
@@ -37,9 +37,12 @@ class MathMLOperatorElement;
 
 class RenderMathMLOperator : public RenderMathMLToken {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLOperator);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLOperator);
 public:
     RenderMathMLOperator(Type, MathMLOperatorElement&, RenderStyle&&);
     RenderMathMLOperator(Type, Document&, RenderStyle&&);
+    virtual ~RenderMathMLOperator();
+
     MathMLOperatorElement& element() const;
 
     void stretchTo(LayoutUnit heightAboveBaseline, LayoutUnit depthBelowBaseline);

--- a/Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLPadded.cpp
@@ -42,6 +42,8 @@ RenderMathMLPadded::RenderMathMLPadded(MathMLPaddedElement& element, RenderStyle
     ASSERT(isRenderMathMLPadded());
 }
 
+RenderMathMLPadded::~RenderMathMLPadded() = default;
+
 LayoutUnit RenderMathMLPadded::voffset() const
 {
     return toUserUnits(element().voffset(), style(), 0);

--- a/Source/WebCore/rendering/mathml/RenderMathMLPadded.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLPadded.h
@@ -34,8 +34,10 @@ namespace WebCore {
 
 class RenderMathMLPadded final : public RenderMathMLRow {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLPadded);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLPadded);
 public:
     RenderMathMLPadded(MathMLPaddedElement&, RenderStyle&&);
+    virtual ~RenderMathMLPadded();
 
 private:
     ASCIILiteral renderName() const final { return "RenderMathMLPadded"_s; }

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.cpp
@@ -54,6 +54,8 @@ RenderMathMLRoot::RenderMathMLRoot(MathMLRootElement& element, RenderStyle&& sty
     ASSERT(isRenderMathMLRoot());
 }
 
+RenderMathMLRoot::~RenderMathMLRoot() = default;
+
 MathMLRootElement& RenderMathMLRoot::element() const
 {
     return static_cast<MathMLRootElement&>(nodeForNonAnonymous());

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
@@ -40,8 +40,11 @@ enum class RootType { SquareRoot, RootWithIndex };
 // Render base^(1/index), or sqrt(base) using radical notation.
 class RenderMathMLRoot final : public RenderMathMLRow {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLRoot);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLRoot);
 public:
     RenderMathMLRoot(MathMLRootElement&, RenderStyle&&);
+    virtual ~RenderMathMLRoot();
+
     void updateStyle();
 
 private:

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.cpp
@@ -50,6 +50,8 @@ RenderMathMLRow::RenderMathMLRow(Type type, MathMLRowElement& element, RenderSty
     ASSERT(isRenderMathMLRow());
 }
 
+RenderMathMLRow::~RenderMathMLRow() = default;
+
 MathMLRowElement& RenderMathMLRow::element() const
 {
     return static_cast<MathMLRowElement&>(nodeForNonAnonymous());

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.h
@@ -36,9 +36,11 @@ class MathMLRowElement;
 
 class RenderMathMLRow : public RenderMathMLBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLRow);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLRow);
 public:
     RenderMathMLRow(Type, MathMLRowElement&, RenderStyle&&);
     MathMLRowElement& element() const;
+    virtual ~RenderMathMLRow();
 
 protected:
     void layoutBlock(bool relayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) override;

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
@@ -50,6 +50,8 @@ RenderMathMLScripts::RenderMathMLScripts(Type type, MathMLScriptsElement& elemen
 {
 }
 
+RenderMathMLScripts::~RenderMathMLScripts() = default;
+
 MathMLScriptsElement& RenderMathMLScripts::element() const
 {
     return static_cast<MathMLScriptsElement&>(nodeForNonAnonymous());

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.h
@@ -37,8 +37,11 @@ namespace WebCore {
 // Render a base with scripts.
 class RenderMathMLScripts : public RenderMathMLBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLScripts);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLScripts);
 public:
     RenderMathMLScripts(Type, MathMLScriptsElement&, RenderStyle&&);
+    virtual ~RenderMathMLScripts();
+
     RenderMathMLOperator* unembellishedOperator() const final;
 
 protected:

--- a/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLSpace.cpp
@@ -43,6 +43,8 @@ RenderMathMLSpace::RenderMathMLSpace(MathMLSpaceElement& element, RenderStyle&& 
     ASSERT(isRenderMathMLSpace());
 }
 
+RenderMathMLSpace::~RenderMathMLSpace() = default;
+
 void RenderMathMLSpace::computePreferredLogicalWidths()
 {
     ASSERT(preferredLogicalWidthsDirty());

--- a/Source/WebCore/rendering/mathml/RenderMathMLSpace.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLSpace.h
@@ -34,8 +34,11 @@ namespace WebCore {
 
 class RenderMathMLSpace final : public RenderMathMLBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLSpace);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLSpace);
 public:
     RenderMathMLSpace(MathMLSpaceElement&, RenderStyle&&);
+    virtual ~RenderMathMLSpace();
+
     MathMLSpaceElement& element() const { return static_cast<MathMLSpaceElement&>(nodeForNonAnonymous()); }
 
 private:

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.cpp
@@ -57,6 +57,8 @@ RenderMathMLToken::RenderMathMLToken(Type type, Document& document, RenderStyle&
 {
 }
 
+RenderMathMLToken::~RenderMathMLToken() = default;
+
 MathMLTokenElement& RenderMathMLToken::element()
 {
     return static_cast<MathMLTokenElement&>(nodeForNonAnonymous());

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.h
@@ -37,9 +37,11 @@ class MathMLTokenElement;
 
 class RenderMathMLToken : public RenderMathMLBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLToken);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLToken);
 public:
     RenderMathMLToken(Type, MathMLTokenElement&, RenderStyle&&);
     RenderMathMLToken(Type, Document&, RenderStyle&&);
+    virtual ~RenderMathMLToken();
 
     MathMLTokenElement& element();
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.cpp
@@ -47,6 +47,8 @@ RenderMathMLUnderOver::RenderMathMLUnderOver(MathMLUnderOverElement& element, Re
     ASSERT(isRenderMathMLUnderOver());
 }
 
+RenderMathMLUnderOver::~RenderMathMLUnderOver() = default;
+
 MathMLUnderOverElement& RenderMathMLUnderOver::element() const
 {
     return static_cast<MathMLUnderOverElement&>(nodeForNonAnonymous());

--- a/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.h
@@ -36,8 +36,10 @@ class MathMLUnderOverElement;
 
 class RenderMathMLUnderOver final : public RenderMathMLScripts {
     WTF_MAKE_ISO_ALLOCATED(RenderMathMLUnderOver);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLUnderOver);
 public:
     RenderMathMLUnderOver(MathMLUnderOverElement&, RenderStyle&&);
+    virtual ~RenderMathMLUnderOver();
 
 private:
     bool isRenderMathMLScripts() const final { return false; }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -295,8 +295,9 @@ struct PseudoStyleCache {
 };
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(RenderStyle);
-class RenderStyle : public CanMakeCheckedPtr<RenderStyle> {
+class RenderStyle final : public CanMakeCheckedPtr<RenderStyle> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(RenderStyle);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderStyle);
 private:
     enum CloneTag { Clone };
     enum CreateDefaultStyleTag { CreateDefaultStyle };

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
@@ -41,6 +41,8 @@ RenderSVGBlock::RenderSVGBlock(Type type, SVGGraphicsElement& element, RenderSty
 {
 }
 
+RenderSVGBlock::~RenderSVGBlock() = default;
+
 void RenderSVGBlock::updateFromStyle()
 {
     RenderBlockFlow::updateFromStyle();

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.h
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.h
@@ -28,12 +28,15 @@ class SVGGraphicsElement;
 
 class RenderSVGBlock : public RenderBlockFlow {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGBlock);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGBlock);
 public:
     inline SVGGraphicsElement& graphicsElement() const;
     inline Ref<SVGGraphicsElement> protectedGraphicsElement() const;
 
 protected:
     RenderSVGBlock(Type, SVGGraphicsElement&, RenderStyle&&);
+    virtual ~RenderSVGBlock();
+
     void willBeDestroyed() override;
 
     void computeOverflow(LayoutUnit oldClientAfterEdge, bool recomputeFloats = false) override;

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.h
@@ -32,6 +32,7 @@ class SVGElement;
 
 class RenderSVGContainer : public RenderSVGModelObject {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGContainer);
 public:
     virtual ~RenderSVGContainer();
 

--- a/Source/WebCore/rendering/svg/RenderSVGEllipse.h
+++ b/Source/WebCore/rendering/svg/RenderSVGEllipse.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class RenderSVGEllipse final : public RenderSVGShape {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGEllipse);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGEllipse);
 public:
     RenderSVGEllipse(SVGGraphicsElement&, RenderStyle&&);
     virtual ~RenderSVGEllipse();

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
@@ -33,6 +33,7 @@ class SVGForeignObjectElement;
 
 class RenderSVGForeignObject final : public RenderSVGBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGForeignObject);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGForeignObject);
 public:
     RenderSVGForeignObject(SVGForeignObjectElement&, RenderStyle&&);
     virtual ~RenderSVGForeignObject();

--- a/Source/WebCore/rendering/svg/RenderSVGGradientStop.h
+++ b/Source/WebCore/rendering/svg/RenderSVGGradientStop.h
@@ -31,6 +31,7 @@ class SVGStopElement;
 // This class exists mostly so we can hear about gradient stop style changes
 class RenderSVGGradientStop final : public RenderElement {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGGradientStop);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGGradientStop);
 public:
     RenderSVGGradientStop(SVGStopElement&, RenderStyle&&);
     virtual ~RenderSVGGradientStop();

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.cpp
@@ -35,6 +35,8 @@ RenderSVGHiddenContainer::RenderSVGHiddenContainer(Type type, SVGElement& elemen
     ASSERT(isRenderSVGHiddenContainer());
 }
 
+RenderSVGHiddenContainer::~RenderSVGHiddenContainer() = default;
+
 void RenderSVGHiddenContainer::layout()
 {
     StackStats::LayoutCheckPoint layoutCheckPoint;

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
@@ -30,8 +30,10 @@ class SVGElement;
 // <defs>, <linearGradient>, <radialGradient> are all good examples
 class RenderSVGHiddenContainer : public RenderSVGContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGHiddenContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGHiddenContainer);
 public:
     RenderSVGHiddenContainer(Type, SVGElement&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
+    virtual ~RenderSVGHiddenContainer();
 
 protected:
     void layout() override;

--- a/Source/WebCore/rendering/svg/RenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.h
@@ -34,6 +34,7 @@ class SVGImageElement;
 
 class RenderSVGImage final : public RenderSVGModelObject {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGImage);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGImage);
 public:
     RenderSVGImage(SVGImageElement&, RenderStyle&&);
     virtual ~RenderSVGImage();

--- a/Source/WebCore/rendering/svg/RenderSVGInline.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.cpp
@@ -43,6 +43,8 @@ RenderSVGInline::RenderSVGInline(Type type, SVGGraphicsElement& element, RenderS
     ASSERT(isRenderSVGInline());
 }
 
+RenderSVGInline::~RenderSVGInline() = default;
+
 std::unique_ptr<LegacyInlineFlowBox> RenderSVGInline::createInlineFlowBox()
 {
     auto box = makeUnique<SVGInlineFlowBox>(*this);

--- a/Source/WebCore/rendering/svg/RenderSVGInline.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInline.h
@@ -28,8 +28,10 @@ class SVGGraphicsElement;
 
 class RenderSVGInline : public RenderInline {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGInline);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGInline);
 public:
     RenderSVGInline(Type, SVGGraphicsElement&, RenderStyle&&);
+    virtual ~RenderSVGInline();
 
     inline SVGGraphicsElement& graphicsElement() const;
 

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.cpp
@@ -80,6 +80,8 @@ RenderSVGInlineText::RenderSVGInlineText(Text& textNode, const String& string)
     ASSERT(isRenderSVGInlineText());
 }
 
+RenderSVGInlineText::~RenderSVGInlineText() = default;
+
 String RenderSVGInlineText::originalText() const
 {
     return textNode().data();

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.h
@@ -32,8 +32,10 @@ class SVGInlineTextBox;
 
 class RenderSVGInlineText final : public RenderText {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGInlineText);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGInlineText);
 public:
     RenderSVGInlineText(Text&, const String&);
+    virtual ~RenderSVGInlineText();
 
     Text& textNode() const { return downcast<Text>(nodeForNonAnonymous()); }
 

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -68,6 +68,8 @@ RenderSVGModelObject::RenderSVGModelObject(Type type, SVGElement& element, Rende
     ASSERT(isRenderSVGModelObject());
 }
 
+RenderSVGModelObject::~RenderSVGModelObject() = default;
+
 void RenderSVGModelObject::updateFromStyle()
 {
     RenderLayerModelObject::updateFromStyle();

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.h
@@ -47,7 +47,10 @@ class SVGElement;
 
 class RenderSVGModelObject : public RenderLayerModelObject {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGModelObject);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGModelObject);
 public:
+    virtual ~RenderSVGModelObject();
+
     bool requiresLayer() const override { return true; }
 
     void styleDidChange(StyleDifference, const RenderStyle* oldStyle) override;

--- a/Source/WebCore/rendering/svg/RenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.h
@@ -32,6 +32,7 @@ namespace WebCore {
 
 class RenderSVGPath final : public RenderSVGShape {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGPath);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGPath);
 public:
     RenderSVGPath(SVGGraphicsElement&, RenderStyle&&);
     virtual ~RenderSVGPath();

--- a/Source/WebCore/rendering/svg/RenderSVGRect.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.h
@@ -36,6 +36,7 @@ class SVGRectElement;
 
 class RenderSVGRect final : public RenderSVGShape {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGRect);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGRect);
 public:
     RenderSVGRect(SVGRectElement&, RenderStyle&&);
     virtual ~RenderSVGRect();

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
@@ -31,6 +31,7 @@ class SVGGraphicsElement;
 
 class RenderSVGResourceClipper final : public RenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceClipper);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGResourceClipper);
 public:
     RenderSVGResourceClipper(SVGClipPathElement&, RenderStyle&&);
     virtual ~RenderSVGResourceClipper();

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.h
@@ -26,6 +26,7 @@ namespace WebCore {
 
 class RenderSVGResourceContainer : public RenderSVGHiddenContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGResourceContainer);
 public:
     virtual ~RenderSVGResourceContainer();
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
@@ -28,6 +28,7 @@ class Gradient;
 
 class RenderSVGResourceGradient : public RenderSVGResourcePaintServer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceGradient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGResourceGradient);
 public:
     virtual ~RenderSVGResourceGradient();
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.h
@@ -32,6 +32,7 @@ class SVGLinearGradientElement;
 
 class RenderSVGResourceLinearGradient final : public RenderSVGResourceGradient {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceLinearGradient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGResourceLinearGradient);
 public:
     RenderSVGResourceLinearGradient(SVGLinearGradientElement&, RenderStyle&&);
     virtual ~RenderSVGResourceLinearGradient();

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
@@ -30,6 +30,7 @@ class SVGMarkerElement;
 
 class RenderSVGResourceMarker final : public RenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceMarker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGResourceMarker);
 public:
     RenderSVGResourceMarker(SVGMarkerElement&, RenderStyle&&);
     virtual ~RenderSVGResourceMarker();

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
@@ -32,6 +32,7 @@ class SVGMaskElement;
 
 class RenderSVGResourceMasker final : public RenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceMasker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGResourceMasker);
 public:
     RenderSVGResourceMasker(SVGMaskElement&, RenderStyle&&);
     virtual ~RenderSVGResourceMasker();

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePaintServer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePaintServer.h
@@ -30,6 +30,7 @@ class RenderSVGShape;
 
 class RenderSVGResourcePaintServer : public RenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourcePaintServer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGResourcePaintServer);
 public:
     virtual ~RenderSVGResourcePaintServer();
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
@@ -28,8 +28,9 @@ class Pattern;
 
 namespace WebCore {
 
-class RenderSVGResourcePattern : public RenderSVGResourcePaintServer {
+class RenderSVGResourcePattern final : public RenderSVGResourcePaintServer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourcePattern);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGResourcePattern);
 public:
     RenderSVGResourcePattern(SVGElement&, RenderStyle&&);
     virtual ~RenderSVGResourcePattern();

--- a/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceRadialGradient.h
@@ -32,6 +32,7 @@ class SVGRadialGradientElement;
 
 class RenderSVGResourceRadialGradient final : public RenderSVGResourceGradient {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGResourceRadialGradient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGResourceRadialGradient);
 public:
     RenderSVGResourceRadialGradient(SVGRadialGradientElement&, RenderStyle&&);
     virtual ~RenderSVGResourceRadialGradient();

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -34,6 +34,7 @@ class SVGSVGElement;
 
 class RenderSVGRoot final : public RenderReplaced {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGRoot);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGRoot);
 public:
     RenderSVGRoot(SVGSVGElement&, RenderStyle&&);
     virtual ~RenderSVGRoot();

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -43,6 +43,7 @@ class SVGGraphicsElement;
 
 class RenderSVGShape : public RenderSVGModelObject {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGShape);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGShape);
 public:
     friend FloatRect SVGRenderSupport::calculateApproximateStrokeBoundingBox(const RenderElement&);
 

--- a/Source/WebCore/rendering/svg/RenderSVGTSpan.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTSpan.h
@@ -29,6 +29,7 @@ namespace WebCore {
 
 class RenderSVGTSpan final : public RenderSVGInline {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGTSpan);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGTSpan);
 public:
     explicit RenderSVGTSpan(SVGTextPositioningElement& element, RenderStyle&& style)
         : RenderSVGInline(Type::SVGTSpan, element, WTFMove(style))

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -34,6 +34,7 @@ class RenderSVGInlineText;
 
 class RenderSVGText final : public RenderSVGBlock {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGText);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGText);
 public:
     RenderSVGText(SVGTextElement&, RenderStyle&&);
     virtual ~RenderSVGText();

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
@@ -46,6 +46,8 @@ RenderSVGTextPath::RenderSVGTextPath(SVGTextPathElement& element, RenderStyle&& 
     ASSERT(isRenderSVGTextPath());
 }
 
+RenderSVGTextPath::~RenderSVGTextPath() = default;
+
 SVGTextPathElement& RenderSVGTextPath::textPathElement() const
 {
     return downcast<SVGTextPathElement>(RenderSVGInline::graphicsElement());

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.h
@@ -30,8 +30,10 @@ class SVGTextPathElement;
 
 class RenderSVGTextPath final : public RenderSVGInline {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGTextPath);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGTextPath);
 public:
     RenderSVGTextPath(SVGTextPathElement&, RenderStyle&&);
+    virtual ~RenderSVGTextPath();
 
     SVGTextPathElement& textPathElement() const;
     SVGGeometryElement* targetElement() const;

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
@@ -41,6 +41,8 @@ RenderSVGTransformableContainer::RenderSVGTransformableContainer(SVGGraphicsElem
     ASSERT(isRenderSVGTransformableContainer());
 }
 
+RenderSVGTransformableContainer::~RenderSVGTransformableContainer() = default;
+
 SVGGraphicsElement& RenderSVGTransformableContainer::graphicsElement() const
 {
     return downcast<SVGGraphicsElement>(RenderSVGContainer::element());

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
@@ -29,8 +29,10 @@ class SVGGraphicsElement;
 
 class RenderSVGTransformableContainer final : public RenderSVGContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGTransformableContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGTransformableContainer);
 public:
     RenderSVGTransformableContainer(SVGGraphicsElement&, RenderStyle&&);
+    virtual ~RenderSVGTransformableContainer();
 
 private:
     ASCIILiteral renderName() const final { return "RenderSVGTransformableContainer"_s; }

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
@@ -49,6 +49,8 @@ RenderSVGViewportContainer::RenderSVGViewportContainer(SVGSVGElement& element, R
     ASSERT(isRenderSVGViewportContainer());
 }
 
+RenderSVGViewportContainer::~RenderSVGViewportContainer() = default;
+
 SVGSVGElement& RenderSVGViewportContainer::svgSVGElement() const
 {
     if (isOutermostSVGViewportContainer()) {

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
@@ -32,9 +32,11 @@ class SVGSVGElement;
 
 class RenderSVGViewportContainer final : public RenderSVGContainer {
     WTF_MAKE_ISO_ALLOCATED(RenderSVGViewportContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGViewportContainer);
 public:
     RenderSVGViewportContainer(RenderSVGRoot&, RenderStyle&&);
     RenderSVGViewportContainer(SVGSVGElement&, RenderStyle&&);
+    virtual ~RenderSVGViewportContainer();
 
     SVGSVGElement& svgSVGElement() const;
     Ref<SVGSVGElement> protectedSVGSVGElement() const;

--- a/Source/WebCore/rendering/svg/SVGRootInlineBox.h
+++ b/Source/WebCore/rendering/svg/SVGRootInlineBox.h
@@ -32,6 +32,7 @@ class SVGInlineTextBox;
 
 class SVGRootInlineBox final : public LegacyRootInlineBox {
     WTF_MAKE_ISO_ALLOCATED(SVGRootInlineBox);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGRootInlineBox);
 public:
     explicit SVGRootInlineBox(RenderSVGText&);
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.h
@@ -30,6 +30,7 @@ class SVGElement;
 
 class LegacyRenderSVGContainer : public LegacyRenderSVGModelObject {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGContainer);
 public:
     virtual ~LegacyRenderSVGContainer();
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.h
@@ -32,6 +32,7 @@ namespace WebCore {
 
 class LegacyRenderSVGEllipse final : public LegacyRenderSVGShape {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGEllipse);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGEllipse);
 public:
     LegacyRenderSVGEllipse(SVGGraphicsElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGEllipse();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
@@ -31,6 +31,7 @@ class SVGForeignObjectElement;
 
 class LegacyRenderSVGForeignObject final : public RenderSVGBlock {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGForeignObject);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGForeignObject);
 public:
     LegacyRenderSVGForeignObject(SVGForeignObjectElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGForeignObject();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h
@@ -29,6 +29,7 @@ class SVGElement;
 // <defs>, <linearGradient>, <radialGradient> are all good examples
 class LegacyRenderSVGHiddenContainer : public LegacyRenderSVGContainer {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGHiddenContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGHiddenContainer);
 public:
     LegacyRenderSVGHiddenContainer(Type, SVGElement&, RenderStyle&&, OptionSet<SVGModelObjectFlag> = { });
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
@@ -34,6 +34,7 @@ class SVGImageElement;
 
 class LegacyRenderSVGImage final : public LegacyRenderSVGModelObject {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGImage);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGImage);
 public:
     LegacyRenderSVGImage(SVGImageElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGImage();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -53,6 +53,8 @@ LegacyRenderSVGModelObject::LegacyRenderSVGModelObject(Type type, SVGElement& el
     ASSERT(!isRenderSVGModelObject());
 }
 
+LegacyRenderSVGModelObject::~LegacyRenderSVGModelObject() = default;
+
 LayoutRect LegacyRenderSVGModelObject::clippedOverflowRect(const RenderLayerModelObject* repaintContainer, VisibleRectContext context) const
 {
     return SVGRenderSupport::clippedOverflowRectForRepaint(*this, repaintContainer, context);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
@@ -45,7 +45,10 @@ class SVGElement;
 
 class LegacyRenderSVGModelObject : public RenderElement {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGModelObject);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGModelObject);
 public:
+    virtual ~LegacyRenderSVGModelObject();
+
     LayoutRect clippedOverflowRect(const RenderLayerModelObject* repaintContainer, VisibleRectContext) const override;
     RepaintRects rectsForRepaintingAfterLayout(const RenderLayerModelObject* repaintContainer, RepaintOutlineBounds) const override;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
@@ -31,6 +31,7 @@ namespace WebCore {
 
 class LegacyRenderSVGPath final : public LegacyRenderSVGShape {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGPath);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGPath);
 public:
     LegacyRenderSVGPath(SVGGraphicsElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGPath();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.h
@@ -34,6 +34,7 @@ namespace WebCore {
 
 class LegacyRenderSVGRect final : public LegacyRenderSVGShape {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGRect);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGRect);
 public:
     LegacyRenderSVGRect(SVGRectElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGRect();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -59,6 +59,7 @@ struct ClipperData {
 
 class LegacyRenderSVGResourceClipper final : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGResourceClipper);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourceClipper);
 public:
     LegacyRenderSVGResourceClipper(SVGClipPathElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGResourceClipper();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
@@ -30,6 +30,7 @@ class RenderLayer;
 
 class LegacyRenderSVGResourceContainer : public LegacyRenderSVGHiddenContainer, public LegacyRenderSVGResource {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGResourceContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourceContainer);
 public:
     virtual ~LegacyRenderSVGResourceContainer();
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
@@ -55,6 +55,7 @@ public:
 
 class LegacyRenderSVGResourceFilter final : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGResourceFilter);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourceFilter);
 public:
     LegacyRenderSVGResourceFilter(SVGFilterElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGResourceFilter();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.h
@@ -35,6 +35,7 @@ class SVGFilterPrimitiveStandardAttributes;
 
 class LegacyRenderSVGResourceFilterPrimitive final : public LegacyRenderSVGHiddenContainer {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGResourceFilterPrimitive);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourceFilterPrimitive);
 public:
     LegacyRenderSVGResourceFilterPrimitive(SVGFilterPrimitiveStandardAttributes&, RenderStyle&&);
     SVGFilterPrimitiveStandardAttributes& filterPrimitiveElement() const;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.cpp
@@ -41,6 +41,8 @@ LegacyRenderSVGResourceGradient::LegacyRenderSVGResourceGradient(Type type, SVGG
 {
 }
 
+LegacyRenderSVGResourceGradient::~LegacyRenderSVGResourceGradient() = default;
+
 void LegacyRenderSVGResourceGradient::removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers)
 {
     m_gradientMap.clear();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
@@ -58,7 +58,10 @@ struct GradientData {
 
 class LegacyRenderSVGResourceGradient : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGResourceGradient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourceGradient);
 public:
+    virtual ~LegacyRenderSVGResourceGradient();
+
     SVGGradientElement& gradientElement() const { return static_cast<SVGGradientElement&>(LegacyRenderSVGResourceContainer::element()); }
 
     void removeAllClientsFromCacheIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) final;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.h
@@ -29,6 +29,7 @@ class SVGLinearGradientElement;
 
 class LegacyRenderSVGResourceLinearGradient final : public LegacyRenderSVGResourceGradient {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGResourceLinearGradient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourceLinearGradient);
 public:
     LegacyRenderSVGResourceLinearGradient(SVGLinearGradientElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGResourceLinearGradient();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
@@ -29,6 +29,7 @@ class SVGMarkerElement;
 
 class LegacyRenderSVGResourceMarker final : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGResourceMarker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourceMarker);
 public:
     LegacyRenderSVGResourceMarker(SVGMarkerElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGResourceMarker();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
@@ -39,6 +39,7 @@ struct MaskerData {
 
 class LegacyRenderSVGResourceMasker final : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGResourceMasker);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourceMasker);
 public:
     LegacyRenderSVGResourceMasker(SVGMaskElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGResourceMasker();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
@@ -43,6 +43,8 @@ LegacyRenderSVGResourcePattern::LegacyRenderSVGResourcePattern(SVGPatternElement
 {
 }
 
+LegacyRenderSVGResourcePattern::~LegacyRenderSVGResourcePattern() = default;
+
 SVGPatternElement& LegacyRenderSVGResourcePattern::patternElement() const
 {
     return downcast<SVGPatternElement>(LegacyRenderSVGResourceContainer::element());

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
@@ -41,8 +41,11 @@ public:
 
 class LegacyRenderSVGResourcePattern final : public LegacyRenderSVGResourceContainer {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGResourcePattern);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourcePattern);
 public:
     LegacyRenderSVGResourcePattern(SVGPatternElement&, RenderStyle&&);
+    virtual ~LegacyRenderSVGResourcePattern();
+
     SVGPatternElement& patternElement() const;
     Ref<SVGPatternElement> protectedPatternElement() const;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h
@@ -29,6 +29,7 @@ class SVGRadialGradientElement;
 
 class LegacyRenderSVGResourceRadialGradient final : public LegacyRenderSVGResourceGradient {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGResourceRadialGradient);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourceRadialGradient);
 public:
     LegacyRenderSVGResourceRadialGradient(SVGRadialGradientElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGResourceRadialGradient();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -35,6 +35,7 @@ class SVGSVGElement;
 
 class LegacyRenderSVGRoot final : public RenderReplaced {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGRoot);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGRoot);
 public:
     LegacyRenderSVGRoot(SVGSVGElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGRoot();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
@@ -40,6 +40,7 @@ class SVGGraphicsElement;
 
 class LegacyRenderSVGShape : public LegacyRenderSVGModelObject {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGShape);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGShape);
 public:
     friend FloatRect SVGRenderSupport::calculateApproximateStrokeBoundingBox(const RenderElement&);
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
@@ -42,6 +42,8 @@ LegacyRenderSVGTransformableContainer::LegacyRenderSVGTransformableContainer(SVG
     ASSERT(isLegacyRenderSVGTransformableContainer());
 }
 
+LegacyRenderSVGTransformableContainer::~LegacyRenderSVGTransformableContainer() = default;
+
 bool LegacyRenderSVGTransformableContainer::calculateLocalTransform()
 {
     Ref element = graphicsElement();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
@@ -28,8 +28,10 @@ class SVGGraphicsElement;
 
 class LegacyRenderSVGTransformableContainer final : public LegacyRenderSVGContainer {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGTransformableContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGTransformableContainer);
 public:
     LegacyRenderSVGTransformableContainer(SVGGraphicsElement&, RenderStyle&&);
+    virtual ~LegacyRenderSVGTransformableContainer();
 
     const AffineTransform& localToParentTransform() const override { return m_localTransform; }
     void setNeedsTransformUpdate() override { m_needsTransformUpdate = true; }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.cpp
@@ -42,6 +42,8 @@ LegacyRenderSVGViewportContainer::LegacyRenderSVGViewportContainer(SVGSVGElement
     ASSERT(isLegacyRenderSVGViewportContainer());
 }
 
+LegacyRenderSVGViewportContainer::~LegacyRenderSVGViewportContainer() = default;
+
 SVGSVGElement& LegacyRenderSVGViewportContainer::svgSVGElement() const
 {
     return downcast<SVGSVGElement>(LegacyRenderSVGContainer::element());

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h
@@ -30,8 +30,10 @@ namespace WebCore {
 // thus we inherit from LegacyRenderSVGContainer instead of LegacyRenderSVGTransformableContainer
 class LegacyRenderSVGViewportContainer final : public LegacyRenderSVGContainer {
     WTF_MAKE_ISO_ALLOCATED(LegacyRenderSVGViewportContainer);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGViewportContainer);
 public:
     LegacyRenderSVGViewportContainer(SVGSVGElement&, RenderStyle&&);
+    virtual ~LegacyRenderSVGViewportContainer();
 
     SVGSVGElement& svgSVGElement() const;
 

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -67,8 +67,9 @@ class CustomPropertyRegistry;
 class Resolver;
 class RuleSet;
 
-class Scope : public CanMakeWeakPtr<Scope>, public CanMakeCheckedPtr<Scope> {
+class Scope final : public CanMakeWeakPtr<Scope>, public CanMakeCheckedPtr<Scope> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Scope);
 public:
     explicit Scope(Document&);
     explicit Scope(ShadowRoot&);

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -54,8 +54,9 @@ struct TextUpdate {
     std::optional<std::unique_ptr<RenderStyle>> inheritedDisplayContentsStyle;
 };
 
-class Update : public CanMakeCheckedPtr<Update> {
+class Update final : public CanMakeCheckedPtr<Update> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Update);
 public:
     Update(Document&);
     ~Update();

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -38,8 +38,10 @@ class SVGSVGElement;
 class SVGUseElement;
 class WeakPtrImplWithEventTargetData;
 
-class SVGDocumentExtensions : public CanMakeCheckedPtr<SVGDocumentExtensions> {
-    WTF_MAKE_NONCOPYABLE(SVGDocumentExtensions); WTF_MAKE_FAST_ALLOCATED;
+class SVGDocumentExtensions final : public CanMakeCheckedPtr<SVGDocumentExtensions> {
+    WTF_MAKE_NONCOPYABLE(SVGDocumentExtensions);
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGDocumentExtensions);
 public:
     explicit SVGDocumentExtensions(Document&);
     ~SVGDocumentExtensions();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -181,14 +181,20 @@ template<typename IDLType> class DOMPromiseDeferred;
 
 struct MockWebAuthenticationConfiguration;
 
-class Internals final : public RefCounted<Internals>, private ContextDestructionObserver
+class Internals final
+    : public RefCounted<Internals>
+    , private ContextDestructionObserver
 #if ENABLE(MEDIA_STREAM)
+    , public CanMakeCheckedPtr<Internals>
     , public RealtimeMediaSource::Observer
     , private RealtimeMediaSource::AudioSampleObserver
     , private RealtimeMediaSource::VideoFrameObserver
-    , public CanMakeCheckedPtr<Internals>
 #endif
     {
+    WTF_MAKE_FAST_ALLOCATED;
+#if ENABLE(MEDIA_STREAM)
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Internals);
+#endif
 public:
     static Ref<Internals> create(Document&);
     virtual ~Internals();
@@ -1467,6 +1473,7 @@ private:
 #if ENABLE(MEDIA_STREAM)
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG
@@ -1475,7 +1482,7 @@ private:
     void moveCheckedPtr(const void* source, const void* destination) const final { CanMakeCheckedPtr::moveCheckedPtr(source, destination); }
     void unregisterCheckedPtr(const void* pointer) const final { CanMakeCheckedPtr::unregisterCheckedPtr(pointer); }
 #endif // CHECKED_POINTER_DEBUG
-#endif
+#endif // ENABLE(MEDIA_STREAM)
 
     Document* contextDocument() const;
     LocalFrame* frame() const;

--- a/Source/WebCore/workers/WorkerFontLoadRequest.h
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.h
@@ -41,8 +41,9 @@ class WorkerGlobalScope;
 
 struct FontCustomPlatformData;
 
-class WorkerFontLoadRequest : public FontLoadRequest, public ThreadableLoaderClient {
+class WorkerFontLoadRequest final : public FontLoadRequest, public ThreadableLoaderClient {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerFontLoadRequest);
 public:
     WorkerFontLoadRequest(URL&&, LoadedFromOpaqueSource);
     ~WorkerFontLoadRequest() = default;

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.h
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.h
@@ -53,9 +53,10 @@ class WorkerConsoleClient;
 class WorkerOrWorkletGlobalScope;
 class WorkerScriptFetcher;
 
-class WorkerOrWorkletScriptController : public CanMakeCheckedPtr<WorkerOrWorkletScriptController> {
+class WorkerOrWorkletScriptController final : public CanMakeCheckedPtr<WorkerOrWorkletScriptController> {
     WTF_MAKE_NONCOPYABLE(WorkerOrWorkletScriptController);
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerOrWorkletScriptController);
 public:
     WorkerOrWorkletScriptController(WorkerThreadType, Ref<JSC::VM>&&, WorkerOrWorkletGlobalScope*);
     ~WorkerOrWorkletScriptController();

--- a/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/Source/WebCore/workers/WorkerScriptLoader.h
@@ -55,8 +55,9 @@ struct ServiceWorkerRegistrationData;
 struct WorkerFetchResult;
 enum class CertificateInfoPolicy : uint8_t;
 
-class WorkerScriptLoader : public RefCounted<WorkerScriptLoader>, public ThreadableLoaderClient {
+class WorkerScriptLoader final : public RefCounted<WorkerScriptLoader>, public ThreadableLoaderClient {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WorkerScriptLoader);
 public:
     static Ref<WorkerScriptLoader> create()
     {

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -85,6 +85,7 @@ class SWServer : public RefCounted<SWServer>, public CanMakeWeakPtr<SWServer> {
 public:
     class Connection : public CanMakeWeakPtr<Connection>, public CanMakeCheckedPtr<Connection> {
         WTF_MAKE_FAST_ALLOCATED;
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Connection);
         friend class SWServer;
     public:
         WEBCORE_EXPORT virtual ~Connection();

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.h
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.h
@@ -38,8 +38,9 @@ class SWServerWorker;
 class ServiceWorkerJob;
 struct WorkerFetchResult;
 
-class SWServerJobQueue : public CanMakeCheckedPtr<SWServerJobQueue> {
+class SWServerJobQueue final : public CanMakeCheckedPtr<SWServerJobQueue> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SWServerJobQueue);
 public:
     explicit SWServerJobQueue(SWServer&, const ServiceWorkerRegistrationKey&);
     SWServerJobQueue(const SWServerRegistration&) = delete;

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -53,6 +53,7 @@ enum class WorkerThreadMode : bool;
 
 class SWServerToContextConnection: public CanMakeWeakPtr<SWServerToContextConnection>, public CanMakeCheckedPtr<SWServerToContextConnection>, public Identified<SWServerToContextConnectionIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SWServerToContextConnection);
 public:
     WEBCORE_EXPORT virtual ~SWServerToContextConnection();
 

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -56,6 +56,7 @@ struct OwnedString;
 
 class XMLHttpRequest final : public ActiveDOMObject, public RefCounted<XMLHttpRequest>, private ThreadableLoaderClient, public XMLHttpRequestEventTarget {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(XMLHttpRequest, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(XMLHttpRequest);
 public:
     static Ref<XMLHttpRequest> create(ScriptExecutionContext&);
     WEBCORE_EXPORT ~XMLHttpRequest();

--- a/Source/WebCore/xml/parser/XMLDocumentParser.h
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.h
@@ -63,6 +63,7 @@ private:
 
 class XMLDocumentParser final : public ScriptableDocumentParser, public PendingScriptClient, public CanMakeCheckedPtr<XMLDocumentParser> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(XMLDocumentParser);
 public:
     static Ref<XMLDocumentParser> create(Document& document, LocalFrameView* view, OptionSet<ParserContentPolicy> policy = DefaultParserContentPolicy)
     {
@@ -94,6 +95,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadManager.h
@@ -71,6 +71,7 @@ public:
 
         // CheckedPtr interface
         virtual uint32_t ptrCount() const = 0;
+        virtual uint32_t ptrCountWithoutThreadCheck() const = 0;
         virtual void incrementPtrCount() const = 0;
         virtual void decrementPtrCount() const = 0;
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -131,10 +131,11 @@ class Cache;
 enum class CacheOption : uint8_t;
 }
 
-class NetworkProcess : public AuxiliaryProcess, private DownloadManager::Client, public ThreadSafeRefCounted<NetworkProcess>, public CanMakeCheckedPtr<NetworkProcess>
+class NetworkProcess final : public AuxiliaryProcess, private DownloadManager::Client, public ThreadSafeRefCounted<NetworkProcess>, public CanMakeCheckedPtr<NetworkProcess>
 {
     WTF_MAKE_NONCOPYABLE(NetworkProcess);
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkProcess);
 public:
     using RegistrableDomain = WebCore::RegistrableDomain;
     using TopFrameDomain = WebCore::RegistrableDomain;
@@ -426,6 +427,7 @@ public:
 private:
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -103,6 +103,7 @@ class Cache;
 
 class NetworkSession : public WebCore::SWServerDelegate, public CanMakeCheckedPtr<NetworkSession> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkSession);
 public:
     static std::unique_ptr<NetworkSession> create(NetworkProcess&, const NetworkSessionCreationParameters&);
     virtual ~NetworkSession();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.h
@@ -46,6 +46,7 @@ class NetworkSession;
 
 class ServiceWorkerNavigationPreloader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerNavigationPreloader>, public CanMakeCheckedPtr<ServiceWorkerNavigationPreloader> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ServiceWorkerNavigationPreloader);
 public:
     ServiceWorkerNavigationPreloader(NetworkSession&, NetworkLoadParameters&&, const WebCore::NavigationPreloadState&, bool shouldCaptureExtraNetworkLoadMetrics);
     ~ServiceWorkerNavigationPreloader();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.h
@@ -48,6 +48,7 @@ class NetworkSession;
 
 class ServiceWorkerSoftUpdateLoader final : public NetworkLoadClient, public CanMakeWeakPtr<ServiceWorkerSoftUpdateLoader>, public CanMakeCheckedPtr<ServiceWorkerSoftUpdateLoader> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ServiceWorkerSoftUpdateLoader);
 public:
     using Handler = CompletionHandler<void(WebCore::WorkerFetchResult&&)>;
     ServiceWorkerSoftUpdateLoader(NetworkSession&, WebCore::ServiceWorkerJobData&&, bool shouldRefreshCache, WebCore::ResourceRequest&&, Handler&&);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.h
@@ -67,6 +67,8 @@ class NetworkResourceLoader;
 class ServiceWorkerFetchTask;
 
 class WebSWServerConnection final : public WebCore::SWServer::Connection, public IPC::MessageSender, public IPC::MessageReceiver {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebSWServerConnection);
 public:
     WebSWServerConnection(NetworkConnectionToWebProcess&, WebCore::SWServer&, IPC::Connection&, WebCore::ProcessIdentifier);
     WebSWServerConnection(const WebSWServerConnection&) = delete;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -57,6 +57,8 @@ class ServiceWorkerDownloadTask;
 class WebSWServerConnection;
 
 class WebSWServerToContextConnection final: public WebCore::SWServerToContextConnection, public IPC::MessageSender, public IPC::MessageReceiver {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebSWServerToContextConnection);
 public:
     using WebCore::SWServerToContextConnection::weakPtrFactory;
     using WebCore::SWServerToContextConnection::WeakValueType;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -99,6 +99,8 @@ private:
 };
 
 class NetworkSessionCocoa final : public NetworkSession {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkSessionCocoa);
 public:
     static std::unique_ptr<NetworkSession> create(NetworkProcess&, const NetworkSessionCreationParameters&);
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -92,6 +92,7 @@ class StorageAreaRegistry;
 
 class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver, public CanMakeCheckedPtr<NetworkStorageManager> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkStorageManager);
 public:
     static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled);
     static bool canHandleTypes(OptionSet<WebsiteDataType>);

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
@@ -38,6 +38,7 @@ namespace WebKit {
 using namespace WebCore;
 
 class PlaybackSessionInterfaceLMK final : public PlaybackSessionInterfaceIOS {
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceLMK);
 public:
     static Ref<PlaybackSessionInterfaceLMK> create(PlaybackSessionModel&);
     ~PlaybackSessionInterfaceLMK();

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -40,7 +40,9 @@ namespace WebKit {
 
 using namespace WebCore;
 
-class VideoPresentationInterfaceLMK : public VideoPresentationInterfaceIOS {
+class VideoPresentationInterfaceLMK final : public VideoPresentationInterfaceIOS {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VideoPresentationInterfaceLMK);
 public:
     static Ref<VideoPresentationInterfaceLMK> create(PlaybackSessionInterfaceIOS&);
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
@@ -54,6 +54,7 @@ namespace WebKit {
 
 class _WKRemoteWebInspectorUIProxyClient final : public RemoteWebInspectorUIProxyClient {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(_WKRemoteWebInspectorUIProxyClient);
 public:
     _WKRemoteWebInspectorUIProxyClient(_WKRemoteWebInspectorViewController *controller)
         : m_controller(controller)

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -68,7 +68,8 @@ class AuxiliaryProcessProxy
     , public IPC::Connection::Client
     , public CanMakeThreadSafeCheckedPtr<AuxiliaryProcessProxy> {
     WTF_MAKE_NONCOPYABLE(AuxiliaryProcessProxy);
-
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AuxiliaryProcessProxy);
 protected:
     AuxiliaryProcessProxy(ShouldTakeUIBackgroundAssertion, AlwaysRunsAtBackgroundPriority = AlwaysRunsAtBackgroundPriority::No, Seconds responsivenessTimeout = ResponsivenessTimer::defaultResponsivenessTimeout);
 

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -55,12 +55,13 @@
 namespace WebKit {
 using namespace WebCore;
 
-class UserMediaCaptureManagerProxy::SourceProxy
+class UserMediaCaptureManagerProxy::SourceProxy final
     : public RealtimeMediaSource::Observer
     , private RealtimeMediaSource::AudioSampleObserver
     , private RealtimeMediaSource::VideoFrameObserver
     , public CanMakeCheckedPtr<UserMediaCaptureManagerProxy::SourceProxy> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SourceProxy);
 public:
     SourceProxy(RealtimeMediaSourceIdentifier id, Ref<IPC::Connection>&& connection, ProcessIdentity&& resourceOwner, Ref<RealtimeMediaSource>&& source, RefPtr<RemoteVideoFrameObjectHeap>&& videoFrameObjectHeap)
         : m_id(id)
@@ -277,6 +278,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebKit/UIProcess/DisplayLink.h
+++ b/Source/WebKit/UIProcess/DisplayLink.h
@@ -51,6 +51,7 @@ class DisplayLink {
 public:
     class Client : public CanMakeThreadSafeCheckedPtr<Client> {
         WTF_MAKE_FAST_ALLOCATED;
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Client);
     friend class DisplayLink;
     public:
         virtual ~Client() = default;

--- a/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h
+++ b/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h
@@ -38,6 +38,7 @@ class WebProcessProxy;
 class DisplayLinkProcessProxyClient final : public DisplayLink::Client {
 public:
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DisplayLinkProcessProxyClient);
 public:
     DisplayLinkProcessProxyClient() = default;
     ~DisplayLinkProcessProxyClient() = default;

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -69,6 +69,7 @@ struct GPUProcessPreferencesForWebProcess;
 class GPUProcessProxy final : public AuxiliaryProcessProxy {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_MAKE_NONCOPYABLE(GPUProcessProxy);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(GPUProcessProxy);
     friend LazyNeverDestroyed<GPUProcessProxy>;
 public:
     static void keepProcessAliveTemporarily();

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -67,6 +67,7 @@ class WebInspectorUIExtensionControllerProxy;
 
 class RemoteWebInspectorUIProxyClient : public CanMakeWeakPtr<RemoteWebInspectorUIProxyClient>, public CanMakeCheckedPtr<RemoteWebInspectorUIProxyClient> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteWebInspectorUIProxyClient);
 public:
     virtual ~RemoteWebInspectorUIProxyClient() { }
     virtual void sendMessageToBackend(const String& message) = 0;

--- a/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/glib/RemoteInspectorClient.cpp
@@ -42,7 +42,8 @@
 namespace WebKit {
 
 class RemoteInspectorProxy final : public RemoteWebInspectorUIProxyClient {
-    WTF_MAKE_FAST_ALLOCATED();
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteInspectorProxy);
 public:
     RemoteInspectorProxy(RemoteInspectorClient& inspectorClient, uint64_t connectionID, uint64_t targetID)
         : m_inspectorClient(inspectorClient)

--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorClient.cpp
@@ -38,7 +38,8 @@
 namespace WebKit {
 
 class RemoteInspectorProxy final : public RemoteWebInspectorUIProxyClient {
-    WTF_MAKE_FAST_ALLOCATED();
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteInspectorProxy);
 public:
     RemoteInspectorProxy(RemoteInspectorClient& inspectorClient, ConnectionID connectionID, TargetID targetID, Inspector::DebuggableType debuggableType)
         : m_proxy(RemoteWebInspectorUIProxy::create())

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -110,6 +110,7 @@ struct WebsiteDataStoreParameters;
 
 class NetworkProcessProxy final : public AuxiliaryProcessProxy {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(NetworkProcessProxy);
 public:
     using RegistrableDomain = WebCore::RegistrableDomain;
     using TopFrameDomain = WebCore::RegistrableDomain;

--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -47,8 +47,9 @@ static constexpr Seconds processSuspensionTimeout { 20_s };
 static constexpr Seconds removeAllAssertionsTimeout { 8_min };
 static constexpr Seconds processAssertionCacheLifetime { 1_s };
 
-class ProcessThrottler::ProcessAssertionCache : public CanMakeCheckedPtr<ProcessThrottler::ProcessAssertionCache> {
+class ProcessThrottler::ProcessAssertionCache final : public CanMakeCheckedPtr<ProcessThrottler::ProcessAssertionCache> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ProcessAssertionCache);
 public:
     void add(Ref<ProcessAssertion>&& assertion)
     {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -56,6 +56,7 @@ static NSString * const transientZoomScrollPositionOverrideAnimationKey = @"wkSc
 class RemoteLayerTreeDisplayLinkClient final : public DisplayLink::Client {
 public:
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeDisplayLinkClient);
 public:
     explicit RemoteLayerTreeDisplayLinkClient(WebPageProxyIdentifier pageID)
         : m_pageIdentifier(pageID)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -50,6 +50,7 @@ using namespace WebCore;
 class RemoteLayerTreeEventDispatcherDisplayLinkClient final : public DisplayLink::Client {
 public:
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RemoteLayerTreeEventDispatcherDisplayLinkClient);
 public:
     explicit RemoteLayerTreeEventDispatcherDisplayLinkClient(RemoteLayerTreeEventDispatcher& eventDispatcher)
         : m_eventDispatcher(&eventDispatcher)

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -55,6 +55,7 @@ enum class ShouldDelayClosingUntilFirstLayerFlush : bool { No, Yes };
 
 class SuspendedPageProxy final: public IPC::MessageReceiver, public CanMakeCheckedPtr<SuspendedPageProxy> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SuspendedPageProxy);
 public:
     SuspendedPageProxy(WebPageProxy&, Ref<WebProcessProxy>&&, Ref<WebFrameProxy>&& mainFrame, Ref<BrowsingContextGroup>&&, ShouldDelayClosingUntilFirstLayerFlush);
     ~SuspendedPageProxy();

--- a/Source/WebKit/UIProcess/WebBackForwardCache.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.h
@@ -40,8 +40,9 @@ class WebPageProxy;
 class WebProcessPool;
 class WebProcessProxy;
 
-class WebBackForwardCache : public CanMakeCheckedPtr<WebBackForwardCache> {
+class WebBackForwardCache final : public CanMakeCheckedPtr<WebBackForwardCache> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebBackForwardCache);
 public:
     explicit WebBackForwardCache(WebProcessPool&);
     ~WebBackForwardCache();

--- a/Source/WebKit/UIProcess/WebProcessCache.h
+++ b/Source/WebKit/UIProcess/WebProcessCache.h
@@ -40,8 +40,9 @@ class ProcessThrottlerActivity;
 class WebProcessPool;
 class WebsiteDataStore;
 
-class WebProcessCache : public CanMakeCheckedPtr<WebProcessCache> {
+class WebProcessCache final : public CanMakeCheckedPtr<WebProcessCache> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebProcessCache);
 public:
     explicit WebProcessCache(WebProcessPool&);
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -147,6 +147,8 @@ using WebProcessWithMediaStreamingToken = WebProcessWithMediaStreamingCounter::T
 enum class CheckBackForwardList : bool { No, Yes };
 
 class WebProcessProxy : public AuxiliaryProcessProxy {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebProcessProxy);
 public:
     using WebPageProxyMap = HashMap<WebPageProxyIdentifier, WeakRef<WebPageProxy>>;
     using UserInitiatedActionByAuthorizationTokenMap = HashMap<WTF::UUID, RefPtr<API::UserInitiatedAction>>;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -63,8 +63,9 @@ static const Seconds bannerMinimumHideDelay = 1_s;
 
 @class WKFullscreenStackView;
 
-class WKFullScreenViewControllerPlaybackSessionModelClient : WebCore::PlaybackSessionModelClient, public CanMakeCheckedPtr<WKFullScreenViewControllerPlaybackSessionModelClient> {
+class WKFullScreenViewControllerPlaybackSessionModelClient final : WebCore::PlaybackSessionModelClient, public CanMakeCheckedPtr<WKFullScreenViewControllerPlaybackSessionModelClient> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WKFullScreenViewControllerPlaybackSessionModelClient);
 public:
     void setParent(WKFullScreenViewController *parent) { m_parent = parent; }
 
@@ -99,6 +100,7 @@ public:
 private:
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -184,9 +184,10 @@ typedef id <NSValidatedUserInterfaceItem> ValidationItem;
 typedef Vector<RetainPtr<ValidationItem>> ValidationVector;
 typedef HashMap<String, ValidationVector> ValidationMap;
 
-class WebViewImpl : public CanMakeWeakPtr<WebViewImpl>, public CanMakeCheckedPtr<WebViewImpl> {
-    WTF_MAKE_FAST_ALLOCATED;
+class WebViewImpl final : public CanMakeWeakPtr<WebViewImpl>, public CanMakeCheckedPtr<WebViewImpl> {
     WTF_MAKE_NONCOPYABLE(WebViewImpl);
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebViewImpl);
 public:
     WebViewImpl(NSView <WebViewImplDelegate> *, WKWebView *outerWebView, WebProcessPool&, Ref<API::PageConfiguration>&&);
 

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
@@ -37,14 +37,21 @@ namespace WebKit {
 
 class WebView;
 
-class WebPopupMenuProxyWin : public WebPopupMenuProxy, private WebCore::ScrollableArea {
+class WebPopupMenuProxyWin final : public CanMakeCheckedPtr<WebPopupMenuProxyWin>, public WebPopupMenuProxy, private WebCore::ScrollableArea {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebPopupMenuProxyWin);
 public:
     static Ref<WebPopupMenuProxyWin> create(WebView* webView, WebPopupMenuProxy::Client& client)
     {
         return adoptRef(*new WebPopupMenuProxyWin(webView, client));
     }
     ~WebPopupMenuProxyWin();
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     void showPopupMenu(const WebCore::IntRect&, WebCore::TextDirection, double pageScaleFactor, const Vector<WebPopupItem>&, const PlatformPopupMenuData&, int32_t selectedIndex) override;
     void hidePopupMenu() override;

--- a/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/MediaRecorderPrivate.h
@@ -54,6 +54,7 @@ class MediaRecorderPrivate final
     , public CanMakeWeakPtr<MediaRecorderPrivate>
     , private Identified<MediaRecorderIdentifier> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MediaRecorderPrivate);
 public:
     MediaRecorderPrivate(WebCore::MediaStreamPrivate&, const WebCore::MediaRecorderPrivateOptions&);
     ~MediaRecorderPrivate();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -77,12 +77,14 @@ class WebWheelEvent;
 struct WebHitTestResultData;
 
 class PDFPlugin final : public PDFPluginBase {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PDFPlugin);
 public:
     static bool pdfKitLayerControllerIsAvailable();
 
     static Ref<PDFPlugin> create(WebCore::HTMLPlugInElement&);
-    virtual ~PDFPlugin() = default;
 
+    virtual ~PDFPlugin();
 
     void paintControlForLayerInContext(CALayer *, CGContextRef);
     void setActiveAnnotation(RetainPtr<PDFAnnotation>&&) final;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -562,6 +562,8 @@ PDFPlugin::PDFPlugin(HTMLPlugInElement& element)
         [getPDFLayerControllerClass() setUseIOSurfaceForTiles:false];
 }
 
+PDFPlugin::~PDFPlugin() = default;
+
 void PDFPlugin::updateScrollbars()
 {
     PDFPluginBase::updateScrollbars();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -87,9 +87,10 @@ using ByteRangeRequestIdentifier = ObjectIdentifier<ByteRangeRequestIdentifierTy
 
 enum class CheckValidRanges : bool { No, Yes };
 
-class PDFPluginBase : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PDFPluginBase>, public WebCore::ScrollableArea, public PDFScriptEvaluator::Client, public Identified<PDFPluginIdentifier> {
-    WTF_MAKE_FAST_ALLOCATED;
+class PDFPluginBase : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PDFPluginBase>, public CanMakeThreadSafeCheckedPtr<PDFPluginBase>, public WebCore::ScrollableArea, public PDFScriptEvaluator::Client, public Identified<PDFPluginIdentifier> {
     WTF_MAKE_NONCOPYABLE(PDFPluginBase);
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PDFPluginBase);
     friend class PDFIncrementalLoader;
     friend class PDFPluginChoiceAnnotation;
     friend class PDFPluginTextAnnotation;
@@ -97,6 +98,12 @@ public:
     static WebCore::PluginInfo pluginInfo();
 
     virtual ~PDFPluginBase();
+
+    // CheckedPtr interface
+    uint32_t ptrCount() const final { return CanMakeThreadSafeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const final { CanMakeThreadSafeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeThreadSafeCheckedPtr::decrementPtrCount(); }
 
     using WebKit::PDFScriptEvaluator::Client::weakPtrFactory;
     using WebKit::PDFScriptEvaluator::Client::WeakValueType;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -95,9 +95,13 @@ enum class AnnotationSearchDirection : bool {
 };
 
 class UnifiedPDFPlugin final : public PDFPluginBase, public WebCore::GraphicsLayerClient {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(UnifiedPDFPlugin);
+
     friend class AsyncPDFRenderer;
 public:
     static Ref<UnifiedPDFPlugin> create(WebCore::HTMLPlugInElement&);
+    virtual ~UnifiedPDFPlugin();
 
     enum class PDFElementType : uint16_t {
         Page       = 1 << 0,

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -165,6 +165,8 @@ UnifiedPDFPlugin::UnifiedPDFPlugin(HTMLPlugInElement& element)
 #endif
 }
 
+UnifiedPDFPlugin::~UnifiedPDFPlugin() = default;
+
 static String mutationObserverNotificationString()
 {
     static NeverDestroyed<String> notificationString = "PDFFormDidChangeValue"_s;

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -54,12 +54,13 @@ namespace WebKit {
 
 using namespace WebCore;
 
-class SpeechRecognitionRealtimeMediaSourceManager::Source
+class SpeechRecognitionRealtimeMediaSourceManager::Source final
     : private RealtimeMediaSource::Observer
     , private RealtimeMediaSource::AudioSampleObserver
     , public CanMakeCheckedPtr<SpeechRecognitionRealtimeMediaSourceManager::Source>
 {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Source);
 public:
     Source(RealtimeMediaSourceIdentifier identifier, Ref<RealtimeMediaSource>&& source, Ref<IPC::Connection>&& connection)
         : m_identifier(identifier)
@@ -89,6 +90,7 @@ public:
 private:
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebAlternativeTextClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebAlternativeTextClient.h
@@ -33,6 +33,7 @@ class WebPage;
 
 class WebAlternativeTextClient final : public WebCore::AlternativeTextClient {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebAlternativeTextClient);
 public:
     explicit WebAlternativeTextClient(WebPage*);
     virtual ~WebAlternativeTextClient();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.h
@@ -33,6 +33,8 @@ namespace WebKit {
 class WebPage;
 
 class WebDiagnosticLoggingClient : public WebCore::DiagnosticLoggingClient {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebDiagnosticLoggingClient);
 public:
     WebDiagnosticLoggingClient(WebPage&);
     virtual ~WebDiagnosticLoggingClient();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.h
@@ -44,6 +44,7 @@ class WebPage;
 
 class WebEditorClient final : public WebCore::EditorClient, public WebCore::TextCheckerClient {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebEditorClient);
 public:
     WebEditorClient(WebPage* page)
         : m_page(page)

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -39,6 +39,7 @@ using namespace WebCore;
 
 class WCTiledBacking final : public TiledBacking {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WCTiledBacking);
 public:
     WCTiledBacking(GraphicsLayerWC& owner)
         : m_owner(owner) { }

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -60,6 +60,8 @@ class PlaybackSessionInterfaceContext final
     : public RefCounted<PlaybackSessionInterfaceContext>
     , public WebCore::PlaybackSessionModelClient
     , public CanMakeCheckedPtr<PlaybackSessionInterfaceContext> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionInterfaceContext);
 public:
     static Ref<PlaybackSessionInterfaceContext> create(PlaybackSessionManager& manager, PlaybackSessionContextIdentifier contextId)
     {
@@ -74,6 +76,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -67,10 +67,12 @@ class PlaybackSessionInterfaceContext;
 class PlaybackSessionManager;
 class VideoPresentationManager;
 
-class VideoPresentationInterfaceContext
+class VideoPresentationInterfaceContext final
     : public RefCounted<VideoPresentationInterfaceContext>
     , public WebCore::VideoPresentationModelClient
     , public CanMakeCheckedPtr<VideoPresentationInterfaceContext> {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(VideoPresentationInterfaceContext);
 public:
     static Ref<VideoPresentationInterfaceContext> create(VideoPresentationManager& manager, PlaybackSessionContextIdentifier contextId)
     {
@@ -106,6 +108,7 @@ private:
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 #if CHECKED_POINTER_DEBUG

--- a/Source/WebKitLegacy/Storage/StorageThread.h
+++ b/Source/WebKitLegacy/Storage/StorageThread.h
@@ -37,8 +37,10 @@ namespace WebCore {
 class StorageAreaSync;
 class StorageTask;
 
-class StorageThread : public CanMakeCheckedPtr<StorageThread> {
-    WTF_MAKE_NONCOPYABLE(StorageThread); WTF_MAKE_FAST_ALLOCATED;
+class StorageThread final : public CanMakeCheckedPtr<StorageThread> {
+    WTF_MAKE_NONCOPYABLE(StorageThread);
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(StorageThread);
 public:
     enum class Type { LocalStorage, IndexedDB };
     StorageThread(Type = Type::LocalStorage);

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
@@ -83,8 +83,10 @@ private:
     bool isSuspendingPendingRequests() const { return !!m_suspendPendingRequestsCount; }
     void isResourceLoadFinished(WebCore::CachedResource&, CompletionHandler<void(bool)>&&) final;
 
-    class HostInformation : public CanMakeWeakPtr<HostInformation>, public CanMakeCheckedPtr<HostInformation> {
-        WTF_MAKE_NONCOPYABLE(HostInformation); WTF_MAKE_FAST_ALLOCATED;
+    class HostInformation final : public CanMakeWeakPtr<HostInformation>, public CanMakeCheckedPtr<HostInformation> {
+        WTF_MAKE_NONCOPYABLE(HostInformation);
+        WTF_MAKE_FAST_ALLOCATED;
+        WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HostInformation);
     public:
         HostInformation(const String&, unsigned);
         ~HostInformation();

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.h
@@ -30,6 +30,7 @@
 
 class WebAlternativeTextClient : public WebCore::AlternativeTextClient {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebAlternativeTextClient);
 public:
     explicit WebAlternativeTextClient(WebView *);
     virtual ~WebAlternativeTextClient();

--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedPtr.cpp
@@ -38,11 +38,14 @@ namespace TestWebKitAPI {
 
 class CheckedObject : public CanMakeCheckedPtr<CheckedObject> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CheckedObject);
 public:
     int someFunction() const { return -7; }
 };
 
 class DerivedCheckedObject : public CheckedObject {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DerivedCheckedObject);
 };
 
 TEST(WTF_CheckedPtr, Basic)
@@ -350,8 +353,9 @@ TEST(WTF_CheckedPtr, ReferenceCountLimit)
     EXPECT_EQ(object.ptrCount(), count);
 }
 
-class ThreadSafeCheckedPtrObject : public CanMakeThreadSafeCheckedPtr<ThreadSafeCheckedPtrObject> {
+class ThreadSafeCheckedPtrObject final : public CanMakeThreadSafeCheckedPtr<ThreadSafeCheckedPtrObject> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ThreadSafeCheckedPtrObject);
 public:
     std::atomic<unsigned> value { 0 };
 };

--- a/Tools/TestWebKitAPI/Tests/WTF/CheckedRef.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/CheckedRef.cpp
@@ -38,6 +38,7 @@ namespace {
 class CheckedObject : public CanMakeCheckedPtr<CheckedObject> {
     WTF_MAKE_NONCOPYABLE(CheckedObject);
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(CheckedObject);
 public:
     CheckedObject(int value = -7)
         : m_value(value)
@@ -52,6 +53,8 @@ private:
 };
 
 class DerivedCheckedObject : public CheckedObject {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DerivedCheckedObject);
 public:
     DerivedCheckedObject(int value = -11)
         : CheckedObject(value)

--- a/Tools/TestWebKitAPI/Tests/WTF/Hasher.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Hasher.cpp
@@ -233,8 +233,9 @@ TEST(WTF, Hasher_RefPtr)
 
 namespace {
 
-struct CheckedObject : public CanMakeCheckedPtr<CheckedObject> {
+struct CheckedObject final : public CanMakeCheckedPtr<CheckedObject> {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
+    WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(CheckedObject);
     CheckedObject() = default;
 };
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/curl/CurlMultipartHandleTests.cpp
@@ -59,8 +59,9 @@ static CurlResponse createCurlResponse(std::optional<String> contentType = "mult
     return response;
 }
 
-class MultipartHandleClient : public CurlMultipartHandleClient, public CanMakeCheckedPtr<MultipartHandleClient> {
+class MultipartHandleClient final : public CurlMultipartHandleClient, public CanMakeCheckedPtr<MultipartHandleClient> {
     WTF_MAKE_FAST_ALLOCATED;
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MultipartHandleClient);
 public:
     void setMultipartHandle();
 
@@ -93,9 +94,10 @@ public:
 
 private:
     // CheckedPtr interface
-    uint32_t ptrCount() const final { return CanMakeCheckedPtr<MultipartHandleClient>::ptrCount(); }
-    void incrementPtrCount() const final { CanMakeCheckedPtr<MultipartHandleClient>::incrementPtrCount(); }
-    void decrementPtrCount() const final { CanMakeCheckedPtr<MultipartHandleClient>::decrementPtrCount(); }
+    uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
+    uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
+    void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
+    void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
 
     Vector<String> m_headers;
     Vector<uint8_t> m_data;


### PR DESCRIPTION
#### bf47ad4f9e351004a197f61b30dae13c11a03c37
<pre>
CheckedPtr should use zombie mode
<a href="https://github.com/WebKit/WebKit/pull/27212">https://github.com/WebKit/WebKit/pull/27212</a>

Reviewed by Ryosuke Niwa.

Previously a dangling CheckedPtr triggered a crash in the destructor of the
pointed-to object. That kind of crash was hard to debug, since the backtrace
didn&apos;t report any information about the pointer. As a result, we&apos;ve had to limit
CheckedPtr adoption.

Now a dangling CheckedPtr triggers a crash in the CheckedPtr&apos;s destructor,
so the backtrace points the finger at the dangling pointer. Now, we can use
CheckedPtr as much as we like.

Note: We explicitly check-and-crash in the CheckedPtr&apos;s destructor, but in
release builds we don&apos;t explicitly check-and-crash in the CheckedPtr&apos;s
accessor methods. This maintains CheckedPtr&apos;s feature of having nearly
identical performance to a raw pointer.

Even though we don&apos;t explicitly check-and-crash in the CheckedPtr&apos;s
accessor methods, all accesses are memory safe. The implementation
detects a dangling CheckedPtr, and then zeroes and leaks the pointed-to
object instead of freeing it. Therefore, any attempt to dereference a
pointer data member in the pointed-to object deterministically crashes
with a nullptr dereference.

This change requires putting a special macro in every subclass in a class
hierarchy that uses CheckedPtr, since we need to override operator delete
in order to leak the pointed-to object. (If you forget the macro entirely,
you&apos;ll get a compile-time failure. If you remember the macro in a base
class but forget it in a subclass, you&apos;ll get a debug assertion. This is
similar to how IsoHeaps work.)

When we check ptrCount() at destruction time, we use a new function,
SingleThreadIntegralWrapper::valueWithoutThreadCheck(). We use this
because checking happens after ~SingleThreadIntegralWrapper() runs, which
means that SingleThreadIntegralWrapper::m_thread is null. It&apos;s thread-safe
to stop doing thread checks after destruction; in theory no thread has any
outstanding reference anymore.

Canonical link: <a href="https://commits.webkit.org/277590@main">https://commits.webkit.org/277590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13fea38c5c06a2be40b3c9b10d89d52c425ce281

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48043 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44104 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24742 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/39278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24918 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20388 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22399 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6097 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41340 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52626 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47537 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19450 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45455 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10604 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25156 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55032 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24078 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11316 "Passed tests") | 
<!--EWS-Status-Bubble-End-->