### PR TITLE
Update StringView::UpconvertedCharactersWithSize to store its size

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlCache.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCache.cpp
@@ -43,14 +43,14 @@ UDateTimePatternGenerator* IntlCache::cacheSharedPatternGenerator(const CString&
     return m_cachedDateTimePatternGenerator.get();
 }
 
-Vector<UChar, 32> IntlCache::getBestDateTimePattern(const CString& locale, const UChar* skeleton, unsigned skeletonSize, UErrorCode& status)
+Vector<UChar, 32> IntlCache::getBestDateTimePattern(const CString& locale, std::span<const UChar> skeleton, UErrorCode& status)
 {
     // Always use ICU date format generator, rather than our own pattern list and matcher.
     auto sharedGenerator = getSharedPatternGenerator(locale, status);
     if (U_FAILURE(status))
         return { };
     Vector<UChar, 32> patternBuffer;
-    status = callBufferProducingFunction(udatpg_getBestPatternWithOptions, sharedGenerator, skeleton, skeletonSize, UDATPG_MATCH_HOUR_FIELD_LENGTH, patternBuffer);
+    status = callBufferProducingFunction(udatpg_getBestPatternWithOptions, sharedGenerator, skeleton.data(), skeleton.size(), UDATPG_MATCH_HOUR_FIELD_LENGTH, patternBuffer);
     if (U_FAILURE(status))
         return { };
     return patternBuffer;

--- a/Source/JavaScriptCore/runtime/IntlCache.h
+++ b/Source/JavaScriptCore/runtime/IntlCache.h
@@ -39,7 +39,7 @@ class IntlCache {
 public:
     IntlCache() = default;
 
-    Vector<UChar, 32> getBestDateTimePattern(const CString& locale, const UChar* skeleton, unsigned skeletonSize, UErrorCode&);
+    Vector<UChar, 32> getBestDateTimePattern(const CString& locale, std::span<const UChar> skeleton, UErrorCode&);
     Vector<UChar, 32> getFieldDisplayName(const CString& locale, UDateTimePatternField, UDateTimePGDisplayWidth, UErrorCode&);
 
 private:

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp
@@ -890,7 +890,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
                 replaceHourCycleInSkeleton(skeleton, specifiedHour12);
                 dataLogLnIf(IntlDateTimeFormatInternal::verbose, "replaced:(", StringView { skeleton.span() }, ")");
 
-                patternBuffer = vm.intlCache().getBestDateTimePattern(dataLocaleWithExtensions, skeleton.data(), skeleton.size(), status);
+                patternBuffer = vm.intlCache().getBestDateTimePattern(dataLocaleWithExtensions, skeleton.span(), status);
                 if (U_FAILURE(status)) {
                     throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat"_s);
                     return;
@@ -929,7 +929,7 @@ void IntlDateTimeFormat::initializeDateTimeFormat(JSGlobalObject* globalObject, 
 
         String skeleton = buildSkeleton(weekday, era, year, month, day, hour12, hourCycle, hour, dayPeriod, minute, second, fractionalSecondDigits, timeZoneName);
         UErrorCode status = U_ZERO_ERROR;
-        patternBuffer = vm.intlCache().getBestDateTimePattern(dataLocaleWithExtensions, StringView(skeleton).upconvertedCharacters().get(), skeleton.length(), status);
+        patternBuffer = vm.intlCache().getBestDateTimePattern(dataLocaleWithExtensions, StringView(skeleton).upconvertedCharacters(), status);
         if (U_FAILURE(status)) {
             throwTypeError(globalObject, scope, "failed to initialize DateTimeFormat"_s);
             return;

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -521,11 +521,14 @@ class StringView::UpconvertedCharactersWithSize {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     explicit UpconvertedCharactersWithSize(StringView);
-    operator const UChar*() const { return m_characters; }
-    const UChar* get() const { return m_characters; }
+    operator const UChar*() const { return m_characters.data(); }
+    const UChar* get() const { return m_characters.data(); }
+    operator std::span<const UChar>() const { return m_characters; }
+    std::span<const UChar> span() const { return m_characters; }
+
 private:
     Vector<UChar, N> m_upconvertedCharacters;
-    const UChar* m_characters;
+    std::span<const UChar> m_characters;
 };
 
 template<size_t N>
@@ -642,12 +645,12 @@ template<size_t N>
 inline StringView::UpconvertedCharactersWithSize<N>::UpconvertedCharactersWithSize(StringView string)
 {
     if (!string.is8Bit()) {
-        m_characters = string.characters16();
+        m_characters = string.span16();
         return;
     }
     m_upconvertedCharacters.grow(string.m_length);
     StringImpl::copyCharacters(m_upconvertedCharacters.data(), string.span8());
-    m_characters = m_upconvertedCharacters.data();
+    m_characters = m_upconvertedCharacters.span();
 }
 
 inline String StringView::toString() const

--- a/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodecCJK.cpp
@@ -273,7 +273,7 @@ static Vector<uint8_t> eucJPEncode(StringView string, Function<void(char32_t, Ve
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator({ characters.get(), string.length() }); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<UChar> iterator(characters); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint)) {
             result.append(codePoint);
@@ -590,7 +590,7 @@ static Vector<uint8_t> iso2022JPEncode(StringView string, Function<void(char32_t
     };
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator({ characters.get(), string.length() }); !iterator.atEnd(); ++iterator)
+    for (WTF::CodePointIterator<UChar> iterator(characters); !iterator.atEnd(); ++iterator)
         parseCodePoint(*iterator);
 
     if (state != State::ASCII)
@@ -644,7 +644,7 @@ static Vector<uint8_t> shiftJISEncode(StringView string, Function<void(char32_t,
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator({ characters.get(), string.length() }); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<UChar> iterator(characters); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint) || codePoint == 0x0080) {
             result.append(codePoint);
@@ -712,7 +712,7 @@ static Vector<uint8_t> eucKREncode(StringView string, Function<void(char32_t, Ve
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator({ characters.get(), string.length() }); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<UChar> iterator(characters); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint)) {
             result.append(codePoint);
@@ -783,7 +783,7 @@ static Vector<uint8_t> big5Encode(StringView string, Function<void(char32_t, Vec
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator({ characters.get(), string.length() }); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<UChar> iterator(characters); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint)) {
             result.append(codePoint);
@@ -1045,7 +1045,7 @@ static Vector<uint8_t> gbEncodeShared(StringView string, Function<void(char32_t,
     result.reserveInitialCapacity(string.length());
 
     auto characters = string.upconvertedCharacters();
-    for (WTF::CodePointIterator<UChar> iterator({ characters.get(), string.length() }); !iterator.atEnd(); ++iterator) {
+    for (WTF::CodePointIterator<UChar> iterator(characters); !iterator.atEnd(); ++iterator) {
         auto codePoint = *iterator;
         if (isASCII(codePoint)) {
             result.append(codePoint);

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -3985,15 +3985,15 @@ static Vector<SimpleRange> scanForTelephoneNumbers(const SimpleRange& range)
 
     auto text = plainText(range);
     Vector<SimpleRange> result;
-    unsigned length = text.length();
-    unsigned scannerPosition = 0;
     int relativeStartPosition = 0;
     int relativeEndPosition = 0;
     auto characters = StringView { text }.upconvertedCharacters();
-    while (scannerPosition < length && TelephoneNumberDetector::find(&characters[scannerPosition], length - scannerPosition, &relativeStartPosition, &relativeEndPosition)) {
-        ASSERT(scannerPosition + relativeEndPosition <= length);
+    auto span = characters.span();
+    while (!span.empty() && TelephoneNumberDetector::find(span, &relativeStartPosition, &relativeEndPosition)) {
+        auto scannerPosition = span.data() - characters.span().data();
+        ASSERT(scannerPosition + relativeEndPosition <= text.length());
         result.append(resolveCharacterRange(range, CharacterRange(scannerPosition + relativeStartPosition, relativeEndPosition - relativeStartPosition)));
-        scannerPosition += relativeEndPosition;
+        span = span.subspan(relativeEndPosition);
     }
     return result;
 }

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -105,15 +105,15 @@ UniqueArray<Length> newLengthArray(const String& string, int& len)
 
     auto upconvertedCharacters = StringView(str.get()).upconvertedCharacters();
     while ((pos2 = str->find(',', pos)) != notFound) {
-        r[i++] = parseLength({ upconvertedCharacters + pos, pos2 - pos });
+        r[i++] = parseLength(upconvertedCharacters.span().subspan(pos, pos2 - pos));
         pos = pos2+1;
     }
 
     ASSERT(i == len - 1);
 
     // IE Quirk: If the last comma is the last char skip it and reduce len by one.
-    if (str->length()-pos > 0)
-        r[i] = parseLength({ upconvertedCharacters + pos, str->length() - pos });
+    if (str->length() - pos > 0)
+        r[i] = parseLength(upconvertedCharacters.span().subspan(pos));
     else
         len--;
 

--- a/Source/WebCore/platform/SharedStringHash.cpp
+++ b/Source/WebCore/platform/SharedStringHash.cpp
@@ -285,8 +285,7 @@ SharedStringHash computeVisitedLinkHash(const URL& base, const AtomString& attri
         return computeSharedStringHashInline(base, attributeURL.span8());
 
     auto upconvertedCharacters = StringView(attributeURL.string()).upconvertedCharacters();
-    const UChar* characters = upconvertedCharacters;
-    return computeSharedStringHashInline(base, std::span { characters, attributeURL.length() });
+    return computeSharedStringHashInline(base, upconvertedCharacters.span());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/TelephoneNumberDetector.h
+++ b/Source/WebCore/platform/TelephoneNumberDetector.h
@@ -35,7 +35,7 @@ namespace TelephoneNumberDetector {
 
 void prewarm();
 bool isSupported();
-bool find(const UChar* buffer, unsigned length, int* startPos, int* endPos);
+bool find(std::span<const UChar> buffer, int* startPos, int* endPos);
 
 } // namespace TelephoneNumberDetector
 } // namespace WebCore

--- a/Source/WebCore/platform/cocoa/TelephoneNumberDetectorCocoa.cpp
+++ b/Source/WebCore/platform/cocoa/TelephoneNumberDetectorCocoa.cpp
@@ -71,10 +71,10 @@ bool isSupported()
     return phoneNumbersScanner() != nullptr;
 }
 
-bool find(const UChar* buffer, unsigned length, int* startPos, int* endPos)
+bool find(std::span<const UChar> buffer, int* startPos, int* endPos)
 {
     ASSERT(isSupported());
-    return DDDFAScannerFirstResultInUnicharArray(phoneNumbersScanner(), reinterpret_cast<const UniChar*>(buffer), length, startPos, endPos);
+    return DDDFAScannerFirstResultInUnicharArray(phoneNumbersScanner(), reinterpret_cast<const UniChar*>(buffer.data()), buffer.size(), startPos, endPos);
 }
 
 } // namespace TelephoneNumberDetector

--- a/Source/WebCore/platform/graphics/StringTruncator.cpp
+++ b/Source/WebCore/platform/graphics/StringTruncator.cpp
@@ -193,9 +193,9 @@ static unsigned leftTruncateToBuffer(const String& string, unsigned length, unsi
     return length - adjustedStartIndex;
 }
 
-static float stringWidth(const FontCascade& renderer, const UChar* characters, unsigned length)
+static float stringWidth(const FontCascade& renderer, std::span<const UChar> characters)
 {
-    TextRun run(StringView { std::span { characters, length } });
+    TextRun run(StringView { characters });
     return renderer.width(run);
 }
 
@@ -209,7 +209,7 @@ static String truncateString(const String& string, float maxWidth, const FontCas
 
     ASSERT(maxWidth >= 0);
 
-    float currentEllipsisWidth = shouldInsertEllipsis ? stringWidth(font, &horizontalEllipsis, 1) : customTruncationElementWidth;
+    float currentEllipsisWidth = shouldInsertEllipsis ? stringWidth(font, span(horizontalEllipsis)) : customTruncationElementWidth;
 
     UChar stringBuffer[STRING_BUFFER_SIZE];
     unsigned truncatedLength;
@@ -228,7 +228,7 @@ static String truncateString(const String& string, float maxWidth, const FontCas
         truncatedLength = length;
     }
 
-    float width = stringWidth(font, stringBuffer, truncatedLength);
+    float width = stringWidth(font, { stringBuffer, truncatedLength });
     if (!shouldInsertEllipsis && alwaysTruncate)
         width += customTruncationElementWidth;
     if ((width - maxWidth) < 0.0001) { // Ignore rounding errors.
@@ -268,7 +268,7 @@ static String truncateString(const String& string, float maxWidth, const FontCas
 
         truncatedLength = truncateToBuffer(string, length, keepCount, stringBuffer, shouldInsertEllipsis);
 
-        width = stringWidth(font, stringBuffer, truncatedLength);
+        width = stringWidth(font, { stringBuffer, truncatedLength });
         if (!shouldInsertEllipsis)
             width += customTruncationElementWidth;
         if (width <= maxWidth) {
@@ -306,7 +306,7 @@ String StringTruncator::rightTruncate(const String& string, float maxWidth, cons
 
 float StringTruncator::width(const String& string, const FontCascade& font)
 {
-    return stringWidth(font, StringView(string).upconvertedCharacters(), string.length());
+    return stringWidth(font, StringView(string).upconvertedCharacters());
 }
 
 String StringTruncator::centerTruncate(const String& string, float maxWidth, const FontCascade& font, float& resultWidth, bool shouldInsertEllipsis, float customTruncationElementWidth)

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -996,7 +996,7 @@ TEST(WTF, StringViewUpconvert)
     for (auto literal : data) {
         StringView string(literal);
         auto upconverted = string.upconvertedCharacters();
-        const UChar* characters = upconverted.get();
+        auto characters = upconverted.span();
         for (unsigned index = 1; index < string.length(); ++index)
             EXPECT_EQ(characters[index], string[index]) << index << " " << literal.characters();
     }


### PR DESCRIPTION
#### fd9e18c7f3c6303f8a7bb1d8b0af8767bb392410
<pre>
Update StringView::UpconvertedCharactersWithSize to store its size
<a href="https://bugs.webkit.org/show_bug.cgi?id=272629">https://bugs.webkit.org/show_bug.cgi?id=272629</a>

Reviewed by Darin Adler.

Update StringView::UpconvertedCharactersWithSize to store its size and add a
span() function.

* Source/JavaScriptCore/runtime/IntlCache.cpp:
(JSC::IntlCache::getBestDateTimePattern):
* Source/JavaScriptCore/runtime/IntlCache.h:
* Source/JavaScriptCore/runtime/IntlDateTimeFormat.cpp:
(JSC::IntlDateTimeFormat::initializeDateTimeFormat):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::convertToUppercaseWithoutLocale):
(WTF::StringImpl::convertToLowercaseWithLocale):
(WTF::StringImpl::convertToUppercaseWithLocale):
(WTF::StringImpl::foldCase):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::UpconvertedCharactersWithSize::operator const UChar* const):
(WTF::StringView::UpconvertedCharactersWithSize::get const):
(WTF::StringView::UpconvertedCharactersWithSize::span const):
(WTF::StringView::UpconvertedCharactersWithSize&lt;N&gt;::UpconvertedCharactersWithSize):
* Source/WebCore/PAL/pal/text/TextCodecCJK.cpp:
(PAL::eucJPEncode):
(PAL::iso2022JPEncode):
(PAL::shiftJISEncode):
(PAL::eucKREncode):
(PAL::big5Encode):
(PAL::gbEncodeShared):
* Source/WebCore/editing/Editor.cpp:
(WebCore::scanForTelephoneNumbers):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::linkifyPhoneNumbers):
* Source/WebCore/platform/Length.cpp:
(WebCore::newLengthArray):
* Source/WebCore/platform/SharedStringHash.cpp:
(WebCore::computeVisitedLinkHash):
* Source/WebCore/platform/TelephoneNumberDetector.h:
* Source/WebCore/platform/cocoa/TelephoneNumberDetectorCocoa.cpp:
(WebCore::TelephoneNumberDetector::find):
* Source/WebCore/platform/graphics/StringTruncator.cpp:
(WebCore::stringWidth):
(WebCore::truncateString):
(WebCore::StringTruncator::width):
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST(WTF, StringViewUpconvert)):

Canonical link: <a href="https://commits.webkit.org/277464@main">https://commits.webkit.org/277464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8742d8f6b7da579ae9a9687883351af0717ed195

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50368 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43740 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24351 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38818 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24532 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20115 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22013 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5734 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/40967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44034 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52260 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47176 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19055 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23993 "Built successfully") | | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/45154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24781 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54676 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6742 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23713 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11219 "Passed tests") | 
<!--EWS-Status-Bubble-End-->