### PR TITLE
Fix potential unified build error

### DIFF
--- a/Source/WebCore/page/UserScript.cpp
+++ b/Source/WebCore/page/UserScript.cpp
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-static WTF::URL generateUniqueURL()
+static WTF::URL generateUserScriptUniqueURL()
 {
     static uint64_t identifier;
     return { { }, makeString("user-script:", ++identifier) };
@@ -38,7 +38,7 @@ static WTF::URL generateUniqueURL()
 
 UserScript::UserScript(String&& source, URL&& url, Vector<String>&& allowlist, Vector<String>&& blocklist, UserScriptInjectionTime injectionTime, UserContentInjectedFrames injectedFrames, WaitForNotificationBeforeInjecting waitForNotification)
     : m_source(WTFMove(source))
-    , m_url(url.isEmpty() ? generateUniqueURL() : WTFMove(url))
+    , m_url(url.isEmpty() ? generateUserScriptUniqueURL() : WTFMove(url))
     , m_allowlist(WTFMove(allowlist))
     , m_blocklist(WTFMove(blocklist))
     , m_injectionTime(injectionTime)

--- a/Source/WebCore/page/UserStyleSheet.cpp
+++ b/Source/WebCore/page/UserStyleSheet.cpp
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-static WTF::URL generateUniqueURL()
+static WTF::URL generateUserStyleUniqueURL()
 {
     static uint64_t identifier;
     return { { }, makeString("user-style:", ++identifier) };
@@ -38,7 +38,7 @@ static WTF::URL generateUniqueURL()
 
 UserStyleSheet::UserStyleSheet(const String& source, const URL& url, Vector<String>&& allowlist, Vector<String>&& blocklist, UserContentInjectedFrames injectedFrames, UserStyleLevel level, std::optional<PageIdentifier> pageID)
     : m_source(source)
-    , m_url(url.isEmpty() ? generateUniqueURL() : url)
+    , m_url(url.isEmpty() ? generateUserStyleUniqueURL() : url)
     , m_allowlist(WTFMove(allowlist))
     , m_blocklist(WTFMove(blocklist))
     , m_injectedFrames(injectedFrames)


### PR DESCRIPTION
#### 4e328a1f0c16540edf91761db254128479cbfae6
<pre>
Fix potential unified build error
<a href="https://bugs.webkit.org/show_bug.cgi?id=272666">https://bugs.webkit.org/show_bug.cgi?id=272666</a>

Reviewed by Adrian Perez de Castro.

The problem is the same name of global static function in two cpp files.
This change resolves potential compiler error in unified build.

* Source/WebCore/page/UserScript.cpp:
(WebCore::generateUserScriptUniqueURL):
(WebCore::UserScript::UserScript):
(WebCore::generateUniqueURL): Deleted.
* Source/WebCore/page/UserStyleSheet.cpp:
(WebCore::generateUserStyleUniqueURL):
(WebCore::UserStyleSheet::UserStyleSheet):
(WebCore::generateUniqueURL): Deleted.

Canonical link: <a href="https://commits.webkit.org/277533@main">https://commits.webkit.org/277533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/027995256842085a1f83faa4082ddf49d7835dcb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/26966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50457 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43829 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/32831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/38881 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20178 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/42477 "Passed tests") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/44141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/42899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52351 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46188 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24083 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45226 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10565 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/24872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->