### PR TITLE
[JSC] add support for `RegExp.escape`

### DIFF
--- a/JSTests/stress/regexp-escape.js
+++ b/JSTests/stress/regexp-escape.js
@@ -1,0 +1,33 @@
+//@ requireOptions("--useRegExpEscape=1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);
+}
+
+function notReached() {
+    throw new Error("should not reach here");
+}
+
+for (const x of [undefined, null, true, 42, [], {}]) {
+    try {
+        RegExp.escape(x);
+        notReached();
+    } catch (e) {
+        shouldBe(e instanceof TypeError, true);
+        shouldBe(e.message, "RegExp.escape requires a string");
+    }
+}
+
+shouldBe(RegExp.escape("test"), "\\x74est");
+shouldBe(RegExp.escape("1234"), "\\x31234");
+shouldBe(RegExp.escape("✅unicode✅"), "✅unicode✅");
+shouldBe(RegExp.escape("\t"), "\\t");
+shouldBe(RegExp.escape("\n"), "\\n");
+shouldBe(RegExp.escape("\v"), "\\v");
+shouldBe(RegExp.escape("\f"), "\\f");
+shouldBe(RegExp.escape("\r"), "\\r");
+shouldBe(RegExp.escape("^$\\.*+?()[]{}|/"), "\\^\\$\\\\\\.\\*\\+\\?\\(\\)\\[\\]\\{\\}\\|\\/");
+shouldBe(RegExp.escape(",-=<>#&!%:;@~'`\""), "\\x2c\\x2d\\x3d\\x3c\\x3e\\x23\\x26\\x21\\x25\\x3a\\x3b\\x40\\x7e\\x27\\x60\\x22");
+shouldBe(RegExp.escape(" \uFEFF\u2000\u3000"), "\\x20\\ufeff\\u2000\\u3000");
+shouldBe(RegExp.escape("\uD7FF_\uD800_\uD801_\uDFFE_\uDFFF_\uE000"), "\uD7FF_\\ud800_\\ud801_\\udffe_\\udfff_\uE000");

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -592,6 +592,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useIntlDurationFormat, true, Normal, "Expose the Intl DurationFormat.") \
     v(Bool, usePromiseWithResolversMethod, true, Normal, "Expose the Promise.withResolvers() method.") \
     v(Bool, usePromiseTryMethod, false, Normal, "Expose the Promise.try() method.") \
+    v(Bool, useRegExpEscape, false, Normal, "Expose RegExp.escape feature.") \
     v(Bool, useResizableArrayBuffer, true, Normal, "Expose ResizableArrayBuffer feature.") \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object.") \


### PR DESCRIPTION
#### 990058dd93878188d65e53e02eda4b64feb69c1d
<pre>
[JSC] add support for `RegExp.escape`
<a href="https://bugs.webkit.org/show_bug.cgi?id=272622">https://bugs.webkit.org/show_bug.cgi?id=272622</a>

Reviewed by Justin Michaud and Ross Kirsling.

This will help developers construct regular expressions that contain special characters without having to manually escape/replace them (e.g. URLs often contain a `.` so making a regular expression to match would require that all of them be replaced with `\.` instead).

Spec: &lt;<a href="https://tc39.es/proposal-regex-escaping/">https://tc39.es/proposal-regex-escaping/</a>&gt;
Proposal: &lt;<a href="https://github.com/tc39/proposal-regex-escaping">https://github.com/tc39/proposal-regex-escaping</a>&gt;

* Source/JavaScriptCore/runtime/RegExpConstructor.cpp:
(JSC::RegExpConstructor::finishCreation):
(JSC::regExpConstructorEscape): Added.

* Source/JavaScriptCore/runtime/OptionsList.h:
Add a feature flag for this.

* JSTests/stress/regexp-escape.js: Added.

Canonical link: <a href="https://commits.webkit.org/277793@main">https://commits.webkit.org/277793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a11907fb9cc6443c0c4d7b0bd5fb76bed20bf7b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/48591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/51552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/51278 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/44656 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/25331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39736 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/49173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/25467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41922 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20832 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22944 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43096 "Found 1 new test failure: fast/css/viewport-height-border.html (failure)") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/6647 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41890 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44883 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/43583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/53186 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/48082 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/23638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47029 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24903 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/42127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45956 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10711 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25708 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/55576 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/24625 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11430 "Passed tests") | 
<!--EWS-Status-Bubble-End-->