### PR TITLE
sequence<T> should map to Ref<T>, not RefPtr<T>

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.h
@@ -38,13 +38,12 @@ struct GPUPipelineLayoutDescriptor : public GPUObjectDescriptorBase {
         return {
             { label },
             bindGroupLayouts.map([](const auto& bindGroupLayout) -> std::reference_wrapper<WebGPU::BindGroupLayout> {
-                ASSERT(bindGroupLayout);
                 return bindGroupLayout->backing();
             }),
         };
     }
 
-    Vector<RefPtr<GPUBindGroupLayout>> bindGroupLayouts;
+    Vector<Ref<GPUBindGroupLayout>> bindGroupLayouts;
 };
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -60,12 +60,10 @@ void GPUQueue::setLabel(String&& label)
     m_backing->setLabel(WTFMove(label));
 }
 
-void GPUQueue::submit(Vector<RefPtr<GPUCommandBuffer>>&& commandBuffers)
+void GPUQueue::submit(Vector<Ref<GPUCommandBuffer>>&& commandBuffers)
 {
-    auto result = WTF::compactMap(commandBuffers, [](auto& commandBuffer) -> std::optional<std::reference_wrapper<WebGPU::CommandBuffer>> {
-        if (commandBuffer)
-            return commandBuffer->backing();
-        return std::nullopt;
+    auto result = WTF::map(commandBuffers, [](auto& commandBuffer) -> std::reference_wrapper<WebGPU::CommandBuffer> {
+        return commandBuffer->backing();
     });
     m_backing->submit(WTFMove(result));
 }

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.h
@@ -55,7 +55,7 @@ public:
     String label() const;
     void setLabel(String&&);
 
-    void submit(Vector<RefPtr<GPUCommandBuffer>>&&);
+    void submit(Vector<Ref<GPUCommandBuffer>>&&);
 
     using OnSubmittedWorkDonePromise = DOMPromiseDeferred<IDLNull>;
     void onSubmittedWorkDone(OnSubmittedWorkDonePromise&&);

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp
@@ -150,12 +150,10 @@ void GPURenderPassEncoder::endOcclusionQuery()
     m_backing->endOcclusionQuery();
 }
 
-void GPURenderPassEncoder::executeBundles(Vector<RefPtr<GPURenderBundle>>&& bundles)
+void GPURenderPassEncoder::executeBundles(Vector<Ref<GPURenderBundle>>&& bundles)
 {
-    auto result = WTF::compactMap(bundles, [](auto& bundle) -> std::optional<std::reference_wrapper<WebGPU::RenderBundle>> {
-        if (bundle)
-            return bundle->backing();
-        return std::nullopt;
+    auto result = WTF::map(bundles, [](auto& bundle) -> std::reference_wrapper<WebGPU::RenderBundle> {
+        return bundle->backing();
     });
     m_backing->executeBundles(WTFMove(result));
 }

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h
@@ -96,7 +96,7 @@ public:
     void beginOcclusionQuery(GPUSize32 queryIndex);
     void endOcclusionQuery();
 
-    void executeBundles(Vector<RefPtr<GPURenderBundle>>&&);
+    void executeBundles(Vector<Ref<GPURenderBundle>>&&);
     void end();
 
     WebGPU::RenderPassEncoder& backing() { return m_backing; }

--- a/Source/WebCore/Modules/applepay/ApplePayCouponCodeUpdate.h
+++ b/Source/WebCore/Modules/applepay/ApplePayCouponCodeUpdate.h
@@ -36,7 +36,7 @@
 namespace WebCore {
 
 struct ApplePayCouponCodeUpdate final : public ApplePayDetailsUpdateBase {
-    Vector<RefPtr<ApplePayError>> errors;
+    Vector<Ref<ApplePayError>> errors;
     Vector<ApplePayShippingMethod> newShippingMethods;
 };
 

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizationResult.h
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizationResult.h
@@ -47,7 +47,7 @@ struct ApplePayPaymentAuthorizationResult {
     static constexpr Status PINLockout = 7;
 
     Status status; // required
-    Vector<RefPtr<ApplePayError>> errors;
+    Vector<Ref<ApplePayError>> errors;
 
 #if ENABLE(APPLE_PAY_PAYMENT_ORDER_DETAILS)
     std::optional<ApplePayPaymentOrderDetails> orderDetails;

--- a/Source/WebCore/Modules/applepay/ApplePayPaymentMethodUpdate.h
+++ b/Source/WebCore/Modules/applepay/ApplePayPaymentMethodUpdate.h
@@ -38,7 +38,7 @@ namespace WebCore {
 
 struct ApplePayPaymentMethodUpdate final : public ApplePayDetailsUpdateBase {
 #if ENABLE(APPLE_PAY_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_LINE_ITEMS)
-    Vector<RefPtr<ApplePayError>> errors;
+    Vector<Ref<ApplePayError>> errors;
 
     Vector<ApplePayShippingMethod> newShippingMethods;
 #endif

--- a/Source/WebCore/Modules/applepay/ApplePaySetup.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySetup.cpp
@@ -82,7 +82,7 @@ void ApplePaySetup::getSetupFeatures(Document& document, SetupFeaturesPromise&& 
     });
 }
 
-void ApplePaySetup::begin(Document& document, Vector<RefPtr<ApplePaySetupFeature>>&& features, BeginPromise&& promise)
+void ApplePaySetup::begin(Document& document, Vector<Ref<ApplePaySetupFeature>>&& features, BeginPromise&& promise)
 {
     auto canCall = PaymentSession::canCreateSession(document);
     if (canCall.hasException()) {

--- a/Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h
@@ -49,7 +49,7 @@ public:
     void getSetupFeatures(Document&, SetupFeaturesPromise&&);
 
     using BeginPromise = DOMPromiseDeferred<IDLBoolean>;
-    void begin(Document&, Vector<RefPtr<ApplePaySetupFeature>>&&, BeginPromise&&);
+    void begin(Document&, Vector<Ref<ApplePaySetupFeature>>&&, BeginPromise&&);
 
 private:
     ApplePaySetup(ScriptExecutionContext&, ApplePaySetupConfiguration&&);

--- a/Source/WebCore/Modules/applepay/ApplePayShippingContactUpdate.h
+++ b/Source/WebCore/Modules/applepay/ApplePayShippingContactUpdate.h
@@ -36,7 +36,7 @@
 namespace WebCore {
 
 struct ApplePayShippingContactUpdate final : public ApplePayDetailsUpdateBase {
-    Vector<RefPtr<ApplePayError>> errors;
+    Vector<Ref<ApplePayError>> errors;
     Vector<ApplePayShippingMethod> newShippingMethods;
 };
 

--- a/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinator.cpp
@@ -292,7 +292,7 @@ void PaymentCoordinator::getSetupFeatures(const ApplePaySetupConfiguration& conf
     });
 }
 
-void PaymentCoordinator::beginApplePaySetup(const ApplePaySetupConfiguration& configuration, const URL& url, Vector<RefPtr<ApplePaySetupFeature>>&& features, CompletionHandler<void(bool)>&& completionHandler)
+void PaymentCoordinator::beginApplePaySetup(const ApplePaySetupConfiguration& configuration, const URL& url, Vector<Ref<ApplePaySetupFeature>>&& features, CompletionHandler<void(bool)>&& completionHandler)
 {
     PAYMENT_COORDINATOR_RELEASE_LOG("beginApplePaySetup()");
     m_client->beginApplePaySetup(configuration, url, WTFMove(features), [this, weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](bool success) mutable {

--- a/Source/WebCore/Modules/applepay/PaymentCoordinator.h
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinator.h
@@ -93,7 +93,7 @@ public:
     std::optional<String> validatedPaymentNetwork(Document&, unsigned version, const String&) const;
 
     void getSetupFeatures(const ApplePaySetupConfiguration&, const URL&, CompletionHandler<void(Vector<Ref<ApplePaySetupFeature>>&&)>&&);
-    void beginApplePaySetup(const ApplePaySetupConfiguration&, const URL&, Vector<RefPtr<ApplePaySetupFeature>>&&, CompletionHandler<void(bool)>&&);
+    void beginApplePaySetup(const ApplePaySetupConfiguration&, const URL&, Vector<Ref<ApplePaySetupFeature>>&&, CompletionHandler<void(bool)>&&);
     void endApplePaySetup();
 
 private:

--- a/Source/WebCore/Modules/applepay/PaymentCoordinatorClient.h
+++ b/Source/WebCore/Modules/applepay/PaymentCoordinatorClient.h
@@ -69,7 +69,7 @@ public:
     virtual bool isWebPaymentCoordinator() const { return false; }
 
     virtual void getSetupFeatures(const ApplePaySetupConfiguration&, const URL&, CompletionHandler<void(Vector<Ref<ApplePaySetupFeature>>&&)>&& completionHandler) { completionHandler({ }); }
-    virtual void beginApplePaySetup(const ApplePaySetupConfiguration&, const URL&, Vector<RefPtr<ApplePaySetupFeature>>&&, CompletionHandler<void(bool)>&& completionHandler) { completionHandler(false); }
+    virtual void beginApplePaySetup(const ApplePaySetupConfiguration&, const URL&, Vector<Ref<ApplePaySetupFeature>>&&, CompletionHandler<void(bool)>&& completionHandler) { completionHandler(false); }
     virtual void endApplePaySetup() { }
 
     virtual ~PaymentCoordinatorClient() = default;

--- a/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.h
+++ b/Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.h
@@ -59,16 +59,16 @@ private:
 
     ExceptionOr<Vector<ApplePayShippingMethod>> computeShippingMethods() const;
     ExceptionOr<std::tuple<ApplePayLineItem, Vector<ApplePayLineItem>>> computeTotalAndLineItems() const;
-    Vector<RefPtr<ApplePayError>> computeErrors(String&& error, AddressErrors&&, PayerErrorFields&&, JSC::JSObject* paymentMethodErrors) const;
-    Vector<RefPtr<ApplePayError>> computeErrors(JSC::JSObject* paymentMethodErrors) const;
-    void computeAddressErrors(String&& error, AddressErrors&&, Vector<RefPtr<ApplePayError>>&) const;
-    void computePayerErrors(PayerErrorFields&&, Vector<RefPtr<ApplePayError>>&) const;
-    ExceptionOr<void> computePaymentMethodErrors(JSC::JSObject* paymentMethodErrors, Vector<RefPtr<ApplePayError>>&) const;
+    Vector<Ref<ApplePayError>> computeErrors(String&& error, AddressErrors&&, PayerErrorFields&&, JSC::JSObject* paymentMethodErrors) const;
+    Vector<Ref<ApplePayError>> computeErrors(JSC::JSObject* paymentMethodErrors) const;
+    void computeAddressErrors(String&& error, AddressErrors&&, Vector<Ref<ApplePayError>>&) const;
+    void computePayerErrors(PayerErrorFields&&, Vector<Ref<ApplePayError>>&) const;
+    ExceptionOr<void> computePaymentMethodErrors(JSC::JSObject* paymentMethodErrors, Vector<Ref<ApplePayError>>&) const;
     ExceptionOr<std::optional<std::tuple<PaymentDetailsModifier, ApplePayModifier>>> firstApplicableModifier() const;
 
-    ExceptionOr<void> shippingAddressUpdated(Vector<RefPtr<ApplePayError>>&& errors);
+    ExceptionOr<void> shippingAddressUpdated(Vector<Ref<ApplePayError>>&& errors);
     ExceptionOr<void> shippingOptionUpdated();
-    ExceptionOr<void> paymentMethodUpdated(Vector<RefPtr<ApplePayError>>&& errors);
+    ExceptionOr<void> paymentMethodUpdated(Vector<Ref<ApplePayError>>&& errors);
 
     // PaymentHandler
     ExceptionOr<void> convertData(Document&, JSC::JSValue) final;

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.cpp
@@ -273,7 +273,7 @@ Clipboard::SessionIsValid Clipboard::updateSessionValidity()
     return SessionIsValid::Yes;
 }
 
-void Clipboard::write(const Vector<RefPtr<ClipboardItem>>& items, Ref<DeferredPromise>&& promise)
+void Clipboard::write(const Vector<Ref<ClipboardItem>>& items, Ref<DeferredPromise>&& promise)
 {
     RefPtr frame = this->frame();
     if (!frame || !shouldProceedWithClipboardWrite(*frame)) {
@@ -314,7 +314,7 @@ Clipboard::ItemWriter::ItemWriter(Clipboard& clipboard, Ref<DeferredPromise>&& p
 
 Clipboard::ItemWriter::~ItemWriter() = default;
 
-void Clipboard::ItemWriter::write(const Vector<RefPtr<ClipboardItem>>& items)
+void Clipboard::ItemWriter::write(const Vector<Ref<ClipboardItem>>& items)
 {
     ASSERT(m_promise);
     ASSERT(m_clipboard);

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.h
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.h
@@ -58,7 +58,7 @@ public:
     void writeText(const String& data, Ref<DeferredPromise>&&);
 
     void read(Ref<DeferredPromise>&&);
-    void write(const Vector<RefPtr<ClipboardItem>>& data, Ref<DeferredPromise>&&);
+    void write(const Vector<Ref<ClipboardItem>>& data, Ref<DeferredPromise>&&);
 
     void getType(ClipboardItem&, const String& type, Ref<DeferredPromise>&&);
 
@@ -88,7 +88,7 @@ private:
 
         ~ItemWriter();
 
-        void write(const Vector<RefPtr<ClipboardItem>>&);
+        void write(const Vector<Ref<ClipboardItem>>&);
         void invalidate();
 
     private:

--- a/Source/WebCore/Modules/gamepad/Navigator+Gamepad.idl
+++ b/Source/WebCore/Modules/gamepad/Navigator+Gamepad.idl
@@ -28,6 +28,6 @@
     Conditional=GAMEPAD,
     ImplementedBy=NavigatorGamepad
 ] partial interface Navigator {
-    [EnabledBySetting=GamepadsEnabled] sequence<Gamepad> getGamepads();
+    [EnabledBySetting=GamepadsEnabled] sequence<Gamepad?> getGamepads();
 };
 

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -207,7 +207,7 @@ void MediaSession::setReadyState(MediaSessionReadyState state)
 #endif
 
 #if ENABLE(MEDIA_SESSION_PLAYLIST)
-ExceptionOr<void> MediaSession::setPlaylist(ScriptExecutionContext& context, Vector<RefPtr<MediaMetadata>>&& playlist)
+ExceptionOr<void> MediaSession::setPlaylist(ScriptExecutionContext& context, Vector<Ref<MediaMetadata>>&& playlist)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -88,7 +88,7 @@ public:
 
 #if ENABLE(MEDIA_SESSION_PLAYLIST)
     const Vector<Ref<MediaMetadata>>& playlist() const { return m_playlist; }
-    ExceptionOr<void> setPlaylist(ScriptExecutionContext&, Vector<RefPtr<MediaMetadata>>&&);
+    ExceptionOr<void> setPlaylist(ScriptExecutionContext&, Vector<Ref<MediaMetadata>>&&);
 #endif
 
     bool hasActiveActionHandlers() const;

--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -55,10 +55,9 @@ Ref<MediaStream> MediaStream::create(Document& document, MediaStream& stream)
     return mediaStream;
 }
 
-Ref<MediaStream> MediaStream::create(Document& document, const Vector<RefPtr<MediaStreamTrack>>& tracks)
+Ref<MediaStream> MediaStream::create(Document& document, const Vector<Ref<MediaStreamTrack>>& tracks)
 {
-    auto nonNullTracks = map(tracks, [](auto& track) { return Ref { *track }; });
-    auto mediaStream = adoptRef(*new MediaStream(document, WTFMove(nonNullTracks)));
+    auto mediaStream = adoptRef(*new MediaStream(document, tracks));
     mediaStream->suspendIfNeeded();
     return mediaStream;
 }
@@ -118,13 +117,13 @@ RefPtr<MediaStream> MediaStream::clone()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    Vector<RefPtr<MediaStreamTrack>> clonedTracks;
+    Vector<Ref<MediaStreamTrack>> clonedTracks;
     clonedTracks.reserveInitialCapacity(m_trackMap.size());
     for (auto& track : m_trackMap.values()) {
         if (auto clone = track->clone())
-            clonedTracks.append(WTFMove(clone));
+            clonedTracks.append(clone.releaseNonNull());
     }
-    return MediaStream::create(*document(), clonedTracks);
+    return MediaStream::create(*document(), WTFMove(clonedTracks));
 }
 
 void MediaStream::addTrack(MediaStreamTrack& track)

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -59,7 +59,7 @@ class MediaStream final
 public:
     static Ref<MediaStream> create(Document&);
     static Ref<MediaStream> create(Document&, MediaStream&);
-    static Ref<MediaStream> create(Document&, const Vector<RefPtr<MediaStreamTrack>>&);
+    static Ref<MediaStream> create(Document&, const Vector<Ref<MediaStreamTrack>>&);
     static Ref<MediaStream> create(Document&, Ref<MediaStreamPrivate>&&);
     WEBCORE_EXPORT virtual ~MediaStream();
 

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -208,7 +208,7 @@ static void setAssociatedRemoteStreams(RTCRtpReceiver& receiver, const PeerConne
 
     for (auto& stream : state.receiverStreams) {
         if (!anyOf(receiver.associatedStreams(), [&stream](auto& currentStream) { return stream->id() == currentStream->id(); }))
-            addList.append({ *stream, Ref { receiver.track() } });
+            addList.append({ stream, Ref { receiver.track() } });
     }
 
     receiver.setAssociatedStreams(WTF::map(state.receiverStreams, [](auto& stream) { return WeakPtr { stream.get() }; }));

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -142,7 +142,7 @@ public:
     };
     struct TransceiverState {
         String mid;
-        Vector<RefPtr<MediaStream>> receiverStreams;
+        Vector<Ref<MediaStream>> receiverStreams;
         std::optional<RTCRtpTransceiverDirection> firedDirection;
     };
     using TransceiverStates = Vector<TransceiverState>;
@@ -234,7 +234,7 @@ protected:
     struct PendingTrackEvent {
         Ref<RTCRtpReceiver> receiver;
         Ref<MediaStreamTrack> track;
-        Vector<RefPtr<MediaStream>> streams;
+        Vector<Ref<MediaStream>> streams;
         RefPtr<RTCRtpTransceiver> transceiver;
     };
     void addPendingTrackEvent(PendingTrackEvent&&);

--- a/Source/WebCore/Modules/mediastream/RTCConfiguration.h
+++ b/Source/WebCore/Modules/mediastream/RTCConfiguration.h
@@ -47,7 +47,7 @@ struct RTCConfiguration {
     RTCBundlePolicy bundlePolicy;
     RTCPMuxPolicy rtcpMuxPolicy;
     unsigned short iceCandidatePoolSize;
-    Vector<RefPtr<RTCCertificate>> certificates;
+    Vector<Ref<RTCCertificate>> certificates;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -497,7 +497,7 @@ ExceptionOr<void> RTCPeerConnection::setConfiguration(RTCConfiguration&& configu
 
         for (auto& certificate : configuration.certificates) {
             bool isThere = m_configuration.certificates.findIf([&certificate](const auto& item) {
-                return item.get() == certificate.get();
+                return item == certificate;
             }) != notFound;
             if (!isThere)
                 return Exception { ExceptionCode::InvalidModificationError, "A certificate given in constructor is not present"_s };

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -77,7 +77,7 @@ struct RTCSessionDescriptionInit;
 
 struct RTCRtpTransceiverInit {
     RTCRtpTransceiverDirection direction { RTCRtpTransceiverDirection::Sendrecv };
-    Vector<RefPtr<MediaStream>> streams;
+    Vector<Ref<MediaStream>> streams;
     Vector<RTCRtpEncodingParameters> sendEncodings;
 };
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
@@ -51,7 +51,7 @@ ExceptionOr<Ref<RTCRtpScriptTransform>> RTCRtpScriptTransform::create(JSC::JSGlo
     if (!context)
         return Exception { ExceptionCode::InvalidStateError, "Invalid context"_s };
 
-    Vector<RefPtr<MessagePort>> transferredPorts;
+    Vector<Ref<MessagePort>> transferredPorts;
     auto serializedOptions = SerializedScriptValue::create(state, options, WTFMove(transfer), transferredPorts);
     if (serializedOptions.hasException())
         return serializedOptions.releaseException();

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -66,7 +66,7 @@ ExceptionOr<Ref<RTCRtpScriptTransformer>> RTCRtpScriptTransformer::create(Script
     return transformer;
 }
 
-RTCRtpScriptTransformer::RTCRtpScriptTransformer(ScriptExecutionContext& context, Ref<SerializedScriptValue>&& options, Vector<RefPtr<MessagePort>>&& ports, Ref<ReadableStream>&& readable, Ref<SimpleReadableStreamSource>&& readableSource)
+RTCRtpScriptTransformer::RTCRtpScriptTransformer(ScriptExecutionContext& context, Ref<SerializedScriptValue>&& options, Vector<Ref<MessagePort>>&& ports, Ref<ReadableStream>&& readable, Ref<SimpleReadableStreamSource>&& readableSource)
     : ActiveDOMObject(&context)
     , m_options(WTFMove(options))
     , m_ports(WTFMove(ports))

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h
@@ -75,7 +75,7 @@ public:
     void clear(ClearCallback);
 
 private:
-    RTCRtpScriptTransformer(ScriptExecutionContext&, Ref<SerializedScriptValue>&&, Vector<RefPtr<MessagePort>>&&, Ref<ReadableStream>&&, Ref<SimpleReadableStreamSource>&&);
+    RTCRtpScriptTransformer(ScriptExecutionContext&, Ref<SerializedScriptValue>&&, Vector<Ref<MessagePort>>&&, Ref<ReadableStream>&&, Ref<SimpleReadableStreamSource>&&);
 
     // ActiveDOMObject
     const char* activeDOMObjectName() const final { return "RTCRtpScriptTransformer"; }
@@ -86,7 +86,7 @@ private:
     void enqueueFrame(ScriptExecutionContext&, Ref<RTCRtpTransformableFrame>&&);
 
     Ref<SerializedScriptValue> m_options;
-    Vector<RefPtr<MessagePort>> m_ports;
+    Vector<Ref<MessagePort>> m_ports;
 
     Ref<SimpleReadableStreamSource> m_readableSource;
     Ref<ReadableStream> m_readable;

--- a/Source/WebCore/Modules/mediastream/RTCTrackEvent.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCTrackEvent.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(RTCTrackEvent);
 
-Ref<RTCTrackEvent> RTCTrackEvent::create(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, RefPtr<RTCRtpReceiver>&& receiver, RefPtr<MediaStreamTrack>&& track, Vector<RefPtr<MediaStream>>&& streams, RefPtr<RTCRtpTransceiver>&& transceiver)
+Ref<RTCTrackEvent> RTCTrackEvent::create(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, RefPtr<RTCRtpReceiver>&& receiver, RefPtr<MediaStreamTrack>&& track, Vector<Ref<MediaStream>>&& streams, RefPtr<RTCRtpTransceiver>&& transceiver)
 {
     return adoptRef(*new RTCTrackEvent(type, canBubble, cancelable, WTFMove(receiver), WTFMove(track), WTFMove(streams), WTFMove(transceiver)));
 }
@@ -52,7 +52,7 @@ Ref<RTCTrackEvent> RTCTrackEvent::create(const AtomString& type, const Init& ini
     return adoptRef(*new RTCTrackEvent(type, initializer, isTrusted));
 }
 
-RTCTrackEvent::RTCTrackEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, RefPtr<RTCRtpReceiver>&& receiver, RefPtr<MediaStreamTrack>&& track, Vector<RefPtr<MediaStream>>&& streams, RefPtr<RTCRtpTransceiver>&& transceiver)
+RTCTrackEvent::RTCTrackEvent(const AtomString& type, CanBubble canBubble, IsCancelable cancelable, RefPtr<RTCRtpReceiver>&& receiver, RefPtr<MediaStreamTrack>&& track, Vector<Ref<MediaStream>>&& streams, RefPtr<RTCRtpTransceiver>&& transceiver)
     : Event(EventInterfaceType::RTCTrackEvent, type, canBubble, cancelable)
     , m_receiver(WTFMove(receiver))
     , m_track(WTFMove(track))

--- a/Source/WebCore/Modules/mediastream/RTCTrackEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCTrackEvent.h
@@ -42,7 +42,7 @@ class MediaStreamTrack;
 class RTCRtpReceiver;
 class RTCRtpTransceiver;
 
-typedef Vector<RefPtr<MediaStream>> MediaStreamArray;
+typedef Vector<Ref<MediaStream>> MediaStreamArray;
 
 class RTCTrackEvent final : public Event {
     WTF_MAKE_ISO_ALLOCATED(RTCTrackEvent);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -332,7 +332,7 @@ void GStreamerPeerConnectionBackend::dispatchPendingTrackEvents(MediaStream& med
 {
     auto events = WTFMove(m_pendingTrackEvents);
     for (auto& event : events) {
-        event.streams = Vector<RefPtr<MediaStream>>({ &mediaStream });
+        event.streams = Vector<Ref<MediaStream>>({ mediaStream });
         dispatchTrackEvent(event);
     }
 }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -730,8 +730,8 @@ void LibWebRTCMediaEndpoint::setLocalSessionDescriptionSucceeded()
             return;
 
         auto transceiverStates = WTF::map(rtcTransceiverStates, [this](auto& state) -> PeerConnectionBackend::TransceiverState {
-            auto streams = WTF::map(state.receiverStreamIds, [this](auto& id) -> RefPtr<MediaStream> {
-                return &mediaStreamFromRTCStreamId(id);
+            auto streams = WTF::map(state.receiverStreamIds, [this](auto& id) -> Ref<MediaStream> {
+                return mediaStreamFromRTCStreamId(id);
             });
             return { WTFMove(state.mid), WTFMove(streams), state.firedDirection };
         });
@@ -757,8 +757,8 @@ void LibWebRTCMediaEndpoint::setRemoteSessionDescriptionSucceeded()
             return;
 
         auto transceiverStates = WTF::map(rtcTransceiverStates, [this](auto& state) -> PeerConnectionBackend::TransceiverState {
-            auto streams = WTF::map(state.receiverStreamIds, [this](auto& id) -> RefPtr<MediaStream> {
-                return &mediaStreamFromRTCStreamId(id);
+            auto streams = WTF::map(state.receiverStreamIds, [this](auto& id) -> Ref<MediaStream> {
+                return mediaStreamFromRTCStreamId(id);
             });
             return { WTFMove(state.mid), WTFMove(streams), state.firedDirection };
         });

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -82,7 +82,7 @@ static ExceptionOr<Ref<SerializedScriptValue>> createSerializedScriptValue(Scrip
     if (!globalObject)
         return Exception { ExceptionCode::TypeError, "Notification cannot be created without a global object"_s };
 
-    Vector<RefPtr<MessagePort>> dummyPorts;
+    Vector<Ref<MessagePort>> dummyPorts;
     return SerializedScriptValue::create(*globalObject, value, { }, dummyPorts);
 }
 

--- a/Source/WebCore/Modules/webxr/WebXRFrame.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.cpp
@@ -281,7 +281,7 @@ ExceptionOr<RefPtr<WebXRJointPose>> WebXRFrame::getJointPose(const Document& doc
 }
 
 // https://immersive-web.github.io/webxr-hand-input/#dom-xrframe-filljointradii
-ExceptionOr<bool> WebXRFrame::fillJointRadii(const Vector<RefPtr<WebXRJointSpace>>& jointSpaces, Float32Array& radii)
+ExceptionOr<bool> WebXRFrame::fillJointRadii(const Vector<Ref<WebXRJointSpace>>& jointSpaces, Float32Array& radii)
 {
     // If frame’s active boolean is false, throw an InvalidStateError and abort these steps.
     if (!m_active)
@@ -290,7 +290,7 @@ ExceptionOr<bool> WebXRFrame::fillJointRadii(const Vector<RefPtr<WebXRJointSpace
     // For each joint in the jointSpaces:
     // If joint’s session is different from session, throw an InvalidStateError and abort these steps.
     for (const auto& jointSpace : jointSpaces) {
-        if (!jointSpace || jointSpace->session() != m_session.ptr())
+        if (jointSpace->session() != m_session.ptr())
             return Exception { ExceptionCode::InvalidStateError, "Joint space's session does not match frame's session"_s };
     }
 
@@ -321,7 +321,7 @@ ExceptionOr<bool> WebXRFrame::fillJointRadii(const Vector<RefPtr<WebXRJointSpace
 }
 
 // https://immersive-web.github.io/webxr-hand-input/#dom-xrframe-fillposes
-ExceptionOr<bool> WebXRFrame::fillPoses(const Document& document, const Vector<RefPtr<WebXRSpace>>& spaces, const WebXRSpace& baseSpace, Float32Array& transforms)
+ExceptionOr<bool> WebXRFrame::fillPoses(const Document& document, const Vector<Ref<WebXRSpace>>& spaces, const WebXRSpace& baseSpace, Float32Array& transforms)
 {
     // If frame’s active boolean is false, throw an InvalidStateError and abort these steps.
     if (!m_active)
@@ -330,7 +330,7 @@ ExceptionOr<bool> WebXRFrame::fillPoses(const Document& document, const Vector<R
     // For each space in the spaces sequence:
     // If space’s session is different from session, throw an InvalidStateError and abort these steps.
     for (const auto& space : spaces) {
-        if (!space || space->session() != m_session.ptr())
+        if (space->session() != m_session.ptr())
             return Exception { ExceptionCode::InvalidStateError, "Space's session does not match frame's session"_s };
     }
 
@@ -354,7 +354,7 @@ ExceptionOr<bool> WebXRFrame::fillPoses(const Document& document, const Vector<R
     // For each space in the spaces sequence:
     for (size_t spaceIndex = 0; spaceIndex < spaces.size(); ++spaceIndex) {
         // 1. Populate the pose of space in baseSpace at the time represented by frame into pose.
-        auto populatePoseResult = populatePose(document, *(spaces[spaceIndex]), baseSpace);
+        auto populatePoseResult = populatePose(document, spaces[spaceIndex], baseSpace);
         if (populatePoseResult.hasException())
             return populatePoseResult.releaseException();
 

--- a/Source/WebCore/Modules/webxr/WebXRFrame.h
+++ b/Source/WebCore/Modules/webxr/WebXRFrame.h
@@ -61,8 +61,8 @@ public:
 
 #if ENABLE(WEBXR_HANDS)
     ExceptionOr<RefPtr<WebXRJointPose>> getJointPose(const Document&, const WebXRJointSpace&, const WebXRSpace&);
-    ExceptionOr<bool> fillJointRadii(const Vector<RefPtr<WebXRJointSpace>>&, Float32Array&);
-    ExceptionOr<bool> fillPoses(const Document&, const Vector<RefPtr<WebXRSpace>>&, const WebXRSpace&, Float32Array&);
+    ExceptionOr<bool> fillJointRadii(const Vector<Ref<WebXRJointSpace>>&, Float32Array&);
+    ExceptionOr<bool> fillPoses(const Document&, const Vector<Ref<WebXRSpace>>&, const WebXRSpace&, Float32Array&);
 #endif
 
     void setTime(DOMHighResTimeStamp time) { m_time = time; }

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
@@ -79,9 +79,9 @@ void WebXRInputSourceArray::clear()
 // https://immersive-web.github.io/webxr/#list-of-active-xr-input-sources
 void WebXRInputSourceArray::update(double timestamp, const InputSourceList& inputSources)
 {
-    Vector<RefPtr<WebXRInputSource>> added;
-    Vector<RefPtr<WebXRInputSource>> removed;
-    Vector<RefPtr<WebXRInputSource>> removedWithInputEvents;
+    Vector<Ref<WebXRInputSource>> added;
+    Vector<Ref<WebXRInputSource>> removed;
+    Vector<Ref<WebXRInputSource>> removedWithInputEvents;
     Vector<Ref<XRInputSourceEvent>> inputEvents;
 
     handleRemovedInputSources(inputSources, removed, removedWithInputEvents, inputEvents);
@@ -129,7 +129,7 @@ void WebXRInputSourceArray::update(double timestamp, const InputSourceList& inpu
 }
 
 // https://immersive-web.github.io/webxr/#list-of-active-xr-input-sources
-void WebXRInputSourceArray::handleRemovedInputSources(const InputSourceList& inputSources, Vector<RefPtr<WebXRInputSource>>& removed, Vector<RefPtr<WebXRInputSource>>& removedWithInputEvents, Vector<Ref<XRInputSourceEvent>>& inputEvents)
+void WebXRInputSourceArray::handleRemovedInputSources(const InputSourceList& inputSources, Vector<Ref<WebXRInputSource>>& removed, Vector<Ref<WebXRInputSource>>& removedWithInputEvents, Vector<Ref<XRInputSourceEvent>>& inputEvents)
 {
     // When any previously added XR input sources are no longer available for XRSession session, the user agent MUST run the following steps:
     // 1. If session's promise resolved flag is not set, abort these steps.
@@ -143,9 +143,9 @@ void WebXRInputSourceArray::handleRemovedInputSources(const InputSourceList& inp
             source->disconnect();
             source->pollEvents(sourceInputEvents);
             if (sourceInputEvents.isEmpty())
-                removed.append(source.copyRef());
+                removed.append(source);
             else
-                removedWithInputEvents.append(source.copyRef());
+                removedWithInputEvents.append(source);
             inputEvents.appendVector(sourceInputEvents);
             return true;
         }
@@ -154,7 +154,7 @@ void WebXRInputSourceArray::handleRemovedInputSources(const InputSourceList& inp
 }
 
 // https://immersive-web.github.io/webxr/#list-of-active-xr-input-sources
-void WebXRInputSourceArray::handleAddedOrUpdatedInputSources(double timestamp, const InputSourceList& inputSources, Vector<RefPtr<WebXRInputSource>>& added, Vector<RefPtr<WebXRInputSource>>& removed, Vector<RefPtr<WebXRInputSource>>& removedWithInputEvents, Vector<Ref<XRInputSourceEvent>>& inputEvents)
+void WebXRInputSourceArray::handleAddedOrUpdatedInputSources(double timestamp, const InputSourceList& inputSources, Vector<Ref<WebXRInputSource>>& added, Vector<Ref<WebXRInputSource>>& removed, Vector<Ref<WebXRInputSource>>& removedWithInputEvents, Vector<Ref<XRInputSourceEvent>>& inputEvents)
 {
     RefPtr document = downcast<Document>(m_session.scriptExecutionContext());
     if (!document)
@@ -171,7 +171,7 @@ void WebXRInputSourceArray::handleAddedOrUpdatedInputSources(double timestamp, c
             //   3.2 Add inputSource to added.
 
             auto input = WebXRInputSource::create(*document, m_session, timestamp, inputSource);
-            added.append(input.copyRef());
+            added.append(input);
             input->pollEvents(inputEvents);
             m_inputSources.append(WTFMove(input));
             continue;
@@ -186,21 +186,21 @@ void WebXRInputSourceArray::handleAddedOrUpdatedInputSources(double timestamp, c
         //  4.1 Let newInputSource be a new XRInputSource in the relevant realm of session.
         //  4.1 Add oldInputSource to removed.
         //  4.1 Add newInputSource to added.
-        auto& input = m_inputSources[index];
+        Ref input = m_inputSources[index];
 
         if (input->requiresInputSourceChange(inputSource)) {
             Vector<Ref<XRInputSourceEvent>> sourceInputEvents;
             input->disconnect();
             input->pollEvents(sourceInputEvents);
             if (sourceInputEvents.isEmpty())
-                removed.append(input.copyRef());
+                removed.append(input);
             else
-                removedWithInputEvents.append(input.copyRef());
+                removedWithInputEvents.append(input);
             inputEvents.appendVector(sourceInputEvents);
             m_inputSources.remove(index);
 
             auto newInputSource = WebXRInputSource::create(*document, m_session, timestamp, inputSource);
-            added.append(newInputSource.copyRef());
+            added.append(newInputSource);
             newInputSource->pollEvents(inputEvents);
             m_inputSources.append(WTFMove(newInputSource));
         } else {

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.h
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.h
@@ -65,8 +65,8 @@ public:
 private:
     WebXRInputSourceArray(WebXRSession&);
 
-    void handleRemovedInputSources(const InputSourceList&, Vector<RefPtr<WebXRInputSource>>&, Vector<RefPtr<WebXRInputSource>>&, Vector<Ref<XRInputSourceEvent>>&);
-    void handleAddedOrUpdatedInputSources(double timestamp, const InputSourceList&, Vector<RefPtr<WebXRInputSource>>&, Vector<RefPtr<WebXRInputSource>>&, Vector<RefPtr<WebXRInputSource>>&, Vector<Ref<XRInputSourceEvent>>&);
+    void handleRemovedInputSources(const InputSourceList&, Vector<Ref<WebXRInputSource>>&, Vector<Ref<WebXRInputSource>>&, Vector<Ref<XRInputSourceEvent>>&);
+    void handleAddedOrUpdatedInputSources(double timestamp, const InputSourceList&, Vector<Ref<WebXRInputSource>>&, Vector<Ref<WebXRInputSource>>&, Vector<Ref<WebXRInputSource>>&, Vector<Ref<XRInputSourceEvent>>&);
 
     WebXRSession& m_session;
     Vector<Ref<WebXRInputSource>> m_inputSources;

--- a/Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.cpp
+++ b/Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.cpp
@@ -56,12 +56,12 @@ const WebXRSession& XRInputSourcesChangeEvent::session() const
     return m_session;
 }
 
-const Vector<RefPtr<WebXRInputSource>>& XRInputSourcesChangeEvent::added() const
+const Vector<Ref<WebXRInputSource>>& XRInputSourcesChangeEvent::added() const
 {
     return m_added;
 }
 
-const Vector<RefPtr<WebXRInputSource>>& XRInputSourcesChangeEvent::removed() const
+const Vector<Ref<WebXRInputSource>>& XRInputSourcesChangeEvent::removed() const
 {
     return m_removed;
 }

--- a/Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.h
+++ b/Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.h
@@ -41,23 +41,23 @@ class XRInputSourcesChangeEvent final : public Event {
 public:
     struct Init : EventInit {
         RefPtr<WebXRSession> session;
-        Vector<RefPtr<WebXRInputSource>> added;
-        Vector<RefPtr<WebXRInputSource>> removed;
+        Vector<Ref<WebXRInputSource>> added;
+        Vector<Ref<WebXRInputSource>> removed;
     };
 
     static Ref<XRInputSourcesChangeEvent> create(const AtomString&, const Init&, IsTrusted = IsTrusted::No);
     virtual ~XRInputSourcesChangeEvent();
 
     const WebXRSession& session() const;
-    const Vector<RefPtr<WebXRInputSource>>& added() const;
-    const Vector<RefPtr<WebXRInputSource>>& removed() const;
+    const Vector<Ref<WebXRInputSource>>& added() const;
+    const Vector<Ref<WebXRInputSource>>& removed() const;
 
 private:
     XRInputSourcesChangeEvent(const AtomString&, const Init&, IsTrusted);
 
     Ref<WebXRSession> m_session;
-    Vector<RefPtr<WebXRInputSource>> m_added;
-    Vector<RefPtr<WebXRInputSource>> m_removed;
+    Vector<Ref<WebXRInputSource>> m_added;
+    Vector<Ref<WebXRInputSource>> m_removed;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRRenderStateInit.h
+++ b/Source/WebCore/Modules/webxr/XRRenderStateInit.h
@@ -38,7 +38,7 @@ struct XRRenderStateInit {
     std::optional<double> depthFar;
     std::optional<double> inlineVerticalFieldOfView;
     RefPtr<WebXRWebGLLayer> baseLayer;
-    std::optional<Vector<RefPtr<WebXRLayer>>> layers;
+    std::optional<Vector<Ref<WebXRLayer>>> layers;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -714,7 +714,7 @@ private:
     static AXRelationType attributeToRelationType(const QualifiedName&);
     enum class AddSymmetricRelation : bool { No, Yes };
     static AXRelationType symmetricRelation(AXRelationType);
-    bool addRelation(Element*, Element*, AXRelationType);
+    bool addRelation(Element&, Element&, AXRelationType);
     bool addRelation(AccessibilityObject*, AccessibilityObject*, AXRelationType, AddSymmetricRelation = AddSymmetricRelation::Yes);
     bool addRelation(Element&, const QualifiedName&);
     void addLabelForRelation(Element&);

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -4126,18 +4126,14 @@ Vector<Ref<Element>> AccessibilityObject::elementsFromAttribute(const QualifiedN
         }
     } else if (Element::isElementsArrayReflectionAttribute(attribute)) {
         if (auto reflectedElements = element->getElementsArrayAttribute(attribute)) {
-            return WTF::map(reflectedElements.value(), [](RefPtr<Element> element) -> Ref<Element> {
-                return *element;
-            });
+            return reflectedElements.value();
         }
     }
 
     auto& idsString = getAttribute(attribute);
     if (idsString.isEmpty()) {
         if (auto* defaultARIA = element->customElementDefaultARIAIfExists()) {
-            return WTF::map(defaultARIA->elementsForAttribute(*element, attribute), [](RefPtr<Element> element) -> Ref<Element> {
-                return *element;
-            });
+            return defaultARIA->elementsForAttribute(*element, attribute);
         }
         return { };
     }

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -215,6 +215,7 @@ template<typename T> struct IDLWrapper : IDLType<RefPtr<T>> {
     using RawType = T;
 
     using StorageType = Ref<T>;
+    using SequenceStorageType = Ref<T>;
 
     using ParameterType = T&;
     using NullableParameterType = T*;
@@ -254,18 +255,18 @@ template<typename T> struct IDLNullable : IDLType<typename T::NullableType> {
     template<typename U> static inline auto extractValueFromNullable(U&& value) -> decltype(T::extractValueFromNullable(std::forward<U>(value))) { return T::extractValueFromNullable(std::forward<U>(value)); }
 };
 
-template<typename T> struct IDLSequence : IDLType<Vector<typename T::ImplementationType>> {
+template<typename T> struct IDLSequence : IDLType<Vector<typename T::InnerParameterType>> {
     using InnerType = T;
 
     using ParameterType = const Vector<typename T::InnerParameterType>&;
     using NullableParameterType = const std::optional<Vector<typename T::InnerParameterType>>&;
 };
 
-template<typename T> struct IDLFrozenArray : IDLType<Vector<typename T::ImplementationType>> {
+template<typename T> struct IDLFrozenArray : IDLType<Vector<typename T::InnerParameterType>> {
     using InnerType = T;
 
-    using ParameterType = const Vector<typename T::ImplementationType>&;
-    using NullableParameterType = const std::optional<Vector<typename T::ImplementationType>>&;
+    using ParameterType = const Vector<typename T::InnerParameterType>&;
+    using NullableParameterType = const std::optional<Vector<typename T::InnerParameterType>>&;
 };
 
 template<typename K, typename V> struct IDLRecord : IDLType<Vector<KeyValuePair<typename K::ImplementationType, typename V::ImplementationType>>> {
@@ -299,7 +300,7 @@ template<typename T> struct IDLBufferSource : IDLWrapper<T> { };
 
 struct IDLArrayBuffer : IDLBufferSource<JSC::ArrayBuffer> { };
 // NOTE: WebIDL defines ArrayBufferView as an IDL union of all the TypedArray types.
-//       and DataView. For convience in our implementation, we give it a distinct
+//       and DataView. For convenience in our implementation, we give it a distinct
 //       type that maps to the shared based class of all those classes.
 struct IDLArrayBufferView : IDLBufferSource<JSC::ArrayBufferView> { };
 struct IDLDataView : IDLBufferSource<JSC::DataView> { };

--- a/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
+++ b/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
@@ -406,7 +406,7 @@ static JSValue deserializeIDBValueToJSValue(JSGlobalObject& lexicalGlobalObject,
     auto serializedValue = SerializedScriptValue::createFromWireBytes(Vector<uint8_t>(data));
 
     lexicalGlobalObject.vm().apiLock().lock();
-    Vector<RefPtr<MessagePort>> messagePorts;
+    Vector<Ref<MessagePort>> messagePorts;
     JSValue result = serializedValue->deserialize(lexicalGlobalObject, &globalObject, messagePorts, value.blobURLs(), value.blobFilePaths(), SerializationErrorMode::NonThrowing);
     lexicalGlobalObject.vm().apiLock().unlock();
 

--- a/Source/WebCore/bindings/js/JSElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementCustom.cpp
@@ -99,11 +99,11 @@ static JSValue getElementsArrayAttribute(JSGlobalObject& lexicalGlobalObject, co
         const_cast<JSElement&>(thisObject).putDirect(vm, builtinNames(vm).cachedAttrAssociatedElementsPrivateName(), cachedObject);
     }
 
-    std::optional<Vector<RefPtr<Element>>> elements = thisObject.wrapped().getElementsArrayAttribute(attributeName);
+    std::optional<Vector<Ref<Element>>> elements = thisObject.wrapped().getElementsArrayAttribute(attributeName);
     auto propertyName = PropertyName(Identifier::fromString(vm, attributeName.toString()));
     JSValue cachedValue = cachedObject->getDirect(vm, propertyName);
     if (!cachedValue.isEmpty()) {
-        std::optional<Vector<RefPtr<Element>>> cachedElements = convert<IDLNullable<IDLFrozenArray<IDLInterface<Element>>>>(lexicalGlobalObject, cachedValue);
+        std::optional<Vector<Ref<Element>>> cachedElements = convert<IDLNullable<IDLFrozenArray<IDLInterface<Element>>>>(lexicalGlobalObject, cachedValue);
         if (elements == cachedElements)
             return cachedValue;
     }

--- a/Source/WebCore/bindings/js/JSElementInternalsCustom.cpp
+++ b/Source/WebCore/bindings/js/JSElementInternalsCustom.cpp
@@ -86,11 +86,11 @@ static JSValue getElementsArrayAttribute(JSGlobalObject& lexicalGlobalObject, co
         const_cast<JSElementInternals&>(thisObject).putDirect(vm, builtinNames(vm).cachedAttrAssociatedElementsPrivateName(), cachedObject);
     }
 
-    std::optional<Vector<RefPtr<Element>>> elements = thisObject.wrapped().getElementsArrayAttribute(attributeName);
+    std::optional<Vector<Ref<Element>>> elements = thisObject.wrapped().getElementsArrayAttribute(attributeName);
     auto propertyName = PropertyName(Identifier::fromString(vm, attributeName.toString()));
     JSValue cachedValue = cachedObject->getDirect(vm, propertyName);
     if (!cachedValue.isEmpty()) {
-        std::optional<Vector<RefPtr<Element>>> cachedElements = convert<IDLNullable<IDLFrozenArray<IDLInterface<Element>>>>(lexicalGlobalObject, cachedValue);
+        std::optional<Vector<Ref<Element>>> cachedElements = convert<IDLNullable<IDLFrozenArray<IDLInterface<Element>>>>(lexicalGlobalObject, cachedValue);
         if (elements == cachedElements)
             return cachedValue;
     }

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1020,18 +1020,18 @@ template <> bool writeLittleEndian<uint8_t>(Vector<uint8_t>& buffer, std::span<c
 
 class CloneSerializer;
 #if ASSERT_ENABLED
-static void validateSerializedResult(CloneSerializer&, SerializationReturnCode, Vector<uint8_t>& result, JSGlobalObject*, Vector<RefPtr<MessagePort>>&, ArrayBufferContentsArray&, ArrayBufferContentsArray& sharedBuffers, Vector<RefPtr<MessagePort>>&);
+static void validateSerializedResult(CloneSerializer&, SerializationReturnCode, Vector<uint8_t>& result, JSGlobalObject*, Vector<Ref<MessagePort>>&, ArrayBufferContentsArray&, ArrayBufferContentsArray& sharedBuffers, Vector<Ref<MessagePort>>&);
 #endif
 
 class CloneSerializer : public CloneBase {
     WTF_FORBID_HEAP_ALLOCATION;
 public:
-    static SerializationReturnCode serialize(JSGlobalObject* lexicalGlobalObject, JSValue value, Vector<RefPtr<MessagePort>>& messagePorts, Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers, const Vector<RefPtr<ImageBitmap>>& imageBitmaps,
+    static SerializationReturnCode serialize(JSGlobalObject* lexicalGlobalObject, JSValue value, Vector<Ref<MessagePort>>& messagePorts, Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers, const Vector<RefPtr<ImageBitmap>>& imageBitmaps,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
             const Vector<RefPtr<OffscreenCanvas>>& offscreenCanvases,
             Vector<RefPtr<OffscreenCanvas>>& inMemoryOffscreenCanvases,
 #endif
-            Vector<RefPtr<MessagePort>>& inMemoryMessagePorts,
+            Vector<Ref<MessagePort>>& inMemoryMessagePorts,
 #if ENABLE(WEB_RTC)
             const Vector<Ref<RTCDataChannel>>& rtcDataChannels,
 #endif
@@ -1119,12 +1119,12 @@ public:
 private:
     using ObjectPoolMap = HashMap<JSObject*, uint32_t>;
 
-    CloneSerializer(JSGlobalObject* lexicalGlobalObject, Vector<RefPtr<MessagePort>>& messagePorts, Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers, const Vector<RefPtr<ImageBitmap>>& imageBitmaps,
+    CloneSerializer(JSGlobalObject* lexicalGlobalObject, Vector<Ref<MessagePort>>& messagePorts, Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers, const Vector<RefPtr<ImageBitmap>>& imageBitmaps,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
             const Vector<RefPtr<OffscreenCanvas>>& offscreenCanvases,
             Vector<RefPtr<OffscreenCanvas>>& inMemoryOffscreenCanvases,
 #endif
-            Vector<RefPtr<MessagePort>>& inMemoryMessagePorts,
+            Vector<Ref<MessagePort>>& inMemoryMessagePorts,
 #if ENABLE(WEB_RTC)
             const Vector<Ref<RTCDataChannel>>& rtcDataChannels,
 #endif
@@ -1940,7 +1940,7 @@ private:
                 } else if (m_context == SerializationContext::CloneAcrossWorlds) {
                     write(InMemoryMessagePortTag);
                     write(static_cast<uint32_t>(m_inMemoryMessagePorts.size()));
-                    m_inMemoryMessagePorts.append(&jsCast<JSMessagePort*>(obj)->wrapped());
+                    m_inMemoryMessagePorts.append(jsCast<JSMessagePort*>(obj)->wrapped());
                     return true;
                 }
                 // MessagePort object could not be found in transferred message ports
@@ -2011,7 +2011,7 @@ private:
                 write(CryptoKeyTag);
                 Vector<uint8_t> serializedKey;
                 Vector<URLKeepingBlobAlive> dummyBlobHandles;
-                Vector<RefPtr<MessagePort>> dummyMessagePorts;
+                Vector<Ref<MessagePort>> dummyMessagePorts;
                 Vector<RefPtr<JSC::ArrayBuffer>> dummyArrayBuffers;
 #if ENABLE(WEB_CODECS)
                 Vector<RefPtr<WebCodecsEncodedVideoChunkStorage>> dummyVideoChunks;
@@ -2030,7 +2030,7 @@ private:
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
                 Vector<RefPtr<OffscreenCanvas>> dummyInMemoryOffscreenCanvases;
 #endif
-                Vector<RefPtr<MessagePort>> dummyInMemoryMessagePorts;
+                Vector<Ref<MessagePort>> dummyInMemoryMessagePorts;
                 CloneSerializer rawKeySerializer(m_lexicalGlobalObject, dummyMessagePorts, dummyArrayBuffers, { },
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
                     { },
@@ -2680,7 +2680,7 @@ private:
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
     Vector<RefPtr<OffscreenCanvas>>& m_inMemoryOffscreenCanvases;
 #endif
-    Vector<RefPtr<MessagePort>>& m_inMemoryMessagePorts;
+    Vector<Ref<MessagePort>>& m_inMemoryMessagePorts;
 #if ENABLE(WEBASSEMBLY)
     WasmModuleArray& m_wasmModules;
     WasmMemoryHandleArray& m_wasmMemoryHandles;
@@ -2990,12 +2990,12 @@ public:
         return str;
     }
 
-    static DeserializationResult deserialize(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<RefPtr<MessagePort>>& messagePorts, Vector<std::optional<DetachedImageBitmap>>&& detachedImageBitmaps
+    static DeserializationResult deserialize(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<Ref<MessagePort>>& messagePorts, Vector<std::optional<DetachedImageBitmap>>&& detachedImageBitmaps
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         , Vector<std::unique_ptr<DetachedOffscreenCanvas>>&& detachedOffscreenCanvases
         , const Vector<RefPtr<OffscreenCanvas>>& inMemoryOffscreenCanvases
 #endif
-        , const Vector<RefPtr<MessagePort>>& inMemoryMessagePorts
+        , const Vector<Ref<MessagePort>>& inMemoryMessagePorts
 #if ENABLE(WEB_RTC)
         , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& detachedRTCDataChannels
 #endif
@@ -3124,12 +3124,12 @@ private:
         size_t m_index { 0 };
     };
 
-    CloneDeserializer(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<RefPtr<MessagePort>>& messagePorts, ArrayBufferContentsArray* arrayBufferContents, Vector<std::optional<DetachedImageBitmap>>&& detachedImageBitmaps, const Vector<uint8_t>& buffer
+    CloneDeserializer(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<Ref<MessagePort>>& messagePorts, ArrayBufferContentsArray* arrayBufferContents, Vector<std::optional<DetachedImageBitmap>>&& detachedImageBitmaps, const Vector<uint8_t>& buffer
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         , Vector<std::unique_ptr<DetachedOffscreenCanvas>>&& detachedOffscreenCanvases = { }
         , const Vector<RefPtr<OffscreenCanvas>>& inMemoryOffscreenCanvases = { }
 #endif
-        , const Vector<RefPtr<MessagePort>>& inMemoryMessagePorts = { }
+        , const Vector<Ref<MessagePort>>& inMemoryMessagePorts = { }
 #if ENABLE(WEB_RTC)
         , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& detachedRTCDataChannels = { }
 #endif
@@ -3203,12 +3203,12 @@ private:
         }
     }
 
-    CloneDeserializer(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<RefPtr<MessagePort>>& messagePorts, ArrayBufferContentsArray* arrayBufferContents, const Vector<uint8_t>& buffer, const Vector<String>& blobURLs, const Vector<String> blobFilePaths, ArrayBufferContentsArray* sharedBuffers, Vector<std::optional<DetachedImageBitmap>>&& detachedImageBitmaps
+    CloneDeserializer(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<Ref<MessagePort>>& messagePorts, ArrayBufferContentsArray* arrayBufferContents, const Vector<uint8_t>& buffer, const Vector<String>& blobURLs, const Vector<String> blobFilePaths, ArrayBufferContentsArray* sharedBuffers, Vector<std::optional<DetachedImageBitmap>>&& detachedImageBitmaps
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         , Vector<std::unique_ptr<DetachedOffscreenCanvas>>&& detachedOffscreenCanvases
         , const Vector<RefPtr<OffscreenCanvas>>& inMemoryOffscreenCanvases
 #endif
-        , const Vector<RefPtr<MessagePort>>& inMemoryMessagePorts
+        , const Vector<Ref<MessagePort>>& inMemoryMessagePorts
 #if ENABLE(WEB_RTC)
         , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& detachedRTCDataChannels
 #endif
@@ -5255,7 +5255,7 @@ private:
             }
 
             JSValue cryptoKey;
-            Vector<RefPtr<MessagePort>> dummyMessagePorts;
+            Vector<Ref<MessagePort>> dummyMessagePorts;
             CloneDeserializer rawKeyDeserializer(m_lexicalGlobalObject, m_globalObject, dummyMessagePorts, nullptr, { }, *serializedKey);
             if (!rawKeyDeserializer.readCryptoKey(cryptoKey)) {
                 SERIALIZE_TRACE("FAIL deserialize");
@@ -5343,7 +5343,7 @@ private:
     unsigned m_minorVersion;
     Vector<CachedString> m_constantPool;
     Vector<Ref<ImageData>> m_imageDataPool;
-    const Vector<RefPtr<MessagePort>>& m_messagePorts;
+    const Vector<Ref<MessagePort>>& m_messagePorts;
     ArrayBufferContentsArray* m_arrayBufferContents;
     Vector<RefPtr<JSC::ArrayBuffer>> m_arrayBuffers;
     Vector<String> m_blobURLs;
@@ -5356,7 +5356,7 @@ private:
     Vector<RefPtr<OffscreenCanvas>> m_offscreenCanvases;
     const Vector<RefPtr<OffscreenCanvas>>& m_inMemoryOffscreenCanvases;
 #endif
-    const Vector<RefPtr<MessagePort>>& m_inMemoryMessagePorts;
+    const Vector<Ref<MessagePort>>& m_inMemoryMessagePorts;
 #if ENABLE(WEB_RTC)
     Vector<std::unique_ptr<DetachedRTCDataChannel>> m_detachedRTCDataChannels;
     Vector<RefPtr<RTCDataChannel>> m_rtcDataChannels;
@@ -5396,7 +5396,7 @@ private:
     }
 
 #if ASSERT_ENABLED
-    friend void validateSerializedResult(CloneSerializer&, SerializationReturnCode, Vector<uint8_t>&, JSGlobalObject*, Vector<RefPtr<MessagePort>>&, ArrayBufferContentsArray&, ArrayBufferContentsArray&, Vector<RefPtr<MessagePort>>&);
+    friend void validateSerializedResult(CloneSerializer&, SerializationReturnCode, Vector<uint8_t>&, JSGlobalObject*, Vector<Ref<MessagePort>>&, ArrayBufferContentsArray&, ArrayBufferContentsArray&, Vector<Ref<MessagePort>>&);
 #endif
 };
 
@@ -5622,7 +5622,7 @@ error:
 }
 
 #if ASSERT_ENABLED
-void validateSerializedResult(CloneSerializer& serializer, SerializationReturnCode code, Vector<uint8_t>& result, JSGlobalObject* lexicalGlobalObject, Vector<RefPtr<MessagePort>>& messagePorts, ArrayBufferContentsArray& arrayBufferContentsArray, ArrayBufferContentsArray& sharedBuffers, Vector<RefPtr<MessagePort>>& inMemoryMessagePorts)
+void validateSerializedResult(CloneSerializer& serializer, SerializationReturnCode code, Vector<uint8_t>& result, JSGlobalObject* lexicalGlobalObject, Vector<Ref<MessagePort>>& messagePorts, ArrayBufferContentsArray& arrayBufferContentsArray, ArrayBufferContentsArray& sharedBuffers, Vector<Ref<MessagePort>>& inMemoryMessagePorts)
 {
     if (!JSC::Options::validateSerializedValue())
         return;
@@ -5785,7 +5785,7 @@ SerializedScriptValue::SerializedScriptValue(Vector<uint8_t>&& buffer, Vector<UR
         , Vector<std::unique_ptr<DetachedOffscreenCanvas>>&& detachedOffscreenCanvases
         , Vector<RefPtr<OffscreenCanvas>>&& inMemoryOffscreenCanvases
 #endif
-        , Vector<RefPtr<MessagePort>>&& inMemoryMessagePorts
+        , Vector<Ref<MessagePort>>&& inMemoryMessagePorts
 #if ENABLE(WEB_RTC)
         , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& detachedRTCDataChannels
 #endif
@@ -6044,19 +6044,19 @@ static bool canDetachMediaSourceHandles(const Vector<Ref<MediaSourceHandle>>& ha
 
 RefPtr<SerializedScriptValue> SerializedScriptValue::create(JSC::JSGlobalObject& globalObject, JSC::JSValue value, SerializationForStorage forStorage, SerializationErrorMode throwExceptions, SerializationContext serializationContext)
 {
-    Vector<RefPtr<MessagePort>> dummyPorts;
+    Vector<Ref<MessagePort>> dummyPorts;
     auto result = create(globalObject, value, { }, dummyPorts, forStorage, throwExceptions, serializationContext);
     if (result.hasException())
         return nullptr;
     return result.releaseReturnValue();
 }
 
-ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalObject& globalObject, JSValue value, Vector<JSC::Strong<JSC::JSObject>>&& transferList, Vector<RefPtr<MessagePort>>& messagePorts, SerializationForStorage forStorage, SerializationContext serializationContext)
+ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalObject& globalObject, JSValue value, Vector<JSC::Strong<JSC::JSObject>>&& transferList, Vector<Ref<MessagePort>>& messagePorts, SerializationForStorage forStorage, SerializationContext serializationContext)
 {
     return create(globalObject, value, WTFMove(transferList), messagePorts, forStorage, SerializationErrorMode::NonThrowing, serializationContext);
 }
 
-ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalObject& lexicalGlobalObject, JSValue value, Vector<JSC::Strong<JSC::JSObject>>&& transferList, Vector<RefPtr<MessagePort>>& messagePorts, SerializationForStorage forStorage, SerializationErrorMode throwExceptions, SerializationContext context)
+ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalObject& lexicalGlobalObject, JSValue value, Vector<JSC::Strong<JSC::JSObject>>&& transferList, Vector<Ref<MessagePort>>& messagePorts, SerializationForStorage forStorage, SerializationErrorMode throwExceptions, SerializationContext context)
 {
     VM& vm = lexicalGlobalObject.vm();
     Vector<RefPtr<JSC::ArrayBuffer>> arrayBuffers;
@@ -6097,7 +6097,7 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
         if (auto port = JSMessagePort::toWrapped(vm, transferable.get())) {
             if (port->isDetached())
                 return Exception { ExceptionCode::DataCloneError, "MessagePort is detached"_s };
-            messagePorts.append(WTFMove(port));
+            messagePorts.append(*port);
             continue;
         }
 
@@ -6185,7 +6185,7 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
     Vector<RefPtr<OffscreenCanvas>> inMemoryOffscreenCanvases;
 #endif
-    Vector<RefPtr<MessagePort>> inMemoryMessagePorts;
+    Vector<Ref<MessagePort>> inMemoryMessagePorts;
 #if ENABLE(WEBASSEMBLY)
     WasmModuleArray wasmModules;
     WasmMemoryHandleArray wasmMemoryHandles;
@@ -6339,14 +6339,14 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
     return deserialize(lexicalGlobalObject, globalObject, { }, throwExceptions, didFail);
 }
 
-JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<RefPtr<MessagePort>>& messagePorts, SerializationErrorMode throwExceptions, bool* didFail)
+JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<Ref<MessagePort>>& messagePorts, SerializationErrorMode throwExceptions, bool* didFail)
 {
     Vector<String> dummyBlobs;
     Vector<String> dummyPaths;
     return deserialize(lexicalGlobalObject, globalObject, messagePorts, dummyBlobs, dummyPaths, throwExceptions, didFail);
 }
 
-JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<RefPtr<MessagePort>>& messagePorts, const Vector<String>& blobURLs, const Vector<String>& blobFilePaths, SerializationErrorMode throwExceptions, bool* didFail)
+JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, JSGlobalObject* globalObject, const Vector<Ref<MessagePort>>& messagePorts, const Vector<String>& blobURLs, const Vector<String>& blobFilePaths, SerializationErrorMode throwExceptions, bool* didFail)
 {
     DeserializationResult result = CloneDeserializer::deserialize(&lexicalGlobalObject, globalObject, messagePorts, WTFMove(m_internals.detachedImageBitmaps)
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -88,7 +88,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SerializedScriptValue);
 class SerializedScriptValue : public ThreadSafeRefCounted<SerializedScriptValue> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(SerializedScriptValue);
 public:
-    WEBCORE_EXPORT static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<RefPtr<MessagePort>>&, SerializationForStorage = SerializationForStorage::No, SerializationContext = SerializationContext::Default);
+    WEBCORE_EXPORT static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<Ref<MessagePort>>&, SerializationForStorage = SerializationForStorage::No, SerializationContext = SerializationContext::Default);
     WEBCORE_EXPORT static RefPtr<SerializedScriptValue> create(JSC::JSGlobalObject&, JSC::JSValue, SerializationForStorage = SerializationForStorage::No, SerializationErrorMode = SerializationErrorMode::Throwing, SerializationContext = SerializationContext::Default);
     static RefPtr<SerializedScriptValue> convert(JSC::JSGlobalObject& globalObject, JSC::JSValue value) { return create(globalObject, value, SerializationForStorage::Yes); }
 
@@ -97,8 +97,8 @@ public:
     static Ref<SerializedScriptValue> nullValue();
 
     WEBCORE_EXPORT JSC::JSValue deserialize(JSC::JSGlobalObject&, JSC::JSGlobalObject*, SerializationErrorMode = SerializationErrorMode::Throwing, bool* didFail = nullptr);
-    WEBCORE_EXPORT JSC::JSValue deserialize(JSC::JSGlobalObject&, JSC::JSGlobalObject*, const Vector<RefPtr<MessagePort>>&, SerializationErrorMode = SerializationErrorMode::Throwing, bool* didFail = nullptr);
-    JSC::JSValue deserialize(JSC::JSGlobalObject&, JSC::JSGlobalObject*, const Vector<RefPtr<MessagePort>>&, const Vector<String>& blobURLs, const Vector<String>& blobFilePaths, SerializationErrorMode = SerializationErrorMode::Throwing, bool* didFail = nullptr);
+    WEBCORE_EXPORT JSC::JSValue deserialize(JSC::JSGlobalObject&, JSC::JSGlobalObject*, const Vector<Ref<MessagePort>>&, SerializationErrorMode = SerializationErrorMode::Throwing, bool* didFail = nullptr);
+    JSC::JSValue deserialize(JSC::JSGlobalObject&, JSC::JSGlobalObject*, const Vector<Ref<MessagePort>>&, const Vector<String>& blobURLs, const Vector<String>& blobFilePaths, SerializationErrorMode = SerializationErrorMode::Throwing, bool* didFail = nullptr);
 
     WEBCORE_EXPORT String toString() const;
 
@@ -125,7 +125,7 @@ public:
 private:
     friend struct IPC::ArgumentCoder<SerializedScriptValue, void>;
 
-    static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<RefPtr<MessagePort>>&, SerializationForStorage, SerializationErrorMode, SerializationContext);
+    static ExceptionOr<Ref<SerializedScriptValue>> create(JSC::JSGlobalObject&, JSC::JSValue, Vector<JSC::Strong<JSC::JSObject>>&& transfer, Vector<Ref<MessagePort>>&, SerializationForStorage, SerializationErrorMode, SerializationContext);
     WEBCORE_EXPORT SerializedScriptValue(Vector<unsigned char>&&, std::unique_ptr<ArrayBufferContentsArray>&& = nullptr
 #if ENABLE(WEB_RTC)
         , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& = { }
@@ -149,7 +149,7 @@ private:
         , Vector<std::unique_ptr<DetachedOffscreenCanvas>>&& = { }
         , Vector<RefPtr<OffscreenCanvas>>&& = { }
 #endif
-        , Vector<RefPtr<MessagePort>>&& = { }
+        , Vector<Ref<MessagePort>>&& = { }
 #if ENABLE(WEB_RTC)
         , Vector<std::unique_ptr<DetachedRTCDataChannel>>&& = { }
 #endif
@@ -197,7 +197,7 @@ private:
         Vector<std::unique_ptr<DetachedOffscreenCanvas>> detachedOffscreenCanvases { };
         Vector<RefPtr<OffscreenCanvas>> inMemoryOffscreenCanvases { };
 #endif
-        Vector<RefPtr<MessagePort>> inMemoryMessagePorts { };
+        Vector<Ref<MessagePort>> inMemoryMessagePorts { };
 #if ENABLE(WEBASSEMBLY)
         std::unique_ptr<WasmModuleArray> wasmModulesArray { };
         std::unique_ptr<WasmMemoryHandleArray> wasmMemoryHandlesArray { };

--- a/Source/WebCore/css/CSSStyleSheetObservableArray.cpp
+++ b/Source/WebCore/css/CSSStyleSheetObservableArray.cpp
@@ -62,9 +62,9 @@ bool CSSStyleSheetObservableArray::setValueAt(JSC::JSGlobalObject* lexicalGlobal
     }
 
     if (index == m_sheets.size())
-        m_sheets.append(sheet.copyRef());
+        m_sheets.append(*sheet);
     else
-        m_sheets[index] = sheet.copyRef();
+        m_sheets[index] = *sheet;
 
     didAddSheet(*sheet);
     return true;
@@ -74,7 +74,7 @@ void CSSStyleSheetObservableArray::removeLast()
 {
     RELEASE_ASSERT(!m_sheets.isEmpty());
     auto sheet = m_sheets.takeLast();
-    willRemoveSheet(*sheet);
+    willRemoveSheet(sheet);
 }
 
 void CSSStyleSheetObservableArray::shrinkTo(unsigned length)
@@ -87,21 +87,21 @@ JSC::JSValue CSSStyleSheetObservableArray::valueAt(JSC::JSGlobalObject* lexicalG
 {
     if (index >= m_sheets.size())
         return JSC::jsUndefined();
-    return toJS(lexicalGlobalObject, JSC::jsCast<JSDOMGlobalObject*>(lexicalGlobalObject), m_sheets[index].get());
+    return toJS(lexicalGlobalObject, JSC::jsCast<JSDOMGlobalObject*>(lexicalGlobalObject), m_sheets[index]);
 }
 
-ExceptionOr<void> CSSStyleSheetObservableArray::setSheets(Vector<RefPtr<CSSStyleSheet>>&& sheets)
+ExceptionOr<void> CSSStyleSheetObservableArray::setSheets(Vector<Ref<CSSStyleSheet>>&& sheets)
 {
     for (auto& sheet : sheets) {
-        if (auto exception = shouldThrowWhenAddingSheet(*sheet))
+        if (auto exception = shouldThrowWhenAddingSheet(sheet))
             return WTFMove(*exception);
     }
 
     for (auto& sheet : m_sheets)
-        willRemoveSheet(*sheet);
+        willRemoveSheet(sheet);
     m_sheets = WTFMove(sheets);
     for (auto& sheet : m_sheets)
-        didAddSheet(*sheet);
+        didAddSheet(sheet);
 
     return { };
 }

--- a/Source/WebCore/css/CSSStyleSheetObservableArray.h
+++ b/Source/WebCore/css/CSSStyleSheetObservableArray.h
@@ -37,8 +37,8 @@ class CSSStyleSheetObservableArray : public JSC::ObservableArray {
 public:
     static Ref<CSSStyleSheetObservableArray> create(ContainerNode& treeScope);
 
-    ExceptionOr<void> setSheets(Vector<RefPtr<CSSStyleSheet>>&&);
-    const Vector<RefPtr<CSSStyleSheet>>& sheets() const { return m_sheets; }
+    ExceptionOr<void> setSheets(Vector<Ref<CSSStyleSheet>>&&);
+    const Vector<Ref<CSSStyleSheet>>& sheets() const { return m_sheets; }
 
 private:
     explicit CSSStyleSheetObservableArray(ContainerNode& treeScope);
@@ -58,7 +58,7 @@ private:
     void willRemoveSheet(CSSStyleSheet&);
 
     WeakPtr<ContainerNode, WeakPtrImplWithEventTargetData> m_treeScope;
-    Vector<RefPtr<CSSStyleSheet>> m_sheets;
+    Vector<Ref<CSSStyleSheet>> m_sheets;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/FontFaceSet.cpp
+++ b/Source/WebCore/css/FontFaceSet.cpp
@@ -45,7 +45,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(FontFaceSet);
 
-Ref<FontFaceSet> FontFaceSet::create(ScriptExecutionContext& context, const Vector<RefPtr<FontFace>>& initialFaces)
+Ref<FontFaceSet> FontFaceSet::create(ScriptExecutionContext& context, const Vector<Ref<FontFace>>& initialFaces)
 {
     Ref<FontFaceSet> result = adoptRef(*new FontFaceSet(context, initialFaces));
     result->suspendIfNeeded();
@@ -59,14 +59,14 @@ Ref<FontFaceSet> FontFaceSet::create(ScriptExecutionContext& context, CSSFontFac
     return result;
 }
 
-FontFaceSet::FontFaceSet(ScriptExecutionContext& context, const Vector<RefPtr<FontFace>>& initialFaces)
+FontFaceSet::FontFaceSet(ScriptExecutionContext& context, const Vector<Ref<FontFace>>& initialFaces)
     : ActiveDOMObject(&context)
     , m_backing(CSSFontFaceSet::create())
     , m_readyPromise(makeUniqueRef<ReadyPromise>(*this, &FontFaceSet::readyPromiseResolve))
 {
     m_backing->addFontEventClient(*this);
     for (auto& face : initialFaces)
-        add(*face);
+        add(face);
 }
 
 FontFaceSet::FontFaceSet(ScriptExecutionContext& context, CSSFontFaceSet& backing)

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -41,7 +41,7 @@ class DOMException;
 class FontFaceSet final : public RefCounted<FontFaceSet>, private CSSFontFaceSet::FontEventClient, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_ISO_ALLOCATED(FontFaceSet);
 public:
-    static Ref<FontFaceSet> create(ScriptExecutionContext&, const Vector<RefPtr<FontFace>>& initialFaces);
+    static Ref<FontFaceSet> create(ScriptExecutionContext&, const Vector<Ref<FontFace>>& initialFaces);
     static Ref<FontFaceSet> create(ScriptExecutionContext&, CSSFontFaceSet& backing);
     virtual ~FontFaceSet();
 
@@ -95,7 +95,7 @@ private:
         bool hasReachedTerminalState { false };
     };
 
-    FontFaceSet(ScriptExecutionContext&, const Vector<RefPtr<FontFace>>&);
+    FontFaceSet(ScriptExecutionContext&, const Vector<Ref<FontFace>>&);
     FontFaceSet(ScriptExecutionContext&, CSSFontFaceSet&);
 
     // CSSFontFaceSet::FontEventClient

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -97,7 +97,7 @@ static ExceptionOr<Ref<CSSTransformComponent>> createTransformComponent(CSSFunct
 
 ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(const CSSTransformListValue& list)
 {
-    Vector<RefPtr<CSSTransformComponent>> components;
+    Vector<Ref<CSSTransformComponent>> components;
     for (auto& value : list) {
         auto* functionValue = dynamicDowncast<CSSFunctionValue>(value);
         if (!functionValue)
@@ -110,7 +110,7 @@ ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(const CSSTransform
     return adoptRef(*new CSSTransformValue(WTFMove(components)));
 }
 
-ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(Vector<RefPtr<CSSTransformComponent>>&& transforms)
+ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(Vector<Ref<CSSTransformComponent>>&& transforms)
 {
     // https://drafts.css-houdini.org/css-typed-om/#dom-csstransformvalue-csstransformvalue
     if (transforms.isEmpty())
@@ -120,10 +120,10 @@ ExceptionOr<Ref<CSSTransformValue>> CSSTransformValue::create(Vector<RefPtr<CSST
 
 RefPtr<CSSTransformComponent> CSSTransformValue::item(size_t index)
 {
-    return index < m_components.size() ? m_components[index] : nullptr;
+    return index < m_components.size() ? m_components[index].ptr() : nullptr;
 }
 
-ExceptionOr<RefPtr<CSSTransformComponent>> CSSTransformValue::setItem(size_t index, Ref<CSSTransformComponent>&& value)
+ExceptionOr<Ref<CSSTransformComponent>> CSSTransformValue::setItem(size_t index, Ref<CSSTransformComponent>&& value)
 {
     if (index > m_components.size())
         return Exception { ExceptionCode::RangeError, makeString("Index ", index, " exceeds the range of CSSTransformValue.") };
@@ -133,14 +133,14 @@ ExceptionOr<RefPtr<CSSTransformComponent>> CSSTransformValue::setItem(size_t ind
     else
         m_components[index] = WTFMove(value);
 
-    return RefPtr<CSSTransformComponent> { m_components[index] };
+    return Ref<CSSTransformComponent> { m_components[index] };
 }
 
 bool CSSTransformValue::is2D() const
 {
     // https://drafts.css-houdini.org/css-typed-om/#dom-csstransformvalue-is2d
     return WTF::allOf(m_components, [] (auto& component) {
-        return component && component->is2D();
+        return component->is2D();
     });
 }
 
@@ -162,7 +162,7 @@ ExceptionOr<Ref<DOMMatrix>> CSSTransformValue::toMatrix()
     return DOMMatrix::create(WTFMove(matrix), is2D);
 }
 
-CSSTransformValue::CSSTransformValue(Vector<RefPtr<CSSTransformComponent>>&& transforms)
+CSSTransformValue::CSSTransformValue(Vector<Ref<CSSTransformComponent>>&& transforms)
     : m_components(WTFMove(transforms))
 {
 }

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.h
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.h
@@ -40,12 +40,12 @@ class CSSTransformValue final : public CSSStyleValue {
     WTF_MAKE_ISO_ALLOCATED(CSSTransformValue);
 public:
     static ExceptionOr<Ref<CSSTransformValue>> create(const CSSTransformListValue&);
-    static ExceptionOr<Ref<CSSTransformValue>> create(Vector<RefPtr<CSSTransformComponent>>&&);
+    static ExceptionOr<Ref<CSSTransformValue>> create(Vector<Ref<CSSTransformComponent>>&&);
 
     size_t length() const { return m_components.size(); }
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_components.size(); }
     RefPtr<CSSTransformComponent> item(size_t);
-    ExceptionOr<RefPtr<CSSTransformComponent>> setItem(size_t, Ref<CSSTransformComponent>&&);
+    ExceptionOr<Ref<CSSTransformComponent>> setItem(size_t, Ref<CSSTransformComponent>&&);
     
     bool is2D() const;
     
@@ -56,10 +56,10 @@ public:
     RefPtr<CSSValue> toCSSValue() const final;
 
 private:
-    CSSTransformValue(Vector<RefPtr<CSSTransformComponent>>&&);
+    CSSTransformValue(Vector<Ref<CSSTransformComponent>>&&);
     void serialize(StringBuilder&, OptionSet<SerializationArguments>) const final;
 
-    Vector<RefPtr<CSSTransformComponent>> m_components;
+    Vector<Ref<CSSTransformComponent>> m_components;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -76,7 +76,7 @@ Ref<AbortSignal> AbortSignal::timeout(ScriptExecutionContext& context, uint64_t 
     return signal;
 }
 
-Ref<AbortSignal> AbortSignal::any(ScriptExecutionContext& context, const Vector<RefPtr<AbortSignal>>& signals)
+Ref<AbortSignal> AbortSignal::any(ScriptExecutionContext& context, const Vector<Ref<AbortSignal>>& signals)
 {
     Ref resultSignal = AbortSignal::create(&context);
 
@@ -88,7 +88,7 @@ Ref<AbortSignal> AbortSignal::any(ScriptExecutionContext& context, const Vector<
 
     resultSignal->markAsDependent();
     for (auto& signal : signals)
-        resultSignal->addSourceSignal(*signal);
+        resultSignal->addSourceSignal(signal);
 
     return resultSignal;
 }

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -48,7 +48,7 @@ public:
 
     static Ref<AbortSignal> abort(JSDOMGlobalObject&, ScriptExecutionContext&, JSC::JSValue reason);
     static Ref<AbortSignal> timeout(ScriptExecutionContext&, uint64_t milliseconds);
-    static Ref<AbortSignal> any(ScriptExecutionContext&, const Vector<RefPtr<AbortSignal>>&);
+    static Ref<AbortSignal> any(ScriptExecutionContext&, const Vector<Ref<AbortSignal>>&);
 
     static uint32_t addAbortAlgorithmToSignal(AbortSignal&, Ref<AbortAlgorithm>&&);
     static void removeAbortAlgorithmFromSignal(AbortSignal&, uint32_t algorithmIdentifier);

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -200,7 +200,7 @@ ExceptionOr<void> BroadcastChannel::postMessage(JSC::JSGlobalObject& globalObjec
     if (m_isClosed)
         return Exception { ExceptionCode::InvalidStateError, "This BroadcastChannel is closed"_s };
 
-    Vector<RefPtr<MessagePort>> ports;
+    Vector<Ref<MessagePort>> ports;
     auto messageData = SerializedScriptValue::create(globalObject, message, { }, ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (messageData.hasException())
         return messageData.releaseException();

--- a/Source/WebCore/dom/CustomElementDefaultARIA.h
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.h
@@ -49,8 +49,8 @@ public:
     void setValueForAttribute(const QualifiedName&, const AtomString&);
     RefPtr<Element> elementForAttribute(const Element& thisElement, const QualifiedName&) const;
     void setElementForAttribute(const QualifiedName&, Element*);
-    Vector<RefPtr<Element>> elementsForAttribute(const Element& thisElement, const QualifiedName&) const;
-    void setElementsForAttribute(const QualifiedName&, std::optional<Vector<RefPtr<Element>>>&&);
+    Vector<Ref<Element>> elementsForAttribute(const Element& thisElement, const QualifiedName&) const;
+    void setElementsForAttribute(const QualifiedName&, std::optional<Vector<Ref<Element>>>&&);
 
 private:
     using WeakElementPtr = WeakPtr<Element, WeakPtrImplWithEventTargetData>;

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -161,8 +161,8 @@ public:
     WEBCORE_EXPORT void setUnsignedIntegralAttribute(const QualifiedName& attributeName, unsigned value);
     WEBCORE_EXPORT RefPtr<Element> getElementAttribute(const QualifiedName& attributeName) const;
     WEBCORE_EXPORT void setElementAttribute(const QualifiedName& attributeName, Element* value);
-    WEBCORE_EXPORT std::optional<Vector<RefPtr<Element>>> getElementsArrayAttribute(const QualifiedName& attributeName) const;
-    WEBCORE_EXPORT void setElementsArrayAttribute(const QualifiedName& attributeName, std::optional<Vector<RefPtr<Element>>>&& value);
+    WEBCORE_EXPORT std::optional<Vector<Ref<Element>>> getElementsArrayAttribute(const QualifiedName& attributeName) const;
+    WEBCORE_EXPORT void setElementsArrayAttribute(const QualifiedName& attributeName, std::optional<Vector<Ref<Element>>>&& value);
     static bool isElementReflectionAttribute(const Settings&, const QualifiedName&);
     static bool isElementsArrayReflectionAttribute(const QualifiedName&);
 

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -172,7 +172,7 @@ void ElementInternals::setElementAttribute(const QualifiedName& name, Element* v
         cache->deferAttributeChangeIfNeeded(element.get(), name, oldValue, computeValueForAttribute(*element, name));
 }
 
-std::optional<Vector<RefPtr<Element>>> ElementInternals::getElementsArrayAttribute(const QualifiedName& name) const
+std::optional<Vector<Ref<Element>>> ElementInternals::getElementsArrayAttribute(const QualifiedName& name) const
 {
     RefPtr element = m_element.get();
     CheckedPtr defaultARIA = m_element->customElementDefaultARIAIfExists();
@@ -181,7 +181,7 @@ std::optional<Vector<RefPtr<Element>>> ElementInternals::getElementsArrayAttribu
     return defaultARIA->elementsForAttribute(*element, name);
 }
 
-void ElementInternals::setElementsArrayAttribute(const QualifiedName& name, std::optional<Vector<RefPtr<Element>>>&& value)
+void ElementInternals::setElementsArrayAttribute(const QualifiedName& name, std::optional<Vector<Ref<Element>>>&& value)
 {
     RefPtr element = m_element.get();
     auto oldValue = computeValueForAttribute(*element, name);

--- a/Source/WebCore/dom/ElementInternals.h
+++ b/Source/WebCore/dom/ElementInternals.h
@@ -70,8 +70,8 @@ public:
 
     RefPtr<Element> getElementAttribute(const QualifiedName&) const;
     void setElementAttribute(const QualifiedName&, Element*);
-    std::optional<Vector<RefPtr<Element>>> getElementsArrayAttribute(const QualifiedName&) const;
-    void setElementsArrayAttribute(const QualifiedName&, std::optional<Vector<RefPtr<Element>>>&&);
+    std::optional<Vector<Ref<Element>>> getElementsArrayAttribute(const QualifiedName&) const;
+    void setElementsArrayAttribute(const QualifiedName&, std::optional<Vector<Ref<Element>>>&&);
 
     CustomStateSet& states();
 

--- a/Source/WebCore/dom/GetHTMLOptions.h
+++ b/Source/WebCore/dom/GetHTMLOptions.h
@@ -31,7 +31,7 @@ class ShadowRoot;
 
 struct GetHTMLOptions {
     bool serializableShadowRoots { false };
-    Vector<RefPtr<ShadowRoot>> shadowRoots;
+    Vector<Ref<ShadowRoot>> shadowRoots;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/MessageEvent.cpp
+++ b/Source/WebCore/dom/MessageEvent.cpp
@@ -56,7 +56,7 @@ inline MessageEvent::MessageEvent(const AtomString& type, Init&& initializer, Is
 {
 }
 
-inline MessageEvent::MessageEvent(const AtomString& type, DataType&& data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&& source, Vector<RefPtr<MessagePort>>&& ports)
+inline MessageEvent::MessageEvent(const AtomString& type, DataType&& data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&& source, Vector<Ref<MessagePort>>&& ports)
     : Event(EventInterfaceType::MessageEvent, type, CanBubble::No, IsCancelable::No)
     , m_data(WTFMove(data))
     , m_origin(origin)
@@ -66,7 +66,7 @@ inline MessageEvent::MessageEvent(const AtomString& type, DataType&& data, const
 {
 }
 
-auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScriptValue>&& data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&& source, Vector<RefPtr<MessagePort>>&& ports) -> MessageEventWithStrongData
+auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScriptValue>&& data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&& source, Vector<Ref<MessagePort>>&& ports) -> MessageEventWithStrongData
 {
     auto& vm = globalObject.vm();
     Locker<JSC::JSLock> locker(vm.apiLock());
@@ -84,12 +84,12 @@ auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScrip
     return MessageEventWithStrongData { event, WTFMove(strongWrapper) };
 }
 
-Ref<MessageEvent> MessageEvent::create(const AtomString& type, DataType&& data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&& source, Vector<RefPtr<MessagePort>>&& ports)
+Ref<MessageEvent> MessageEvent::create(const AtomString& type, DataType&& data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&& source, Vector<Ref<MessagePort>>&& ports)
 {
     return adoptRef(*new MessageEvent(type, WTFMove(data), origin, lastEventId, WTFMove(source), WTFMove(ports)));
 }
 
-Ref<MessageEvent> MessageEvent::create(DataType&& data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&& source, Vector<RefPtr<MessagePort>>&& ports)
+Ref<MessageEvent> MessageEvent::create(DataType&& data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&& source, Vector<Ref<MessagePort>>&& ports)
 {
     return create(eventNames().messageEvent, WTFMove(data), origin, lastEventId, WTFMove(source), WTFMove(ports));
 }
@@ -106,7 +106,7 @@ Ref<MessageEvent> MessageEvent::create(const AtomString& type, Init&& initialize
 
 MessageEvent::~MessageEvent() = default;
 
-void MessageEvent::initMessageEvent(const AtomString& type, bool canBubble, bool cancelable, JSValue data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&& source, Vector<RefPtr<MessagePort>>&& ports)
+void MessageEvent::initMessageEvent(const AtomString& type, bool canBubble, bool cancelable, JSValue data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&& source, Vector<Ref<MessagePort>>&& ports)
 {
     if (isBeingDispatched())
         return;

--- a/Source/WebCore/dom/MessageEvent.h
+++ b/Source/WebCore/dom/MessageEvent.h
@@ -46,8 +46,8 @@ class MessageEvent final : public Event {
 public:
     struct JSValueTag { };
     using DataType = std::variant<JSValueTag, Ref<SerializedScriptValue>, String, Ref<Blob>, Ref<ArrayBuffer>>;
-    static Ref<MessageEvent> create(const AtomString& type, DataType&&, const String& origin = { }, const String& lastEventId = { }, std::optional<MessageEventSource>&& = std::nullopt, Vector<RefPtr<MessagePort>>&& = { });
-    static Ref<MessageEvent> create(DataType&&, const String& origin = { }, const String& lastEventId = { }, std::optional<MessageEventSource>&& = std::nullopt, Vector<RefPtr<MessagePort>>&& = { });
+    static Ref<MessageEvent> create(const AtomString& type, DataType&&, const String& origin = { }, const String& lastEventId = { }, std::optional<MessageEventSource>&& = std::nullopt, Vector<Ref<MessagePort>>&& = { });
+    static Ref<MessageEvent> create(DataType&&, const String& origin = { }, const String& lastEventId = { }, std::optional<MessageEventSource>&& = std::nullopt, Vector<Ref<MessagePort>>&& = { });
     static Ref<MessageEvent> createForBindings();
 
     struct MessageEventWithStrongData {
@@ -55,25 +55,25 @@ public:
         JSC::Strong<JSC::JSObject> strongWrapper; // Keep the wrapper alive until the event is fired, since it is what keeps `data` alive.
     };
 
-    static MessageEventWithStrongData create(JSC::JSGlobalObject&, Ref<SerializedScriptValue>&&, const String& origin = { }, const String& lastEventId = { }, std::optional<MessageEventSource>&& = std::nullopt, Vector<RefPtr<MessagePort>>&& = { });
+    static MessageEventWithStrongData create(JSC::JSGlobalObject&, Ref<SerializedScriptValue>&&, const String& origin = { }, const String& lastEventId = { }, std::optional<MessageEventSource>&& = std::nullopt, Vector<Ref<MessagePort>>&& = { });
 
     struct Init : EventInit {
         JSC::JSValue data;
         String origin;
         String lastEventId;
         std::optional<MessageEventSource> source;
-        Vector<RefPtr<MessagePort>> ports;
+        Vector<Ref<MessagePort>> ports;
     };
     static Ref<MessageEvent> create(const AtomString& type, Init&&, IsTrusted = IsTrusted::No);
 
     virtual ~MessageEvent();
 
-    void initMessageEvent(const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&&, Vector<RefPtr<MessagePort>>&&);
+    void initMessageEvent(const AtomString& type, bool canBubble, bool cancelable, JSC::JSValue data, const String& origin, const String& lastEventId, std::optional<MessageEventSource>&&, Vector<Ref<MessagePort>>&&);
 
     const String& origin() const { return m_origin; }
     const String& lastEventId() const { return m_lastEventId; }
     const std::optional<MessageEventSource>& source() const { return m_source; }
-    const Vector<RefPtr<MessagePort>>& ports() const { return m_ports; }
+    const Vector<Ref<MessagePort>>& ports() const { return m_ports; }
 
     const DataType& data() const { return m_data; }
 
@@ -86,13 +86,13 @@ public:
 private:
     MessageEvent();
     MessageEvent(const AtomString& type, Init&&, IsTrusted);
-    MessageEvent(const AtomString& type, DataType&&, const String& origin, const String& lastEventId = { }, std::optional<MessageEventSource>&& = std::nullopt, Vector<RefPtr<MessagePort>>&& = { });
+    MessageEvent(const AtomString& type, DataType&&, const String& origin, const String& lastEventId = { }, std::optional<MessageEventSource>&& = std::nullopt, Vector<Ref<MessagePort>>&& = { });
 
     DataType m_data WTF_GUARDED_BY_LOCK(m_concurrentDataAccessLock);
     String m_origin;
     String m_lastEventId;
     std::optional<MessageEventSource> m_source;
-    Vector<RefPtr<MessagePort>> m_ports;
+    Vector<Ref<MessagePort>> m_ports;
 
     JSValueInWrappedObject m_jsData;
     JSValueInWrappedObject m_cachedData;

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -142,7 +142,7 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
 {
     LOG(MessagePorts, "Attempting to post message to port %s (to be received by port %s)", m_identifier.logString().utf8().data(), m_remoteIdentifier.logString().utf8().data());
 
-    Vector<RefPtr<MessagePort>> ports;
+    Vector<Ref<MessagePort>> ports;
     auto messageData = SerializedScriptValue::create(state, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (messageData.hasException())
         return messageData.releaseException();
@@ -322,7 +322,7 @@ MessagePort* MessagePort::locallyEntangledPort() const
     return nullptr;
 }
 
-ExceptionOr<Vector<TransferredMessagePort>> MessagePort::disentanglePorts(Vector<RefPtr<MessagePort>>&& ports)
+ExceptionOr<Vector<TransferredMessagePort>> MessagePort::disentanglePorts(Vector<Ref<MessagePort>>&& ports)
 {
     if (ports.isEmpty())
         return Vector<TransferredMessagePort> { };
@@ -330,7 +330,7 @@ ExceptionOr<Vector<TransferredMessagePort>> MessagePort::disentanglePorts(Vector
     // Walk the incoming array - if there are any duplicate ports, or null ports or cloned ports, throw an error (per section 8.3.3 of the HTML5 spec).
     HashSet<Ref<MessagePort>> portSet;
     for (auto& port : ports) {
-        if (!port || !port->m_entangled || !portSet.add(*port).isNewEntry)
+        if (!port->m_entangled || !portSet.add(port).isNewEntry)
             return Exception { ExceptionCode::DataCloneError };
     }
 
@@ -340,14 +340,14 @@ ExceptionOr<Vector<TransferredMessagePort>> MessagePort::disentanglePorts(Vector
     });
 }
 
-Vector<RefPtr<MessagePort>> MessagePort::entanglePorts(ScriptExecutionContext& context, Vector<TransferredMessagePort>&& transferredPorts)
+Vector<Ref<MessagePort>> MessagePort::entanglePorts(ScriptExecutionContext& context, Vector<TransferredMessagePort>&& transferredPorts)
 {
     LOG(MessagePorts, "Entangling %zu transferred ports to ScriptExecutionContext %s (%p)", transferredPorts.size(), context.url().string().utf8().data(), &context);
 
     if (transferredPorts.isEmpty())
         return { };
 
-    return WTF::map(transferredPorts, [&](auto& port) -> RefPtr<MessagePort> {
+    return WTF::map(WTFMove(transferredPorts), [&](auto&& port) -> Ref<MessagePort> {
         return MessagePort::entangle(context, WTFMove(port));
     });
 }

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -65,8 +65,8 @@ public:
     void entangle();
 
     // Returns nullptr if the passed-in vector is empty.
-    static ExceptionOr<Vector<TransferredMessagePort>> disentanglePorts(Vector<RefPtr<MessagePort>>&&);
-    static Vector<RefPtr<MessagePort>> entanglePorts(ScriptExecutionContext&, Vector<TransferredMessagePort>&&);
+    static ExceptionOr<Vector<TransferredMessagePort>> disentanglePorts(Vector<Ref<MessagePort>>&&);
+    static Vector<Ref<MessagePort>> entanglePorts(ScriptExecutionContext&, Vector<TransferredMessagePort>&&);
 
     WEBCORE_EXPORT static bool isMessagePortAliveForTesting(const MessagePortIdentifier&);
     WEBCORE_EXPORT static void notifyMessageAvailable(const MessagePortIdentifier&);

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -586,9 +586,9 @@ CSSStyleSheetObservableArray& TreeScope::ensureAdoptedStyleSheets()
     return *m_adoptedStyleSheets;
 }
 
-std::span<const RefPtr<CSSStyleSheet>> TreeScope::adoptedStyleSheets() const
+std::span<const Ref<CSSStyleSheet>> TreeScope::adoptedStyleSheets() const
 {
-    return m_adoptedStyleSheets ? m_adoptedStyleSheets->sheets().span() : std::span<const RefPtr<CSSStyleSheet>> { };
+    return m_adoptedStyleSheets ? m_adoptedStyleSheets->sheets().span() : std::span<const Ref<CSSStyleSheet>> { };
 }
 
 JSC::JSValue TreeScope::adoptedStyleSheetWrapper(JSDOMGlobalObject& lexicalGlobalObject)
@@ -596,7 +596,7 @@ JSC::JSValue TreeScope::adoptedStyleSheetWrapper(JSDOMGlobalObject& lexicalGloba
     return JSC::JSObservableArray::create(&lexicalGlobalObject, ensureAdoptedStyleSheets());
 }
 
-ExceptionOr<void> TreeScope::setAdoptedStyleSheets(Vector<RefPtr<CSSStyleSheet>>&& sheets)
+ExceptionOr<void> TreeScope::setAdoptedStyleSheets(Vector<Ref<CSSStyleSheet>>&& sheets)
 {
     if (!m_adoptedStyleSheets && sheets.isEmpty())
         return { };

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -132,8 +132,8 @@ public:
     RadioButtonGroups& radioButtonGroups();
 
     JSC::JSValue adoptedStyleSheetWrapper(JSDOMGlobalObject&);
-    std::span<const RefPtr<CSSStyleSheet>> adoptedStyleSheets() const;
-    ExceptionOr<void> setAdoptedStyleSheets(Vector<RefPtr<CSSStyleSheet>>&&);
+    std::span<const Ref<CSSStyleSheet>> adoptedStyleSheets() const;
+    ExceptionOr<void> setAdoptedStyleSheets(Vector<Ref<CSSStyleSheet>>&&);
 
     void addSVGResource(const AtomString& id, LegacyRenderSVGResourceContainer&);
     void removeSVGResource(const AtomString& id);

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -193,7 +193,7 @@ void MarkupAccumulator::appendCharactersReplacingEntities(StringBuilder& result,
         appendCharactersReplacingEntitiesInternal<UChar>(result, source, offset, length, entityMask);
 }
 
-MarkupAccumulator::MarkupAccumulator(Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, SerializationSyntax serializationSyntax, HashMap<String, String>&& replacementURLStrings, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots serializeShadowRoots, Vector<RefPtr<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
+MarkupAccumulator::MarkupAccumulator(Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, SerializationSyntax serializationSyntax, HashMap<String, String>&& replacementURLStrings, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots serializeShadowRoots, Vector<Ref<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
     : m_nodes(nodes)
     , m_resolveURLs(resolveURLs)
     , m_serializationSyntax(serializationSyntax)
@@ -247,7 +247,7 @@ bool MarkupAccumulator::includeShadowRoot(const ShadowRoot& shadowRoot) const
     if (m_serializeShadowRoots == SerializeShadowRoots::Serializable && shadowRoot.serializable())
         return true;
 
-    if (m_explicitShadowRoots.contains(&shadowRoot))
+    if (m_explicitShadowRoots.containsIf([&shadowRoot](const auto& item) { return item.ptr() == &shadowRoot; }))
         return true;
 
     return false;

--- a/Source/WebCore/editing/MarkupAccumulator.h
+++ b/Source/WebCore/editing/MarkupAccumulator.h
@@ -67,7 +67,7 @@ constexpr auto EntityMaskInHTMLAttributeValue = { EntityMask::Amp, EntityMask::Q
 class MarkupAccumulator {
     WTF_MAKE_NONCOPYABLE(MarkupAccumulator);
 public:
-    MarkupAccumulator(Vector<Ref<Node>>*, ResolveURLs, SerializationSyntax, HashMap<String, String>&& replacementURLStrings = { }, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet = { }, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<RefPtr<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
+    MarkupAccumulator(Vector<Ref<Node>>*, ResolveURLs, SerializationSyntax, HashMap<String, String>&& replacementURLStrings = { }, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet = { }, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<Ref<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
     virtual ~MarkupAccumulator();
 
     String serializeNodes(Node& targetNode, SerializedNodes);
@@ -126,7 +126,7 @@ private:
     HashMap<String, String> m_replacementURLStrings;
     HashMap<RefPtr<CSSStyleSheet>, String> m_replacementURLStringsForCSSStyleSheet;
     SerializeShadowRoots m_serializeShadowRoots;
-    Vector<RefPtr<ShadowRoot>> m_explicitShadowRoots;
+    Vector<Ref<ShadowRoot>> m_explicitShadowRoots;
     Vector<MarkupExclusionRule> m_exclusionRules;
 };
 

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1207,7 +1207,7 @@ Ref<DocumentFragment> createFragmentFromMarkup(Document& document, const String&
     return fragment;
 }
 
-String serializeFragment(const Node& node, SerializedNodes root, Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, std::optional<SerializationSyntax> serializationSyntax, HashMap<String, String>&& replacementURLStrings, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots serializeShadowRoots, Vector<RefPtr<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
+String serializeFragment(const Node& node, SerializedNodes root, Vector<Ref<Node>>* nodes, ResolveURLs resolveURLs, std::optional<SerializationSyntax> serializationSyntax, HashMap<String, String>&& replacementURLStrings, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet, SerializeShadowRoots serializeShadowRoots, Vector<Ref<ShadowRoot>>&& explicitShadowRoots, const Vector<MarkupExclusionRule>& exclusionRules)
 {
     if (!serializationSyntax)
         serializationSyntax = node.document().isHTMLDocument() ? SerializationSyntax::HTML : SerializationSyntax::XML;

--- a/Source/WebCore/editing/markup.h
+++ b/Source/WebCore/editing/markup.h
@@ -103,7 +103,7 @@ String serializePreservingVisualAppearance(const VisibleSelection&, ResolveURLs 
 enum class SerializedNodes : uint8_t { SubtreeIncludingNode, SubtreesOfChildren };
 enum class SerializationSyntax : uint8_t { HTML, XML };
 enum class SerializeShadowRoots : uint8_t { Explicit, Serializable, AllForInterchange };
-WEBCORE_EXPORT String serializeFragment(const Node&, SerializedNodes, Vector<Ref<Node>>* = nullptr, ResolveURLs = ResolveURLs::No, std::optional<SerializationSyntax> = std::nullopt, HashMap<String, String>&& replacementURLStrings = { }, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet = { }, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<RefPtr<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
+WEBCORE_EXPORT String serializeFragment(const Node&, SerializedNodes, Vector<Ref<Node>>* = nullptr, ResolveURLs = ResolveURLs::No, std::optional<SerializationSyntax> = std::nullopt, HashMap<String, String>&& replacementURLStrings = { }, HashMap<RefPtr<CSSStyleSheet>, String>&& replacementURLStringsForCSSStyleSheet = { }, SerializeShadowRoots = SerializeShadowRoots::Explicit, Vector<Ref<ShadowRoot>>&& explicitShadowRoots = { }, const Vector<MarkupExclusionRule>& exclusionRules = { });
 
 String urlToMarkup(const URL&, const String& title);
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1741,7 +1741,7 @@ RefPtr<WebGLActiveInfo> WebGLRenderingContextBase::getActiveUniform(WebGLProgram
     return WebGLActiveInfo::create(info.name, info.type, info.size);
 }
 
-std::optional<Vector<RefPtr<WebGLShader>>> WebGLRenderingContextBase::getAttachedShaders(WebGLProgram& program)
+std::optional<Vector<Ref<WebGLShader>>> WebGLRenderingContextBase::getAttachedShaders(WebGLProgram& program)
 {
     if (isContextLost())
         return std::nullopt;
@@ -1752,10 +1752,11 @@ std::optional<Vector<RefPtr<WebGLShader>>> WebGLRenderingContextBase::getAttache
         GraphicsContextGL::VERTEX_SHADER,
         GraphicsContextGL::FRAGMENT_SHADER
     };
-    Vector<RefPtr<WebGLShader>> shaderObjects;
+
+    Vector<Ref<WebGLShader>> shaderObjects;
     for (auto shaderType : shaderTypes) {
         if (RefPtr shader = program.getAttachedShader(shaderType))
-            shaderObjects.append(WTFMove(shader));
+            shaderObjects.append(shader.releaseNonNull());
     }
     return shaderObjects;
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -244,7 +244,7 @@ public:
 
     RefPtr<WebGLActiveInfo> getActiveAttrib(WebGLProgram&, GCGLuint index);
     RefPtr<WebGLActiveInfo> getActiveUniform(WebGLProgram&, GCGLuint index);
-    std::optional<Vector<RefPtr<WebGLShader>>> getAttachedShaders(WebGLProgram&);
+    std::optional<Vector<Ref<WebGLShader>>> getAttachedShaders(WebGLProgram&);
     GCGLint getAttribLocation(WebGLProgram&, const String& name);
     WebGLAny getBufferParameter(GCGLenum target, GCGLenum pname);
     WEBCORE_EXPORT std::optional<WebGLContextAttributes> getContextAttributes();

--- a/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp
@@ -91,24 +91,24 @@ ExceptionOr<RefPtr<Node>> InspectorAuditAccessibilityObject::getActiveDescendant
     return nullptr;
 }
 
-static void addChildren(AXCoreObject& parentObject, Vector<RefPtr<Node>>& childNodes)
+static void addChildren(AXCoreObject& parentObject, Vector<Ref<Node>>& childNodes)
 {
     for (const auto& childObject : parentObject.children()) {
-        if (Node* childNode = childObject->node())
-            childNodes.append(childNode);
+        if (RefPtr childNode = childObject->node())
+            childNodes.append(childNode.releaseNonNull());
         else
             addChildren(*childObject, childNodes);
     }
 }
 
-ExceptionOr<std::optional<Vector<RefPtr<Node>>>> InspectorAuditAccessibilityObject::getChildNodes(Node& node)
+ExceptionOr<std::optional<Vector<Ref<Node>>>> InspectorAuditAccessibilityObject::getChildNodes(Node& node)
 {
     ERROR_IF_NO_ACTIVE_AUDIT();
 
-    std::optional<Vector<RefPtr<Node>>> result;
+    std::optional<Vector<Ref<Node>>> result;
 
     if (auto* axObject = accessibilityObjectForNode(node)) {
-        Vector<RefPtr<Node>> childNodes;
+        Vector<Ref<Node>> childNodes;
         addChildren(*axObject, childNodes);
         result = WTFMove(childNodes);
     }
@@ -240,15 +240,15 @@ ExceptionOr<std::optional<InspectorAuditAccessibilityObject::ComputedProperties>
     return result;
 }
 
-ExceptionOr<std::optional<Vector<RefPtr<Node>>>> InspectorAuditAccessibilityObject::getControlledNodes(Node& node)
+ExceptionOr<std::optional<Vector<Ref<Node>>>> InspectorAuditAccessibilityObject::getControlledNodes(Node& node)
 {
     ERROR_IF_NO_ACTIVE_AUDIT();
 
-    std::optional<Vector<RefPtr<Node>>> result;
+    std::optional<Vector<Ref<Node>>> result;
 
     if (auto* axObject = accessibilityObjectForNode(node)) {
         auto controlledElements = axObject->elementsFromAttribute(HTMLNames::aria_controlsAttr);
-        result = WTF::map(WTFMove(controlledElements), [](auto&& element) -> RefPtr<Node> {
+        result = WTF::map(WTFMove(controlledElements), [](auto&& element) -> Ref<Node> {
             return WTFMove(element);
         });
     }
@@ -256,15 +256,15 @@ ExceptionOr<std::optional<Vector<RefPtr<Node>>>> InspectorAuditAccessibilityObje
     return result;
 }
 
-ExceptionOr<std::optional<Vector<RefPtr<Node>>>> InspectorAuditAccessibilityObject::getFlowedNodes(Node& node)
+ExceptionOr<std::optional<Vector<Ref<Node>>>> InspectorAuditAccessibilityObject::getFlowedNodes(Node& node)
 {
     ERROR_IF_NO_ACTIVE_AUDIT();
 
-    std::optional<Vector<RefPtr<Node>>> result;
+    std::optional<Vector<Ref<Node>>> result;
 
     if (auto* axObject = accessibilityObjectForNode(node)) {
         auto flowedElements = axObject->elementsFromAttribute(HTMLNames::aria_flowtoAttr);
-        result = WTF::map(WTFMove(flowedElements), [](auto&& element) -> RefPtr<Node> {
+        result = WTF::map(WTFMove(flowedElements), [](auto&& element) -> Ref<Node> {
             return WTFMove(element);
         });
     }
@@ -282,16 +282,16 @@ ExceptionOr<RefPtr<Node>> InspectorAuditAccessibilityObject::getMouseEventNode(N
     return nullptr;
 }
 
-ExceptionOr<std::optional<Vector<RefPtr<Node>>>> InspectorAuditAccessibilityObject::getOwnedNodes(Node& node)
+ExceptionOr<std::optional<Vector<Ref<Node>>>> InspectorAuditAccessibilityObject::getOwnedNodes(Node& node)
 {
     ERROR_IF_NO_ACTIVE_AUDIT();
 
-    std::optional<Vector<RefPtr<Node>>> result;
+    std::optional<Vector<Ref<Node>>> result;
 
     if (auto* axObject = accessibilityObjectForNode(node)) {
         if (axObject->supportsARIAOwns()) {
             auto ownedElements = axObject->elementsFromAttribute(HTMLNames::aria_ownsAttr);
-            result = WTF::map(WTFMove(ownedElements), [](auto&& element) -> RefPtr<Node> {
+            result = WTF::map(WTFMove(ownedElements), [](auto&& element) -> Ref<Node> {
                 return WTFMove(element);
             });
         }
@@ -312,19 +312,19 @@ ExceptionOr<RefPtr<Node>> InspectorAuditAccessibilityObject::getParentNode(Node&
     return nullptr;
 }
 
-ExceptionOr<std::optional<Vector<RefPtr<Node>>>> InspectorAuditAccessibilityObject::getSelectedChildNodes(Node& node)
+ExceptionOr<std::optional<Vector<Ref<Node>>>> InspectorAuditAccessibilityObject::getSelectedChildNodes(Node& node)
 {
     ERROR_IF_NO_ACTIVE_AUDIT();
 
-    std::optional<Vector<RefPtr<Node>>> result;
+    std::optional<Vector<Ref<Node>>> result;
 
     if (auto* axObject = accessibilityObjectForNode(node)) {
-        Vector<RefPtr<Node>> selectedChildNodes;
+        Vector<Ref<Node>> selectedChildNodes;
 
         if (auto selectedChildren = axObject->selectedChildren()) {
             for (auto& selectedChildObject : *selectedChildren) {
-                if (Node* selectedChildNode = selectedChildObject->node())
-                    selectedChildNodes.append(selectedChildNode);
+                if (RefPtr selectedChildNode = selectedChildObject->node())
+                    selectedChildNodes.append(selectedChildNode.releaseNonNull());
             }
         }
 

--- a/Source/WebCore/inspector/InspectorAuditAccessibilityObject.h
+++ b/Source/WebCore/inspector/InspectorAuditAccessibilityObject.h
@@ -71,14 +71,14 @@ public:
     };
 
     ExceptionOr<RefPtr<Node>> getActiveDescendant(Node&);
-    ExceptionOr<std::optional<Vector<RefPtr<Node>>>> getChildNodes(Node&);
+    ExceptionOr<std::optional<Vector<Ref<Node>>>> getChildNodes(Node&);
     ExceptionOr<std::optional<ComputedProperties>> getComputedProperties(Node&);
-    ExceptionOr<std::optional<Vector<RefPtr<Node>>>> getControlledNodes(Node&);
-    ExceptionOr<std::optional<Vector<RefPtr<Node>>>> getFlowedNodes(Node&);
+    ExceptionOr<std::optional<Vector<Ref<Node>>>> getControlledNodes(Node&);
+    ExceptionOr<std::optional<Vector<Ref<Node>>>> getFlowedNodes(Node&);
     ExceptionOr<RefPtr<Node>> getMouseEventNode(Node&);
-    ExceptionOr<std::optional<Vector<RefPtr<Node>>>> getOwnedNodes(Node&);
+    ExceptionOr<std::optional<Vector<Ref<Node>>>> getOwnedNodes(Node&);
     ExceptionOr<RefPtr<Node>> getParentNode(Node&);
-    ExceptionOr<std::optional<Vector<RefPtr<Node>>>> getSelectedChildNodes(Node&);
+    ExceptionOr<std::optional<Vector<Ref<Node>>>> getSelectedChildNodes(Node&);
 
 private:
     explicit InspectorAuditAccessibilityObject(Inspector::InspectorAuditAgent&);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -990,7 +990,7 @@ ExceptionOr<void> LocalDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobal
     if (targetSecurityOrigin.hasException())
         return targetSecurityOrigin.releaseException();
 
-    Vector<RefPtr<MessagePort>> ports;
+    Vector<Ref<MessagePort>> ports;
     auto messageData = SerializedScriptValue::create(lexicalGlobalObject, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WindowPostMessage);
     if (messageData.hasException())
         return messageData.releaseException();

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -148,7 +148,7 @@ ExceptionOr<RefPtr<SerializedScriptValue>> Navigation::serializeState(JSC::JSVal
     if (state.isUndefined())
         return { nullptr };
 
-    Vector<RefPtr<MessagePort>> dummyPorts;
+    Vector<Ref<MessagePort>> dummyPorts;
     auto serializeResult = SerializedScriptValue::create(*protectedScriptExecutionContext()->globalObject(), state, { }, dummyPorts, SerializationForStorage::Yes);
     if (serializeResult.hasException())
         return serializeResult.releaseException();

--- a/Source/WebCore/page/PerformanceMark.cpp
+++ b/Source/WebCore/page/PerformanceMark.cpp
@@ -77,7 +77,7 @@ ExceptionOr<Ref<PerformanceMark>> PerformanceMark::create(JSC::JSGlobalObject& g
         detail = JSC::jsNull();
     }
 
-    Vector<RefPtr<MessagePort>> ignoredMessagePorts;
+    Vector<Ref<MessagePort>> ignoredMessagePorts;
     auto serializedDetail = SerializedScriptValue::create(globalObject, detail, { }, ignoredMessagePorts);
     if (serializedDetail.hasException())
         return serializedDetail.releaseException();

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -227,7 +227,7 @@ ExceptionOr<Ref<PerformanceMeasure>> PerformanceUserTiming::measure(JSC::JSGloba
     if (detail.isUndefined())
         detail = JSC::jsNull();
 
-    Vector<RefPtr<MessagePort>> ignoredMessagePorts;
+    Vector<Ref<MessagePort>> ignoredMessagePorts;
     auto serializedDetail = SerializedScriptValue::create(globalObject, detail, { }, ignoredMessagePorts);
     if (serializedDetail.hasException())
         return serializedDetail.releaseException();

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -117,7 +117,7 @@ ExceptionOr<void> RemoteDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGloba
     if (auto origin = targetSecurityOrigin.releaseReturnValue())
         target = origin->data();
 
-    Vector<RefPtr<MessagePort>> ports;
+    Vector<Ref<MessagePort>> ports;
     auto messageData = SerializedScriptValue::create(lexicalGlobalObject, message, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WindowPostMessage);
     if (messageData.hasException())
         return messageData.releaseException();

--- a/Source/WebCore/page/ShareData.h
+++ b/Source/WebCore/page/ShareData.h
@@ -24,6 +24,7 @@
  */
 
 #pragma once
+
 #include "File.h"
 #include "SharedBuffer.h"
 #include <wtf/URL.h>
@@ -36,14 +37,14 @@ struct ShareData {
     String title;
     String text;
     String url;
-    Vector<RefPtr<File>> files { };
+    Vector<Ref<File>> files { };
 };
 
 struct RawFile {
     String fileName;
     RefPtr<SharedBuffer> fileData;
 };
-    
+
 struct ShareDataWithParsedURL {
     ShareData shareData;
     std::optional<URL> url;

--- a/Source/WebCore/page/ShareDataReader.cpp
+++ b/Source/WebCore/page/ShareDataReader.cpp
@@ -53,7 +53,7 @@ void ShareDataReader::start(Document* document, ShareDataWithParsedURL&& shareDa
         m_pendingFileLoads.append(makeUniqueRef<BlobLoader>([this, count, fileName = blob->name()](BlobLoader&) {
             this->didFinishLoading(count, fileName);
         }));
-        m_pendingFileLoads.last()->start(*blob, document, FileReaderLoader::ReadAsArrayBuffer);
+        m_pendingFileLoads.last()->start(blob, document, FileReaderLoader::ReadAsArrayBuffer);
         if (m_pendingFileLoads.isEmpty()) {
             // The previous load failed synchronously and cancel() was called. We should not attempt to do any further loads.
             break;

--- a/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
+++ b/Source/WebCore/page/WindowOrWorkerGlobalScope.cpp
@@ -50,7 +50,7 @@ void WindowOrWorkerGlobalScope::reportError(JSDOMGlobalObject& globalObject, JSC
 
 ExceptionOr<JSC::JSValue> WindowOrWorkerGlobalScope::structuredClone(JSDOMGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& relevantGlobalObject, JSC::JSValue value, StructuredSerializeOptions&& options)
 {
-    Vector<RefPtr<MessagePort>> ports;
+    Vector<Ref<MessagePort>> ports;
     auto messageData = SerializedScriptValue::create(lexicalGlobalObject, value, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WindowPostMessage);
     if (messageData.hasException())
         return messageData.releaseException();
@@ -59,7 +59,7 @@ ExceptionOr<JSC::JSValue> WindowOrWorkerGlobalScope::structuredClone(JSDOMGlobal
     if (disentangledPorts.hasException())
         return disentangledPorts.releaseException();
 
-    Vector<RefPtr<MessagePort>> entangledPorts;
+    Vector<Ref<MessagePort>> entangledPorts;
     if (auto* scriptExecutionContext = relevantGlobalObject.scriptExecutionContext())
         entangledPorts = MessagePort::entanglePorts(*scriptExecutionContext, disentangledPorts.releaseReturnValue());
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -473,10 +473,10 @@ auto Scope::collectActiveStyleSheets() -> ActiveStyleSheetCollection
     };
 
     for (auto& adoptedStyleSheet : treeScope().adoptedStyleSheets()) {
-        if (!canActivateAdoptedStyleSheet(*adoptedStyleSheet))
+        if (!canActivateAdoptedStyleSheet(adoptedStyleSheet.get()))
             continue;
-        styleSheetsForStyleSheetsList.append(adoptedStyleSheet);
-        sheets.append(adoptedStyleSheet);
+        styleSheetsForStyleSheetsList.append(adoptedStyleSheet.ptr());
+        sheets.append(adoptedStyleSheet.ptr());
     }
 
     return { WTFMove(sheets), WTFMove(styleSheetsForStyleSheetsList) };

--- a/Source/WebCore/testing/MockPaymentCoordinator.cpp
+++ b/Source/WebCore/testing/MockPaymentCoordinator.cpp
@@ -190,14 +190,11 @@ void MockPaymentCoordinator::completeShippingMethodSelection(std::optional<Apple
 #endif
 }
 
-static Vector<MockPaymentError> convert(Vector<RefPtr<ApplePayError>>&& errors)
+static Vector<MockPaymentError> convert(Vector<Ref<ApplePayError>>&& errors)
 {
-    Vector<MockPaymentError> result;
-    for (auto& error : errors) {
-        if (error)
-            result.append({ error->code(), error->message(), error->contactField() });
-    }
-    return result;
+    return WTF::map(WTFMove(errors), [] (auto&& error) -> MockPaymentError {
+        return { error->code(), error->message(), error->contactField() };
+    });
 }
 
 void MockPaymentCoordinator::completeShippingContactSelection(std::optional<ApplePayShippingContactUpdate>&& shippingContactUpdate)
@@ -363,7 +360,7 @@ void MockPaymentCoordinator::getSetupFeatures(const ApplePaySetupConfiguration& 
     completionHandler(WTFMove(setupFeaturesCopy));
 }
 
-void MockPaymentCoordinator::beginApplePaySetup(const ApplePaySetupConfiguration& configuration, const URL&, Vector<RefPtr<ApplePaySetupFeature>>&&, CompletionHandler<void(bool)>&& completionHandler)
+void MockPaymentCoordinator::beginApplePaySetup(const ApplePaySetupConfiguration& configuration, const URL&, Vector<Ref<ApplePaySetupFeature>>&&, CompletionHandler<void(bool)>&& completionHandler)
 {
     m_setupConfiguration = configuration;
     completionHandler(true);

--- a/Source/WebCore/testing/MockPaymentCoordinator.h
+++ b/Source/WebCore/testing/MockPaymentCoordinator.h
@@ -137,7 +137,7 @@ private:
     bool isMockPaymentCoordinator() const final { return true; }
 
     void getSetupFeatures(const ApplePaySetupConfiguration&, const URL&, CompletionHandler<void(Vector<Ref<ApplePaySetupFeature>>&&)>&&) final;
-    void beginApplePaySetup(const ApplePaySetupConfiguration&, const URL&, Vector<RefPtr<ApplePaySetupFeature>>&&, CompletionHandler<void(bool)>&&) final;
+    void beginApplePaySetup(const ApplePaySetupConfiguration&, const URL&, Vector<Ref<ApplePaySetupFeature>>&&, CompletionHandler<void(bool)>&&) final;
 
     void dispatchIfShowing(Function<void()>&&);
 

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -91,7 +91,7 @@ void DedicatedWorkerGlobalScope::prepareForDestruction()
 
 ExceptionOr<void> DedicatedWorkerGlobalScope::postMessage(JSC::JSGlobalObject& state, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
 {
-    Vector<RefPtr<MessagePort>> ports;
+    Vector<Ref<MessagePort>> ports;
     auto message = SerializedScriptValue::create(state, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (message.hasException())
         return message.releaseException();

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -135,7 +135,7 @@ Worker::~Worker()
 
 ExceptionOr<void> Worker::postMessage(JSC::JSGlobalObject& state, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
 {
-    Vector<RefPtr<MessagePort>> ports;
+    Vector<Ref<MessagePort>> ports;
     auto message = SerializedScriptValue::create(state, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (message.hasException())
         return message.releaseException();

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ExtendableMessageEvent);
 
-Ref<ExtendableMessageEvent> ExtendableMessageEvent::create(Vector<RefPtr<MessagePort>>&& ports, RefPtr<SerializedScriptValue>&& data, const String& origin, const String& lastEventId, std::optional<ExtendableMessageEventSource>&& source)
+Ref<ExtendableMessageEvent> ExtendableMessageEvent::create(Vector<Ref<MessagePort>>&& ports, RefPtr<SerializedScriptValue>&& data, const String& origin, const String& lastEventId, std::optional<ExtendableMessageEventSource>&& source)
 {
     return adoptRef(*new ExtendableMessageEvent(WTFMove(data), origin, lastEventId, WTFMove(source), WTFMove(ports)));
 }
@@ -49,7 +49,7 @@ ExtendableMessageEvent::ExtendableMessageEvent(JSC::JSGlobalObject& state, const
 {
 }
 
-ExtendableMessageEvent::ExtendableMessageEvent(RefPtr<SerializedScriptValue>&& data, const String& origin, const String& lastEventId, std::optional<ExtendableMessageEventSource>&& source, Vector<RefPtr<MessagePort>>&& ports)
+ExtendableMessageEvent::ExtendableMessageEvent(RefPtr<SerializedScriptValue>&& data, const String& origin, const String& lastEventId, std::optional<ExtendableMessageEventSource>&& source, Vector<Ref<MessagePort>>&& ports)
     : ExtendableEvent(EventInterfaceType::ExtendableMessageEvent, eventNames().messageEvent, CanBubble::No, IsCancelable::No)
     , m_data(WTFMove(data))
     , m_origin(origin)

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.h
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.h
@@ -53,7 +53,7 @@ public:
         String origin;
         String lastEventId;
         std::optional<ExtendableMessageEventSource> source;
-        Vector<RefPtr<MessagePort>> ports;
+        Vector<Ref<MessagePort>> ports;
     };
 
     static Ref<ExtendableMessageEvent> create(JSC::JSGlobalObject& state, const AtomString& type, const Init& initializer, IsTrusted isTrusted = IsTrusted::No)
@@ -61,7 +61,7 @@ public:
         return adoptRef(*new ExtendableMessageEvent(state, type, initializer, isTrusted));
     }
 
-    static Ref<ExtendableMessageEvent> create(Vector<RefPtr<MessagePort>>&&, RefPtr<SerializedScriptValue>&&, const String& origin = { }, const String& lastEventId = { }, std::optional<ExtendableMessageEventSource>&& source = std::nullopt);
+    static Ref<ExtendableMessageEvent> create(Vector<Ref<MessagePort>>&&, RefPtr<SerializedScriptValue>&&, const String& origin = { }, const String& lastEventId = { }, std::optional<ExtendableMessageEventSource>&& source = std::nullopt);
 
     ~ExtendableMessageEvent();
 
@@ -69,17 +69,17 @@ public:
     const String& origin() const { return m_origin; }
     const String& lastEventId() const { return m_lastEventId; }
     const std::optional<ExtendableMessageEventSource>& source() const { return m_source; }
-    const Vector<RefPtr<MessagePort>>& ports() const { return m_ports; }
+    const Vector<Ref<MessagePort>>& ports() const { return m_ports; }
 
 private:
     ExtendableMessageEvent(JSC::JSGlobalObject&, const AtomString&, const Init&, IsTrusted);
-    ExtendableMessageEvent(RefPtr<SerializedScriptValue>&& data, const String& origin, const String& lastEventId, std::optional<ExtendableMessageEventSource>&&, Vector<RefPtr<MessagePort>>&&);
+    ExtendableMessageEvent(RefPtr<SerializedScriptValue>&& data, const String& origin, const String& lastEventId, std::optional<ExtendableMessageEventSource>&&, Vector<Ref<MessagePort>>&&);
 
     RefPtr<SerializedScriptValue> m_data;
     String m_origin;
     String m_lastEventId;
     std::optional<ExtendableMessageEventSource> m_source;
-    Vector<RefPtr<MessagePort>> m_ports;
+    Vector<Ref<MessagePort>> m_ports;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -104,7 +104,7 @@ ExceptionOr<void> ServiceWorker::postMessage(JSC::JSGlobalObject& globalObject, 
     if (m_isStopped)
         return Exception { ExceptionCode::InvalidStateError };
 
-    Vector<RefPtr<MessagePort>> ports;
+    Vector<Ref<MessagePort>> ports;
     auto messageData = SerializedScriptValue::create(globalObject, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (messageData.hasException())
         return messageData.releaseException();

--- a/Source/WebCore/workers/service/ServiceWorkerClient.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClient.cpp
@@ -77,7 +77,7 @@ String ServiceWorkerClient::id() const
 
 ExceptionOr<void> ServiceWorkerClient::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
 {
-    Vector<RefPtr<MessagePort>> ports;
+    Vector<Ref<MessagePort>> ports;
     auto messageData = SerializedScriptValue::create(globalObject, messageValue, WTFMove(options.transfer), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (messageData.hasException())
         return messageData.releaseException();

--- a/Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp
@@ -66,8 +66,7 @@ void SharedWorkerGlobalScope::postConnectEvent(TransferredMessagePort&& transfer
     SCOPE_RELEASE_LOG("postConnectEvent:");
     auto ports = MessagePort::entanglePorts(*this, { WTFMove(transferredPort) });
     ASSERT(ports.size() == 1);
-    auto port = ports[0];
-    ASSERT(port);
+    RefPtr port = ports[0].ptr();
     auto event = MessageEvent::create(emptyString(), sourceOrigin, { }, port, WTFMove(ports));
     event->initEvent(eventNames().connectEvent, false, false);
 

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm
@@ -195,10 +195,10 @@ static NSError *toNSError(const WebCore::ApplePayError& error)
     return [NSError errorWithDomain:PKPaymentErrorDomain code:toPKPaymentErrorCode(error.code()) userInfo:userInfo.get()];
 }
 
-static RetainPtr<NSArray> toNSErrors(const Vector<RefPtr<WebCore::ApplePayError>>& errors)
+static RetainPtr<NSArray> toNSErrors(const Vector<Ref<WebCore::ApplePayError>>& errors)
 {
     return createNSArray(errors, [] (auto& error) -> NSError * {
-        return error ? toNSError(*error) : nil;
+        return toNSError(error);
     });
 }
 

--- a/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeatures.mm
+++ b/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeatures.mm
@@ -37,17 +37,16 @@
 
 namespace WebKit {
 
-static NSArray<PKPaymentSetupFeature *> *toPlatformFeatures(Vector<RefPtr<WebCore::ApplePaySetupFeature>>&& features)
+static NSArray<PKPaymentSetupFeature *> *toPlatformFeatures(Vector<Ref<WebCore::ApplePaySetupFeature>>&& features)
 {
     NSMutableArray *platformFeatures = [NSMutableArray arrayWithCapacity:features.size()];
     for (auto& feature : features) {
-        if (feature)
-            [platformFeatures addObject:feature->platformFeature()];
+        [platformFeatures addObject:feature->platformFeature()];
     }
     return platformFeatures;
 }
 
-PaymentSetupFeatures::PaymentSetupFeatures(Vector<RefPtr<WebCore::ApplePaySetupFeature>>&& features)
+PaymentSetupFeatures::PaymentSetupFeatures(Vector<Ref<WebCore::ApplePaySetupFeature>>&& features)
     : m_platformFeatures { toPlatformFeatures(WTFMove(features)) }
 {
 }

--- a/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h
+++ b/Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h
@@ -44,7 +44,7 @@ namespace WebKit {
 
 class PaymentSetupFeatures {
 public:
-    PaymentSetupFeatures(Vector<RefPtr<WebCore::ApplePaySetupFeature>>&&);
+    PaymentSetupFeatures(Vector<Ref<WebCore::ApplePaySetupFeature>>&&);
     PaymentSetupFeatures(RetainPtr<NSArray>&& = nullptr);
 
     NSArray *platformFeatures() const { return m_platformFeatures.get(); }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -878,7 +878,7 @@ struct WebCore::ShareData {
     String title;
     String text;
     String url;
-    [NotSerialized] Vector<RefPtr<WebCore::File>> files;
+    [NotSerialized] Vector<Ref<WebCore::File>> files;
 };
 
 enum class WebCore::ShareDataOriginator : bool
@@ -1173,7 +1173,7 @@ struct WebCore::ApplePayDetailsUpdateBase {
 
 struct WebCore::ApplePayPaymentMethodUpdate : WebCore::ApplePayDetailsUpdateBase {
 #if ENABLE(APPLE_PAY_UPDATE_SHIPPING_METHODS_WHEN_CHANGING_LINE_ITEMS)
-    Vector<RefPtr<WebCore::ApplePayError>> errors;
+    Vector<Ref<WebCore::ApplePayError>> errors;
     Vector<WebCore::ApplePayShippingMethod> newShippingMethods;
 #endif
 #if ENABLE(APPLE_PAY_INSTALLMENTS)
@@ -1182,7 +1182,7 @@ struct WebCore::ApplePayPaymentMethodUpdate : WebCore::ApplePayDetailsUpdateBase
 };
 
 struct WebCore::ApplePayShippingContactUpdate : WebCore::ApplePayDetailsUpdateBase {
-    Vector<RefPtr<WebCore::ApplePayError>> errors;
+    Vector<Ref<WebCore::ApplePayError>> errors;
     Vector<WebCore::ApplePayShippingMethod> newShippingMethods;
 };
 
@@ -1194,7 +1194,7 @@ struct WebCore::ApplePayShippingMethodUpdate : WebCore::ApplePayDetailsUpdateBas
 
 struct WebCore::ApplePayPaymentAuthorizationResult {
     unsigned short status;
-    Vector<RefPtr<WebCore::ApplePayError>> errors;
+    Vector<Ref<WebCore::ApplePayError>> errors;
 #if ENABLE(APPLE_PAY_PAYMENT_ORDER_DETAILS)
     std::optional<WebCore::ApplePayPaymentOrderDetails> orderDetails;
 #endif
@@ -1273,7 +1273,7 @@ enum class WebCore::ApplePayInstallmentRetailChannel : uint8_t {
 
 #if ENABLE(APPLE_PAY_COUPON_CODE)
 struct WebCore::ApplePayCouponCodeUpdate : WebCore::ApplePayDetailsUpdateBase {
-    Vector<RefPtr<WebCore::ApplePayError>> errors;
+    Vector<Ref<WebCore::ApplePayError>> errors;
     Vector<WebCore::ApplePayShippingMethod> newShippingMethods;
 };
 #endif
@@ -7350,7 +7350,7 @@ headers: <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmap.h> <WebCore/MessageP
     [NotSerialized] Vector<std::unique_ptr<WebCore::DetachedOffscreenCanvas>> detachedOffscreenCanvases;
     [NotSerialized] Vector<RefPtr<WebCore::OffscreenCanvas>> inMemoryOffscreenCanvases;
 #endif
-    [NotSerialized] Vector<RefPtr<WebCore::MessagePort>> inMemoryMessagePorts;
+    [NotSerialized] Vector<Ref<WebCore::MessagePort>> inMemoryMessagePorts;
 #if ENABLE(WEBASSEMBLY)
     [NotSerialized] std::unique_ptr<Vector<RefPtr<JSC::Wasm::Module>>> wasmModulesArray;
     [NotSerialized] std::unique_ptr<Vector<RefPtr<JSC::SharedArrayBufferContents>>> wasmMemoryHandlesArray;

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
@@ -219,7 +219,7 @@ void WebPaymentCoordinator::getSetupFeatures(const WebCore::ApplePaySetupConfigu
     m_webPage.sendWithAsyncReply(Messages::WebPaymentCoordinatorProxy::GetSetupFeatures(PaymentSetupConfiguration { configuration, url }), WTFMove(completionHandler));
 }
 
-void WebPaymentCoordinator::beginApplePaySetup(const WebCore::ApplePaySetupConfiguration& configuration, const URL& url, Vector<RefPtr<WebCore::ApplePaySetupFeature>>&& features, CompletionHandler<void(bool)>&& completionHandler)
+void WebPaymentCoordinator::beginApplePaySetup(const WebCore::ApplePaySetupConfiguration& configuration, const URL& url, Vector<Ref<WebCore::ApplePaySetupFeature>>&& features, CompletionHandler<void(bool)>&& completionHandler)
 {
     m_webPage.sendWithAsyncReply(Messages::WebPaymentCoordinatorProxy::BeginApplePaySetup(PaymentSetupConfiguration { configuration, url }, PaymentSetupFeatures { WTFMove(features) }), WTFMove(completionHandler));
 }

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
@@ -80,7 +80,7 @@ private:
     bool isWebPaymentCoordinator() const override { return true; }
 
     void getSetupFeatures(const WebCore::ApplePaySetupConfiguration&, const URL&, CompletionHandler<void(Vector<Ref<WebCore::ApplePaySetupFeature>>&&)>&&) final;
-    void beginApplePaySetup(const WebCore::ApplePaySetupConfiguration&, const URL&, Vector<RefPtr<WebCore::ApplePaySetupFeature>>&&, CompletionHandler<void(bool)>&&) final;
+    void beginApplePaySetup(const WebCore::ApplePaySetupConfiguration&, const URL&, Vector<Ref<WebCore::ApplePaySetupFeature>>&&, CompletionHandler<void(bool)>&&) final;
     void endApplePaySetup() final;
 
     // IPC::MessageReceiver.


### PR DESCRIPTION
#### 40f8011866933c1c5c07169d4fe5ef141ed18a1c
<pre>
sequence&lt;T&gt; should map to Ref&lt;T&gt;, not RefPtr&lt;T&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=272512">https://bugs.webkit.org/show_bug.cgi?id=272512</a>

Reviewed by Chris Dumez.

Improve non-null hygiene by correctly mapping WebIDL sequence&lt;T&gt;
(and FrozenArray&lt;T&gt;) to Vector&lt;Ref&lt;T&gt;&gt; rather than Vector&lt;RefPtr&lt;T&gt;&gt;
when T is an interface.

If Vector&lt;RefPtr&lt;T&gt;&gt; is needed to allow nullptr values, sequence&lt;T?&gt;
(and FrozenArray&lt;T?&gt;) will work. An example of this would be
`Navigator.getGamepads()` in Navigator+Gamepad.idl (see below).

The main implementation changes for this are:

* Source/WebCore/bindings/IDLTypes.h:
    IDLWrapper gained a SequenceStorageType, changing it from the
    default value which was RefPtr&lt;T&gt; to Ref&lt;T&gt;.

    IDLSequence and IDLFrozenArray had their ImplementationTypes
    updated to use T::InnerParameterType rather than T::ImplementationType
    (which map to Ref&lt;T&gt; rather than RefPtr&lt;T&gt;) and IDLFrozenArray
    was further updated to have its ParameterType and NullableParameterType
    match IDLSequence (having them differ has no value, they should both
    be using Ref&lt;T&gt; rather than RefPtr&lt;T&gt; for non-nullable interfaces).

* Source/WebCore/bindings/js/JSDOMConvertSequences.h:
    Conversion of the inner types was pulled out into a GenericSequenceInnerConverter
    type so that it could be specialized for IDLInterface&lt;T&gt;. This is needed
    because Converter&lt;IDLInterface&lt;T&gt;&gt;::convert() returns T* but guarantees
    that T* is non-null when there is no exception. We use this to convert
    it to the needed Ref&lt;T&gt;.

    A better long term change would be to update Converter to return a result
    type (similar, though distinct from ExceptionOr) that can encapsulate
    the result state fully, removing the need for the specialization.

* Source/WebCore/Modules/gamepad/Navigator+Gamepad.idl:
    Updated to use `sequence&lt;Gamepad?&gt;` rather than `sequence&lt;Gamepad&gt;` as this
    explicitly wants to support null values in the sequence. This now correctly
    matches the spec <a href="https://w3c.github.io/gamepad/#extensions-to-the-navigator-interface.">https://w3c.github.io/gamepad/#extensions-to-the-navigator-interface.</a>

The remainder is all updating implementation files from using RefPtr&lt;T&gt; to Ref&lt;T&gt;.

Future improvements would be to tackle replacing more use of RefPtr&lt;T&gt; for known
non-null values. Some places to start:

    In WebCore alone, there are 537 matches for `Vector&lt;RefPtr&lt;`. From a cursory
    look, most of these should be `Vector&lt;Ref&lt;` (there are some examples like the
    Gamepad one above that should stay).

    IDL dictionaries currently require interface members to use RefPtr&lt;T&gt; (for
    example, see XRInputSourcesChangeEventInit and its session member). To resolve
    this, code generation of the convertDictionary&lt;&gt; functions would be need to be
    updated to delay construction of the struct until all the values are available
    since otherwise it can&apos;t have a Ref&lt;&gt; member.

    IDL record and unions currently use RefPtr&lt;T&gt; for interfaces and should be
    improved like sequence to use Ref&lt;T&gt;.

* Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.h:
(WebCore::GPUPipelineLayoutDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::GPUQueue::submit):
* Source/WebCore/Modules/WebGPU/GPUQueue.h:
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.cpp:
(WebCore::GPURenderPassEncoder::executeBundles):
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.h:
* Source/WebCore/Modules/applepay/ApplePayCouponCodeUpdate.h:
* Source/WebCore/Modules/applepay/ApplePayPaymentAuthorizationResult.h:
* Source/WebCore/Modules/applepay/ApplePayPaymentMethodUpdate.h:
* Source/WebCore/Modules/applepay/ApplePaySetup.cpp:
(WebCore::ApplePaySetup::begin):
* Source/WebCore/Modules/applepay/ApplePaySetupWebCore.h:
* Source/WebCore/Modules/applepay/ApplePayShippingContactUpdate.h:
* Source/WebCore/Modules/applepay/PaymentCoordinator.cpp:
(WebCore::PaymentCoordinator::beginApplePaySetup):
* Source/WebCore/Modules/applepay/PaymentCoordinator.h:
* Source/WebCore/Modules/applepay/PaymentCoordinatorClient.h:
(WebCore::PaymentCoordinatorClient::beginApplePaySetup):
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.cpp:
(WebCore::appendShippingContactInvalidError):
(WebCore::ApplePayPaymentHandler::computeErrors const):
(WebCore::ApplePayPaymentHandler::computeAddressErrors const):
(WebCore::ApplePayPaymentHandler::computePayerErrors const):
(WebCore::ApplePayPaymentHandler::computePaymentMethodErrors const):
(WebCore::ApplePayPaymentHandler::shippingAddressUpdated):
(WebCore::ApplePayPaymentHandler::paymentMethodUpdated):
(WebCore::ApplePayPaymentHandler::retry):
* Source/WebCore/Modules/applepay/paymentrequest/ApplePayPaymentHandler.h:
* Source/WebCore/Modules/async-clipboard/Clipboard.cpp:
(WebCore::Clipboard::write):
(WebCore::Clipboard::ItemWriter::write):
* Source/WebCore/Modules/async-clipboard/Clipboard.h:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::setPlaylist):
* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/Modules/mediastream/MediaStream.cpp:
(WebCore::MediaStream::create):
(WebCore::MediaStream::clone):
* Source/WebCore/Modules/mediastream/MediaStream.h:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::setAssociatedRemoteStreams):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.h:
* Source/WebCore/Modules/mediastream/RTCConfiguration.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::setConfiguration):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp:
(WebCore::RTCRtpScriptTransform::create):
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp:
(WebCore::RTCRtpScriptTransformer::RTCRtpScriptTransformer):
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.h:
* Source/WebCore/Modules/mediastream/RTCTrackEvent.cpp:
(WebCore::RTCTrackEvent::create):
(WebCore::RTCTrackEvent::RTCTrackEvent):
* Source/WebCore/Modules/mediastream/RTCTrackEvent.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::setLocalSessionDescriptionSucceeded):
(WebCore::LibWebRTCMediaEndpoint::setRemoteSessionDescriptionSucceeded):
* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::createSerializedScriptValue):
* Source/WebCore/Modules/webxr/WebXRFrame.cpp:
(WebCore::WebXRFrame::fillJointRadii):
(WebCore::WebXRFrame::fillPoses):
* Source/WebCore/Modules/webxr/WebXRFrame.h:
* Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp:
(WebCore::WebXRInputSourceArray::update):
(WebCore::WebXRInputSourceArray::handleRemovedInputSources):
(WebCore::WebXRInputSourceArray::handleAddedOrUpdatedInputSources):
* Source/WebCore/Modules/webxr/WebXRInputSourceArray.h:
* Source/WebCore/Modules/webxr/XRInputSourcesChangeEvent.h:
* Source/WebCore/Modules/webxr/XRRenderStateInit.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::validRelation):
(WebCore::AXObjectCache::addRelation):
(WebCore::AXObjectCache::addLabelForRelation):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::elementsFromAttribute const):
* Source/WebCore/bindings/js/IDBBindingUtilities.cpp:
(WebCore::deserializeIDBValueToJSValue):
* Source/WebCore/bindings/js/JSElementCustom.cpp:
(WebCore::getElementsArrayAttribute):
* Source/WebCore/bindings/js/JSElementInternalsCustom.cpp:
(WebCore::getElementsArrayAttribute):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::serialize):
(WebCore::CloneSerializer::CloneSerializer):
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneDeserializer::deserialize):
(WebCore::CloneDeserializer::CloneDeserializer):
(WebCore::CloneDeserializer::readTerminal):
(WebCore::validateSerializedResult):
(WebCore::SerializedScriptValue::SerializedScriptValue):
(WebCore::SerializedScriptValue::create):
(WebCore::SerializedScriptValue::deserialize):
* Source/WebCore/bindings/js/SerializedScriptValue.h:
* Source/WebCore/css/CSSStyleSheetObservableArray.cpp:
(WebCore::CSSStyleSheetObservableArray::setValueAt):
(WebCore::CSSStyleSheetObservableArray::removeLast):
(WebCore::CSSStyleSheetObservableArray::valueAt const):
(WebCore::CSSStyleSheetObservableArray::setSheets):
* Source/WebCore/css/CSSStyleSheetObservableArray.h:
(WebCore::CSSStyleSheetObservableArray::sheets const):
* Source/WebCore/css/FontFaceSet.cpp:
(WebCore::FontFaceSet::create):
(WebCore::FontFaceSet::FontFaceSet):
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/css/typedom/transform/CSSTransformValue.cpp:
(WebCore::CSSTransformValue::create):
(WebCore::CSSTransformValue::item):
(WebCore::CSSTransformValue::setItem):
(WebCore::CSSTransformValue::is2D const):
(WebCore::CSSTransformValue::CSSTransformValue):
* Source/WebCore/css/typedom/transform/CSSTransformValue.h:
* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::any):
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::postMessage):
* Source/WebCore/dom/CustomElementDefaultARIA.cpp:
(WebCore::CustomElementDefaultARIA::elementsForAttribute const):
(WebCore::CustomElementDefaultARIA::setElementsForAttribute):
* Source/WebCore/dom/CustomElementDefaultARIA.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::getElementsArrayAttribute const):
(WebCore::Element::setElementsArrayAttribute):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementInternals.cpp:
(WebCore::ElementInternals::getElementsArrayAttribute const):
(WebCore::ElementInternals::setElementsArrayAttribute):
* Source/WebCore/dom/ElementInternals.h:
* Source/WebCore/dom/MessageEvent.cpp:
(WebCore::MessageEvent::MessageEvent):
(WebCore::MessageEvent::create):
(WebCore::MessageEvent::initMessageEvent):
* Source/WebCore/dom/MessageEvent.h:
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::postMessage):
(WebCore::MessagePort::disentanglePorts):
(WebCore::MessagePort::entanglePorts):
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::TreeScope::adoptedStyleSheets const):
(WebCore::TreeScope::setAdoptedStyleSheets):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::getAttachedShaders):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/inspector/InspectorAuditAccessibilityObject.cpp:
(WebCore::addChildren):
(WebCore::InspectorAuditAccessibilityObject::getChildNodes):
(WebCore::InspectorAuditAccessibilityObject::getControlledNodes):
(WebCore::InspectorAuditAccessibilityObject::getFlowedNodes):
(WebCore::InspectorAuditAccessibilityObject::getOwnedNodes):
(WebCore::InspectorAuditAccessibilityObject::getSelectedChildNodes):
* Source/WebCore/inspector/InspectorAuditAccessibilityObject.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::postMessage):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::serializeState):
* Source/WebCore/page/PerformanceMark.cpp:
(WebCore::PerformanceMark::create):
* Source/WebCore/page/PerformanceUserTiming.cpp:
(WebCore::PerformanceUserTiming::measure):
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::postMessage):
* Source/WebCore/page/ShareData.h:
* Source/WebCore/page/ShareDataReader.cpp:
(WebCore::ShareDataReader::start):
* Source/WebCore/page/WindowOrWorkerGlobalScope.cpp:
(WebCore::WindowOrWorkerGlobalScope::structuredClone):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::collectActiveStyleSheets):
* Source/WebCore/testing/MockPaymentCoordinator.cpp:
(WebCore::convert):
(WebCore::MockPaymentCoordinator::beginApplePaySetup):
* Source/WebCore/testing/MockPaymentCoordinator.h:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
(WebCore::DedicatedWorkerGlobalScope::postMessage):
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::postMessage):
* Source/WebCore/workers/service/ExtendableMessageEvent.cpp:
(WebCore::ExtendableMessageEvent::create):
(WebCore::ExtendableMessageEvent::ExtendableMessageEvent):
* Source/WebCore/workers/service/ExtendableMessageEvent.h:
* Source/WebCore/workers/service/ServiceWorker.cpp:
(WebCore::ServiceWorker::postMessage):
* Source/WebCore/workers/service/ServiceWorkerClient.cpp:
(WebCore::ServiceWorkerClient::postMessage):
* Source/WebCore/workers/shared/SharedWorkerGlobalScope.cpp:
(WebCore::SharedWorkerGlobalScope::postConnectEvent):
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.mm:
(WebKit::toNSErrors):
* Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeatures.mm:
(WebKit::PaymentSetupFeatures::PaymentSetupFeatures):
* Source/WebKit/Shared/ApplePay/ApplePayPaymentSetupFeaturesWebKit.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp:
(WebKit::WebPaymentCoordinator::beginApplePaySetup):
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h:

Canonical link: <a href="https://commits.webkit.org/277512@main">https://commits.webkit.org/277512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/202204db783e3c712bcdd32cbb5c4b4cb23b7f56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50391 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43763 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50015 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38830 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41191 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20127 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22033 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42382 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5757 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44054 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52284 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46133 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24016 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45167 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10553 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24804 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23736 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->