### PR TITLE
Use std::span and char8_t more for UTF-8 handling

### DIFF
--- a/LayoutTests/platform/mac-wk1/fast/dom/Window/alert-with-unmatched-utf16-surrogate-should-not-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/dom/Window/alert-with-unmatched-utf16-surrogate-should-not-crash-expected.txt
@@ -1,4 +1,4 @@
-ALERT: �
+ALERT: (null)
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/Source/JavaScriptCore/API/JSStringRef.cpp
+++ b/Source/JavaScriptCore/API/JSStringRef.cpp
@@ -32,7 +32,6 @@
 #include <wtf/unicode/UTF8Conversion.h>
 
 using namespace JSC;
-using namespace WTF::Unicode;
 
 JSStringRef JSStringCreateWithCharacters(const JSChar* chars, size_t numChars)
 {
@@ -46,12 +45,11 @@ JSStringRef JSStringCreateWithUTF8CString(const char* string)
     if (string) {
         auto stringSpan = span8(string);
         Vector<UChar, 1024> buffer(stringSpan.size());
-        UChar* p = buffer.data();
-        bool sourceContainsOnlyASCII;
-        if (convertUTF8ToUTF16(spanReinterpretCast<const char8_t>(stringSpan), &p, p + buffer.size(), &sourceContainsOnlyASCII)) {
-            if (sourceContainsOnlyASCII)
+        auto result = WTF::Unicode::convert(spanReinterpretCast<const char8_t>(stringSpan), buffer.mutableSpan());
+        if (result.code == WTF::Unicode::ConversionResultCode::Success) {
+            if (result.isAllASCII)
                 return &OpaqueJSString::create(stringSpan).leakRef();
-            return &OpaqueJSString::create({ buffer.data(), p }).leakRef();
+            return &OpaqueJSString::create(result.buffer).leakRef();
         }
     }
 
@@ -100,18 +98,17 @@ size_t JSStringGetUTF8CString(JSStringRef string, char* buffer, size_t bufferSiz
     if (!string || !buffer || !bufferSize)
         return 0;
 
-    char* destination = buffer;
-    bool failed = false;
+    std::span<char8_t> target { reinterpret_cast<char8_t*>(buffer), bufferSize - 1 };
+    WTF::Unicode::ConversionResult<char8_t> result;
     if (string->is8Bit())
-        convertLatin1ToUTF8(string->span8(), &destination, destination + bufferSize - 1);
-    else {
-        auto characters = string->span16();
-        auto result = convertUTF16ToUTF8(characters, &destination, destination + bufferSize - 1);
-        failed = result != ConversionResult::Success && result != ConversionResult::TargetExhausted;
-    }
+        result = WTF::Unicode::convert(string->span8(), target);
+    else
+        result = WTF::Unicode::convert(string->span16(), target);
+    if (result.code == WTF::Unicode::ConversionResultCode::SourceInvalid)
+        return 0;
 
-    *destination++ = '\0';
-    return failed ? 0 : destination - buffer;
+    buffer[result.buffer.size()] = '\0';
+    return result.buffer.size() + 1;
 }
 
 bool JSStringIsEqual(JSStringRef a, JSStringRef b)

--- a/Source/JavaScriptCore/API/OpaqueJSString.h
+++ b/Source/JavaScriptCore/API/OpaqueJSString.h
@@ -23,8 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#ifndef OpaqueJSString_h
-#define OpaqueJSString_h
+#pragma once
 
 #include <atomic>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -105,5 +104,3 @@ private:
     // This will be initialized on demand when characters() is called if the string needs up-conversion.
     std::atomic<UChar*> m_characters;
 };
-
-#endif

--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -24,9 +24,9 @@
 #include <wtf/text/AtomString.h>
 
 #include <mutex>
-#include <wtf/text/IntegerToStringConversion.h>
-
+#include <wtf/Algorithms.h>
 #include <wtf/dtoa.h>
+#include <wtf/text/IntegerToStringConversion.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/unicode/CharacterNames.h>
 
@@ -120,7 +120,7 @@ AtomString AtomString::number(double number)
 AtomString AtomString::fromUTF8Internal(std::span<const char> characters)
 {
     ASSERT(!characters.empty());
-    return AtomStringImpl::addUTF8(characters);
+    return AtomStringImpl::add(spanReinterpretCast<const char8_t>(characters));
 }
 
 #ifndef NDEBUG

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -66,7 +66,7 @@ public:
     ALWAYS_INLINE static RefPtr<AtomStringImpl> addCString(const char* s) { return s ? add(WTF::span8(s)) : nullptr; }
 
     // Returns null if the input data contains an invalid UTF-8 sequence.
-    static RefPtr<AtomStringImpl> addUTF8(std::span<const char> start);
+    static RefPtr<AtomStringImpl> add(std::span<const char8_t>);
 
 #if USE(CF)
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(CFStringRef);

--- a/Source/WTF/wtf/text/StringConcatenate.h
+++ b/Source/WTF/wtf/text/StringConcatenate.h
@@ -290,48 +290,28 @@ public:
     }
 };
 
