### PR TITLE
[Remote Inspection] Targeting incorrectly prefers pseudos over targets that contain their hosts

### DIFF
--- a/LayoutTests/fast/element-targeting/target-container-with-pseudo-elements-expected.txt
+++ b/LayoutTests/fast/element-targeting/target-container-with-pseudo-elements-expected.txt
@@ -1,0 +1,6 @@
+PASS firstSelector is "BODY > SECTION:first-of-type"
+PASS secondSelector is "BODY > SECTION:last-of-type"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This test requires WebKitTestRunner

--- a/LayoutTests/fast/element-targeting/target-container-with-pseudo-elements.html
+++ b/LayoutTests/fast/element-targeting/target-container-with-pseudo-elements.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<style>
+body, html {
+    margin: 0;
+}
+
+.boxes {
+    width: 200px;
+    height: 100px;
+}
+
+.box {
+    width: 100px;
+    height: 100px;
+    border: 1px solid gray;
+    box-sizing: border-box;
+    background: blue;
+    padding-left: 100px;
+    color: white;
+}
+
+.box::after {
+    content: "::after";
+    display: inline-block;
+    width: 100px;
+    height: 100px;
+    border: 1px solid red;
+    box-sizing: border-box;
+    background: tomato;
+    color: white;
+}
+</style>
+</head>
+<body>
+<section class="boxes">
+    <div class="box"></div>
+</section>
+<section class="boxes">
+    <div class="box"></div>
+</section>
+<p>This test requires WebKitTestRunner</p>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async event => {
+    firstSelector = await UIHelper.adjustVisibilityForFrontmostTarget(50, 50);
+    secondSelector = await UIHelper.adjustVisibilityForFrontmostTarget(150, 150);
+
+    shouldBeEqualToString("firstSelector", "BODY > SECTION:first-of-type");
+    shouldBeEqualToString("secondSelector", "BODY > SECTION:last-of-type");
+    finishJSTest();
+});
+</script>
+</html>


### PR DESCRIPTION
#### 52af773ed3aebb787b7471e81634d5d68d2f7923
<pre>
[Remote Inspection] Targeting incorrectly prefers pseudos over targets that contain their hosts
<a href="https://bugs.webkit.org/show_bug.cgi?id=272647">https://bugs.webkit.org/show_bug.cgi?id=272647</a>
<a href="https://rdar.apple.com/126299041">rdar://126299041</a>

Reviewed by Abrar Rahman Protyasha.

When a candidate is chosen as a target, logic in the while loop in `findTargets` filters out other
candidate elements that are redundant, due to being contained within the newly chosen target.
However, this logic doesn&apos;t currently handle pseudo elements correctly, which means that front-most
pseudo elements are surfaced as higher-priority targets, even though another container element
enclosing them has already been chosen.

Fix this by augmenting the check to omit pseudo element candidates if their host element is
contained within the newly chosen target.

* LayoutTests/fast/element-targeting/target-container-with-pseudo-elements-expected.txt: Added.
* LayoutTests/fast/element-targeting/target-container-with-pseudo-elements.html: Added.
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::findTargets):

Canonical link: <a href="https://commits.webkit.org/277475@main">https://commits.webkit.org/277475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b304ef85b25f440214092b104a5a0a74e60843c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50404 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43776 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38839 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41201 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20136 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22043 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42392 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5770 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52298 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46144 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45178 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10531 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24817 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23749 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->