### PR TITLE
Use std::span in InspectorStyleSheet.cpp and ApplicationCacheManifestParser.cpp

### DIFF
--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -299,7 +299,7 @@ private:
     void observeComment(unsigned startOffset, unsigned endOffset) override;
     
     Ref<CSSRuleSourceData> popRuleData();
-    template <typename CharacterType> inline void setRuleHeaderEnd(const CharacterType*, unsigned);
+    template <typename CharacterType> inline void setRuleHeaderEnd(std::span<const CharacterType>);
     void fixUnparsedPropertyRanges(CSSRuleSourceData*);
     
     const String& m_parsedText;
@@ -322,18 +322,18 @@ void StyleSheetHandler::startRuleHeader(StyleRuleType type, unsigned offset)
     m_currentRuleDataStack.append(WTFMove(data));
 }
 
-template <typename CharacterType> inline void StyleSheetHandler::setRuleHeaderEnd(const CharacterType* dataStart, unsigned listEndOffset)
+template <typename CharacterType> inline void StyleSheetHandler::setRuleHeaderEnd(std::span<const CharacterType> data)
 {
-    while (listEndOffset > m_currentRuleDataStack.last()->ruleHeaderRange.start) {
-        if (isASCIIWhitespace<CharacterType>(*(dataStart + listEndOffset - 1)))
-            --listEndOffset;
+    while (data.size() > m_currentRuleDataStack.last()->ruleHeaderRange.start) {
+        if (isASCIIWhitespace<CharacterType>(data[data.size() - 1]))
+            data = data.first(data.size() - 1);
         else
             break;
     }
 
-    m_currentRuleDataStack.last()->ruleHeaderRange.end = listEndOffset;
+    m_currentRuleDataStack.last()->ruleHeaderRange.end = data.size();
     if (!m_currentRuleDataStack.last()->selectorRanges.isEmpty())
-        m_currentRuleDataStack.last()->selectorRanges.last().end = listEndOffset;
+        m_currentRuleDataStack.last()->selectorRanges.last().end = data.size();
 }
 
 void StyleSheetHandler::endRuleHeader(unsigned offset)
@@ -341,9 +341,9 @@ void StyleSheetHandler::endRuleHeader(unsigned offset)
     ASSERT(!m_currentRuleDataStack.isEmpty());
     
     if (m_parsedText.is8Bit())
-        setRuleHeaderEnd<LChar>(m_parsedText.characters8(), offset);
+        setRuleHeaderEnd<LChar>(m_parsedText.span8().first(offset));
     else
-        setRuleHeaderEnd<UChar>(m_parsedText.characters16(), offset);
+        setRuleHeaderEnd<UChar>(m_parsedText.span16().first(offset));
 }
 
 void StyleSheetHandler::observeSelector(unsigned startOffset, unsigned endOffset)

--- a/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
@@ -60,9 +60,9 @@ template<typename CharacterType> static constexpr bool isManifestWhitespaceOrNew
     return isManifestWhitespace(character) || isManifestNewline(character);
 }
 
-template<typename CharacterType> static URL makeManifestURL(const URL& manifestURL, const CharacterType* start, const CharacterType* end)
+template<typename CharacterType> static URL makeManifestURL(const URL& manifestURL, std::span<const CharacterType> relativeURL)
 {
-    URL url(manifestURL, String({ start, end }));
+    URL url(manifestURL, String(relativeURL));
     url.removeFragmentIdentifier();
     return url;
 }
@@ -149,7 +149,7 @@ std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL&
                 // Look for whitespace separating the URL from subsequent ignored tokens.
                 skipUntil<isManifestWhitespace>(lineBuffer);
 
-                auto url = makeManifestURL(manifestURL, lineStart, lineBuffer.position());
+                auto url = makeManifestURL(manifestURL, std::span { lineStart, lineBuffer.position() });
                 if (!url.isValid())
                     continue;
                 
@@ -173,7 +173,7 @@ std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL&
                     continue;
                 }
                 
-                auto url = makeManifestURL(manifestURL, lineStart, lineBuffer.position());
+                auto url = makeManifestURL(manifestURL, std::span { lineStart, lineBuffer.position() });
                 if (!url.isValid())
                     continue;
                 
@@ -193,7 +193,7 @@ std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL&
                     continue;
                 }
 
-                auto namespaceURL = makeManifestURL(manifestURL, lineStart, lineBuffer.position());
+                auto namespaceURL = makeManifestURL(manifestURL, std::span { lineStart, lineBuffer.position() });
                 if (!namespaceURL.isValid())
                     continue;
 
@@ -214,7 +214,7 @@ std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL&
                 // Look for whitespace separating the URL from subsequent ignored tokens.
                 skipUntil<isManifestWhitespace>(lineBuffer);
 
-                auto fallbackURL = makeManifestURL(manifestURL, fallbackStart, lineBuffer.position());
+                auto fallbackURL = makeManifestURL(manifestURL, std::span { fallbackStart, lineBuffer.position() });
                 if (!fallbackURL.isValid())
                     continue;
 


### PR DESCRIPTION
#### 68cebc10af146d4dd585d0c68e703f526c5027e8
<pre>
Use std::span in InspectorStyleSheet.cpp and ApplicationCacheManifestParser.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=272634">https://bugs.webkit.org/show_bug.cgi?id=272634</a>

Reviewed by Brent Fulgham.

* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::StyleSheetHandler::setRuleHeaderEnd):
(WebCore::StyleSheetHandler::endRuleHeader):
* Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp:
(WebCore::makeManifestURL):
(WebCore::parseApplicationCacheManifest):

Canonical link: <a href="https://commits.webkit.org/277463@main">https://commits.webkit.org/277463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37e86827af52b1e88b30aa54632ed4468712e090

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50358 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43730 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/49982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32714 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38811 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24521 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20108 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22002 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5724 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44023 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52250 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46116 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/23983 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45147 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24771 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6741 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->