### PR TITLE
[GCC] Unreviewed, build fix for Ubuntu LTS after 277466@main

### DIFF
--- a/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
+++ b/Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp
@@ -119,7 +119,7 @@ std::optional<ApplicationCacheManifest> parseApplicationCacheManifest(const URL&
             while (lineEnd > lineStart && isManifestWhitespace(*lineEnd))
                 --lineEnd;
 
-            StringParsingBuffer lineBuffer(std::span { lineStart, lineEnd + 1 });
+            StringParsingBuffer lineBuffer(std::span(lineStart, lineEnd + 1));
 
             if (lineBuffer[lineBuffer.lengthRemaining() - 1] == ':') {
                 if (skipCharactersExactly(lineBuffer, cacheModeIdentifier<CharacterType>) && lineBuffer.lengthRemaining() == 1) {

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -249,7 +249,7 @@ template<typename CharacterType> void ContentSecurityPolicySourceList::parse(Str
         auto beginSource = buffer.position();
         skipWhile<isSourceCharacter>(buffer);
 
-        StringParsingBuffer sourceBuffer(std::span { beginSource, buffer.position() });
+        StringParsingBuffer sourceBuffer(std::span(beginSource, buffer.position()));
 
         if (parseNonceSource(sourceBuffer))
             continue;

--- a/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp
@@ -100,7 +100,7 @@ void ContentSecurityPolicyTrustedTypesDirective::parse(const String& value)
             auto beginPolicy = buffer.position();
             skipWhile<isTrustedTypeCharacter>(buffer);
 
-            StringParsingBuffer policyBuffer(std::span { beginPolicy, buffer.position() });
+            StringParsingBuffer policyBuffer(std::span(beginPolicy, buffer.position()));
 
             if (skipExactlyIgnoringASCIICase(policyBuffer, "'allow-duplicates'"_s)) {
                 m_allowDuplicates = true;


### PR DESCRIPTION
#### faafe6773774b3c1b779ef5af3915fafc8ea7e87
<pre>
[GCC] Unreviewed, build fix for Ubuntu LTS after 277466@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=272630">https://bugs.webkit.org/show_bug.cgi?id=272630</a>

Several build bots using GCC10.2 (Debian 11) and GCC 11.4 (Ubuntu 22.04)
are failing, possibly due to limitations in the compiler.

* Source/WebCore/loader/appcache/ApplicationCacheManifestParser.cpp:
(WebCore::parseApplicationCacheManifest):
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::ContentSecurityPolicySourceList::parse):
* Source/WebCore/page/csp/ContentSecurityPolicyTrustedTypesDirective.cpp:
(WebCore::ContentSecurityPolicyTrustedTypesDirective::parse):

Canonical link: <a href="https://commits.webkit.org/277484@main">https://commits.webkit.org/277484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6abcc504c3f2e20ce926d982b3137530352a1130

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50437 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43809 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24427 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24601 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/41240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20163 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22082 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42430 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5803 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44106 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52331 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22791 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/50/builds/19132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/46171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24063 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45207 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24851 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6753 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->