### PR TITLE
Prefer checked ObjectC casts in ObjCObjectGraph

### DIFF
--- a/Source/WebKit/Shared/mac/ObjCObjectGraph.mm
+++ b/Source/WebKit/Shared/mac/ObjCObjectGraph.mm
@@ -139,7 +139,7 @@ void ObjCObjectGraph::encode(IPC::Encoder& encoder, id object)
 
     auto type = typeFromObject(object);
     if (!type)
-        [NSException raise:NSInvalidArgumentException format:@"Can not encode objects of class type '%@'", static_cast<NSString *>(NSStringFromClass([object class]))];
+        [NSException raise:NSInvalidArgumentException format:@"Can not encode objects of class type '%@'", checked_objc_cast<NSString>(NSStringFromClass([object class]))];
 
     encoder << *type;
 
@@ -148,38 +148,38 @@ void ObjCObjectGraph::encode(IPC::Encoder& encoder, id object)
         return;
 
     case ObjCType::NSArray: {
-        IPC::encode(encoder, static_cast<NSArray *>(object));
+        IPC::encode(encoder, checked_objc_cast<NSArray>(object));
         return;
     }
 
     case ObjCType::NSData: {
-        IPC::encode(encoder, static_cast<NSData *>(object));
+        IPC::encode(encoder, checked_objc_cast<NSData>(object));
         return;
     }
 
     case ObjCType::NSDate: {
-        IPC::encode(encoder, static_cast<NSDate *>(object));
+        IPC::encode(encoder, checked_objc_cast<NSDate>(object));
         return;
     }
 
     case ObjCType::NSDictionary: {
-        IPC::encode(encoder, static_cast<NSDictionary *>(object));
+        IPC::encode(encoder, checked_objc_cast<NSDictionary>(object));
         return;
     }
 
     case ObjCType::NSNumber: {
-        IPC::encode(encoder, static_cast<NSNumber *>(object));
+        IPC::encode(encoder, checked_objc_cast<NSNumber>(object));
         return;
     }
 
     case ObjCType::NSString: {
-        IPC::encode(encoder, static_cast<NSString *>(object));
+        IPC::encode(encoder, checked_objc_cast<NSString>(object));
         return;
     }
 
     case ObjCType::WKBrowsingContextHandle: {
-        encoder << static_cast<WKBrowsingContextHandle *>(object).pageProxyID;
-        encoder << static_cast<WKBrowsingContextHandle *>(object).webPageID;
+        encoder << checked_objc_cast<WKBrowsingContextHandle>(object).pageProxyID;
+        encoder << checked_objc_cast<WKBrowsingContextHandle>(object).webPageID;
         return;
     }
     }


### PR DESCRIPTION
#### ff42ff7f7c3827f5f57171879e1e979473336eae
<pre>
Prefer checked ObjectC casts in ObjCObjectGraph
<a href="https://bugs.webkit.org/show_bug.cgi?id=272626">https://bugs.webkit.org/show_bug.cgi?id=272626</a>

Reviewed by Darin Adler.

Static casts are risky, prefer checked casts.

* Source/WebKit/Shared/mac/ObjCObjectGraph.mm:
(WebKit::ObjCObjectGraph::encode):

Canonical link: <a href="https://commits.webkit.org/277467@main">https://commits.webkit.org/277467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04c469f29d79f4f343fb6771a7b1f8dc28a413ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50347 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43719 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38804 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48246 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20101 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/21988 "Passed tests") | | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5713 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44009 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52239 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19030 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46108 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23972 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45139 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10527 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24760 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23692 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->