### PR TITLE
[JHBuild] Upgrade 'libdrm' module to version '2.4.113'

### DIFF
--- a/Tools/gtk/jhbuild.modules
+++ b/Tools/gtk/jhbuild.modules
@@ -374,12 +374,15 @@
             hash="sha256:cde1d55e8dd70c3cbb3d1ec72f60e60000041579caa1d6a262bd9c35e93723a5"/>
   </autotools>
 
-  <autotools id="libdrm" autogen-sh="configure">
+  <!-- libdrm required for function 'drmGetFormatName' (defined since 'libdrm-2.4.113') -->
+  <meson id="libdrm" mesonargs="-Dtegra=enabled -Dcairo-tests=disabled -Dman-pages=disabled -Dvalgrind=disabled -Dudev=false -Dtests=false">
     <pkg-config>libdrm.pc</pkg-config>
-    <branch module="/libdrm/libdrm-${version}.tar.bz2" version="2.4.100"
-            repo="dri.freedesktop.org"
-            hash="sha256:c77cc828186c9ceec3e56ae202b43ee99eb932b4a87255038a80e8a1060d0a5d"/>
-  </autotools>
+    <branch module="mesa/drm.git"
+            version="2.4.113"
+            tag="libdrm-2.4.113"
+            checkoutdir="libdrm-2.4.113"
+            repo="git.freedesktop.org" />
+  </meson>
 
   <autotools id="mesa"
              autogen-sh="configure"

--- a/Tools/jhbuild/jhbuild-minimal.modules
+++ b/Tools/jhbuild/jhbuild-minimal.modules
@@ -5,35 +5,37 @@
 
   <metamodule id="webkitgtk-minimal-dependencies">
     <dependencies>
-      <dep package="wpebackend-fdo"/>
-      <dep package="icu"/>
-      <dep package="manette"/>
-      <dep package="libjxl"/>
-      <dep package="libvpx"/>
-      <dep package="glib"/>
-      <dep package="glib-networking"/>
       <dep package="atk"/>
       <dep package="at-spi2-atk"/>
+      <dep package="glib"/>
+      <dep package="glib-networking"/>
+      <dep package="icu"/>
+      <dep package="libdrm"/>
+      <dep package="libjxl"/>
       <dep package="libsoup"/>
+      <dep package="libvpx"/>
+      <dep package="manette"/>
       <dep package="wayland"/>
       <dep package="wayland-protocols"/>
+      <dep package="wpebackend-fdo"/>
     </dependencies>
   </metamodule>
 
   <metamodule id="webkitwpe-minimal-dependencies">
     <dependencies>
-      <dep package="wpebackend-fdo"/>
-      <dep package="icu"/>
-      <dep package="openxr"/>
-      <dep package="libjxl"/>
-      <dep package="libvpx"/>
-      <dep package="glib"/>
-      <dep package="glib-networking"/>
       <dep package="atk"/>
       <dep package="at-spi2-atk"/>
+      <dep package="glib"/>
+      <dep package="glib-networking"/>
+      <dep package="icu"/>
+      <dep package="libdrm"/>
+      <dep package="libjxl"/>
       <dep package="libsoup"/>
+      <dep package="libvpx"/>
+      <dep package="openxr"/>
       <dep package="wayland"/>
       <dep package="wayland-protocols"/>
+      <dep package="wpebackend-fdo"/>
     </dependencies>
   </metamodule>
 
@@ -112,6 +114,16 @@
       <patch file="icudata-stdlibs.patch" strip="1"/>
     </branch>
   </autotools>
+
+  <!-- libdrm required for function 'drmGetFormatName' (defined since 'libdrm-2.4.113') -->
+  <meson id="libdrm" mesonargs="-Dtegra=enabled -Dcairo-tests=disabled -Dman-pages=disabled -Dvalgrind=disabled -Dudev=false -Dtests=false">
+    <pkg-config>libdrm.pc</pkg-config>
+    <branch module="mesa/drm.git"
+            version="2.4.113"
+            tag="libdrm-2.4.113"
+            checkoutdir="libdrm-2.4.113"
+            repo="git.freedesktop.org" />
+  </meson>
 
   <meson id="libsoup" mesonargs="-Dgssapi=disabled -Dvapi=disabled -Dntlm=disabled -Dsysprof=disabled -Dautobahn=disabled -Dpkcs11_tests=disabled">
     <pkg-config>libsoup-3.0.pc</pkg-config>

--- a/Tools/wpe/jhbuild.modules
+++ b/Tools/wpe/jhbuild.modules
@@ -16,19 +16,20 @@
       <dep package="glib"/>
       <dep package="harfbuzz"/>
       <dep package="icu"/>
+      <dep package="libdrm"/>
       <dep package="libepoxy"/>
       <dep package="libgcrypt"/>
       <dep package="libgpg-error"/>
       <dep package="libjxl"/>
+      <dep package="libsoup"/>
       <dep package="libwpe"/>
       <dep package="libxml2"/>
       <dep package="shared-mime-info"/>
       <dep package="wayland"/>
       <dep package="wayland-protocols"/>
+      <dep package="webkit-gstreamer-testing-dependencies"/>
       <dep package="wpebackend-fdo"/>
       <dep package="xdg-dbus-proxy"/>
-      <dep package="webkit-gstreamer-testing-dependencies"/>
-      <dep package="libsoup"/>
     </dependencies>
   </metamodule>
 
@@ -155,6 +156,16 @@
       <patch file="icudata-stdlibs.patch" strip="1"/>
     </branch>
   </autotools>
+
+  <!-- libdrm required for function 'drmGetFormatName' (defined since 'libdrm-2.4.113') -->
+  <meson id="libdrm" mesonargs="-Dtegra=enabled -Dcairo-tests=disabled -Dman-pages=disabled -Dvalgrind=disabled -Dudev=false -Dtests=false">
+    <pkg-config>libdrm.pc</pkg-config>
+    <branch module="mesa/drm.git"
+            version="2.4.113"
+            tag="libdrm-2.4.113"
+            checkoutdir="libdrm-2.4.113"
+            repo="git.freedesktop.org" />
+  </meson>
 
   <autotools id="pixman"
              autogen-sh="configure"


### PR DESCRIPTION
#### 8d7eceb1f07dd13e4e2195f14d02fc27489a87a9
<pre>
[JHBuild] Upgrade &apos;libdrm&apos; module to version &apos;2.4.113&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=272518">https://bugs.webkit.org/show_bug.cgi?id=272518</a>

Reviewed by Carlos Garcia Campos.

Changeset &apos;277428@main&apos; makes use of function &apos;drmGetFormatName&apos;, which is
only available since libdrm version &apos;2.4.113&apos;.

* Tools/gtk/jhbuild.modules:
* Tools/jhbuild/jhbuild-minimal.modules:
* Tools/wpe/jhbuild.modules:

Canonical link: <a href="https://commits.webkit.org/277486@main">https://commits.webkit.org/277486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78379cd1a9deaed0052a7eaaa5f9e65d4fdeff88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50440 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43812 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24430 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/38872 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20169 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42435 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5806 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44110 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52334 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46175 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24066 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45211 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24854 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6755 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->