### PR TITLE
[UnifiedPDF] Can't drag-scroll (autoscroll) in main frame PDFs

### DIFF
--- a/Source/WebCore/page/AutoscrollController.cpp
+++ b/Source/WebCore/page/AutoscrollController.cpp
@@ -45,9 +45,6 @@ namespace WebCore {
 // Delay time in second for start autoscroll if pointer is in border edge of scrollable element.
 static const Seconds autoscrollDelay { 200_ms };
 
-// When the autoscroll or the panScroll is triggered when do the scroll every 50ms to make it smooth.
-static const Seconds autoscrollInterval { 50_ms };
-
 #if ENABLE(PAN_SCROLLING)
 static LocalFrame* getMainFrame(LocalFrame* frame)
 {

--- a/Source/WebCore/page/AutoscrollController.h
+++ b/Source/WebCore/page/AutoscrollController.h
@@ -49,6 +49,9 @@ enum class AutoscrollType : uint8_t {
 #endif
 };
 
+// When the autoscroll or the panScroll is triggered when do the scroll every 50ms to make it smooth.
+constexpr Seconds autoscrollInterval { 50_ms };
+
 // AutscrollController handles autoscroll and pan scroll for EventHandler.
 class AutoscrollController {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -33,6 +33,7 @@
 #include <WebCore/GraphicsLayer.h>
 #include <WebCore/GraphicsLayerClient.h>
 #include <WebCore/Page.h>
+#include <WebCore/Timer.h>
 #include <wtf/OptionSet.h>
 
 OBJC_CLASS PDFAction;
@@ -319,6 +320,14 @@ private:
     PDFDocumentLayout::DisplayMode displayModeFromContextMenuItemTag(const ContextMenuItemTag&) const;
 #endif
 
+    // Autoscroll
+    // FIXME: Refactor and hook into WebCore::AutoscrollController instead of manually implementing these.
+    void beginAutoscroll();
+    void autoscrollTimerFired();
+    void continueAutoscroll();
+    void stopAutoscroll();
+    void scrollWithDelta(const WebCore::IntSize&);
+
     // Selections
     enum class SelectionGranularity : uint8_t {
         Character,
@@ -548,6 +557,9 @@ private:
     };
     SelectionTrackingData m_selectionTrackingData;
     RetainPtr<PDFSelection> m_currentSelection;
+
+    bool m_inActiveAutoscroll { false };
+    WebCore::Timer m_autoscrollTimer { *this, &UnifiedPDFPlugin::autoscrollTimerFired };
 
     RetainPtr<WKPDFFormMutationObserver> m_pdfMutationObserver;
 


### PR DESCRIPTION
#### 3a5275e3072b335f164864694b212a6f6da75393
<pre>
[UnifiedPDF] Can&apos;t drag-scroll (autoscroll) in main frame PDFs
<a href="https://bugs.webkit.org/show_bug.cgi?id=272668">https://bugs.webkit.org/show_bug.cgi?id=272668</a>
<a href="https://rdar.apple.com/125636987">rdar://125636987</a>

Reviewed by Simon Fraser.

This patch implements autoscrolling behavior in PDFs. We do so by
drawing inspiration from the methods exposed by
WebCore::AutoscrollController.

Specifically, we maintain a timer that starts repeating whenever we drag
across a selection, and if we have dragged outside of the plugin&apos;s
bounds, we update our scroll offset to reflect the drag-scroll behavior.

* Source/WebCore/page/AutoscrollController.cpp:
* Source/WebCore/page/AutoscrollController.h:

Expose the autoscroll delay as a constexpr value in the WebCore
namespace, so as to provide a consistent experience in Unified PDF
autoscrolling.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::handleMouseEvent):

Make state cleanup for selection and autoscrolling more ergonomic by
providing the work as a scope exit conditioned behind if the mouse event
to be handled is a MouseUp event. We do so because handleMouseEvent has
many exit paths, and we want to reset selection/autoscroll state in
all of them (if we are handling a MouseUp event).

(WebKit::UnifiedPDFPlugin::continueTrackingSelection):
(WebKit::UnifiedPDFPlugin::rectForSelectionInRootView const):
(WebKit::UnifiedPDFPlugin::beginAutoscroll):
(WebKit::UnifiedPDFPlugin::autoscrollTimerFired):
(WebKit::UnifiedPDFPlugin::continueAutoscroll):
(WebKit::UnifiedPDFPlugin::stopAutoscroll):
(WebKit::UnifiedPDFPlugin::scrollWithDelta):

Canonical link: <a href="https://commits.webkit.org/277569@main">https://commits.webkit.org/277569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7c9460fb462bd88190c01f9875290e41126e0ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/47946 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/27149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/50827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/50627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/43999 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/50252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/33022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/24636 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/39012 "Failure limit exceed. At least found 1 new test failure: fast/css-custom-paint/out-of-memory-while-adding-worklet-module.html (failure)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/48528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/24819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/41472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/20313 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/22295 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/42657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-skia](https://ews-build.webkit.org/#/builders/52/builds/5993 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/44291 "Build was cancelled. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/43090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/52521 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/22989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/19337 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/46321 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/24258 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/45367 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/10584 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/25052 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/23980 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->