### PR TITLE
REGRESSION(271848@main): "Watch later" checkbox on youtube.com mis-renders

### DIFF
--- a/LayoutTests/fast/block/positioning/simple-out-of-flow-percent-height-expected.html
+++ b/LayoutTests/fast/block/positioning/simple-out-of-flow-percent-height-expected.html
@@ -1,0 +1,18 @@
+<style>
+#rel {
+    position: relative;
+    height: 20px;
+    border: 2px solid red;
+}
+#abs {
+    position: absolute;
+    border: 2px solid green;
+    height: 50%;
+    width: 100px;
+    display: block;
+}
+</style>
+<div id=rel>
+<div id=abs>
+</div>
+</div>

--- a/LayoutTests/fast/block/positioning/simple-out-of-flow-percent-height.html
+++ b/LayoutTests/fast/block/positioning/simple-out-of-flow-percent-height.html
@@ -1,0 +1,25 @@
+<style>
+#rel {
+    position: relative;
+    height: 20px;
+    border: 2px solid red;
+}
+#abs {
+    position: absolute;
+    border: 2px solid green;
+    height: 50%;
+    width: 100px;
+    display: none;
+}
+#abs.disp {
+    display: block;
+}
+</style>
+<div id=rel>
+<div id=abs>
+</div>
+</div>
+<script>
+document.body.offsetHeight;
+abs.classList.add("disp");
+</script>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3913,9 +3913,14 @@ void RenderBlockFlow::layoutModernLines(bool relayoutChildren, LayoutUnit& repai
         if (childNeedsPreferredWidthComputation)
             renderer.setPreferredLogicalWidthsDirty(true, MarkOnlyThis);
 
-        if (renderer.isOutOfFlowPositioned())
+        if (renderer.isOutOfFlowPositioned()) {
             renderer.containingBlock()->insertPositionedObject(*box);
-        else
+            // FIXME: This is only needed because of the synchronous layout call in setStaticPositionsForSimpleOutOfFlowContent
+            // which itself appears to be a workaround for a bad subtree layout shown by
+            // fast/block/positioning/static_out_of_flow_inside_layout_boundary.html
+            if (renderer.style().logicalHeight().isPercentOrCalculated())
+                hasSimpleOutOfFlowContentOnly = false;
+        } else
             hasSimpleOutOfFlowContentOnly = false;
 
         if (!renderer.needsLayout() && !renderer.preferredLogicalWidthsDirty())


### PR DESCRIPTION
#### 21426dee35a1783145f695ceed7defb1d464652e
<pre>
REGRESSION(271848@main): &quot;Watch later&quot; checkbox on youtube.com mis-renders
<a href="https://bugs.webkit.org/show_bug.cgi?id=272665">https://bugs.webkit.org/show_bug.cgi?id=272665</a>
<a href="https://rdar.apple.com/125644808">rdar://125644808</a>

Reviewed by Alan Baradlay.

Percent height out-of-flow positioned boxes taking the fast path may end up with miscomputed height.

* LayoutTests/fast/block/positioning/simple-out-of-flow-percent-height-expected.html: Added.
* LayoutTests/fast/block/positioning/simple-out-of-flow-percent-height.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutModernLines):

Disable the out-of-flow fast path if there are percent height boxes. The problem is that the fast path
does a synchronous layout for these boxes before the height of the parent is computed.

The synchronous layout itself is a workaround but fixing it may be more complicated.

Canonical link: <a href="https://commits.webkit.org/277501@main">https://commits.webkit.org/277501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ef5b9992d970529736fdac182f9dffc8cd479dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47770 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50453 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43825 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24447 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38879 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24630 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20176 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42464 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5819 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52347 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22807 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46185 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24079 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/41418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45223 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10544 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24868 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23800 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->