### PR TITLE
[svg] WPT test `svg/path/property/test_style_flush_on_dom_api_with_d_property.html` has failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/test_style_flush_on_dom_api_with_d_property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/test_style_flush_on_dom_api_with_d_property-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL getTotalLength() with d property assert_equals: the total length expected 10 but got 0
-FAIL getPointAtLength() with d property assert_equals: x-axis position expected 10 but got 0
+PASS getTotalLength() with d property
+PASS getPointAtLength() with d property
 PASS isPointInFill() with d property
 PASS isPointInStroke() with d property
 

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -178,11 +178,15 @@ void SVGPathElement::removedFromAncestor(RemovalType removalType, ContainerNode&
 
 float SVGPathElement::getTotalLength() const
 {
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+
     return getTotalLengthOfSVGPathByteStream(pathByteStream());
 }
 
 ExceptionOr<Ref<SVGPoint>> SVGPathElement::getPointAtLength(float distance) const
 {
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+
     // Spec: Clamp distance to [0, length].
     distance = clampTo<float>(distance, 0, getTotalLength());
 
@@ -192,6 +196,8 @@ ExceptionOr<Ref<SVGPoint>> SVGPathElement::getPointAtLength(float distance) cons
 
 unsigned SVGPathElement::getPathSegAtLength(float length) const
 {
+    protectedDocument()->updateLayoutIgnorePendingStylesheets({ LayoutOptions::ContentVisibilityForceLayout }, this);
+
     return getSVGPathSegAtLengthFromSVGPathByteStream(pathByteStream(), length);
 }
 
@@ -218,6 +224,18 @@ RenderPtr<RenderElement> SVGPathElement::createElementRenderer(RenderStyle&& sty
     if (document().settings().layerBasedSVGEngineEnabled())
         return createRenderer<RenderSVGPath>(*this, WTFMove(style));
     return createRenderer<LegacyRenderSVGPath>(*this, WTFMove(style));
+}
+
+const SVGPathByteStream& SVGPathElement::pathByteStream() const
+{
+    if (auto* renderer = this->renderer()) {
+        if (auto* basicShapePath = renderer->style().d()) {
+            if (auto* pathData = basicShapePath->pathData())
+                return *pathData;
+        }
+    }
+
+    return m_pathSegList->currentPathByteStream();
 }
 
 Path SVGPathElement::path() const

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -96,7 +96,7 @@ public:
     Ref<SVGPathSegList>& pathSegList() { return m_pathSegList->baseVal(); }
     RefPtr<SVGPathSegList>& animatedPathSegList() { return m_pathSegList->animVal(); }
 
-    const SVGPathByteStream& pathByteStream() const { return m_pathSegList->currentPathByteStream(); }
+    const SVGPathByteStream& pathByteStream() const;
     Path path() const;
     size_t approximateMemoryCost() const final { return m_pathSegList->approximateMemoryCost(); }
 


### PR DESCRIPTION
#### 7356f4b2ed16787880fb34b55415f3ec6569f20f
<pre>
[svg] WPT test `svg/path/property/test_style_flush_on_dom_api_with_d_property.html` has failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=272621">https://bugs.webkit.org/show_bug.cgi?id=272621</a>

Reviewed by Nikolas Zimmermann.

Since path data can be set via style now, we must make sure that layout is updated when the various
`SVGGeometryElement` DOM methods are called for path-related computations, including `getTotalLength()`,
`getPointAtLength()` and the `SVGPathElement` method `getPathSegAtLength()`. This was already done
for the other `SVGGeometryElement` DOM APIs `isPointInFill()` and `isPointInStroke()`.

We also ensure that the `SVGPathByteStream` we use to run the necessary computations in those methods
is the one held on the `SVGRenderStyle` by making `SVGPathElement::pathByteStream()` account for it.

* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/test_style_flush_on_dom_api_with_d_property-expected.txt:
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::getTotalLength const):
(WebCore::SVGPathElement::getPointAtLength const):
(WebCore::SVGPathElement::getPathSegAtLength const):
(WebCore::SVGPathElement::pathByteStream const):
* Source/WebCore/svg/SVGPathElement.h:

Canonical link: <a href="https://commits.webkit.org/277455@main">https://commits.webkit.org/277455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaa5d5c2751fab6b6972f841c47e11c902e3c534

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50342 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24313 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24495 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41068 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21978 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42261 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5708 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/43998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52234 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46102 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23967 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45133 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24755 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6736 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23687 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->