### PR TITLE
[GTK][WPE] Sync WebGL content with fences when available

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -32,6 +32,7 @@
 #include "ANGLEHeaders.h"
 #include "DMABufEGLUtilities.h"
 #include "GBMDevice.h"
+#include "GLFence.h"
 #include "Logging.h"
 #include "PixelBuffer.h"
 
@@ -106,6 +107,8 @@ void GraphicsContextGLGBM::prepareForDisplay()
 
     m_swapchain.displayBO = WTFMove(m_swapchain.drawBO);
     allocateDrawBufferObject();
+
+    m_frameFence = GLFence::create();
 }
 
 bool GraphicsContextGLGBM::platformInitializeContext()

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
@@ -42,6 +42,8 @@ class GCGLANGLELayer;
 
 namespace WebCore {
 
+class GLFence;
+
 class GraphicsContextGLGBM : public GraphicsContextGLANGLE {
 public:
     static RefPtr<GraphicsContextGLGBM> create(WebCore::GraphicsContextGLAttributes&&);
@@ -106,6 +108,7 @@ private:
 
     EGLExtensions m_eglExtensions;
     Swapchain m_swapchain;
+    std::unique_ptr<GLFence> m_frameFence;
 
 #if USE(NICOSIA)
     friend class Nicosia::GCGLANGLELayer;

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp
@@ -65,7 +65,7 @@ void GCGLANGLELayer::swapBuffersIfNeeded()
                 DMABufObject(reinterpret_cast<uintptr_t>(swapchain.swapchain.get()) + bo->handle()),
                 [&](auto&& object) {
                     return bo->createDMABufObject(object.handle);
-                }, flags);
+                }, flags, WTFMove(static_cast<GraphicsContextGLGBM&>(m_context).m_frameFence));
         }
         return;
     }
