### PR TITLE
Adopt std::span in more places

### DIFF
--- a/Source/JavaScriptCore/API/JSValueRef.cpp
+++ b/Source/JavaScriptCore/API/JSValueRef.cpp
@@ -390,12 +390,11 @@ JSValueRef JSValueMakeFromJSONString(JSContextRef ctx, JSStringRef string)
     JSGlobalObject* globalObject = toJS(ctx);
     JSLockHolder locker(globalObject);
     String str = string->string();
-    unsigned length = str.length();
-    if (!length || str.is8Bit()) {
-        LiteralParser<LChar> parser(globalObject, str.characters8(), length, StrictJSON);
+    if (str.is8Bit()) {
+        LiteralParser parser(globalObject, str.span8(), StrictJSON);
         return toRef(globalObject, parser.tryLiteralParse());
     }
-    LiteralParser<UChar> parser(globalObject, str.characters16(), length, StrictJSON);
+    LiteralParser parser(globalObject, str.span16(), StrictJSON);
     return toRef(globalObject, parser.tryLiteralParse());
 }
 

--- a/Source/JavaScriptCore/API/glib/JSCValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCValue.cpp
@@ -2071,12 +2071,12 @@ JSCValue* jsc_value_new_from_json(JSCContext* context, const char* json)
     JSC::JSValue jsValue;
     String jsonString = String::fromUTF8(json);
     if (jsonString.is8Bit()) {
-        JSC::LiteralParser<LChar> jsonParser(globalObject, jsonString.characters8(), jsonString.length(), JSC::StrictJSON);
+        JSC::LiteralParser jsonParser(globalObject, jsonString.span8(), JSC::StrictJSON);
         jsValue = jsonParser.tryLiteralParse();
         if (!jsValue)
             exception = toRef(JSC::createSyntaxError(globalObject, jsonParser.getErrorMessage()));
     } else {
-        JSC::LiteralParser<UChar> jsonParser(globalObject, jsonString.characters16(), jsonString.length(), JSC::StrictJSON);
+        JSC::LiteralParser jsonParser(globalObject, jsonString.span16(), JSC::StrictJSON);
         jsValue = jsonParser.tryLiteralParse();
         if (!jsValue)
             exception = toRef(JSC::createSyntaxError(globalObject, jsonParser.getErrorMessage()));

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -160,12 +160,12 @@ JSValue eval(CallFrame* callFrame, JSValue thisValue, JSScope* callerScopeChain,
     if (!eval) {
         if (!ecmaMode.isStrict()) {
             if (programSource.is8Bit()) {
-                LiteralParser<LChar> preparser(globalObject, programSource.characters8(), programSource.length(), SloppyJSON, callerBaselineCodeBlock);
+                LiteralParser preparser(globalObject, programSource.span8(), SloppyJSON, callerBaselineCodeBlock);
                 if (JSValue parsedObject = preparser.tryLiteralParse())
                     RELEASE_AND_RETURN(scope, parsedObject);
 
             } else {
-                LiteralParser<UChar> preparser(globalObject, programSource.characters16(), programSource.length(), SloppyJSON, callerBaselineCodeBlock);
+                LiteralParser preparser(globalObject, programSource.span16(), SloppyJSON, callerBaselineCodeBlock);
                 if (JSValue parsedObject = preparser.tryLiteralParse())
                     RELEASE_AND_RETURN(scope, parsedObject);
 
@@ -962,10 +962,10 @@ JSValue Interpreter::executeProgram(const SourceCode& source, JSGlobalObject*, J
     if (programSource.isNull())
         return jsUndefined();
     if (programSource.is8Bit()) {
-        LiteralParser<LChar> literalParser(globalObject, programSource.characters8(), programSource.length(), JSONP);
+        LiteralParser literalParser(globalObject, programSource.span8(), JSONP);
         parseResult = literalParser.tryJSONPParse(JSONPData, globalObject->globalObjectMethodTable()->supportsRichSourceInfo(globalObject));
     } else {
-        LiteralParser<UChar> literalParser(globalObject, programSource.characters16(), programSource.length(), JSONP);
+        LiteralParser literalParser(globalObject, programSource.span16(), JSONP);
         parseResult = literalParser.tryJSONPParse(JSONPData, globalObject->globalObjectMethodTable()->supportsRichSourceInfo(globalObject));
     }
 

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -59,12 +59,12 @@ std::optional<TimeZoneID> parseTimeZoneName(StringView string)
 }
 
 template<typename CharType>
-static int32_t parseDecimalInt32(const CharType* characters, unsigned length)
+static int32_t parseDecimalInt32(std::span<const CharType> characters)
 {
     int32_t result = 0;
-    for (unsigned index = 0; index < length; ++index) {
-        ASSERT(isASCIIDigit(characters[index]));
-        result = (result * 10) + characters[index] - '0';
+    for (auto character : characters) {
+        ASSERT(isASCIIDigit(character));
+        result = (result * 10) + character - '0';
     }
     return result;
 }
@@ -81,7 +81,7 @@ static void handleFraction(Duration& duration, int factor, StringView fractionSt
     for (unsigned i = 0; i < fractionLength; i++)
         padded[i] = fractionString[i];
 
-    int64_t fraction = static_cast<int64_t>(factor) * parseDecimalInt32(padded.data(), 9);
+    int64_t fraction = static_cast<int64_t>(factor) * parseDecimalInt32(padded.span());
     if (!fraction)
         return;
 
@@ -362,9 +362,9 @@ static std::optional<PlainTime> parseTimeSpec(StringParsingBuffer<CharacterType>
         padded[i] = buffer[i];
     buffer.advanceBy(digits);
 
-    unsigned millisecond = parseDecimalInt32(padded.data(), 3);
-    unsigned microsecond = parseDecimalInt32(padded.data() + 3, 3);
-    unsigned nanosecond = parseDecimalInt32(padded.data() + 6, 3);
+    unsigned millisecond = parseDecimalInt32(padded.span().first(3));
+    unsigned microsecond = parseDecimalInt32(padded.subspan(3, 3));
+    unsigned nanosecond = parseDecimalInt32(padded.subspan(6, 3));
 
     return PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
 }
@@ -917,7 +917,7 @@ static std::optional<PlainDate> parseDate(StringParsingBuffer<CharacterType>& bu
             if (!isASCIIDigit(buffer[index]))
                 return std::nullopt;
         }
-        year = parseDecimalInt32(buffer.position(), 6) * yearFactor;
+        year = parseDecimalInt32(std::span { buffer.position(), 6 }) * yearFactor;
         if (!year && yearFactor < 0)
             return std::nullopt;
         buffer.advanceBy(6);
@@ -928,7 +928,7 @@ static std::optional<PlainDate> parseDate(StringParsingBuffer<CharacterType>& bu
             if (!isASCIIDigit(buffer[index]))
                 return std::nullopt;
         }
-        year = parseDecimalInt32(buffer.position(), 4);
+        year = parseDecimalInt32(std::span { buffer.position(), 4 });
         buffer.advanceBy(4);
     }
 

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -1525,7 +1525,7 @@ JSC_DEFINE_HOST_FUNCTION(jsonProtoFuncParse, (JSGlobalObject* globalObject, Call
 
     JSValue unfiltered;
     if (view.is8Bit()) {
-        LiteralParser<LChar> jsonParser(globalObject, view.characters8(), view.length(), StrictJSON);
+        LiteralParser jsonParser(globalObject, view.span8(), StrictJSON);
         unfiltered = jsonParser.tryLiteralParse();
         EXCEPTION_ASSERT(!scope.exception() || !unfiltered);
         if (!unfiltered) {
@@ -1533,7 +1533,7 @@ JSC_DEFINE_HOST_FUNCTION(jsonProtoFuncParse, (JSGlobalObject* globalObject, Call
             return throwVMError(globalObject, scope, createSyntaxError(globalObject, jsonParser.getErrorMessage()));
         }
     } else {
-        LiteralParser<UChar> jsonParser(globalObject, view.characters16(), view.length(), StrictJSON);
+        LiteralParser jsonParser(globalObject, view.span16(), StrictJSON);
         unfiltered = jsonParser.tryLiteralParse();
         EXCEPTION_ASSERT(!scope.exception() || !unfiltered);
         if (!unfiltered) {
@@ -1567,11 +1567,11 @@ JSValue JSONParse(JSGlobalObject* globalObject, StringView json)
         return JSValue();
 
     if (json.is8Bit()) {
-        LiteralParser<LChar> jsonParser(globalObject, json.characters8(), json.length(), StrictJSON);
+        LiteralParser jsonParser(globalObject, json.span8(), StrictJSON);
         return jsonParser.tryLiteralParse();
     }
 
-    LiteralParser<UChar> jsonParser(globalObject, json.characters16(), json.length(), StrictJSON);
+    LiteralParser jsonParser(globalObject, json.span16(), StrictJSON);
     return jsonParser.tryLiteralParse();
 }
 
@@ -1584,7 +1584,7 @@ JSValue JSONParseWithException(JSGlobalObject* globalObject, StringView json)
         return JSValue();
 
     if (json.is8Bit()) {
-        LiteralParser<LChar> jsonParser(globalObject, json.characters8(), json.length(), StrictJSON);
+        LiteralParser jsonParser(globalObject, json.span8(), StrictJSON);
         JSValue result = jsonParser.tryLiteralParse();
         RETURN_IF_EXCEPTION(scope, { });
         if (!result)
@@ -1592,7 +1592,7 @@ JSValue JSONParseWithException(JSGlobalObject* globalObject, StringView json)
         return result;
     }
 
-    LiteralParser<UChar> jsonParser(globalObject, json.characters16(), json.length(), StrictJSON);
+    LiteralParser jsonParser(globalObject, json.span16(), StrictJSON);
     JSValue result = jsonParser.tryLiteralParse();
     RETURN_IF_EXCEPTION(scope, { });
     if (!result)

--- a/Source/JavaScriptCore/runtime/LiteralParser.h
+++ b/Source/JavaScriptCore/runtime/LiteralParser.h
@@ -95,10 +95,10 @@ ALWAYS_INLINE void setParserTokenString(LiteralParserToken<CharType>&, const Cha
 template <typename CharType>
 class LiteralParser {
 public:
-    LiteralParser(JSGlobalObject* globalObject, const CharType* characters, unsigned length, ParserMode mode, CodeBlock* nullOrCodeBlock = nullptr)
+    LiteralParser(JSGlobalObject* globalObject, std::span<const CharType> characters, ParserMode mode, CodeBlock* nullOrCodeBlock = nullptr)
         : m_globalObject(globalObject)
         , m_nullOrCodeBlock(nullOrCodeBlock)
-        , m_lexer(characters, length, mode)
+        , m_lexer(characters, mode)
         , m_mode(mode)
     {
     }
@@ -134,10 +134,10 @@ public:
 private:
     class Lexer {
     public:
-        Lexer(const CharType* characters, unsigned length, ParserMode mode)
+        Lexer(std::span<const CharType> characters, ParserMode mode)
             : m_mode(mode)
-            , m_ptr(characters)
-            , m_end(characters + length)
+            , m_ptr(characters.data())
+            , m_end(characters.data() + characters.size())
         {
         }
         

--- a/Source/JavaScriptCore/runtime/ParseInt.h
+++ b/Source/JavaScriptCore/runtime/ParseInt.h
@@ -49,12 +49,12 @@ ALWAYS_INLINE static int parseDigit(unsigned short c, int radix)
     return digit;
 }
 
-static double parseIntOverflow(const LChar* s, unsigned length, int radix)
+static double parseIntOverflow(std::span<const LChar> s, int radix)
 {
     double number = 0.0;
     double radixMultiplier = 1.0;
 
-    for (const LChar* p = s + length - 1; p >= s; p--) {
+    for (const LChar* p = s.data() + s.size() - 1; p >= s.data(); p--) {
         if (radixMultiplier == std::numeric_limits<double>::infinity()) {
             if (*p != '0') {
                 number = std::numeric_limits<double>::infinity();
@@ -71,12 +71,12 @@ static double parseIntOverflow(const LChar* s, unsigned length, int radix)
     return number;
 }
 
-static double parseIntOverflow(const UChar* s, unsigned length, int radix)
+static double parseIntOverflow(std::span<const UChar> s, int radix)
 {
     double number = 0.0;
     double radixMultiplier = 1.0;
 
-    for (const UChar* p = s + length - 1; p >= s; p--) {
+    for (const UChar* p = s.data() + s.size() - 1; p >= s.data(); p--) {
         if (radixMultiplier == std::numeric_limits<double>::infinity()) {
             if (*p != '0') {
                 number = std::numeric_limits<double>::infinity();
@@ -96,8 +96,8 @@ static double parseIntOverflow(const UChar* s, unsigned length, int radix)
 static double parseIntOverflow(StringView string, int radix)
 {
     if (string.is8Bit())
-        return parseIntOverflow(string.characters8(), string.length(), radix);
-    return parseIntOverflow(string.characters16(), string.length(), radix);
+        return parseIntOverflow(string.span8(), radix);
+    return parseIntOverflow(string.span16(), radix);
 }
 
 ALWAYS_INLINE static bool isStrWhiteSpace(UChar c)

--- a/Source/WebCore/html/parser/ParsingUtilities.h
+++ b/Source/WebCore/html/parser/ParsingUtilities.h
@@ -128,6 +128,18 @@ template<bool characterPredicate(UChar)> void skipUntil(const UChar*& position, 
         ++position;
 }
 
+template<bool characterPredicate(LChar)> void skipUntil(std::span<const LChar>& buffer)
+{
+    while (!buffer.empty() && !characterPredicate(buffer.front()))
+        buffer = buffer.subspan(1);
+}
+
+template<bool characterPredicate(UChar)> void skipUntil(std::span<const UChar>& buffer)
+{
+    while (!buffer.empty() && !characterPredicate(buffer.front()))
+        buffer = buffer.subspan(1);
+}
+
 template<bool characterPredicate(LChar)> void skipUntil(StringParsingBuffer<LChar>& buffer)
 {
     while (buffer.hasCharactersRemaining() && !characterPredicate(*buffer))


### PR DESCRIPTION
#### 5ec5a2c519e1e62d602d432ad243edf1641bd920
<pre>
Adopt std::span in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=272656">https://bugs.webkit.org/show_bug.cgi?id=272656</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/API/JSValueRef.cpp:
(JSValueMakeFromJSONString):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::eval):
(JSC::Interpreter::executeProgram):
* Source/JavaScriptCore/runtime/ISO8601.cpp:
(JSC::ISO8601::parseDecimalInt32):
(JSC::ISO8601::handleFraction):
(JSC::ISO8601::parseTimeSpec):
(JSC::ISO8601::parseDate):
* Source/JavaScriptCore/runtime/Identifier.h:
(JSC::parseIndex):
* Source/JavaScriptCore/runtime/JSGlobalObjectFunctions.cpp:
(JSC::isInfinity):
(JSC::jsBinaryIntegerLiteral):
(JSC::jsOctalIntegerLiteral):
(JSC::jsHexIntegerLiteral):
(JSC::jsStrDecimalLiteral):
(JSC::toDouble):
(JSC::jsToNumber):
(JSC::parseFloat):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSONParse):
(JSC::JSONParseWithException):
* Source/JavaScriptCore/runtime/LiteralParser.h:
(JSC::LiteralParser::LiteralParser):
(JSC::LiteralParser::Lexer::Lexer):
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::transformCanLikelyUseFastPath):
(WebCore::parseSimpleTransformList):
(WebCore::parseSimpleTransform):
* Source/WebCore/dom/Document.cpp:
(WebCore::isValidNameNonASCII):
(WebCore::isValidNameASCII):
(WebCore::Document::isValidName):
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
(WebCore::appendDescriptorAndReset):
(WebCore::parseImageCandidatesFromSrcsetAttribute):

Canonical link: <a href="https://commits.webkit.org/277508@main">https://commits.webkit.org/277508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/100c53fadfed8bff0d28a60f5dda75758017a06c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50474 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43846 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50098 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24470 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38899 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 27 flakes 75 failures; Uploaded test results; 14 flakes 59 failures; Running compile-webkit-without-change") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20196 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42497 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5840 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/41079 "Build is in progress. Recent messages:OS: Monterey (12.6.8), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Running jscore-test") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44160 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52368 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/47284 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19190 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46205 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24100 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45246 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24890 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/54782 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6764 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23821 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/11250 "Passed tests") | 
<!--EWS-Status-Bubble-End-->