-struct UTF8Adapter {
-    const char8_t* characters;
-    unsigned lengthUTF8 { 0 };
-    unsigned lengthUTF16 { 0 };
-    bool is8Bit { true };
-    bool conversionFailed { true };
-
-    UTF8Adapter(std::span<const char8_t> characters)
-        : characters { characters.data() }
-    {
-        auto result = Unicode::computeUTFLengths(characters);
-        if (result.result == Unicode::ConversionResult::SourceIllegal)
-            return;
-        if (result.lengthUTF16 > String::MaxLength)
-            return;
-        lengthUTF8 = result.lengthUTF8;
-        lengthUTF16 = result.lengthUTF16;
-        is8Bit = result.isAllASCII;
-        conversionFailed = false;
-    }
-};
-
-template<> class StringTypeAdapter<UTF8Adapter, void> {
+template<> class StringTypeAdapter<Unicode::CheckedUTF8, void> {
 public:
-    StringTypeAdapter(UTF8Adapter characters)
+    StringTypeAdapter(Unicode::CheckedUTF8 characters)
         : m_characters { characters }
     {
+        if (m_characters.lengthUTF16 > String::MaxLength)
+            m_characters.lengthUTF16 = 0;
     }
 
     unsigned length() const { return m_characters.lengthUTF16; }
-    bool is8Bit() const { return m_characters.is8Bit; }
-    void writeTo(LChar* destination) const { memcpy(destination, m_characters.characters, m_characters.lengthUTF16); }
-    void writeTo(UChar* destination) const { Unicode::convertUTF8ToUTF16({ m_characters.characters, m_characters.lengthUTF8 }, &destination, destination + m_characters.lengthUTF16); }
+    bool is8Bit() const { return m_characters.isAllASCII; }
+    void writeTo(LChar* destination) const { memcpy(destination, m_characters.characters.data(), m_characters.lengthUTF16); }
+    void writeTo(UChar* destination) const { Unicode::convert(m_characters.characters, std::span { destination, m_characters.lengthUTF16 }); }
 
 private:
-    UTF8Adapter m_characters;
+    Unicode::CheckedUTF8 m_characters;
 };
 
-template<size_t Extent> class StringTypeAdapter<std::span<const char8_t, Extent>, void> : public StringTypeAdapter<UTF8Adapter, void> {
+template<size_t Extent> class StringTypeAdapter<std::span<const char8_t, Extent>, void> : public StringTypeAdapter<Unicode::CheckedUTF8, void> {
 public:
     StringTypeAdapter(std::span<const char8_t, Extent> span)
-        : StringTypeAdapter<UTF8Adapter, void> { span }
+        : StringTypeAdapter<Unicode::CheckedUTF8, void> { Unicode::checkUTF8(span) }
     {
     }
 };
@@ -629,7 +609,6 @@ inline String WARN_UNUSED_RETURN makeStringByInserting(StringView originalString
 
 using WTF::Indentation;
 using WTF::IndentationScope;
-using WTF::UTF8Adapter;
 using WTF::makeAtomString;
 using WTF::makeString;
 using WTF::makeStringByInserting;

--- a/Source/WTF/wtf/text/UTF8ConversionError.h
+++ b/Source/WTF/wtf/text/UTF8ConversionError.h
@@ -27,11 +27,7 @@
 
 namespace WTF {
 
-enum class UTF8ConversionError : uint8_t {
-    OutOfMemory,
-    IllegalSource,
-    SourceExhausted
-};
+enum class UTF8ConversionError : uint8_t { OutOfMemory, Invalid };
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2010 Patrick Gansterer <paroga@paroga.com>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,178 +36,176 @@ namespace WTF::Unicode {
 
 static constexpr char32_t sentinelCodePoint = U_SENTINEL;
 
-bool convertLatin1ToUTF8(std::span<const LChar> source, char** targetStart, const char* targetEnd)
+enum class Replacement : bool { None, ReplaceInvalidSequences };
+
+template<Replacement = Replacement::None, typename CharacterType> static char32_t next(std::span<const CharacterType>, size_t& offset);
+template<Replacement = Replacement::None, typename CharacterType> static bool append(std::span<CharacterType>, size_t& offset, char32_t character);
+
+template<> char32_t next<Replacement::None, LChar>(std::span<const LChar> characters, size_t& offset)
 {
-    char* target = *targetStart;
-    int32_t i = 0;
-    for (auto sourceCharacter : source) {
-        UBool sawError = false;
-        // Work around bug in either Windows compiler or old version of ICU, where passing a uint8_t to
-        // U8_APPEND warns, by converting from uint8_t to a wider type.
-        char32_t character = sourceCharacter;
-        U8_APPEND(target, i, targetEnd - *targetStart, character, sawError);
-        ASSERT_WITH_MESSAGE(!sawError, "UTF8 destination buffer was not big enough");
-        if (sawError)
-            return false;
-    }
-    *targetStart = target + i;
-    return true;
+    return characters[offset++];
 }
 
-ConversionResult convertUTF16ToUTF8(std::span<const UChar>& sourceSpan, char** targetStart, const char* targetEnd, bool strict)
+template<> char32_t next<Replacement::None, char8_t>(std::span<const char8_t> characters, size_t& offset)
 {
-    auto result = ConversionResult::Success;
-    auto* source = sourceSpan.data();
-    auto* sourceEnd = sourceSpan.data() + sourceSpan.size();
-    char* target = *targetStart;
+    char32_t character;
+    U8_NEXT(characters, offset, characters.size(), character);
+    return U_IS_SURROGATE(character) ? sentinelCodePoint : character;
+}
+
+template<> char32_t next<Replacement::ReplaceInvalidSequences, char8_t>(std::span<const char8_t> characters, size_t& offset)
+{
+    char32_t character;
+    U8_NEXT_OR_FFFD(characters, offset, characters.size(), character);
+    return character;
+}
+
+template<> char32_t next<Replacement::None, char16_t>(std::span<const char16_t> characters, size_t& offset)
+{
+    char32_t character;
+    U16_NEXT(characters, offset, characters.size(), character);
+    return U_IS_SURROGATE(character) ? sentinelCodePoint : character;
+}
+
+template<> char32_t next<Replacement::ReplaceInvalidSequences, char16_t>(std::span<const char16_t> characters, size_t& offset)
+{
+    char32_t character;
+    U16_NEXT_OR_FFFD(characters, offset, characters.size(), character);
+    return character;
+}
+
+template<> bool append<Replacement::None, char8_t>(std::span<char8_t> characters, size_t& offset, char32_t character)
+{
     UBool sawError = false;
-    int32_t i = 0;
-    while (source < sourceEnd) {
-        char32_t ch;
-        int j = 0;
-        U16_NEXT(source, j, sourceEnd - source, ch);
-        if (U_IS_SURROGATE(ch)) {
-            if (source + j == sourceEnd && U_IS_SURROGATE_LEAD(ch)) {
-                result = ConversionResult::SourceExhausted;
-                break;
-            }
-            if (strict) {
-                result = ConversionResult::SourceIllegal;
-                break;
-            }
-            ch = replacementCharacter;
-        }
-        U8_APPEND(reinterpret_cast<uint8_t*>(target), i, targetEnd - target, ch, sawError);
-        if (sawError) {
-            result = ConversionResult::TargetExhausted;
+    U8_APPEND(characters, offset, characters.size(), character, sawError);
+    return sawError;
+}
+
+template<> bool append<Replacement::ReplaceInvalidSequences, char8_t>(std::span<char8_t> characters, size_t& offset, char32_t character)
+{
+    return append(characters, offset, character)
+        && append(characters, offset, replacementCharacter);
+}
+
+template<> bool append<Replacement::None, char16_t>(std::span<char16_t> characters, size_t& offset, char32_t character)
+{
+    UBool sawError = false;
+    U16_APPEND(characters, offset, characters.size(), character, sawError);
+    return sawError;
+}
+
+template<> bool append<Replacement::ReplaceInvalidSequences, char16_t>(std::span<char16_t> characters, size_t& offset, char32_t character)
+{
+    return append(characters, offset, character)
+        && append(characters, offset, replacementCharacter);
+}
+
+template<Replacement replacement = Replacement::None, typename SourceCharacterType, typename BufferCharacterType> static ConversionResult<BufferCharacterType> convertInternal(std::span<const SourceCharacterType> source, std::span<BufferCharacterType> buffer)
+{
+    auto resultCode = ConversionResultCode::Success;
+    size_t bufferOffset = 0;
+    char32_t orAllData = 0;
+    for (size_t sourceOffset = 0; sourceOffset < source.size(); ) {
+        char32_t character = next<replacement>(source, sourceOffset);
+        if (character == sentinelCodePoint) {
+            resultCode = ConversionResultCode::SourceInvalid;
             break;
         }
-        source += j;
-    }
-    sourceSpan = { source, sourceEnd };
-    *targetStart = target + i;
-    return result;
-}
-
-template<bool replaceInvalidSequences>
-bool convertUTF8ToUTF16Impl(std::span<const char8_t> source, UChar** targetStart, const UChar* targetEnd, bool* sourceAllASCII)
-{
-    RELEASE_ASSERT(source.size() <= std::numeric_limits<int>::max());
-    UBool error = false;
-    UChar* target = *targetStart;
-    size_t targetSize = targetEnd - target;
-    char32_t orAllData = 0;
-    size_t targetOffset = 0;
-    for (size_t sourceOffset = 0; sourceOffset < source.size(); ) {
-        char32_t character;
-        if constexpr (replaceInvalidSequences) {
-            U8_NEXT_OR_FFFD(source, sourceOffset, source.size(), character);
-        } else {
-            U8_NEXT(source, sourceOffset, source.size(), character);
-            if (character == sentinelCodePoint)
-                return false;
+        if (bufferOffset == buffer.size()) {
+            resultCode = ConversionResultCode::TargetExhausted;
+            break;
         }
-        U16_APPEND(target, targetOffset, targetSize, character, error);
-        if (error)
-            return false;
+        bool sawError = append<replacement>(buffer, bufferOffset, character);
+        if (sawError) {
+            resultCode = ConversionResultCode::TargetExhausted;
+            break;
+        }
         orAllData |= character;
     }
-    RELEASE_ASSERT(target + targetOffset <= targetEnd);
-    *targetStart = target + targetOffset;
-    if (sourceAllASCII)
-        *sourceAllASCII = isASCII(orAllData);
-    return true;
+    return { resultCode, buffer.first(bufferOffset), isASCII(orAllData) };
 }
 
-bool convertUTF8ToUTF16(std::span<const char8_t> source, UChar** targetStart, const UChar* targetEnd, bool* sourceAllASCII)
+ConversionResult<char8_t> convert(std::span<const char16_t> source, std::span<char8_t> buffer)
 {
-    return convertUTF8ToUTF16Impl<false>(source, targetStart, targetEnd, sourceAllASCII);
+    return convertInternal(source, buffer);
 }
 
-bool convertUTF8ToUTF16ReplacingInvalidSequences(std::span<const char8_t> source, UChar** targetStart, const UChar* targetEnd, bool* sourceAllASCII)
+ConversionResult<char16_t> convert(std::span<const char8_t> source, std::span<char16_t> buffer)
 {
-    return convertUTF8ToUTF16Impl<true>(source, targetStart, targetEnd, sourceAllASCII);
+    return convertInternal(source, buffer);
 }
 
-ComputeUTFLengthsResult computeUTFLengths(std::span<const char8_t> source)
+ConversionResult<char8_t> convert(std::span<const LChar> source, std::span<char8_t> buffer)
+{
+    return convertInternal(source, buffer);
+}
+
+ConversionResult<char8_t> convertReplacingInvalidSequences(std::span<const char16_t> source, std::span<char8_t> buffer)
+{
+    return convertInternal<Replacement::ReplaceInvalidSequences>(source, buffer);
+}
+
+ConversionResult<char16_t> convertReplacingInvalidSequences(std::span<const char8_t> source, std::span<char16_t> buffer)
+{
+    return convertInternal<Replacement::ReplaceInvalidSequences>(source, buffer);
+}
+
+CheckedUTF8 checkUTF8(std::span<const char8_t> source)
 {
     size_t lengthUTF16 = 0;
     char32_t orAllData = 0;
-    ConversionResult result = ConversionResult::Success;
-    size_t sourceOffset = 0;
-    while (sourceOffset < source.size()) {
-        char32_t character;
+    size_t sourceOffset;
+    for (sourceOffset = 0; sourceOffset < source.size(); ) {
         size_t nextSourceOffset = sourceOffset;
-        U8_NEXT(source, nextSourceOffset, source.size(), character);
-        if (character == sentinelCodePoint) {
-            result = nextSourceOffset == source.size() ? ConversionResult::SourceExhausted : ConversionResult::SourceIllegal;
+        char32_t character = next(source, nextSourceOffset);
+        if (character == sentinelCodePoint)
             break;
-        }
         sourceOffset = nextSourceOffset;
         lengthUTF16 += U16_LENGTH(character);
         orAllData |= character;
     }
-    return { result, sourceOffset, lengthUTF16, isASCII(orAllData) };
+    return { source.first(sourceOffset), lengthUTF16, isASCII(orAllData) };
 }
 
-unsigned calculateStringHashAndLengthFromUTF8MaskingTop8Bits(std::span<const char> span, unsigned& dataLength, unsigned& utf16Length)
+UTF16LengthWithHash computeUTF16LengthWithHash(std::span<const char8_t> source)
 {
-    StringHasher stringHasher;
-    utf16Length = 0;
-    size_t inputOffset = 0;
-    auto* data = span.data();
-    size_t inputLength = span.size();
-    while (inputOffset < inputLength) {
-        char32_t character;
-        U8_NEXT(data, inputOffset, inputLength, character);
+    StringHasher hasher;
+    size_t lengthUTF16 = 0;
+    for (size_t sourceOffset = 0; sourceOffset < source.size(); ) {
+        char32_t character = next(source, sourceOffset);
         if (character == sentinelCodePoint)
-            return 0;
+            return { };
         if (U_IS_BMP(character)) {
-            ASSERT(!U_IS_SURROGATE(character));
-            stringHasher.addCharacter(character);
-            utf16Length++;
+            hasher.addCharacter(character);
+            ++lengthUTF16;
         } else {
-            ASSERT(U_IS_SUPPLEMENTARY(character));
-            stringHasher.addCharacter(U16_LEAD(character));
-            stringHasher.addCharacter(U16_TRAIL(character));
-            utf16Length += 2;
+            hasher.addCharacter(U16_LEAD(character));
+            hasher.addCharacter(U16_TRAIL(character));
+            lengthUTF16 += 2;
         }
     }
-    dataLength = inputOffset;
-    return stringHasher.hashWithTop8BitsMasked();
+    return { lengthUTF16, hasher.hashWithTop8BitsMasked() };
 }
 
-bool equalUTF16WithUTF8(const UChar* a, const char* b, const char* bEnd)
+template<typename CharacterTypeA, typename CharacterTypeB> bool equalInternal(std::span<CharacterTypeA> a, std::span<CharacterTypeB> b)
 {
-    // It is the caller's responsibility to ensure a is long enough, which is why it is safe to use U16_NEXT_UNSAFE here.
     size_t offsetA = 0;
     size_t offsetB = 0;
-    size_t lengthB = bEnd - b;
-    while (offsetB < lengthB) {
-        char32_t characterB;
-        U8_NEXT(b, offsetB, lengthB, characterB);
-        if (characterB == sentinelCodePoint)
-            return false;
-        char16_t characterA;
-        U16_NEXT_UNSAFE(a, offsetA, characterA);
-        if (characterB != characterA)
+    while (offsetA < a.size() && offsetB < b.size()) {
+        if (next(a, offsetA) != next(b, offsetB))
             return false;
     }
-    return true;
+    return offsetA == a.size() && offsetB == b.size();
 }
 
-bool equalLatin1WithUTF8(const LChar* a, const char* b, const char* bEnd)
+bool equal(std::span<const UChar> a, std::span<const char8_t> b)
 {
-    // It is the caller's responsibility to ensure a is long enough, which is why it is safe to use *a++ here.
-    size_t offsetB = 0;
-    size_t lengthB = bEnd - b;
-    while (offsetB < lengthB) {
-        char32_t characterB;
-        U8_NEXT(b, offsetB, lengthB, characterB);
-        if (*a++ != characterB)
-            return false;
-    }
-    return true;
+    return equalInternal(a, b);
+}
+
+bool equal(std::span<const LChar> a, std::span<const char8_t> b)
+{
+    return equalInternal(a, b);
 }
 
 } // namespace WTF::Unicode

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -169,12 +169,13 @@ static inline void setXSLTLoadCallBack(xsltDocLoaderFunc func, XSLTProcessor* pr
 static int writeToStringBuilder(void* context, const char* buffer, int length)
 {
     auto& builder = *static_cast<StringBuilder*>(context);
-    UTF8Adapter adapter({ reinterpret_cast<const char8_t*>(buffer), static_cast<size_t>(length) });
-    ASSERT(!adapter.conversionFailed);
-    if (adapter.conversionFailed)
+    if (!length)
+        return 0;
+    auto checkedString = WTF::Unicode::checkUTF8({ reinterpret_cast<const char8_t*>(buffer), static_cast<size_t>(length) });
+    if (checkedString.characters.empty())
         return -1;
-    builder.append(adapter);
-    return adapter.lengthUTF8;
+    builder.append(checkedString);
+    return checkedString.characters.size();
 }
 
 static bool saveResultToString(xmlDocPtr resultDoc, xsltStylesheetPtr sheet, String& resultString)

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -1157,15 +1157,14 @@ static xmlEntityPtr sharedXHTMLEntity()
 
 static size_t convertUTF16EntityToUTF8(std::span<const UChar> utf16Entity, char* target, size_t targetSize)
 {
-    const char* originalTarget = target;
-    auto conversionResult = WTF::Unicode::convertUTF16ToUTF8(utf16Entity, &target, target + targetSize);
-    if (conversionResult != WTF::Unicode::ConversionResult::Success)
+    auto result = WTF::Unicode::convert(utf16Entity, { reinterpret_cast<char8_t*>(target), targetSize });
+    if (result.code != WTF::Unicode::ConversionResultCode::Success)
         return 0;
 
     // Even though we must pass the length, libxml expects the entity string to be null terminated.
-    ASSERT(target >= originalTarget + 1);
-    *target = '\0';
-    return target - originalTarget;
+    ASSERT(!result.buffer.empty());
+    target[result.buffer.size()] = '\0';
+    return result.buffer.size();
 }
 
 static xmlEntityPtr getXHTMLEntity(const xmlChar* name)

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -124,6 +124,7 @@ set(TestWTF_SOURCES
     Tests/WTF/Time.cpp
     Tests/WTF/URL.cpp
     Tests/WTF/URLParser.cpp
+    Tests/WTF/UTF8Conversion.cpp
     Tests/WTF/UniqueArray.cpp
     Tests/WTF/UniqueRef.cpp
     Tests/WTF/UniqueRefVector.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -858,6 +858,7 @@
 		93AF4ECE1506F064007FD57E /* NewFirstVisuallyNonEmptyLayoutForImages_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93AF4ECD1506F064007FD57E /* NewFirstVisuallyNonEmptyLayoutForImages_Bundle.cpp */; };
 		93AF4ED11506F130007FD57E /* lots-of-images.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93AF4ECF1506F123007FD57E /* lots-of-images.html */; };
 		93BCBC8423CC6F4400CA2221 /* IDBObjectStoreInfoUpgradeToV2.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93BCBC8223CC6EF500CA2221 /* IDBObjectStoreInfoUpgradeToV2.html */; };
+		93C3647B2BDD8800006D8B55 /* UTF8Conversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93C3647A2BDD8800006D8B55 /* UTF8Conversion.cpp */; };
 		93CFA8671CEB9E38000565A8 /* autofocused-text-input.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93CFA8661CEB9DE1000565A8 /* autofocused-text-input.html */; };
 		93D119FC22C680F7009BE3C7 /* localstorage-open-window-private.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 93D119FB22C57112009BE3C7 /* localstorage-open-window-private.html */; };
 		93E2C5551FD3204100E1DF6A /* LineEnding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93E2C5541FD3204100E1DF6A /* LineEnding.cpp */; };
@@ -3034,6 +3035,7 @@
 		93BCBC8023CC6EE800CA2221 /* IDBObjectStoreInfoUpgradeToV2.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IDBObjectStoreInfoUpgradeToV2.mm; sourceTree = "<group>"; };
 		93BCBC8123CC6EF500CA2221 /* IDBObjectStoreInfoUpgrade.sqlite3 */ = {isa = PBXFileReference; lastKnownFileType = file; path = IDBObjectStoreInfoUpgrade.sqlite3; sourceTree = "<group>"; };
 		93BCBC8223CC6EF500CA2221 /* IDBObjectStoreInfoUpgradeToV2.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = IDBObjectStoreInfoUpgradeToV2.html; sourceTree = "<group>"; };
+		93C3647A2BDD8800006D8B55 /* UTF8Conversion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UTF8Conversion.cpp; sourceTree = "<group>"; };
 		93CFA8661CEB9DE1000565A8 /* autofocused-text-input.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "autofocused-text-input.html"; sourceTree = "<group>"; };
 		93CFA8681CEBCFED000565A8 /* CandidateTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CandidateTests.mm; sourceTree = "<group>"; };
 		93D119FB22C57112009BE3C7 /* localstorage-open-window-private.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "localstorage-open-window-private.html"; sourceTree = "<group>"; };
@@ -5471,6 +5473,7 @@
 				3A1337AB28F9177600F29B73 /* UniqueRefVector.cpp */,
 				E3A1E78021B25B79008C6007 /* URL.cpp */,
 				E3A1E78421B25B91008C6007 /* URLParser.cpp */,
+				93C3647A2BDD8800006D8B55 /* UTF8Conversion.cpp */,
 				144D40EC221B46A7004B474F /* UUID.cpp */,
 				BC55F5F814AD78EE00484BE1 /* Vector.cpp */,
 				1CB9BC371A67482300FE5678 /* WeakPtr.cpp */,
@@ -6470,6 +6473,7 @@
 				E3A1E78221B25B7A008C6007 /* URL.cpp in Sources */,
 				E3C21A7C21B25CA2003B31A3 /* URLExtras.mm in Sources */,
 				E3A1E78521B25B91008C6007 /* URLParser.cpp in Sources */,
+				93C3647B2BDD8800006D8B55 /* UTF8Conversion.cpp in Sources */,
 				7C83E03B1D0A602700FEBCF3 /* UtilitiesCocoa.mm in Sources */,
 				41D2A21F27906F9F0088FCCE /* UUID.cpp in Sources */,
 				3A31EA7D29C0D1AA0045E65B /* UUIDCocoa.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp
@@ -1,0 +1,550 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Apple Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "Test.h"
+
+namespace TestWebKitAPI {
+
+template<typename... ValueTypes> constexpr auto char8Array(ValueTypes... values)
+{
+    return std::array<char8_t, sizeof...(values)> { static_cast<char8_t>(values)... };
+}
+
+template<typename... ValueTypes> constexpr auto char16Array(ValueTypes... values)
+{
+    return std::array<char16_t, sizeof...(values)> { static_cast<char16_t>(values)... };
+}
+
+template<typename... ValueTypes> constexpr auto latin1Array(ValueTypes... values)
+{
+    return std::array<LChar, sizeof...(values)> { static_cast<LChar>(values)... };
+}
+
+template<typename CharacterType> const char* serialize(const WTF::Unicode::ConversionResult<CharacterType>& result)
+{
+    using namespace WTF::Unicode;
+
+    std::ostringstream stream;
+    auto separator = "";
+    stream << std::hex << std::uppercase;
+    bool isAllASCII = true;
+    for (auto character : result.buffer) {
+        stream << std::exchange(separator, " ") << std::setfill('0') << std::setw(sizeof(CharacterType) * 2) << static_cast<unsigned>(character);
+        if (!isASCII(character))
+            isAllASCII = false;
+    }
+    switch (result.code) {
+    case ConversionResultCode::Success:
+        break;
+    case ConversionResultCode::SourceInvalid:
+        stream << std::exchange(separator, " ") << "source invalid";
+        break;
+    case ConversionResultCode::TargetExhausted:
+        stream << std::exchange(separator, " ") << "target exhausted";
+        break;
+    default:
+        stream << std::exchange(separator, " ") << "bad result code";
+    }
+    if (isAllASCII != result.isAllASCII)
+        stream << std::exchange(separator, " ") << "bad ASCII flag";
+
+    static std::string singleGlobalResult;
+    singleGlobalResult = stream.str();
+    return singleGlobalResult.c_str();
+}
+
+static const char* serialize(WTF::Unicode::CheckedUTF8 result)
+{
+    std::ostringstream stream;
+    stream << result.characters.size() << " UTF-8, " << result.lengthUTF16 << " UTF-16";
+    bool isAllASCII = true;
+    for (auto character : result.characters) {
+        if (!isASCII(character))
+            isAllASCII = false;
+    }
+    if (isAllASCII != result.isAllASCII)
+        stream << ", bad ASCII flag";
+
+    static std::string singleGlobalResult;
+    singleGlobalResult = stream.str();
+    return singleGlobalResult.c_str();
+}
+
+static const char* serialize(WTF::Unicode::UTF16LengthWithHash result)
+{
+    if (!result.lengthUTF16 && !result.hash)
+        return "source invalid";
+
+    std::ostringstream stream;
+    stream << result.lengthUTF16 << " UTF-16, " << std::hex << std::uppercase << std::setfill('0') << std::setw(6) << result.hash;
+
+    static std::string singleGlobalResult;
+    singleGlobalResult = stream.str();
+    return singleGlobalResult.c_str();
+}
+
+TEST(WTF_UTF8Conversion, UTF8ToUTF16)
+{
+    using namespace WTF::Unicode;
+
+    std::array<char16_t, 32> buffer;
+    std::array<char16_t, 1> buffer1;
+    std::array<char16_t, 2> buffer2;
+
+    EXPECT_STREQ("", serialize(convert(char8Array(), buffer)));
+    EXPECT_STREQ("0000", serialize(convert(char8Array(0), buffer)));
+    EXPECT_STREQ("0061", serialize(convert(char8Array('a'), buffer)));
+
+    EXPECT_STREQ("D7FF", serialize(convert(char8Array(0xED, 0x9F, 0xBF), buffer)));
+    EXPECT_STREQ("E000", serialize(convert(char8Array(0xEE, 0x80, 0x80), buffer)));
+    EXPECT_STREQ("FFFD", serialize(convert(char8Array(0xEF, 0xBF, 0xBD), buffer)));
+    EXPECT_STREQ("FFFE", serialize(convert(char8Array(0xEF, 0xBF, 0xBE), buffer)));
+    EXPECT_STREQ("FFFF", serialize(convert(char8Array(0xEF, 0xBF, 0xBF), buffer)));
+    EXPECT_STREQ("D800 DC00", serialize(convert(char8Array(0xF0, 0x90, 0x80, 0x80), buffer)));
+    EXPECT_STREQ("DBFF DFFF", serialize(convert(char8Array(0xF4, 0x8F, 0xBF, 0xBF), buffer)));
+
+    EXPECT_STREQ("0000 0000", serialize(convert(char8Array(0, 0), buffer)));
+    EXPECT_STREQ("0061 0000", serialize(convert(char8Array('a', 0), buffer)));
+    EXPECT_STREQ("D7FF 0000", serialize(convert(char8Array(0xED, 0x9F, 0xBF, 0), buffer)));
+
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0x80), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xA0, 0x80), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xAF, 0xBF), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xB0, 0x80), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xBF, 0xBF), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0x80, 0), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xA0, 0x80, 0), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xF4, 0x90, 0x80, 0x80), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xA0, 0x80, 0xED, 0xBF, 0xBF), buffer)));
+
+    EXPECT_STREQ("0080 source invalid", serialize(convert(char8Array(0xC2, 0x80, 0x80), buffer)));
+
+    EXPECT_STREQ("", serialize(convert(char8Array(), buffer1)));
+    EXPECT_STREQ("0000", serialize(convert(char8Array(0), buffer1)));
+    EXPECT_STREQ("0061", serialize(convert(char8Array('a'), buffer1)));
+
+    EXPECT_STREQ("D7FF", serialize(convert(char8Array(0xED, 0x9F, 0xBF), buffer1)));
+    EXPECT_STREQ("E000", serialize(convert(char8Array(0xEE, 0x80, 0x80), buffer1)));
+    EXPECT_STREQ("FFFD", serialize(convert(char8Array(0xEF, 0xBF, 0xBD), buffer1)));
+    EXPECT_STREQ("FFFE", serialize(convert(char8Array(0xEF, 0xBF, 0xBE), buffer1)));
+    EXPECT_STREQ("FFFF", serialize(convert(char8Array(0xEF, 0xBF, 0xBF), buffer1)));
+
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0x80), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xA0, 0x80), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xAF, 0xBF), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xB0, 0x80), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xBF, 0xBF), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xF4, 0x90, 0x80, 0x80), buffer1)));
+
+    EXPECT_STREQ("0000 target exhausted", serialize(convert(char8Array(0, 0), buffer1)));
+    EXPECT_STREQ("0061 target exhausted", serialize(convert(char8Array('a', 0), buffer1)));
+    EXPECT_STREQ("D7FF target exhausted", serialize(convert(char8Array(0xED, 0x9F, 0xBF, 0), buffer1)));
+
+    EXPECT_STREQ("target exhausted", serialize(convert(char8Array(0xF0, 0x90, 0x80, 0x80), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convert(char8Array(0xF4, 0x8F, 0xBF, 0xBF), buffer1)));
+
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0x80, 0), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xA0, 0x80, 0), buffer1)));
+
+    EXPECT_STREQ("", serialize(convert(char8Array(), buffer2)));
+    EXPECT_STREQ("0000", serialize(convert(char8Array(0), buffer2)));
+    EXPECT_STREQ("0061", serialize(convert(char8Array('a'), buffer2)));
+
+    EXPECT_STREQ("D7FF", serialize(convert(char8Array(0xED, 0x9F, 0xBF), buffer2)));
+    EXPECT_STREQ("E000", serialize(convert(char8Array(0xEE, 0x80, 0x80), buffer2)));
+    EXPECT_STREQ("FFFD", serialize(convert(char8Array(0xEF, 0xBF, 0xBD), buffer2)));
+    EXPECT_STREQ("FFFE", serialize(convert(char8Array(0xEF, 0xBF, 0xBE), buffer2)));
+    EXPECT_STREQ("FFFF", serialize(convert(char8Array(0xEF, 0xBF, 0xBF), buffer2)));
+    EXPECT_STREQ("D800 DC00", serialize(convert(char8Array(0xF0, 0x90, 0x80, 0x80), buffer2)));
+    EXPECT_STREQ("DBFF DFFF", serialize(convert(char8Array(0xF4, 0x8F, 0xBF, 0xBF), buffer2)));
+
+    EXPECT_STREQ("0000 0000", serialize(convert(char8Array(0, 0), buffer2)));
+    EXPECT_STREQ("0061 0000", serialize(convert(char8Array('a', 0), buffer2)));
+    EXPECT_STREQ("D7FF 0000", serialize(convert(char8Array(0xED, 0x9F, 0xBF, 0), buffer2)));
+
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0x80), buffer2)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xA0, 0x80), buffer2)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xAF, 0xBF), buffer2)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xB0, 0x80), buffer2)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xBF, 0xBF), buffer2)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xF4, 0x90, 0x80, 0x80), buffer2)));
+
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0x80, 0), buffer2)));
+    EXPECT_STREQ("source invalid", serialize(convert(char8Array(0xED, 0xA0, 0x80, 0), buffer2)));
+}
+
+TEST(WTF_UTF8Conversion, UTF16ToUTF8)
+{
+    using namespace WTF::Unicode;
+
+    std::array<char8_t, 32> buffer;
+    std::array<char8_t, 1> buffer1;
+
+    EXPECT_STREQ("", serialize(convert(char16Array(), buffer)));
+    EXPECT_STREQ("00", serialize(convert(char16Array(0), buffer)));
+    EXPECT_STREQ("61", serialize(convert(char16Array('a'), buffer)));
+
+    EXPECT_STREQ("ED 9F BF", serialize(convert(char16Array(0xD7FF), buffer)));
+    EXPECT_STREQ("EE 80 80", serialize(convert(char16Array(0xE000), buffer)));
+    EXPECT_STREQ("EF BF BD", serialize(convert(char16Array(0xFFFD), buffer)));
+    EXPECT_STREQ("EF BF BE", serialize(convert(char16Array(0xFFFE), buffer)));
+    EXPECT_STREQ("EF BF BF", serialize(convert(char16Array(0xFFFF), buffer)));
+    EXPECT_STREQ("F0 90 80 80", serialize(convert(char16Array(0xD800, 0xDC00), buffer)));
+    EXPECT_STREQ("F4 8F BF BF", serialize(convert(char16Array(0xDBFF, 0xDFFF), buffer)));
+
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xD800), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xDBFF), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xDC00), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xDFFF), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xD800, 0xD800), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xDC00, 0xD800), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xDC00, 0xDC00), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xD800, 0), buffer)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xD800, 0xE000), buffer)));
+
+    EXPECT_STREQ("", serialize(convert(char16Array(), buffer1)));
+    EXPECT_STREQ("00", serialize(convert(char16Array(0), buffer1)));
+    EXPECT_STREQ("61", serialize(convert(char16Array('a'), buffer1)));
+
+    EXPECT_STREQ("target exhausted", serialize(convert(char16Array(0xD7FF), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convert(char16Array(0xE000), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convert(char16Array(0xFFFD), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convert(char16Array(0xFFFE), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convert(char16Array(0xFFFF), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convert(char16Array(0xD800, 0xDC00), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convert(char16Array(0xDBFF, 0xDFFF), buffer1)));
+
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xD800), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xDBFF), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xDC00), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xDFFF), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xD800, 0xD800), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xDC00, 0xD800), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xDC00, 0xDC00), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xD800, 0), buffer1)));
+    EXPECT_STREQ("source invalid", serialize(convert(char16Array(0xD800, 0xE000), buffer1)));
+}
+
+TEST(WTF_UTF8Conversion, Latin1ToUTF8)
+{
+    using namespace WTF::Unicode;
+
+    std::array<char8_t, 32> buffer;
+    std::array<char8_t, 1> buffer1;
+
+    EXPECT_STREQ("", serialize(convert(latin1Array(), buffer)));
+    EXPECT_STREQ("00", serialize(convert(latin1Array(0), buffer)));
+    EXPECT_STREQ("61", serialize(convert(latin1Array('a'), buffer)));
+    EXPECT_STREQ("61 62", serialize(convert(latin1Array('a', 'b'), buffer)));
+    EXPECT_STREQ("7F", serialize(convert(latin1Array(0x7F), buffer)));
+    EXPECT_STREQ("7F 62", serialize(convert(latin1Array(0x7F, 'b'), buffer)));
+    EXPECT_STREQ("C2 80", serialize(convert(latin1Array(0x80), buffer)));
+    EXPECT_STREQ("C3 BF", serialize(convert(latin1Array(0xFF), buffer)));
+    EXPECT_STREQ("C2 80 C3 BF", serialize(convert(latin1Array(0x80, 0xFF), buffer)));
+
+    EXPECT_STREQ("", serialize(convert(latin1Array(), buffer1)));
+    EXPECT_STREQ("00", serialize(convert(latin1Array(0), buffer1)));
+    EXPECT_STREQ("61", serialize(convert(latin1Array('a'), buffer1)));
+    EXPECT_STREQ("61 target exhausted", serialize(convert(latin1Array('a', 'b'), buffer1)));
+    EXPECT_STREQ("7F", serialize(convert(latin1Array(0x7F), buffer1)));
+    EXPECT_STREQ("7F target exhausted", serialize(convert(latin1Array(0x7F, 'b'), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convert(latin1Array(0x80), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convert(latin1Array(0xFF), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convert(latin1Array(0x80, 0xFF), buffer1)));
+}
+
+TEST(WTF_UTF8Conversion, EqualUTF16ToUTF8)
+{
+    using namespace WTF::Unicode;
+
+    EXPECT_TRUE(equal(char16Array(), char8Array()));
+    EXPECT_TRUE(equal(char16Array(0), char8Array(0)));
+    EXPECT_TRUE(equal(char16Array('a'), char8Array('a')));
+    EXPECT_FALSE(equal(char16Array(0x0080), char8Array(0x80)));
+    EXPECT_TRUE(equal(char16Array(0xD7FF), char8Array(0xED, 0x9F, 0xBF)));
+    EXPECT_TRUE(equal(char16Array(0xE000), char8Array(0xEE, 0x80, 0x80)));
+    EXPECT_TRUE(equal(char16Array(0xFFFD), char8Array(0xEF, 0xBF, 0xBD)));
+    EXPECT_TRUE(equal(char16Array(0xFFFE), char8Array(0xEF, 0xBF, 0xBE)));
+    EXPECT_TRUE(equal(char16Array(0xFFFF), char8Array(0xEF, 0xBF, 0xBF)));
+    EXPECT_TRUE(equal(char16Array(0xD800, 0xDC00), char8Array(0xF0, 0x90, 0x80, 0x80)));
+    EXPECT_TRUE(equal(char16Array(0xDBFF, 0xDFFF), char8Array(0xF4, 0x8F, 0xBF, 0xBF)));
+
+    EXPECT_FALSE(equal(char16Array(), char8Array(0)));
+    EXPECT_FALSE(equal(char16Array(0), char8Array(1)));
+    EXPECT_FALSE(equal(char16Array(0), char8Array(1)));
+    EXPECT_FALSE(equal(char16Array(1), char8Array(0)));
+    EXPECT_FALSE(equal(char16Array(0xD800), char8Array()));
+    EXPECT_FALSE(equal(char16Array(0xD800), char8Array(0xED, 0xA0, 0x80)));
+    EXPECT_FALSE(equal(char16Array(0xDC00), char8Array(0xED, 0xB0, 0x80)));
+    EXPECT_FALSE(equal(char16Array(0xD800, 0xDC00), char8Array(0xED, 0xA0, 0x80, 0xED, 0xB0, 0x80)));
+    EXPECT_FALSE(equal(char16Array(0xDFFF), char8Array(0xED, 0xBF, 0xBF)));
+    EXPECT_FALSE(equal(char16Array(0xD800, 0xD800), char8Array(0xED, 0xA0, 0x80, 0xED, 0xA0, 0x80)));
+    EXPECT_FALSE(equal(char16Array(0xDC00, 0xD800), char8Array(0xED, 0xB0, 0x80, 0xED, 0xA0, 0x80)));
+    EXPECT_FALSE(equal(char16Array(0xDC00, 0xDC00), char8Array(0xED, 0xB0, 0x80, 0xED, 0xB0, 0x80)));
+    EXPECT_FALSE(equal(char16Array(0xD800, 0), char8Array(0xED, 0xA0, 0x80, 0x00)));
+}
+
+TEST(WTF_UTF8Conversion, EqualLatin1ToUTF8)
+{
+    using namespace WTF::Unicode;
+
+    EXPECT_TRUE(equal(latin1Array(), char8Array()));
+    EXPECT_TRUE(equal(latin1Array(0), char8Array(0)));
+    EXPECT_TRUE(equal(latin1Array(0x61), char8Array(0x61)));
+    EXPECT_TRUE(equal(latin1Array(0x61, 0x62), char8Array(0x61, 0x62)));
+    EXPECT_TRUE(equal(latin1Array(0x7F), char8Array(0x7F)));
+    EXPECT_TRUE(equal(latin1Array(0x7F, 0x62), char8Array(0x7F, 0x62)));
+    EXPECT_TRUE(equal(latin1Array(0x80), char8Array(0xC2, 0x80)));
+    EXPECT_TRUE(equal(latin1Array(0xFF), char8Array(0xC3, 0xBF)));
+    EXPECT_TRUE(equal(latin1Array(0x80, 0xFF), char8Array(0xC2, 0x80, 0xC3, 0xBF)));
+
+    EXPECT_FALSE(equal(latin1Array(), char8Array(0)));
+    EXPECT_FALSE(equal(latin1Array(0), char8Array(1)));
+    EXPECT_FALSE(equal(latin1Array(0), char8Array(1)));
+    EXPECT_FALSE(equal(latin1Array(1), char8Array(0)));
+}
+
+TEST(WTF_UTF8Conversion, UTF8ToUTF16ReplacingInvalidSequences)
+{
+    using namespace WTF::Unicode;
+
+    std::array<char16_t, 32> buffer;
+    std::array<char16_t, 1> buffer1;
+    std::array<char16_t, 2> buffer2;
+
+    EXPECT_STREQ("", serialize(convertReplacingInvalidSequences(char8Array(), buffer)));
+    EXPECT_STREQ("0000", serialize(convertReplacingInvalidSequences(char8Array(0), buffer)));
+    EXPECT_STREQ("0061", serialize(convertReplacingInvalidSequences(char8Array('a'), buffer)));
+
+    EXPECT_STREQ("D7FF", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0x9F, 0xBF), buffer)));
+    EXPECT_STREQ("E000", serialize(convertReplacingInvalidSequences(char8Array(0xEE, 0x80, 0x80), buffer)));
+    EXPECT_STREQ("FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xEF, 0xBF, 0xBD), buffer)));
+    EXPECT_STREQ("FFFE", serialize(convertReplacingInvalidSequences(char8Array(0xEF, 0xBF, 0xBE), buffer)));
+    EXPECT_STREQ("FFFF", serialize(convertReplacingInvalidSequences(char8Array(0xEF, 0xBF, 0xBF), buffer)));
+    EXPECT_STREQ("D800 DC00", serialize(convertReplacingInvalidSequences(char8Array(0xF0, 0x90, 0x80, 0x80), buffer)));
+    EXPECT_STREQ("DBFF DFFF", serialize(convertReplacingInvalidSequences(char8Array(0xF4, 0x8F, 0xBF, 0xBF), buffer)));
+
+    EXPECT_STREQ("0000 0000", serialize(convertReplacingInvalidSequences(char8Array(0, 0), buffer)));
+    EXPECT_STREQ("0061 0000", serialize(convertReplacingInvalidSequences(char8Array('a', 0), buffer)));
+    EXPECT_STREQ("D7FF 0000", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0x9F, 0xBF, 0), buffer)));
+
+    EXPECT_STREQ("FFFD", serialize(convertReplacingInvalidSequences(char8Array(0x80), buffer)));
+    EXPECT_STREQ("FFFD 0000", serialize(convertReplacingInvalidSequences(char8Array(0x80, 0), buffer)));
+
+    EXPECT_STREQ("FFFD FFFD FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xA0, 0x80), buffer)));
+    EXPECT_STREQ("FFFD FFFD FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xAF, 0xBF), buffer)));
+    EXPECT_STREQ("FFFD FFFD FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xB0, 0x80), buffer)));
+    EXPECT_STREQ("FFFD FFFD FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xBF, 0xBF), buffer)));
+    EXPECT_STREQ("FFFD FFFD FFFD FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xF4, 0x90, 0x80, 0x80), buffer)));
+    EXPECT_STREQ("FFFD FFFD FFFD FFFD FFFD FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xA0, 0x80, 0xED, 0xBF, 0xBF), buffer)));
+
+    EXPECT_STREQ("FFFD FFFD FFFD 0000", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xA0, 0x80, 0), buffer)));
+
+    EXPECT_STREQ("0080 FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xC2, 0x80, 0x80), buffer)));
+
+    EXPECT_STREQ("", serialize(convertReplacingInvalidSequences(char8Array(), buffer1)));
+    EXPECT_STREQ("0000", serialize(convertReplacingInvalidSequences(char8Array(0), buffer1)));
+    EXPECT_STREQ("0061", serialize(convertReplacingInvalidSequences(char8Array('a'), buffer1)));
+
+    EXPECT_STREQ("D7FF", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0x9F, 0xBF), buffer1)));
+    EXPECT_STREQ("E000", serialize(convertReplacingInvalidSequences(char8Array(0xEE, 0x80, 0x80), buffer1)));
+    EXPECT_STREQ("FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xEF, 0xBF, 0xBD), buffer1)));
+    EXPECT_STREQ("FFFE", serialize(convertReplacingInvalidSequences(char8Array(0xEF, 0xBF, 0xBE), buffer1)));
+    EXPECT_STREQ("FFFF", serialize(convertReplacingInvalidSequences(char8Array(0xEF, 0xBF, 0xBF), buffer1)));
+
+    EXPECT_STREQ("FFFD", serialize(convertReplacingInvalidSequences(char8Array(0x80), buffer1)));
+
+    EXPECT_STREQ("FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xA0, 0x80), buffer1)));
+    EXPECT_STREQ("FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xAF, 0xBF), buffer1)));
+    EXPECT_STREQ("FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xB0, 0x80), buffer1)));
+    EXPECT_STREQ("FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xBF, 0xBF), buffer1)));
+
+    EXPECT_STREQ("0000 target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0, 0), buffer1)));
+    EXPECT_STREQ("0061 target exhausted", serialize(convertReplacingInvalidSequences(char8Array('a', 0), buffer1)));
+    EXPECT_STREQ("D7FF target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0x9F, 0xBF, 0), buffer1)));
+
+    EXPECT_STREQ("FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xF0, 0x90, 0x80, 0x80), buffer1)));
+    EXPECT_STREQ("FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xF4, 0x8F, 0xBF, 0xBF), buffer1)));
+
+    EXPECT_STREQ("FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xF4, 0x90, 0x80, 0x80), buffer1)));
+
+    EXPECT_STREQ("FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0x80, 0), buffer1)));
+    EXPECT_STREQ("FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xA0, 0x80, 0), buffer1)));
+
+    EXPECT_STREQ("", serialize(convertReplacingInvalidSequences(char8Array(), buffer2)));
+    EXPECT_STREQ("0000", serialize(convertReplacingInvalidSequences(char8Array(0), buffer2)));
+    EXPECT_STREQ("0061", serialize(convertReplacingInvalidSequences(char8Array('a'), buffer2)));
+
+    EXPECT_STREQ("D7FF", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0x9F, 0xBF), buffer2)));
+    EXPECT_STREQ("E000", serialize(convertReplacingInvalidSequences(char8Array(0xEE, 0x80, 0x80), buffer2)));
+    EXPECT_STREQ("FFFD", serialize(convertReplacingInvalidSequences(char8Array(0xEF, 0xBF, 0xBD), buffer2)));
+    EXPECT_STREQ("FFFE", serialize(convertReplacingInvalidSequences(char8Array(0xEF, 0xBF, 0xBE), buffer2)));
+    EXPECT_STREQ("FFFF", serialize(convertReplacingInvalidSequences(char8Array(0xEF, 0xBF, 0xBF), buffer2)));
+    EXPECT_STREQ("D800 DC00", serialize(convertReplacingInvalidSequences(char8Array(0xF0, 0x90, 0x80, 0x80), buffer2)));
+    EXPECT_STREQ("DBFF DFFF", serialize(convertReplacingInvalidSequences(char8Array(0xF4, 0x8F, 0xBF, 0xBF), buffer2)));
+
+    EXPECT_STREQ("0000 0000", serialize(convertReplacingInvalidSequences(char8Array(0, 0), buffer2)));
+    EXPECT_STREQ("0061 0000", serialize(convertReplacingInvalidSequences(char8Array('a', 0), buffer2)));
+    EXPECT_STREQ("D7FF 0000", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0x9F, 0xBF, 0), buffer2)));
+
+    EXPECT_STREQ("FFFD", serialize(convertReplacingInvalidSequences(char8Array(0x80), buffer2)));
+    EXPECT_STREQ("FFFD 0000", serialize(convertReplacingInvalidSequences(char8Array(0x80, 0), buffer2)));
+
+    EXPECT_STREQ("FFFD FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xA0, 0x80), buffer2)));
+    EXPECT_STREQ("FFFD FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xAF, 0xBF), buffer2)));
+    EXPECT_STREQ("FFFD FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xB0, 0x80), buffer2)));
+    EXPECT_STREQ("FFFD FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xBF, 0xBF), buffer2)));
+    EXPECT_STREQ("FFFD FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xF4, 0x90, 0x80, 0x80), buffer2)));
+    EXPECT_STREQ("FFFD FFFD target exhausted", serialize(convertReplacingInvalidSequences(char8Array(0xED, 0xA0, 0x80, 0), buffer2)));
+}
+
+TEST(WTF_UTF8Conversion, UTF16ToUTF8ReplacingInvalidSequences)
+{
+    using namespace WTF::Unicode;
+
+    std::array<char8_t, 32> buffer;
+    std::array<char8_t, 1> buffer1;
+
+    EXPECT_STREQ("", serialize(convertReplacingInvalidSequences(char16Array(), buffer)));
+    EXPECT_STREQ("00", serialize(convertReplacingInvalidSequences(char16Array(0), buffer)));
+    EXPECT_STREQ("61", serialize(convertReplacingInvalidSequences(char16Array('a'), buffer)));
+
+    EXPECT_STREQ("ED 9F BF", serialize(convertReplacingInvalidSequences(char16Array(0xD7FF), buffer)));
+    EXPECT_STREQ("EE 80 80", serialize(convertReplacingInvalidSequences(char16Array(0xE000), buffer)));
+    EXPECT_STREQ("EF BF BD", serialize(convertReplacingInvalidSequences(char16Array(0xFFFD), buffer)));
+    EXPECT_STREQ("EF BF BE", serialize(convertReplacingInvalidSequences(char16Array(0xFFFE), buffer)));
+    EXPECT_STREQ("EF BF BF", serialize(convertReplacingInvalidSequences(char16Array(0xFFFF), buffer)));
+    EXPECT_STREQ("F0 90 80 80", serialize(convertReplacingInvalidSequences(char16Array(0xD800, 0xDC00), buffer)));
+    EXPECT_STREQ("F4 8F BF BF", serialize(convertReplacingInvalidSequences(char16Array(0xDBFF, 0xDFFF), buffer)));
+
+    EXPECT_STREQ("EF BF BD", serialize(convertReplacingInvalidSequences(char16Array(0xD800), buffer)));
+    EXPECT_STREQ("EF BF BD", serialize(convertReplacingInvalidSequences(char16Array(0xDBFF), buffer)));
+    EXPECT_STREQ("EF BF BD", serialize(convertReplacingInvalidSequences(char16Array(0xDC00), buffer)));
+    EXPECT_STREQ("EF BF BD", serialize(convertReplacingInvalidSequences(char16Array(0xDFFF), buffer)));
+    EXPECT_STREQ("EF BF BD EF BF BD", serialize(convertReplacingInvalidSequences(char16Array(0xD800, 0xD800), buffer)));
+    EXPECT_STREQ("EF BF BD EF BF BD", serialize(convertReplacingInvalidSequences(char16Array(0xDC00, 0xD800), buffer)));
+    EXPECT_STREQ("EF BF BD EF BF BD", serialize(convertReplacingInvalidSequences(char16Array(0xDC00, 0xDC00), buffer)));
+    EXPECT_STREQ("EF BF BD 00", serialize(convertReplacingInvalidSequences(char16Array(0xD800, 0), buffer)));
+    EXPECT_STREQ("EF BF BD EE 80 80", serialize(convertReplacingInvalidSequences(char16Array(0xD800, 0xE000), buffer)));
+
+    EXPECT_STREQ("", serialize(convertReplacingInvalidSequences(char16Array(), buffer1)));
+    EXPECT_STREQ("00", serialize(convertReplacingInvalidSequences(char16Array(0), buffer1)));
+    EXPECT_STREQ("61", serialize(convertReplacingInvalidSequences(char16Array('a'), buffer1)));
+
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xD7FF), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xE000), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xFFFD), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xFFFE), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xFFFF), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xD800, 0xDC00), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xDBFF, 0xDFFF), buffer1)));
+
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xD800), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xDBFF), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xDC00), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xDFFF), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xD800, 0xD800), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xDC00, 0xD800), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xDC00, 0xDC00), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xD800, 0), buffer1)));
+    EXPECT_STREQ("target exhausted", serialize(convertReplacingInvalidSequences(char16Array(0xD800, 0xE000), buffer1)));
+}
+
+TEST(WTF_UTF8Conversion, CheckUTF8)
+{
+    using namespace WTF::Unicode;
+
+    EXPECT_STREQ("0 UTF-8, 0 UTF-16", serialize(checkUTF8(char8Array())));
+    EXPECT_STREQ("1 UTF-8, 1 UTF-16", serialize(checkUTF8(char8Array(0))));
+    EXPECT_STREQ("1 UTF-8, 1 UTF-16", serialize(checkUTF8(char8Array('a'))));
+
+    EXPECT_STREQ("3 UTF-8, 1 UTF-16", serialize(checkUTF8(char8Array(0xED, 0x9F, 0xBF))));
+    EXPECT_STREQ("3 UTF-8, 1 UTF-16", serialize(checkUTF8(char8Array(0xEE, 0x80, 0x80))));
+    EXPECT_STREQ("3 UTF-8, 1 UTF-16", serialize(checkUTF8(char8Array(0xEF, 0xBF, 0xBD))));
+    EXPECT_STREQ("3 UTF-8, 1 UTF-16", serialize(checkUTF8(char8Array(0xEF, 0xBF, 0xBE))));
+    EXPECT_STREQ("3 UTF-8, 1 UTF-16", serialize(checkUTF8(char8Array(0xEF, 0xBF, 0xBF))));
+    EXPECT_STREQ("4 UTF-8, 2 UTF-16", serialize(checkUTF8(char8Array(0xF0, 0x90, 0x80, 0x80))));
+    EXPECT_STREQ("4 UTF-8, 2 UTF-16", serialize(checkUTF8(char8Array(0xF4, 0x8F, 0xBF, 0xBF))));
+
+    EXPECT_STREQ("2 UTF-8, 2 UTF-16", serialize(checkUTF8(char8Array(0, 0))));
+    EXPECT_STREQ("2 UTF-8, 2 UTF-16", serialize(checkUTF8(char8Array('a', 0))));
+    EXPECT_STREQ("4 UTF-8, 2 UTF-16", serialize(checkUTF8(char8Array(0xED, 0x9F, 0xBF, 0))));
+
+    EXPECT_STREQ("0 UTF-8, 0 UTF-16", serialize(checkUTF8(char8Array(0x80))));
+    EXPECT_STREQ("0 UTF-8, 0 UTF-16", serialize(checkUTF8(char8Array(0xED, 0xA0, 0x80))));
+    EXPECT_STREQ("0 UTF-8, 0 UTF-16", serialize(checkUTF8(char8Array(0xED, 0xAF, 0xBF))));
+    EXPECT_STREQ("0 UTF-8, 0 UTF-16", serialize(checkUTF8(char8Array(0xED, 0xB0, 0x80))));
+    EXPECT_STREQ("0 UTF-8, 0 UTF-16", serialize(checkUTF8(char8Array(0xED, 0xBF, 0xBF))));
+    EXPECT_STREQ("0 UTF-8, 0 UTF-16", serialize(checkUTF8(char8Array(0x80, 0))));
+    EXPECT_STREQ("0 UTF-8, 0 UTF-16", serialize(checkUTF8(char8Array(0xED, 0xA0, 0x80, 0))));
+    EXPECT_STREQ("0 UTF-8, 0 UTF-16", serialize(checkUTF8(char8Array(0xF4, 0x90, 0x80, 0x80))));
+    EXPECT_STREQ("0 UTF-8, 0 UTF-16", serialize(checkUTF8(char8Array(0xED, 0xA0, 0x80, 0xED, 0xBF, 0xBF))));
+
+    EXPECT_STREQ("1 UTF-8, 1 UTF-16", serialize(checkUTF8(char8Array(0x00, 0x80))));
+    EXPECT_STREQ("2 UTF-8, 1 UTF-16", serialize(checkUTF8(char8Array(0xC2, 0x80, 0x80))));
+}
+
+TEST(WTF_UTF8Conversion, ComputeUTF16LengthWithHash)
+{
+    using namespace WTF::Unicode;
+
+    EXPECT_STREQ("0 UTF-16, EC889E", serialize(computeUTF16LengthWithHash(char8Array())));
+    EXPECT_STREQ("1 UTF-16, 3ABF44", serialize(computeUTF16LengthWithHash(char8Array(0))));
+    EXPECT_STREQ("1 UTF-16, 95343B", serialize(computeUTF16LengthWithHash(char8Array('a'))));
+
+    EXPECT_STREQ("1 UTF-16, C9438B", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0x9F, 0xBF))));
+    EXPECT_STREQ("1 UTF-16, 5AA931", serialize(computeUTF16LengthWithHash(char8Array(0xEE, 0x80, 0x80))));
+    EXPECT_STREQ("1 UTF-16, 4AB82F", serialize(computeUTF16LengthWithHash(char8Array(0xEF, 0xBF, 0xBD))));
+    EXPECT_STREQ("1 UTF-16, A9541A", serialize(computeUTF16LengthWithHash(char8Array(0xEF, 0xBF, 0xBE))));
+    EXPECT_STREQ("1 UTF-16, 39215E", serialize(computeUTF16LengthWithHash(char8Array(0xEF, 0xBF, 0xBF))));
+    EXPECT_STREQ("2 UTF-16, 2F4E65", serialize(computeUTF16LengthWithHash(char8Array(0xF0, 0x90, 0x80, 0x80))));
+    EXPECT_STREQ("2 UTF-16, F121B5", serialize(computeUTF16LengthWithHash(char8Array(0xF4, 0x8F, 0xBF, 0xBF))));
+
+    EXPECT_STREQ("2 UTF-16, 6F6D50", serialize(computeUTF16LengthWithHash(char8Array(0, 0))));
+    EXPECT_STREQ("2 UTF-16, 36A996", serialize(computeUTF16LengthWithHash(char8Array('a', 0))));
+    EXPECT_STREQ("2 UTF-16, 2E15E1", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0x9F, 0xBF, 0))));
+
+    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0x80))));
+    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0xA0, 0x80))));
+    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0xAF, 0xBF))));
+    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0xB0, 0x80))));
+    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0xBF, 0xBF))));
+    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0x80, 0))));
+    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0xA0, 0x80, 0))));
+    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xF4, 0x90, 0x80, 0x80))));
+    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0xA0, 0x80, 0xED, 0xBF, 0xBF))));
+
+    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0x00, 0x80))));
+    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xC2, 0x80, 0x80))));
+}
+
+} // namespace


### PR DESCRIPTION
#### f5b6bcdb33c73c2e96577017d6ce3fc854aab795
<pre>
Use std::span and char8_t more for UTF-8 handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=272644">https://bugs.webkit.org/show_bug.cgi?id=272644</a>
<a href="https://rdar.apple.com/126441747">rdar://126441747</a>

Reviewed by Chris Dumez.

* LayoutTests/fast/dom/Window/alert-with-unmatched-utf16-surrogate-should-not-crash-expected.txt:
Updated because the test accidentally depended on a peculiar form of
strictness that only applied to an unpaired lead surrogate at the
end of the string; that&apos;s gone now.

* LayoutTests/platform/mac-wk1/fast/dom/Window/alert-with-unmatched-utf16-surrogate-should-not-crash-expected.txt: Added.
On Cocoa platforms, legacy WebKit uses -[NSString UTF8String] to
serialize, which is strict, causing this test to have a different result.
This difference was hidden before by accidental strictness in the one
specific case here, in WTF UTF-8 conversion. The best way to handle this
is an exception for the legacy WebKit test result.

* Source/JavaScriptCore/API/JSStringRef.cpp:
(JSStringCreateWithUTF8CString): Use new span-based functions.
(JSStringGetUTF8CString): Ditto.

* Source/JavaScriptCore/jsc.cpp:
(toCString): Simplified code, and removed unneeded distinct handling
for source exhausted vs. invalid, which is a distinction that is not
valuable in this context, and in fact not needed in any context!

* Source/JavaScriptCore/wasm/WasmParser.h: Changed large Parser class
template to be a tiny one, since the only thing dependent on the
template argument was a single type, Parser::Result. Moved all the
rest of the code into a ParserBase non-template class.
(JSC::Wasm::ParserBase::consumeUTF8String): Use new checkUTF8 function,
which is a more efficient way to check the string than converting into
a UTF-16 buffer and then discarding the buffer, what the code did before.

* Source/WTF/wtf/text/AtomString.cpp:
(WTF::AtomString::fromUTF8Internal): Use add instead of addUTF8, since
the char8_t type now expresses the fact that it&apos;s UTF-8.

* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::HashedUTF8CharactersTranslator::hash): Use UTF16LengthWithHash.
(WTF::HashedUTF8CharactersTranslator::equal): Ditto. Use equal functions
from UTF8Conversion.h and StringCommon.h instead of writing out alternate
implementations here.
(WTF::HashedUTF8CharactersTranslator::translate): Ditto.
(WTF::AtomStringImpl::add): Renamed from addUTF8 and changed argument
type to use char8_t.

* Source/WTF/wtf/text/AtomStringImpl.h: Renamed addUTF8 to add and changed
argument type to use char8_t.

* Source/WTF/wtf/text/StringConcatenate.h: Removed UTF8Adapter, use
CheckedUTF8 from UTF8Conversion.h instead.

* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::putUTF8Triple): Deleted.
(WTF::StringImpl::utf8ForCharactersIntoBuffer): Use convert and
convertReplacingInvalidSequences instead of writing out more complex code
here. The old code was more complex to work around limitations in
UTF8Conversion.h that were easier to deal with at that level. Also, there
are two identical modes here that were implemented differently.

* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::tryGetUTF8ForCharacters): Use new span-based functions.

* Source/WTF/wtf/text/UTF8ConversionError.h: Removed the distinct
&quot;source exhausted&quot; error, since there is no need to make that distinction.
Use the word &quot;invalid&quot; instead of &quot;illegal&quot; for invalid UTF-8 sequences.

* Source/WTF/wtf/text/WTFString.cpp:
(WTF::fromUTF8Impl): Use new span-based functions.

* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::next): Added helpers so the convertInternal function can
handle various combinations without a lot of if statements.
(WTF::Unicode::append): Ditto.
(WTF::Unicode::convertInternal): Added. This is the main implementation
shared by the various convert functions below.
(WTF::Unicode::convert): Use convertInternal. Renamed from various names,
using types and overloading to make clear what&apos;s being converted, and
eliminating both out arguments and boolean &quot;strict&quot; arguments.
(WTF::Unicode::convertReplacingInvalidSequences): Ditto.
(WTF::Unicode::checkUTF8): Renamed from computeUTFLengths and changed
return type.
(WTF::Unicode::computeUTF16LengthWithHash): Renamed from
calculateStringHashAndLengthFromUTF8MaskingTop8Bits and use char8_t and
return value instead of out arguments.
(WTF::Unicode::equal): Use spans for arguments, remove no-longer-accurate
comments about being safe only because callers must check lengths.

* Source/WTF/wtf/unicode/UTF8Conversion.h: Use span, char8_t, and return values

* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::utf8Buffer): Use new functions.
* Source/WebCore/xml/XSLTProcessorLibxslt.cpp:
(WebCore::writeToStringBuilder): Ditto.
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::convertUTF16EntityToUTF8): Ditto.
* Source/WebKit/Shared/API/c/WKString.cpp:
(WKStringGetUTF8CStringImpl): Ditto.

* Tools/TestWebKitAPI/CMakeLists.txt: Added UTF8Conversion.cpp.
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj: Ditto.

* Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp: Added.
Some basic tests for all the functions in UTF8Conversion.h.

Canonical link: <a href="https://commits.webkit.org/278094@main">https://commits.webkit.org/278094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5e5f14c26e25f280a1af39be50d8929d8d6dda7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/49443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/28725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/52479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/52682 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/116 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/51747 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/34742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/26345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/40361 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/51543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/26273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/42600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/21478 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/23731 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/43783 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/7812 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/42779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/45647 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/44288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/54194 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/48936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/24525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/20717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/47727 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/25797 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/42804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/46739 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10866 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/26636 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/56426 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/25520 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11589 "Passed tests") | 
<!--EWS-Status-Bubble-End-->