@@ -83,6 +83,9 @@ void GCGLANGLELayer::swapBuffersIfNeeded()
     auto fboSize = m_context.getInternalFramebufferSize();
     Locker locker { proxy.lock() };
     auto layerBuffer = makeUnique<TextureMapperPlatformLayerBuffer>(static_cast<GraphicsContextGLTextureMapperANGLE&>(m_context).m_compositorTextureID, fboSize, flags, colorFormat);
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    layerBuffer->setFence(WTFMove(static_cast<GraphicsContextGLTextureMapperANGLE&>(m_context).m_frameFence));
+#endif
     downcast<TextureMapperPlatformLayerProxyGL>(proxy).pushNextBuffer(WTFMove(layerBuffer));
 }
 

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -54,6 +54,10 @@
 #include "GraphicsContextGLGBMTextureMapper.h"
 #endif
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+#include "GLFence.h"
+#endif
+
 namespace WebCore {
 
 GraphicsContextGLANGLE::~GraphicsContextGLANGLE()
@@ -360,6 +364,10 @@ void GraphicsContextGLTextureMapperANGLE::prepareForDisplay()
 
     prepareTexture();
     swapCompositorTexture();
+
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    m_frameFence = GLFence::create();
+#endif
 }
 
 GLContextWrapper::Type GraphicsContextGLTextureMapperANGLE::type() const

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h
@@ -38,6 +38,10 @@ class GCGLANGLELayer;
 
 namespace WebCore {
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+class GLFence;
+#endif
+
 class TextureMapperGCGLPlatformLayer;
 
 class WEBCORE_EXPORT GraphicsContextGLTextureMapperANGLE : public GLContextWrapper, public GraphicsContextGLANGLE {
@@ -82,6 +86,10 @@ private:
     RefPtr<GraphicsLayerContentsDisplayDelegate> m_layerContentsDisplayDelegate;
 
     GCGLuint m_compositorTexture { 0 };
+
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    std::unique_ptr<GLFence> m_frameFence;
+#endif
 
 #if USE(NICOSIA)
     GCGLuint m_textureID { 0 };

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp
@@ -96,6 +96,13 @@ std::unique_ptr<TextureMapperPlatformLayerBuffer> TextureMapperPlatformLayerBuff
 
 void TextureMapperPlatformLayerBuffer::paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity)
 {
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    if (m_fence) {
+        m_fence->wait(WebCore::GLFence::FlushCommands::No);
+        m_fence = nullptr;
+    }
+#endif
+
     if (m_hasManagedTexture) {
         ASSERT(m_texture);
         textureMapper.drawTexture(m_texture->id(), m_extraFlags | m_texture->colorConvertFlags(), targetRect, modelViewMatrix, opacity);

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.h
@@ -35,6 +35,10 @@
 #include <wtf/MonotonicTime.h>
 #include <wtf/OptionSet.h>
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+#include "GLFence.h"
+#endif
+
 namespace WebCore {
 
 class TextureMapperPlatformLayerBuffer : public TextureMapperPlatformLayer {
@@ -99,6 +103,10 @@ public:
 
     void setHolePunchClient(std::unique_ptr<HolePunchClient>&& client) { m_holePunchClient = WTFMove(client); }
 
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    void setFence(std::unique_ptr<GLFence>&& fence) { m_fence = WTFMove(fence); }
+#endif
+
     const TextureVariant& textureVariant() const { return m_variant; }
     IntSize size() const { return m_size; }
 
@@ -115,6 +123,10 @@ private:
     bool m_hasManagedTexture;
     std::unique_ptr<UnmanagedBufferDataHolder> m_unmanagedBufferDataHolder;
     std::unique_ptr<HolePunchClient> m_holePunchClient;
+
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    std::unique_ptr<GLFence> m_fence;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp
@@ -190,6 +190,11 @@ void TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper(Te
     if (!m_imageData)
         return;
 
+    if (m_fence) {
+        m_fence->wait(WebCore::GLFence::FlushCommands::No);
+        m_fence = nullptr;
+    }
+
     static constexpr std::array<GLfloat, 16> s_bt601ConversionMatrix {
         1.164383561643836,  0.0,                1.596026785714286, -0.874202217873451,
         1.164383561643836, -0.391762290094914, -0.812967647237771,  0.531667823499146,

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.h
@@ -32,6 +32,7 @@
 
 #include "DMABufFormat.h"
 #include "DMABufObject.h"
+#include "GLFence.h"
 #include "TextureMapperFlags.h"
 #include "TextureMapperPlatformLayer.h"
 #include <cstdint>
@@ -61,6 +62,7 @@ public:
         virtual ~DMABufLayer();
 
         void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = { }, float opacity = 1.0) final;
+        void setFence(std::unique_ptr<GLFence>&& fence) { m_fence = WTFMove(fence); }
 
         void release()
         {
@@ -79,10 +81,11 @@ public:
 
         static constexpr unsigned c_maximumAge { 16 };
         unsigned m_age { 0 };
+        std::unique_ptr<GLFence> m_fence;
     };
 
     template<typename F>
-    void pushDMABuf(DMABufObject&& dmabufObject, const F& constructor, OptionSet<TextureMapperFlags> flags = { })
+    void pushDMABuf(DMABufObject&& dmabufObject, const F& constructor, OptionSet<TextureMapperFlags> flags = { }, std::unique_ptr<GLFence>&& fence = nullptr)
     {
         ASSERT(m_lock.isHeld());
 
@@ -90,6 +93,7 @@ public:
             [&] {
                 return adoptRef(*new DMABufLayer(constructor(WTFMove(dmabufObject)), flags));
             });
+        result.iterator->value->setFence(WTFMove(fence));
         pushDMABuf(result.iterator->value.copyRef());
     }
 


### PR DESCRIPTION
#### 930c92835e20e92630212bd77890bd5bd7d7ae9d
<pre>
[GTK][WPE] Sync WebGL content with fences when available
<a href="https://bugs.webkit.org/show_bug.cgi?id=272663">https://bugs.webkit.org/show_bug.cgi?id=272663</a>

Reviewed by Carlos Garcia Campos.

Create a fence for each WebGL frame that&apos;s generated. The fence is passed
together with the buffer through the proxy to the compositor. During the
composition, before painting the buffer there&apos;s a wait for the fence to
ensure that the WebGL is finished.

* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLGBM::prepareForDisplay):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h:
* Source/WebCore/platform/graphics/nicosia/NicosiaGCGLANGLELayer.cpp:
(Nicosia::GCGLANGLELayer::swapBuffersIfNeeded):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::prepareForDisplay):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.cpp:
(WebCore::TextureMapperPlatformLayerBuffer::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerBuffer.h:
(WebCore::TextureMapperPlatformLayerBuffer::setFence):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.cpp:
(WebCore::TextureMapperPlatformLayerProxyDMABuf::DMABufLayer::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/TextureMapperPlatformLayerProxyDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/277495@main">https://commits.webkit.org/277495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28dd39594f537ca2f0d41f546cf6f59616854588

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50451 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38876 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48350 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20173 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22101 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5817 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44130 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/42883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52345 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19147 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46182 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24077 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45220 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24866 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/6758 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23798 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->