### PR TITLE
Update StringParsingBuffer to use std::span

### DIFF
--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -348,8 +348,8 @@ static std::optional<PlainTime> parseTimeSpec(StringParsingBuffer<CharacterType>
         return PlainTime(hour, minute, second, 0, 0, 0);
     buffer.advance();
 
-    unsigned digits = 0;
-    unsigned maxCount = std::min(buffer.lengthRemaining(), 9u);
+    size_t digits = 0;
+    size_t maxCount = std::min<size_t>(buffer.lengthRemaining(), 9);
     for (; digits < maxCount; ++digits) {
         if (!isASCIIDigit(buffer[digits]))
             break;
@@ -358,7 +358,7 @@ static std::optional<PlainTime> parseTimeSpec(StringParsingBuffer<CharacterType>
         return std::nullopt;
 
     Vector<LChar, 9> padded(9, '0');
-    for (unsigned i = 0; i < digits; ++i)
+    for (size_t i = 0; i < digits; ++i)
         padded[i] = buffer[i];
     buffer.advanceBy(digits);
 

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp
@@ -34,8 +34,10 @@
 namespace WebCore {
 
 template<typename CharacterType>
-auto CSSCustomPropertySyntax::parseComponent(StringParsingBuffer<CharacterType> buffer) -> std::optional<Component>
+auto CSSCustomPropertySyntax::parseComponent(std::span<const CharacterType> span) -> std::optional<Component>
 {
+    StringParsingBuffer buffer { span };
+
     auto consumeMultiplier = [&] {
         if (skipExactly(buffer, '+'))
             return Multiplier::SpaceList;
@@ -50,7 +52,7 @@ auto CSSCustomPropertySyntax::parseComponent(StringParsingBuffer<CharacterType> 
         if (buffer.position() == begin)
             return { };
 
-        auto dataTypeName = StringView(std::span(begin, buffer.position() - begin));
+        auto dataTypeName = StringView(std::span(begin, buffer.position()));
         if (!skipExactly(buffer, '>'))
             return { };
 
@@ -75,7 +77,7 @@ auto CSSCustomPropertySyntax::parseComponent(StringParsingBuffer<CharacterType> 
         ++buffer;
 
     auto ident = [&] {
-        auto tokenizer = CSSTokenizer::tryCreate(StringView(std::span(begin, buffer.position() - begin)).toStringWithoutCopying());
+        auto tokenizer = CSSTokenizer::tryCreate(StringView(std::span(begin, buffer.position())).toStringWithoutCopying());
         if (!tokenizer)
             return nullAtom();
 
@@ -117,7 +119,7 @@ std::optional<CSSCustomPropertySyntax> CSSCustomPropertySyntax::parse(StringView
 
             skipUntil(buffer, '|');
 
-            auto component = parseComponent(StringParsingBuffer { begin, buffer.position() });
+            auto component = parseComponent(std::span { begin, buffer.position() });
             if (!component)
                 return { };
 

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
@@ -70,7 +70,7 @@ struct CSSCustomPropertySyntax {
     static CSSCustomPropertySyntax universal() { return { }; }
 
 private:
-    template<typename CharacterType> static std::optional<Component> parseComponent(StringParsingBuffer<CharacterType>);
+    template<typename CharacterType> static std::optional<Component> parseComponent(std::span<const CharacterType>);
     static Type typeForTypeName(StringView);
 };
 

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -198,7 +198,7 @@ public:
     HTMLFastPathParser(CharacterSpan source, Document& document, ContainerNode& destinationParent)
         : m_document(document)
         , m_destinationParent(destinationParent)
-        , m_parsingBuffer(source.data(), source.size())
+        , m_parsingBuffer(source)
     {
     }
 

--- a/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
@@ -119,7 +119,7 @@ std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL&
             while (lineEnd > lineStart && isManifestWhitespace(*lineEnd))
                 --lineEnd;
 
-            auto lineBuffer = StringParsingBuffer { lineStart, lineEnd + 1 };
+            StringParsingBuffer lineBuffer(std::span { lineStart, lineEnd + 1 });
 
             if (lineBuffer[lineBuffer.lengthRemaining() - 1] == ':') {
                 if (skipCharactersExactly(lineBuffer, cacheModeIdentifier<CharacterType>) && lineBuffer.lengthRemaining() == 1) {

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -473,7 +473,7 @@ void ContentSecurityPolicyDirectiveList::parse(const String& policy, ContentSecu
             auto directiveBegin = buffer.position();
             skipUntil(buffer, ';');
 
-            if (auto directive = parseDirective(StringParsingBuffer { directiveBegin, buffer.position() })) {
+            if (auto directive = parseDirective(std::span { directiveBegin, buffer.position() })) {
                 ASSERT(!directive->name.isEmpty());
                 if (policyFrom == ContentSecurityPolicy::PolicyFrom::Inherited) {
                     if (equalIgnoringASCIICase(directive->name, ContentSecurityPolicyDirectiveNames::upgradeInsecureRequests))
@@ -504,8 +504,9 @@ void ContentSecurityPolicyDirectiveList::parse(const String& policy, ContentSecu
 // directive-name    = 1*( ALPHA / DIGIT / "-" )
 // directive-value   = *( WSP / <VCHAR except ";"> )
 //
-template<typename CharacterType> auto ContentSecurityPolicyDirectiveList::parseDirective(StringParsingBuffer<CharacterType> buffer) -> std::optional<ParsedDirective>
+template<typename CharacterType> auto ContentSecurityPolicyDirectiveList::parseDirective(std::span<const CharacterType> span) -> std::optional<ParsedDirective>
 {
+    StringParsingBuffer buffer { span };
     skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
 
     // Empty directive (e.g. ";;;"). Exit early.

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
@@ -103,7 +103,7 @@ private:
         String name;
         String value;
     };
-    template<typename CharacterType> std::optional<ParsedDirective> parseDirective(StringParsingBuffer<CharacterType>);
+    template<typename CharacterType> std::optional<ParsedDirective> parseDirective(std::span<const CharacterType>);
     void parseReportTo(ParsedDirective&&);
     void parseReportURI(ParsedDirective&&);
     void parseRequireTrustedTypesFor(ParsedDirective&&);

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -249,7 +249,7 @@ template<typename CharacterType> void ContentSecurityPolicySourceList::parse(Str
         auto beginSource = buffer.position();
         skipWhile<isSourceCharacter>(buffer);
 
-        auto sourceBuffer = StringParsingBuffer { beginSource, buffer.position() };
+        StringParsingBuffer sourceBuffer(std::span { beginSource, buffer.position() });
 
         if (parseNonceSource(sourceBuffer))
             continue;
@@ -349,7 +349,7 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
     if (buffer.atEnd()) {
         // host
         //     ^
-        auto host = parseHost(StringParsingBuffer { beginHost, buffer.position() });
+        auto host = parseHost(std::span { beginHost, buffer.position() });
         if (!host)
             return std::nullopt;
 
@@ -360,11 +360,11 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
     if (buffer.hasCharactersRemaining() && *buffer == '/') {
         // host/path || host/ || /
         //     ^            ^    ^
-        auto host = parseHost(StringParsingBuffer { beginHost, buffer.position() });
+        auto host = parseHost(std::span { beginHost, buffer.position() });
         if (!host)
             return std::nullopt;
 
-        auto path = parsePath(buffer);
+        auto path = parsePath(buffer.span());
         if (!path)
             return std::nullopt;
 
@@ -377,7 +377,7 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
         if (buffer.lengthRemaining() == 1) {
             // scheme:
             //       ^
-            auto scheme = parseScheme(StringParsingBuffer { begin, buffer.position() });
+            auto scheme = parseScheme(StringParsingBuffer(std::span { begin, buffer.position() }));
             if (!scheme)
                 return std::nullopt;
 
@@ -388,7 +388,7 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
         if (buffer[1] == '/') {
             // scheme://host || scheme://
             //       ^                ^
-            auto scheme = parseScheme(StringParsingBuffer { begin, buffer.position() });
+            auto scheme = parseScheme(StringParsingBuffer(std::span { begin, buffer.position() }));
             if (!scheme
                 || !skipExactly(buffer, ':')
                 || !skipExactly(buffer, '/')
@@ -420,12 +420,12 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
         beginPath = buffer.position();
     }
 
-    auto host = parseHost(StringParsingBuffer { beginHost, beginPort ? beginPort : beginPath });
+    auto host = parseHost(std::span { beginHost, beginPort ? beginPort : beginPath });
     if (!host)
         return std::nullopt;
 
     if (beginPort) {
-        auto port = parsePort(StringParsingBuffer { beginPort, beginPath });
+        auto port = parsePort(std::span { beginPort, beginPath });
         if (!port)
             return std::nullopt;
 
@@ -433,7 +433,7 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
     }
 
     if (beginPath != buffer.end()) {
-        auto path = parsePath(StringParsingBuffer { beginPath, buffer.end() });
+        auto path = parsePath(std::span { beginPath, buffer.end() });
         if (!path)
             return std::nullopt;
 
@@ -471,8 +471,9 @@ template<typename CharacterType> StringView ContentSecurityPolicySourceList::par
 //                   / "*"
 // host-char         = ALPHA / DIGIT / "-"
 //
-template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::Host> ContentSecurityPolicySourceList::parseHost(StringParsingBuffer<CharacterType> buffer)
+template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::Host> ContentSecurityPolicySourceList::parseHost(std::span<const CharacterType> span)
 {
+    StringParsingBuffer buffer { span };
     ASSERT(buffer.position() <= buffer.end());
 
     if (buffer.atEnd())
@@ -507,8 +508,9 @@ template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::
     return host;
 }
 
-template<typename CharacterType> String ContentSecurityPolicySourceList::parsePath(StringParsingBuffer<CharacterType> buffer)
+template<typename CharacterType> String ContentSecurityPolicySourceList::parsePath(std::span<const CharacterType> span)
 {
+    StringParsingBuffer buffer { span };
     ASSERT(buffer.position() <= buffer.end());
     
     auto begin = buffer.position();
@@ -526,8 +528,9 @@ template<typename CharacterType> String ContentSecurityPolicySourceList::parsePa
 
 // port              = ":" ( 1*DIGIT / "*" )
 //
-template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::Port> ContentSecurityPolicySourceList::parsePort(StringParsingBuffer<CharacterType> buffer)
+template<typename CharacterType> std::optional<ContentSecurityPolicySourceList::Port> ContentSecurityPolicySourceList::parsePort(std::span<const CharacterType> span)
 {
+    StringParsingBuffer buffer { span };
     ASSERT(buffer.position() <= buffer.end());
     
     if (!skipExactly(buffer, ':'))

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.h
@@ -81,9 +81,9 @@ private:
     template<typename CharacterType> void parse(StringParsingBuffer<CharacterType>);
     template<typename CharacterType> std::optional<Source> parseSource(StringParsingBuffer<CharacterType>);
     template<typename CharacterType> StringView parseScheme(StringParsingBuffer<CharacterType>);
-    template<typename CharacterType> std::optional<Host> parseHost(StringParsingBuffer<CharacterType>);
-    template<typename CharacterType> std::optional<Port> parsePort(StringParsingBuffer<CharacterType>);
-    template<typename CharacterType> String parsePath(StringParsingBuffer<CharacterType>);
+    template<typename CharacterType> std::optional<Host> parseHost(std::span<const CharacterType>);
+    template<typename CharacterType> std::optional<Port> parsePort(std::span<const CharacterType>);
+    template<typename CharacterType> String parsePath(std::span<const CharacterType>);
     template<typename CharacterType> bool parseNonceSource(StringParsingBuffer<CharacterType>);
     template<typename CharacterType> bool parseHashSource(StringParsingBuffer<CharacterType>);
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
@@ -100,7 +100,7 @@ void ContentSecurityPolicyTrustedTypesDirective::parse(const String& value)
             auto beginPolicy = buffer.position();
             skipWhile<isTrustedTypeCharacter>(buffer);
 
-            auto policyBuffer = StringParsingBuffer { beginPolicy, buffer.position() };
+            StringParsingBuffer policyBuffer(std::span { beginPolicy, buffer.position() });
 
             if (skipExactlyIgnoringASCIICase(policyBuffer, "'allow-duplicates'"_s)) {
                 m_allowDuplicates = true;

--- a/Source/WebCore/svg/SVGParserUtilities.cpp
+++ b/Source/WebCore/svg/SVGParserUtilities.cpp
@@ -289,8 +289,9 @@ std::optional<HashSet<String>> parseGlyphName(StringView string)
 
 }
 
-template<typename CharacterType> static std::optional<UnicodeRange> parseUnicodeRange(StringParsingBuffer<CharacterType> buffer)
+template<typename CharacterType> static std::optional<UnicodeRange> parseUnicodeRange(std::span<const CharacterType> span)
 {
+    StringParsingBuffer buffer { span };
     unsigned length = buffer.lengthRemaining();
     if (length < 2 || buffer[0] != 'U' || buffer[1] != '+')
         return std::nullopt;
@@ -378,7 +379,7 @@ std::optional<std::pair<UnicodeRanges, HashSet<String>>> parseKerningUnicodeStri
                 break;
 
             // Try to parse unicode range first
-            if (auto range = parseUnicodeRange(StringParsingBuffer { inputStart, buffer.position() }))
+            if (auto range = parseUnicodeRange(std::span { inputStart, buffer.position() }))
                 rangeList.append(WTFMove(*range));
             else
                 stringList.add(String({ inputStart, buffer.position() }));

--- a/Source/WebCore/svg/SVGPathStringViewSource.cpp
+++ b/Source/WebCore/svg/SVGPathStringViewSource.cpp
@@ -31,9 +31,9 @@ SVGPathStringViewSource::SVGPathStringViewSource(StringView view)
     ASSERT(!view.isEmpty());
 
     if (m_is8BitSource)
-        m_buffer8 = { view.characters8(), view.length() };
+        m_buffer8 = view.span8();
     else
-        m_buffer16 = { view.characters16(), view.length() };
+        m_buffer16 = view.span16();
 }
 
 bool SVGPathStringViewSource::hasMoreData() const

--- a/Tools/TestWebKitAPI/Tests/WTF/StringParsingBuffer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringParsingBuffer.cpp
@@ -47,7 +47,7 @@ TEST(WTF, StringParsingBufferEmpty)
 TEST(WTF, StringParsingBufferInitial)
 {
     StringView string { "abc"_s };
-    StringParsingBuffer<LChar> parsingBuffer { string.characters8(), string.length() };
+    StringParsingBuffer parsingBuffer { string.span8() };
 
     EXPECT_FALSE(parsingBuffer.atEnd());
     EXPECT_TRUE(parsingBuffer.hasCharactersRemaining());
@@ -60,7 +60,7 @@ TEST(WTF, StringParsingBufferInitial)
 TEST(WTF, StringParsingBufferAdvance)
 {
     StringView string { "abc"_s };
-    StringParsingBuffer<LChar> parsingBuffer { string.characters8(), string.length() };
+    StringParsingBuffer parsingBuffer { string.span8() };
 
     parsingBuffer.advance();
     EXPECT_FALSE(parsingBuffer.atEnd());
@@ -72,7 +72,7 @@ TEST(WTF, StringParsingBufferAdvance)
 TEST(WTF, StringParsingBufferAdvanceBy)
 {
     StringView string { "abc"_s };
-    StringParsingBuffer<LChar> parsingBuffer { string.characters8(), string.length() };
+    StringParsingBuffer parsingBuffer { string.span8() };
 
     parsingBuffer.advanceBy(2);
     EXPECT_FALSE(parsingBuffer.atEnd());
@@ -84,7 +84,7 @@ TEST(WTF, StringParsingBufferAdvanceBy)
 TEST(WTF, StringParsingBufferPreIncrement)
 {
     StringView string { "abc"_s };
-    StringParsingBuffer<LChar> parsingBuffer { string.characters8(), string.length() };
+    StringParsingBuffer parsingBuffer { string.span8() };
 
     auto preIncrementedParsingBuffer = ++parsingBuffer;
     EXPECT_FALSE(parsingBuffer.atEnd());
@@ -100,7 +100,7 @@ TEST(WTF, StringParsingBufferPreIncrement)
 TEST(WTF, StringParsingBufferPostIncrement)
 {
     StringView string { "abc"_s };
-    StringParsingBuffer<LChar> parsingBuffer { string.characters8(), string.length() };
+    StringParsingBuffer parsingBuffer { string.span8() };
 
     auto postIncrementedParsingBuffer = parsingBuffer++;
     EXPECT_FALSE(parsingBuffer.atEnd());
@@ -116,7 +116,7 @@ TEST(WTF, StringParsingBufferPostIncrement)
 TEST(WTF, StringParsingBufferPlusEquals)
 {
     StringView string { "abc"_s };
-    StringParsingBuffer<LChar> parsingBuffer { string.characters8(), string.length() };
+    StringParsingBuffer parsingBuffer { string.span8() };
 
     parsingBuffer += 2;
     EXPECT_FALSE(parsingBuffer.atEnd());
@@ -128,7 +128,7 @@ TEST(WTF, StringParsingBufferPlusEquals)
 TEST(WTF, StringParsingBufferEnd)
 {
     StringView string { "abc"_s };
-    StringParsingBuffer<LChar> parsingBuffer { string.characters8(), string.length() };
+    StringParsingBuffer parsingBuffer { string.span8() };
 
     ++parsingBuffer;
     EXPECT_FALSE(parsingBuffer.atEnd());
@@ -148,7 +148,7 @@ TEST(WTF, StringParsingBufferEnd)
 TEST(WTF, StringParsingBufferSubscript)
 {
     StringView string { "abc"_s };
-    StringParsingBuffer<LChar> parsingBuffer { string.characters8(), string.length() };
+    StringParsingBuffer parsingBuffer { string.span8() };
     
     ++parsingBuffer;
     EXPECT_EQ(parsingBuffer[0], 'b');
@@ -158,7 +158,7 @@ TEST(WTF, StringParsingBufferSubscript)
 TEST(WTF, StringParsingBufferStringView)
 {
     StringView string { "abc"_s };
-    StringParsingBuffer<LChar> parsingBuffer { string.characters8(), string.length() };
+    StringParsingBuffer parsingBuffer { string.span8() };
 
     ++parsingBuffer;
     auto viewRemaining = parsingBuffer.stringViewOfCharactersRemaining();


### PR DESCRIPTION
#### d2a029f757b316ef28a6935af9d87a3b9d9d72e2
<pre>
Update StringParsingBuffer to use std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=272630">https://bugs.webkit.org/show_bug.cgi?id=272630</a>

Reviewed by Darin Adler.

Update StringParsingBuffer to use std::span.

* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::parseTimeSpec):
* Source/WTF/wtf/text/StringParsingBuffer.h:
(WTF::readCharactersForParsing):
* Source/WebCore/css/parser/CSSCustomPropertySyntax.cpp:
(WebCore::CSSCustomPropertySyntax::parseComponent):
(WebCore::CSSCustomPropertySyntax::parse):
* Source/WebCore/css/parser/CSSCustomPropertySyntax.h:
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::HTMLFastPathParser):
* Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp:
(WebCore::parseApplicationCacheManifest):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::ContentSecurityPolicyDirectiveList::parse):
(WebCore::ContentSecurityPolicyDirectiveList::parseDirective):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h:
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::ContentSecurityPolicySourceList::parse):
(WebCore::ContentSecurityPolicySourceList::parseSource):
(WebCore::ContentSecurityPolicySourceList::parseHost):
(WebCore::ContentSecurityPolicySourceList::parsePath):
(WebCore::ContentSecurityPolicySourceList::parsePort):
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.h:
* Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp:
(WebCore::ContentSecurityPolicyTrustedTypesDirective::parse):
* Source/WebCore/svg/SVGParserUtilities.cpp:
(WebCore::parseUnicodeRange):
(WebCore::parseKerningUnicodeString):
* Source/WebCore/svg/SVGPathStringViewSource.cpp:
(WebCore::SVGPathStringViewSource::SVGPathStringViewSource):
* Tools/TestWebKitAPI/Tests/WTF/StringParsingBuffer.cpp:
(TestWebKitAPI::TEST(WTF, StringParsingBufferInitial)):
(TestWebKitAPI::TEST(WTF, StringParsingBufferAdvance)):
(TestWebKitAPI::TEST(WTF, StringParsingBufferAdvanceBy)):
(TestWebKitAPI::TEST(WTF, StringParsingBufferPreIncrement)):
(TestWebKitAPI::TEST(WTF, StringParsingBufferPostIncrement)):
(TestWebKitAPI::TEST(WTF, StringParsingBufferPlusEquals)):
(TestWebKitAPI::TEST(WTF, StringParsingBufferEnd)):
(TestWebKitAPI::TEST(WTF, StringParsingBufferSubscript)):
(TestWebKitAPI::TEST(WTF, StringParsingBufferStringView)):

Canonical link: <a href="https://commits.webkit.org/277466@main">https://commits.webkit.org/277466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/176967149a4c23b4a42e4f9da8e52c51000b2b52

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50364 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43736 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24346 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38815 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24528 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20112 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22009 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5730 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/40963 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44030 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52256 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47172 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46119 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23989 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45150 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24777 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54672 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6739 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23709 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11215 "Passed tests") | 
<!--EWS-Status-Bubble-End-->