### PR TITLE
[Remote Inspection] Tune viewport area ratio size thresholds to be less restrictive on mobile sites

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1147,6 +1147,7 @@
 		F407FE391F1D0DFC0017CF25 /* enormous.svg in Copy Resources */ = {isa = PBXBuildFile; fileRef = F407FE381F1D0DE60017CF25 /* enormous.svg */; };
 		F4094CC725545BD5003D73E3 /* DisplayListTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F4094CC625545BD5003D73E3 /* DisplayListTests.cpp */; };
 		F40B8D5E281086E500346417 /* fade-in-image.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F40B8D5D2810855900346417 /* fade-in-image.html */; };
+		F41289A92BCC97E700D6E0E7 /* element-targeting-6.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41289A12BCC97DA00D6E0E7 /* element-targeting-6.html */; };
 		F41462BA2BC346B80027261C /* event.ics in Copy Resources */ = {isa = PBXBuildFile; fileRef = F41462AA2BC346130027261C /* event.ics */; };
 		F415086D1DA040C50044BE9B /* play-audio-on-click.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F415086C1DA040C10044BE9B /* play-audio-on-click.html */; };
 		F418BE151F71B7DC001970E6 /* RoundedRectTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F418BE141F71B7DC001970E6 /* RoundedRectTests.cpp */; };
@@ -1634,6 +1635,7 @@
 				F41E446D2BBCDD81002A856F /* element-targeting-3.html in Copy Resources */,
 				F44A2A772BC205060044694E /* element-targeting-4.html in Copy Resources */,
 				F4FB84A82BC9F1F6000D0B47 /* element-targeting-5.html in Copy Resources */,
+				F41289A92BCC97E700D6E0E7 /* element-targeting-6.html in Copy Resources */,
 				51C8E1A91F27F49600BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist in Copy Resources */,
 				49D902B328209B3300E2C3B8 /* emptyTable.html in Copy Resources */,
 				A14AAB651E78DC5400C1ADC2 /* encrypted.pdf in Copy Resources */,
@@ -3511,6 +3513,7 @@
 		F4094CC625545BD5003D73E3 /* DisplayListTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DisplayListTests.cpp; sourceTree = "<group>"; };
 		F40B8D5D2810855900346417 /* fade-in-image.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "fade-in-image.html"; sourceTree = "<group>"; };
 		F4106C6821ACBF84004B89A1 /* WKWebViewFirstResponderTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewFirstResponderTests.mm; sourceTree = "<group>"; };
+		F41289A12BCC97DA00D6E0E7 /* element-targeting-6.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-targeting-6.html"; sourceTree = "<group>"; };
 		F41462AA2BC346130027261C /* event.ics */ = {isa = PBXFileReference; lastKnownFileType = text; path = event.ics; sourceTree = "<group>"; };
 		F415086C1DA040C10044BE9B /* play-audio-on-click.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "play-audio-on-click.html"; sourceTree = "<group>"; };
 		F418BE141F71B7DC001970E6 /* RoundedRectTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RoundedRectTests.cpp; sourceTree = "<group>"; };
@@ -4848,6 +4851,7 @@
 				F41E44652BBCDC74002A856F /* element-targeting-3.html */,
 				F44A2A6E2BC202840044694E /* element-targeting-4.html */,
 				F4FB84A02BC9F13A000D0B47 /* element-targeting-5.html */,
+				F41289A12BCC97DA00D6E0E7 /* element-targeting-6.html */,
 				51C8E1A81F27F47300BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist */,
 				F4C2AB211DD6D94100E06D5B /* enormous-video-with-sound.html */,
 				F407FE381F1D0DE60017CF25 /* enormous.svg */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-6.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-6.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+html, body {
+    margin: 0;
+}
+
+p {
+    font-size: 16px;
+    font-family: monospace;
+    line-height: 1.5em;
+    height: 400px;
+    border: 1px solid black;
+}
+
+img {
+    width: 100%;
+    height: 400px;
+    object-fit: cover;
+    border: 1px solid black;
+}
+</style>
+</head>
+<body>
+    <main>
+        <p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</p>
+        <img src="sunset-in-cupertino-200px.png" />
+        <p class="bottom-text">Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</p>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
#### 866b410bceb84beb179dff08a712f1c00c962ecd
<pre>
[Remote Inspection] Tune viewport area ratio size thresholds to be less restrictive on mobile sites
<a href="https://bugs.webkit.org/show_bug.cgi?id=272654">https://bugs.webkit.org/show_bug.cgi?id=272654</a>
<a href="https://rdar.apple.com/126271452">rdar://126271452</a>

Reviewed by Abrar Rahman Protyasha.

Currently, the constants used to identify absolutely-positioned or in-flow candidates when finding
targets have been (for the most part) tested against desktop content on macOS. However, these
thresholds are slightly too restrictive on mobile, where potential targets tend to fill a larger
portion of the viewport.

To account for this, this patch turns the 5 constant values below into linearly-interpolated values,
depending on the viewport area. At roughly desktop-class viewport areas, these are equivalent to
their current values; on mobile, these are tuned to be relatively larger.

```
Form Factor    Area       Max AbsPos      Max In-Flow    Min In-Flow    Max Nearby    Max Adj. Area
---------------------------------------------------------------------------------------------------
Desktop        800000     0.750           0.500          0.005          0.250         0.250
Mobile         200000     1.000           1.000          0.010          0.500         0.300
```

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::linearlyInterpolatedViewportRatio):
(WebCore::maximumAreaRatioForAbsolutelyPositionedContent):
(WebCore::maximumAreaRatioForInFlowContent):
(WebCore::maximumAreaRatioForNearbyTargets):
(WebCore::minimumAreaRatioForInFlowContent):
(WebCore::maximumAreaRatioForTrackingAdjustmentAreas):

Turn all of these hard-coded constants into helper functions that take the current viewport size as
input, and return linearly-interpolated values, clamped to the given minimum/maximum values.

(WebCore::inflatedClientRectForAdjustmentRegionTracking):
(WebCore::ElementTargetingController::findTargets):

Make an additional adjustment: treat candidates with no children as targets, even if they&apos;re above
size thresholds.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(-[WKWebView expectSingleTargetedSelector:at:]):

Pull this testing helper out of `ElementTargeting.ParentRelativeSelectors` and into a helper method
in a testing category on `TestWKWebView`, so that we can use it from both of the below tests.

(TestWebKitAPI::TEST(ElementTargeting, ParentRelativeSelectors)):
(TestWebKitAPI::TEST(ElementTargeting, TargetInFlowElements)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-6.html: Added.

Canonical link: <a href="https://commits.webkit.org/277502@main">https://commits.webkit.org/277502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/868cd00d0d37216085a40edaf25363b13119f4b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43798 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38856 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20153 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22065 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42413 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5792 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44088 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52320 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22779 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19108 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46160 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24051 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45194 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10545 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24839 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->