### PR TITLE
Adopt std::span in GIFImageReader

### DIFF
--- a/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp
@@ -217,16 +217,12 @@ bool GIFImageDecoder::haveDecodedRow(unsigned frameIndex, const Vector<unsigned 
         return true;
 
     // Get the colormap.
-    const unsigned char* colorMap;
-    unsigned colorMapSize;
-    if (frameContext->isLocalColormapDefined) {
+    std::span<const uint8_t> colorMap;
+    if (frameContext->isLocalColormapDefined)
         colorMap = m_reader->localColormap(frameContext);
-        colorMapSize = m_reader->localColormapSize(frameContext);
-    } else {
+    else
         colorMap = m_reader->globalColormap();
-        colorMapSize = m_reader->globalColormapSize();
-    }
-    if (!colorMap)
+    if (colorMap.empty())
         return true;
 
     // Initialize the frame if necessary.
@@ -238,7 +234,7 @@ bool GIFImageDecoder::haveDecodedRow(unsigned frameIndex, const Vector<unsigned 
     // Write one row's worth of data into the frame.  
     for (int x = xBegin; x < xEnd; ++x) {
         const unsigned char sourceValue = rowBuffer[x - frameContext->xOffset];
-        if ((!frameContext->isTransparent || (sourceValue != frameContext->tpixel)) && (sourceValue < colorMapSize)) {
+        if ((!frameContext->isTransparent || (sourceValue != frameContext->tpixel)) && (sourceValue < colorMap.size())) {
             const size_t colorIndex = static_cast<size_t>(sourceValue) * 3;
             buffer.backingStore()->setPixel(currentAddress, colorMap[colorIndex], colorMap[colorIndex + 1], colorMap[colorIndex + 2], 255);
         } else {

--- a/Source/WebCore/platform/image-decoders/gif/GIFImageReader.h
+++ b/Source/WebCore/platform/image-decoders/gif/GIFImageReader.h
@@ -100,7 +100,7 @@ public:
 
     bool prepareToDecode();
     bool outputRow();
-    bool doLZW(const unsigned char* block, size_t bytesInBlock);
+    bool doLZW(std::span<const uint8_t> block);
     bool hasRemainingRows() { return rowsRemaining; }
 
 private:
@@ -194,7 +194,7 @@ public:
         m_lzwBlocks.append(GIFLZWBlock(position, size));
     }
 
-    bool decode(const unsigned char* data, size_t length, WebCore::GIFImageDecoder* client, bool* frameDecoded);
+    bool decode(std::span<const uint8_t> data, WebCore::GIFImageDecoder* client, bool& frameDecoded);
 
     bool isComplete() const { return m_isComplete; }
     void setComplete() { m_isComplete = true; }
@@ -219,7 +219,7 @@ private:
 class GIFImageReader {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    GIFImageReader(WebCore::GIFImageDecoder* client = 0)
+    GIFImageReader(WebCore::GIFImageDecoder* client = nullptr)
         : m_client(client)
         , m_state(GIFType)
         , m_bytesToConsume(6) // Number of bytes for GIF type, either "GIF87a" or "GIF89a".
@@ -237,7 +237,7 @@ public:
     {
     }
 
-    void setData(const WebCore::SharedBuffer& data) { m_data = &data; }
+    void setData(Ref<const WebCore::SharedBuffer>&& data) { m_data = WTFMove(data); }
     // FIXME: haltAtFrame should be size_t.
     bool decode(WebCore::GIFImageDecoder::GIFQuery, unsigned haltAtFrame);
 
@@ -253,22 +253,14 @@ public:
     }
     int loopCount() const { return m_loopCount; }
 
-    const unsigned char* globalColormap() const
+    std::span<const uint8_t> globalColormap() const
     {
-        return m_isGlobalColormapDefined ? data(m_globalColormapPosition) : 0;
-    }
-    int globalColormapSize() const
-    {
-        return m_isGlobalColormapDefined ? m_globalColormapSize : 0;
+        return m_isGlobalColormapDefined ? data(m_globalColormapPosition, m_globalColormapSize) : std::span<const uint8_t> { };
     }
 
-    const unsigned char* localColormap(const GIFFrameContext* frame) const
+    std::span<const uint8_t> localColormap(const GIFFrameContext* frame) const
     {
-        return frame->isLocalColormapDefined ? data(frame->localColormapPosition) : 0;
-    }
-    int localColormapSize(const GIFFrameContext* frame) const
-    {
-        return frame->isLocalColormapDefined ? frame->localColormapSize : 0;
+        return frame->isLocalColormapDefined ? data(frame->localColormapPosition, frame->localColormapSize) : std::span<const uint8_t> { };
     }
 
     const GIFFrameContext* frameContext() const
@@ -285,9 +277,9 @@ private:
     bool parse(size_t dataPosition, size_t len, bool parseSizeOnly);
     void setRemainingBytes(size_t);
 
-    const uint8_t* data(size_t dataPosition) const
+    std::span<const uint8_t> data(size_t offset, size_t length) const
     {
-        return m_data->data() + dataPosition;
+        return m_data->span().subspan(offset, length);
     }
 
     void addFrameIfNecessary();


### PR DESCRIPTION
#### 6c6ce2d397a52ce87ebd8e320943148333d5ad8d
<pre>
Adopt std::span in GIFImageReader
<a href="https://bugs.webkit.org/show_bug.cgi?id=272640">https://bugs.webkit.org/show_bug.cgi?id=272640</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/image-decoders/gif/GIFImageDecoder.cpp:
(WebCore::GIFImageDecoder::haveDecodedRow):
* Source/WebCore/platform/image-decoders/gif/GIFImageReader.cpp:
(GIFLZWContext::doLZW):
(GIFFrameContext::decode):
(GIFImageReader::decode):
(GIFImageReader::parse):
* Source/WebCore/platform/image-decoders/gif/GIFImageReader.h:
(GIFImageReader::GIFImageReader):
(GIFImageReader::setData):
(GIFImageReader::globalColormap const):
(GIFImageReader::localColormap const):
(GIFImageReader::data const):
(GIFImageReader::globalColormapSize const): Deleted.
(GIFImageReader::localColormapSize const): Deleted.

Canonical link: <a href="https://commits.webkit.org/277476@main">https://commits.webkit.org/277476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3182b3dcac0bfd974a273266ffeb7fc58c685a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47733 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50416 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32776 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38849 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41208 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20146 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42399 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5782 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44077 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52310 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22769 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19097 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46154 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24041 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45188 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24829 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6747 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23761 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->