### PR TITLE
[Skia] Add support for non-accelerated offscreen canvas

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -316,6 +316,12 @@ bool CanvasBase::shouldAccelerate(uint64_t area) const
     if (!scriptExecutionContext()->settingsValues().acceleratedCompositingEnabled)
         return false;
 #endif
+#if USE(SKIA)
+    // FIXME: Skia based ports don't implement accelerated offscreen canvas yet.
+    auto* context = renderingContext();
+    if (context && context->isOffscreen2d())
+        return false;
+#endif
     return true;
 #else
     UNUSED_PARAM(area);


### PR DESCRIPTION
#### c0cc4c7874ba0bbea8c59af39f378f10b1aa62d6
<pre>
[Skia] Add support for non-accelerated offscreen canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=272664">https://bugs.webkit.org/show_bug.cgi?id=272664</a>

Reviewed by Miguel Gomez.

Accelerated offscreen canvas requires more work to support different
skia GL contexts per thread, so fo nor we can use non-accelerated canvas
to make offscreen canvas work.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::shouldAccelerate const):
* Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp:
(Nicosia::NicosiaImageBufferPipeSource::handle):

Canonical link: <a href="https://commits.webkit.org/277496@main">https://commits.webkit.org/277496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c70ccbe836e136860847ac1876e5036124b71989

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50450 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43822 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24443 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38877 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20174 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42460 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5816 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44124 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52344 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46181 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24076 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45219 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24865 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6759 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23797 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->